### PR TITLE
[Enhancement] Add monitor metrics for iceberg table sink. (backport #69506)

### DIFF
--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -2004,3 +2004,43 @@ Latency metrics expose percentile series such as `merge_commit_request_latency_9
 - Type: Cumulative
 - Labels: `delete_type` (`position` or `metadata`)
 - Description: Total deleted rows from Iceberg `DELETE` tasks. For `metadata` delete, this represents the number of rows in deleted data files. For `position` delete, this represents the number of position deletes created.
+
+### Iceberg write FE metrics
+
+#### iceberg_write_total
+
+- Unit: Count
+- Type: Cumulative
+- Labels:
+  - `status` (`success` or `failed`)
+  - `reason` (`none`, `timeout`, `oom`, `access_denied`, `unknown`)
+  - `write_type` (`insert`, `overwrite`, or `ctas`)
+- Description: Total number of `INSERT`, `INSERT OVERWRITE`, or `CTAS` tasks that target Iceberg tables. The metric is incremented by 1 after each task ends, regardless of success or failure. `write_type` distinguishes between the operation types.
+
+#### iceberg_write_duration_ms_total
+
+- Unit: Millisecond
+- Type: Cumulative
+- Labels: `write_type` (`insert`, `overwrite`, or `ctas`)
+- Description: Total execution time of Iceberg write tasks (`INSERT`, `INSERT OVERWRITE`, `CTAS`) in milliseconds. The duration of each task is added after it ends. `write_type` distinguishes between the operation types.
+
+#### iceberg_write_bytes
+
+- Unit: Bytes
+- Type: Cumulative
+- Labels: `write_type` (`insert`, `overwrite`, or `ctas`)
+- Description: Total written bytes from Iceberg write tasks (`INSERT`, `INSERT OVERWRITE`, `CTAS`). This represents the total size of data files written to the Iceberg table. `write_type` distinguishes between the operation types.
+
+#### iceberg_write_rows
+
+- Unit: Rows
+- Type: Cumulative
+- Labels: `write_type` (`insert`, `overwrite`, or `ctas`)
+- Description: Total written rows from Iceberg write tasks (`INSERT`, `INSERT OVERWRITE`, `CTAS`). This represents the number of rows written to the Iceberg table. `write_type` distinguishes between the operation types.
+
+#### iceberg_write_files
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `write_type` (`insert`, `overwrite`, or `ctas`)
+- Description: Total number of data files written to Iceberg from write tasks (`INSERT`, `INSERT OVERWRITE`, `CTAS`). This represents the count of data files written to the Iceberg table. `write_type` distinguishes between the operation types.

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -2001,3 +2001,43 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 - タイプ: Cumulative
 - ラベル: `delete_type` (`position` または `metadata`)
 - 説明: Iceberg `DELETE` タスクによって削除された総行数。`metadata` 削除の場合、削除されたデータファイル内の行数を表します。`position` 削除の場合、作成された position delete レコード数を表します。
+
+### Iceberg write FE メトリクス
+
+#### iceberg_write_total
+
+- 単位: Count
+- タイプ: Cumulative
+- ラベル:
+  - `status` (`success` または `failed`)
+  - `reason` (`none`, `timeout`, `oom`, `access_denied`, `unknown`)
+  - `write_type` (`insert`, `overwrite`, または `ctas`)
+- 説明: Iceberg テーブルを対象とした `INSERT`、`INSERT OVERWRITE`、または `CTAS` タスクの総数。タスクが終了するたびに成功/失敗に関わらず 1 増加します。`write_type` は 3 つの操作タイプを区別します。
+
+#### iceberg_write_duration_ms_total
+
+- 単位: Millisecond
+- タイプ: Cumulative
+- ラベル: `write_type` (`insert`, `overwrite`, または `ctas`)
+- 説明: Iceberg 書き込みタスク（`INSERT`、`INSERT OVERWRITE`、`CTAS`）の総実行時間（ミリ秒）。タスクが終了するたびにそのタスクの実行時間が加算されます。`write_type` は 3 つの操作タイプを区別します。
+
+#### iceberg_write_bytes
+
+- 単位: Bytes
+- タイプ: Cumulative
+- ラベル: `write_type` (`insert`, `overwrite`, または `ctas`)
+- 説明: Iceberg 書き込みタスク（`INSERT`、`INSERT OVERWRITE`、`CTAS`）の書き込み総バイト数。Iceberg テーブルに書き込まれたデータファイルの総サイズを表します。`write_type` は 3 つの操作タイプを区別します。
+
+#### iceberg_write_rows
+
+- 単位: Rows
+- タイプ: Cumulative
+- ラベル: `write_type` (`insert`, `overwrite`, または `ctas`)
+- 説明: Iceberg 書き込みタスク（`INSERT`、`INSERT OVERWRITE`、`CTAS`）の書き込み総行数。Iceberg テーブルに書き込まれた行数を表します。`write_type` は 3 つの操作タイプを区別します。
+
+#### iceberg_write_files
+
+- 単位: Count
+- タイプ: Cumulative
+- ラベル: `write_type` (`insert`, `overwrite`, または `ctas`)
+- 説明: Iceberg 書き込みタスク（`INSERT`、`INSERT OVERWRITE`、`CTAS`）で書き込まれたデータファイルの総数。Iceberg テーブルに書き込まれたデータファイルの個数を表します。`write_type` は 3 つの操作タイプを区別します。

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -2003,3 +2003,43 @@ displayed_sidebar: docs
 - 类型：累积值
 - 标签：`delete_type`（`position` 或 `metadata`）
 - 描述：Iceberg `DELETE` 任务删除的总行数。对于 `metadata` 删除，表示被删除数据文件中的行数；对于 `position` 删除，表示创建的 position delete 记录数。
+
+### Iceberg 写入 FE 指标
+
+#### iceberg_write_total
+
+- 单位：个
+- 类型：累积值
+- 标签：
+  - `status`（`success` 或 `failed`）
+  - `reason`（`none`、`timeout`、`oom`、`access_denied`、`unknown`）
+  - `write_type`（`insert`、`overwrite` 或 `ctas`）
+- 描述：目标表为 Iceberg 的 `INSERT`、`INSERT OVERWRITE` 或 `CTAS` 任务总数。每个任务结束后都会加 1，无论成功还是失败。`write_type` 区分三种操作类型。
+
+#### iceberg_write_duration_ms_total
+
+- 单位：毫秒
+- 类型：累积值
+- 标签：`write_type`（`insert`、`overwrite` 或 `ctas`）
+- 描述：Iceberg 写入任务（`INSERT`、`INSERT OVERWRITE`、`CTAS`）的总耗时（毫秒）。每个任务结束后会累加该任务耗时。`write_type` 区分三种操作类型。
+
+#### iceberg_write_bytes
+
+- 单位：字节
+- 类型：累积值
+- 标签：`write_type`（`insert`、`overwrite` 或 `ctas`）
+- 描述：Iceberg 写入任务（`INSERT`、`INSERT OVERWRITE`、`CTAS`）的写入总字节数。表示写入到 Iceberg 表的数据文件总大小。`write_type` 区分三种操作类型。
+
+#### iceberg_write_rows
+
+- 单位：行
+- 类型：累积值
+- 标签：`write_type`（`insert`、`overwrite` 或 `ctas`）
+- 描述：Iceberg 写入任务（`INSERT`、`INSERT OVERWRITE`、`CTAS`）的写入总行数。表示写入到 Iceberg 表的行数。`write_type` 区分三种操作类型。
+
+#### iceberg_write_files
+
+- 单位：个数
+- 类型：累积值
+- 标签：`write_type`（`insert`、`overwrite` 或 `ctas`）
+- 描述：Iceberg 写入任务（`INSERT`、`INSERT OVERWRITE`、`CTAS`）写入的数据文件总数。表示写入到 Iceberg 表的数据文件个数。`write_type` 区分三种操作类型。

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1754,6 +1754,17 @@ public class IcebergMetadata implements ConnectorMetadata {
                                      boolean isOverwrite, boolean isRewrite, Object extra,
                                      String dbName, String tableName,
                                      ConnectContext context) {
+        long startMs = System.currentTimeMillis();
+        // Determine write type: ctas, overwrite, insert (default)
+        String writeType;
+        if (context != null && context.isCTAS()) {
+            writeType = "ctas";
+        } else if (isOverwrite) {
+            writeType = "overwrite";
+        } else {
+            writeType = "insert";
+        }
+
         BatchWrite batchWrite = getBatchWrite(transaction, isOverwrite, isRewrite);
 
         if (branch != null) {
@@ -1800,10 +1811,34 @@ public class IcebergMetadata implements ConnectorMetadata {
                     context.getCurrentUserIdentity() != null ? context.getCurrentUserIdentity().getUser() : "None");
         }
 
-        commitWithCleanup(() -> {
-            batchWrite.commit();
-            transaction.commitTransaction();
-        }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+        try {
+            commitWithCleanup(() -> {
+                batchWrite.commit();
+                transaction.commitTransaction();
+            }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+
+            // Record metrics after successful commit
+            Snapshot newSnapshot = nativeTbl.currentSnapshot();
+            if (newSnapshot != null && newSnapshot.summary() != null) {
+                Map<String, String> summary = newSnapshot.summary();
+                long writtenRows = Long.parseLong(
+                        summary.getOrDefault(SnapshotSummary.ADDED_RECORDS_PROP, "0"));
+                long writtenBytes = Long.parseLong(
+                        summary.getOrDefault(SnapshotSummary.ADDED_FILE_SIZE_PROP, "0"));
+                IcebergMetricsMgr.increaseIcebergWriteTotalSuccess(writeType);
+                IcebergMetricsMgr.increaseIcebergWriteRows(writtenRows, writeType);
+                IcebergMetricsMgr.increaseIcebergWriteBytes(writtenBytes, writeType);
+                IcebergMetricsMgr.increaseIcebergWriteFiles(dataFiles.size(), writeType);
+            } else {
+                IcebergMetricsMgr.increaseIcebergWriteTotalSuccess(writeType);
+            }
+        } catch (Exception e) {
+            IcebergMetricsMgr.increaseIcebergWriteTotalFail(e, writeType);
+            throw e;
+        } finally {
+            IcebergMetricsMgr.increaseIcebergWriteDurationMsTotal(System.currentTimeMillis() - startMs, writeType);
+        }
+
         asyncRefreshOthersFeMetadataCache(dbName, tableName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/IcebergMetricsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/IcebergMetricsMgr.java
@@ -36,6 +36,18 @@ public class IcebergMetricsMgr {
 
     private static final String DELETE_TYPE_POSITION = "position";
     private static final String DELETE_TYPE_METADATA = "metadata";
+
+    // Iceberg write metrics with write_type label (insert/overwrite/ctas)
+    private static final Map<String, LongCounterMetric> COUNTER_ICEBERG_WRITE_TOTAL = new ConcurrentHashMap<>();
+    private static final Map<String, LongCounterMetric> COUNTER_ICEBERG_WRITE_DURATION_MS_TOTAL =
+            new ConcurrentHashMap<>();
+    private static final Map<String, LongCounterMetric> COUNTER_ICEBERG_WRITE_BYTES = new ConcurrentHashMap<>();
+    private static final Map<String, LongCounterMetric> COUNTER_ICEBERG_WRITE_ROWS = new ConcurrentHashMap<>();
+    private static final Map<String, LongCounterMetric> COUNTER_ICEBERG_WRITE_FILES = new ConcurrentHashMap<>();
+
+    private static final String WRITE_TYPE_INSERT = "insert";
+    private static final String WRITE_TYPE_OVERWRITE = "overwrite";
+    private static final String WRITE_TYPE_CTAS = "ctas";
     private static final String STATUS_SUCCESS = "success";
     private static final String STATUS_FAILED = "failed";
     private static final String REASON_NONE = "none";
@@ -155,6 +167,159 @@ public class IcebergMetricsMgr {
             return metric;
         });
         counter.increase(rows);
+    }
+
+    // ======================= Iceberg Write Metrics =======================
+
+    /**
+     * Record a completed Iceberg write task.
+     * This method automatically normalizes status, reason and writeType.
+     *
+     * @param status    "success" or "failed" (will be normalized)
+     * @param reason    failure reason: "none", "timeout", "oom", "access_denied", "unknown" (will be normalized)
+     * @param writeType "insert", "overwrite", or "ctas" (will be normalized)
+     */
+    public static void increaseIcebergWriteTotal(String status, String reason, String writeType) {
+        String normalizedStatus = normalizeStatus(status);
+        String normalizedReason = normalizeReason(reason);
+        String normalizedWriteType = normalizeWriteType(writeType);
+
+        String metricKey = normalizedStatus + "|" + normalizedReason + "|" + normalizedWriteType;
+        LongCounterMetric counter = COUNTER_ICEBERG_WRITE_TOTAL.computeIfAbsent(metricKey, k -> {
+            LongCounterMetric metric = new LongCounterMetric("iceberg_write_total", Metric.MetricUnit.REQUESTS,
+                    "total iceberg write tasks by status, reason and write type");
+            metric.addLabel(new MetricLabel("status", normalizedStatus));
+            metric.addLabel(new MetricLabel("reason", normalizedReason));
+            metric.addLabel(new MetricLabel("write_type", normalizedWriteType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+        counter.increase(1L);
+    }
+
+    /**
+     * Record a failed Iceberg write task with automatic error classification.
+     * This is a convenience method that combines error classification and metric recording.
+     *
+     * @param throwable the throwable to classify for reason
+     * @param writeType "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteTotalFail(Throwable throwable, String writeType) {
+        String reason = classifyFailReason(throwable);
+        increaseIcebergWriteTotal(STATUS_FAILED, reason, writeType);
+    }
+
+    /**
+     * Record a failed Iceberg write task with automatic error classification from error message.
+     * This is a convenience method that combines error classification and metric recording.
+     *
+     * @param errorMessage the error message to classify for reason
+     * @param writeType    "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteTotalFail(String errorMessage, String writeType) {
+        String reason = classifyFailReason(errorMessage);
+        increaseIcebergWriteTotal(STATUS_FAILED, reason, writeType);
+    }
+
+    /**
+     * Record a successful Iceberg write task.
+     * This is a convenience method.
+     *
+     * @param writeType "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteTotalSuccess(String writeType) {
+        increaseIcebergWriteTotal(STATUS_SUCCESS, REASON_NONE, writeType);
+    }
+
+    /**
+     * Record the duration of an Iceberg write task.
+     *
+     * @param durationMs duration in milliseconds
+     * @param writeType  "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteDurationMsTotal(long durationMs, String writeType) {
+        String normalizedWriteType = normalizeWriteType(writeType);
+        LongCounterMetric counter = COUNTER_ICEBERG_WRITE_DURATION_MS_TOTAL.computeIfAbsent(normalizedWriteType, k -> {
+            LongCounterMetric metric = new LongCounterMetric("iceberg_write_duration_ms_total",
+                    Metric.MetricUnit.MILLISECONDS, "total duration in milliseconds of iceberg write tasks by write type");
+            metric.addLabel(new MetricLabel("write_type", normalizedWriteType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+        counter.increase(durationMs);
+    }
+
+    /**
+     * Record the number of bytes written.
+     *
+     * @param bytes     number of bytes written
+     * @param writeType "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteBytes(long bytes, String writeType) {
+        String normalizedWriteType = normalizeWriteType(writeType);
+        LongCounterMetric counter = COUNTER_ICEBERG_WRITE_BYTES.computeIfAbsent(normalizedWriteType, k -> {
+            LongCounterMetric metric = new LongCounterMetric("iceberg_write_bytes", Metric.MetricUnit.BYTES,
+                    "total written bytes of iceberg write tasks by write type");
+            metric.addLabel(new MetricLabel("write_type", normalizedWriteType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+        counter.increase(bytes);
+    }
+
+    /**
+     * Record the number of rows written.
+     *
+     * @param rows      number of rows written
+     * @param writeType "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteRows(long rows, String writeType) {
+        String normalizedWriteType = normalizeWriteType(writeType);
+        LongCounterMetric counter = COUNTER_ICEBERG_WRITE_ROWS.computeIfAbsent(normalizedWriteType, k -> {
+            LongCounterMetric metric = new LongCounterMetric("iceberg_write_rows", Metric.MetricUnit.ROWS,
+                    "total written rows of iceberg write tasks by write type");
+            metric.addLabel(new MetricLabel("write_type", normalizedWriteType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+        counter.increase(rows);
+    }
+
+    /**
+     * Record the number of data files written to Iceberg.
+     *
+     * @param files     number of data files written
+     * @param writeType "insert", "overwrite", or "ctas"
+     */
+    public static void increaseIcebergWriteFiles(long files, String writeType) {
+        String normalizedWriteType = normalizeWriteType(writeType);
+        LongCounterMetric counter = COUNTER_ICEBERG_WRITE_FILES.computeIfAbsent(normalizedWriteType, k -> {
+            LongCounterMetric metric = new LongCounterMetric("iceberg_write_files", Metric.MetricUnit.NOUNIT,
+                    "total number of data files written to iceberg by write type");
+            metric.addLabel(new MetricLabel("write_type", normalizedWriteType));
+            MetricRepo.addMetric(metric);
+            return metric;
+        });
+        counter.increase(files);
+    }
+
+    /**
+     * Normalize write type to "insert", "overwrite", "ctas", or "unknown".
+     *
+     * @param writeType the write type to normalize
+     * @return normalized write type
+     */
+    public static String normalizeWriteType(String writeType) {
+        if (WRITE_TYPE_INSERT.equalsIgnoreCase(writeType)) {
+            return WRITE_TYPE_INSERT;
+        }
+        if (WRITE_TYPE_OVERWRITE.equalsIgnoreCase(writeType)) {
+            return WRITE_TYPE_OVERWRITE;
+        }
+        if (WRITE_TYPE_CTAS.equalsIgnoreCase(writeType)) {
+            return WRITE_TYPE_CTAS;
+        }
+        return writeType == null ? REASON_UNKNOWN : writeType;
     }
 
     // Normalization and classification methods

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -280,6 +280,9 @@ public class ConnectContext {
     private boolean skipFinishSink = false;
     private FinishSinkHandler handler = null;
 
+    // Track if current write is CTAS (Create Table As Select)
+    private boolean isCTAS = false;
+
     public void setTxnId(long txnId) {
         this.txnId = txnId;
     }
@@ -1779,6 +1782,14 @@ public class ConnectContext {
 
     public FinishSinkHandler getFinishSinkHandler() {
         return handler;
+    }
+
+    public void setCTAS(boolean isCTAS) {
+        this.isCTAS = isCTAS;
+    }
+
+    public boolean isCTAS() {
+        return isCTAS;
     }
 
     public interface Listener {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1359,6 +1359,8 @@ public class StmtExecutor {
         // if create table failed should not drop table. because table may already exist,
         // and for other cases the exception will throw and the rest of the code will not be executed.
         try {
+            // Set CTAS flag for metrics tracking
+            context.setCTAS(true);
             InsertStmt insertStmt = createTableAsSelectStmt.getInsertStmt();
             ExecPlan execPlan = StatementPlanner.plan(insertStmt, context);
             handleDMLStmtWithProfile(execPlan, ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt());
@@ -1369,6 +1371,9 @@ public class StmtExecutor {
             LOG.warn("handle create table as select stmt fail", t);
             dropTableCreatedByCTAS(createTableAsSelectStmt);
             throw t;
+        } finally {
+            // Reset CTAS flag
+            context.setCTAS(false);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -485,4 +485,77 @@ public class MetricRepoTest extends PlanTestBase {
         Assertions.assertEquals("unknown", IcebergMetricsMgr.classifyFailReason(new RuntimeException("unknown error")));
         Assertions.assertEquals("unknown", IcebergMetricsMgr.classifyFailReason((Throwable) null));
     }
+
+    @Test
+    public void testIcebergWriteMetrics() {
+        // Test insert write metrics using basic method
+        IcebergMetricsMgr.increaseIcebergWriteTotal("success", "none", "insert");
+        IcebergMetricsMgr.increaseIcebergWriteTotal("failed", "timeout", "insert");
+        IcebergMetricsMgr.increaseIcebergWriteDurationMsTotal(123L, "insert");
+        IcebergMetricsMgr.increaseIcebergWriteRows(10L, "insert");
+        IcebergMetricsMgr.increaseIcebergWriteBytes(1000L, "insert");
+        IcebergMetricsMgr.increaseIcebergWriteFiles(1L, "insert");
+
+        // Test overwrite write metrics
+        IcebergMetricsMgr.increaseIcebergWriteTotal("success", "none", "overwrite");
+        IcebergMetricsMgr.increaseIcebergWriteDurationMsTotal(456L, "overwrite");
+        IcebergMetricsMgr.increaseIcebergWriteRows(20L, "overwrite");
+        IcebergMetricsMgr.increaseIcebergWriteBytes(2000L, "overwrite");
+        IcebergMetricsMgr.increaseIcebergWriteFiles(2L, "overwrite");
+
+        // Test ctas write metrics
+        IcebergMetricsMgr.increaseIcebergWriteTotal("success", "none", "ctas");
+        IcebergMetricsMgr.increaseIcebergWriteDurationMsTotal(789L, "ctas");
+        IcebergMetricsMgr.increaseIcebergWriteRows(30L, "ctas");
+        IcebergMetricsMgr.increaseIcebergWriteBytes(3000L, "ctas");
+        IcebergMetricsMgr.increaseIcebergWriteFiles(3L, "ctas");
+
+        // Test convenience methods for success/failure
+        IcebergMetricsMgr.increaseIcebergWriteTotalSuccess("insert");
+        IcebergMetricsMgr.increaseIcebergWriteTotalFail("out of memory", "overwrite");
+        IcebergMetricsMgr.increaseIcebergWriteTotalFail(new RuntimeException("timeout"), "ctas");
+
+        PrometheusMetricVisitor visitor = new PrometheusMetricVisitor("ut");
+        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true, true);
+        MetricRepo.getMetric(visitor, params);
+        String output = visitor.build();
+
+        Assertions.assertTrue(output.contains("ut_iceberg_write_total{"),
+                "iceberg_write_total should be exposed");
+        Assertions.assertTrue(output.contains("status=\"success\""),
+                "iceberg_write_total should contain status=success");
+        Assertions.assertTrue(output.contains("status=\"failed\""),
+                "iceberg_write_total should contain status=failed");
+        Assertions.assertTrue(output.contains("reason=\"timeout\""),
+                "iceberg_write_total should contain reason=timeout");
+        Assertions.assertTrue(output.contains("reason=\"oom\""),
+                "iceberg_write_total should contain reason=oom");
+        Assertions.assertTrue(output.contains("write_type=\"insert\""),
+                "iceberg_write_total should contain write_type=insert");
+        Assertions.assertTrue(output.contains("write_type=\"overwrite\""),
+                "iceberg_write_total should contain write_type=overwrite");
+        Assertions.assertTrue(output.contains("write_type=\"ctas\""),
+                "iceberg_write_total should contain write_type=ctas");
+        Assertions.assertTrue(output.contains("ut_iceberg_write_duration_ms_total"),
+                "iceberg_write_duration_ms_total should be exposed");
+        Assertions.assertTrue(output.contains("ut_iceberg_write_rows"),
+                "iceberg_write_rows should be exposed");
+        Assertions.assertTrue(output.contains("ut_iceberg_write_bytes"),
+                "iceberg_write_bytes should be exposed");
+        Assertions.assertTrue(output.contains("ut_iceberg_write_files"),
+                "iceberg_write_files should be exposed");
+    }
+
+    @Test
+    public void testIcebergWriteTypeNormalization() {
+        // Test write type normalization
+        Assertions.assertEquals("insert", IcebergMetricsMgr.normalizeWriteType("insert"));
+        Assertions.assertEquals("insert", IcebergMetricsMgr.normalizeWriteType("INSERT"));
+        Assertions.assertEquals("insert", IcebergMetricsMgr.normalizeWriteType("Insert"));
+        Assertions.assertEquals("overwrite", IcebergMetricsMgr.normalizeWriteType("overwrite"));
+        Assertions.assertEquals("overwrite", IcebergMetricsMgr.normalizeWriteType("OVERWRITE"));
+        Assertions.assertEquals("ctas", IcebergMetricsMgr.normalizeWriteType("ctas"));
+        Assertions.assertEquals("ctas", IcebergMetricsMgr.normalizeWriteType("CTAS"));
+        Assertions.assertEquals("unknown", IcebergMetricsMgr.normalizeWriteType(null));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

This pull request adds comprehensive support for tracking Iceberg write metrics in StarRocks, including new metrics for write operations (insert, overwrite, CTAS), and exposes them in documentation across English, Japanese, and Chinese. The changes also introduce logic to distinguish CTAS operations for accurate metric labeling and ensure metrics are recorded for both successful and failed writes.

### Iceberg Write Metrics Implementation

* Added new metrics for Iceberg write operations: total tasks (`iceberg_write_total`), execution duration (`iceberg_write_duration_ms_total`), bytes written (`iceberg_write_bytes`), rows written (`iceberg_write_rows`), and files written (`iceberg_write_files`). These metrics are tracked by operation type (`insert`, `overwrite`, `ctas`) and status (`success`, `failed`) with error reasons. 
* Updated `IcebergMetadata.java` to record these metrics after each write operation, including handling of CTAS, overwrite, and insert types, and capturing task duration, success/failure, and resource usage. 

### CTAS Operation Tracking

* Introduced a flag in `ConnectContext` to track whether the current operation is CTAS, enabling correct metric labeling for Iceberg writes. 
* Updated `StmtExecutor.java` to set and reset the CTAS flag during the lifecycle of a CTAS statement execution.

### Documentation Updates

* Added documentation for the new Iceberg write metrics in English (`docs/en/administration/management/monitoring/metrics.md`), Japanese (`docs/ja/administration/management/monitoring/metrics.md`), and Chinese (`docs/zh/administration/management/monitoring/metrics.md`), detailing metric names, units, labels, and descriptions. 

### Metric Key Normalization

* Implemented normalization and classification for metric keys (status, reason, write_type) to ensure consistent metric labeling and aggregation. 

### Internal Refactoring

* Refactored metric manager to add new counters and support for write metric tracking, including helper methods for error classification and normalization. 

These changes provide detailed observability for Iceberg write operations, enabling improved monitoring and troubleshooting for StarRocks clusters.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4