### PR TITLE
[Enhancement] remove high-cost log location patterns to fix FE latency 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -325,13 +325,11 @@ public class Log4jConfig extends XmlConfiguration {
                             "'level':{'$resolver':'level','field':'name'}," +
                             "'thread.name':{'$resolver':'thread','field':'name'}," +
                             "'thread.id':{'$resolver':'thread','field':'id'}," +
-                            "'line':{'$resolver':'source','field':'lineNumber'}," +
-                            "'file':{'$resolver':'source','field':'fileName'}," +
-                            "'method':{'$resolver':'source','field':'methodName'}," +
+                            "'logger':{'$resolver':'logger','field':'name'}," +
                             "'message':{'$resolver':'message','stringfield':'true'}," +
                             "'exception':{'$resolver':'exception','field':'stackTrace','stackTrace':{'stringified':true,'full':true}}}";
             jsonConfig = jsonConfig.replace("'", "\"");
-            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"true\">\n" +
+            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"false\">\n" +
                     "<EventTemplate><![CDATA[" + jsonConfig + "]]></EventTemplate>\n" + "</JsonTemplateLayout>";
             String jsonLayoutDefault = String.format(jsonLayoutFormatter, Config.sys_log_json_max_string_length);
             String jsonLayoutProfile = String.format(jsonLayoutFormatter, Config.sys_log_json_profile_max_string_length);
@@ -344,9 +342,9 @@ public class Log4jConfig extends XmlConfiguration {
         } else {
             // fallback to plaintext logging
             properties.put("syslog_default_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n\"/>");
             properties.put("syslog_warning_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n %ex\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n%ex\"/>");
             properties.put("syslog_audit_layout",
                     "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
             properties.put("syslog_dump_layout",

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -358,13 +358,11 @@ public class Log4jConfig extends XmlConfiguration {
                             "'level':{'$resolver':'level','field':'name'}," +
                             "'thread.name':{'$resolver':'thread','field':'name'}," +
                             "'thread.id':{'$resolver':'thread','field':'id'}," +
-                            "'line':{'$resolver':'source','field':'lineNumber'}," +
-                            "'file':{'$resolver':'source','field':'fileName'}," +
-                            "'method':{'$resolver':'source','field':'methodName'}," +
+                            "'logger':{'$resolver':'logger','field':'name'}," +
                             "'message':{'$resolver':'message','stringfield':'true'}," +
                             "'exception':{'$resolver':'exception','field':'stackTrace','stackTrace':{'stringified':true,'full':true}}}";
             jsonConfig = jsonConfig.replace("'", "\"");
-            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"true\">\n" +
+            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"false\">\n" +
                     "<EventTemplate><![CDATA[" + jsonConfig + "]]></EventTemplate>\n" + "</JsonTemplateLayout>";
             String jsonLayoutDefault = String.format(jsonLayoutFormatter, Config.sys_log_json_max_string_length);
             String jsonLayoutProfile = String.format(jsonLayoutFormatter, Config.sys_log_json_profile_max_string_length);
@@ -377,9 +375,9 @@ public class Log4jConfig extends XmlConfiguration {
         } else {
             // fallback to plaintext logging
             properties.put("syslog_default_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n\"/>");
             properties.put("syslog_warning_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n %ex\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n%ex\"/>");
             properties.put("syslog_audit_layout",
                     "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
             properties.put("syslog_dump_layout",

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jLocationPatternBenchmark.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jLocationPatternBenchmark.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Benchmark)
+public class Log4jLocationPatternBenchmark {
+    private static final String LOGGER_NAME = "com.starrocks.qe.QeProcessorImpl";
+    private static final ThreadLocal<int[]> FORMATTED_LENGTH = ThreadLocal.withInitial(() -> new int[1]);
+
+    @Param({"%C{1}.%M():%L", "%c{1}"})
+    public String callerPattern;
+
+    private LoggerContext context;
+    private Logger logger;
+
+    public static void main(String[] args) throws IOException {
+        String[] effectiveArgs = new String[args.length + 1];
+        effectiveArgs[0] = Log4jLocationPatternBenchmark.class.getSimpleName();
+        System.arraycopy(args, 0, effectiveArgs, 1, args.length);
+        org.openjdk.jmh.Main.main(effectiveArgs);
+    }
+
+    @Setup(org.openjdk.jmh.annotations.Level.Trial)
+    public void setUp() {
+        context = new LoggerContext(LOGGER_NAME + '-' + callerPattern);
+        DefaultConfiguration configuration = new DefaultConfiguration();
+        context.start(configuration);
+
+        PatternLayout layout = PatternLayout.newBuilder()
+                .withConfiguration(configuration)
+                .withPattern('[' + callerPattern + "] %m%n")
+                .build();
+        FormattingAppender appender = new FormattingAppender("benchmark-appender", layout);
+        appender.start();
+        configuration.addAppender(appender);
+
+        LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.INFO, false);
+        loggerConfig.addAppender(appender, Level.INFO, null);
+        boolean expectedLocation = callerPattern.contains("%C");
+        if (layout.requiresLocation() != expectedLocation || loggerConfig.requiresLocation() != expectedLocation) {
+            throw new IllegalStateException("benchmark does not exercise the expected caller location path");
+        }
+        configuration.addLogger(LOGGER_NAME, loggerConfig);
+        context.updateLoggers();
+        logger = context.getLogger(LOGGER_NAME);
+    }
+
+    @TearDown(org.openjdk.jmh.annotations.Level.Trial)
+    public void tearDown() {
+        context.stop();
+    }
+
+    @Benchmark
+    public int formatOnly() {
+        return logMissingQueryStatus();
+    }
+
+    private int logMissingQueryStatus() {
+        logger.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002");
+        return FORMATTED_LENGTH.get()[0];
+    }
+
+    private static final class FormattingAppender extends AbstractAppender {
+        private FormattingAppender(String name, PatternLayout layout) {
+            super(name, null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            String formattedLog = getLayout().toSerializable(event).toString();
+            FORMATTED_LENGTH.get()[0] = formattedLog.length();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileAppenderBenchmark.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileAppenderBenchmark.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import org.apache.logging.log4j.core.Logger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+// Thread counts are supplied by the JMH CLI. High thread counts are saturation stress cases, not replays of
+// a production arrival pattern.
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Benchmark)
+public class Log4jRollingFileAppenderBenchmark {
+    @Param({"%C{1}.%M():%L", "%c{1}"})
+    public String callerPattern;
+
+    private Log4jRollingFileBenchmarkSupport.Session session;
+    private Logger logger;
+
+    public static void main(String[] args) throws IOException {
+        String[] effectiveArgs = new String[args.length + 1];
+        effectiveArgs[0] = Log4jRollingFileAppenderBenchmark.class.getSimpleName();
+        System.arraycopy(args, 0, effectiveArgs, 1, args.length);
+        org.openjdk.jmh.Main.main(effectiveArgs);
+    }
+
+    @Setup(org.openjdk.jmh.annotations.Level.Trial)
+    public void setUp() throws IOException {
+        session = Log4jRollingFileBenchmarkSupport.open(callerPattern);
+        logger = session.logger();
+    }
+
+    @TearDown(org.openjdk.jmh.annotations.Level.Trial)
+    public void tearDown() throws IOException {
+        session.close();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void latency() {
+        logMissingQueryStatus();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void throughput() {
+        logMissingQueryStatus();
+    }
+
+    private void logMissingQueryStatus() {
+        logger.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileBenchmarkSupport.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileBenchmarkSupport.java
@@ -1,0 +1,209 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.NoOpTriggeringPolicy;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+final class Log4jRollingFileBenchmarkSupport {
+    static final String LOGGER_NAME = "com.starrocks.qe.QeProcessorImpl";
+    private static final ThreadLocal<int[]> FORMATTED_LENGTH = ThreadLocal.withInitial(() -> new int[1]);
+
+    private Log4jRollingFileBenchmarkSupport() {
+    }
+
+    static Session open(String callerPattern) throws IOException {
+        Path logDirectory = Files.createTempDirectory("starrocks-log4j-rolling-");
+        Path logFile = logDirectory.resolve("fe.log");
+        LoggerContext context = new LoggerContext(LOGGER_NAME + '-' + callerPattern);
+        try {
+            Configuration configuration = new org.apache.logging.log4j.core.config.DefaultConfiguration();
+            context.start(configuration);
+            PatternLayout layout = PatternLayout.newBuilder()
+                    .withConfiguration(configuration)
+                    .withPattern("%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [" + callerPattern + "] %m%n")
+                    .build();
+            RollingFileAppender appender = RollingFileAppender.newBuilder()
+                    .setName("Sys")
+                    .setConfiguration(configuration)
+                    .setLayout(layout)
+                    .withFileName(logFile.toString())
+                    .withFilePattern(logFile + ".%i")
+                    // Exercise the real synchronous file write path without adding rollover as another variable.
+                    .withPolicy(NoOpTriggeringPolicy.INSTANCE)
+                    .withAppend(false)
+                    .setBufferedIo(true)
+                    .setImmediateFlush(true)
+                    .build();
+            if (appender == null) {
+                throw new IllegalStateException("failed to create RollingFileAppender");
+            }
+            appender.start();
+            configuration.addAppender(appender);
+
+            LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, org.apache.logging.log4j.Level.INFO, false);
+            loggerConfig.addAppender(appender, org.apache.logging.log4j.Level.INFO, null);
+            configuration.addLogger(LOGGER_NAME, loggerConfig);
+            context.updateLoggers();
+
+            verifyConfiguration(configuration, callerPattern);
+            return new Session(context, context.getLogger(LOGGER_NAME), logDirectory);
+        } catch (RuntimeException e) {
+            if (context.stop(30, TimeUnit.SECONDS)) {
+                try {
+                    deleteDirectory(logDirectory);
+                } catch (IOException cleanupFailure) {
+                    e.addSuppressed(cleanupFailure);
+                }
+            } else {
+                e.addSuppressed(new IllegalStateException("logger context did not stop; temporary logs retained"));
+            }
+            throw e;
+        }
+    }
+
+    static Session openFormatting(String callerPattern) {
+        LoggerContext context = new LoggerContext(LOGGER_NAME + "-format-only-" + callerPattern);
+        try {
+            Configuration configuration = new DefaultConfiguration();
+            context.start(configuration);
+            PatternLayout layout = PatternLayout.newBuilder()
+                    .withConfiguration(configuration)
+                    .withPattern("%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [" +
+                            callerPattern + "] %m%n")
+                    .build();
+            FormattingAppender appender = new FormattingAppender("Formatting", layout);
+            appender.start();
+            configuration.addAppender(appender);
+
+            LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.INFO, false);
+            loggerConfig.addAppender(appender, Level.INFO, null);
+            configuration.addLogger(LOGGER_NAME, loggerConfig);
+            context.updateLoggers();
+
+            verifyLocationRequirement(layout, loggerConfig, callerPattern);
+            return new Session(context, context.getLogger(LOGGER_NAME), null);
+        } catch (RuntimeException e) {
+            context.stop(30, TimeUnit.SECONDS);
+            throw e;
+        }
+    }
+
+    private static void verifyConfiguration(Configuration configuration, String callerPattern) {
+        Appender appender = configuration.getAppender("Sys");
+        if (!(appender instanceof RollingFileAppender)) {
+            throw new IllegalStateException("benchmark must use a real RollingFileAppender");
+        }
+        if (!(appender.getLayout() instanceof PatternLayout)) {
+            throw new IllegalStateException("benchmark must use PatternLayout");
+        }
+        PatternLayout layout = (PatternLayout) appender.getLayout();
+        LoggerConfig loggerConfig = configuration.getLoggerConfig(LOGGER_NAME);
+        verifyLocationRequirement(layout, loggerConfig, callerPattern);
+    }
+
+    private static void verifyLocationRequirement(PatternLayout layout, LoggerConfig loggerConfig,
+                                                  String callerPattern) {
+        boolean expectedLocation = callerPattern.contains("%C");
+        if (layout.requiresLocation() != expectedLocation || loggerConfig.requiresLocation() != expectedLocation) {
+            throw new IllegalStateException("benchmark does not exercise the expected caller location path");
+        }
+    }
+
+    private static void deleteDirectory(Path directory) throws IOException {
+        if (directory == null || !Files.exists(directory)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(directory)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new DeleteFailedException(e);
+                }
+            });
+        } catch (DeleteFailedException e) {
+            throw e.getCause();
+        }
+    }
+
+    static final class Session implements AutoCloseable {
+        private final LoggerContext context;
+        private final Logger logger;
+        private final Path logDirectory;
+
+        private Session(LoggerContext context, Logger logger, Path logDirectory) {
+            this.context = context;
+            this.logger = logger;
+            this.logDirectory = logDirectory;
+        }
+
+        Logger logger() {
+            return logger;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!context.stop(30, TimeUnit.SECONDS)) {
+                throw new IOException("logger context did not stop" +
+                        (logDirectory == null ? "" : "; temporary logs retained at " + logDirectory));
+            }
+            if (logDirectory != null) {
+                deleteDirectory(logDirectory);
+            }
+        }
+    }
+
+    private static final class FormattingAppender extends AbstractAppender {
+        private FormattingAppender(String name, PatternLayout layout) {
+            super(name, null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            String formattedLog = getLayout().toSerializable(event).toString();
+            FORMATTED_LENGTH.get()[0] = formattedLog.length();
+        }
+    }
+
+    private static final class DeleteFailedException extends RuntimeException {
+        private DeleteFailedException(IOException cause) {
+            super(cause);
+        }
+
+        @Override
+        public synchronized IOException getCause() {
+            return (IOException) super.getCause();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileBurstReplay.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jRollingFileBurstReplay.java
@@ -1,0 +1,646 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import org.apache.logging.log4j.core.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+
+// Reconstructs the observed millisecond-bucket arrival counts and uses 122 workers as a production-scale
+// concurrency cap. It does not preserve within-millisecond ordering or per-thread identities. The production
+// schedule preserves the two observed waves; "uniform" is retained as a control.
+// Amplification repeats each observed event at the same timestamp and is always reported separately from 1x.
+// For JDK-8221393, run an isolated Linux JDK 11 JVM with ZGC and a synthetic prefill such as 1000x100 or
+// 1000x500, then use JDK 17 ZGC as the negative control. These sizes are deterministic stress conditions, not
+// production ResolvedMethodTable measurements. A fresh-JVM run uses prefill=0x0. The preconditioner retains
+// generated StackWalker frames, so gc-before-each-burst clears transient caller-location entries while keeping
+// the synthetic table load alive. rolling-file exercises the synchronous RollingFileAppender non-rollover path;
+// format-only removes file-appender serialization to isolate caller-location cost. Each run writes raw CSV,
+// metadata, and a summary.
+public final class Log4jRollingFileBurstReplay {
+    private static final String[] CALLER_PATTERNS = {"%C{1}.%M():%L", "%c{1}"};
+    private static final int PRODUCTION_MESSAGES = 407;
+    private static final int MAX_REPLAY_MESSAGES = 100_000;
+    private static final int MAX_WORKERS = 512;
+    private static final int MAX_TOTAL_CYCLES = 100;
+    private static final int MAX_MEASURED_SAMPLES_PER_PATTERN = 1_000_000;
+    private static final long PRODUCTION_WINDOW_MILLIS = 221;
+    private static final int[][] PRODUCTION_MILLIS_COUNTS = {
+            {0, 3}, {1, 5}, {2, 3}, {3, 4}, {4, 20}, {5, 16}, {6, 16}, {7, 15}, {8, 18}, {9, 15},
+            {10, 16}, {11, 7}, {21, 1}, {32, 1}, {33, 4}, {34, 16}, {35, 24}, {36, 2}, {43, 13},
+            {44, 3}, {46, 2}, {47, 2}, {48, 4}, {49, 1}, {54, 1}, {55, 2}, {213, 27}, {214, 32},
+            {215, 55}, {216, 39}, {217, 11}, {218, 12}, {219, 12}, {220, 4}, {221, 1}
+    };
+
+    private Log4jRollingFileBurstReplay() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        Arguments arguments = Arguments.parse(args);
+        Path output = arguments.output.toAbsolutePath();
+        Path parent = output.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        String environment = environmentDescription(arguments);
+        System.out.println(environment);
+        Path preconditionCycles = Paths.get(output + ".precondition.cycles.csv");
+        String precondition = Log4jStackWalkerPreconditioner.age(
+                arguments.prefillMethods, arguments.prefillCycles, preconditionCycles);
+        List<String> summaries;
+        try (BufferedWriter samples = Files.newBufferedWriter(output, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            samples.write("schedule,amplification,pattern,cycle,order_in_cycle,message,scheduled_offset_ns," +
+                    "actual_start_offset_ns,completion_offset_ns,start_lag_ns,logger_call_latency_ns," +
+                    "end_to_end_ns\n");
+            summaries = runReplay(arguments, samples);
+        }
+        summaries.forEach(System.out::println);
+
+        Path metadata = Paths.get(output + ".metadata.txt");
+        Path summary = Paths.get(output + ".summary.txt");
+        Files.write(metadata, Arrays.asList(environment, precondition), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        Files.write(summary, summaries, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        System.out.println("Raw samples saved to " + output);
+        System.out.println("Environment saved to " + metadata);
+        System.out.println("Summary saved to " + summary);
+    }
+
+    private static List<String> runReplay(Arguments arguments, BufferedWriter output) throws Exception {
+        AtomicInteger threadNumber = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(arguments.workers, runnable -> {
+            Thread thread = new Thread(runnable, "log4j-burst-worker-" + threadNumber.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+        List<PatternRun> patternRuns = new ArrayList<>();
+        Throwable primaryFailure = null;
+        try {
+            int measuredSamples = Math.multiplyExact(
+                    arguments.scheduleOffsets.length, arguments.measurementBursts);
+            for (String callerPattern : CALLER_PATTERNS) {
+                patternRuns.add(new PatternRun(callerPattern,
+                        openSession(callerPattern, arguments.appenderMode), measuredSamples,
+                        arguments.measurementBursts));
+            }
+            int totalCycles = Math.addExact(arguments.warmupBursts, arguments.measurementBursts);
+            int burstSequence = 0;
+            for (int cycle = 0; cycle < totalCycles; cycle++) {
+                boolean newPatternFirst = arguments.newPatternFirst ^ ((cycle & 1) == 1);
+                int[] order = newPatternFirst ? new int[] {1, 0} : new int[] {0, 1};
+                for (int orderInCycle = 0; orderInCycle < order.length; orderInCycle++) {
+                    int patternIndex = order[orderInCycle];
+                    if (burstSequence++ > 0 && arguments.pauseMillis > 0) {
+                        Thread.sleep(arguments.pauseMillis);
+                    }
+                    if (arguments.gcBeforeEachBurst) {
+                        Log4jStackWalkerPreconditioner.requestVerifiedGc();
+                    }
+                    PatternRun patternRun = patternRuns.get(patternIndex);
+                    BurstResult result = runBurst(arguments, executor, patternRun.session.logger());
+                    int measurement = cycle - arguments.warmupBursts;
+                    if (measurement >= 0) {
+                        patternRun.record(measurement, orderInCycle, result);
+                    }
+                }
+            }
+        } catch (Exception | Error t) {
+            primaryFailure = t;
+            throw t;
+        } finally {
+            try {
+                closeResources(executor, patternRuns);
+            } catch (Exception | Error cleanupFailure) {
+                if (primaryFailure != null) {
+                    primaryFailure.addSuppressed(cleanupFailure);
+                } else {
+                    throw cleanupFailure;
+                }
+            }
+        }
+        for (PatternRun patternRun : patternRuns) {
+            patternRun.writeSamples(output, arguments);
+        }
+        List<String> summaries = new ArrayList<>();
+        for (PatternRun patternRun : patternRuns) {
+            summaries.add(patternRun.summary(arguments));
+        }
+        summaries.addAll(pairedSummaries(patternRuns));
+        return summaries;
+    }
+
+    private static Log4jRollingFileBenchmarkSupport.Session openSession(String callerPattern, String appenderMode)
+            throws IOException {
+        if ("format-only".equals(appenderMode)) {
+            return Log4jRollingFileBenchmarkSupport.openFormatting(callerPattern);
+        }
+        return Log4jRollingFileBenchmarkSupport.open(callerPattern);
+    }
+
+    private static void closeResources(ExecutorService executor, List<PatternRun> patternRuns)
+            throws IOException, InterruptedException {
+        executor.shutdownNow();
+        if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("burst executor did not terminate; logger session left open for safety");
+        }
+        IOException closeFailure = null;
+        for (PatternRun patternRun : patternRuns) {
+            try {
+                patternRun.session.close();
+            } catch (IOException e) {
+                if (closeFailure == null) {
+                    closeFailure = e;
+                } else {
+                    closeFailure.addSuppressed(e);
+                }
+            }
+        }
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
+    }
+
+    private static BurstResult runBurst(Arguments arguments, ExecutorService executor, Logger logger)
+            throws InterruptedException {
+        int messages = arguments.scheduleOffsets.length;
+        CountDownLatch ready = new CountDownLatch(Math.min(arguments.workers, messages));
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(messages);
+        long[] actualStartOffsets = new long[messages];
+        long[] completionOffsets = new long[messages];
+        long[] loggerCallLatencies = new long[messages];
+        long[] startLags = new long[messages];
+        long[] endToEndLatencies = new long[messages];
+        AtomicLong burstStart = new AtomicLong();
+        AtomicReference<Throwable> taskFailure = new AtomicReference<>();
+
+        for (int message = 0; message < messages; message++) {
+            int index = message;
+            long scheduledOffset = arguments.scheduleOffsets[index];
+            executor.execute(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    waitUntil(burstStart.get() + scheduledOffset);
+                    long logStart = System.nanoTime();
+                    actualStartOffsets[index] = logStart - burstStart.get();
+                    logMissingQueryStatus(logger);
+                    long logEnd = System.nanoTime();
+                    completionOffsets[index] = logEnd - burstStart.get();
+                    loggerCallLatencies[index] = logEnd - logStart;
+                    startLags[index] = actualStartOffsets[index] - scheduledOffset;
+                    endToEndLatencies[index] = completionOffsets[index] - scheduledOffset;
+                } catch (Throwable t) {
+                    if (t instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
+                    taskFailure.compareAndSet(null, t);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        if (!ready.await(30, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("burst workers did not become ready within 30 seconds");
+        }
+        burstStart.set(System.nanoTime());
+        start.countDown();
+        if (!done.await(2, TimeUnit.MINUTES)) {
+            throw new IllegalStateException("burst did not finish within two minutes");
+        }
+        if (taskFailure.get() != null) {
+            throw new IllegalStateException("burst worker failed", taskFailure.get());
+        }
+        return new BurstResult(actualStartOffsets, completionOffsets, loggerCallLatencies, startLags,
+                endToEndLatencies, Arrays.stream(completionOffsets).max().orElse(0));
+    }
+
+    private static void logMissingQueryStatus(Logger logger) {
+        logger.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002");
+    }
+
+    private static void waitUntil(long deadlineNanos) throws InterruptedException {
+        while (true) {
+            long remaining = deadlineNanos - System.nanoTime();
+            if (remaining <= 0) {
+                return;
+            }
+            LockSupport.parkNanos(remaining);
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+        }
+    }
+
+    private static long[] sorted(List<Long> values) {
+        return values.stream().mapToLong(Long::longValue).sorted().toArray();
+    }
+
+    private static long[] sorted(long[] values) {
+        long[] sorted = values.clone();
+        Arrays.sort(sorted);
+        return sorted;
+    }
+
+    private static String percentiles(long[] sortedValues) {
+        return String.format(Locale.ROOT, "p50=%.3fms p95=%.3fms p99=%.3fms max=%.3fms",
+                nanosToMillis(percentile(sortedValues, 0.50)), nanosToMillis(percentile(sortedValues, 0.95)),
+                nanosToMillis(percentile(sortedValues, 0.99)), nanosToMillis(percentile(sortedValues, 1.00)));
+    }
+
+    private static long percentile(long[] sortedValues, double quantile) {
+        int index = (int) Math.ceil(quantile * sortedValues.length) - 1;
+        return sortedValues[Math.max(0, Math.min(index, sortedValues.length - 1))];
+    }
+
+    private static double nanosToMillis(long nanos) {
+        return nanos / 1_000_000.0;
+    }
+
+    private static List<String> pairedSummaries(List<PatternRun> patternRuns) {
+        if (patternRuns.size() != 2 || patternRuns.get(0).recordedBursts.size() !=
+                patternRuns.get(1).recordedBursts.size()) {
+            throw new IllegalStateException("paired comparison requires two patterns with the same burst count");
+        }
+        PatternRun oldPattern = patternRuns.get(0);
+        PatternRun newPattern = patternRuns.get(1);
+        List<Long> loggerCallP99Deltas = new ArrayList<>();
+        List<Long> endToEndP99Deltas = new ArrayList<>();
+        List<Long> drainDeltas = new ArrayList<>();
+        List<Long> oldFirstLoggerCallP99Deltas = new ArrayList<>();
+        List<Long> newFirstLoggerCallP99Deltas = new ArrayList<>();
+        double[] loggerCallP99Ratios = new double[oldPattern.recordedBursts.size()];
+        List<String> perCycle = new ArrayList<>();
+        for (int index = 0; index < oldPattern.recordedBursts.size(); index++) {
+            RecordedBurst old = oldPattern.recordedBursts.get(index);
+            RecordedBurst replacement = newPattern.recordedBursts.get(index);
+            if (old.cycle != replacement.cycle || old.orderInCycle == replacement.orderInCycle) {
+                throw new IllegalStateException("patterns are not a valid pair for cycle " + index);
+            }
+            long oldLoggerCallP99 = percentile(sorted(old.result.loggerCallLatencies), 0.99);
+            long newLoggerCallP99 = percentile(sorted(replacement.result.loggerCallLatencies), 0.99);
+            long oldEndToEndP99 = percentile(sorted(old.result.endToEndLatencies), 0.99);
+            long newEndToEndP99 = percentile(sorted(replacement.result.endToEndLatencies), 0.99);
+            long oldDrain = old.result.completionNanos - old.result.lastScheduledOffsetNanos;
+            long newDrain = replacement.result.completionNanos - replacement.result.lastScheduledOffsetNanos;
+            loggerCallP99Deltas.add(oldLoggerCallP99 - newLoggerCallP99);
+            endToEndP99Deltas.add(oldEndToEndP99 - newEndToEndP99);
+            drainDeltas.add(oldDrain - newDrain);
+            (old.orderInCycle == 0 ? oldFirstLoggerCallP99Deltas : newFirstLoggerCallP99Deltas)
+                    .add(oldLoggerCallP99 - newLoggerCallP99);
+            loggerCallP99Ratios[index] = oldLoggerCallP99 / (double) Math.max(1, newLoggerCallP99);
+            perCycle.add(String.format(Locale.ROOT,
+                    "pairCycle=%d order=%s oldLoggerCallP99=%.3fms newLoggerCallP99=%.3fms " +
+                            "oldMinusNewLoggerCallP99=%.3fms oldOverNewLoggerCallP99=%.3fx " +
+                            "oldEndToEndP99=%.3fms newEndToEndP99=%.3fms oldDrain=%.3fms newDrain=%.3fms",
+                    old.cycle, old.orderInCycle == 0 ? "old-first" : "new-first",
+                    nanosToMillis(oldLoggerCallP99), nanosToMillis(newLoggerCallP99),
+                    nanosToMillis(oldLoggerCallP99 - newLoggerCallP99), loggerCallP99Ratios[index],
+                    nanosToMillis(oldEndToEndP99), nanosToMillis(newEndToEndP99),
+                    nanosToMillis(oldDrain), nanosToMillis(newDrain)));
+        }
+        Arrays.sort(loggerCallP99Ratios);
+        List<String> result = new ArrayList<>();
+        result.add(String.format(Locale.ROOT,
+                "pairedBurstComparison cycles=%d unit=burst oldMinusNewLoggerCallP99={%s} " +
+                        "oldOverNewLoggerCallP99={%s} oldMinusNewEndToEndP99={%s} " +
+                        "oldMinusNewDrainAfterLastArrival={%s} oldFirstLoggerCallP99Delta={%s} " +
+                        "newFirstLoggerCallP99Delta={%s}",
+                oldPattern.recordedBursts.size(), medianRange(sorted(loggerCallP99Deltas)),
+                ratioMedianRange(loggerCallP99Ratios), medianRange(sorted(endToEndP99Deltas)),
+                medianRange(sorted(drainDeltas)), medianRange(sorted(oldFirstLoggerCallP99Deltas)),
+                medianRange(sorted(newFirstLoggerCallP99Deltas))));
+        result.addAll(perCycle);
+        return result;
+    }
+
+    private static String medianRange(long[] sortedValues) {
+        return String.format(Locale.ROOT, "min=%.3fms p50=%.3fms max=%.3fms",
+                nanosToMillis(sortedValues[0]), nanosToMillis(percentile(sortedValues, 0.50)),
+                nanosToMillis(sortedValues[sortedValues.length - 1]));
+    }
+
+    private static String ratioMedianRange(double[] sortedValues) {
+        return String.format(Locale.ROOT, "min=%.3fx p50=%.3fx max=%.3fx",
+                sortedValues[0], sortedValues[(int) Math.ceil(sortedValues.length * 0.50) - 1],
+                sortedValues[sortedValues.length - 1]);
+    }
+
+    private static String environmentDescription(Arguments arguments) {
+        String garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                .map(bean -> bean.getName())
+                .collect(Collectors.joining("+"));
+        boolean candidateJdk11Zgc = "11".equals(System.getProperty("java.specification.version")) &&
+                garbageCollectors.contains("ZGC");
+        return String.format(Locale.ROOT,
+                "java=%s runtime=%s vendor=%s vm=%s vmVersion=%s gc=%s candidateJdk11Zgc=%s os=%s/%s " +
+                        "processors=%d jvmArgs=%s schedule=%s appender=%s replayModel=millisecond-bucket-upper-bound " +
+                        "amplification=%dx prefillMethods=%d prefillCycles=%d workers=%d messages=%d windowMs=%d " +
+                        "warmupBursts=%d measurementBursts=%d pauseMs=%d gcBeforeEachBurst=%s " +
+                        "pairedAlternating=true initialOrder=%s",
+                System.getProperty("java.version"), System.getProperty("java.runtime.version"),
+                System.getProperty("java.vendor"), System.getProperty("java.vm.name"),
+                System.getProperty("java.vm.version"), garbageCollectors, candidateJdk11Zgc,
+                System.getProperty("os.name"), System.getProperty("os.arch"),
+                Runtime.getRuntime().availableProcessors(), ManagementFactory.getRuntimeMXBean().getInputArguments(),
+                arguments.scheduleName, arguments.appenderMode, arguments.amplification,
+                arguments.prefillMethods, arguments.prefillCycles,
+                arguments.workers,
+                arguments.scheduleOffsets.length, arguments.windowMillis(), arguments.warmupBursts,
+                arguments.measurementBursts, arguments.pauseMillis, arguments.gcBeforeEachBurst,
+                arguments.newPatternFirst ? "new-first" : "old-first");
+    }
+
+    private static final class PatternRun {
+        private final String callerPattern;
+        private final Log4jRollingFileBenchmarkSupport.Session session;
+        private final List<Long> loggerCallLatencies;
+        private final List<Long> startLags;
+        private final List<Long> endToEndLatencies;
+        private final List<Long> burstCompletions;
+        private final List<Long> drainAfterLastArrivals;
+        private final List<RecordedBurst> recordedBursts;
+
+        private PatternRun(String callerPattern, Log4jRollingFileBenchmarkSupport.Session session,
+                           int measuredSamples, int measurementBursts) {
+            this.callerPattern = callerPattern;
+            this.session = session;
+            this.loggerCallLatencies = new ArrayList<>(measuredSamples);
+            this.startLags = new ArrayList<>(measuredSamples);
+            this.endToEndLatencies = new ArrayList<>(measuredSamples);
+            this.burstCompletions = new ArrayList<>(measurementBursts);
+            this.drainAfterLastArrivals = new ArrayList<>(measurementBursts);
+            this.recordedBursts = new ArrayList<>(measurementBursts);
+        }
+
+        private void record(int cycle, int orderInCycle, BurstResult result) {
+            recordedBursts.add(new RecordedBurst(cycle, orderInCycle, result));
+            burstCompletions.add(result.completionNanos);
+            drainAfterLastArrivals.add(result.completionNanos - result.lastScheduledOffsetNanos);
+            for (int message = 0; message < result.loggerCallLatencies.length; message++) {
+                loggerCallLatencies.add(result.loggerCallLatencies[message]);
+                startLags.add(result.startLags[message]);
+                endToEndLatencies.add(result.endToEndLatencies[message]);
+            }
+        }
+
+        private void writeSamples(BufferedWriter output, Arguments arguments) throws IOException {
+            for (RecordedBurst recorded : recordedBursts) {
+                BurstResult result = recorded.result;
+                for (int message = 0; message < result.loggerCallLatencies.length; message++) {
+                    output.write(String.format(Locale.ROOT, "%s,%d,%s,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
+                            arguments.scheduleName, arguments.amplification, callerPattern, recorded.cycle,
+                            recorded.orderInCycle, message, arguments.scheduleOffsets[message],
+                            result.actualStartOffsets[message], result.completionOffsets[message],
+                            result.startLags[message], result.loggerCallLatencies[message],
+                            result.endToEndLatencies[message]));
+                }
+            }
+        }
+
+        private String summary(Arguments arguments) {
+            long[] loggerCall = sorted(loggerCallLatencies);
+            long[] startLag = sorted(startLags);
+            long[] endToEnd = sorted(endToEndLatencies);
+            long[] completion = sorted(burstCompletions);
+            long[] drain = sorted(drainAfterLastArrivals);
+            return String.format(Locale.ROOT,
+                    "schedule=%s amplification=%dx prefill=%dx%d pattern=%s workers=%d messages=%d " +
+                            "windowMs=%d bursts=%d samples=%d loggerCall={%s} startLag={%s} endToEnd={%s} " +
+                            "burstCompletion={%s} drainAfterLastArrival={%s}",
+                    arguments.scheduleName, arguments.amplification, arguments.prefillMethods,
+                    arguments.prefillCycles, callerPattern, arguments.workers, arguments.scheduleOffsets.length,
+                    arguments.windowMillis(), arguments.measurementBursts, loggerCall.length,
+                    percentiles(loggerCall), percentiles(startLag), percentiles(endToEnd),
+                    percentiles(completion), percentiles(drain));
+        }
+    }
+
+    private static final class BurstResult {
+        private final long[] actualStartOffsets;
+        private final long[] completionOffsets;
+        private final long[] loggerCallLatencies;
+        private final long[] startLags;
+        private final long[] endToEndLatencies;
+        private final long completionNanos;
+        private final long lastScheduledOffsetNanos;
+
+        private BurstResult(long[] actualStartOffsets, long[] completionOffsets, long[] loggerCallLatencies,
+                            long[] startLags, long[] endToEndLatencies, long completionNanos) {
+            this.actualStartOffsets = actualStartOffsets;
+            this.completionOffsets = completionOffsets;
+            this.loggerCallLatencies = loggerCallLatencies;
+            this.startLags = startLags;
+            this.endToEndLatencies = endToEndLatencies;
+            this.completionNanos = completionNanos;
+            this.lastScheduledOffsetNanos = completionOffsets.length == 0 ? 0 :
+                    PRODUCTION_WINDOW_MILLIS * TimeUnit.MILLISECONDS.toNanos(1);
+        }
+    }
+
+    private static final class RecordedBurst {
+        private final int cycle;
+        private final int orderInCycle;
+        private final BurstResult result;
+
+        private RecordedBurst(int cycle, int orderInCycle, BurstResult result) {
+            this.cycle = cycle;
+            this.orderInCycle = orderInCycle;
+            this.result = result;
+        }
+    }
+
+    private static final class Arguments {
+        private final String scheduleName;
+        private final int workers;
+        private final int amplification;
+        private final int prefillMethods;
+        private final int prefillCycles;
+        private final int warmupBursts;
+        private final int measurementBursts;
+        private final long pauseMillis;
+        private final Path output;
+        private final boolean newPatternFirst;
+        private final boolean gcBeforeEachBurst;
+        private final String appenderMode;
+        private final long[] scheduleOffsets;
+
+        private Arguments(String scheduleName, int workers, int amplification, int prefillMethods,
+                          int prefillCycles, int warmupBursts, int measurementBursts, long pauseMillis,
+                          Path output, boolean newPatternFirst, boolean gcBeforeEachBurst, String appenderMode) {
+            this.scheduleName = scheduleName;
+            this.workers = workers;
+            this.amplification = amplification;
+            this.prefillMethods = prefillMethods;
+            this.prefillCycles = prefillCycles;
+            this.warmupBursts = warmupBursts;
+            this.measurementBursts = measurementBursts;
+            this.pauseMillis = pauseMillis;
+            this.output = output;
+            this.newPatternFirst = newPatternFirst;
+            this.gcBeforeEachBurst = gcBeforeEachBurst;
+            this.appenderMode = appenderMode;
+            this.scheduleOffsets = createSchedule(scheduleName, amplification);
+        }
+
+        private static Arguments parse(String[] args) {
+            if (args.length != 0 && (args.length < 9 || args.length > 12)) {
+                throw new IllegalArgumentException("usage: [production|uniform workers amplification " +
+                        "prefillMethods prefillCycles warmupBursts measurementBursts pauseMs outputCsv " +
+                        "[old-first|new-first] [gc-before-each-burst|no-gc] " +
+                        "[rolling-file|format-only]]");
+            }
+            Arguments arguments = args.length == 0
+                    ? new Arguments("production", 122, 1, 0, 0, 3, 10, 1000,
+                            Paths.get("log4j-rolling-burst.csv"), false, false, "rolling-file")
+                    : new Arguments(args[0], Integer.parseInt(args[1]), Integer.parseInt(args[2]),
+                            Integer.parseInt(args[3]), Integer.parseInt(args[4]), Integer.parseInt(args[5]),
+                            Integer.parseInt(args[6]), Long.parseLong(args[7]), Paths.get(args[8]),
+                            args.length >= 10 && parseNewPatternFirst(args[9]),
+                            args.length >= 11 && parseGcBeforeEachBurst(args[10]),
+                            args.length == 12 ? parseAppenderMode(args[11]) : "rolling-file");
+            if (arguments.workers <= 0 || arguments.amplification <= 0 || arguments.warmupBursts < 0 ||
+                    arguments.prefillMethods < 0 || arguments.prefillCycles < 0 ||
+                    arguments.measurementBursts <= 0 || arguments.pauseMillis < 0 ||
+                    (arguments.prefillMethods == 0) != (arguments.prefillCycles == 0)) {
+                throw new IllegalArgumentException("workers/amplification/measurementBursts must be positive; " +
+                        "prefillMethods/prefillCycles must both be zero or positive; " +
+                        "warmupBursts/pauseMs must be non-negative");
+            }
+            if (arguments.prefillMethods > 50_000) {
+                throw new IllegalArgumentException("prefillMethods must not exceed 50000");
+            }
+            if ((arguments.measurementBursts & 1) != 0) {
+                throw new IllegalArgumentException("measurementBursts must be even to balance pattern order");
+            }
+            if (arguments.workers > MAX_WORKERS) {
+                throw new IllegalArgumentException("workers must not exceed " + MAX_WORKERS);
+            }
+            long totalCycles = (long) arguments.warmupBursts + arguments.measurementBursts;
+            if (totalCycles > MAX_TOTAL_CYCLES) {
+                throw new IllegalArgumentException("warmupBursts + measurementBursts must not exceed " +
+                        MAX_TOTAL_CYCLES);
+            }
+            long measuredSamples = (long) arguments.scheduleOffsets.length * arguments.measurementBursts;
+            if (measuredSamples > MAX_MEASURED_SAMPLES_PER_PATTERN) {
+                throw new IllegalArgumentException("measured samples per pattern must not exceed " +
+                        MAX_MEASURED_SAMPLES_PER_PATTERN);
+            }
+            if ((long) arguments.prefillMethods * arguments.prefillCycles > 1_000_000) {
+                throw new IllegalArgumentException("prefillMethods * prefillCycles must not exceed 1000000");
+            }
+            return arguments;
+        }
+
+        private static long[] createSchedule(String scheduleName, int amplification) {
+            int messages = checkedMessageCount(amplification);
+            if ("production".equals(scheduleName)) {
+                long[] offsets = new long[messages];
+                int index = 0;
+                for (int[] millisCount : PRODUCTION_MILLIS_COUNTS) {
+                    long offset = TimeUnit.MILLISECONDS.toNanos(millisCount[0]);
+                    for (int count = 0; count < millisCount[1] * amplification; count++) {
+                        offsets[index++] = offset;
+                    }
+                }
+                if (index != offsets.length) {
+                    throw new IllegalStateException("production schedule must contain 407 messages");
+                }
+                return offsets;
+            }
+            if ("uniform".equals(scheduleName)) {
+                long[] offsets = new long[messages];
+                long windowNanos = TimeUnit.MILLISECONDS.toNanos(PRODUCTION_WINDOW_MILLIS);
+                for (int index = 0; index < messages; index++) {
+                    offsets[index] = messages == 1 ? 0 : windowNanos * index / (messages - 1);
+                }
+                return offsets;
+            }
+            throw new IllegalArgumentException("schedule must be production or uniform");
+        }
+
+        private static int checkedMessageCount(int amplification) {
+            if (amplification <= 0) {
+                throw new IllegalArgumentException("amplification must be positive");
+            }
+            int messages;
+            try {
+                messages = Math.multiplyExact(PRODUCTION_MESSAGES, amplification);
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException("amplification is too large", e);
+            }
+            if (messages > MAX_REPLAY_MESSAGES) {
+                throw new IllegalArgumentException("replay must not exceed " + MAX_REPLAY_MESSAGES + " messages");
+            }
+            return messages;
+        }
+
+        private static boolean parseNewPatternFirst(String order) {
+            if ("new-first".equals(order)) {
+                return true;
+            }
+            if ("old-first".equals(order)) {
+                return false;
+            }
+            throw new IllegalArgumentException("pattern order must be old-first or new-first");
+        }
+
+        private static boolean parseGcBeforeEachBurst(String gcMode) {
+            if ("gc-before-each-burst".equals(gcMode)) {
+                return true;
+            }
+            if ("no-gc".equals(gcMode)) {
+                return false;
+            }
+            throw new IllegalArgumentException("GC mode must be gc-before-each-burst or no-gc");
+        }
+
+        private static String parseAppenderMode(String appenderMode) {
+            if ("rolling-file".equals(appenderMode) || "format-only".equals(appenderMode)) {
+                return appenderMode;
+            }
+            throw new IllegalArgumentException("appender mode must be rolling-file or format-only");
+        }
+
+        private long windowMillis() {
+            return TimeUnit.NANOSECONDS.toMillis(scheduleOffsets[scheduleOffsets.length - 1]);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jStackWalkerPreconditioner.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/Log4jStackWalkerPreconditioner.java
@@ -1,0 +1,480 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+// Creates and retains unique StackWalker frames to keep a deterministic synthetic load in the
+// ResolvedMethodTable. The requested entry count is not a production measurement. It models the large pre-cleanup
+// table reported by JDK-8221393 without depending on when a particular collector unlinks dead weak entries.
+final class Log4jStackWalkerPreconditioner {
+    private static final String GENERATED_CLASS_PREFIX = "Log4jGeneratedStackFrames";
+    private static final String PRECOMPILED_CLASS_DIRECTORY_PROPERTY = "log4j.precondition.classDir";
+    private static final int MAX_PREFILL_ENTRIES = 1_000_000;
+    private static final long GC_TIMEOUT_MILLIS = 10_000;
+    private static final List<StackWalker.StackFrame> RETAINED_FRAMES = new ArrayList<>();
+
+    private Log4jStackWalkerPreconditioner() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 4 && "generate".equals(args[0])) {
+            int methodCount = parseMethodCount(args[1]);
+            int cycles = parseCycles(args[2]);
+            validateTotalEntries(methodCount, cycles);
+            Path outputDirectory = Paths.get(args[3]).toAbsolutePath();
+            Files.createDirectories(outputDirectory);
+            compileGeneratedClasses(methodCount, cycles, outputDirectory);
+            System.out.printf("Generated %,d unique StackWalker frame methods in %s sha256=%s%n",
+                    (long) methodCount * cycles, outputDirectory,
+                    generatedClassesSha256(outputDirectory, cycles));
+            return;
+        }
+        if (args.length != 2 && args.length != 3) {
+            throw new IllegalArgumentException("usage: prefillMethods prefillCycles [outputFile], or " +
+                    "generate prefillMethods prefillCycles outputDirectory");
+        }
+        int methodCount = parseMethodCount(args[0]);
+        int cycles = parseCycles(args[1]);
+        validateTotalEntries(methodCount, cycles);
+        String garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                .map(GarbageCollectorMXBean::getName)
+                .collect(Collectors.joining("+"));
+        String environment = String.format(Locale.ROOT,
+                "java=%s runtime=%s vendor=%s vm=%s vmVersion=%s gc=%s jvmArgs=%s",
+                System.getProperty("java.version"), System.getProperty("java.runtime.version"),
+                System.getProperty("java.vendor"), System.getProperty("java.vm.name"),
+                System.getProperty("java.vm.version"), garbageCollectors,
+                ManagementFactory.getRuntimeMXBean().getInputArguments());
+        System.out.println(environment);
+        Path outputFile = args.length == 3 ? Paths.get(args[2]).toAbsolutePath() : null;
+        Path cycleOutputFile = outputFile == null ? null : Paths.get(outputFile + ".cycles.csv");
+        String result = age(methodCount, cycles, cycleOutputFile);
+        if (args.length == 3) {
+            Path parent = outputFile.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.write(outputFile, Arrays.asList(environment, result), StandardCharsets.UTF_8);
+            System.out.println("Precondition result saved to " + outputFile);
+            System.out.println("Per-cycle precondition data saved to " + cycleOutputFile);
+        }
+    }
+
+    static String age(int methodCount, int cycles) throws Exception {
+        return age(methodCount, cycles, null);
+    }
+
+    static String age(int methodCount, int cycles, Path cycleOutputFile) throws Exception {
+        if (methodCount == 0 && cycles == 0) {
+            return "StackWalker precondition disabled";
+        }
+        validateTotalEntries(methodCount, cycles);
+        if (!RETAINED_FRAMES.isEmpty()) {
+            throw new IllegalStateException("StackWalker precondition may only run once per JVM");
+        }
+        AgingResult agingResult;
+        String precompiledDirectory = System.getProperty(PRECOMPILED_CLASS_DIRECTORY_PROPERTY);
+        boolean deleteCompileDirectory = precompiledDirectory == null;
+        Path compileDirectory = deleteCompileDirectory
+                ? Files.createTempDirectory("starrocks-log4j-stackwalker-")
+                : Paths.get(precompiledDirectory).toAbsolutePath();
+        try {
+            if (deleteCompileDirectory) {
+                compileGeneratedClasses(methodCount, cycles, compileDirectory);
+            } else if (!containsGeneratedClasses(compileDirectory, cycles)) {
+                throw new IllegalStateException("precompiled StackWalker class not found in " + compileDirectory);
+            }
+
+            String generatedClassesSha256 = generatedClassesSha256(compileDirectory, cycles);
+            long startNanos = System.nanoTime();
+            ClassLoader parentLoader = Log4jStackWalkerPreconditioner.class.getClassLoader();
+            try (URLClassLoader loader = new URLClassLoader(
+                    new URL[] {compileDirectory.toUri().toURL()}, parentLoader)) {
+                agingResult = fillResolvedMethodTable(loader, methodCount, cycles);
+            }
+            if (cycleOutputFile != null) {
+                agingResult.writeCycles(cycleOutputFile);
+            }
+            String result = String.format(Locale.ROOT,
+                    "StackWalker precondition completed: methodsPerClass=%d classes=%d retainedFrames=%d " +
+                            "generatedClasses=%s generatedClassesSha256=%s fillGcCountDelta=%d " +
+                            "postFillGcCountDelta=%d " +
+                            "elapsed=%.3fs cycleDuration={%s} first10Mean=%.3fms last10Mean=%.3fms " +
+                            "lastOverFirst=%.3fx noCompletedGcFirst10={%s} noCompletedGcLast10={%s} " +
+                            "noCompletedGcLastOverFirst=%s. The retained frame count and cycle measurements do " +
+                            "not by " +
+                            "themselves prove table layout; confirm it with -Xlog:membername+table=trace on the " +
+                            "candidate JDK 11 ZGC runtime.",
+                    methodCount, cycles, agingResult.retainedFrames,
+                    deleteCompileDirectory ? "in-process" : "precompiled", generatedClassesSha256,
+                    agingResult.fillGcCountDelta, agingResult.postFillGcCountDelta,
+                    (System.nanoTime() - startNanos) / (double) TimeUnit.SECONDS.toNanos(1),
+                    agingResult.durationSummary(), nanosToMillis(agingResult.firstDecileMean()),
+                    nanosToMillis(agingResult.lastDecileMean()),
+                    agingResult.lastDecileMean() / (double) agingResult.firstDecileMean(),
+                    agingResult.noCompletedGcFirstDecileSummary(),
+                    agingResult.noCompletedGcLastDecileSummary(),
+                    agingResult.noCompletedGcLastOverFirst());
+            System.out.println(result);
+            return result;
+        } finally {
+            if (deleteCompileDirectory) {
+                deleteDirectory(compileDirectory);
+            }
+        }
+    }
+
+    static long requestVerifiedGc() {
+        if (ManagementFactory.getRuntimeMXBean().getInputArguments().contains("-XX:+DisableExplicitGC")) {
+            throw new IllegalStateException("explicit GC is disabled by -XX:+DisableExplicitGC");
+        }
+        long collectionsBefore = completedGcCycles();
+        System.gc();
+        return awaitCompletedGcCycle(collectionsBefore) - collectionsBefore;
+    }
+
+    private static int parseMethodCount(String value) {
+        int methodCount = Integer.parseInt(value);
+        if (methodCount <= 0 || methodCount > 50_000) {
+            throw new IllegalArgumentException("prefillMethods must be positive and must not exceed 50000");
+        }
+        return methodCount;
+    }
+
+    private static int parseCycles(String value) {
+        int cycles = Integer.parseInt(value);
+        if (cycles <= 0) {
+            throw new IllegalArgumentException("prefillCycles must be positive");
+        }
+        return cycles;
+    }
+
+    private static void validateTotalEntries(int methodCount, int cycles) {
+        long entries = (long) methodCount * cycles;
+        if (entries > MAX_PREFILL_ENTRIES) {
+            throw new IllegalArgumentException("prefillMethods * prefillCycles must not exceed " +
+                    MAX_PREFILL_ENTRIES);
+        }
+    }
+
+    private static boolean containsGeneratedClasses(Path compileDirectory, int cycles) {
+        return Files.isRegularFile(compileDirectory.resolve(generatedClassName(0) + ".class")) &&
+                Files.isRegularFile(compileDirectory.resolve(generatedClassName(cycles - 1) + ".class"));
+    }
+
+    private static void compileGeneratedClasses(int methodCount, int cycles, Path compileDirectory)
+            throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("a full JDK is required to generate StackWalker frame methods");
+        }
+        List<String> compilerArguments = new ArrayList<>();
+        compilerArguments.add("--release");
+        compilerArguments.add("11");
+        compilerArguments.add("-d");
+        compilerArguments.add(compileDirectory.toString());
+        for (int cycle = 0; cycle < cycles; cycle++) {
+            String className = generatedClassName(cycle);
+            Path sourceFile = compileDirectory.resolve(className + ".java");
+            Files.write(sourceFile, generatedSource(className, methodCount).getBytes(StandardCharsets.UTF_8));
+            compilerArguments.add(sourceFile.toString());
+        }
+        ByteArrayOutputStream compilerOutput = new ByteArrayOutputStream();
+        int exitCode = compiler.run(null, compilerOutput, compilerOutput,
+                compilerArguments.toArray(new String[0]));
+        if (exitCode != 0) {
+            throw new IllegalStateException("failed to compile StackWalker precondition class: " +
+                    compilerOutput.toString(StandardCharsets.UTF_8.name()));
+        }
+    }
+
+    private static String generatedClassName(int cycle) {
+        return GENERATED_CLASS_PREFIX + cycle;
+    }
+
+    private static String generatedClassesSha256(Path compileDirectory, int cycles) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (int cycle = 0; cycle < cycles; cycle++) {
+                Path classFile = compileDirectory.resolve(generatedClassName(cycle) + ".class");
+                digest.update(classFile.getFileName().toString().getBytes(StandardCharsets.UTF_8));
+                digest.update(Files.readAllBytes(classFile));
+            }
+            StringBuilder result = new StringBuilder(64);
+            for (byte value : digest.digest()) {
+                result.append(String.format(Locale.ROOT, "%02x", value & 0xff));
+            }
+            return result.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private static String generatedSource(String className, int methodCount) {
+        StringBuilder source = new StringBuilder(methodCount * 64);
+        source.append("public final class ").append(className).append(" {\n");
+        for (int method = 0; method < methodCount; method++) {
+            source.append("  public static void frame").append(method)
+                    .append("(Runnable capture) { capture.run(); }\n");
+        }
+        return source.append("}\n").toString();
+    }
+
+    private static AgingResult fillResolvedMethodTable(URLClassLoader loader, int expectedMethodCount, int cycles)
+            throws Exception {
+        StackWalker stackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+        long[] cycleDurations = new long[cycles];
+        long[] cycleGcCountDeltas = new long[cycles];
+        int[] retainedFramesAfterCycles = new int[cycles];
+        int progressInterval = Math.max(1, cycles / 10);
+        long fillGcCountBefore = completedGcCycles();
+        long agingStartNanos = System.nanoTime();
+        for (int cycle = 0; cycle < cycles; cycle++) {
+            long cycleGcCountBefore = completedGcCycles();
+            long cycleStartNanos = System.nanoTime();
+            Class<?> generatedClass = Class.forName(generatedClassName(cycle), true, loader);
+            Runnable capture = () -> retainGeneratedFrame(stackWalker, generatedClass);
+            Method[] generatedMethods = Stream.of(generatedClass.getDeclaredMethods())
+                    .filter(method -> method.getName().startsWith("frame"))
+                    .toArray(Method[]::new);
+            if (generatedMethods.length != expectedMethodCount) {
+                throw new IllegalStateException("generated class does not contain the requested number of methods");
+            }
+            for (Method method : generatedMethods) {
+                method.invoke(null, capture);
+            }
+            cycleDurations[cycle] = System.nanoTime() - cycleStartNanos;
+            cycleGcCountDeltas[cycle] = completedGcCycles() - cycleGcCountBefore;
+            retainedFramesAfterCycles[cycle] = RETAINED_FRAMES.size();
+            if ((cycle + 1) % progressInterval == 0 || cycle + 1 == cycles) {
+                System.out.printf(Locale.ROOT, "StackWalker precondition progress: cycle=%d/%d elapsed=%.3fs%n",
+                        cycle + 1, cycles,
+                        (System.nanoTime() - agingStartNanos) / (double) TimeUnit.SECONDS.toNanos(1));
+            }
+        }
+        int expectedFrames = Math.multiplyExact(expectedMethodCount, cycles);
+        if (RETAINED_FRAMES.size() != expectedFrames) {
+            throw new IllegalStateException("did not retain the requested number of StackWalker frames");
+        }
+        long fillGcCountDelta = completedGcCycles() - fillGcCountBefore;
+        long postFillGcCountDelta = requestVerifiedGc();
+        return new AgingResult(fillGcCountDelta, postFillGcCountDelta, RETAINED_FRAMES.size(),
+                cycleDurations, cycleGcCountDeltas, retainedFramesAfterCycles);
+    }
+
+    private static void retainGeneratedFrame(StackWalker stackWalker, Class<?> generatedClass) {
+        List<StackWalker.StackFrame> generatedFrames = stackWalker.walk(frames -> frames
+                .filter(frame -> frame.getDeclaringClass() == generatedClass)
+                .collect(Collectors.toList()));
+        if (generatedFrames.size() != 1) {
+            throw new IllegalStateException("generated StackWalker frame not found");
+        }
+        RETAINED_FRAMES.add(generatedFrames.get(0));
+    }
+
+    private static long completedGcCycles() {
+        boolean hasCycleCollector = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                .anyMatch(collector -> collector.getName().contains("Cycles"));
+        long completed = 0;
+        boolean supported = false;
+        for (GarbageCollectorMXBean collector : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (hasCycleCollector && !collector.getName().contains("Cycles")) {
+                continue;
+            }
+            long collectionCount = collector.getCollectionCount();
+            if (collectionCount >= 0) {
+                completed += collectionCount;
+                supported = true;
+            }
+        }
+        if (!supported) {
+            throw new IllegalStateException("GC collection counters are unavailable");
+        }
+        return completed;
+    }
+
+    private static long awaitCompletedGcCycle(long collectionsBefore) {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(GC_TIMEOUT_MILLIS);
+        while (completedGcCycles() <= collectionsBefore) {
+            if (System.nanoTime() >= deadline) {
+                throw new IllegalStateException("explicit GC did not complete; check -XX:+DisableExplicitGC");
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+        }
+        return completedGcCycles();
+    }
+
+    private static double nanosToMillis(long nanos) {
+        return nanos / 1_000_000.0;
+    }
+
+    private static void deleteDirectory(Path directory) throws IOException {
+        if (!Files.exists(directory)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(directory)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new DeleteFailedException(e);
+                }
+            });
+        } catch (DeleteFailedException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static final class DeleteFailedException extends RuntimeException {
+        private DeleteFailedException(IOException cause) {
+            super(cause);
+        }
+
+        @Override
+        public synchronized IOException getCause() {
+            return (IOException) super.getCause();
+        }
+    }
+
+    private static final class AgingResult {
+        private final long fillGcCountDelta;
+        private final long postFillGcCountDelta;
+        private final int retainedFrames;
+        private final long[] cycleDurations;
+        private final long[] cycleGcCountDeltas;
+        private final int[] retainedFramesAfterCycles;
+
+        private AgingResult(long fillGcCountDelta, long postFillGcCountDelta, int retainedFrames,
+                            long[] cycleDurations, long[] cycleGcCountDeltas, int[] retainedFramesAfterCycles) {
+            this.fillGcCountDelta = fillGcCountDelta;
+            this.postFillGcCountDelta = postFillGcCountDelta;
+            this.retainedFrames = retainedFrames;
+            this.cycleDurations = cycleDurations;
+            this.cycleGcCountDeltas = cycleGcCountDeltas;
+            this.retainedFramesAfterCycles = retainedFramesAfterCycles;
+        }
+
+        private void writeCycles(Path outputFile) throws IOException {
+            Path parent = outputFile.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            try (java.io.BufferedWriter output = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
+                output.write("cycle,duration_ns,gc_count_delta,retained_frames_after_cycle\n");
+                for (int cycle = 0; cycle < cycleDurations.length; cycle++) {
+                    output.write(String.format(Locale.ROOT, "%d,%d,%d,%d%n", cycle, cycleDurations[cycle],
+                            cycleGcCountDeltas[cycle], retainedFramesAfterCycles[cycle]));
+                }
+            }
+        }
+
+        private String durationSummary() {
+            long[] sorted = cycleDurations.clone();
+            Arrays.sort(sorted);
+            return String.format(Locale.ROOT, "p50=%.3fms p95=%.3fms p99=%.3fms max=%.3fms",
+                    nanosToMillis(sorted[sorted.length / 2]),
+                    nanosToMillis(sorted[(int) Math.ceil(sorted.length * 0.95) - 1]),
+                    nanosToMillis(sorted[(int) Math.ceil(sorted.length * 0.99) - 1]),
+                    nanosToMillis(sorted[sorted.length - 1]));
+        }
+
+        private long firstDecileMean() {
+            return mean(0, decileSize());
+        }
+
+        private long lastDecileMean() {
+            return mean(cycleDurations.length - decileSize(), cycleDurations.length);
+        }
+
+        private String noCompletedGcFirstDecileSummary() {
+            return noCompletedGcSummary(0, decileSize());
+        }
+
+        private String noCompletedGcLastDecileSummary() {
+            return noCompletedGcSummary(cycleDurations.length - decileSize(), cycleDurations.length);
+        }
+
+        private String noCompletedGcLastOverFirst() {
+            long first = noCompletedGcMean(0, decileSize());
+            long last = noCompletedGcMean(cycleDurations.length - decileSize(), cycleDurations.length);
+            return first < 0 || last < 0 ? "n/a" : String.format(Locale.ROOT, "%.3fx", last / (double) first);
+        }
+
+        private int decileSize() {
+            return Math.max(1, cycleDurations.length / 10);
+        }
+
+        private long mean(int startInclusive, int endExclusive) {
+            long total = 0;
+            for (int index = startInclusive; index < endExclusive; index++) {
+                total += cycleDurations[index];
+            }
+            return total / (endExclusive - startInclusive);
+        }
+
+        private String noCompletedGcSummary(int startInclusive, int endExclusive) {
+            int count = noCompletedGcCount(startInclusive, endExclusive);
+            long mean = noCompletedGcMean(startInclusive, endExclusive);
+            return count == 0 ? "cycles=0 mean=n/a" :
+                    String.format(Locale.ROOT, "cycles=%d mean=%.3fms", count, nanosToMillis(mean));
+        }
+
+        private int noCompletedGcCount(int startInclusive, int endExclusive) {
+            int count = 0;
+            for (int index = startInclusive; index < endExclusive; index++) {
+                if (cycleGcCountDeltas[index] == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        private long noCompletedGcMean(int startInclusive, int endExclusive) {
+            long total = 0;
+            int count = 0;
+            for (int index = startInclusive; index < endExclusive; index++) {
+                if (cycleGcCountDeltas[index] == 0) {
+                    total += cycleDurations[index];
+                    count++;
+                }
+            }
+            return count == 0 ? -1 : total / count;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
@@ -87,6 +87,26 @@ public class Log4jConfigTest {
     }
 
     @Test
+    public void testLogLayoutsDisableLocationLookup() throws IOException {
+        Config.sys_log_format = "plaintext";
+        String plaintextConfig = Log4jConfig.generateActiveLog4jXmlConfig();
+        Assertions.assertFalse(plaintextConfig.contains("%C"));
+        Assertions.assertFalse(plaintextConfig.contains("%M"));
+        Assertions.assertFalse(plaintextConfig.contains("%L"));
+        Assertions.assertTrue(plaintextConfig.contains("%c{1}"));
+
+        Config.sys_log_format = "json";
+        String jsonConfig = Log4jConfig.generateActiveLog4jXmlConfig();
+        Assertions.assertTrue(jsonConfig.contains("locationInfoEnabled=\"false\""));
+        Assertions.assertFalse(jsonConfig.contains("\"$resolver\":\"source\""));
+        Assertions.assertFalse(jsonConfig.contains("\"field\":\"lineNumber\""));
+        Assertions.assertFalse(jsonConfig.contains("\"field\":\"fileName\""));
+        Assertions.assertFalse(jsonConfig.contains("\"field\":\"methodName\""));
+        Assertions.assertTrue(jsonConfig.contains("\"thread.id\":{\"$resolver\":\"thread\",\"field\":\"id\"}"));
+        Assertions.assertTrue(jsonConfig.contains("\"logger\":{\"$resolver\":\"logger\",\"field\":\"name\"}"));
+    }
+
+    @Test
     public void testJsonLogOutputFormat() throws IOException {
         // enable logging with json format to console
         // with `sys_log_to_console = true`, the log will be written to System.err
@@ -116,8 +136,10 @@ public class Log4jConfigTest {
         Reader reader = new InputStreamReader(new ByteArrayInputStream(byteOs.toByteArray()));
         JsonObject jsonObject = Streams.parse(new JsonReader(reader)).getAsJsonObject();
 
-        Assertions.assertEquals("testJsonLogOutputFormat", jsonObject.get("method").getAsString());
-        Assertions.assertEquals("Log4jConfigTest.java", jsonObject.get("file").getAsString());
+        Assertions.assertFalse(jsonObject.has("method"));
+        Assertions.assertFalse(jsonObject.has("file"));
+        Assertions.assertFalse(jsonObject.has("line"));
+        Assertions.assertEquals(Log4jConfigTest.class.getName(), jsonObject.get("logger").getAsString());
         Assertions.assertEquals("WARN", jsonObject.get("level").getAsString());
         Assertions.assertEquals(logMessage, jsonObject.get("message").getAsString());
     }


### PR DESCRIPTION
## Why I'm doing this

FE production monitoring observed HTTP/JDBC latency spikes, sometimes reaching 10s to 14s.

In one dial-test case, Arthas showed that most of the latency in the connection path was spent in Log4j2 caller-location lookup rather than log file I/O. The affected FE nodes were already using NVMe disks, and the trace showed the time under `StackLocator.calcLocation()` / `StackWalker.walk()`:

```text
---[5354.485427ms] com.starrocks.mysql.nio.AcceptListener:handleEvent()
    +---[3103.027647ms] org.apache.logging.log4j.Logger:info()
        ---[2643.006046ms] org.apache.logging.log4j.util.StackLocator:calcLocation()
            ---[2622.302338ms] java.lang.StackWalker:walk()
```

When the log layout contains `%C`, `%M`, `%L`, or JSON `source` resolvers, Log4j2 needs to walk the stack to resolve caller class, method, file, and line number for each emitted log event. This cost is usually unnecessary in production FE logs.

## Scope of the issue

This is likely a general production risk rather than a problem tied to one specific log statement.

The mechanism is common: when `%C`, `%M`, `%L`, or JSON `source` resolvers are configured, caller-location lookup introduces stack walking into the logging path for emitted FE log events.

The visible impact is workload-dependent. A single `StackWalker.walk()` may be cheap in some clusters or observation windows. However, production FE workloads contain many hot log paths, including connection handling, query registration, transaction replay, scheduler tasks, and schema-change replay. If caller-location lookup happens on a hot path or while metadata locks are held, the cost can be amplified into visible latency.

We observed this in at least two production cases:

- a dial-test connection path, where `AcceptListener.handleEvent()` spent most of its time in `Logger.info()` / `StackWalker.walk()`;
- a schema-change replay case on an older 3.1-based branch, where the table had about 20k partitions and replay/finish emitted one `visualise the shadow index` INFO log per partition while metadata DB write locks were held.

In the schema-change case, the DB lock information is important. The slow-lock dump showed the `replayer` thread holding a metadata DB write lock for about 30s, while several `starrocks-mysql-nio-pool-*` threads were waiting for the same lock. The `replayer` stack was inside:

```text
StackWalker.walk
  -> StackLocator.calcLocation
  -> AbstractLogger.info
  -> PhysicalPartition.visualiseShadowIndex
  -> SchemaChangeJobV2.replayFinished
  -> EditLog.loadJournal
  -> GlobalStateMgr.replayJournalInner
```

So this was not only high-frequency logging. It was high-frequency caller-location lookup while a metadata DB write lock was held, which amplified the impact on FE latency.

This PR does not claim that every FE latency issue is caused by logging. It removes an avoidable stack-walking cost from production FE logging layouts.

## Latency improvement after the change

After applying this change in affected production clusters, FE latency dropped significantly.

Observed improvements include:

- FE HTTP request latency dropped from second-level spikes to millisecond-level in affected clusters.
- Dial-test query latency became stable after removing caller-location lookup.
- In the schema-change replay case, replay/finish became much faster because high-frequency INFO logs no longer triggered stack walking while metadata locks were held.

### FE HTTP latency improvement
<img width="556" height="228" alt="image" src="https://github.com/user-attachments/assets/1da22afb-a29f-4ec5-ae38-057120d564d2" />
<img width="1213" height="231" alt="image" src="https://github.com/user-attachments/assets/52f815f3-1f47-4490-88d0-9d8260e2b7d7" />

### Dial-test latency improvement

<img width="555" height="190" alt="image" src="https://github.com/user-attachments/assets/91dda621-5c3f-40bd-831c-bdca0c7486bd" />

## What I'm doing

Optimize FE logging layouts by removing caller-location lookup from production log patterns:

- Plaintext layout: replace `%C{1}.%M():%L` with logger name `%c{1}`.
- JSON layout: remove `source` resolvers for `line`, `file`, and `method`, and set `locationInfoEnabled="false"`.
- Keep useful class identification through the logger name, which does not require stack walking.

## Tests

Added regression tests to verify that:

- plaintext layout no longer contains `%C`, `%M`, or `%L`;
- plaintext layout still contains logger name `%c{1}`;
- JSON layout disables location info and does not contain `source` resolvers;
- JSON log output remains valid and still includes useful fields such as `level`, `logger`, `thread`, and `message`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
