### PR TITLE
[BugFix] Fix KILL ANALYZE sometimes not stopping ANALYZE TABLE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
@@ -30,11 +30,11 @@ import java.util.Map;
 public class ConstQueryJob extends HyperQueryJob {
     private final Map<Long, Long> partitionRowCounts = Maps.newHashMap();
 
-    protected ConstQueryJob(ConnectContext context, Database db,
+    protected ConstQueryJob(ConnectContext context, long analyzeId, Database db,
                             Table table,
                             List<ColumnStats> columnStats,
                             List<Long> partitionIdList) {
-        super(context, db, table, columnStats, partitionIdList);
+        super(context, analyzeId, db, table, columnStats, partitionIdList);
         initPartitionRowCounts();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullMultiColumnQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullMultiColumnQueryJob.java
@@ -26,8 +26,9 @@ import java.util.List;
 
 public class FullMultiColumnQueryJob extends MultiColumnQueryJob {
 
-    public FullMultiColumnQueryJob(ConnectContext context, Database db, Table table, List<ColumnStats> columnStats) {
-        super(context, db, table, columnStats);
+    public FullMultiColumnQueryJob(ConnectContext context, long analyzeId,
+                                   Database db, Table table, List<ColumnStats> columnStats) {
+        super(context, analyzeId, db, table, columnStats);
     }
 
     @Override
@@ -40,7 +41,8 @@ public class FullMultiColumnQueryJob extends MultiColumnQueryJob {
             context.put("tableName", table.getName());
             context.put("columnIdsStr", columnStats.getColumnNameStr());
             context.put("ndvFunction", columnStats.getNDV());
-            String sql = HyperStatisticSQLs.build(context, HyperStatisticSQLs.FULL_MULTI_COLUMN_STATISTICS_SELECT_TEMPLATE);
+            String sql = HyperStatisticSQLs.build(
+                    context, HyperStatisticSQLs.FULL_MULTI_COLUMN_STATISTICS_SELECT_TEMPLATE);
             sqlList.add(sql);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullQueryJob.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class FullQueryJob extends HyperQueryJob {
-    protected FullQueryJob(ConnectContext context, Database db,
+    protected FullQueryJob(ConnectContext context, long analyzeId, Database db,
                            Table table,
                            List<ColumnStats> columnStats,
                            List<Long> partitionIdList) {
-        super(context, db, table, columnStats, partitionIdList);
+        super(context, analyzeId, db, table, columnStats, partitionIdList);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/MultiColumnQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/MultiColumnQueryJob.java
@@ -34,17 +34,19 @@ import static com.starrocks.statistic.StatsConstants.COLUMN_ID_SEPARATOR;
 
 public abstract class MultiColumnQueryJob extends HyperQueryJob {
 
-    public MultiColumnQueryJob(ConnectContext context, Database db, Table table, List<ColumnStats> columnStats) {
-        super(context, db, table, columnStats, null);
+    public MultiColumnQueryJob(ConnectContext context, long analyzeId, Database db, Table table, List<ColumnStats> columnStats) {
+        super(context, analyzeId, db, table, columnStats, null);
     }
 
     protected abstract String buildStatisticsQuery();
 
     @Override
     public void queryStatistics() {
+        checkCancelled();
         String sql = buildStatisticsQuery();
         List<TStatisticData> dataList = executeStatisticsQuery(sql, context);
         for (TStatisticData data : dataList) {
+            checkCancelled();
             String tableName = StringEscapeUtils.escapeSql(db.getOriginName() + "." + table.getName());
             sqlBuffer.add(createInsertValueSQL(data, tableName));
             rowsBuffer.add(createInsertValueExpr(data, tableName));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/SampleMultiColumnQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/SampleMultiColumnQueryJob.java
@@ -35,9 +35,9 @@ public class SampleMultiColumnQueryJob extends MultiColumnQueryJob {
     private final SampleInfo sampleInfo;
     private final TabletSampleManager manager;
 
-    public SampleMultiColumnQueryJob(ConnectContext context, Database db, Table table,
+    public SampleMultiColumnQueryJob(ConnectContext context, long analyzeId, Database db, Table table,
                                      List<ColumnStats> columnStats, TabletSampleManager sampleManager) {
-        super(context, db, table, columnStats);
+        super(context, analyzeId, db, table, columnStats);
         this.manager = sampleManager;
         this.sampleInfo = sampleManager.generateSampleInfo();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/SampleQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/SampleQueryJob.java
@@ -28,11 +28,11 @@ import java.util.List;
 public class SampleQueryJob extends HyperQueryJob {
     private final PartitionSampler sampler;
 
-    protected SampleQueryJob(ConnectContext context, Database db,
+    protected SampleQueryJob(ConnectContext context, long analyzeId, Database db,
                              Table table,
                              List<ColumnStats> columnStats,
                              List<Long> partitionIdList, PartitionSampler sampler) {
-        super(context, db, table, columnStats, partitionIdList);
+        super(context, analyzeId, db, table, columnStats, partitionIdList);
         this.sampler = sampler;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/MultiColumnHyperJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/MultiColumnHyperJobTest.java
@@ -83,8 +83,8 @@ public class MultiColumnHyperJobTest extends DistributedEnvPlanTestBase {
     public void testFullMultiColumnHyperJob() {
         List<String> columnNames = List.of("c1", "c2", "c3");
 
-        List<HyperQueryJob> jobs = HyperQueryJob.createMultiColumnQueryJobs(connectContext, db, table, List.of(columnNames),
-                StatsConstants.AnalyzeType.FULL, List.of(StatisticsType.MCDISTINCT), null);
+        List<HyperQueryJob> jobs = HyperQueryJob.createMultiColumnQueryJobs(1L, connectContext, db, table,
+                List.of(columnNames), StatsConstants.AnalyzeType.FULL, List.of(StatisticsType.MCDISTINCT), null);
 
         Assertions.assertEquals(1, jobs.size());
 
@@ -98,8 +98,8 @@ public class MultiColumnHyperJobTest extends DistributedEnvPlanTestBase {
     public void testSampleMultiColumnHyperJob() {
         List<String> columnNames = List.of("c1", "c2", "c3");
 
-        List<HyperQueryJob> jobs = HyperQueryJob.createMultiColumnQueryJobs(connectContext, db, table, List.of(columnNames),
-                StatsConstants.AnalyzeType.SAMPLE, List.of(StatisticsType.MCDISTINCT), new HashMap<>());
+        List<HyperQueryJob> jobs = HyperQueryJob.createMultiColumnQueryJobs(1L, connectContext, db, table,
+                List.of(columnNames), StatsConstants.AnalyzeType.SAMPLE, List.of(StatisticsType.MCDISTINCT), new HashMap<>());
         Assertions.assertEquals(1, jobs.size());
         String sql = ((MultiColumnQueryJob) jobs.get(0)).buildStatisticsQuery();
         String expectedSql = "WITH base_cte_table as (SELECT murmur_hash3_32(coalesce(`c1`, ''), " +


### PR DESCRIPTION
## Why I'm doing:
`KILL ANALYZE <id>` is currently best-effort: it only cancels the currently running internal statistics SQL. When Hyper statistics collection is between SQL executions (building SQL/results), the kill can miss the window, so the ANALYZE task may keep running and require multiple kills.

## What I'm doing:
Make cancellation deterministic for Hyper statistics collection by recording cancellation in `AnalyzeMgr` and checking it frequently inside `HyperQueryJob.queryStatistics()` (before executing each SQL and while iterating results), so the job exits promptly without relying on hitting a running SQL window. Add a unit test to verify the job fails fast after `killConnection(analyzeId)`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
