### PR TITLE
[BugFix] Catch all the exception of RowGroupWriter

### DIFF
--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -17,7 +17,6 @@
 #include "base/time/monotime.h"
 #include "base/time/time.h"
 #include "column/chunk.h"
-#include "common/status.h"
 #include "connector/async_flush_stream_poller.h"
 #include "connector/connector_sink_executor.h"
 #include "connector/sink_memory_manager.h"
@@ -118,7 +117,7 @@ Status PartitionChunkWriter::commit_file() {
         return Status::OK();
     }
     SCOPED_TIMER(_sink_profile ? _sink_profile->commit_file_timer : nullptr);
-    auto result = _file_writer->commit();
+    auto result = _file_writer->close();
     _commit_callback(result.set_extra_data(_commit_extra_data));
     _file_writer = nullptr;
     VLOG(3) << "commit to remote file, filename: " << _out_stream->filename()
@@ -434,7 +433,7 @@ Status SpillPartitionChunkWriter::_merge_chunks() {
 }
 
 bool SpillPartitionChunkWriter::_mem_insufficent() {
-    // Return false because we will triger spill by sink memory manager.
+    // Return false because we will trigger spill by sink memory manager.
     return false;
 }
 

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -144,8 +144,8 @@ Status CSVFileWriter::write(Chunk* chunk) {
     return Status::OK();
 }
 
-FileWriter::CommitResult CSVFileWriter::commit() {
-    FileWriter::CommitResult result{
+FileWriter::CommitResult CSVFileWriter::close() {
+    CommitResult result{
             .io_status = Status::OK(), .format = CSV, .location = _location, .rollback_action = _rollback_action};
 
     // Ensure header is written even if no data was written

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -65,7 +65,7 @@ public:
 
     Status write(Chunk* chunk) override;
 
-    CommitResult commit() override;
+    CommitResult close() override;
 
 private:
     const std::string _location;

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -65,9 +65,7 @@ public:
     virtual int64_t get_allocated_bytes() = 0;
     virtual int64_t get_flush_batch_size() = 0;
     virtual Status write(Chunk* chunk) = 0;
-    // TODO: It is better to rename this function to close()?
-    // This function should always be invoked, whether the write operation is successful or fails.
-    virtual CommitResult commit() = 0;
+    virtual CommitResult close() = 0;
 };
 
 struct WriterAndStream {

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -114,8 +114,8 @@ Status ORCFileWriter::write(Chunk* chunk) {
     return Status::OK();
 }
 
-FileWriter::CommitResult ORCFileWriter::commit() {
-    FileWriter::CommitResult result{
+FileWriter::CommitResult ORCFileWriter::close() {
+    CommitResult result{
             .io_status = Status::OK(), .format = ORC, .location = _location, .rollback_action = _rollback_action};
     try {
         if (_writer != nullptr) {
@@ -136,8 +136,8 @@ FileWriter::CommitResult ORCFileWriter::commit() {
         result.file_statistics.file_size = _output_stream->getLength();
     }
 
-    auto promise = std::make_shared<std::promise<FileWriter::CommitResult>>();
-    std::future<FileWriter::CommitResult> future = promise->get_future();
+    auto promise = std::make_shared<std::promise<CommitResult>>();
+    std::future<CommitResult> future = promise->get_future();
 
     _writer = nullptr;
     return result;

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -54,7 +54,7 @@ private:
     bool _is_closed = false;
 };
 
-struct ORCWriterOptions : public FileWriterOptions {};
+struct ORCWriterOptions : FileWriterOptions {};
 
 class ORCFileWriter final : public FileWriter {
 public:
@@ -76,7 +76,7 @@ public:
 
     Status write(Chunk* chunk) override;
 
-    CommitResult commit() override;
+    CommitResult close() override;
 
 private:
     static StatusOr<orc::CompressionKind> _convert_compression_type(TCompressionType::type type);

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -51,6 +51,7 @@ namespace starrocks::formats {
 
 DEFINE_FAIL_POINT(parquet_writer_close_failed);
 DEFINE_FAIL_POINT(parquet_writer_throw_exception);
+DEFINE_FAIL_POINT(parquet_writer_rowgroup_write_failed);
 
 Status ParquetFileWriter::write(Chunk* chunk) {
     if (_rowgroup_writer == nullptr) {
@@ -61,6 +62,9 @@ Status ParquetFileWriter::write(Chunk* chunk) {
 
     RETURN_IF_ERROR(_rowgroup_writer->write(chunk));
 
+    FAIL_POINT_TRIGGER_EXECUTE(parquet_writer_rowgroup_write_failed, {
+        _writer_options->rowgroup_size = 0;
+    });
     if (_rowgroup_writer->estimated_buffered_bytes() >= _writer_options->rowgroup_size) {
         return _flush_row_group();
     }
@@ -68,7 +72,7 @@ Status ParquetFileWriter::write(Chunk* chunk) {
     return Status::OK();
 }
 
-FileWriter::CommitResult ParquetFileWriter::commit() {
+FileWriter::CommitResult ParquetFileWriter::close() {
     CommitResult result{
             .io_status = Status::OK(), .format = PARQUET, .location = _location, .rollback_action = _rollback_action};
     try {
@@ -118,7 +122,10 @@ Status ParquetFileWriter::_flush_row_group() {
     DCHECK(_rowgroup_writer != nullptr);
     try {
         _rowgroup_writer->close();
-    } catch (const ::parquet::ParquetStatusException& e) {
+        FAIL_POINT_TRIGGER_EXECUTE(parquet_writer_rowgroup_write_failed, {
+            throw ::parquet::ParquetException("Parquet row group writer throws exception by fail point");
+        });
+    } catch (const std::exception& e) {
         Status exception = Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what()));
         LOG(WARNING) << exception;
         return exception;

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -62,9 +62,7 @@ Status ParquetFileWriter::write(Chunk* chunk) {
 
     RETURN_IF_ERROR(_rowgroup_writer->write(chunk));
 
-    FAIL_POINT_TRIGGER_EXECUTE(parquet_writer_rowgroup_write_failed, {
-        _writer_options->rowgroup_size = 0;
-    });
+    FAIL_POINT_TRIGGER_EXECUTE(parquet_writer_rowgroup_write_failed, { _writer_options->rowgroup_size = 0; });
     if (_rowgroup_writer->estimated_buffered_bytes() >= _writer_options->rowgroup_size) {
         return _flush_row_group();
     }

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -118,7 +118,7 @@ public:
 
     Status write(Chunk* chunk) override;
 
-    CommitResult commit() override;
+    CommitResult close() override;
 
 private:
     arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> _make_schema(

--- a/be/test/connector_sink/iceberg_chunk_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_chunk_sink_test.cpp
@@ -62,17 +62,17 @@ public:
     MOCK_METHOD(StatusOr<WriterAndStream>, create, (const std::string&), (const override));
 };
 
-class MockWriter : public formats::FileWriter {
+class MockWriter final : public formats::FileWriter {
 public:
     MOCK_METHOD(Status, init, (), (override));
     MOCK_METHOD(int64_t, get_written_bytes, (), (override));
     MOCK_METHOD(int64_t, get_allocated_bytes, (), (override));
     MOCK_METHOD(int64_t, get_flush_batch_size, (), (override));
     MOCK_METHOD(Status, write, (Chunk * chunk), (override));
-    MOCK_METHOD(CommitResult, commit, (), (override));
+    MOCK_METHOD(CommitResult, close, (), (override));
 };
 
-class MockFile : public WritableFile {
+class MockFile final : public WritableFile {
 public:
     MOCK_METHOD(Status, append, (const Slice& data), (override));
     MOCK_METHOD(Status, appendv, (const Slice* data, size_t cnt), (override));

--- a/be/test/connector_sink/partition_chunk_writer_test.cpp
+++ b/be/test/connector_sink/partition_chunk_writer_test.cpp
@@ -134,7 +134,7 @@ public:
 
     void set_flush_batch_size(int64_t flush_batch_size) { _flush_batch_size = flush_batch_size; }
 
-    CommitResult commit() override {
+    CommitResult close() override {
         size_t num_rows = WriterHelper::instance()->commit();
         CommitResult commit_result = {
                 .io_status = Status::OK(),

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -108,7 +108,7 @@ TEST_F(CSVFileWriterTest, TestWriteIntergers) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -149,7 +149,7 @@ TEST_F(CSVFileWriterTest, TestWriteBoolean) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -190,7 +190,7 @@ TEST_F(CSVFileWriterTest, TestWriteFloat) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -231,7 +231,7 @@ TEST_F(CSVFileWriterTest, TestWriteDouble) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -281,7 +281,7 @@ TEST_F(CSVFileWriterTest, TestWriteDate) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -331,7 +331,7 @@ TEST_F(CSVFileWriterTest, TestWriteDatetime) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -374,7 +374,7 @@ TEST_F(CSVFileWriterTest, TestWriteVarchar) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -440,7 +440,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayInt) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -497,7 +497,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayBigInt) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 2);
 
@@ -559,7 +559,7 @@ TEST_F(CSVFileWriterTest, TestWriteArrayWithNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 2);
 
@@ -627,7 +627,7 @@ TEST_F(CSVFileWriterTest, TestWriteHiveArray) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -721,7 +721,7 @@ TEST_F(CSVFileWriterTest, TestWriteNestedArray) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 2);
 
@@ -823,7 +823,7 @@ TEST_F(CSVFileWriterTest, TestWriteWithHeader) {
     }
 
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -852,7 +852,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderOnly) {
     ASSERT_OK(writer->init());
 
     // Commit without writing any data
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -882,7 +882,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithSpecialChars) {
                                                      std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -913,7 +913,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithCustomDelimiter) {
                                                      std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -943,7 +943,7 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderEscapeCustomDelimiter) {
                                                      std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -979,7 +979,7 @@ TEST_F(CSVFileWriterTest, TestWriteWithoutHeader) {
     }
 
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
 
     std::string content;
@@ -1044,11 +1044,11 @@ TEST_F(CSVFileWriterTest, TestWriteIntegersWithGzipCompression) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
-    // Note: writer->commit() already calls finalize() on CompressedOutputStream
+    // Note: writer->close() already calls finalize() on CompressedOutputStream
     // which internally closes the async stream, so we don't call async_stream->close() here
 
     // verify correctness - read compressed data and decompress
@@ -1098,11 +1098,11 @@ TEST_F(CSVFileWriterTest, TestWriteVarcharWithGzipCompression) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
-    // Note: writer->commit() already calls finalize() which closes the async stream
+    // Note: writer->close() already calls finalize() which closes the async stream
 
     // verify correctness
     std::string compressed_content;
@@ -1156,11 +1156,11 @@ TEST_F(CSVFileWriterTest, TestWriteLargeDataWithGzipCompression) {
         total_rows += rows_per_chunk;
     }
 
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, total_rows);
 
-    // Note: writer->commit() already calls finalize() which closes the async stream
+    // Note: writer->close() already calls finalize() which closes the async stream
 
     // Verify compressed file size is smaller than expected uncompressed size
     std::string compressed_content;
@@ -1220,7 +1220,7 @@ TEST_F(CSVFileWriterTest, TestCompressionRatio) {
         chunk->append_column(std::move(data_column), chunk->num_columns());
 
         ASSERT_OK(writer->write(chunk.get()));
-        ASSERT_OK(writer->commit().io_status);
+        ASSERT_OK(writer->close().io_status);
     }
 
     // Read and verify compressed file
@@ -1268,11 +1268,11 @@ TEST_F(CSVFileWriterTest, TestFactoryWithGzipCompression) {
 
     ASSERT_OK(writer_and_stream.writer->init());
     ASSERT_OK(writer_and_stream.writer->write(chunk.get()));
-    auto result = writer_and_stream.writer->commit();
+    auto result = writer_and_stream.writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 2);
 
-    // Note: writer->commit() already calls finalize() which closes the stream
+    // Note: writer->close() already calls finalize() which closes the stream
 
     // Verify compressed output
     std::string compressed_content;
@@ -1318,11 +1318,11 @@ TEST_F(CSVFileWriterTest, TestCompressionWithCustomDelimiters) {
     }
 
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 2);
 
-    // Note: writer->commit() already calls finalize() which closes the async stream
+    // Note: writer->close() already calls finalize() which closes the async stream
 
     // Verify custom delimiters are preserved after compression
     std::string compressed_content;

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -165,7 +165,7 @@ TEST_F(OrcFileWriterTest, TestWriteIntergersNullable) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -201,7 +201,7 @@ TEST_F(OrcFileWriterTest, TestWriteIntergersNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -231,7 +231,7 @@ TEST_F(OrcFileWriterTest, TestWriteFloat) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -260,7 +260,7 @@ TEST_F(OrcFileWriterTest, TestWriteDouble) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -288,7 +288,7 @@ TEST_F(OrcFileWriterTest, TestWriteBooleanNullable) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -317,7 +317,7 @@ TEST_F(OrcFileWriterTest, TestWriteBooleanNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -352,7 +352,7 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNullable) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -385,7 +385,7 @@ TEST_F(OrcFileWriterTest, TestWriteStringsNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -434,7 +434,7 @@ TEST_F(OrcFileWriterTest, TestWriteDecimal) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -483,7 +483,7 @@ TEST_F(OrcFileWriterTest, TestWriteDecimalNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -528,7 +528,7 @@ TEST_F(OrcFileWriterTest, TestWriteDate) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -569,7 +569,7 @@ TEST_F(OrcFileWriterTest, TestWriteDateNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -616,7 +616,7 @@ TEST_F(OrcFileWriterTest, TestAllocatedBytes) {
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_TRUE(writer->get_allocated_bytes() > 0);
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_TRUE(writer->get_allocated_bytes() == 0);
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -663,7 +663,7 @@ TEST_F(OrcFileWriterTest, TestWriteTimestamp) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -705,7 +705,7 @@ TEST_F(OrcFileWriterTest, TestWriteTimestampNotNull) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
 
@@ -760,7 +760,7 @@ TEST_F(OrcFileWriterTest, TestWriteMapNullable) {
                                                            std::move(column_evaluators),
                                                            TCompressionType::NO_COMPRESSION, _write_options, []() {});
     ASSERT_OK(writer->init());
-    ASSERT_OK(writer->commit().io_status);
+    ASSERT_OK(writer->close().io_status);
 }
 
 TEST_F(OrcFileWriterTest, TestWriteMapNotNull) {
@@ -776,7 +776,7 @@ TEST_F(OrcFileWriterTest, TestWriteMapNotNull) {
                                                            std::move(column_evaluators),
                                                            TCompressionType::NO_COMPRESSION, _write_options, []() {});
     ASSERT_OK(writer->init());
-    ASSERT_OK(writer->commit().io_status);
+    ASSERT_OK(writer->close().io_status);
 }
 
 TEST_F(OrcFileWriterTest, TestWriteArrayNullable) {
@@ -864,7 +864,7 @@ TEST_F(OrcFileWriterTest, TestOrcPatchedBaseWrongBaseWidth) {
     }
 
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 22);
 

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -160,7 +160,7 @@ TEST_F(ParquetFileWriterTest, TestWriteIntegralTypes) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -199,7 +199,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDecimal) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -239,7 +239,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDecimalCompatibleWithHiveReader) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -262,7 +262,7 @@ TEST_F(ParquetFileWriterTest, TestWriteBoolean) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -285,7 +285,7 @@ TEST_F(ParquetFileWriterTest, TestWriteFloat) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -308,7 +308,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDouble) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -345,7 +345,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDate) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -383,7 +383,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetime) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -425,7 +425,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetimeCompatibleWithHiveReader) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 5);
@@ -449,7 +449,7 @@ TEST_F(ParquetFileWriterTest, TestWriteVarchar) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -479,7 +479,7 @@ TEST_F(ParquetFileWriterTest, TestWriteArray) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -515,7 +515,7 @@ TEST_F(ParquetFileWriterTest, TestWriteStruct) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -551,7 +551,7 @@ TEST_F(ParquetFileWriterTest, TestWriteMap) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -617,7 +617,7 @@ TEST_F(ParquetFileWriterTest, TestWriteNestedArray) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);
@@ -640,7 +640,7 @@ TEST_F(ParquetFileWriterTest, TestWriteVarbinary) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 4);
@@ -665,7 +665,7 @@ TEST_F(ParquetFileWriterTest, TestAllocatedBytes) {
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_TRUE(writer->get_allocated_bytes() > 0);
-    auto result = writer->commit();
+    auto result = writer->close();
     ASSERT_TRUE(writer->get_allocated_bytes() == 0);
 
     ASSERT_OK(result.io_status);
@@ -691,7 +691,7 @@ TEST_F(ParquetFileWriterTest, TestFlushRowgroup) {
     // write chunk twice
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 8);
@@ -711,7 +711,7 @@ TEST_F(ParquetFileWriterTest, TestWriteWithFieldID) {
     // write chunk twice
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 8);
@@ -757,7 +757,7 @@ TEST_F(ParquetFileWriterTest, TestWriteJson) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);
@@ -782,7 +782,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsAllRequired) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);
@@ -823,7 +823,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsMixed) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);
@@ -866,7 +866,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsDefaultEmpty) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);
@@ -910,7 +910,7 @@ TEST_F(ParquetFileWriterTest, TestIcebergDeleteFileColumnsRequired) {
 
     // write chunk
     ASSERT_OK(writer->write(chunk.get()));
-    auto result = writer->commit();
+    auto result = writer->close();
 
     ASSERT_OK(result.io_status);
     ASSERT_EQ(result.file_statistics.record_count, 3);

--- a/test/sql/test_sink/R/test_file_sink_commit_failed
+++ b/test/sql/test_sink/R/test_file_sink_commit_failed
@@ -41,6 +41,21 @@ insert into files(
 admin disable failpoint 'parquet_writer_throw_exception';
 -- result:
 -- !result
+admin enable failpoint 'parquet_writer_rowgroup_write_failed';
+-- result:
+-- !result
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+-- result:
+[REGEX].*flush rowgroup error: Parquet row group writer throws exception by fail point.*
+-- !result
+admin disable failpoint 'parquet_writer_rowgroup_write_failed';
+-- result:
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -48,4 +63,6 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_fail
 -- !result
 CLEANUP {
     admin disable failpoint 'parquet_writer_close_failed';
+    admin disable failpoint 'parquet_writer_throw_exception';
+    admin disable failpoint 'parquet_writer_rowgroup_write_failed';
 } END CLEANUP

--- a/test/sql/test_sink/T/test_file_sink_commit_failed
+++ b/test/sql/test_sink/T/test_file_sink_commit_failed
@@ -28,8 +28,21 @@ insert into files(
 
 admin disable failpoint 'parquet_writer_throw_exception';
 
+admin enable failpoint 'parquet_writer_rowgroup_write_failed';
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+
+admin disable failpoint 'parquet_writer_rowgroup_write_failed';
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 
 CLEANUP {
     admin disable failpoint 'parquet_writer_close_failed';
+    admin disable failpoint 'parquet_writer_throw_exception';
+    admin disable failpoint 'parquet_writer_rowgroup_write_failed';
 } END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

Similar to https://github.com/StarRocks/starrocks/pull/69492, we should catch all exceptions from RowGroupWriter::Close(), otherwise it will lead to unexpected behavior.



## What I'm doing:

Catch all the exception of RowGroupWriter

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
