### PR TITLE
[Feature] Support Iceberg v3 default value feature

### DIFF
--- a/be/src/connector/cache_stats_connector.cpp
+++ b/be/src/connector/cache_stats_connector.cpp
@@ -16,6 +16,7 @@
 
 #include "connector/connector.h"
 #include "exec/cache_stats_scanner.h"
+#include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::connector {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -85,10 +85,15 @@ HiveDataSource::HiveDataSource(const HiveDataSourceProvider* provider, const THd
 Status HiveDataSource::_check_all_slots_nullable() {
     for (const auto* slot : _tuple_desc->slots()) {
         if (!slot->is_nullable()) {
-            return Status::RuntimeError(fmt::format(
-                    "All columns must be nullable for external table. Column '{}' is not nullable, You can rebuild the"
-                    "external table and We strongly recommend that you use catalog to access external data.",
-                    slot->col_name()));
+            // Check if the non-nullable column has a default value
+            // If it has a default value, allow scanning as old data files can be filled with the default
+            if (_materialize_slot_default_values.find(slot->id()) == _materialize_slot_default_values.end()) {
+                return Status::RuntimeError(fmt::format(
+                        "All columns must be nullable for external table. Column '{}' is not nullable, You can rebuild "
+                        "the"
+                        "external table and We strongly recommend that you use catalog to access external data.",
+                        slot->col_name()));
+            }
         }
     }
     return Status::OK();

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -411,6 +411,12 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         } else {
             _materialize_slots.push_back(slots[i]);
             _materialize_index_in_chunk.push_back(i);
+            if (_hive_table != nullptr) {
+                auto default_value = _hive_table->get_column_default_value(slots[i]);
+                if (default_value.has_value()) {
+                    _materialize_slot_default_values.emplace(slots[i]->id(), *default_value);
+                }
+            }
         }
     }
 
@@ -742,6 +748,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.tuple_desc = _tuple_desc;
     scanner_params.materialize_slots = _materialize_slots;
     scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;
+    scanner_params.materialize_slot_default_values = _materialize_slot_default_values;
     scanner_params.partition_slots = _partition_slots;
     scanner_params.partition_index_in_chunk = _partition_index_in_chunk;
     scanner_params._partition_index_in_hdfs_partition_columns = _partition_index_in_hdfs_partition_columns;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
 #include "exec/connector_scan_node.h"
@@ -155,6 +157,9 @@ private:
     // materialized columns.
     std::vector<SlotDescriptor*> _materialize_slots;
     std::vector<int> _materialize_index_in_chunk;
+    // default values for materialize_slots that have default value defined.
+    // used when the slot doesn't exist in the data file during scanning.
+    std::unordered_map<SlotId, std::string> _materialize_slot_default_values;
 
     // partition columns.
     std::vector<SlotDescriptor*> _partition_slots;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -45,9 +45,8 @@ static Status fill_default_value_for_not_existed_slot(SlotDescriptor* slot_desc,
         return Status::InternalError(fmt::format("failed to get type info for slot {}", slot_desc->col_name()));
     }
     if (default_value.empty() && !slot_desc->type().is_string_type()) {
-        return Status::InvalidArgument(
-                fmt::format("empty default value is only supported for string-like columns, col_name={}",
-                            slot_desc->col_name()));
+        return Status::InvalidArgument(fmt::format(
+                "empty default value is only supported for string-like columns, col_name={}", slot_desc->col_name()));
     }
 
     // Parse default value into Datum using TypeInfo::from_string

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -16,6 +16,7 @@
 
 #include "cache/data_cache_hit_rate_counter.hpp"
 #include "column/column_helper.h"
+#include "column/datum_convert.h"
 #include "column/type_traits.h"
 #include "common/config_cache_fwd.h"
 #include "common/config_scan_io_fwd.h"
@@ -29,6 +30,7 @@
 #include "storage/predicate_parser.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/runtime_range_pruner.hpp"
+#include "storage/type_info_allocator_adapter.h"
 #include "storage/types.h"
 #include "util/compression/compression_utils.h"
 #include "util/compression/stream_decompressor.h"
@@ -42,11 +44,33 @@ static Status fill_default_value_for_not_existed_slot(SlotDescriptor* slot_desc,
     if (type_info == nullptr) {
         return Status::InternalError(fmt::format("failed to get type info for slot {}", slot_desc->col_name()));
     }
-    std::unique_ptr<DefaultValueColumnIterator> default_value_iter = std::make_unique<DefaultValueColumnIterator>(
-            true, default_value, slot_desc->is_nullable(), type_info, slot_desc->type().len, row_count);
-    ColumnIteratorOptions iter_opts;
-    RETURN_IF_ERROR(default_value_iter->init(iter_opts));
-    return default_value_iter->fetch_values_by_rowid(nullptr, row_count, column);
+
+    // For Iceberg: treat the default value string literally
+    // - Empty string means SQL NULL (when IcebergApiConverter returns null in Java)
+    // - "NULL" is a literal string, not SQL null
+    if (default_value.empty()) {
+        if (!slot_desc->is_nullable()) {
+            return Status::InternalError(
+                    fmt::format("non-nullable column {} has empty default value", slot_desc->col_name()));
+        }
+        [[maybe_unused]] bool ok = column->append_nulls(row_count);
+        DCHECK(ok) << "cannot append null to non-nullable column";
+        return Status::OK();
+    }
+
+    // Parse default value into Datum using TypeInfo::from_string
+    // This handles all basic types: INT, BIGINT, FLOAT, DOUBLE, BOOLEAN, STRING, DATE, TIMESTAMP
+    MemPool mem_pool;
+    TypeInfoAllocator type_info_allocator = make_type_info_allocator(&mem_pool);
+    Datum datum;
+    RETURN_IF_ERROR(datum_from_string(type_info.get(), &datum, default_value, &type_info_allocator));
+
+    // Fill column with the default value
+    for (size_t i = 0; i < row_count; ++i) {
+        column->append_datum(datum);
+    }
+
+    return Status::OK();
 }
 
 class CountedSeekableInputStream final : public io::SeekableInputStreamWrapper {

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -27,12 +27,27 @@
 #include "io/compressed_input_stream.h"
 #include "io/shared_buffered_input_stream.h"
 #include "storage/predicate_parser.h"
+#include "storage/rowset/default_value_column_iterator.h"
 #include "storage/runtime_range_pruner.hpp"
+#include "storage/types.h"
 #include "util/compression/compression_utils.h"
 #include "util/compression/stream_decompressor.h"
 namespace starrocks {
 
 static const std::string kCountOptColumnName = "___count___";
+
+static Status fill_default_value_for_not_existed_slot(SlotDescriptor* slot_desc, const std::string& default_value,
+                                                      size_t row_count, Column* column) {
+    auto type_info = get_type_info(slot_desc->type());
+    if (type_info == nullptr) {
+        return Status::InternalError(fmt::format("failed to get type info for slot {}", slot_desc->col_name()));
+    }
+    std::unique_ptr<DefaultValueColumnIterator> default_value_iter = std::make_unique<DefaultValueColumnIterator>(
+            true, default_value, slot_desc->is_nullable(), type_info, slot_desc->type().len, row_count);
+    ColumnIteratorOptions iter_opts;
+    RETURN_IF_ERROR(default_value_iter->init(iter_opts));
+    return default_value_iter->fetch_values_by_rowid(nullptr, row_count, column);
+}
 
 class CountedSeekableInputStream final : public io::SeekableInputStreamWrapper {
 public:
@@ -161,6 +176,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.slot_descs = _scanner_params.tuple_desc->slots();
     ctx.scan_range = _scanner_params.scan_range;
     ctx.scan_range_id = _scanner_params.scan_range_id;
+    ctx.materialize_slot_default_values = _scanner_params.materialize_slot_default_values;
     ctx.runtime_filter_collector = _scanner_params.runtime_filter_collector;
     ctx.min_max_conjunct_ctxs = _scanner_params.min_max_conjunct_ctxs;
     ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
@@ -652,6 +668,9 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
                 col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
                 col->append_datum(int64_t(1));
                 col->assign(row_count, 0);
+            } else if (auto it = materialize_slot_default_values.find(slot_desc->id());
+                       it != materialize_slot_default_values.end()) {
+                RETURN_IF_ERROR(fill_default_value_for_not_existed_slot(slot_desc, it->second, row_count, col.get()));
             } else {
                 col->append_default(row_count);
             }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -44,18 +44,10 @@ static Status fill_default_value_for_not_existed_slot(SlotDescriptor* slot_desc,
     if (type_info == nullptr) {
         return Status::InternalError(fmt::format("failed to get type info for slot {}", slot_desc->col_name()));
     }
-
-    // For Iceberg: treat the default value string literally
-    // - Empty string means SQL NULL (when IcebergApiConverter returns null in Java)
-    // - "NULL" is a literal string, not SQL null
-    if (default_value.empty()) {
-        if (!slot_desc->is_nullable()) {
-            return Status::InternalError(
-                    fmt::format("non-nullable column {} has empty default value", slot_desc->col_name()));
-        }
-        [[maybe_unused]] bool ok = column->append_nulls(row_count);
-        DCHECK(ok) << "cannot append null to non-nullable column";
-        return Status::OK();
+    if (default_value.empty() && !slot_desc->type().is_string_type()) {
+        return Status::InvalidArgument(
+                fmt::format("empty default value is only supported for string-like columns, col_name={}",
+                            slot_desc->col_name()));
     }
 
     // Parse default value into Datum using TypeInfo::from_string

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -233,6 +233,9 @@ struct HdfsScannerParams {
     // columns read from file
     std::vector<SlotDescriptor*> materialize_slots;
     std::vector<int> materialize_index_in_chunk;
+    // default values for materialize_slots that have default value defined.
+    // used when the slot doesn't exist in the data file during scanning.
+    std::unordered_map<SlotId, std::string> materialize_slot_default_values;
 
     // columns of partition info
     std::vector<SlotDescriptor*> partition_slots;
@@ -413,6 +416,9 @@ struct HdfsScannerContext {
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
+    // default values for materialize_slots that have default value defined.
+    // used when the slot doesn't exist in the data file during scanning.
+    std::unordered_map<SlotId, std::string> materialize_slot_default_values;
     // for iceberg reserved fields
     std::vector<SlotDescriptor*> reserved_field_slots;
     std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -316,6 +316,19 @@ int HiveTableDescriptor::get_partition_col_index(const SlotDescriptor* slot) con
     return -1;
 }
 
+std::optional<std::string> HiveTableDescriptor::get_column_default_value(const SlotDescriptor* slot) const {
+    for (const auto& column : _columns) {
+        if (column.column_name != slot->col_name()) {
+            continue;
+        }
+        if (column.__isset.default_value) {
+            return column.default_value;
+        }
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
 IcebergMetadataTableDescriptor::IcebergMetadataTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
         : HiveTableDescriptor(tdesc, pool) {
     _hive_column_names = tdesc.hdfsTable.hive_column_names;

--- a/be/src/runtime/descriptors_ext.h
+++ b/be/src/runtime/descriptors_ext.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <vector>
@@ -74,6 +75,7 @@ public:
 
     Status add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
                                const THdfsPartition& thrift_partition);
+    std::optional<std::string> get_column_default_value(const SlotDescriptor* slot) const;
 
 protected:
     std::string _hdfs_base_path;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(EXEC_FILES
         ./column/column_cow_test.cpp
         ./common/uri_test.cpp
         ./connector/benchmark_connector_test.cpp
+        ./connector/hive_connector_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp

--- a/be/test/connector/hive_connector_test.cpp
+++ b/be/test/connector/hive_connector_test.cpp
@@ -38,7 +38,7 @@ TEST_F(HiveConnectorTest, test_connector_type) {
 // Test HiveDataSourceProvider creates data source
 TEST_F(HiveConnectorTest, test_create_data_source) {
     THdfsScanNode hdfs_scan_node;
-    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+    HiveDataSourceProvider provider(nullptr, 0, hdfs_scan_node);
 
     TScanRange scan_range;
     scan_range.__set_hdfs_scan_range(THdfsScanRange());
@@ -52,7 +52,7 @@ TEST_F(HiveConnectorTest, test_create_data_source) {
 TEST_F(HiveConnectorTest, test_open_no_data) {
     THdfsScanNode hdfs_scan_node;
     hdfs_scan_node.__set_tuple_id(0);
-    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+    HiveDataSourceProvider provider(nullptr, 0, hdfs_scan_node);
 
     THdfsScanRange hdfs_scan_range;
     hdfs_scan_range.file_length = 0; // Triggers early return before _check_all_slots_nullable
@@ -75,7 +75,7 @@ TEST_F(HiveConnectorTest, test_bucket_properties) {
     THdfsScanNode hdfs_scan_node;
     hdfs_scan_node.__isset.bucket_properties = true;
 
-    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+    HiveDataSourceProvider provider(nullptr, 0, hdfs_scan_node);
 
     TScanRange scan_range;
     scan_range.__set_hdfs_scan_range(THdfsScanRange());
@@ -90,7 +90,7 @@ TEST_F(HiveConnectorTest, test_extended_column_index) {
     hdfs_scan_node.__isset.extended_slot_ids = true;
     hdfs_scan_node.extended_slot_ids = {10, 20, 30};
 
-    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+    HiveDataSourceProvider provider(nullptr, 0, hdfs_scan_node);
 
     THdfsScanRange hdfs_scan_range;
     auto data_source = std::make_unique<HiveDataSource>(&provider, hdfs_scan_range);
@@ -105,7 +105,7 @@ TEST_F(HiveConnectorTest, test_extended_column_index) {
 TEST_F(HiveConnectorTest, test_scan_range_indicate_const_column_index) {
     THdfsScanNode hdfs_scan_node;
 
-    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+    HiveDataSourceProvider provider(nullptr, 0, hdfs_scan_node);
 
     THdfsScanRange hdfs_scan_range;
     hdfs_scan_range.__isset.identity_partition_slot_ids = true;

--- a/be/test/connector/hive_connector_test.cpp
+++ b/be/test/connector/hive_connector_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/hive_connector.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::connector {
+
+class HiveConnectorTest : public ::testing::Test {
+public:
+    void SetUp() override { _exec_env = ExecEnv::GetInstance(); }
+
+protected:
+    ExecEnv* _exec_env = nullptr;
+};
+
+// Test HiveConnector type
+TEST_F(HiveConnectorTest, test_connector_type) {
+    HiveConnector connector;
+    EXPECT_EQ(connector.connector_type(), ConnectorType::HIVE);
+}
+
+// Test HiveDataSourceProvider creates data source
+TEST_F(HiveConnectorTest, test_create_data_source) {
+    THdfsScanNode hdfs_scan_node;
+    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+
+    TScanRange scan_range;
+    scan_range.__set_hdfs_scan_range(THdfsScanRange());
+
+    auto data_source = provider.create_data_source(scan_range);
+    EXPECT_NE(data_source, nullptr);
+    EXPECT_EQ(data_source->name(), "HiveDataSource");
+}
+
+// Test open with no data (file_length = 0) - covers early return path
+TEST_F(HiveConnectorTest, test_open_no_data) {
+    THdfsScanNode hdfs_scan_node;
+    hdfs_scan_node.__set_tuple_id(0);
+    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+
+    THdfsScanRange hdfs_scan_range;
+    hdfs_scan_range.file_length = 0; // Triggers early return before _check_all_slots_nullable
+
+    auto data_source = std::make_unique<HiveDataSource>(&provider, hdfs_scan_range);
+
+    TUniqueId fragment_id;
+    TQueryOptions query_options;
+    TQueryGlobals query_globals;
+    auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+    TUniqueId id;
+    runtime_state->init_mem_trackers(id);
+
+    auto status = data_source->open(runtime_state.get());
+    EXPECT_TRUE(status.ok());
+}
+
+// Test bucket properties constructor
+TEST_F(HiveConnectorTest, test_bucket_properties) {
+    THdfsScanNode hdfs_scan_node;
+    hdfs_scan_node.__isset.bucket_properties = true;
+
+    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+
+    TScanRange scan_range;
+    scan_range.__set_hdfs_scan_range(THdfsScanRange());
+
+    auto data_source = provider.create_data_source(scan_range);
+    EXPECT_NE(data_source, nullptr);
+}
+
+// Test extended column index
+TEST_F(HiveConnectorTest, test_extended_column_index) {
+    THdfsScanNode hdfs_scan_node;
+    hdfs_scan_node.__isset.extended_slot_ids = true;
+    hdfs_scan_node.extended_slot_ids = {10, 20, 30};
+
+    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+
+    THdfsScanRange hdfs_scan_range;
+    auto data_source = std::make_unique<HiveDataSource>(&provider, hdfs_scan_range);
+
+    EXPECT_EQ(data_source->extended_column_index(10), 0);
+    EXPECT_EQ(data_source->extended_column_index(20), 1);
+    EXPECT_EQ(data_source->extended_column_index(30), 2);
+    EXPECT_EQ(data_source->extended_column_index(99), -1); // Not found
+}
+
+// Test scan_range_indicate_const_column_index
+TEST_F(HiveConnectorTest, test_scan_range_indicate_const_column_index) {
+    THdfsScanNode hdfs_scan_node;
+
+    HiveDataSourceProvider provider(nullptr, hdfs_scan_node);
+
+    THdfsScanRange hdfs_scan_range;
+    hdfs_scan_range.__isset.identity_partition_slot_ids = true;
+    hdfs_scan_range.identity_partition_slot_ids = {5, 10, 15};
+
+    auto data_source = std::make_unique<HiveDataSource>(&provider, hdfs_scan_range);
+
+    EXPECT_EQ(data_source->scan_range_indicate_const_column_index(5), 0);
+    EXPECT_EQ(data_source->scan_range_indicate_const_column_index(10), 1);
+    EXPECT_EQ(data_source->scan_range_indicate_const_column_index(15), 2);
+    EXPECT_EQ(data_source->scan_range_indicate_const_column_index(99), -1); // Not found
+}
+
+} // namespace starrocks::connector

--- a/be/test/exec/cache_stats_scanner_test.cpp
+++ b/be/test/exec/cache_stats_scanner_test.cpp
@@ -28,6 +28,7 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "storage/lake/fixed_location_provider.h"

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -282,36 +282,44 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
     EXPECT_EQ("[42, NULL]", chunk->debug_row(0));
 }
 
-// Test filling not existed column with empty default value and nullable slot
+// Empty string defaults should be preserved for string columns.
 TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
-    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)}, {""}};
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    // Empty string means SQL NULL for nullable columns
     ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     ASSERT_EQ(1, chunk->num_rows());
-    // Should be NULL because empty default for nullable column
-    EXPECT_TRUE(chunk->get_column_by_index(0)->is_null(0));
+    EXPECT_EQ("['']", chunk->debug_row(0));
 }
 
-// Test filling not existed column with empty default value and non-nullable slot
+// Empty string defaults should also work for non-nullable string columns.
 TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
-    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)}, {""}};
     auto* tuple_desc = _create_tuple_desc_with_nullable(descs, false);
     HdfsScannerContext ctx;
     ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    // Empty string for non-nullable column should cause error
+    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+
+    ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
+    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("['']", chunk->debug_row(0));
+}
+
+TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonString) {
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
+    auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerContext ctx;
+    ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
     ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
     auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
-    // Should return error because non-nullable column has empty default value
     EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.message().find("non-nullable") != std::string::npos);
 }
 
 // ========================= ORC SCANNER ============================

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -261,6 +261,22 @@ TEST_F(HdfsScannerTest, TestParquetGetNext) {
     scanner->close();
 }
 
+TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
+                        {"c2", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
+                        {""}};
+    auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerContext ctx;
+    ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
+    ctx.not_existed_slots.push_back(tuple_desc->slots()[1]);
+    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
+
+    ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
+    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("[42, NULL]", chunk->debug_row(0));
+}
+
 // ========================= ORC SCANNER ============================
 
 static TTypeDesc create_primitive_type_desc(TPrimitiveType::type type) {

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -70,6 +70,7 @@ protected:
 
     THdfsScanRange* _create_scan_range(const std::string& file, uint64_t offset, uint64_t length);
     TupleDescriptor* _create_tuple_desc(SlotDesc* descs);
+    TupleDescriptor* _create_tuple_desc_with_nullable(SlotDesc* descs, bool nullable);
 
     ObjectPool _pool;
     RuntimeProfile* _runtime_profile = nullptr;
@@ -165,12 +166,16 @@ void HdfsScannerTest::build_hive_column_names(HdfsScannerParams* params, const T
 }
 
 TupleDescriptor* HdfsScannerTest::_create_tuple_desc(SlotDesc* descs) {
+    return _create_tuple_desc_with_nullable(descs, true);
+}
+
+TupleDescriptor* HdfsScannerTest::_create_tuple_desc_with_nullable(SlotDesc* descs, bool nullable) {
     TDescriptorTableBuilder table_desc_builder;
     TSlotDescriptorBuilder slot_desc_builder;
     TTupleDescriptorBuilder tuple_desc_builder;
     int slot_id = 0;
     while (descs->name != "") {
-        slot_desc_builder.column_name(descs->name).type(descs->type).id(slot_id).nullable(true);
+        slot_desc_builder.column_name(descs->name).type(descs->type).id(slot_id).nullable(nullable);
         tuple_desc_builder.add_slot(slot_desc_builder.build());
         descs += 1;
         slot_id += 1;
@@ -275,6 +280,38 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     ASSERT_EQ(1, chunk->num_rows());
     EXPECT_EQ("[42, NULL]", chunk->debug_row(0));
+}
+
+// Test filling not existed column with empty default value and nullable slot
+TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
+    auto* tuple_desc = _create_tuple_desc(descs);
+    HdfsScannerContext ctx;
+    ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
+    // Empty string means SQL NULL for nullable columns
+    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+
+    ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
+    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_EQ(1, chunk->num_rows());
+    // Should be NULL because empty default for nullable column
+    EXPECT_TRUE(chunk->get_column_by_index(0)->is_null(0));
+}
+
+// Test filling not existed column with empty default value and non-nullable slot
+TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
+    SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
+    auto* tuple_desc = _create_tuple_desc_with_nullable(descs, false);
+    HdfsScannerContext ctx;
+    ctx.not_existed_slots.push_back(tuple_desc->slots()[0]);
+    // Empty string for non-nullable column should cause error
+    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+
+    ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 0);
+    auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
+    // Should return error because non-nullable column has empty default value
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.message().find("non-nullable") != std::string::npos);
 }
 
 // ========================= ORC SCANNER ============================

--- a/docs/en/data_source/catalog/iceberg/DDL.md
+++ b/docs/en/data_source/catalog/iceberg/DDL.md
@@ -84,12 +84,59 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
 #### `column_definition`
 
 ```SQL
-col_name col_type [COMMENT 'comment']
+col_name col_type [COMMENT 'comment'] [DEFAULT default_value]
 ```
 
 :::note
 All non-partition columns must use `NULL` as the default value. Partition columns must be defined after non-partition columns and cannot use `NULL` as the default value.
 :::
+
+##### Default values
+
+From v4.1 onwards, StarRocks supports setting default values for columns in Iceberg tables. This feature requires Iceberg format version 3 (`"format-version" = "3"`).
+
+**Usage:**
+
+- **Write-time filling**: When executing an INSERT statement, if a value is not specified for a column, the system automatically uses the column's default value.
+- **Schema Evolution filling**: When a new column is added to an existing table, reading old data files (that do not contain the new column) will use the new column's default value.
+
+**Syntax:**
+
+```SQL
+col_name col_type DEFAULT default_value
+```
+
+**Requirements:**
+
+- The table must use Iceberg format version 3 (`"format-version" = "3"`).
+- Default values for numeric types (INT, BIGINT, FLOAT, DOUBLE), BOOLEAN, STRING, and DATE/TIMESTAMP types must be wrapped in quotes. For example: `DEFAULT "18"`, `DEFAULT "100.0"`, `DEFAULT "true"`.
+
+**Examples:**
+
+- **Create a table with default values:**
+
+```SQL
+CREATE TABLE user_info (
+    id INT,
+    name STRING,
+    age INT DEFAULT "18",
+    score DOUBLE DEFAULT "100.0",
+    status STRING DEFAULT 'active',
+    is_active BOOLEAN DEFAULT "true"
+) PROPERTIES ("format-version" = "3");
+```
+
+- **Add a column with a default value:**
+
+```SQL
+ALTER TABLE user_info ADD COLUMN bonus DOUBLE DEFAULT "50.5";
+```
+
+- **Modify a column's default value:**
+
+```SQL
+ALTER TABLE user_info MODIFY COLUMN status STRING DEFAULT "inactive";
+```
 
 #### `partition_desc`
 

--- a/docs/ja/data_source/catalog/iceberg/DDL.md
+++ b/docs/ja/data_source/catalog/iceberg/DDL.md
@@ -91,12 +91,60 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
 #### column_definition
 
 ```SQL
-col_name col_type [COMMENT 'comment']
+col_name col_type [COMMENT 'comment'] [DEFAULT default_value]
 ```
 
 :::note
 非パーティション列にはすべて `NULL` をデフォルト値として使用する必要があります。パーティション列は非パーティション列の後に定義する必要があり、`NULL` をデフォルト値として使用することはできません。
 :::
+
+##### デフォルト値
+
+v4.1以降、StarRocksはIcebergテーブルの列にデフォルト値を設定することをサポートしています。この機能には、Icebergフォーマットバージョン3（`"format-version" = "3"`）が必要です。
+
+**用途：**
+
+- **書き込み時の補完**: INSERT文を実行する際、列に値が指定されていない場合、システムは自動的にその列のデフォルト値を使用します。
+- **スキーマ進化時の補完**: 既存のテーブルに新しい列を追加した後、古いデータファイル（新しい列を含まない）を読み取る際、システムは新しい列のデフォルト値を使用します。
+
+**構文:**
+
+```SQL
+col_name col_type DEFAULT default_value
+```
+
+**要件:**
+
+- テーブルはIcebergフォーマットバージョン3（`"format-version" = "3"`）を使用する必要があります。
+- 数値型（INT、BIGINT、FLOAT、DOUBLE）、BOOLEAN、DATE/TIMESTAMP型のデフォルト値は二重引用符で囲む必要があります。例：`DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
+- 数値型（INT、BIGINT、FLOAT、DOUBLE）、BOOLEAN、STRING、DATE/TIMESTAMP型のデフォルト値は引用符で囲む必要があります。例：`DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
+
+**例:**
+
+- **デフォルト値を持つテーブルを作成する:**
+
+```SQL
+CREATE TABLE user_info (
+    id INT,
+    name STRING,
+    age INT DEFAULT "18",
+    score DOUBLE DEFAULT "100.0",
+    status STRING DEFAULT 'active',
+    is_active BOOLEAN DEFAULT "true"
+) PROPERTIES ("format-version" = "3");
+```
+
+- **デフォルト値を持つ列を追加する:**
+
+```SQL
+ALTER TABLE user_info ADD COLUMN bonus DOUBLE DEFAULT "50.5";
+```
+
+- **列のデフォルト値を変更する:**
+
+```SQL
+ALTER TABLE user_info MODIFY COLUMN status STRING DEFAULT "inactive";
+```
 
 #### partition_desc
 

--- a/docs/zh/data_source/catalog/iceberg/DDL.md
+++ b/docs/zh/data_source/catalog/iceberg/DDL.md
@@ -91,12 +91,59 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
 #### column_definition
 
 ```SQL
-col_name col_type [COMMENT 'comment']
+col_name col_type [COMMENT 'comment'] [DEFAULT default_value]
 ```
 
 :::note
 所有非分区列必须使用 `NULL` 作为默认值。分区列必须在非分区列之后定义，且不能使用 `NULL` 作为默认值。
 :::
+
+##### 默认值
+
+从 v4.1 开始，StarRocks 支持为 Iceberg 表的列设置默认值。此功能需要 Iceberg 格式版本 3（`"format-version" = "3"`）。
+
+**用途：**
+
+- **写入时填充**：当执行 INSERT 语句时，如果未为某列指定值，系统将自动使用该列的默认值填充。
+- **Schema Evolution 填充**：当为已存在的表添加新列后，读取旧数据文件（不包含新列）时，系统将使用新列的默认值进行填充。
+
+**语法：**
+
+```SQL
+col_name col_type DEFAULT default_value
+```
+
+**要求：**
+
+- 表必须使用 Iceberg 格式版本 3（`"format-version" = "3"`）。
+- 数值类型（INT、BIGINT、FLOAT、DOUBLE）、BOOLEAN、STRING 和 DATE/TIMESTAMP 类型的默认值必须使用引号包裹。例如：`DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
+
+**示例：**
+
+- **创建带有默认值的表：**
+
+```SQL
+CREATE TABLE user_info (
+    id INT,
+    name STRING,
+    age INT DEFAULT "18",
+    score DOUBLE DEFAULT "100.0",
+    status STRING DEFAULT 'active',
+    is_active BOOLEAN DEFAULT "true"
+) PROPERTIES ("format-version" = "3");
+```
+
+- **添加带有默认值的列：**
+
+```SQL
+ALTER TABLE user_info ADD COLUMN bonus DOUBLE DEFAULT "50.5";
+```
+
+- **修改列的默认值：**
+
+```SQL
+ALTER TABLE user_info MODIFY COLUMN status STRING DEFAULT "inactive";
+```
 
 #### partition_desc
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
@@ -16,10 +16,14 @@ package com.starrocks.common.proc;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
+import org.apache.iceberg.Schema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,14 +52,26 @@ public class ExternalSchemaProcNode implements ProcNodeInterface {
 
         List<Column> schema = table.getFullVisibleSchema();
         List<String> partitionColumns = table.getPartitionColumnNames();
+        Schema icebergSchema = null;
+        if (table.isIcebergTable()) {
+            icebergSchema = ((IcebergTable) table).getNativeTable().schema();
+        }
 
         for (Column column : schema) {
             String extraStr = partitionColumns.contains(column.getName()) ? PARTITION_KEY : "";
+            String defaultStr = icebergSchema == null ? null :
+                    IcebergApiConverter.getWriteDefaultValue(icebergSchema, column.getName());
+            if (defaultStr == null) {
+                defaultStr = column.getMetaDefaultValue(Lists.newArrayList());
+            }
+            if (defaultStr == null) {
+                defaultStr = DEFAULT_STR;
+            }
             List<String> rowList = Arrays.asList(column.getName(),
                     column.getType().canonicalName(),
                     column.isAllowNull() ? "Yes" : "No",
                     ((Boolean) column.isKey()).toString(),
-                    DEFAULT_STR,
+                    defaultStr,
                     extraStr,
                     column.getComment());
             result.addRow(rowList);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalSchemaProcNode.java
@@ -18,12 +18,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
-import com.starrocks.connector.iceberg.IcebergApiConverter;
-import org.apache.iceberg.Schema;
 
 import java.util.Arrays;
 import java.util.List;
@@ -52,18 +49,10 @@ public class ExternalSchemaProcNode implements ProcNodeInterface {
 
         List<Column> schema = table.getFullVisibleSchema();
         List<String> partitionColumns = table.getPartitionColumnNames();
-        Schema icebergSchema = null;
-        if (table.isIcebergTable()) {
-            icebergSchema = ((IcebergTable) table).getNativeTable().schema();
-        }
 
         for (Column column : schema) {
             String extraStr = partitionColumns.contains(column.getName()) ? PARTITION_KEY : "";
-            String defaultStr = icebergSchema == null ? null :
-                    IcebergApiConverter.getWriteDefaultValue(icebergSchema, column.getName());
-            if (defaultStr == null) {
-                defaultStr = column.getMetaDefaultValue(Lists.newArrayList());
-            }
+            String defaultStr = column.getMetaDefaultValue(Lists.newArrayList());
             if (defaultStr == null) {
                 defaultStr = DEFAULT_STR;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorAlterTableExecutor;
 import com.starrocks.connector.HdfsEnvironment;
@@ -61,6 +63,7 @@ import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -117,10 +120,13 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
             if (!columnDef.isAllowNull()) {
                 throw new StarRocksConnectorException("column in iceberg table must be nullable.");
             }
-            updateSchema.addColumn(
-                    columnDef.getName(),
-                    toIcebergColumnType(columnDef.getType()),
-                    columnDef.getComment());
+            org.apache.iceberg.types.Type icebergType = toIcebergColumnType(columnDef.getType());
+            Literal<?> defaultLiteral = buildIcebergDefaultLiteral(columnDef, icebergType);
+            if (defaultLiteral != null) {
+                updateSchema.addColumn(columnDef.getName(), icebergType, columnDef.getComment(), defaultLiteral);
+            } else {
+                updateSchema.addColumn(columnDef.getName(), icebergType, columnDef.getComment());
+            }
 
             // AFTER column / FIRST
             if (pos != null) {
@@ -148,10 +154,13 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
                 if (!columnDef.isAllowNull()) {
                     throw new StarRocksConnectorException("column in iceberg table must be nullable.");
                 }
-                updateSchema.addColumn(
-                        columnDef.getName(),
-                        toIcebergColumnType(columnDef.getType()),
-                        columnDef.getComment());
+                org.apache.iceberg.types.Type icebergType = toIcebergColumnType(columnDef.getType());
+                Literal<?> defaultLiteral = buildIcebergDefaultLiteral(columnDef, icebergType);
+                if (defaultLiteral != null) {
+                    updateSchema.addColumn(columnDef.getName(), icebergType, columnDef.getComment(), defaultLiteral);
+                } else {
+                    updateSchema.addColumn(columnDef.getName(), icebergType, columnDef.getComment());
+                }
             }
             updateSchema.commit();
         });
@@ -204,6 +213,13 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
             } else {
                 throw new StarRocksConnectorException(
                         "column in iceberg table must be nullable.");
+            }
+
+            if (columnDef.getDefaultValueDef().isSet) {
+                Literal<?> defaultLiteral = buildIcebergDefaultLiteral(columnDef, colType);
+                if (defaultLiteral != null) {
+                    updateSchema.updateColumnDefault(columnDef.getName(), defaultLiteral);
+                }
             }
 
             // AFTER column / FIRST
@@ -488,6 +504,14 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         } else {
             throw new SemanticException("Does not support partition clause: " + expr);
         }
+    }
+
+    private Literal<?> buildIcebergDefaultLiteral(ColumnDef columnDef, org.apache.iceberg.types.Type icebergType) {
+        if (!columnDef.getDefaultValueDef().isSet) {
+            return null;
+        }
+        Column column = ColumnBuilder.buildColumn(columnDef);
+        return IcebergApiConverter.toIcebergDefaultLiteral(column, icebergType);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -217,9 +217,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
 
             if (columnDef.getDefaultValueDef().isSet) {
                 Literal<?> defaultLiteral = buildIcebergDefaultLiteral(columnDef, colType);
-                if (defaultLiteral != null) {
-                    updateSchema.updateColumnDefault(columnDef.getName(), defaultLiteral);
-                }
+                updateSchema.updateColumnDefault(columnDef.getName(), defaultLiteral);
             }
 
             // AFTER column / FIRST

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -368,9 +368,11 @@ public class IcebergApiConverter {
             }
             Column column = new Column(field.name(), srType, field.isOptional());
             column.setComment(field.doc());
-            String initialDefault = toInitialDefaultValueString(field);
-            if (initialDefault != null) {
-                column.setDefaultValue(initialDefault);
+            // Prioritize write-default (used for INSERT) over initial-default (used for backfill)
+            String writeDefault = toWriteDefaultValueString(field);
+            String defaultVal = writeDefault != null ? writeDefault : toInitialDefaultValueString(field);
+            if (defaultVal != null) {
+                column.setDefaultValue(defaultVal);
             }
             fullSchema.add(column);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -66,18 +66,21 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.transforms.PartitionSpecVisitor;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -141,9 +144,18 @@ public class IcebergApiConverter {
             int index = icebergColumns.size();
             org.apache.iceberg.types.Type type = toIcebergColumnType(column.getType());
             String colComment = StringUtils.defaultIfBlank(column.getComment(), null);
-            Types.NestedField field = Types.NestedField.of(
-                    index, column.isAllowNull(), column.getName(), type, colComment);
-            icebergColumns.add(field);
+            Types.NestedField.Builder fieldBuilder = Types.NestedField.builder()
+                    .withId(index)
+                    .isOptional(column.isAllowNull())
+                    .withName(column.getName())
+                    .ofType(type)
+                    .withDoc(colComment);
+            Literal<?> defaultLiteral = toIcebergDefaultLiteral(column, type);
+            if (defaultLiteral != null) {
+                fieldBuilder.withInitialDefault(defaultLiteral);
+                fieldBuilder.withWriteDefault(defaultLiteral);
+            }
+            icebergColumns.add(fieldBuilder.build());
         }
 
         org.apache.iceberg.types.Type icebergSchema = Types.StructType.of(icebergColumns);
@@ -354,11 +366,165 @@ public class IcebergApiConverter {
                 LOG.error("Failed to convert iceberg type {}", field.type().toString(), e);
                 srType = UnknownType.UNKNOWN_TYPE;
             }
-            Column column = new Column(field.name(), srType, true);
+            Column column = new Column(field.name(), srType, field.isOptional());
             column.setComment(field.doc());
+            String initialDefault = toInitialDefaultValueString(field);
+            if (initialDefault != null) {
+                column.setDefaultValue(initialDefault);
+            }
             fullSchema.add(column);
         }
         return fullSchema;
+    }
+
+    private static String toInitialDefaultValueString(Types.NestedField field) {
+        return toDefaultValueString(field, false);
+    }
+
+    public static String toWriteDefaultValueString(Types.NestedField field) {
+        return toDefaultValueString(field, true);
+    }
+
+    public static String getWriteDefaultValue(Schema schema, String columnName) {
+        Types.NestedField field = schema.findField(columnName);
+        if (field == null) {
+            field = schema.columns().stream()
+                    .filter(col -> col.name().equalsIgnoreCase(columnName))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (field == null) {
+            return null;
+        }
+        return toWriteDefaultValueString(field);
+    }
+
+    public static Literal<?> toIcebergDefaultLiteral(Column column, org.apache.iceberg.types.Type icebergType) {
+        Column.DefaultValueType defaultValueType = column.getDefaultValueType();
+        if (defaultValueType == Column.DefaultValueType.NULL) {
+            return null;
+        }
+        if (defaultValueType == Column.DefaultValueType.VARY) {
+            throw new StarRocksConnectorException(
+                    "Unsupported iceberg default expression for column %s: %s",
+                    column.getName(),
+                    column.getDefaultExpr().toSql());
+        }
+
+        String defaultValue = column.calculatedDefaultValue();
+        if (defaultValue == null && column.getDefaultExpr() != null && !column.getDefaultExpr().hasExprObject()) {
+            defaultValue = column.getDefaultExpr().getExpr();
+        }
+        if (defaultValue == null) {
+            throw new StarRocksConnectorException("Unsupported iceberg default value for column %s", column.getName());
+        }
+
+        try {
+            PrimitiveType primitiveType = column.getType().getPrimitiveType();
+            Literal<?> literal;
+            switch (primitiveType) {
+                case BOOLEAN:
+                    if ("1".equals(defaultValue) || "true".equalsIgnoreCase(defaultValue)) {
+                        literal = Literal.of(true).to(icebergType);
+                    } else if ("0".equals(defaultValue) || "false".equalsIgnoreCase(defaultValue)) {
+                        literal = Literal.of(false).to(icebergType);
+                    } else {
+                        throw new StarRocksConnectorException("Invalid boolean default value '%s' for column %s",
+                                defaultValue, column.getName());
+                    }
+                    break;
+                case TINYINT:
+                case SMALLINT:
+                case INT:
+                    literal = Literal.of(Integer.parseInt(defaultValue)).to(icebergType);
+                    break;
+                case BIGINT:
+                    literal = Literal.of(Long.parseLong(defaultValue)).to(icebergType);
+                    break;
+                case FLOAT:
+                    literal = Literal.of(Float.parseFloat(defaultValue)).to(icebergType);
+                    break;
+                case DOUBLE:
+                    literal = Literal.of(Double.parseDouble(defaultValue)).to(icebergType);
+                    break;
+                case DECIMAL32:
+                case DECIMAL64:
+                case DECIMAL128:
+                case DECIMAL256:
+                    literal = Literal.of(new BigDecimal(defaultValue)).to(icebergType);
+                    break;
+                case CHAR:
+                case VARCHAR:
+                    literal = Literal.of(defaultValue).to(icebergType);
+                    break;
+                case DATE:
+                case TIME:
+                    literal = Literal.of(defaultValue).to(icebergType);
+                    break;
+                case DATETIME:
+                    String timestampValue = defaultValue.contains("T") ? defaultValue : defaultValue.replace(' ', 'T');
+                    literal = Literal.of(timestampValue).to(icebergType);
+                    break;
+                default:
+                    throw new StarRocksConnectorException("Unsupported iceberg default type %s for column %s",
+                            primitiveType, column.getName());
+            }
+            if (literal == null) {
+                throw new StarRocksConnectorException(
+                        "Unsupported iceberg default value '%s' for column %s", defaultValue, column.getName());
+            }
+            return literal;
+        } catch (RuntimeException e) {
+            throw new StarRocksConnectorException(
+                    String.format("Failed to convert default value '%s' for column %s", defaultValue, column.getName()), e);
+        }
+    }
+
+    private static String toDefaultValueString(Types.NestedField field, boolean useWriteDefault) {
+        Object defaultValue;
+        if (useWriteDefault) {
+            if (field.writeDefaultLiteral() == null) {
+                return null;
+            }
+            defaultValue = field.writeDefault();
+        } else {
+            if (field.initialDefaultLiteral() == null) {
+                return null;
+            }
+            defaultValue = field.initialDefault();
+        }
+        if (defaultValue == null) {
+            return null;
+        }
+        try {
+            switch (field.type().typeId()) {
+                case BOOLEAN:
+                    return Boolean.TRUE.equals(defaultValue) ? "1" : "0";
+                case INTEGER:
+                case LONG:
+                case FLOAT:
+                case DOUBLE:
+                case DECIMAL:
+                case STRING:
+                    return defaultValue.toString();
+                case DATE:
+                    return DateTimeUtil.daysToIsoDate(((Number) defaultValue).intValue());
+                case TIME:
+                    return DateTimeUtil.microsToIsoTime(((Number) defaultValue).longValue());
+                case TIMESTAMP:
+                    Types.TimestampType timestampType = (Types.TimestampType) field.type();
+                    long micros = ((Number) defaultValue).longValue();
+                    return (timestampType.shouldAdjustToUTC()
+                            ? DateTimeUtil.timestamptzFromMicros(micros).toLocalDateTime()
+                            : DateTimeUtil.timestampFromMicros(micros)).toString().replace('T', ' ');
+                default:
+                    return null;
+            }
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to convert {} default value for iceberg field {}",
+                    useWriteDefault ? "write" : "initial", field.name(), e);
+            return null;
+        }
     }
 
     public static Map<String, String> toIcebergProps(Optional<Map<String, String>> properties, String nativeCatalogType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -40,7 +40,6 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.ConnectorSinkSortScope;
-import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -638,7 +637,7 @@ public class InsertPlanner {
                         if (isAutoIncrement) {
                             row.set(columnIdx, new NullLiteral());
                         } else {
-                            row.set(columnIdx, getInsertDefaultExpr(targetColumn, insertStatement));
+                            row.set(columnIdx, new StringLiteral(targetColumn.calculatedDefaultValue()));
                         }
                     }
                     row.set(columnIdx, TypeManager.addCastExpr(row.get(columnIdx), targetColumn.getType()));
@@ -658,7 +657,7 @@ public class InsertPlanner {
                             if (isAutoIncrement) {
                                 row.set(idx, new NullLiteral());
                             } else {
-                                row.set(idx, getInsertDefaultExpr(targetColumn, insertStatement));
+                                row.set(idx, new StringLiteral(targetColumn.calculatedDefaultValue()));
                             }
                         }
                         row.set(idx, TypeManager.addCastExpr(row.get(idx), targetColumn.getType()));
@@ -689,7 +688,32 @@ public class InsertPlanner {
             } else {
                 int idx = insertStatement.getTargetColumnNames().indexOf(targetColumn.getName().toLowerCase());
                 if (idx == -1) {
-                    ScalarOperator scalarOperator = getInsertDefaultScalarOperator(targetColumn, insertStatement);
+                    ScalarOperator scalarOperator;
+                    Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
+                    if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
+                        scalarOperator = ConstantOperator.createNull(targetColumn.getType());
+                    } else if (defaultValueType == Column.DefaultValueType.CONST) {
+                        if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().getExprObject() != null) {
+                            Expr expr = targetColumn.getDefaultExpr().obtainExpr();
+                            if (!expr.getType().equals(targetColumn.getType())) {
+                                expr = new CastExpr(targetColumn.getType(), expr);
+                            }
+                            scalarOperator = SqlToScalarOperatorTranslator.translate(expr);
+                        } else {
+                            scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
+                        }
+                    } else if (defaultValueType == Column.DefaultValueType.VARY) {
+                        if (isValidDefaultFunction(targetColumn.getDefaultExpr().getExpr())) {
+                            scalarOperator = SqlToScalarOperatorTranslator.
+                                    translate(targetColumn.getDefaultExpr().obtainExpr());
+                        } else {
+                            throw new SemanticException(
+                                    "Column:" + targetColumn.getName() + " has unsupported default value:"
+                                            + targetColumn.getDefaultExpr().getExpr());
+                        }
+                    } else {
+                        throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
+                    }
                     ColumnRefOperator col = columnRefFactory
                             .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
 
@@ -1072,67 +1096,6 @@ public class InsertPlanner {
         }
 
         return skip;
-    }
-
-    private Expr getInsertDefaultExpr(Column targetColumn, InsertStmt insertStatement) {
-        String writeDefault = getIcebergWriteDefaultValue(targetColumn, insertStatement);
-        if (writeDefault != null) {
-            return new StringLiteral(writeDefault);
-        }
-        if (insertStatement.getTargetTable() instanceof IcebergTable) {
-            if (targetColumn.isAllowNull()) {
-                return new NullLiteral();
-            }
-            throw new SemanticException("Column has no write default value, column=%s", targetColumn.getName());
-        }
-        return new StringLiteral(targetColumn.calculatedDefaultValue());
-    }
-
-    private ScalarOperator getInsertDefaultScalarOperator(Column targetColumn, InsertStmt insertStatement) {
-        String writeDefault = getIcebergWriteDefaultValue(targetColumn, insertStatement);
-        if (writeDefault != null) {
-            return ConstantOperator.createVarchar(writeDefault);
-        }
-        if (insertStatement.getTargetTable() instanceof IcebergTable) {
-            if (!targetColumn.isAllowNull() && !targetColumn.isAutoIncrement()) {
-                throw new SemanticException("Column has no write default value, column=%s", targetColumn.getName());
-            }
-            return ConstantOperator.createNull(targetColumn.getType());
-        }
-
-        Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
-        if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
-            return ConstantOperator.createNull(targetColumn.getType());
-        } else if (defaultValueType == Column.DefaultValueType.CONST) {
-            if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().getExprObject() != null) {
-                Expr expr = targetColumn.getDefaultExpr().obtainExpr();
-                if (!expr.getType().equals(targetColumn.getType())) {
-                    expr = new CastExpr(targetColumn.getType(), expr);
-                }
-                return SqlToScalarOperatorTranslator.translate(expr);
-            } else {
-                return ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
-            }
-        } else if (defaultValueType == Column.DefaultValueType.VARY) {
-            if (isValidDefaultFunction(targetColumn.getDefaultExpr().getExpr())) {
-                return SqlToScalarOperatorTranslator.translate(targetColumn.getDefaultExpr().obtainExpr());
-            } else {
-                throw new SemanticException(
-                        "Column:" + targetColumn.getName() + " has unsupported default value:"
-                                + targetColumn.getDefaultExpr().getExpr());
-            }
-        } else {
-            throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
-        }
-    }
-
-    private String getIcebergWriteDefaultValue(Column targetColumn, InsertStmt insertStatement) {
-        Table targetTable = insertStatement.getTargetTable();
-        if (!(targetTable instanceof IcebergTable)) {
-            return null;
-        }
-        IcebergTable icebergTable = (IcebergTable) targetTable;
-        return IcebergApiConverter.getWriteDefaultValue(icebergTable.getNativeTable().schema(), targetColumn.getName());
     }
 
     private boolean checkPartitionInsertValid(Table targetTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -40,6 +40,7 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.ConnectorSinkSortScope;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -637,7 +638,7 @@ public class InsertPlanner {
                         if (isAutoIncrement) {
                             row.set(columnIdx, new NullLiteral());
                         } else {
-                            row.set(columnIdx, new StringLiteral(targetColumn.calculatedDefaultValue()));
+                            row.set(columnIdx, getInsertDefaultExpr(targetColumn, insertStatement));
                         }
                     }
                     row.set(columnIdx, TypeManager.addCastExpr(row.get(columnIdx), targetColumn.getType()));
@@ -657,7 +658,7 @@ public class InsertPlanner {
                             if (isAutoIncrement) {
                                 row.set(idx, new NullLiteral());
                             } else {
-                                row.set(idx, new StringLiteral(targetColumn.calculatedDefaultValue()));
+                                row.set(idx, getInsertDefaultExpr(targetColumn, insertStatement));
                             }
                         }
                         row.set(idx, TypeManager.addCastExpr(row.get(idx), targetColumn.getType()));
@@ -688,32 +689,7 @@ public class InsertPlanner {
             } else {
                 int idx = insertStatement.getTargetColumnNames().indexOf(targetColumn.getName().toLowerCase());
                 if (idx == -1) {
-                    ScalarOperator scalarOperator;
-                    Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
-                    if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
-                        scalarOperator = ConstantOperator.createNull(targetColumn.getType());
-                    } else if (defaultValueType == Column.DefaultValueType.CONST) {
-                        if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().getExprObject() != null) {
-                            Expr expr = targetColumn.getDefaultExpr().obtainExpr();
-                            if (!expr.getType().equals(targetColumn.getType())) {
-                                expr = new CastExpr(targetColumn.getType(), expr);
-                            }
-                            scalarOperator = SqlToScalarOperatorTranslator.translate(expr);
-                        } else {
-                            scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
-                        }
-                    } else if (defaultValueType == Column.DefaultValueType.VARY) {
-                        if (isValidDefaultFunction(targetColumn.getDefaultExpr().getExpr())) {
-                            scalarOperator = SqlToScalarOperatorTranslator.
-                                    translate(targetColumn.getDefaultExpr().obtainExpr());
-                        } else {
-                            throw new SemanticException(
-                                    "Column:" + targetColumn.getName() + " has unsupported default value:"
-                                            + targetColumn.getDefaultExpr().getExpr());
-                        }
-                    } else {
-                        throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
-                    }
+                    ScalarOperator scalarOperator = getInsertDefaultScalarOperator(targetColumn, insertStatement);
                     ColumnRefOperator col = columnRefFactory
                             .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
 
@@ -1096,6 +1072,67 @@ public class InsertPlanner {
         }
 
         return skip;
+    }
+
+    private Expr getInsertDefaultExpr(Column targetColumn, InsertStmt insertStatement) {
+        String writeDefault = getIcebergWriteDefaultValue(targetColumn, insertStatement);
+        if (writeDefault != null) {
+            return new StringLiteral(writeDefault);
+        }
+        if (insertStatement.getTargetTable() instanceof IcebergTable) {
+            if (targetColumn.isAllowNull()) {
+                return new NullLiteral();
+            }
+            throw new SemanticException("Column has no write default value, column=%s", targetColumn.getName());
+        }
+        return new StringLiteral(targetColumn.calculatedDefaultValue());
+    }
+
+    private ScalarOperator getInsertDefaultScalarOperator(Column targetColumn, InsertStmt insertStatement) {
+        String writeDefault = getIcebergWriteDefaultValue(targetColumn, insertStatement);
+        if (writeDefault != null) {
+            return ConstantOperator.createVarchar(writeDefault);
+        }
+        if (insertStatement.getTargetTable() instanceof IcebergTable) {
+            if (!targetColumn.isAllowNull() && !targetColumn.isAutoIncrement()) {
+                throw new SemanticException("Column has no write default value, column=%s", targetColumn.getName());
+            }
+            return ConstantOperator.createNull(targetColumn.getType());
+        }
+
+        Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
+        if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
+            return ConstantOperator.createNull(targetColumn.getType());
+        } else if (defaultValueType == Column.DefaultValueType.CONST) {
+            if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().getExprObject() != null) {
+                Expr expr = targetColumn.getDefaultExpr().obtainExpr();
+                if (!expr.getType().equals(targetColumn.getType())) {
+                    expr = new CastExpr(targetColumn.getType(), expr);
+                }
+                return SqlToScalarOperatorTranslator.translate(expr);
+            } else {
+                return ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
+            }
+        } else if (defaultValueType == Column.DefaultValueType.VARY) {
+            if (isValidDefaultFunction(targetColumn.getDefaultExpr().getExpr())) {
+                return SqlToScalarOperatorTranslator.translate(targetColumn.getDefaultExpr().obtainExpr());
+            } else {
+                throw new SemanticException(
+                        "Column:" + targetColumn.getName() + " has unsupported default value:"
+                                + targetColumn.getDefaultExpr().getExpr());
+            }
+        } else {
+            throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
+        }
+    }
+
+    private String getIcebergWriteDefaultValue(Column targetColumn, InsertStmt insertStatement) {
+        Table targetTable = insertStatement.getTargetTable();
+        if (!(targetTable instanceof IcebergTable)) {
+            return null;
+        }
+        IcebergTable icebergTable = (IcebergTable) targetTable;
+        return IcebergApiConverter.getWriteDefaultValue(icebergTable.getNativeTable().schema(), targetColumn.getName());
     }
 
     private boolean checkPartitionInsertValid(Table targetTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -43,7 +43,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PrintableMap;
-import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ParseNode;
@@ -53,7 +52,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.text.translate.UnicodeUnescaper;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
@@ -424,16 +422,8 @@ public class AstToStringBuilder {
                 .append(" (\n");
 
         // Columns
-        List<String> columns;
-        if (table.isIcebergTable()) {
-            Schema schema = ((IcebergTable) table).getNativeTable().schema();
-            columns = table.getFullVisibleSchema().stream()
-                    .map(column -> toMysqlDDL(column, IcebergApiConverter.getWriteDefaultValue(schema, column.getName())))
-                    .collect(Collectors.toList());
-        } else {
-            columns = table.getFullVisibleSchema().stream().map(AstToStringBuilder::toMysqlDDL)
-                    .collect(Collectors.toList());
-        }
+        List<String> columns = table.getFullVisibleSchema().stream().map(AstToStringBuilder::toMysqlDDL)
+                .collect(Collectors.toList());
         createTableSql.append(String.join(",\n", columns))
                 .append("\n)");
 
@@ -540,15 +530,10 @@ public class AstToStringBuilder {
     }
 
     private static String toMysqlDDL(Column column) {
-        return toMysqlDDL(column, null);
-    }
-
-    private static String toMysqlDDL(Column column, String overrideDefaultValue) {
         StringBuilder sb = new StringBuilder();
         sb.append("  `").append(column.getName()).append("` ");
         sb.append(column.getType().toSql());
-        String defaultValue =
-                overrideDefaultValue != null ? overrideDefaultValue : column.getMetaDefaultValue(Lists.newArrayList());
+        String defaultValue = column.getMetaDefaultValue(Lists.newArrayList());
         if (defaultValue == null) {
             sb.append(" DEFAULT NULL");
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -43,6 +43,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PrintableMap;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ParseNode;
@@ -50,6 +51,9 @@ import com.starrocks.sql.formatter.AST2StringVisitor;
 import com.starrocks.sql.formatter.FormatOptions;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.translate.UnicodeUnescaper;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
@@ -420,8 +424,16 @@ public class AstToStringBuilder {
                 .append(" (\n");
 
         // Columns
-        List<String> columns = table.getFullVisibleSchema().stream().map(AstToStringBuilder::toMysqlDDL).
-                collect(Collectors.toList());
+        List<String> columns;
+        if (table.isIcebergTable()) {
+            Schema schema = ((IcebergTable) table).getNativeTable().schema();
+            columns = table.getFullVisibleSchema().stream()
+                    .map(column -> toMysqlDDL(column, IcebergApiConverter.getWriteDefaultValue(schema, column.getName())))
+                    .collect(Collectors.toList());
+        } else {
+            columns = table.getFullVisibleSchema().stream().map(AstToStringBuilder::toMysqlDDL)
+                    .collect(Collectors.toList());
+        }
         createTableSql.append(String.join(",\n", columns))
                 .append("\n)");
 
@@ -437,7 +449,6 @@ public class AstToStringBuilder {
                 createTableSql.append("\nPARTITION BY ").append(String.join(", ", partitionNames));
             }
         }
-
 
         // Comment
         if (!Strings.isNullOrEmpty(table.getComment())) {
@@ -486,6 +497,12 @@ public class AstToStringBuilder {
         } catch (NotImplementedException e) {
         }
 
+        // Iceberg format-version is not stored in properties, need to add it explicitly
+        if (table.isIcebergTable()) {
+            IcebergTable icebergTable = (IcebergTable) table;
+            properties.put("format-version", String.valueOf(icebergTable.getFormatVersion()));
+        }
+
         if (!properties.isEmpty()) {
             createTableSql.append("\nPROPERTIES (");
             createTableSql.append(new PrintableMap<>(properties, "=", true, false, true).toString());
@@ -523,10 +540,22 @@ public class AstToStringBuilder {
     }
 
     private static String toMysqlDDL(Column column) {
+        return toMysqlDDL(column, null);
+    }
+
+    private static String toMysqlDDL(Column column, String overrideDefaultValue) {
         StringBuilder sb = new StringBuilder();
         sb.append("  `").append(column.getName()).append("` ");
         sb.append(column.getType().toSql());
-        sb.append(" DEFAULT NULL");
+        String defaultValue =
+                overrideDefaultValue != null ? overrideDefaultValue : column.getMetaDefaultValue(Lists.newArrayList());
+        if (defaultValue == null) {
+            sb.append(" DEFAULT NULL");
+        } else {
+            sb.append(" DEFAULT \"")
+                    .append(new UnicodeUnescaper().translate(StringEscapeUtils.escapeJava(defaultValue)))
+                    .append("\"");
+        }
 
         if (!Strings.isNullOrEmpty(column.getComment())) {
             sb.append(" COMMENT \"").append(column.getDisplayComment()).append("\"");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -38,6 +38,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -311,13 +312,33 @@ public class InsertAnalyzer {
         }
 
         if (!insertStmt.usePartialUpdate()) {
+            IcebergTable icebergTable = table instanceof IcebergTable ? (IcebergTable) table : null;
             for (Column column : table.getBaseSchema()) {
-                Column.DefaultValueType defaultValueType = column.getDefaultValueType();
-                if (defaultValueType == Column.DefaultValueType.NULL &&
-                        !column.isAllowNull() &&
+                if (icebergTable != null &&
                         !column.isAutoIncrement() &&
                         !column.isGeneratedColumn() &&
                         !mentionedColumns.contains(column.getName())) {
+                    String writeDefault = IcebergApiConverter.getWriteDefaultValue(
+                            icebergTable.getNativeTable().schema(), column.getName());
+                    if (column.isAllowNull() || writeDefault != null) {
+                        continue;
+                    }
+                    StringBuilder msg = new StringBuilder();
+                    for (String s : mentionedColumns) {
+                        msg.append(" ").append(s).append(" ");
+                    }
+                    throw new SemanticException("'%s' must be explicitly mentioned in column permutation: %s",
+                            column.getName(), msg.toString());
+                }
+
+                Column.DefaultValueType defaultValueType = column.getDefaultValueType();
+                if (defaultValueType == Column.DefaultValueType.NULL &&
+                        !column.isAutoIncrement() &&
+                        !column.isGeneratedColumn() &&
+                        !mentionedColumns.contains(column.getName())) {
+                    if (column.isAllowNull()) {
+                        continue;
+                    }
                     StringBuilder msg = new StringBuilder();
                     for (String s : mentionedColumns) {
                         msg.append(" ").append(s).append(" ");
@@ -344,9 +365,20 @@ public class InsertAnalyzer {
         // check default value expr
         if (query instanceof ValuesRelation) {
             ValuesRelation valuesRelation = (ValuesRelation) query;
+            IcebergTable icebergTable = table instanceof IcebergTable ? (IcebergTable) table : null;
             for (List<Expr> row : valuesRelation.getRows()) {
                 for (int columnIdx = 0; columnIdx < row.size(); ++columnIdx) {
                     Column column = targetColumns.get(columnIdx);
+                    if (row.get(columnIdx) instanceof DefaultValueExpr &&
+                            icebergTable != null &&
+                            !column.isAutoIncrement()) {
+                        String writeDefault = IcebergApiConverter.getWriteDefaultValue(
+                                icebergTable.getNativeTable().schema(), column.getName());
+                        if (!column.isAllowNull() && writeDefault == null) {
+                            throw new SemanticException("Column has no default value, column=%s", column.getName());
+                        }
+                        continue;
+                    }
                     Column.DefaultValueType defaultValueType = column.getDefaultValueType();
                     if (row.get(columnIdx) instanceof DefaultValueExpr &&
                             defaultValueType == Column.DefaultValueType.NULL &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -38,7 +38,6 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -312,33 +311,13 @@ public class InsertAnalyzer {
         }
 
         if (!insertStmt.usePartialUpdate()) {
-            IcebergTable icebergTable = table instanceof IcebergTable ? (IcebergTable) table : null;
             for (Column column : table.getBaseSchema()) {
-                if (icebergTable != null &&
-                        !column.isAutoIncrement() &&
-                        !column.isGeneratedColumn() &&
-                        !mentionedColumns.contains(column.getName())) {
-                    String writeDefault = IcebergApiConverter.getWriteDefaultValue(
-                            icebergTable.getNativeTable().schema(), column.getName());
-                    if (column.isAllowNull() || writeDefault != null) {
-                        continue;
-                    }
-                    StringBuilder msg = new StringBuilder();
-                    for (String s : mentionedColumns) {
-                        msg.append(" ").append(s).append(" ");
-                    }
-                    throw new SemanticException("'%s' must be explicitly mentioned in column permutation: %s",
-                            column.getName(), msg.toString());
-                }
-
                 Column.DefaultValueType defaultValueType = column.getDefaultValueType();
                 if (defaultValueType == Column.DefaultValueType.NULL &&
+                        !column.isAllowNull() &&
                         !column.isAutoIncrement() &&
                         !column.isGeneratedColumn() &&
                         !mentionedColumns.contains(column.getName())) {
-                    if (column.isAllowNull()) {
-                        continue;
-                    }
                     StringBuilder msg = new StringBuilder();
                     for (String s : mentionedColumns) {
                         msg.append(" ").append(s).append(" ");
@@ -365,20 +344,9 @@ public class InsertAnalyzer {
         // check default value expr
         if (query instanceof ValuesRelation) {
             ValuesRelation valuesRelation = (ValuesRelation) query;
-            IcebergTable icebergTable = table instanceof IcebergTable ? (IcebergTable) table : null;
             for (List<Expr> row : valuesRelation.getRows()) {
                 for (int columnIdx = 0; columnIdx < row.size(); ++columnIdx) {
                     Column column = targetColumns.get(columnIdx);
-                    if (row.get(columnIdx) instanceof DefaultValueExpr &&
-                            icebergTable != null &&
-                            !column.isAutoIncrement()) {
-                        String writeDefault = IcebergApiConverter.getWriteDefaultValue(
-                                icebergTable.getNativeTable().schema(), column.getName());
-                        if (!column.isAllowNull() && writeDefault == null) {
-                            throw new SemanticException("Column has no default value, column=%s", column.getName());
-                        }
-                        continue;
-                    }
                     Column.DefaultValueType defaultValueType = column.getDefaultValueType();
                     if (row.get(columnIdx) instanceof DefaultValueExpr &&
                             defaultValueType == Column.DefaultValueType.NULL &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1139,9 +1139,7 @@ public class PlanFragmentBuilder {
                 SlotDescriptor slotDescriptor =
                         context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
                 slotDescriptor.setColumn(entry.getValue());
-                // External table scan slots are always nullable because the source data
-                // is not governed by StarRocks NOT NULL constraints and may contain nulls.
-                slotDescriptor.setIsNullable(true);
+                slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setIsOutputColumn(node.getOutputColumns().contains(entry.getKey()));
                 if (slotDescriptor.getOriginType().isComplexType()) {
@@ -1587,6 +1585,12 @@ public class PlanFragmentBuilder {
 
             // set slot
             prepareContextSlots(node, context, tupleDescriptor);
+
+            // Iceberg table scan slots are always nullable because the source data
+            // is not governed by StarRocks NOT NULL constraints and may contain nulls.
+            for (SlotDescriptor slotDescriptor : tupleDescriptor.getSlots()) {
+                slotDescriptor.setIsNullable(true);
+            }
 
             // partition id generator
             PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1139,7 +1139,9 @@ public class PlanFragmentBuilder {
                 SlotDescriptor slotDescriptor =
                         context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
                 slotDescriptor.setColumn(entry.getValue());
-                slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
+                // External table scan slots are always nullable because the source data
+                // is not governed by StarRocks NOT NULL constraints and may contain nulls.
+                slotDescriptor.setIsNullable(true);
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setIsOutputColumn(node.getOutputColumns().contains(entry.getKey()));
                 if (slotDescriptor.getOriginType().isComplexType()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -76,6 +76,8 @@ import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -697,6 +699,242 @@ public class IcebergApiConverterTest {
         assertFalse(columns.get(0).isAllowNull());
         assertTrue(columns.get(1).isAllowNull());
         assertEquals("9", IcebergApiConverter.getWriteDefaultValue(schema, "c_optional"));
+    }
+
+    @Test
+    public void testToDefaultValueStringWithWriteDefault() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        // Boolean with write default
+        fields.add(Types.NestedField.optional("c_bool").withId(1)
+                .ofType(Types.BooleanType.get()).withWriteDefault(false).build());
+        // Long with write default
+        fields.add(Types.NestedField.optional("c_long").withId(2)
+                .ofType(Types.LongType.get()).withWriteDefault(100L).build());
+        // Float with write default
+        fields.add(Types.NestedField.optional("c_float").withId(3)
+                .ofType(Types.FloatType.get()).withWriteDefault(1.5f).build());
+        // Double with write default
+        fields.add(Types.NestedField.optional("c_double").withId(4)
+                .ofType(Types.DoubleType.get()).withWriteDefault(3.14159).build());
+        // Decimal with write default
+        fields.add(Types.NestedField.optional("c_decimal").withId(5)
+                .ofType(Types.DecimalType.of(10, 2)).withWriteDefault(new java.math.BigDecimal("99.99")).build());
+        // String with write default
+        fields.add(Types.NestedField.optional("c_string").withId(6)
+                .ofType(Types.StringType.get()).withWriteDefault("default_value").build());
+
+        Schema schema = new Schema(fields);
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+
+        assertEquals("0", columns.get(0).getDefaultValue()); // false -> "0"
+        assertEquals("100", columns.get(1).getDefaultValue());
+        assertEquals("1.5", columns.get(2).getDefaultValue());
+        assertEquals("3.14159", columns.get(3).getDefaultValue());
+        assertEquals("99.99", columns.get(4).getDefaultValue());
+        assertEquals("default_value", columns.get(5).getDefaultValue());
+    }
+
+    @Test
+    public void testToDefaultValueStringWithTime() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        // Time type
+        long timeMicros = 3661000000L; // 01:01:01.000000
+        fields.add(Types.NestedField.optional("c_time").withId(1)
+                .ofType(Types.TimeType.get()).withInitialDefault(timeMicros).build());
+
+        Schema schema = new Schema(fields);
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+        assertNotNull(columns.get(0).getDefaultValue());
+    }
+
+    @Test
+    public void testToDefaultValueStringWithTimestampTz() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        // Timestamp with timezone
+        long tsMicros = DateTimeUtil.microsFromTimestamp(LocalDateTime.of(2024, 6, 15, 10, 30, 45));
+        fields.add(Types.NestedField.optional("c_ts_tz").withId(1)
+                .ofType(Types.TimestampType.withZone()).withInitialDefault(tsMicros).build());
+
+        Schema schema = new Schema(fields);
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+        assertNotNull(columns.get(0).getDefaultValue());
+        assertTrue(columns.get(0).getDefaultValue().contains("2024"));
+    }
+
+    @Test
+    public void testToIcebergDefaultLiteralWithVariousTypes() {
+        // Test TINYINT
+        Column tinyIntCol = new Column("c_tinyint", IntegerType.TINYINT, true);
+        tinyIntCol.setDefaultValue("10");
+        Schema schema1 = IcebergApiConverter.toIcebergApiSchema(List.of(tinyIntCol));
+        Types.NestedField tinyIntField = schema1.findField("c_tinyint");
+        assertNotNull(tinyIntField.initialDefault());
+        assertEquals(10, tinyIntField.initialDefault());
+
+        // Test SMALLINT
+        Column smallIntCol = new Column("c_smallint", IntegerType.SMALLINT, true);
+        smallIntCol.setDefaultValue("100");
+        Schema schema2 = IcebergApiConverter.toIcebergApiSchema(List.of(smallIntCol));
+        Types.NestedField smallIntField = schema2.findField("c_smallint");
+        assertEquals(100, smallIntField.initialDefault());
+
+        // Test BIGINT
+        Column bigIntCol = new Column("c_bigint", IntegerType.BIGINT, true);
+        bigIntCol.setDefaultValue("1000000");
+        Schema schema3 = IcebergApiConverter.toIcebergApiSchema(List.of(bigIntCol));
+        Types.NestedField bigIntField = schema3.findField("c_bigint");
+        assertEquals(1000000L, bigIntField.initialDefault());
+
+        // Test FLOAT
+        Column floatCol = new Column("c_float", FloatType.FLOAT, true);
+        floatCol.setDefaultValue("3.14");
+        Schema schema4 = IcebergApiConverter.toIcebergApiSchema(List.of(floatCol));
+        Types.NestedField floatField = schema4.findField("c_float");
+        assertEquals(3.14f, floatField.initialDefault());
+
+        // Test CHAR
+        Column charCol = new Column("c_char", new CharType(10), true);
+        charCol.setDefaultValue("abc");
+        Schema schema5 = IcebergApiConverter.toIcebergApiSchema(List.of(charCol));
+        Types.NestedField charField = schema5.findField("c_char");
+        assertEquals("abc", charField.initialDefault());
+    }
+
+    @Test
+    public void testToIcebergDefaultLiteralBooleanFormats() {
+        // Test "1" for true
+        Column col1 = new Column("c1", BooleanType.BOOLEAN, true);
+        col1.setDefaultValue("1");
+        Schema schema1 = IcebergApiConverter.toIcebergApiSchema(List.of(col1));
+        assertTrue((Boolean) schema1.findField("c1").initialDefault());
+
+        // Test "true" for true
+        Column col2 = new Column("c2", BooleanType.BOOLEAN, true);
+        col2.setDefaultValue("true");
+        Schema schema2 = IcebergApiConverter.toIcebergApiSchema(List.of(col2));
+        assertTrue((Boolean) schema2.findField("c2").initialDefault());
+
+        // Test "TRUE" for true
+        Column col3 = new Column("c3", BooleanType.BOOLEAN, true);
+        col3.setDefaultValue("TRUE");
+        Schema schema3 = IcebergApiConverter.toIcebergApiSchema(List.of(col3));
+        assertTrue((Boolean) schema3.findField("c3").initialDefault());
+
+        // Test "0" for false
+        Column col4 = new Column("c4", BooleanType.BOOLEAN, true);
+        col4.setDefaultValue("0");
+        Schema schema4 = IcebergApiConverter.toIcebergApiSchema(List.of(col4));
+        assertFalse((Boolean) schema4.findField("c4").initialDefault());
+
+        // Test "false" for false
+        Column col5 = new Column("c5", BooleanType.BOOLEAN, true);
+        col5.setDefaultValue("false");
+        Schema schema5 = IcebergApiConverter.toIcebergApiSchema(List.of(col5));
+        assertFalse((Boolean) schema5.findField("c5").initialDefault());
+
+        // Test "FALSE" for false
+        Column col6 = new Column("c6", BooleanType.BOOLEAN, true);
+        col6.setDefaultValue("FALSE");
+        Schema schema6 = IcebergApiConverter.toIcebergApiSchema(List.of(col6));
+        assertFalse((Boolean) schema6.findField("c6").initialDefault());
+    }
+
+    @Test
+    public void testToIcebergDefaultLiteralInvalidBoolean() {
+        Column col = new Column("c_bool", BooleanType.BOOLEAN, true);
+        col.setDefaultValue("invalid");
+        assertThrows(StarRocksConnectorException.class, () -> {
+            IcebergApiConverter.toIcebergApiSchema(List.of(col));
+        });
+    }
+
+    @Test
+    public void testGetWriteDefaultValueCaseInsensitive() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("MyColumn").withId(1)
+                .ofType(Types.IntegerType.get()).withWriteDefault(42).build());
+        Schema schema = new Schema(fields);
+
+        // Test case insensitive lookup
+        assertEquals("42", IcebergApiConverter.getWriteDefaultValue(schema, "MyColumn"));
+        assertEquals("42", IcebergApiConverter.getWriteDefaultValue(schema, "mycolumn"));
+        assertEquals("42", IcebergApiConverter.getWriteDefaultValue(schema, "MYCOLUMN"));
+    }
+
+    @Test
+    public void testGetWriteDefaultValueNotFound() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("col1").withId(1)
+                .ofType(Types.IntegerType.get()).build());
+        Schema schema = new Schema(fields);
+
+        assertNull(IcebergApiConverter.getWriteDefaultValue(schema, "nonexistent"));
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithNullDefaultValue() {
+        Column col1 = new Column("c1", IntegerType.INT, true);
+        // No default value set
+        col1.setDefaultValue(null);
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(col1));
+        Types.NestedField field = schema.findField("c1");
+
+        // Should not have default value
+        assertNull(field.initialDefaultLiteral());
+        assertNull(field.writeDefaultLiteral());
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithDecimalTypes() {
+        Column decimal32Col = new Column("c_d32", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2), true);
+        decimal32Col.setDefaultValue("123.45");
+
+        Column decimal64Col = new Column("c_d64", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4), true);
+        decimal64Col.setDefaultValue("123456.7890");
+
+        Column decimal128Col = new Column("c_d128", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 28, 8), true);
+        decimal128Col.setDefaultValue("123456789.12345678");
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(decimal32Col, decimal64Col, decimal128Col));
+
+        assertNotNull(schema.findField("c_d32").initialDefault());
+        assertNotNull(schema.findField("c_d64").initialDefault());
+        assertNotNull(schema.findField("c_d128").initialDefault());
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithDateDefault() {
+        Column dateCol = new Column("c_date", DateType.DATE, true);
+        dateCol.setDefaultValue("2024-06-15");
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(dateCol));
+        Types.NestedField field = schema.findField("c_date");
+
+        assertNotNull(field.initialDefault());
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithDatetimeDefault() {
+        Column datetimeCol = new Column("c_datetime", DateType.DATETIME, true);
+        datetimeCol.setDefaultValue("2024-06-15 10:30:45");
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(datetimeCol));
+        Types.NestedField field = schema.findField("c_datetime");
+
+        assertNotNull(field.initialDefault());
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithDatetimeDefaultWithT() {
+        // Test datetime with 'T' separator
+        Column datetimeCol = new Column("c_datetime", DateType.DATETIME, true);
+        datetimeCol.setDefaultValue("2024-06-15T10:30:45");
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(datetimeCol));
+        Types.NestedField field = schema.findField("c_datetime");
+
+        assertNotNull(field.initialDefault());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.StructProjection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +75,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -632,6 +635,68 @@ public class IcebergApiConverterTest {
             assertTrue(true);
         }
         assertEquals(sortOrder, null);
+    }
+
+    @Test
+    public void testToFullSchemasWithInitialDefaultValue() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("c_bool").withId(1)
+                .ofType(Types.BooleanType.get()).withInitialDefault(true).build());
+        fields.add(Types.NestedField.optional("c_int").withId(2)
+                .ofType(Types.IntegerType.get()).withInitialDefault(7).build());
+        fields.add(Types.NestedField.optional("c_date").withId(3)
+                .ofType(Types.DateType.get()).withInitialDefault(2).build());
+        long tsMicros = DateTimeUtil.microsFromTimestamp(LocalDateTime.of(2024, 1, 2, 3, 4, 5));
+        fields.add(Types.NestedField.optional("c_ts").withId(4)
+                .ofType(Types.TimestampType.withoutZone()).withInitialDefault(tsMicros).build());
+        fields.add(Types.NestedField.optional("c_no_default").withId(5)
+                .ofType(Types.StringType.get()).build());
+
+        Schema schema = new Schema(fields);
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+
+        assertEquals("1", columns.get(0).getDefaultValue());
+        assertEquals("7", columns.get(1).getDefaultValue());
+        assertEquals("1970-01-03", columns.get(2).getDefaultValue());
+        assertEquals("2024-01-02 03:04:05", columns.get(3).getDefaultValue());
+        Assertions.assertNull(columns.get(4).getDefaultValue());
+    }
+
+    @Test
+    public void testToIcebergApiSchemaWithColumnDefaultValue() {
+        Column boolCol = new Column("c_bool", BooleanType.BOOLEAN, true);
+        boolCol.setDefaultValue("1");
+        Column intCol = new Column("c_int", IntegerType.INT, true);
+        intCol.setDefaultValue("7");
+        Column tsCol = new Column("c_ts", DateType.DATETIME, true);
+        tsCol.setDefaultValue("2024-01-02 03:04:05");
+
+        Schema schema = IcebergApiConverter.toIcebergApiSchema(List.of(boolCol, intCol, tsCol));
+        Types.NestedField boolField = schema.findField("c_bool");
+        Types.NestedField intField = schema.findField("c_int");
+        Types.NestedField tsField = schema.findField("c_ts");
+
+        assertTrue((Boolean) boolField.initialDefault());
+        assertTrue((Boolean) boolField.writeDefault());
+        assertEquals(7, intField.initialDefault());
+        assertEquals(7, intField.writeDefault());
+        long expectedMicros = DateTimeUtil.microsFromTimestamp(LocalDateTime.of(2024, 1, 2, 3, 4, 5));
+        assertEquals(expectedMicros, ((Number) tsField.initialDefault()).longValue());
+        assertEquals(expectedMicros, ((Number) tsField.writeDefault()).longValue());
+    }
+
+    @Test
+    public void testToFullSchemasUsesIcebergNullabilityAndWriteDefaultLookup() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.required("c_required").withId(1).ofType(Types.IntegerType.get()).build());
+        fields.add(Types.NestedField.optional("c_optional").withId(2)
+                .ofType(Types.IntegerType.get()).withWriteDefault(9).build());
+        Schema schema = new Schema(fields);
+
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+        assertFalse(columns.get(0).isAllowNull());
+        assertTrue(columns.get(1).isAllowNull());
+        assertEquals("9", IcebergApiConverter.getWriteDefaultValue(schema, "c_optional"));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -385,6 +385,11 @@ public class IcebergMetadataTest extends TableTestBase {
             public List<String> getPartitionColumnNamesWithTransform() {
                 return ImmutableList.of("hour(`c1`)");
             }
+
+            @Mock
+            public int getFormatVersion() {
+                return 1;
+            }
         };
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
@@ -412,12 +417,13 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals("db", icebergTable.getCatalogDBName());
         Assertions.assertEquals("tbl", icebergTable.getCatalogTableName());
         String createSql = AstToStringBuilder.getExternalCatalogTableDdlStmt(actual);
-        Assertions.assertEquals("CREATE TABLE `tbl` (\n" +
-                        "  `c1` int(11) DEFAULT NULL,\n" +
-                        "  `c2` varchar(1048576) DEFAULT NULL\n" +
-                        ")\n" +
-                        "PARTITION BY hour(`c1`)\n" +
-                        "ORDER BY (c1 ASC NULLS FIRST,c2 DESC NULLS LAST);",
+        Assertions.assertEquals("CREATE TABLE `tbl` (\n"
+                        + "  `c1` int(11) DEFAULT NULL,\n"
+                        + "  `c2` varchar(1048576) DEFAULT NULL\n"
+                        + ")\n"
+                        + "PARTITION BY hour(`c1`)\n"
+                        + "ORDER BY (c1 ASC NULLS FIRST,c2 DESC NULLS LAST)\n"
+                        + "PROPERTIES (\"format-version\" = \"1\");",
                 createSql);
     }
 

--- a/test/sql/test_iceberg/R/test_iceberg_show_stmt
+++ b/test/sql/test_iceberg/R/test_iceberg_show_stmt
@@ -14,7 +14,7 @@ partition_transform_table	CREATE TABLE `partition_transform_table` (
   `p2` varchar(1073741824) DEFAULT NULL
 )
 PARTITION BY year(`t1`), month(`t2`), day(`t3`), hour(`t4`), truncate(`p1`, 5), bucket(`p2`, 3)
-PROPERTIES ("owner" = "root", "location" = "oss://starrocks-ci-test/iceberg_ci_db/partition_transform_table");
+PROPERTIES ("owner" = "root", "format-version" = "1", "location" = "oss://starrocks-ci-test/iceberg_ci_db/partition_transform_table");
 -- !result
 drop catalog iceberg_sql_test_${uuid0};
 -- result:

--- a/test/sql/test_iceberg/R/test_iceberg_v3_default_value
+++ b/test/sql/test_iceberg/R/test_iceberg_v3_default_value
@@ -1,0 +1,283 @@
+-- name: testIcebergV3DefaultValueCreateTable
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_hadoop${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_hadoop${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test (
+    id int,
+    name string,
+    age int default "18",
+    score double default "100.0"
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test", 'age` int(11) DEFAULT "18"')
+desc ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test;
+-- result:
+id	INT	Yes	false	None		None
+name	VARCHAR(1073741824)	Yes	false	None		None
+age	INT	Yes	false	18		None
+score	DOUBLE	Yes	false	100.0		None
+-- !result
+drop catalog ice_def_hadoop${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testIcebergV3DefaultValueInsertAndRead
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_insert${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_insert${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (1, 'alice');
+-- result:
+-- !result
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (2, 'bob');
+-- result:
+-- !result
+alter table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test add column age int default "20";
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test", 'age` int(11) DEFAULT "20"')
+select * from ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test order by id;
+-- result:
+1	alice	20
+2	bob	20
+-- !result
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test (id, name) values (3, 'charlie');
+-- result:
+-- !result
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (4, 'david', 25);
+-- result:
+-- !result
+select * from ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test order by id;
+-- result:
+1	alice	20
+2	bob	20
+3	charlie	20
+4	david	25
+-- !result
+drop catalog ice_def_insert${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testIcebergV3DefaultValueAlterColumn
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_alter${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_alter${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (
+    id int,
+    name string,
+    status string default 'active'
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (id, name) values (1, 'item1');
+-- result:
+-- !result
+select * from ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test;
+-- result:
+1	item1	active
+-- !result
+alter table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test modify column status string default "inactive";
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test", 'status` varchar(1073741824) DEFAULT "inactive"')
+insert into ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (id, name) values (2, 'item2');
+-- result:
+-- !result
+select * from ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test order by id;
+-- result:
+1	item1	active
+2	item2	inactive
+-- !result
+drop catalog ice_def_alter${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testIcebergV3DefaultValueMultipleTypes
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_types${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_types${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (
+    id int,
+    int_col int default "100",
+    bigint_col bigint default "1000000",
+    float_col float default "1.5",
+    double_col double default "3.14159",
+    string_col string default 'default_string',
+    bool_col boolean default "true"
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test", 'int_col` int(11) DEFAULT "100"')
+function: assert_query_contains("show create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test", 'double_col` double DEFAULT "3.14159"')
+insert into ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (id) values (1);
+-- result:
+-- !result
+insert into ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (id, int_col, string_col) values (2, 200, 'custom_string');
+-- result:
+-- !result
+select * from ice_def_types${uuid0}.ice_def_db${uuid0}.types_test order by id;
+-- result:
+1	100	1000000	1.5	3.14159	default_string	1
+2	200	1000000	1.5	3.14159	custom_string	1
+-- !result
+drop catalog ice_def_types${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testIcebergV3DefaultValueSchemaEvolution
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_schema${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_schema${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (1, 100);
+-- result:
+-- !result
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (2, 200);
+-- result:
+-- !result
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+-- result:
+1	100
+2	200
+-- !result
+alter table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test add column bonus double default "50.5";
+-- result:
+-- !result
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+-- result:
+1	100	50.5
+2	200	50.5
+-- !result
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test (id, value) values (3, 300);
+-- result:
+-- !result
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (4, 400, 99.9);
+-- result:
+-- !result
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+-- result:
+1	100	50.5
+2	200	50.5
+3	300	50.5
+4	400	99.9
+-- !result
+alter table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test add column category string default 'normal';
+-- result:
+-- !result
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+-- result:
+1	100	50.5	normal
+2	200	50.5	normal
+3	300	50.5	normal
+4	400	99.9	normal
+-- !result
+drop catalog ice_def_schema${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_v3_default_value_supported_types
+++ b/test/sql/test_iceberg/R/test_iceberg_v3_default_value_supported_types
@@ -1,0 +1,293 @@
+-- name: testIcebergV3DefaultValueSupportedTypesOnCreate
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_all_types${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_all_types${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test (
+    id int,
+    bool_col boolean default "1",
+    tinyint_col tinyint default "8",
+    smallint_col smallint default "16",
+    int_col int default "42",
+    bigint_col bigint default "42000000000",
+    float_col float default "3.5",
+    double_col double default "6.25",
+    decimal_col decimal(18, 4) default "1234.5678",
+    char_col char(5) default "abcde",
+    varchar_col varchar(20) default "sr_varchar",
+    string_col string default "sr_string",
+    date_col date default "2024-01-02",
+    datetime_col datetime default "2024-01-02 03:04:05"
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`bool_col` boolean DEFAULT "1"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`tinyint_col` int(11) DEFAULT "8"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`smallint_col` int(11) DEFAULT "16"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`int_col` int(11) DEFAULT "42"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`bigint_col` bigint(20) DEFAULT "42000000000"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`float_col` float DEFAULT "3.5"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`double_col` double DEFAULT "6.25"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`decimal_col` decimal(18, 4) DEFAULT "1234.5678"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`char_col` varchar(1073741824) DEFAULT "abcde"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`varchar_col` varchar(1073741824) DEFAULT "sr_varchar"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`string_col` varchar(1073741824) DEFAULT "sr_string"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`date_col` date DEFAULT "2024-01-02"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`datetime_col` datetime DEFAULT "2024-01-02 03:04:05"')
+-- result:
+None
+-- !result
+insert into ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test (id) values (1);
+-- result:
+-- !result
+select
+    id,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test
+order by id;
+-- result:
+1	1	8	16	42	42000000000	3.5	6.25	1234.5678	abcde	sr_varchar	sr_string	2024-01-02	2024-01-02 03:04:05
+-- !result
+drop catalog ice_def_all_types${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testIcebergV3DefaultValueSupportedTypesOnAlter
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_def_all_types_alter${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0}"
+);
+-- result:
+-- !result
+create database ice_def_all_types_alter${uuid0}.ice_def_db${uuid0};
+-- result:
+-- !result
+create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test values (1, 'old_row');
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column bool_col boolean default "0";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column tinyint_col tinyint default "9";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column smallint_col smallint default "19";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column int_col int default "7";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column bigint_col bigint default "77";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column float_col float default "7.7";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column double_col double default "77.77";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column decimal_col decimal(18, 4) default "77.7700";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column char_col char(5) default "xyzzz";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column varchar_col varchar(20) default "evolve_varchar";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column string_col string default "evolve_string";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column date_col date default "2024-02-03";
+-- result:
+-- !result
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column datetime_col datetime default "2024-02-03 09:08:07";
+-- result:
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`bool_col` boolean DEFAULT "0"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`tinyint_col` int(11) DEFAULT "9"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`smallint_col` int(11) DEFAULT "19"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`int_col` int(11) DEFAULT "7"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`bigint_col` bigint(20) DEFAULT "77"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`float_col` float DEFAULT "7.7"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`double_col` double DEFAULT "77.77"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`decimal_col` decimal(18, 4) DEFAULT "77.7700"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`char_col` varchar(1073741824) DEFAULT "xyzzz"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`varchar_col` varchar(1073741824) DEFAULT "evolve_varchar"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`string_col` varchar(1073741824) DEFAULT "evolve_string"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`date_col` date DEFAULT "2024-02-03"')
+-- result:
+None
+-- !result
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`datetime_col` datetime DEFAULT "2024-02-03 09:08:07"')
+-- result:
+None
+-- !result
+select
+    id,
+    name,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test
+order by id;
+-- result:
+1	old_row	0	9	19	7	77	7.7	77.77	77.7700	xyzzz	evolve_varchar	evolve_string	2024-02-03	2024-02-03 09:08:07
+-- !result
+insert into ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test (id, name) values (2, 'new_row');
+-- result:
+-- !result
+select
+    id,
+    name,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test
+order by id;
+-- result:
+1	old_row	0	9	19	7	77	7.7	77.77	77.7700	xyzzz	evolve_varchar	evolve_string	2024-02-03	2024-02-03 09:08:07
+2	new_row	0	9	19	7	77	7.7	77.77	77.7700	xyzzz	evolve_varchar	evolve_string	2024-02-03	2024-02-03 09:08:07
+-- !result
+drop catalog ice_def_all_types_alter${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v3_default_value
+++ b/test/sql/test_iceberg/T/test_iceberg_v3_default_value
@@ -1,0 +1,225 @@
+-- name: testIcebergV3DefaultValueCreateTable
+-- Test case 1: Create iceberg table with default value for a column
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_hadoop${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0}"
+);
+
+create database ice_def_hadoop${uuid0}.ice_def_db${uuid0};
+
+-- Create table with format-version 3 and default values
+create table ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test (
+    id int,
+    name string,
+    age int default "18",
+    score double default "100.0"
+) properties (
+    "format-version" = "3"
+);
+
+-- Test case 4: Show create table should display default values
+function: assert_query_contains("show create table ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test", 'age` int(11) DEFAULT "18"')
+
+-- Test case 4: Desc table should show default values
+desc ice_def_hadoop${uuid0}.ice_def_db${uuid0}.default_value_test;
+
+drop catalog ice_def_hadoop${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testIcebergV3DefaultValueInsertAndRead
+-- Test case 5: Insert data without specifying column value, should use default value
+-- Test case 6: Read old data after schema change, missing column should use default value
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_insert${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0}"
+);
+
+create database ice_def_insert${uuid0}.ice_def_db${uuid0};
+
+-- Create table with format-version 3
+create table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert initial data
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (1, 'alice');
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (2, 'bob');
+
+-- Test case 2: Add column with default value using alter table
+alter table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test add column age int default "20";
+
+-- Show create table after adding column
+function: assert_query_contains("show create table ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test", 'age` int(11) DEFAULT "20"')
+
+-- Test case 6: Read old data, new column should use default value
+select * from ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test order by id;
+
+-- Insert new data without specifying age column
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test (id, name) values (3, 'charlie');
+
+-- Insert new data with explicit age value
+insert into ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test values (4, 'david', 25);
+
+-- Test case 5: Check inserted data, missing column should use default value
+select * from ice_def_insert${uuid0}.ice_def_db${uuid0}.insert_test order by id;
+
+drop catalog ice_def_insert${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_insert/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testIcebergV3DefaultValueAlterColumn
+-- Test case 3: Alter table to modify default value of existing column
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_alter${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0}"
+);
+
+create database ice_def_alter${uuid0}.ice_def_db${uuid0};
+
+-- Create table with format-version 3 and default value
+create table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (
+    id int,
+    name string,
+    status string default 'active'
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert data with default status
+insert into ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (id, name) values (1, 'item1');
+
+-- Show current state
+select * from ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test;
+
+-- Test case 3: Modify default value of existing column
+alter table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test modify column status string default "inactive";
+
+-- Show create table after modifying default value
+function: assert_query_contains("show create table ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test", 'status` varchar(1073741824) DEFAULT "inactive"')
+
+-- Insert new data, should use new default value
+insert into ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test (id, name) values (2, 'item2');
+
+-- Check data - old data should keep original default, new data should use new default
+select * from ice_def_alter${uuid0}.ice_def_db${uuid0}.alter_test order by id;
+
+drop catalog ice_def_alter${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testIcebergV3DefaultValueMultipleTypes
+-- Test default values with different data types
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_types${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0}"
+);
+
+create database ice_def_types${uuid0}.ice_def_db${uuid0};
+
+-- Create table with various default value types
+create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (
+    id int,
+    int_col int default "100",
+    bigint_col bigint default "1000000",
+    float_col float default "1.5",
+    double_col double default "3.14159",
+    string_col string default 'default_string',
+    bool_col boolean default "true"
+) properties (
+    "format-version" = "3"
+);
+
+-- Show create table
+function: assert_query_contains("show create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test", 'int_col` int(11) DEFAULT "100"')
+function: assert_query_contains("show create table ice_def_types${uuid0}.ice_def_db${uuid0}.types_test", 'double_col` double DEFAULT "3.14159"')
+
+-- Insert data only for id column
+insert into ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (id) values (1);
+
+-- Insert data with some columns specified
+insert into ice_def_types${uuid0}.ice_def_db${uuid0}.types_test (id, int_col, string_col) values (2, 200, 'custom_string');
+
+-- Check all default values are applied correctly
+select * from ice_def_types${uuid0}.ice_def_db${uuid0}.types_test order by id;
+
+drop catalog ice_def_types${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testIcebergV3DefaultValueSchemaEvolution
+-- Test case 6: Schema evolution with default values - reading old data after adding column
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_schema${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0}"
+);
+
+create database ice_def_schema${uuid0}.ice_def_db${uuid0};
+
+-- Create initial table without default value column
+create table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert initial data
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (1, 100);
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (2, 200);
+
+-- Read initial data
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+
+-- Add column with default value
+alter table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test add column bonus double default "50.5";
+
+-- Test case 6: Read old data, new column should be filled with default value
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+
+-- Insert new row without specifying bonus
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test (id, value) values (3, 300);
+
+-- Insert new row with explicit bonus
+insert into ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test values (4, 400, 99.9);
+
+-- Check all data
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+
+-- Add another column with default value
+alter table ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test add column category string default 'normal';
+
+-- Test case 6: Read after multiple schema changes
+select * from ice_def_schema${uuid0}.ice_def_db${uuid0}.schema_test order by id;
+
+drop catalog ice_def_schema${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_v3_default_value_supported_types
+++ b/test/sql/test_iceberg/T/test_iceberg_v3_default_value_supported_types
@@ -1,0 +1,165 @@
+-- name: testIcebergV3DefaultValueSupportedTypesOnCreate
+-- Cover supported Iceberg default value types when creating table.
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_all_types${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0}"
+);
+
+create database ice_def_all_types${uuid0}.ice_def_db${uuid0};
+
+create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test (
+    id int,
+    bool_col boolean default "1",
+    tinyint_col tinyint default "8",
+    smallint_col smallint default "16",
+    int_col int default "42",
+    bigint_col bigint default "42000000000",
+    float_col float default "3.5",
+    double_col double default "6.25",
+    decimal_col decimal(18, 4) default "1234.5678",
+    char_col char(5) default "abcde",
+    varchar_col varchar(20) default "sr_varchar",
+    string_col string default "sr_string",
+    date_col date default "2024-01-02",
+    datetime_col datetime default "2024-01-02 03:04:05"
+) properties (
+    "format-version" = "3"
+);
+
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`bool_col` boolean DEFAULT "1"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`tinyint_col` int(11) DEFAULT "8"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`smallint_col` int(11) DEFAULT "16"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`int_col` int(11) DEFAULT "42"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`bigint_col` bigint(20) DEFAULT "42000000000"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`float_col` float DEFAULT "3.5"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`double_col` double DEFAULT "6.25"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`decimal_col` decimal(18, 4) DEFAULT "1234.5678"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`char_col` varchar(1073741824) DEFAULT "abcde"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`varchar_col` varchar(1073741824) DEFAULT "sr_varchar"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`string_col` varchar(1073741824) DEFAULT "sr_string"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`date_col` date DEFAULT "2024-01-02"')
+function: assert_query_contains("show create table ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test", '`datetime_col` datetime DEFAULT "2024-01-02 03:04:05"')
+
+insert into ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test (id) values (1);
+
+select
+    id,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types${uuid0}.ice_def_db${uuid0}.all_types_test
+order by id;
+
+drop catalog ice_def_all_types${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testIcebergV3DefaultValueSupportedTypesOnAlter
+-- Cover supported Iceberg default value types when adding columns.
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_def_all_types_alter${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0}"
+);
+
+create database ice_def_all_types_alter${uuid0}.ice_def_db${uuid0};
+
+create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+insert into ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test values (1, 'old_row');
+
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column bool_col boolean default "0";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column tinyint_col tinyint default "9";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column smallint_col smallint default "19";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column int_col int default "7";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column bigint_col bigint default "77";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column float_col float default "7.7";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column double_col double default "77.77";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column decimal_col decimal(18, 4) default "77.7700";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column char_col char(5) default "xyzzz";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column varchar_col varchar(20) default "evolve_varchar";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column string_col string default "evolve_string";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column date_col date default "2024-02-03";
+alter table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test add column datetime_col datetime default "2024-02-03 09:08:07";
+
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`bool_col` boolean DEFAULT "0"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`tinyint_col` int(11) DEFAULT "9"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`smallint_col` int(11) DEFAULT "19"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`int_col` int(11) DEFAULT "7"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`bigint_col` bigint(20) DEFAULT "77"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`float_col` float DEFAULT "7.7"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`double_col` double DEFAULT "77.77"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`decimal_col` decimal(18, 4) DEFAULT "77.7700"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`char_col` varchar(1073741824) DEFAULT "xyzzz"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`varchar_col` varchar(1073741824) DEFAULT "evolve_varchar"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`string_col` varchar(1073741824) DEFAULT "evolve_string"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`date_col` date DEFAULT "2024-02-03"')
+function: assert_query_contains("show create table ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test", '`datetime_col` datetime DEFAULT "2024-02-03 09:08:07"')
+
+select
+    id,
+    name,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test
+order by id;
+
+insert into ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test (id, name) values (2, 'new_row');
+
+select
+    id,
+    name,
+    bool_col,
+    tinyint_col,
+    smallint_col,
+    int_col,
+    bigint_col,
+    float_col,
+    double_col,
+    decimal_col,
+    char_col,
+    varchar_col,
+    string_col,
+    date_col,
+    datetime_col
+from ice_def_all_types_alter${uuid0}.ice_def_db${uuid0}.all_types_alter_test
+order by id;
+
+drop catalog ice_def_all_types_alter${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_v3_default_value_supported_types_alter/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION

## Why I'm doing:
Iceberg format version 3 introduces column default values (`initial-default` and `write-default`), which enable automatic value filling during `INSERT` operations and schema evolution. StarRocks users need this feature to simplify data insertion and handle schema changes seamlessly without manual default value management.

## What I'm doing:
 This PR implements Iceberg v3 default value support in StarRocks, including:
 - FE side: Added default value conversion in `IcebergApiConverter`, updated `IcebergAlterTableExecutor` to support `ADD/MODIFY COLUMN` with defaults, and enhanced `InsertPlanner` and `InsertAnalyzer` to apply write-default values during INSERT operations
 - BE side: Updated `HdfsScanner` to apply initial-default values when reading historical data files that lack newly added columns
 - Supported operations: `CREATE TABLE` with default values, `ALTER TABLE ADD COLUMN` with defaults, `ALTER TABLE MODIFY COLUMN` defaults, and `INSERT` statements with missing columns
 - Data types: Supports INT, BIGINT, FLOAT, DOUBLE, BOOLEAN, STRING, DATE, and TIMESTAMP types
 - Added comprehensive SQL integration tests and documentation
 - 
Fixes [#issue](https://github.com/StarRocks/starrocks/issues/69709)

### Notes
Currently, we do not support new syntax for setting Iceberg's write-default and initial-default values ​​separately. When a user sets a default value for a field, that value will be used as the value for both write-default  and initial-default values. This is generally consistent with user scenarios. We may support new syntax to set these two types of default values ​​separately in the future, based on actual needs.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4