### PR TITLE
[BugFix] miss memory tracker for builtin inverted index

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -256,6 +256,8 @@ Status GlobalEnv::_init_mem_tracker() {
     _bitmap_index_mem_tracker = regist_tracker(MemTrackerType::BITMAP_INDEX, -1, column_metadata_mem_tracker());
     _bloom_filter_index_mem_tracker =
             regist_tracker(MemTrackerType::BLOOM_FILTER_INDEX, -1, column_metadata_mem_tracker());
+    _builtin_inverted_index_mem_tracker =
+            regist_tracker(MemTrackerType::BUILTIN_INVERTED_INDEX, -1, column_metadata_mem_tracker());
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_process_mem_tracker->limit());
     _compaction_mem_tracker = regist_tracker(MemTrackerType::COMPACTION, compaction_mem_limit, process_mem_tracker());

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -147,6 +147,7 @@ public:
     MemTracker* ordinal_index_mem_tracker() { return _ordinal_index_mem_tracker.get(); }
     MemTracker* bitmap_index_mem_tracker() { return _bitmap_index_mem_tracker.get(); }
     MemTracker* bloom_filter_index_mem_tracker() { return _bloom_filter_index_mem_tracker.get(); }
+    MemTracker* builtin_inverted_index_mem_tracker() { return _builtin_inverted_index_mem_tracker.get(); }
     MemTracker* segment_zonemap_mem_tracker() { return _segment_zonemap_mem_tracker.get(); }
     MemTracker* short_key_index_mem_tracker() { return _short_key_index_mem_tracker.get(); }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker.get(); }
@@ -211,6 +212,7 @@ private:
     std::shared_ptr<MemTracker> _ordinal_index_mem_tracker;
     std::shared_ptr<MemTracker> _bitmap_index_mem_tracker;
     std::shared_ptr<MemTracker> _bloom_filter_index_mem_tracker;
+    std::shared_ptr<MemTracker> _builtin_inverted_index_mem_tracker;
 
     // The memory used for compaction
     std::shared_ptr<MemTracker> _compaction_mem_tracker;

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -77,6 +77,7 @@ static std::vector<std::pair<MemTrackerType, std::string>> s_mem_types = {
         {MemTrackerType::INDEX_CACHE, "index_cache"},
         {MemTrackerType::DEL_VEC_CACHE, "del_vec_cache"},
         {MemTrackerType::COMPACTION_STATE, "compaction_state"},
+        {MemTrackerType::BUILTIN_INVERTED_INDEX, "builtin_inverted_index"},
 };
 
 static std::map<MemTrackerType, std::string> s_type_to_label_map;

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -117,7 +117,8 @@ enum class MemTrackerType {
     ROWSET_UPDATE_STATE,
     INDEX_CACHE,
     DEL_VEC_CACHE,
-    COMPACTION_STATE
+    COMPACTION_STATE,
+    BUILTIN_INVERTED_INDEX
 };
 
 class MemTracker {

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -249,6 +249,7 @@ void bind_exec_env(ForeignModule& m) {
         REG_METHOD(GlobalEnv, ordinal_index_mem_tracker);
         REG_METHOD(GlobalEnv, bitmap_index_mem_tracker);
         REG_METHOD(GlobalEnv, bloom_filter_index_mem_tracker);
+        REG_METHOD(GlobalEnv, builtin_inverted_index_mem_tracker);
         REG_METHOD(GlobalEnv, segment_zonemap_mem_tracker);
         REG_METHOD(GlobalEnv, short_key_index_mem_tracker);
     }

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -16,11 +16,23 @@
 
 #include <fmt/format.h>
 
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+BuiltinInvertedReader::BuiltinInvertedReader(const uint32_t index_id, int32_t gram_num)
+        : InvertedReader("", index_id), _gram_num(gram_num), _bitmap_index(nullptr) {
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(),
+                             sizeof(BuiltinInvertedReader));
+}
+
+BuiltinInvertedReader::~BuiltinInvertedReader() {
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(), mem_usage());
+}
 
 Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
                                            InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
@@ -52,12 +64,21 @@ Status BuiltinInvertedReader::load(const IndexReadOptions& opt, void* meta) {
         return Status::InvalidArgument("Invalid argument for loading builtin inverted index");
     }
     const BitmapIndexPB bitmap_index_meta = reinterpret_cast<BuiltinInvertedIndexPB*>(meta)->bitmap_index();
-    _bitmap_index = std::make_unique<BitmapIndexReader>(_gram_num);
+    _bitmap_index = std::make_unique<BitmapIndexReader>(_gram_num, false);
 
-    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opt, bitmap_index_meta));
+    auto ret = _bitmap_index->load(opt, bitmap_index_meta);
+    if (!ret.ok()) {
+        _bitmap_index.reset();
+        return Status::InternalError(
+                fmt::format("Failed to load bitmap index for builtin inverted index: {}", ret.status().to_string()));
+    }
+    bool first_load = ret.value();
     if (!first_load) {
+        _bitmap_index.reset();
         return Status::InternalError("loading builtin inverted index more than once");
     }
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(),
+                             mem_usage() - sizeof(BuiltinInvertedReader));
     return Status::OK();
 }
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
@@ -31,10 +31,8 @@ class FunctionContext;
 
 class BuiltinInvertedReader : public InvertedReader {
 public:
-    explicit BuiltinInvertedReader(const uint32_t index_id, int32_t gram_num)
-            : InvertedReader("", index_id), _gram_num(gram_num), _bitmap_index(nullptr) {}
-
-    ~BuiltinInvertedReader() override {}
+    explicit BuiltinInvertedReader(const uint32_t index_id, int32_t gram_num);
+    ~BuiltinInvertedReader() override;
 
     static Status create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
                          std::unique_ptr<InvertedReader>* res);
@@ -43,6 +41,14 @@ public:
                         const IndexReadOptions& index_opt) override;
 
     Status load(const IndexReadOptions& opt, void* meta) override;
+
+    size_t mem_usage() const {
+        size_t size = sizeof(BuiltinInvertedReader);
+        if (_bitmap_index != nullptr) {
+            size += _bitmap_index->mem_usage();
+        }
+        return size;
+    }
 
     /*
        Implemented in BuiltinInvertedIndexIterator. For builtin inverted index, we have to define bitmap index iterator in BuiltinInvertedIndexIterator.

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -53,20 +53,27 @@ namespace starrocks {
 
 using Roaring = roaring::Roaring;
 
-BitmapIndexReader::BitmapIndexReader(int32_t gram_num) : _gram_num(gram_num) {
-    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
+BitmapIndexReader::BitmapIndexReader(int32_t gram_num, bool owned_mem_tracker)
+        : _gram_num(gram_num), _owned_mem_tracker(owned_mem_tracker) {
+    if (_owned_mem_tracker) {
+        MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
+    }
 }
 
 BitmapIndexReader::~BitmapIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), mem_usage());
+    if (_owned_mem_tracker) {
+        MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), mem_usage());
+    }
 }
 
 StatusOr<bool> BitmapIndexReader::load(const IndexReadOptions& opts, const BitmapIndexPB& meta) {
     return success_once(_load_once, [&]() {
         Status st = _do_load(opts, meta);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
-                                     mem_usage() - sizeof(BitmapIndexReader));
+            if (_owned_mem_tracker) {
+                MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
+                                         mem_usage() - sizeof(BitmapIndexReader));
+            }
         } else {
             _reset();
         }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -57,7 +57,7 @@ using Roaring = roaring::Roaring;
 
 class BitmapIndexReader {
 public:
-    BitmapIndexReader(int32_t gram_num = -1);
+    BitmapIndexReader(int32_t gram_num = -1, bool owned_mem_tracker = true);
     ~BitmapIndexReader();
 
     // Load index data into memory.
@@ -124,6 +124,9 @@ private:
     std::unique_ptr<IndexedColumnReader> _ngram_dict_column_reader;
     std::unique_ptr<IndexedColumnReader> _ngram_bitmap_column_reader;
     bool _has_null = false;
+    // if _owned_mem_tracker == false, means there is a parent class holding BitmapIndexReader and
+    // the memory usage of BitmapIndexReader is tracked by the parent class.
+    bool _owned_mem_tracker;
 };
 
 class BitmapIndexIterator {

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -56,6 +56,7 @@
 #include "storage/index/index_descriptor.h"
 #include "types/type_descriptor.h"
 #ifndef __APPLE__
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
 #include "storage/index/inverted/inverted_plugin_factory.h"
 #endif
 #include "base/bit/rle_encoding.h"
@@ -120,6 +121,8 @@ ColumnReader::~ColumnReader() {
         _bloom_filter_index_meta.reset(nullptr);
     }
     if (_builtin_inverted_index_meta != nullptr) {
+        MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(),
+                                 _builtin_inverted_index_meta->SpaceUsedLong());
         _builtin_inverted_index_meta.reset(nullptr);
     }
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_metadata_mem_tracker(), sizeof(ColumnReader));
@@ -208,6 +211,9 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
                 break;
             case BUILTIN_INVERTED_INDEX:
                 _builtin_inverted_index_meta.reset(index_meta->release_builtin_inverted_index());
+                MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(),
+                                         _builtin_inverted_index_meta->SpaceUsedLong());
+                _meta_mem_usage.fetch_add(_builtin_inverted_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
                 break;
             case UNKNOWN_INDEX_TYPE:
                 return Status::Corruption(fmt::format("Bad file {}: unknown index type", file_name()));
@@ -553,28 +559,38 @@ Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& in
 
 #ifndef __APPLE__
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
-    return success_once(_inverted_index_load_once,
-                        [&]() {
-                            LogicalType type;
-                            if (_column_type == LogicalType::TYPE_ARRAY) {
-                                type = _column_child_type;
-                            } else {
-                                type = _column_type;
-                            }
+    return success_once(
+                   _inverted_index_load_once,
+                   [&]() {
+                       LogicalType type;
+                       if (_column_type == LogicalType::TYPE_ARRAY) {
+                           type = _column_child_type;
+                       } else {
+                           type = _column_type;
+                       }
 
-                            ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(*index_meta));
-                            std::string index_path = IndexDescriptor::inverted_index_file_path(
-                                    opts.rowset_path, opts.rowsetid.to_string(), _segment->id(),
-                                    index_meta->index_id());
-                            ASSIGN_OR_RETURN(auto inverted_plugin, InvertedPluginFactory::get_plugin(imp_type));
-                            RETURN_IF_ERROR(inverted_plugin->create_inverted_index_reader(index_path, index_meta, type,
-                                                                                          &_inverted_index));
-                            RETURN_IF_ERROR(_inverted_index->load(index_opt, _builtin_inverted_index_meta.get()));
-                            if (_builtin_inverted_index_meta != nullptr) {
-                                _builtin_inverted_index_meta.reset();
-                            }
-                            return Status::OK();
-                        })
+                       ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(*index_meta));
+                       std::string index_path = IndexDescriptor::inverted_index_file_path(
+                               opts.rowset_path, opts.rowsetid.to_string(), _segment->id(), index_meta->index_id());
+                       ASSIGN_OR_RETURN(auto inverted_plugin, InvertedPluginFactory::get_plugin(imp_type));
+                       RETURN_IF_ERROR(inverted_plugin->create_inverted_index_reader(index_path, index_meta, type,
+                                                                                     &_inverted_index));
+                       RETURN_IF_ERROR(_inverted_index->load(index_opt, _builtin_inverted_index_meta.get()));
+                       if (_builtin_inverted_index_meta != nullptr) {
+                           auto* builtin_inverted_index = dynamic_cast<BuiltinInvertedReader*>(_inverted_index.get());
+                           RETURN_IF(builtin_inverted_index == nullptr,
+                                     Status::Corruption("Inverted index reader type mismatch"));
+
+                           MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker(),
+                                                    _builtin_inverted_index_meta->SpaceUsedLong());
+                           _meta_mem_usage.fetch_sub(_builtin_inverted_index_meta->SpaceUsedLong(),
+                                                     std::memory_order_relaxed);
+                           _meta_mem_usage.fetch_add(builtin_inverted_index->mem_usage(), std::memory_order_relaxed);
+                           _builtin_inverted_index_meta.reset();
+                           _segment->update_cache_size();
+                       }
+                       return Status::OK();
+                   })
             .status();
 #endif
     return Status::OK();

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -285,6 +285,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("ordinal_index_mem_bytes", &_memory_metrics->ordinal_index_mem_bytes);
     registry->register_metric("bitmap_index_mem_bytes", &_memory_metrics->bitmap_index_mem_bytes);
     registry->register_metric("bloom_filter_index_mem_bytes", &_memory_metrics->bloom_filter_index_mem_bytes);
+    registry->register_metric("builtin_inverted_index_mem_bytes", &_memory_metrics->builtin_inverted_index_mem_bytes);
     registry->register_metric("segment_zonemap_mem_bytes", &_memory_metrics->segment_zonemap_mem_bytes);
     registry->register_metric("short_key_index_mem_bytes", &_memory_metrics->short_key_index_mem_bytes);
     registry->register_metric("compaction_mem_bytes", &_memory_metrics->compaction_mem_bytes);
@@ -379,6 +380,7 @@ void SystemMetrics::update_memory_metrics() {
     SET_MEM_METRIC_VALUE(ordinal_index_mem_tracker, ordinal_index_mem_bytes)
     SET_MEM_METRIC_VALUE(bitmap_index_mem_tracker, bitmap_index_mem_bytes)
     SET_MEM_METRIC_VALUE(bloom_filter_index_mem_tracker, bloom_filter_index_mem_bytes)
+    SET_MEM_METRIC_VALUE(builtin_inverted_index_mem_tracker, builtin_inverted_index_mem_bytes)
     SET_MEM_METRIC_VALUE(segment_zonemap_mem_tracker, segment_zonemap_mem_bytes)
     SET_MEM_METRIC_VALUE(short_key_index_mem_tracker, short_key_index_mem_bytes)
     SET_MEM_METRIC_VALUE(compaction_mem_tracker, compaction_mem_bytes)

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -67,6 +67,7 @@ public:
     METRIC_DEFINE_INT_GAUGE(ordinal_index_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(bitmap_index_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(bloom_filter_index_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(builtin_inverted_index_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(segment_zonemap_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(short_key_index_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(compaction_mem_bytes, MetricUnit::BYTES);

--- a/be/test/runtime/mem_tracker_test.cpp
+++ b/be/test/runtime/mem_tracker_test.cpp
@@ -49,6 +49,10 @@ TEST_F(MemTrackerTest, label_type_convert) {
     }
     ASSERT_EQ(MemTracker::type_to_label(MemTrackerType::QUERY), "");
     ASSERT_EQ(MemTracker::label_to_type("not_exist_label"), MemTrackerType::NO_SET);
+
+    // Verify builtin_inverted_index is registered
+    ASSERT_EQ(MemTracker::type_to_label(MemTrackerType::BUILTIN_INVERTED_INDEX), "builtin_inverted_index");
+    ASSERT_EQ(MemTracker::label_to_type("builtin_inverted_index"), MemTrackerType::BUILTIN_INVERTED_INDEX);
 }
 
 TEST_F(MemTrackerTest, get_snapshot) {

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -23,6 +23,7 @@
 #include "fs/fs_memory.h"
 #include "gen_cpp/segment.pb.h"
 #include "roaring/roaring.hh"
+#include "runtime/exec_env.h"
 #include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
 #include "storage/index/inverted/builtin/builtin_inverted_reader.h"
 #include "storage/index/inverted/builtin/builtin_inverted_writer.h"
@@ -801,6 +802,91 @@ TEST_F(BuiltinInvertedIndexTest, test_complex_wildcard_query) {
     ASSERT_OK(iter->close());
 
     delete iter;
+}
+
+// Verify that BuiltinInvertedReader correctly tracks memory via the builtin_inverted_index_mem_tracker.
+// The tracker balance should be zero after the reader is destroyed.
+TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_balance) {
+    auto* tracker = GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    std::vector<std::string> values = {"alpha", "beta", "gamma"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+
+    std::string file_name = kTestDir + "/mem_tracker_test";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    const auto& builtin_meta = meta.indexes(0).builtin_inverted_index();
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+
+    {
+        auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+        std::unique_ptr<InvertedReader> reader;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+        // After construction, tracker should have consumed sizeof(BuiltinInvertedReader).
+        if (tracker != nullptr) {
+            ASSERT_GT(tracker->consumption() - baseline, 0);
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+
+        // Load the index – tracker should grow further.
+        BuiltinInvertedIndexPB builtin_meta_copy = builtin_meta;
+        ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+        auto* builtin_reader = dynamic_cast<BuiltinInvertedReader*>(reader.get());
+        ASSERT_NE(builtin_reader, nullptr);
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(builtin_reader->mem_usage()));
+        }
+    }
+    // After reader is destroyed, tracker should return to baseline.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
+// Verify that load failure does not cause a tracker imbalance.
+TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_balance_on_load_failure) {
+    auto* tracker = GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    {
+        TabletIndex tablet_index;
+        tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+        auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+        std::unique_ptr<InvertedReader> reader;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+        // Load with nullptr meta should fail.
+        ASSERT_FALSE(reader->load(_opts, nullptr).ok());
+    }
+    // Tracker should be back to baseline after failed load + destruction.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
 }
 
 TEST_F(BuiltinInvertedIndexTest, test_simple_analyzer) {

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -889,6 +889,236 @@ TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_balance_on_load_failure) {
     }
 }
 
+// Verify that load failure due to invalid bitmap metadata (corrupt BitmapIndexPB)
+// does not cause a tracker imbalance. This covers the error path in load() where
+// _bitmap_index->load() fails and _bitmap_index is reset.
+TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_balance_on_bitmap_load_failure) {
+    auto* tracker = GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    {
+        TabletIndex tablet_index;
+        tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+        auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+        std::unique_ptr<InvertedReader> reader;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+        // After construction, tracker should have consumed sizeof(BuiltinInvertedReader).
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+
+        // Create an empty file for the read_file option.
+        std::string file_name = kTestDir + "/invalid_bitmap_meta";
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        ASSERT_TRUE(wfile->close().ok());
+        ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+        _opts.read_file = rfile.get();
+
+        // Create a BuiltinInvertedIndexPB with an empty BitmapIndexPB (invalid metadata).
+        // The dict_column inside will have data_type=0 which is unsupported, causing
+        // BitmapIndexReader::_do_load to fail.
+        BuiltinInvertedIndexPB builtin_meta;
+        builtin_meta.mutable_bitmap_index();
+        ASSERT_FALSE(reader->load(_opts, &builtin_meta).ok());
+
+        // After failed load, tracker should still only have sizeof(BuiltinInvertedReader),
+        // because _bitmap_index was reset on failure.
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+    }
+    // After destruction, tracker should return to baseline.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
+// Verify that mem_usage() returns the correct values before and after load.
+TEST_F(BuiltinInvertedIndexTest, test_mem_usage_before_and_after_load) {
+    std::vector<std::string> values = {"foo", "bar", "baz"};
+    std::vector<Slice> slices;
+    for (auto& v : values) slices.emplace_back(v);
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/mem_usage_test";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+    auto* builtin_reader = dynamic_cast<BuiltinInvertedReader*>(reader.get());
+    ASSERT_NE(builtin_reader, nullptr);
+
+    // Before load: mem_usage should be exactly sizeof(BuiltinInvertedReader)
+    // because _bitmap_index is nullptr.
+    ASSERT_EQ(builtin_reader->mem_usage(), sizeof(BuiltinInvertedReader));
+
+    // Load the index.
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    // After load: mem_usage should be > sizeof(BuiltinInvertedReader) because
+    // _bitmap_index is now loaded and has its own memory footprint.
+    ASSERT_GT(builtin_reader->mem_usage(), sizeof(BuiltinInvertedReader));
+    // It should equal sizeof(BuiltinInvertedReader) + _bitmap_index->mem_usage().
+    // Since we can't directly access _bitmap_index, just verify the total is reasonable.
+    ASSERT_GT(builtin_reader->mem_usage(), sizeof(BuiltinInvertedReader) + sizeof(BitmapIndexReader));
+}
+
+// Verify that multiple BuiltinInvertedReaders cumulatively track their memory,
+// and that the tracker returns to baseline after all readers are destroyed.
+TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_multiple_readers) {
+    auto* tracker = GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    std::vector<std::string> values = {"x", "y", "z"};
+    std::vector<Slice> slices;
+    for (auto& v : values) slices.emplace_back(v);
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/multi_reader_test";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+
+    {
+        auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+
+        // Create reader 1.
+        std::unique_ptr<InvertedReader> reader1;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader1));
+
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+
+        // Create reader 2 (without loading, just construction).
+        std::unique_ptr<InvertedReader> reader2;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader2));
+
+        // Two readers constructed: tracker should have 2 * sizeof(BuiltinInvertedReader).
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(2 * sizeof(BuiltinInvertedReader)));
+        }
+
+        // Load reader 1.
+        BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+        ASSERT_OK(reader1->load(_opts, &builtin_meta_copy));
+
+        auto* builtin_reader1 = dynamic_cast<BuiltinInvertedReader*>(reader1.get());
+        ASSERT_NE(builtin_reader1, nullptr);
+
+        if (tracker != nullptr) {
+            // reader1 is fully loaded, reader2 is only constructed.
+            int64_t expected = static_cast<int64_t>(builtin_reader1->mem_usage() + sizeof(BuiltinInvertedReader));
+            ASSERT_EQ(tracker->consumption() - baseline, expected);
+        }
+
+        // Destroy reader2 first.
+        reader2.reset();
+
+        if (tracker != nullptr) {
+            // Only reader1 remains.
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(builtin_reader1->mem_usage()));
+        }
+    }
+    // All readers destroyed.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
+// Verify memory tracking works correctly with the English parser path (tokenized index).
+TEST_F(BuiltinInvertedIndexTest, test_mem_tracker_english_parser) {
+    auto* tracker = GlobalEnv::GetInstance()->builtin_inverted_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    std::vector<std::string> values = {"hello world", "foo bar baz"};
+    std::vector<Slice> slices;
+    for (auto& v : values) slices.emplace_back(v);
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_ENGLISH);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/mem_tracker_english";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+
+    {
+        auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+        std::unique_ptr<InvertedReader> reader;
+        ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+
+        BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+        ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+        auto* builtin_reader = dynamic_cast<BuiltinInvertedReader*>(reader.get());
+        ASSERT_NE(builtin_reader, nullptr);
+
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(builtin_reader->mem_usage()));
+            // Loaded index should use more memory than just the struct size.
+            ASSERT_GT(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BuiltinInvertedReader)));
+        }
+    }
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
 TEST_F(BuiltinInvertedIndexTest, test_simple_analyzer) {
     SimpleAnalyzer analyzer(true);
     char text[] = "Hello World 123";

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -41,6 +41,7 @@
 #include "base/testutil/assert.h"
 #include "column/column_viewer.h"
 #include "fs/fs_memory.h"
+#include "runtime/exec_env.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
@@ -569,6 +570,120 @@ TEST_F(BitmapIndexTest, test_dict_ngram_index) {
         delete reader;
         delete iter;
     }
+}
+
+// Verify that BitmapIndexReader with owned_mem_tracker=false does NOT affect the
+// bitmap_index_mem_tracker during construction, load, or destruction.
+TEST_F(BitmapIndexTest, test_owned_mem_tracker_false_no_tracking) {
+    auto* tracker = GlobalEnv::GetInstance()->bitmap_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    size_t num_rows = 10;
+    int val[10];
+    for (int i = 0; i < 10; ++i) val[i] = i;
+
+    std::string file_name = kTestDir + "/owned_false";
+    ColumnIndexMetaPB meta;
+    write_index_file<TYPE_INT>(file_name, val, num_rows, 0, &meta);
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    {
+        // Create with owned_mem_tracker=false.
+        BitmapIndexReader reader(-1, false);
+
+        // Construction should NOT change the tracker.
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption(), baseline);
+        }
+
+        // Load should succeed.
+        ASSIGN_OR_ABORT(auto first_load, reader.load(_opts, meta.bitmap_index()));
+        ASSERT_TRUE(first_load);
+
+        // After load, tracker should still be unchanged because owned_mem_tracker=false.
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption(), baseline);
+        }
+
+        // Verify the reader is functional.
+        ASSERT_GT(reader.mem_usage(), sizeof(BitmapIndexReader));
+    }
+    // After destruction, tracker should remain at baseline.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
+// Verify that BitmapIndexReader with owned_mem_tracker=true (default) properly tracks
+// memory via bitmap_index_mem_tracker during construction, load, and destruction.
+TEST_F(BitmapIndexTest, test_owned_mem_tracker_true_tracks_memory) {
+    auto* tracker = GlobalEnv::GetInstance()->bitmap_index_mem_tracker();
+    int64_t baseline = tracker != nullptr ? tracker->consumption() : 0;
+
+    size_t num_rows = 10;
+    int val[10];
+    for (int i = 0; i < 10; ++i) val[i] = i;
+
+    std::string file_name = kTestDir + "/owned_true";
+    ColumnIndexMetaPB meta;
+    write_index_file<TYPE_INT>(file_name, val, num_rows, 0, &meta);
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    {
+        // Create with default owned_mem_tracker=true.
+        BitmapIndexReader reader;
+
+        // Construction should consume sizeof(BitmapIndexReader).
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BitmapIndexReader)));
+        }
+
+        // Load should succeed.
+        ASSIGN_OR_ABORT(auto first_load, reader.load(_opts, meta.bitmap_index()));
+        ASSERT_TRUE(first_load);
+
+        // After load, tracker should have consumed the full mem_usage.
+        if (tracker != nullptr) {
+            ASSERT_EQ(tracker->consumption() - baseline, static_cast<int64_t>(reader.mem_usage()));
+            ASSERT_GT(tracker->consumption() - baseline, static_cast<int64_t>(sizeof(BitmapIndexReader)));
+        }
+    }
+    // After destruction, tracker should return to baseline.
+    if (tracker != nullptr) {
+        ASSERT_EQ(tracker->consumption(), baseline);
+    }
+}
+
+// Verify that BitmapIndexReader's mem_usage() returns sizeof(BitmapIndexReader) before load
+// and includes IndexedColumnReader memory after load.
+TEST_F(BitmapIndexTest, test_mem_usage_before_and_after_load) {
+    size_t num_rows = 10;
+    int val[10];
+    for (int i = 0; i < 10; ++i) val[i] = i;
+
+    std::string file_name = kTestDir + "/mem_usage_check";
+    ColumnIndexMetaPB meta;
+    write_index_file<TYPE_INT>(file_name, val, num_rows, 0, &meta);
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    BitmapIndexReader reader;
+
+    // Before load: mem_usage should be sizeof(BitmapIndexReader) since internal readers are null.
+    ASSERT_EQ(reader.mem_usage(), sizeof(BitmapIndexReader));
+    ASSERT_FALSE(reader.loaded());
+
+    ASSIGN_OR_ABORT(auto first_load, reader.load(_opts, meta.bitmap_index()));
+    ASSERT_TRUE(first_load);
+    ASSERT_TRUE(reader.loaded());
+
+    // After load: mem_usage should be larger (includes dict and bitmap column readers).
+    ASSERT_GT(reader.mem_usage(), sizeof(BitmapIndexReader));
 }
 
 } // namespace starrocks

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1543,6 +1543,11 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Unit: Bytes
 - Description: Memory used by bitmap indexes.
 
+### builtin_inverted_index_mem_bytes
+
+- Unit: Bytes
+- Description: Memory used by builtin inverted indexes.
+
 ### update_rowset_commit_apply_duration_us
 
 - Unit: us

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1543,6 +1543,11 @@ displayed_sidebar: docs
 - 单位：Byte
 - 描述：Bitmap 索引使用的内存。
 
+### builtin_inverted_index_mem_bytes
+
+- 单位：Byte
+- 描述：内置倒排索引使用的内存。
+
 ### update_rowset_commit_apply_duration_us
 
 - 单位：微秒


### PR DESCRIPTION
## What I'm Doing:
1. Add memory tracker for builtin inverted index.
2. add some relative metric to check the memory usage.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4