### PR TITLE
[BugFix] Fix sort key not including newly added key columns after schema change on aggregate/unique tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -33,7 +33,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.warehouse.Warehouse;
-import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,8 +181,6 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             List<Column> oldColumns = indexMeta.getSchema();
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
-            Preconditions.checkState(Objects.equals(ListUtils.emptyIfNull(indexMeta.getSortKeyUniqueIds()),
-                    ListUtils.emptyIfNull(schemaInfo.getSortKeyUniqueIds())));
             Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion());
             Preconditions.checkState(Objects.equals(indexMeta.getShortKeyColumnCount(), schemaInfo.getShortKeyColumnCount()));
 
@@ -195,6 +192,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             indexMeta.setSchemaVersion(schemaInfo.getVersion());
             indexMeta.setSchemaId(schemaInfo.getId());
             indexMeta.setSortKeyIdxes(schemaInfo.getSortKeyIndexes());
+            indexMeta.setSortKeyUniqueIds(schemaInfo.getSortKeyUniqueIds());
 
             // update the indexIdToMeta
             table.getIndexMetaIdToMeta().put(indexMetaId, indexMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -174,6 +174,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return sortKeyUniqueIds;
     }
 
+    public void setSortKeyUniqueIds(List<Integer> sortKeyUniqueIds) {
+        this.sortKeyUniqueIds = sortKeyUniqueIds;
+    }
+
     public int getSchemaHash() {
         return schemaHash;
     }

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
@@ -1,0 +1,232 @@
+-- name: test_sort_key_add_key_column_agg @cloud
+create database test_agg_add_key_sort_${uuid0};
+-- result:
+-- !result
+use test_agg_add_key_sort_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `agg_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint SUM DEFAULT '0',
+    `v2` bigint SUM DEFAULT '0'
+)
+AGGREGATE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into agg_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	10	20
+2	1	30	40
+3	2	50	60
+-- !result
+alter table agg_t add column k3 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_t;
+-- result:
+agg_t	CREATE TABLE `agg_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
+  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k2`, `k3`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+-- !result
+insert into agg_t values (4, 4, 70, 80, 1);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+alter table agg_t add column k4 int default '0' after k1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_t;
+-- result:
+agg_t	CREATE TABLE `agg_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
+  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`, `k4`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+-- !result
+insert into agg_t values (5, 2, 90, 100, 1, 2);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+alter table agg_t add column k5 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_t;
+-- result:
+agg_t	CREATE TABLE `agg_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `k5` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
+  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`, `k4`, `k5`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+-- !result
+insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+alter table agg_t order by (k1, k4, k5, k2, k3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_t;
+-- result:
+agg_t	CREATE TABLE `agg_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `k5` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
+  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k1`, `k4`, `k5`, `k2`, `k3`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+drop database test_agg_add_key_sort_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
@@ -1,4 +1,4 @@
--- name: test_sort_key_add_key_column_agg @cloud
+-- name: test_sort_key_add_key_column_agg
 create database test_agg_add_key_sort_${uuid0};
 -- result:
 -- !result
@@ -33,29 +33,6 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table agg_t;
--- result:
-agg_t	CREATE TABLE `agg_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
-  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-AGGREGATE KEY(`k1`, `k2`, `k3`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from agg_t order by k1;
 -- result:
 1	3	0	10	20
@@ -72,6 +49,21 @@ select * from agg_t order by k1;
 3	2	0	50	60
 4	4	70	80	1
 -- !result
+insert into agg_t values (1, 3, 0, 5, 5), (2, 1, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	15	25
+2	1	0	40	50
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	15	25
+2	1	40	50
+-- !result
 alter table agg_t add column k4 int default '0' after k1;
 -- result:
 -- !result
@@ -79,34 +71,10 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table agg_t;
--- result:
-agg_t	CREATE TABLE `agg_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
-  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`, `k4`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	10	20
-2	0	1	0	30	40
+1	0	3	0	15	25
+2	0	1	0	40	50
 3	0	2	0	50	60
 4	0	4	70	80	1
 -- !result
@@ -115,11 +83,27 @@ insert into agg_t values (5, 2, 90, 100, 1, 2);
 -- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	10	20
-2	0	1	0	30	40
+1	0	3	0	15	25
+2	0	1	0	40	50
 3	0	2	0	50	60
 4	0	4	70	80	1
 5	2	90	100	1	2
+-- !result
+insert into agg_t values (1, 0, 3, 0, 5, 5), (2, 0, 1, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	20	30
+2	0	1	0	50	60
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	20	30
+2	1	50	60
 -- !result
 alter table agg_t add column k5 int default '0';
 -- result:
@@ -128,35 +112,10 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table agg_t;
--- result:
-agg_t	CREATE TABLE `agg_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `k5` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
-  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`, `k4`, `k5`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	0	10	20
-2	0	1	0	0	30	40
+1	0	3	0	0	20	30
+2	0	1	0	0	50	60
 3	0	2	0	0	50	60
 4	0	4	70	0	80	1
 5	2	90	100	0	1	2
@@ -166,12 +125,29 @@ insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
 -- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	0	10	20
-2	0	1	0	0	30	40
+1	0	3	0	0	20	30
+2	0	1	0	0	50	60
 3	0	2	0	0	50	60
 4	0	4	70	0	80	1
 5	2	90	100	0	1	2
 6	3	110	120	1	2	3
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	25	35
+2	1	60	70
 -- !result
 alter table agg_t order by (k1, k4, k5, k2, k3);
 -- result:
@@ -180,35 +156,10 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table agg_t;
--- result:
-agg_t	CREATE TABLE `agg_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `k5` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) SUM NULL DEFAULT "0" COMMENT "",
-  `v2` bigint(20) SUM NULL DEFAULT "0" COMMENT ""
-) ENGINE=OLAP 
-AGGREGATE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k1`, `k4`, `k5`, `k2`, `k3`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	0	10	20
-2	0	1	0	0	30	40
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
 3	0	2	0	0	50	60
 4	0	4	70	0	80	1
 5	2	90	100	0	1	2
@@ -219,13 +170,81 @@ insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
 -- !result
 select * from agg_t order by k1;
 -- result:
-1	0	3	0	0	10	20
-2	0	1	0	0	30	40
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
 3	0	2	0	0	50	60
 4	0	4	70	0	80	1
 5	2	90	100	0	1	2
 6	3	110	120	1	2	3
 7	1	130	140	1	2	3
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	30	40
+2	0	1	0	0	70	80
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	30	40
+2	1	70	80
+-- !result
+alter table agg_t add column k6 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	30	40
+2	0	1	0	0	0	70	80
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+-- !result
+insert into agg_t values (8, 2, 4, 1, 2, 4, 150, 160);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	30	40
+2	0	1	0	0	0	70	80
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 0, 5, 5), (2, 0, 1, 0, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	35	45
+2	0	1	0	0	0	80	90
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	35	45
+2	1	80	90
 -- !result
 drop database test_agg_add_key_sort_${uuid0} force;
 -- result:

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
@@ -1,0 +1,232 @@
+-- name: test_sort_key_add_key_column_uniq @cloud
+create database test_uniq_add_key_sort_${uuid0};
+-- result:
+-- !result
+use test_uniq_add_key_sort_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `uniq_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint,
+    `v2` bigint
+)
+UNIQUE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into uniq_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	10	20
+2	1	30	40
+3	2	50	60
+-- !result
+alter table uniq_t add column k3 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table uniq_t;
+-- result:
+uniq_t	CREATE TABLE `uniq_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`, `k3`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+-- !result
+insert into uniq_t values (4, 4, 70, 80, 1);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+alter table uniq_t add column k4 int key default '0' after k1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table uniq_t;
+-- result:
+uniq_t	CREATE TABLE `uniq_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k4`, `k2`, `k3`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`, `k4`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+-- !result
+insert into uniq_t values (5, 2, 90, 100, 1, 2);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+alter table uniq_t add column k5 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table uniq_t;
+-- result:
+uniq_t	CREATE TABLE `uniq_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `k5` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k2`, `k1`, `k3`, `k4`, `k5`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+-- !result
+insert into uniq_t values (6, 3, 110, 120, 1, 2, 3);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+alter table uniq_t order by (k1, k4, k5, k2, k3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table uniq_t;
+-- result:
+uniq_t	CREATE TABLE `uniq_t` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k4` int(11) NULL DEFAULT "0" COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL DEFAULT "0" COMMENT "",
+  `k5` int(11) NULL DEFAULT "0" COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k1`, `k4`, `k5`, `k2`, `k3`)
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"file_bundling" = "true",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+insert into uniq_t values (7, 1, 130, 140, 1, 2, 3);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+drop database test_uniq_add_key_sort_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
@@ -1,4 +1,4 @@
--- name: test_sort_key_add_key_column_uniq @cloud
+-- name: test_sort_key_add_key_column_uniq
 create database test_uniq_add_key_sort_${uuid0};
 -- result:
 -- !result
@@ -33,29 +33,6 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table uniq_t;
--- result:
-uniq_t	CREATE TABLE `uniq_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` bigint(20) NULL COMMENT ""
-) ENGINE=OLAP 
-UNIQUE KEY(`k1`, `k2`, `k3`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from uniq_t order by k1;
 -- result:
 1	3	0	10	20
@@ -78,30 +55,6 @@ alter table uniq_t add column k4 int key default '0' after k1;
 function: wait_alter_table_finish()
 -- result:
 None
--- !result
-show create table uniq_t;
--- result:
-uniq_t	CREATE TABLE `uniq_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` bigint(20) NULL COMMENT ""
-) ENGINE=OLAP 
-UNIQUE KEY(`k1`, `k4`, `k2`, `k3`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`, `k4`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
 -- !result
 select * from uniq_t order by k1;
 -- result:
@@ -127,31 +80,6 @@ alter table uniq_t add column k5 int key default '0';
 function: wait_alter_table_finish()
 -- result:
 None
--- !result
-show create table uniq_t;
--- result:
-uniq_t	CREATE TABLE `uniq_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `k5` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` bigint(20) NULL COMMENT ""
-) ENGINE=OLAP 
-UNIQUE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k2`, `k1`, `k3`, `k4`, `k5`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
 -- !result
 select * from uniq_t order by k1;
 -- result:
@@ -180,31 +108,6 @@ function: wait_alter_table_finish()
 -- result:
 None
 -- !result
-show create table uniq_t;
--- result:
-uniq_t	CREATE TABLE `uniq_t` (
-  `k1` int(11) NOT NULL COMMENT "",
-  `k4` int(11) NULL DEFAULT "0" COMMENT "",
-  `k2` int(11) NOT NULL COMMENT "",
-  `k3` int(11) NULL DEFAULT "0" COMMENT "",
-  `k5` int(11) NULL DEFAULT "0" COMMENT "",
-  `v1` bigint(20) NULL COMMENT "",
-  `v2` bigint(20) NULL COMMENT ""
-) ENGINE=OLAP 
-UNIQUE KEY(`k1`, `k4`, `k2`, `k3`, `k5`)
-COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
-ORDER BY(`k1`, `k4`, `k5`, `k2`, `k3`)
-PROPERTIES (
-"cloud_native_fast_schema_evolution_v2" = "true",
-"compression" = "LZ4",
-"datacache.enable" = "true",
-"enable_async_write_back" = "false",
-"file_bundling" = "true",
-"replication_num" = "1",
-"storage_volume" = "builtin_storage_volume"
-);
--- !result
 select * from uniq_t order by k1;
 -- result:
 1	0	3	0	0	10	20
@@ -226,6 +129,37 @@ select * from uniq_t order by k1;
 5	2	90	100	0	1	2
 6	3	110	120	1	2	3
 7	1	130	140	1	2	3
+-- !result
+alter table uniq_t add column k6 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	0	10	20
+2	0	1	0	0	0	30	40
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+-- !result
+insert into uniq_t values (8, 2, 4, 1, 2, 4, 150, 160);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	0	10	20
+2	0	1	0	0	0	30	40
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
 -- !result
 drop database test_uniq_add_key_sort_${uuid0} force;
 -- result:

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
@@ -1,4 +1,4 @@
--- name: test_sort_key_add_key_column_agg @cloud
+-- name: test_sort_key_add_key_column_agg
 create database test_agg_add_key_sort_${uuid0};
 use test_agg_add_key_sort_${uuid0};
 
@@ -19,33 +19,51 @@ select * from agg_t order by k1;
 -- Add key column at default position (last key)
 alter table agg_t add column k3 int default '0';
 function: wait_alter_table_finish()
-show create table agg_t;
 select * from agg_t order by k1;
 insert into agg_t values (4, 4, 70, 80, 1);
 select * from agg_t order by k1;
+insert into agg_t values (1, 3, 0, 5, 5), (2, 1, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
 
 -- Add key column at middle position (AFTER k1)
 alter table agg_t add column k4 int default '0' after k1;
 function: wait_alter_table_finish()
-show create table agg_t;
 select * from agg_t order by k1;
 insert into agg_t values (5, 2, 90, 100, 1, 2);
 select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 5, 5), (2, 0, 1, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
 
 -- Add key column without specifying position
 alter table agg_t add column k5 int default '0';
 function: wait_alter_table_finish()
-show create table agg_t;
 select * from agg_t order by k1;
 insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
 select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
 
 -- Explicit reorder via ALTER TABLE ORDER BY
 alter table agg_t order by (k1, k4, k5, k2, k3);
 function: wait_alter_table_finish()
-show create table agg_t;
 select * from agg_t order by k1;
 insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
 select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+-- Add key column after reorder
+alter table agg_t add column k6 int default '0';
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (8, 2, 4, 1, 2, 4, 150, 160);
+select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 0, 5, 5), (2, 0, 1, 0, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
 
 drop database test_agg_add_key_sort_${uuid0} force;

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
@@ -1,4 +1,4 @@
--- name: test_agg_add_key_column_sort_key;
+-- name: test_sort_key_add_key_column_agg @cloud
 create database test_agg_add_key_sort_${uuid0};
 use test_agg_add_key_sort_${uuid0};
 

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
@@ -1,0 +1,51 @@
+-- name: test_agg_add_key_column_sort_key;
+create database test_agg_add_key_sort_${uuid0};
+use test_agg_add_key_sort_${uuid0};
+
+CREATE TABLE `agg_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint SUM DEFAULT '0',
+    `v2` bigint SUM DEFAULT '0'
+)
+AGGREGATE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+
+insert into agg_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+select * from agg_t order by k1;
+
+-- Add key column at default position (last key)
+alter table agg_t add column k3 int default '0';
+function: wait_alter_table_finish()
+show create table agg_t;
+select * from agg_t order by k1;
+insert into agg_t values (4, 4, 70, 80, 1);
+select * from agg_t order by k1;
+
+-- Add key column at middle position (AFTER k1)
+alter table agg_t add column k4 int default '0' after k1;
+function: wait_alter_table_finish()
+show create table agg_t;
+select * from agg_t order by k1;
+insert into agg_t values (5, 2, 90, 100, 1, 2);
+select * from agg_t order by k1;
+
+-- Add key column without specifying position
+alter table agg_t add column k5 int default '0';
+function: wait_alter_table_finish()
+show create table agg_t;
+select * from agg_t order by k1;
+insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
+select * from agg_t order by k1;
+
+-- Explicit reorder via ALTER TABLE ORDER BY
+alter table agg_t order by (k1, k4, k5, k2, k3);
+function: wait_alter_table_finish()
+show create table agg_t;
+select * from agg_t order by k1;
+insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
+select * from agg_t order by k1;
+
+drop database test_agg_add_key_sort_${uuid0} force;

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
@@ -1,0 +1,51 @@
+-- name: test_unique_add_key_column_sort_key;
+create database test_uniq_add_key_sort_${uuid0};
+use test_uniq_add_key_sort_${uuid0};
+
+CREATE TABLE `uniq_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint,
+    `v2` bigint
+)
+UNIQUE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+
+insert into uniq_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+select * from uniq_t order by k1;
+
+-- Add key column at default position (last key)
+alter table uniq_t add column k3 int key default '0';
+function: wait_alter_table_finish()
+show create table uniq_t;
+select * from uniq_t order by k1;
+insert into uniq_t values (4, 4, 70, 80, 1);
+select * from uniq_t order by k1;
+
+-- Add key column at middle position (AFTER k1)
+alter table uniq_t add column k4 int key default '0' after k1;
+function: wait_alter_table_finish()
+show create table uniq_t;
+select * from uniq_t order by k1;
+insert into uniq_t values (5, 2, 90, 100, 1, 2);
+select * from uniq_t order by k1;
+
+-- Add key column without specifying position
+alter table uniq_t add column k5 int key default '0';
+function: wait_alter_table_finish()
+show create table uniq_t;
+select * from uniq_t order by k1;
+insert into uniq_t values (6, 3, 110, 120, 1, 2, 3);
+select * from uniq_t order by k1;
+
+-- Explicit reorder via ALTER TABLE ORDER BY
+alter table uniq_t order by (k1, k4, k5, k2, k3);
+function: wait_alter_table_finish()
+show create table uniq_t;
+select * from uniq_t order by k1;
+insert into uniq_t values (7, 1, 130, 140, 1, 2, 3);
+select * from uniq_t order by k1;
+
+drop database test_uniq_add_key_sort_${uuid0} force;

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
@@ -1,4 +1,4 @@
--- name: test_unique_add_key_column_sort_key;
+-- name: test_sort_key_add_key_column_uniq @cloud
 create database test_uniq_add_key_sort_${uuid0};
 use test_uniq_add_key_sort_${uuid0};
 

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
@@ -1,4 +1,4 @@
--- name: test_sort_key_add_key_column_uniq @cloud
+-- name: test_sort_key_add_key_column_uniq
 create database test_uniq_add_key_sort_${uuid0};
 use test_uniq_add_key_sort_${uuid0};
 
@@ -19,7 +19,6 @@ select * from uniq_t order by k1;
 -- Add key column at default position (last key)
 alter table uniq_t add column k3 int key default '0';
 function: wait_alter_table_finish()
-show create table uniq_t;
 select * from uniq_t order by k1;
 insert into uniq_t values (4, 4, 70, 80, 1);
 select * from uniq_t order by k1;
@@ -27,7 +26,6 @@ select * from uniq_t order by k1;
 -- Add key column at middle position (AFTER k1)
 alter table uniq_t add column k4 int key default '0' after k1;
 function: wait_alter_table_finish()
-show create table uniq_t;
 select * from uniq_t order by k1;
 insert into uniq_t values (5, 2, 90, 100, 1, 2);
 select * from uniq_t order by k1;
@@ -35,7 +33,6 @@ select * from uniq_t order by k1;
 -- Add key column without specifying position
 alter table uniq_t add column k5 int key default '0';
 function: wait_alter_table_finish()
-show create table uniq_t;
 select * from uniq_t order by k1;
 insert into uniq_t values (6, 3, 110, 120, 1, 2, 3);
 select * from uniq_t order by k1;
@@ -43,9 +40,15 @@ select * from uniq_t order by k1;
 -- Explicit reorder via ALTER TABLE ORDER BY
 alter table uniq_t order by (k1, k4, k5, k2, k3);
 function: wait_alter_table_finish()
-show create table uniq_t;
 select * from uniq_t order by k1;
 insert into uniq_t values (7, 1, 130, 140, 1, 2, 3);
+select * from uniq_t order by k1;
+
+-- Add key column after reorder
+alter table uniq_t add column k6 int key default '0';
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (8, 2, 4, 1, 2, 4, 150, 160);
 select * from uniq_t order by k1;
 
 drop database test_uniq_add_key_sort_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

After performing schema change (`ALTER TABLE ADD COLUMN` for key columns) on aggregate or unique key tables (both shared-nothing and shared-data), two problems occur:

1. **SHOW CREATE TABLE** output for the `ORDER BY` clause does not include the newly added key column.
2. **Data import fails** with error: `E: (5609, '127.0.0.1: tablet type: 2 sort key columns is different with key columns')`.

For AGG_KEYS/UNIQUE_KEYS tables, the sort key must include all key columns. The bug causes FE metadata and BE expectations to diverge, leading to both display and import failures.

**Reproduction example:**
```
CREATE TABLE t (k0 INT, k1 INT, k2 INT, v INT SUM)
AGGREGATE KEY(k0, k1, k2) ORDER BY(k2, k1, k0)
DISTRIBUTED BY HASH(k0) BUCKETS 1;

ALTER TABLE t ADD COLUMN k3 INT KEY DEFAULT '0';

SHOW CREATE TABLE t;  -- ORDER BY still shows (k2, k1, k0), missing k3
INSERT INTO t VALUES (1,2,3,0,4);  -- Fails: sort key columns is different with key columns
```

## What I'm doing:

### Root Cause Analysis

**1. `calculateShortKey()` (SchemaChangeHandler)**

- During schema change, this method computes `sortKeyIdxes` and `sortKeyUniqueIds` for the new schema.
- It only **remapped** existing sort key columns to their new positions in the altered schema.
- It **did not append** newly added key columns to the sort key lists.
- For AGG_KEYS/UNIQUE_KEYS, sort key must cover all key columns, so the new key column must be added to sort key.

**2. `applyFastSchemaEvolutionMetaChange()` (SchemaChangeHandler)**

- Used for cloud-native tables with `cloud_native_fast_schema_evolution_v2` (both live update and edit log replay).
- It reconstructed `newSortKeyIdxes` and `newSortKeyUniqueIds` from the **old** `currentIndexMeta.getSortKeyUniqueIds()` instead of using the corrected sort key from `SchemaChangeData`.
- It only updated `sortKeyIdxes` in `MaterializedIndexMeta`, not `sortKeyUniqueIds`, causing inconsistency.
- Even if `calculateShortKey()` were fixed, this path would still overwrite with stale metadata.

**3. Why data import fails**

The BE enforces a constraint in `MemTable::_sort_column_inc()` (`be/src/storage/memtable.cpp`):

- For AGG_KEYS/UNIQUE_KEYS, the sort key columns (as a set) must equal the set of all key columns.
- The tablet schema (including `sort_key_idxes`) is derived from FE metadata.
- If FE sends `sort_key_idxes` that omits the new key column, the BE check fails and returns: `tablet type: 2 sort key columns is different with key columns`.

So the import error is a direct consequence of incorrect sort key metadata propagated from FE to BE.

### Fix

**Summary**: In both `calculateShortKey()` and `applyFastSchemaEvolutionMetaChange()`, for AGG_KEYS/UNIQUE_KEYS tables during schema change, append newly added key columns to the end of the sort key lists, and keep `sortKeyIdxes` and `sortKeyUniqueIds` in sync, so FE metadata matches BE constraints.

1. **`appendNewKeyColumnsToSortKey()` helper**: For AGG_KEYS/UNIQUE_KEYS, append any key columns that are not yet in the sort key to the end of `sortKeyIdxes` and `sortKeyUniqueIds`. New key columns are always appended at the end, regardless of their position in the schema (e.g. AFTER / FIRST).

2. **`calculateShortKey()`**: After remapping existing sort key columns, call `appendNewKeyColumnsToSortKey()` so newly added key columns are included.

3. **`applyFastSchemaEvolutionMetaChange()`**: Use the same logic: remap existing sort key by unique ID, then call `appendNewKeyColumnsToSortKey()`. Update both `sortKeyIdxes` and `sortKeyUniqueIds` in `MaterializedIndexMeta`.

4. **`MaterializedIndexMeta.setSortKeyUniqueIds()`**: Add setter so `sortKeyUniqueIds` can be updated programmatically.

### Scope

- **Shared-nothing**: Fixed via `calculateShortKey()` → `SchemaChangeJobV2`.
- **Shared-data non-fast path**: Fixed via `calculateShortKey()` → `LakeTableSchemaChangeJob`.
- **Shared-data fast path (cloud_native_fast_schema_evolution_v2)**: Fixed via both `calculateShortKey()` and `applyFastSchemaEvolutionMetaChange()`.

### Tests

- `LakeFastSchemaChangeTestBase`: shared-data fast schema evolution (V2 and non-V2).
- `SchemaChangeHandlerTest`: shared-nothing.
- `LakeTableSchemaChangeJobTest`: shared-data non-fast schema change.
- SQL integration tests in `test/sql/test_sort_key/`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.1
  - [X] 4.0
  - [X] 3.5
  - [ ] 3.4