### PR TITLE
[Enhancement] Reduce lake pk tablet stat collection overhead in shared-data mode cluster

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,6 +754,19 @@ CONF_mInt32(retry_apply_timeout_second, "7200");
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");
 
+// Whether to use accurate row count for lake primary key tablets by reading delete vectors from object storage.
+// When enabled, each rowset's delete vector is fetched from remote storage to deduct deleted rows, which may
+// significantly increase the overhead of get_tablet_stats RPC.
+// When disabled, the approximate num_dels field stored in rowset metadata is used,
+// which avoids remote I/O but may slightly overcount rows that are deleted but not yet compacted.
+CONF_mBool(lake_enable_accurate_pk_row_count, "true");
+
+// Threshold in milliseconds for logging slow tablet stat collection tasks.
+// When a single tablet stat task takes longer than this threshold, a warning log is emitted
+// with diagnostic info (tablet_id, version, rowset count, accurate_mode, elapsed time).
+// Default is 5 minutes (300000 ms).
+CONF_mInt64(lake_tablet_stat_slow_log_ms, "300000");
+
 // Result buffer cancelled time (unit: second).
 CONF_mInt32(result_buffer_cancelled_interval_time, "300");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -716,6 +716,8 @@
         "lake_enable_alter_struct",
         "table_schema_service_max_retries",
         "lake_publish_version_slow_log_ms",
+        "lake_enable_accurate_pk_row_count",
+        "lake_tablet_stat_slow_log_ms",
         "lake_metadata_cache_limit",
         "lake_cache_select_in_physical_way",
         "lake_enable_publish_version_trace_log",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -30,6 +30,19 @@ CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
 // When enabled, segments whose sort key range does not intersect with query predicates will be skipped.
 CONF_mBool(enable_lake_segment_metadata_filter, "true");
 
+// Whether to use accurate row count for lake primary key tablets by reading delete vectors from object storage.
+// When enabled, each rowset's delete vector is fetched from remote storage to deduct deleted rows, which may
+// significantly increase the overhead of get_tablet_stats RPC.
+// When disabled, the approximate num_dels field stored in rowset metadata is used,
+// which avoids remote I/O but may slightly overcount rows that are deleted but not yet compacted.
+CONF_mBool(lake_enable_accurate_pk_row_count, "true");
+
+// Threshold in milliseconds for logging slow tablet stat collection tasks.
+// When a single tablet stat task takes longer than this threshold, a warning log is emitted
+// with diagnostic info (tablet_id, version, rowset count, accurate_mode, elapsed time).
+// Default is 5 minutes (300000 ms).
+CONF_mInt64(lake_tablet_stat_slow_log_ms, "300000");
+
 // Number of thread for flushing memtable per store in shared-data mode.
 // Default value is cpu cores * 2
 CONF_mInt32(lake_flush_thread_num_per_store, "0");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1163,21 +1163,31 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                     for (const auto& rowset : (*tablet_metadata)->rowsets()) {
                         int64_t num_deletes = 0;
                         if (is_pk_tablet) {
-                            if (config::lake_enable_accurate_pk_row_count) {
-                                // Accurate mode: fetch delete vectors from object storage.
+                            if (accurate_mode) {
+                                // Accurate mode (default): fetch delete vectors from object storage.
                                 // NOTE!! Each segment incurs a remote metadata read - expensive for large tablets.
                                 num_deletes = static_cast<int64_t>(
                                         _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
                             } else {
-                                // Approximate mode (default): use the pre-stored num_dels field in the rowset
-                                // metadata. This avoids any additional I/O while still providing a reasonable
-                                // row count estimate. Rows deleted but not yet compacted may be slightly
-                                // overcounted until the next compaction.
-                                num_deletes = rowset.num_dels();
+                                // Approximate mode: prefer the pre-stored num_dels field in rowset
+                                // metadata. This avoids additional I/O while still providing a reasonable estimate.
+                                // Rows deleted but not yet compacted may be slightly overcounted.
+                                if (rowset.has_num_dels()) {
+                                    num_deletes = rowset.num_dels();
+                                } else {
+                                    // Fallback for old metadata without num_dels.
+                                    num_deletes = static_cast<int64_t>(
+                                            _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
+                                }
                             }
                         }
                         // For non-PK tablets, num_deletes stays 0: they have no delete vectors.
-                        num_rows += rowset.num_rows() - num_deletes;
+                        // Clamp to avoid negative contribution when approximate num_dels overcounts.
+                        int64_t rowset_live_rows = rowset.num_rows() - num_deletes;
+                        if (UNLIKELY(rowset_live_rows < 0)) {
+                            rowset_live_rows = 0;
+                        }
+                        num_rows += rowset_live_rows;
                         data_size += rowset.data_size();
                     }
                     for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {
@@ -1186,6 +1196,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
 
                     auto elapsed_ms = (butil::gettimeofday_us() - task_start_us) / 1000;
                     if (elapsed_ms >= config::lake_tablet_stat_slow_log_ms) {
+                        TEST_SYNC_POINT_CALLBACK("LakeServiceImpl::get_tablet_stats:slow_log", nullptr);
                         LOG(WARNING) << "Slow tablet stat collection. tablet_id: " << tablet_id
                                      << ", version: " << version << ", is_pk_tablet: " << is_pk_tablet
                                      << ", accurate_mode: " << accurate_mode << ", num_rowsets: " << num_rowsets

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1176,8 +1176,9 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                                     num_deletes = rowset.num_dels();
                                 } else {
                                     // Fallback for old metadata without num_dels.
-                                    num_deletes = static_cast<int64_t>(
-                                            _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
+                                    num_deletes =
+                                            static_cast<int64_t>(_tablet_mgr->update_mgr()->get_rowset_num_deletes(
+                                                    tablet_id, version, rowset));
                                 }
                             }
                         }

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1141,6 +1141,8 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                         return;
                     }
 
+                    auto task_start_us = butil::gettimeofday_us();
+
                     // Don't fill meta cache to avoid polluting the cache
                     lake::CacheOptions cache_opts{.fill_meta_cache = false, .fill_data_cache = true};
                     auto tablet_metadata = _tablet_mgr->get_tablet_metadata(tablet_id, version, cache_opts);
@@ -1150,16 +1152,45 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                         return;
                     }
 
+                    // Determine if this is a primary-key tablet.  Only PK tablets maintain delete vectors
+                    // (delvec), so calling get_rowset_num_deletes() for non-PK tablets is wasteful.
+                    const bool is_pk_tablet = (*tablet_metadata)->schema().keys_type() == PRIMARY_KEYS;
+                    const bool accurate_mode = is_pk_tablet && config::lake_enable_accurate_pk_row_count;
+                    const int num_rowsets = (*tablet_metadata)->rowsets_size();
+
                     int64_t num_rows = 0;
                     int64_t data_size = 0;
                     for (const auto& rowset : (*tablet_metadata)->rowsets()) {
-                        size_t num_deletes =
-                                _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset);
+                        int64_t num_deletes = 0;
+                        if (is_pk_tablet) {
+                            if (config::lake_enable_accurate_pk_row_count) {
+                                // Accurate mode: fetch delete vectors from object storage.
+                                // NOTE!! Each segment incurs a remote metadata read - expensive for large tablets.
+                                num_deletes = static_cast<int64_t>(
+                                        _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
+                            } else {
+                                // Approximate mode (default): use the pre-stored num_dels field in the rowset
+                                // metadata. This avoids any additional I/O while still providing a reasonable
+                                // row count estimate. Rows deleted but not yet compacted may be slightly
+                                // overcounted until the next compaction.
+                                num_deletes = rowset.num_dels();
+                            }
+                        }
+                        // For non-PK tablets, num_deletes stays 0: they have no delete vectors.
                         num_rows += rowset.num_rows() - num_deletes;
                         data_size += rowset.data_size();
                     }
                     for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {
                         data_size += file.size();
+                    }
+
+                    auto elapsed_ms = (butil::gettimeofday_us() - task_start_us) / 1000;
+                    if (elapsed_ms >= config::lake_tablet_stat_slow_log_ms) {
+                        LOG(WARNING) << "Slow tablet stat collection. tablet_id: " << tablet_id
+                                     << ", version: " << version << ", is_pk_tablet: " << is_pk_tablet
+                                     << ", accurate_mode: " << accurate_mode << ", num_rowsets: " << num_rowsets
+                                     << ", num_rows: " << num_rows << ", data_size: " << data_size
+                                     << ", elapsed_ms: " << elapsed_ms;
                     }
 
                     std::lock_guard l(response_mtx);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2857,6 +2857,10 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
+    // Prune the metacache so we can verify that get_tablet_stats() itself does not refill it.
+    // publish_version() above may have cached v3 metadata.
+    _tablet_mgr->metacache()->prune();
+
     { // get the tablet stat again
         TabletStatRequest request;
         TabletStatResponse response;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2872,8 +2872,10 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
 
     // get_tablet_stats() should not fill the metadata cache (fill_cache=false) to avoid polluting
     // the precious LRU metacache with stat-collection workloads.
-    auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
-    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr);
+    auto cache_key_v1 = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
+    auto cache_key_v3 = _tablet_mgr->tablet_metadata_location(_tablet_id, 3);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key_v1) == nullptr);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key_v3) == nullptr);
 
     // test timeout
     response.clear_tablet_stats();
@@ -3023,8 +3025,8 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_pk_accurate_mode) {
     ASSERT_EQ(1, response.tablet_stats_size());
     EXPECT_EQ(pk_tablet_id, response.tablet_stats(0).tablet_id());
     // In accurate mode, get_rowset_num_deletes() reads actual delete vectors.
-    // Without actual delete vectors written, the result should be num_rows (no deletes deducted).
-    EXPECT_GE(response.tablet_stats(0).num_rows(), 0);
+    // Without actual delete vectors written, no deletes should be deducted.
+    EXPECT_EQ(200, response.tablet_stats(0).num_rows());
     EXPECT_EQ(8192, response.tablet_stats(0).data_size());
 }
 
@@ -3035,6 +3037,14 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_slow_log) {
     int64_t old_threshold = config::lake_tablet_stat_slow_log_ms;
     config::lake_tablet_stat_slow_log_ms = 0; // 0 ms: any task should be logged as slow
     DeferOp restore_config([old_threshold] { config::lake_tablet_stat_slow_log_ms = old_threshold; });
+    std::atomic<bool> slow_log_triggered = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeServiceImpl::get_tablet_stats:slow_log",
+                                          [&](void* /*arg*/) { slow_log_triggered.store(true); });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp clear_sync_point([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("LakeServiceImpl::get_tablet_stats:slow_log");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
 
     TabletStatRequest request;
     TabletStatResponse response;
@@ -3043,10 +3053,9 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_slow_log) {
     info->set_version(1);
 
     _tablet_mgr->metacache()->prune();
-    // The test verifies that get_tablet_stats completes successfully even when the
-    // slow log code path is exercised. The actual WARNING log can be observed in test output.
     _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
     ASSERT_EQ(1, response.tablet_stats_size());
+    ASSERT_TRUE(slow_log_triggered.load());
     EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
     EXPECT_EQ(0, response.tablet_stats(0).num_rows());
     EXPECT_EQ(0, response.tablet_stats(0).data_size());

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -31,6 +31,7 @@
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "common/config.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/util.h"
 #include "runtime/exec_env.h"
@@ -2869,7 +2870,8 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
         EXPECT_EQ(expected_data_size, response.tablet_stats(0).data_size());
     }
 
-    // get_tablet_stats() should not fill metadata cache
+    // get_tablet_stats() should not fill the metadata cache (fill_cache=false) to avoid polluting
+    // the precious LRU metacache with stat-collection workloads.
     auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
     ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr);
 
@@ -2887,6 +2889,188 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
 
     _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
     ASSERT_EQ(0, response.tablet_stats_size());
+}
+
+// Verify that DUP_KEYS tablet stats are computed correctly without involving
+// get_rowset_num_deletes() (which is only meaningful for PK tablets).
+TEST_F(LakeServiceTest, test_get_tablet_stats_dup_keys_no_delvec) {
+    // Create a DUP_KEYS tablet (the default fixture tablet type)
+    size_t expected_num_rows = 500;
+    size_t expected_data_size = 8192;
+    auto txn_log = generate_write_txn_log(1, expected_num_rows, expected_data_size);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(_tablet_id);
+        req.add_txn_ids(txn_log.txn_id());
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+    // For DUP_KEYS tablets num_dels in rowset metadata is always 0, so num_rows == expected
+    EXPECT_EQ(expected_num_rows, response.tablet_stats(0).num_rows());
+    EXPECT_EQ(expected_data_size, response.tablet_stats(0).data_size());
+}
+
+// Verify that in approximate mode (default), num_dels from rowset metadata is used for PK tablets
+// instead of calling get_rowset_num_deletes() which reads delete vectors from object storage.
+TEST_F(LakeServiceTest, test_get_tablet_stats_pk_approximate_mode) {
+    // Re-create the test tablet as a PRIMARY_KEYS tablet
+    auto pk_metadata = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+    int64_t pk_tablet_id = pk_metadata->id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
+
+    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows)
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    rowset->set_num_rows(100);
+    rowset->set_data_size(4096);
+    rowset->set_num_dels(20); // 20 rows deleted but not yet compacted
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    // Force approximate mode for this case, independent of global default value.
+    bool old_value = config::lake_enable_accurate_pk_row_count;
+    config::lake_enable_accurate_pk_row_count = false;
+    DeferOp restore_config([old_value] { config::lake_enable_accurate_pk_row_count = old_value; });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(pk_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(pk_tablet_id, response.tablet_stats(0).tablet_id());
+    // Approximate mode: num_rows - num_dels = 100 - 20 = 80
+    EXPECT_EQ(80, response.tablet_stats(0).num_rows());
+}
+
+// Verify that in accurate mode, get_rowset_num_deletes() is used for PK tablets
+// to get precise row counts by reading delete vectors from object storage.
+TEST_F(LakeServiceTest, test_get_tablet_stats_pk_accurate_mode) {
+    // Re-create the test tablet as a PRIMARY_KEYS tablet
+    auto pk_metadata = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+    int64_t pk_tablet_id = pk_metadata->id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
+
+    // Simulate a rowset with num_rows=200 and num_dels=50
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    rowset->set_num_rows(200);
+    rowset->set_data_size(8192);
+    rowset->set_num_dels(50);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    // Enable accurate mode
+    bool old_value = config::lake_enable_accurate_pk_row_count;
+    config::lake_enable_accurate_pk_row_count = true;
+    DeferOp restore_config([old_value] { config::lake_enable_accurate_pk_row_count = old_value; });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(pk_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(pk_tablet_id, response.tablet_stats(0).tablet_id());
+    // In accurate mode, get_rowset_num_deletes() reads actual delete vectors.
+    // Without actual delete vectors written, the result should be num_rows (no deletes deducted).
+    EXPECT_GE(response.tablet_stats(0).num_rows(), 0);
+    EXPECT_EQ(8192, response.tablet_stats(0).data_size());
+}
+
+// Verify that tablet stat collection logs a slow warning when elapsed time exceeds
+// the configured threshold (lake_tablet_stat_slow_log_ms).
+TEST_F(LakeServiceTest, test_get_tablet_stats_slow_log) {
+    // Set a very low threshold so that even a fast task triggers the slow log
+    int64_t old_threshold = config::lake_tablet_stat_slow_log_ms;
+    config::lake_tablet_stat_slow_log_ms = 0; // 0 ms: any task should be logged as slow
+    DeferOp restore_config([old_threshold] { config::lake_tablet_stat_slow_log_ms = old_threshold; });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(1);
+
+    _tablet_mgr->metacache()->prune();
+    // The test verifies that get_tablet_stats completes successfully even when the
+    // slow log code path is exercised. The actual WARNING log can be observed in test output.
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+    EXPECT_EQ(0, response.tablet_stats(0).num_rows());
+    EXPECT_EQ(0, response.tablet_stats(0).data_size());
+}
+
+// Verify that get_tablet_stats() does NOT fill the metadata cache (fill_cache=false) so that
+// stat-collection workloads do not evict hot metadata entries from the precious LRU metacache.
+TEST_F(LakeServiceTest, test_get_tablet_stats_does_not_pollute_metacache) {
+    _tablet_mgr->metacache()->prune();
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(1);
+
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+
+    // Metadata must NOT be in the metacache after a stat request
+    auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr)
+            << "get_tablet_stats should not fill the metacache (fill_cache=false)";
 }
 
 TEST_F(LakeServiceTest, test_drop_table_no_thread_pool) {

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2829,6 +2829,24 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The time interval at which Tablet Stat Cache updates.
 - Introduced in: -
 
+##### lake_enable_accurate_pk_row_count
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to use accurate row counts for lake primary-key tablets. When enabled, StarRocks reads each rowset's delete vector from object storage and subtracts deleted rows, producing more accurate stats but potentially increasing `get_tablet_stats` RPC overhead. When disabled, StarRocks uses the approximate `num_dels` value in rowset metadata to avoid remote I/O, which may slightly overcount rows that were deleted but not yet compacted.
+- Introduced in: -
+
+##### lake_tablet_stat_slow_log_ms
+
+- Default: 300000
+- Type: Int64
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Threshold (in milliseconds) for logging slow tablet-stat collection tasks. If a single tablet stat task exceeds this value, StarRocks emits a warning log with diagnostics such as `tablet_id`, version, rowset count, accurate mode, and elapsed time.
+- Introduced in: -
+
 ##### tablet_writer_open_rpc_timeout_sec
 
 - Default: 300

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -2327,6 +2327,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: タブレット統計キャッシュが更新される時間間隔。
 - 導入バージョン: -
 
+##### lake_enable_accurate_pk_row_count
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: Lake（共有データ）主キーテーブルの tablet 行数統計で正確な行数を使うかどうか。`true` の場合、各 rowset の delete vector をオブジェクトストレージから取得して削除行を差し引くため精度は上がりますが、`get_tablet_stats` RPC のオーバーヘッドが増える可能性があります。`false` の場合は rowset メタデータの近似 `num_dels` を使ってリモート I/O を回避しますが、未 compaction の削除行をわずかに過大計上する可能性があります。
+- 導入バージョン: -
+
+##### lake_tablet_stat_slow_log_ms
+
+- デフォルト: 300000
+- タイプ: Int64
+- 単位: Milliseconds
+- 可変: はい
+- 説明: Tablet 統計収集タスクの遅延ログしきい値（ミリ秒）。単一タスクの実行時間がこの値を超えると、`tablet_id`、バージョン、rowset 数、正確モード、経過時間などの診断情報を含む警告ログを出力します。
+- 導入バージョン: -
+
 ##### transaction_apply_worker_count
 
 - デフォルト: 0

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2791,6 +2791,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Tablet Stat Cache 的更新间隔。
 - 引入版本：-
 
+##### lake_enable_accurate_pk_row_count
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否为存算分离（Lake）主键表 tablet 使用精确行数统计。开启后会读取每个 rowset 在对象存储中的 delete vector 来扣减删除行，统计更准确，但会显著增加 `get_tablet_stats` RPC 的开销；关闭后使用 rowset 元数据中的近似 `num_dels`，可避免远端 I/O，但对“已删除但尚未 compaction”的行可能略有高估。
+- 引入版本：-
+
+##### lake_tablet_stat_slow_log_ms
+
+- 默认值：300000
+- 类型：Int64
+- 单位：Milliseconds
+- 是否动态：是
+- 描述：Tablet 统计采集慢日志阈值（毫秒）。单次 tablet 统计任务耗时超过该阈值时，会输出告警日志，附带 `tablet_id`、版本、rowset 数、是否精确模式和耗时等诊断信息。
+- 引入版本：-
+
 ##### tablet_writer_open_rpc_timeout_sec
 
 - 默认值：300


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, the get_tablet_stats RPC invokes get_rowset_num_deletes() for every tablet to read delete vectors from remote object storage. When a Primary Key (PK) tablet contains a large number of segments, the remote I/O overhead becomes significant. This leads to excessive latency in statistics collection, eventually blocking the TabletStatMgr daemon thread on the Frontend (FE).

Additionally, when statistics collection for a specific tablet experiences abnormal latency, there is a lack of diagnostic logging, making it difficult for operations personnel to identify the bottleneck.

## What I'm doing:

Fixes #69542

* Introduce the `lake_enable_accurate_pk_row_count` configuration (default: true):

* Delete vector calculation is performed only for PK tablets; non-PK tablets skip this step to avoid unnecessary overhead.
* By default, accurate mode is enabled, reading delete vectors segment-by-segment from object storage. While set to false, an approximate mode is used (reading the pre-stored num_dels field in rowset metadata), incurring zero additional I/O.

* Add per-tablet slow logs: Introduce the `lake_tablet_stat_slow_log_ms` configuration (default: 5 minutes). A WARNING log is output when the statistics collection time for a single tablet exceeds this threshold.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4