### PR TITLE
[BugFix] Fix task run warehouse display after changing mv warehouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -468,9 +468,10 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             String taskName = TaskBuilder.getMvTaskName(materializedView.getId());
             Task task = taskManager.getTask(taskName);
-            if (task != null && task.getProperties() != null) {
-                // Remove the warehouse property from task so it will be fetched from MV at runtime
-                task.getProperties().remove(PropertyAnalyzer.PROPERTIES_WAREHOUSE);
+            if (task != null) {
+                // Remove the warehouse property from task so it will be fetched from MV at runtime.
+                // Use removeTaskProperty to ensure thread-safe modification under task lock.
+                taskManager.removeTaskProperty(task, PropertyAnalyzer.PROPERTIES_WAREHOUSE);
             }
         } catch (Exception e) {
             LOG.warn("Failed to update task warehouse property for MV {}: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -454,7 +454,28 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             // Note: warehouse is stored as warehouseId and output in getMaterializedViewDdlStmt(),
             // so we don't need to add it to TableProperty.properties to avoid duplication.
             materializedView.setWarehouseId(warehouse.getId());
+            // Also update the associated task's properties to remove stale warehouse
+            updateTaskWarehouseProperty(materializedView);
         });
+    }
+
+    /**
+     * Update the associated task's properties to remove stale warehouse property.
+     * The warehouse will be fetched from MV dynamically during task execution.
+     */
+    private void updateTaskWarehouseProperty(MaterializedView materializedView) {
+        try {
+            TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+            String taskName = TaskBuilder.getMvTaskName(materializedView.getId());
+            Task task = taskManager.getTask(taskName);
+            if (task != null && task.getProperties() != null) {
+                // Remove the warehouse property from task so it will be fetched from MV at runtime
+                task.getProperties().remove(PropertyAnalyzer.PROPERTIES_WAREHOUSE);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to update task warehouse property for MV {}: {}",
+                    materializedView.getName(), e.getMessage());
+        }
     }
 
     private void alterLabelsLocation(Map<String, String> properties,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -147,11 +147,8 @@ public class TaskBuilder {
         taskProperties.put(MV_ID, String.valueOf(materializedView.getId()));
         // Don't put mv table properties into task properties since mv refresh doesn't need them, and the properties
         // will cause task run's meta-data too large.
-        // In PropertyAnalyzer.analyzeMVProperties, it removed the warehouse property, because
-        // it only keeps session started properties
-        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                .getWarehouse(materializedView.getWarehouseId());
-        taskProperties.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE, warehouse.getName());
+        // NOTE: Don't persist warehouse property in task since it may be changed at runtime via
+        // "ALTER MATERIALIZED VIEW SET WAREHOUSE". The warehouse will be fetched from MV in refreshTaskProperties.
         task.setProperties(taskProperties);
 
         task.setDefinition(materializedView.getTaskDefinition());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -596,6 +596,25 @@ public class TaskManager implements MemoryTrackable {
         }
     }
 
+    /**
+     * Remove a property from the task's properties map.
+     * This method is thread-safe and acquires the task lock before modifying the properties.
+     */
+    public void removeTaskProperty(Task task, String propertyKey) {
+        if (task == null || propertyKey == null) {
+            return;
+        }
+        takeTaskLock();
+        try {
+            Map<String, String> current = task.getProperties();
+            if (current != null) {
+                current.remove(propertyKey);
+            }
+        } finally {
+            taskUnlock();
+        }
+    }
+
     public void dropTasks(List<Long> taskIdList) {
         takeTaskLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -352,6 +352,11 @@ public class TaskRun implements Comparable<TaskRun> {
 
         Map<String, String> newProperties = refreshTaskProperties(runCtx);
         properties.putAll(newProperties);
+        // Update status properties with the refreshed values (especially warehouse)
+        // so system tables show the correct information
+        if (status != null) {
+            status.setProperties(properties);
+        }
         Map<String, String> taskRunContextProperties = Maps.newHashMap();
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             String key = entry.getKey();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
@@ -16,6 +16,7 @@ package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,5 +34,59 @@ public class TaskBuilderTest {
         mv.setTableProperty(new TableProperty());
         Task task = TaskBuilder.buildMvTask(mv, "test");
         Assertions.assertEquals("insert overwrite `aa.bb.cc` select * from table1", task.getDefinition());
+    }
+
+    @Test
+    public void testBuildMvTaskDoesNotPersistWarehouse() {
+        // mock the warehouse of MaterializedView for creating task
+        UtFrameUtils.mockInitWarehouseEnv();
+
+        MaterializedView mv = new MaterializedView();
+        mv.setName("test.mv");
+        mv.setViewDefineSql("select * from table1");
+        mv.setTableProperty(new TableProperty());
+        // Set a specific warehouse id
+        mv.setWarehouseId(1000L);
+
+        Task task = TaskBuilder.buildMvTask(mv, "test");
+
+        // Verify the task does NOT contain warehouse property since it may be changed at runtime
+        // via "ALTER MATERIALIZED VIEW SET WAREHOUSE". The warehouse should be fetched from MV
+        // in refreshTaskProperties instead.
+        Assertions.assertNull(task.getProperties().get(PropertyAnalyzer.PROPERTIES_WAREHOUSE),
+                "Warehouse property should not be persisted in task since it can be changed at runtime");
+
+        // Verify MV_ID is still set
+        Assertions.assertEquals(String.valueOf(mv.getId()), task.getProperties().get(TaskRun.MV_ID));
+    }
+
+    @Test
+    public void testRebuildMvTaskPreservesProperties() {
+        // mock the warehouse of MaterializedView for creating task
+        UtFrameUtils.mockInitWarehouseEnv();
+
+        MaterializedView mv = new MaterializedView();
+        mv.setName("test.mv");
+        mv.setViewDefineSql("select * from table1");
+        mv.setTableProperty(new TableProperty());
+        mv.setWarehouseId(1000L);
+
+        // Simulate previous task properties that might contain old warehouse
+        java.util.Map<String, String> previousTaskProperties = new java.util.HashMap<>();
+        previousTaskProperties.put("custom_property", "custom_value");
+        // Note: old warehouse property might exist from before the fix
+        previousTaskProperties.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE, "old_warehouse");
+
+        Task previousTask = new Task("mv-" + mv.getId());
+        previousTask.setProperties(previousTaskProperties);
+
+        Task newTask = TaskBuilder.rebuildMvTask(mv, "test", previousTaskProperties, previousTask);
+
+        // Verify the new task contains the MV_ID
+        Assertions.assertEquals(String.valueOf(mv.getId()), newTask.getProperties().get(TaskRun.MV_ID));
+        // Verify custom properties are preserved
+        Assertions.assertEquals("custom_value", newTask.getProperties().get("custom_property"));
+        // Note: rebuildMvTask uses previousTaskProperties as-is, so old warehouse might still exist
+        // but refreshTaskProperties will override it with the current MV warehouse at runtime
     }
 }


### PR DESCRIPTION
## Why I'm doing:

For MV, the `warehouse` info will be stored both in `Task` and `MV`'s metadata, but when `alter materialized view <name>`, it only changed MV's metadata and will leave the `Task`'s warehouse info outdated, which can cause unexpected  bugs.

## What I'm doing:
- When create a new MV task, no store `warehouse` info in Task meta;
- When alter MV, clear the history `warehouse` info for `Task`;
-  For MV, fetch its warehouse info only from MV's metadata.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
