### PR TITLE
[Refactor] using merge() for scalar functions instead of merge_with_array()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1552,10 +1552,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 return !result.isConstant() ? call : result;
             }
 
-            if (LOW_CARD_STRING_FUNCTIONS.contains(call.getFnName()) ||
-                    LOW_CARD_ARRAY_FUNCTIONS.contains(call.getFnName()) ||
+            if (LOW_CARD_ARRAY_FUNCTIONS.contains(call.getFnName()) ||
                     LOW_CARD_AGGREGATE_FUNCTIONS.contains(call.getFnName())) {
                 return mergeWithArray(visitChildren(call, context), call);
+            }
+            if (LOW_CARD_STRING_FUNCTIONS.contains(call.getFnName())) {
+                return merge(visitChildren(call, context), call);
             }
             if (isEnableStructLowCardinalityOptimize && LOW_CARD_STRUCT_FUNCTIONS.contains(call.getFnName())
                     && call.getChildren().stream().allMatch(


### PR DESCRIPTION
## Why I'm doing:
Currently in DecodeCollector, mergeWithArray() is used for LOW_CARD_STRING_FUNCTIONS. This can become problematic in the future if we have a function which is applicable to both arrays and scalars and only the calls to scalars  can be dictified. (like a hash function which can be applied to both scalars and arrays)

## What I'm doing:
Calling merge() instead of mergeWithArray() for LOW_CARD_STRING_FUNCTIONS.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
