### PR TITLE
[BugFix] Fix sort key not including newly added key columns after schema change on aggregate/unique tables (backport #69529)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -32,7 +32,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.warehouse.Warehouse;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -139,8 +138,6 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(indexId, table.getIndexNameById(indexId), oldSchemaInfo));
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
-            Preconditions.checkState(Objects.equals(ListUtils.emptyIfNull(indexMeta.getSortKeyUniqueIds()),
-                    ListUtils.emptyIfNull(schemaInfo.getSortKeyUniqueIds())));
             Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion());
             Preconditions.checkState(Objects.equals(indexMeta.getShortKeyColumnCount(), schemaInfo.getShortKeyColumnCount()));
 
@@ -152,6 +149,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             indexMeta.setSchemaVersion(schemaInfo.getVersion());
             indexMeta.setSchemaId(schemaInfo.getId());
             indexMeta.setSortKeyIdxes(schemaInfo.getSortKeyIndexes());
+            indexMeta.setSortKeyUniqueIds(schemaInfo.getSortKeyUniqueIds());
 
             // update the indexIdToMeta
             table.getIndexIdToMeta().put(indexId, indexMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1667,6 +1667,9 @@ public class SchemaChangeHandler extends AlterHandler {
                     sortKeyUniqueIds.add(alterSchema.get(sortKeyIdx).getUniqueId());
                 }
             }
+
+            appendNewKeyColumnsToSortKey(olapTable.getKeysType(), alterSchema,
+                    sortKeyIdxes, useSortKeyUniqueId ? sortKeyUniqueIds : null);
         }
 
         if (!sortKeyIdxes.isEmpty()) {
@@ -1703,6 +1706,31 @@ public class SchemaChangeHandler extends AlterHandler {
             boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
             dataBuilder.withNewIndexShortKeyCount(alterIndexId,
                     newShortKeyCount, isShortKeyChanged).withNewIndexSchema(alterIndexId, alterSchema);
+        }
+    }
+
+    /**
+     * For AGG_KEYS/UNIQUE_KEYS tables, sort key must include all key columns.
+     * This method appends newly added key columns to the end of the sort key lists,
+     * regardless of where the column was inserted in the schema (e.g. AFTER / FIRST).
+     *
+     * @param sortKeyUniqueIds if non-null, newly appended columns' unique IDs are also added to this list
+     */
+    private static void appendNewKeyColumnsToSortKey(
+            KeysType keysType, List<Column> schema,
+            List<Integer> sortKeyIdxes, @Nullable List<Integer> sortKeyUniqueIds) {
+        if (keysType != KeysType.AGG_KEYS && keysType != KeysType.UNIQUE_KEYS) {
+            return;
+        }
+        Set<Integer> existing = new HashSet<>(sortKeyIdxes);
+        for (int i = 0; i < schema.size(); i++) {
+            Column col = schema.get(i);
+            if (col.isKey() && !existing.contains(i)) {
+                sortKeyIdxes.add(i);
+                if (sortKeyUniqueIds != null) {
+                    sortKeyUniqueIds.add(col.getUniqueId());
+                }
+            }
         }
     }
 
@@ -3006,6 +3034,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 List<Integer> sortKeyUniqueIds = currentIndexMeta.getSortKeyUniqueIds();
                 List<Integer> newSortKeyIdxes = new ArrayList<>();
+                List<Integer> newSortKeyUniqueIds = new ArrayList<>();
                 if (sortKeyUniqueIds != null) {
                     for (Integer uniqueId : sortKeyUniqueIds) {
                         Optional<Column> col = indexSchema.stream().filter(c -> c.getUniqueId() == uniqueId).findFirst();
@@ -3014,12 +3043,17 @@ public class SchemaChangeHandler extends AlterHandler {
                         }
                         int sortKeyIdx = indexSchema.indexOf(col.get());
                         newSortKeyIdxes.add(sortKeyIdx);
+                        newSortKeyUniqueIds.add(uniqueId);
                     }
+
+                    appendNewKeyColumnsToSortKey(olapTable.getKeysType(), indexSchema,
+                            newSortKeyIdxes, newSortKeyUniqueIds);
                 }
 
                 currentIndexMeta.setSchema(indexSchema);
                 if (!newSortKeyIdxes.isEmpty()) {
                     currentIndexMeta.setSortKeyIdxes(newSortKeyIdxes);
+                    currentIndexMeta.setSortKeyUniqueIds(newSortKeyUniqueIds);
                 }
 
                 int currentSchemaVersion = currentIndexMeta.getSchemaVersion();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -166,6 +166,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return sortKeyUniqueIds;
     }
 
+    public void setSortKeyUniqueIds(List<Integer> sortKeyUniqueIds) {
+        this.sortKeyUniqueIds = sortKeyUniqueIds;
+    }
+
     public int getSchemaHash() {
         return schemaHash;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -783,4 +783,76 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
         Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaByIndexId(indexId).orElse(null));
         Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaBySchemaId(originMeta.getSchemaId()).orElse(null));
     }
+
+    @Test
+    public void testAggTableAddKeyColumnSortKeyUpdated() throws Exception {
+        String createSql = """
+                CREATE TABLE t_agg_sort_key_add_key (
+                k0 INT,
+                k1 INT,
+                k2 INT,
+                k3 INT,
+                v0 INT SUM
+                ) AGGREGATE KEY(k0, k1, k2, k3)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                ORDER BY(k3, k2, k1, k0);""";
+        LakeTable table = createTable(connectContext, createSql);
+        doTestAddKeyColumnSortKeyUpdated(table, "t_agg_sort_key_add_key");
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnSortKeyUpdated() throws Exception {
+        String createSql = """
+                CREATE TABLE t_uniq_sort_key_add_key (
+                k0 INT,
+                k1 INT,
+                k2 INT,
+                k3 INT,
+                v0 VARCHAR(1024)
+                ) UNIQUE KEY(k0, k1, k2, k3)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                ORDER BY(k3, k2, k1, k0);""";
+        LakeTable table = createTable(connectContext, createSql);
+        doTestAddKeyColumnSortKeyUpdated(table, "t_uniq_sort_key_add_key");
+    }
+
+    private void doTestAddKeyColumnSortKeyUpdated(LakeTable table, String tableName) throws Exception {
+        MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(table.getBaseIndexId());
+        List<Integer> expectedInitialSortKeyIdxes = Arrays.asList(3, 2, 1, 0);
+        Assertions.assertEquals(expectedInitialSortKeyIdxes, indexMeta.getSortKeyIdxes());
+
+        // Add a key column with positional clause (AFTER k2)
+        executeAlterAndWaitFinish(table,
+                "ALTER TABLE " + tableName + " ADD COLUMN k_new1 INT KEY AFTER k2", true);
+        Assertions.assertEquals("k0", table.getBaseSchema().get(0).getName());
+        Assertions.assertEquals("k1", table.getBaseSchema().get(1).getName());
+        Assertions.assertEquals("k2", table.getBaseSchema().get(2).getName());
+        Assertions.assertEquals("k_new1", table.getBaseSchema().get(3).getName());
+        Assertions.assertEquals("k3", table.getBaseSchema().get(4).getName());
+        assertSortKey(table, Arrays.asList(4, 2, 1, 0, 3));
+
+        // Add another key column at the default (last key) position
+        executeAlterAndWaitFinish(table,
+                "ALTER TABLE " + tableName + " ADD COLUMN k_new2 INT KEY DEFAULT '0'", true);
+        Assertions.assertEquals("k0", table.getBaseSchema().get(0).getName());
+        Assertions.assertEquals("k1", table.getBaseSchema().get(1).getName());
+        Assertions.assertEquals("k2", table.getBaseSchema().get(2).getName());
+        Assertions.assertEquals("k_new1", table.getBaseSchema().get(3).getName());
+        Assertions.assertEquals("k3", table.getBaseSchema().get(4).getName());
+        Assertions.assertEquals("k_new2", table.getBaseSchema().get(5).getName());
+        assertSortKey(table, Arrays.asList(4, 2, 1, 0, 3, 5));
+    }
+
+    private void assertSortKey(LakeTable table, List<Integer> expectedSortKeyIndexes) {
+        List<Column> columns = table.getBaseSchema();
+        MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(table.getBaseIndexId());
+        Assertions.assertEquals(expectedSortKeyIndexes, indexMeta.getSortKeyIdxes());
+        List<Integer> sortKeyUniqueIds = indexMeta.getSortKeyUniqueIds();
+        Assertions.assertNotNull(sortKeyUniqueIds);
+        Assertions.assertEquals(expectedSortKeyIndexes.size(), sortKeyUniqueIds.size());
+        for (int i = 0; i < expectedSortKeyIndexes.size(); i++) {
+            Assertions.assertEquals(columns.get(expectedSortKeyIndexes.get(i)).getUniqueId(),
+                    (int) sortKeyUniqueIds.get(i));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -19,6 +19,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.SchemaInfo;
@@ -57,6 +58,7 @@ import org.junit.jupiter.api.Test;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -875,5 +877,75 @@ public class LakeTableSchemaChangeJobTest {
             Assertions.assertNotNull(schema1);
             Assertions.assertNotNull(schema2);
         }
+    }
+
+    @Test
+    public void testAggTableAddKeyColumnSortKeyUpdated() throws Exception {
+        LakeTable aggTable = createTable(connectContext,
+                "CREATE TABLE t_agg_sort_key (k0 INT, k1 INT, v0 INT SUM)"
+                        + " AGGREGATE KEY(k0, k1) DISTRIBUTED BY HASH(k0) BUCKETS " + NUM_BUCKETS
+                        + " ORDER BY(k1, k0)");
+        doTestSortKeyUpdatedAfterAddKeyColumn(aggTable, "t_agg_sort_key");
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnSortKeyUpdated() throws Exception {
+        LakeTable uniqTable = createTable(connectContext,
+                "CREATE TABLE t_uniq_sort_key (k0 INT, k1 INT, v0 VARCHAR(1024))"
+                        + " UNIQUE KEY(k0, k1) DISTRIBUTED BY HASH(k0) BUCKETS " + NUM_BUCKETS
+                        + " ORDER BY(k1, k0)");
+        doTestSortKeyUpdatedAfterAddKeyColumn(uniqTable, "t_uniq_sort_key");
+    }
+
+    private void doTestSortKeyUpdatedAfterAddKeyColumn(LakeTable tbl, String tableName) throws Exception {
+        Assertions.assertEquals(Arrays.asList(1, 0),
+                tbl.getIndexMetaByIndexId(tbl.getBaseIndexId()).getSortKeyIdxes());
+
+        alterTable(connectContext, "ALTER TABLE " + tableName + " ADD COLUMN k_new1 INT KEY AFTER k0");
+        runSchemaChangeJobToFinish(tbl);
+
+        Assertions.assertEquals("k0", tbl.getBaseSchema().get(0).getName());
+        Assertions.assertEquals("k_new1", tbl.getBaseSchema().get(1).getName());
+        Assertions.assertEquals("k1", tbl.getBaseSchema().get(2).getName());
+        assertSortKey(tbl, Arrays.asList(2, 0, 1));
+    }
+
+    private void assertSortKey(LakeTable tbl, List<Integer> expectedSortKeyIndexes) {
+        List<Column> columns = tbl.getBaseSchema();
+        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+        Assertions.assertEquals(expectedSortKeyIndexes, indexMeta.getSortKeyIdxes());
+        List<Integer> sortKeyUniqueIds = indexMeta.getSortKeyUniqueIds();
+        Assertions.assertNotNull(sortKeyUniqueIds);
+        Assertions.assertEquals(expectedSortKeyIndexes.size(), sortKeyUniqueIds.size());
+        for (int i = 0; i < expectedSortKeyIndexes.size(); i++) {
+            Assertions.assertEquals(columns.get(expectedSortKeyIndexes.get(i)).getUniqueId(),
+                    (int) sortKeyUniqueIds.get(i));
+        }
+    }
+
+    private LakeTableSchemaChangeJob runSchemaChangeJobToFinish(LakeTable tbl) throws Exception {
+        LakeTableSchemaChangeJob job = getAlterJob(tbl);
+
+        new MockUp<LakeTableSchemaChangeJob>() {
+            @Mock
+            public void sendAgentTask(AgentBatchTask batchTask) {
+                batchTask.getAllTasks().forEach(t -> t.setFinished(true));
+            }
+        };
+        job.runPendingJob();
+        job.runWaitingTxnJob();
+        job.runRunningJob();
+
+        new MockUp<AlterJobV2>() {
+            @Mock
+            public boolean publishVersion() {
+                return true;
+            }
+        };
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
+        return job;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -729,5 +730,86 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
                     exception.getMessage().contains("Alter operation OPTIMIZE conflicts with operation SCHEMA_CHANGE"),
                     exception.getMessage());
         }
+    }
+
+    @Test
+    public void testSortKeyUpdatedAfterAddKeyColumnAgg() throws Exception {
+        createTable("CREATE TABLE test.sc_agg_sort_key (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "k2 INT,\n"
+                + "k3 INT,\n"
+                + "v0 INT SUM DEFAULT '0'\n"
+                + ") AGGREGATE KEY(k0, k1, k2, k3)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k3, k2, k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_agg_sort_key");
+        doTestSortKeyUpdatedAfterAddKeyColumn(tbl, "test.sc_agg_sort_key");
+    }
+
+    @Test
+    public void testSortKeyUpdatedAfterAddKeyColumnUniq() throws Exception {
+        createTable("CREATE TABLE test.sc_uniq_sort_key (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "k2 INT,\n"
+                + "k3 INT,\n"
+                + "v0 VARCHAR(1024)\n"
+                + ") UNIQUE KEY(k0, k1, k2, k3)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k3, k2, k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_uniq_sort_key");
+        doTestSortKeyUpdatedAfterAddKeyColumn(tbl, "test.sc_uniq_sort_key");
+    }
+
+    private void doTestSortKeyUpdatedAfterAddKeyColumn(OlapTable tbl, String qualifiedName) throws Exception {
+        Assertions.assertEquals(Arrays.asList(3, 2, 1, 0), tbl.getIndexMetaByIndexId(tbl.getBaseIndexId()).getSortKeyIdxes());
+
+        // Add a key column with positional clause (AFTER k2)
+        executeAlterAndWaitDone("alter table " + qualifiedName + " add column k_new1 int key after k2");
+        Assertions.assertEquals("k0", tbl.getBaseSchema().get(0).getName());
+        Assertions.assertEquals("k1", tbl.getBaseSchema().get(1).getName());
+        Assertions.assertEquals("k2", tbl.getBaseSchema().get(2).getName());
+        Assertions.assertEquals("k_new1", tbl.getBaseSchema().get(3).getName());
+        Assertions.assertEquals("k3", tbl.getBaseSchema().get(4).getName());
+        assertSortKey(tbl, Arrays.asList(4, 2, 1, 0, 3));
+
+        // Add another key column at the default (last key) position
+        executeAlterAndWaitDone("alter table " + qualifiedName + " add column k_new2 int key default '0'");
+        Assertions.assertEquals("k0", tbl.getBaseSchema().get(0).getName());
+        Assertions.assertEquals("k1", tbl.getBaseSchema().get(1).getName());
+        Assertions.assertEquals("k2", tbl.getBaseSchema().get(2).getName());
+        Assertions.assertEquals("k_new1", tbl.getBaseSchema().get(3).getName());
+        Assertions.assertEquals("k3", tbl.getBaseSchema().get(4).getName());
+        Assertions.assertEquals("k_new2", tbl.getBaseSchema().get(5).getName());
+        assertSortKey(tbl, Arrays.asList(4, 2, 1, 0, 3, 5));
+    }
+
+
+    private void assertSortKey(OlapTable tbl, List<Integer> expectedSortKeyIndexes) {
+        List<Column> columns = tbl.getBaseSchema();
+        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+        Assertions.assertEquals(expectedSortKeyIndexes, indexMeta.getSortKeyIdxes());
+        List<Integer> sortKeyUniqueIds = indexMeta.getSortKeyUniqueIds();
+        Assertions.assertNotNull(sortKeyUniqueIds);
+        Assertions.assertEquals(expectedSortKeyIndexes.size(), sortKeyUniqueIds.size());
+        for (int i = 0; i < expectedSortKeyIndexes.size(); i++) {
+            Assertions.assertEquals(columns.get(expectedSortKeyIndexes.get(i)).getUniqueId(),
+                    (int) sortKeyUniqueIds.get(i));
+        }
+    }
+
+    private void executeAlterAndWaitDone(String sql) throws Exception {
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(sql);
+        DDLStmtExecutor.execute(alterStmt, connectContext);
+        jobSize++;
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        waitAlterJobDone(alterJobs);
     }
 }

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_agg
@@ -1,0 +1,251 @@
+-- name: test_sort_key_add_key_column_agg
+create database test_agg_add_key_sort_${uuid0};
+-- result:
+-- !result
+use test_agg_add_key_sort_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `agg_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint SUM DEFAULT '0',
+    `v2` bigint SUM DEFAULT '0'
+)
+AGGREGATE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into agg_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	10	20
+2	1	30	40
+3	2	50	60
+-- !result
+alter table agg_t add column k3 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+-- !result
+insert into agg_t values (4, 4, 70, 80, 1);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+insert into agg_t values (1, 3, 0, 5, 5), (2, 1, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	3	0	15	25
+2	1	0	40	50
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	15	25
+2	1	40	50
+-- !result
+alter table agg_t add column k4 int default '0' after k1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	15	25
+2	0	1	0	40	50
+3	0	2	0	50	60
+4	0	4	70	80	1
+-- !result
+insert into agg_t values (5, 2, 90, 100, 1, 2);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	15	25
+2	0	1	0	40	50
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+insert into agg_t values (1, 0, 3, 0, 5, 5), (2, 0, 1, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	20	30
+2	0	1	0	50	60
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	20	30
+2	1	50	60
+-- !result
+alter table agg_t add column k5 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	20	30
+2	0	1	0	0	50	60
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+-- !result
+insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	20	30
+2	0	1	0	0	50	60
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	25	35
+2	1	60	70
+-- !result
+alter table agg_t order by (k1, k4, k5, k2, k3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	25	35
+2	0	1	0	0	60	70
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	30	40
+2	0	1	0	0	70	80
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	30	40
+2	1	70	80
+-- !result
+alter table agg_t add column k6 int default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	30	40
+2	0	1	0	0	0	70	80
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+-- !result
+insert into agg_t values (8, 2, 4, 1, 2, 4, 150, 160);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	30	40
+2	0	1	0	0	0	70	80
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
+-- !result
+insert into agg_t values (1, 0, 3, 0, 0, 0, 5, 5), (2, 0, 1, 0, 0, 0, 10, 10);
+-- result:
+-- !result
+select * from agg_t order by k1;
+-- result:
+1	0	3	0	0	0	35	45
+2	0	1	0	0	0	80	90
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
+-- !result
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+-- result:
+1	3	35	45
+2	1	80	90
+-- !result
+drop database test_agg_add_key_sort_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/R/test_sort_key_add_key_column_uniq
@@ -1,0 +1,166 @@
+-- name: test_sort_key_add_key_column_uniq
+create database test_uniq_add_key_sort_${uuid0};
+-- result:
+-- !result
+use test_uniq_add_key_sort_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `uniq_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint,
+    `v2` bigint
+)
+UNIQUE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into uniq_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	10	20
+2	1	30	40
+3	2	50	60
+-- !result
+alter table uniq_t add column k3 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+-- !result
+insert into uniq_t values (4, 4, 70, 80, 1);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	3	0	10	20
+2	1	0	30	40
+3	2	0	50	60
+4	4	70	80	1
+-- !result
+alter table uniq_t add column k4 int key default '0' after k1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+-- !result
+insert into uniq_t values (5, 2, 90, 100, 1, 2);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	10	20
+2	0	1	0	30	40
+3	0	2	0	50	60
+4	0	4	70	80	1
+5	2	90	100	1	2
+-- !result
+alter table uniq_t add column k5 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+-- !result
+insert into uniq_t values (6, 3, 110, 120, 1, 2, 3);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+alter table uniq_t order by (k1, k4, k5, k2, k3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+-- !result
+insert into uniq_t values (7, 1, 130, 140, 1, 2, 3);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	10	20
+2	0	1	0	0	30	40
+3	0	2	0	0	50	60
+4	0	4	70	0	80	1
+5	2	90	100	0	1	2
+6	3	110	120	1	2	3
+7	1	130	140	1	2	3
+-- !result
+alter table uniq_t add column k6 int key default '0';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	0	10	20
+2	0	1	0	0	0	30	40
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+-- !result
+insert into uniq_t values (8, 2, 4, 1, 2, 4, 150, 160);
+-- result:
+-- !result
+select * from uniq_t order by k1;
+-- result:
+1	0	3	0	0	0	10	20
+2	0	1	0	0	0	30	40
+3	0	2	0	0	0	50	60
+4	0	4	70	0	0	80	1
+5	2	90	100	0	0	1	2
+6	3	110	120	1	0	2	3
+7	1	130	140	1	0	2	3
+8	2	4	1	2	4	150	160
+-- !result
+drop database test_uniq_add_key_sort_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_agg
@@ -1,0 +1,69 @@
+-- name: test_sort_key_add_key_column_agg
+create database test_agg_add_key_sort_${uuid0};
+use test_agg_add_key_sort_${uuid0};
+
+CREATE TABLE `agg_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint SUM DEFAULT '0',
+    `v2` bigint SUM DEFAULT '0'
+)
+AGGREGATE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+
+insert into agg_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+select * from agg_t order by k1;
+
+-- Add key column at default position (last key)
+alter table agg_t add column k3 int default '0';
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (4, 4, 70, 80, 1);
+select * from agg_t order by k1;
+insert into agg_t values (1, 3, 0, 5, 5), (2, 1, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+-- Add key column at middle position (AFTER k1)
+alter table agg_t add column k4 int default '0' after k1;
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (5, 2, 90, 100, 1, 2);
+select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 5, 5), (2, 0, 1, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+-- Add key column without specifying position
+alter table agg_t add column k5 int default '0';
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (6, 3, 110, 120, 1, 2, 3);
+select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+-- Explicit reorder via ALTER TABLE ORDER BY
+alter table agg_t order by (k1, k4, k5, k2, k3);
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (7, 1, 130, 140, 1, 2, 3);
+select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 5, 5), (2, 0, 1, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+-- Add key column after reorder
+alter table agg_t add column k6 int default '0';
+function: wait_alter_table_finish()
+select * from agg_t order by k1;
+insert into agg_t values (8, 2, 4, 1, 2, 4, 150, 160);
+select * from agg_t order by k1;
+insert into agg_t values (1, 0, 3, 0, 0, 0, 5, 5), (2, 0, 1, 0, 0, 0, 10, 10);
+select * from agg_t order by k1;
+select k1, k2, v1, v2 from agg_t where k1 in (1, 2) order by k1;
+
+drop database test_agg_add_key_sort_${uuid0} force;

--- a/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
+++ b/test/sql/test_sort_key/T/test_sort_key_add_key_column_uniq
@@ -1,0 +1,54 @@
+-- name: test_sort_key_add_key_column_uniq
+create database test_uniq_add_key_sort_${uuid0};
+use test_uniq_add_key_sort_${uuid0};
+
+CREATE TABLE `uniq_t` (
+    `k1` int NOT NULL,
+    `k2` int NOT NULL,
+    `v1` bigint,
+    `v2` bigint
+)
+UNIQUE KEY(k1, k2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2, k1)
+PROPERTIES ("replication_num" = "1");
+
+insert into uniq_t values (1, 3, 10, 20), (2, 1, 30, 40), (3, 2, 50, 60);
+select * from uniq_t order by k1;
+
+-- Add key column at default position (last key)
+alter table uniq_t add column k3 int key default '0';
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (4, 4, 70, 80, 1);
+select * from uniq_t order by k1;
+
+-- Add key column at middle position (AFTER k1)
+alter table uniq_t add column k4 int key default '0' after k1;
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (5, 2, 90, 100, 1, 2);
+select * from uniq_t order by k1;
+
+-- Add key column without specifying position
+alter table uniq_t add column k5 int key default '0';
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (6, 3, 110, 120, 1, 2, 3);
+select * from uniq_t order by k1;
+
+-- Explicit reorder via ALTER TABLE ORDER BY
+alter table uniq_t order by (k1, k4, k5, k2, k3);
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (7, 1, 130, 140, 1, 2, 3);
+select * from uniq_t order by k1;
+
+-- Add key column after reorder
+alter table uniq_t add column k6 int key default '0';
+function: wait_alter_table_finish()
+select * from uniq_t order by k1;
+insert into uniq_t values (8, 2, 4, 1, 2, 4, 150, 160);
+select * from uniq_t order by k1;
+
+drop database test_uniq_add_key_sort_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
backport #69529

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

