### PR TITLE
[BugFix] 4.1 IVM Fix TVR watermark advancing in PCT fallback

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
@@ -31,7 +32,6 @@ import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshParams;
 import com.starrocks.scheduler.mv.ivm.MVIVMBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.ivm.TvrTableSnapshotInfo;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.plan.ExecPlan;
@@ -104,22 +104,32 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         // and cannot generate multi-task-runs.
         pctProcessor.getMvRefreshParams().setCanGenerateNextTaskRun(false);
 
+        ProcessExecPlan processExecPlan = pctProcessor.getProcessExecPlan(taskRunContext);
+
+        MaterializedView.AsyncRefreshContext asyncRefreshContext = mv.getRefreshScheme().getAsyncRefreshContext();
+        tempMvTvrVersionRangeMap.clear();
+
         // try get the tvr version range map from ivm processor
         final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
-                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
-        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+                asyncRefreshContext.getBaseTableInfoTvrVersionRangeMap();
+        // Use PCT processor's snapshot set because it reflects the actual fallback run context.
+        for (BaseTableSnapshotInfo snapshotInfo : pctProcessor.getSnapshotBaseTables().values()) {
             TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableChangedVersionRange(snapshotInfo,
                     mvTvrVersionRangeMap, this.currentRefreshMode);
             logger.info("Base table: {}, changed version range: {}",
                     snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
-            // collect changed version range
-            TvrTableSnapshotInfo tvrTableSnapshotInfo = new TvrTableSnapshotInfo(snapshotInfo.getBaseTableInfo(),
-                    snapshotInfo.getBaseTable());
-            tempMvTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
-            // update the snapshot info with the changed version range
-            tvrTableSnapshotInfo.setTvrSnapshot(changedVersionRange);
+            // Persist snapshot watermark for fallback path to keep
+            // baseTableInfoTvrVersionRangeMap type-consistent with IVM reads.
+            tempMvTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), TvrTableSnapshot.of(changedVersionRange.to()));
         }
-        return pctProcessor.getProcessExecPlan(taskRunContext);
+        asyncRefreshContext.clearTempBaseTableInfoTvrDeltaMap();
+        asyncRefreshContext.getTempBaseTableInfoTvrDeltaMap().putAll(tempMvTvrVersionRangeMap);
+        if (processExecPlan.state() == Constants.TaskRunState.SKIPPED) {
+            // No meta update path is executed for SKIPPED runs, so clear temp map eagerly.
+            asyncRefreshContext.clearTempBaseTableInfoTvrDeltaMap();
+        }
+
+        return processExecPlan;
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -211,8 +211,13 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
             logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
                     baseTableInfo.getDbName());
-            throw new SemanticException("No tvr delta traits found for base table: %s.%s",
-                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            if (refreshMode.isIncremental()) {
+                throw new SemanticException("No tvr delta traits found for base table: %s.%s",
+                        baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            }
+            logger.info("No tvr delta traits found for base table: {}, db: {}, use max tvr delta: {}",
+                    baseTableInfo.getTableName(), baseTableInfo.getDbName(), maxTvrDelta);
+            return maxTvrDelta;
         }
         // check whether the last delta trait is equal to the max delta
         TvrTableDeltaTrait lastTvrDeltaTrait = tableDeltaTraits.get(tableDeltaTraits.size() - 1);
@@ -235,7 +240,8 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
                 }
             }
         }
-        if (isGenerateNextTaskRun()) {
+        boolean hasNonAppendOnlyDelta = tableDeltaTraits.stream().anyMatch(deltaTrait -> !deltaTrait.isAppendOnly());
+        if (isGenerateNextTaskRun() && !hasNonAppendOnlyDelta) {
             return getBaseTableChangedDeltaAdaptive(baseTableInfo, tableDeltaTraits, maxTvrDelta);
         } else {
             logger.info("Base table: {}, db: {}, use the max tvr delta: {} for sync refresh",
@@ -284,9 +290,23 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
         TvrVersionRange beforeTvrVersionRange = mvTvrVersionRangeMap.get(baseTableInfo);
         logger.info("Base table: {}, before tvr version range: {}, current tvr snapshot: {}",
                 baseTableInfo.getTableName(), beforeTvrVersionRange, currentTvrSnapshot);
-        if (beforeTvrVersionRange == null || !(beforeTvrVersionRange instanceof TvrTableSnapshot)) {
-            throw new SemanticException("Materialized view " + mv.getName()
-                    + " does not have a valid tvr version range for base table: " + baseTableInfo.getTableName());
+        if (beforeTvrVersionRange == null) {
+            logger.warn("Materialized view {} has null tvr version range for base table {}, reset to MIN->current",
+                    mv.getName(), baseTableInfo.getTableName());
+            return TvrTableDelta.of(TvrVersion.MIN, currentVersion);
+        }
+        if (!(beforeTvrVersionRange instanceof TvrTableSnapshot)) {
+            if (beforeTvrVersionRange.to().isMinOrMax()) {
+                logger.warn("Materialized view {} has invalid non-snapshot tvr version range {} for base table {}, " +
+                                "reset to MIN->current", mv.getName(), beforeTvrVersionRange,
+                        baseTableInfo.getTableName());
+                return TvrTableDelta.of(TvrVersion.MIN, currentVersion);
+            }
+            // Backward compatibility: recover legacy/non-snapshot range by pinning to its latest version.
+            TvrTableSnapshot recoveredSnapshot = TvrTableSnapshot.of(beforeTvrVersionRange.to());
+            beforeTvrVersionRange = recoveredSnapshot;
+            logger.warn("Materialized view {} recovered invalid tvr version range for base table {} to {}",
+                    mv.getName(), baseTableInfo.getTableName(), recoveredSnapshot);
         }
         TvrVersion beforeVersion = beforeTvrVersionRange.to;
         if (beforeVersion.equals(currentVersion)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -25,6 +25,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
@@ -293,6 +294,9 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
     public void updateVersionMeta(ExecPlan execPlan,
                                   PCellSortedSet mvRefreshedPartitions,
                                   Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
+        MaterializedView.AsyncRefreshContext refreshContext = mv.getRefreshScheme().getAsyncRefreshContext();
+        Map<BaseTableInfo, TvrVersionRange> tempTvrVersionRangeMap = refreshContext.getTempBaseTableInfoTvrDeltaMap();
+        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, tempTvrVersionRangeMap);
+        refreshContext.clearTempBaseTableInfoTvrDeltaMap();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -14,9 +14,14 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.MVTaskRunProcessor;
+import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -26,6 +31,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+import java.util.Map;
 
 @TestMethodOrder(MethodName.class)
 public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase {
@@ -553,5 +561,82 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
             Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor);
         }
+    }
+
+    @Test
+    public void testAutoRefreshFallbackToPCTAdvancesTvrWatermark() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        // Initial refresh should advance watermark to snapshot 1.
+        advanceTableVersionTo(1);
+        getMVTaskRunProcessor(mv);
+        Map<BaseTableInfo, TvrVersionRange> tvrRangeMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
+        long beforeFallbackEnd = tvrRangeMap.values().stream()
+                .mapToLong(range -> range.end().orElse(-1L))
+                .max()
+                .orElse(-1L);
+
+        // Next refresh falls back to PCT because delta traits contain retractable changes.
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        // Force this run to execute PCT refresh path rather than being skipped by partition checks.
+        taskRun.getProperties().put(TaskRun.FORCE, "true");
+        initAndExecuteTaskRun(taskRun);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybridProcessor =
+                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        // Watermark should still move forward to the latest processed snapshot after fallback.
+        Map<BaseTableInfo, TvrVersionRange> updatedRangeMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
+        long afterFallbackEnd = updatedRangeMap.values().stream()
+                .mapToLong(range -> range.end().orElse(-1L))
+                .max()
+                .orElse(-1L);
+        Assertions.assertEquals(2L, afterFallbackEnd);
+        Assertions.assertTrue(afterFallbackEnd > beforeFallbackEnd);
+    }
+
+    @Test
+    public void testAutoRefreshWithEmptyDeltaTraitsFallsBackToPCT() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits(List.of());
+
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybridProcessor =
+                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+    }
+
+    @Test
+    public void testRecoveryDoesNotMutateTvrMapDuringPlanning() throws Exception {
+        String query = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        BaseTableInfo baseTableInfo = mv.getBaseTableInfos().stream()
+                .filter(info -> "t0".equalsIgnoreCase(info.getTableName()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Missing base table info for t0"));
+        Map<BaseTableInfo, TvrVersionRange> tvrRangeMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
+        tvrRangeMap.put(baseTableInfo, TvrTableDelta.of(TvrVersion.of(1L), TvrVersion.of(2L)));
+
+        advanceTableVersionTo(3);
+        getMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1 with sync mode");
+
+        // Planning should not mutate persisted watermark map before refresh succeeds.
+        Assertions.assertTrue(tvrRangeMap.get(baseTableInfo) instanceof TvrTableDelta);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
in the AUTO refresh fallback path for async MVs on Iceberg: when IVM detected non-append changes and switched to PCT, the TVR watermark was not reliably advanced. This caused repeated reprocessing of old snapshot windows and recurring fallback/errors across runs. We also hit additional edge failures when Iceberg delta traits were empty (for example after skipping REPLACE snapshots) and when legacy/invalid TVR metadata existed.


## What I'm doing:

1. In MVHybridBasedRefreshProcessor, fallback computes TVR changes using the actual PCT snapshot context (pctProcessor.getSnapshotBaseTables()), not stale/empty hybrid state.

2. In MVPCTBasedRefreshProcessor.updateVersionMeta, we now pass async temp TVR map into updatePCTMeta(...) and clear it after use. This ensures successful PCT fallback runs advance the persisted TVR watermark.

3. Fallback now stores TVR progress as TvrTableSnapshot (latest processed snapshot), not delta range objects, so subsequent IVM reads see valid snapshot-type entries.

The result of this is that if we have to fallback to PCT we will run a refresh in PCT mode but we will then ensure the TVR watermark advances. That way when the next refresh occurs it will be checking the delta between the last PCT run and latest table state. Without this incremental would always fail if a non-monotonic snapshot was present because we would never move the watermark past it.

Fixes #69502

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
