### PR TITLE
[BugFix] Skip g_publish_version_failed_tasks metric when resource is busy

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -370,11 +370,11 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                             prealloc_metadata->CopyFrom(*metadata);
                         }
                     } else {
-                        g_publish_version_failed_tasks << 1;
                         if (res.status().is_resource_busy()) {
                             VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_info=" << tablet_info
                                     << " txns=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
                         } else {
+                            g_publish_version_failed_tasks << 1;
                             LOG(WARNING) << "Fail to publish version: " << res.status()
                                          << ". tablet_info=" << tablet_info
                                          << " txn_ids=" << JoinMapped(txns, txn_info_string, ",")
@@ -461,12 +461,12 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                                 }
                             }
                         } else {
-                            g_publish_version_failed_tasks << 1;
                             if (res.is_resource_busy()) {
                                 VLOG(2) << "Failed to publish resharding tablet: " << res
                                         << ". resharding_tablet_info=" << resharding_tablet_info.DebugString()
                                         << " txn=" << txn_info.DebugString() << " version=" << new_version;
                             } else {
+                                g_publish_version_failed_tasks << 1;
                                 LOG(WARNING) << "Failed to publish resharding tablet: " << res
                                              << ". resharding_tablet_info=" << resharding_tablet_info.DebugString()
                                              << " txn=" << txn_info.DebugString() << " version=" << new_version;


### PR DESCRIPTION
## Why I'm doing:

The `g_publish_version_failed_tasks` metric is currently incremented for all publish version failures, including `is_resource_busy` errors. However, `resource_busy` is a transient condition that will be retried automatically and does not represent a real failure. Counting these as failed tasks inflates the failure metric and can trigger false alarms in monitoring systems.

## What I'm doing:

Move the `g_publish_version_failed_tasks << 1` increment into the `else` branch of the `is_resource_busy()` check, so the metric is only recorded for genuine failures, not transient resource contention.

Two locations are changed in `be/src/service/service_be/lake_service.cpp`:
- Normal tablet publish version (around line 373)
- Resharding tablet publish version (around line 464)

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4