### PR TITLE
[BugFix] Fixing derived dictionary translations for expressions with f(null) != null (backport #69376)

### DIFF
--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -374,11 +374,10 @@ Status DictOptimizeParser::_eval_and_rewrite(ExprContext* ctx, Expr* expr, DictO
         ColumnBuilder<LowCardDictType> builder(codes.size());
         // build code convert map
         for (int i = 0; i < num_rows; ++i) {
+            dict_opt_ctx->code_convert_map[codes[i]] = i;
             if (viewer.is_null(i)) {
-                dict_opt_ctx->code_convert_map[codes[i]] = 0;
                 builder.append_null();
             } else {
-                dict_opt_ctx->code_convert_map[codes[i]] = i;
                 builder.append(result_map.find(viewer.value(i))->second);
             }
         }

--- a/be/test/exprs/dict_expr_test.cpp
+++ b/be/test/exprs/dict_expr_test.cpp
@@ -213,4 +213,56 @@ TEST_F(DictMappingTest, test_function_return_exception) {
     }
 }
 
+TEST_F(DictMappingTest, test_expression_returns_null_for_some_values) {
+    // Test case for expression that returns NULL for some dictionary values
+    // and non-NULL strings for others. This simulates: if(v1 = '1', NULL, 'ok')
+    auto origin = pool.add(new ProvideExpr([](const ColumnPtr& column) {
+        ColumnViewer<TYPE_VARCHAR> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(column->size());
+        size_t num_rows = column->size();
+        for (size_t i = 0; i < num_rows; ++i) {
+            if (viewer.is_null(i)) {
+                builder.append("ok");
+            } else if (viewer.value(i) == "1") {
+                builder.append_null();
+            } else {
+                builder.append("ok");
+            }
+        }
+        return builder.build(false);
+    }));
+    auto pl = pool.add(new PlaceHolderRef(node));
+    origin->add_child(pl);
+
+    auto slot = pool.add(new ColumnRef(TypeDescriptor(TYPE_INT), 1));
+    dict_expr = pool.add(new DictMappingExpr(node));
+    context = pool.add(new ExprContext(dict_expr));
+    dict_expr->add_child(slot);
+    dict_expr->add_child(origin);
+
+    ASSERT_OK(context->prepare(&state));
+    ASSERT_OK(context->open(&state));
+
+    auto chunk = std::make_unique<Chunk>();
+    auto dict_column = Int32Column::create();
+    dict_column->get_data().emplace_back(1); // '1' -> should be NULL
+    dict_column->get_data().emplace_back(2); // '2' -> should be 'ok'
+    dict_column->get_data().emplace_back(3); // '3' -> should be 'ok'
+    dict_column->get_data().emplace_back(4); // '4' -> should be 'ok'
+    auto nullable_column = NullableColumn::wrap_if_necessary(dict_column);
+    chunk->append_column(nullable_column, 1);
+    auto result = context->evaluate(chunk.get());
+    ASSERT_OK(result.status());
+    auto result_column = result.value();
+    ASSERT_TRUE(result_column->is_nullable());
+    auto* nullable_result = down_cast<const NullableColumn*>(result_column.get());
+    EXPECT_TRUE(nullable_result->is_null(0)) << "Input '1' should produce NULL";
+    EXPECT_FALSE(nullable_result->is_null(1)) << "Input '2' should produce 'ok'";
+    EXPECT_EQ(nullable_result->get(1).get_slice(), "ok");
+    EXPECT_FALSE(nullable_result->is_null(2)) << "Input '3' should produce 'ok'";
+    EXPECT_EQ(nullable_result->get(2).get_slice(), "ok");
+    EXPECT_FALSE(nullable_result->is_null(3)) << "Input '4' should produce 'ok'";
+    EXPECT_EQ(nullable_result->get(3).get_slice(), "ok");
+}
+
 } // namespace starrocks

--- a/test/sql/test_global_dict/R/dict_basic_query
+++ b/test/sql/test_global_dict/R/dict_basic_query
@@ -20,6 +20,20 @@ create table t2 like t1;
 create table t3 like t1;
 -- result:
 -- !result
+CREATE TABLE `t4` (
+  `v1` varchar(20) COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
 insert into t1 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
 -- result:
 -- !result
@@ -27,6 +41,12 @@ insert into t2 SELECT generate_series%100, generate_series%255 FROM TABLE(genera
 -- result:
 -- !result
 insert into t3 SELECT generate_series%100 + 1000, generate_series%255 + 1000 FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+insert into t4 values ('a');
+-- result:
+-- !result
+insert into t4 values (NULL);
 -- result:
 -- !result
 [UC]analyze full table t1;
@@ -38,6 +58,9 @@ insert into t3 SELECT generate_series%100 + 1000, generate_series%255 + 1000 FRO
 [UC]analyze full table t3;
 -- result:
 -- !result
+[UC]analyze full table t4;
+-- result:
+-- !result
 function: wait_global_dict_ready('v1', 't1')
 -- result:
 
@@ -47,6 +70,10 @@ function: wait_global_dict_ready('v1', 't2')
 
 -- !result
 function: wait_global_dict_ready('v1', 't3')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v1', 't4')
 -- result:
 
 -- !result
@@ -105,4 +132,9 @@ select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1
 -- result:
 None	None	1000
 None	None	1000
+-- !result
+select v1, if(v1='a', null, 'b') from t4 order by 1;
+-- result:
+None	b
+a	None
 -- !result

--- a/test/sql/test_global_dict/T/dict_basic_query
+++ b/test/sql/test_global_dict/T/dict_basic_query
@@ -17,18 +17,35 @@ PROPERTIES (
 create table t2 like t1;
 create table t3 like t1;
 
+CREATE TABLE `t4` (
+  `v1` varchar(20) COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
 -- prepare data and analyze
 insert into t1 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
 insert into t2 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
 insert into t3 SELECT generate_series%100 + 1000, generate_series%255 + 1000 FROM TABLE(generate_series(1, 65535));
+insert into t4 values ('a');
+insert into t4 values (NULL);
 
 [UC]analyze full table t1;
 [UC]analyze full table t2;
 [UC]analyze full table t3;
+[UC]analyze full table t4;
 
 function: wait_global_dict_ready('v1', 't1')
 function: wait_global_dict_ready('v1', 't2')
 function: wait_global_dict_ready('v1', 't3')
+function: wait_global_dict_ready('v1', 't4')
 
 select lower(l.v1) as r1, upper(r.v2) as r2 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2 limit 2;
 select lower(l.v1) as r1, if(l.v1 is null, 1, 0) as r2, upper(r.v2)  as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
@@ -45,3 +62,5 @@ select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 fro
 select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l left join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
 select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
 select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+
+select v1, if(v1='a', null, 'b') from t4 order by 1;


### PR DESCRIPTION
(cherry picked from commit 404cee3d5b6dbde77e3e6094b2053608289cedf1)

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

