### PR TITLE
[Enhancement] when query is killed by kill command, return errorCode '1317' instead of default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1549,6 +1549,10 @@ public class StmtExecutor {
                             PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
                 }
             }
+            if (!killConnection) {
+                // Expose a structured cancellation signal for query-level kill.
+                killCtx.getState().setErrorCode(ErrorCode.ERR_QUERY_INTERRUPTED);
+            }
             killCtx.kill(killConnection, "killed manually: " + originStmt.getOrigStmt());
         }
         context.getState().setOk();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/KillQueryHandleTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe;
 
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
@@ -57,6 +58,7 @@ public class KillQueryHandleTest {
         ConnectContext ctx = kill(ctx1.getQueryId().toString(), false);
         // isKilled is set
         Assertions.assertTrue(ctx1.isKilled());
+        Assertions.assertEquals(ErrorCode.ERR_QUERY_INTERRUPTED, ctx1.getState().getErrorCode());
         Assertions.assertEquals(QueryState.MysqlStateType.OK, ctx.getState().getStateType());
 
         ExecuteEnv.getInstance().getScheduler().unregisterConnection(ctx1);
@@ -179,6 +181,7 @@ public class KillQueryHandleTest {
         ConnectContext ctx = kill("a_custom_query_id", false);
         // isKilled is set
         Assertions.assertTrue(ctx1.isKilled());
+        Assertions.assertEquals(ErrorCode.ERR_QUERY_INTERRUPTED, ctx1.getState().getErrorCode());
         Assertions.assertEquals(QueryState.MysqlStateType.OK, ctx.getState().getStateType());
 
         ExecuteEnv.getInstance().getScheduler().unregisterConnection(ctx1);

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -98,6 +98,7 @@ public enum ErrorCode {
     ERR_UNSUPPORTED_PS(1295, "HY000".getBytes(),
             "This command is not supported in the prepared statement protocol yet"),
     ERR_UNKNOWN_TIME_ZONE(1298, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown or incorrect time zone: '%s'"),
+    ERR_QUERY_INTERRUPTED(1317, new byte[] {'7', '0', '1', '0', '0'}, "Query execution was interrupted"),
     ERR_WRONG_OBJECT(1347, new byte[] {'H', 'Y', '0', '0', '0'}, "'%s'.'%s' is not '%s'"),
     ERR_VIEW_WRONG_LIST(1353, new byte[] {'H', 'Y', '0', '0', '0'},
             "View's SELECT and view's field list have different column counts"),


### PR DESCRIPTION
## Why I'm doing:
when query is killed by kill command, right now only return default error code  and sqlState 
## What I'm doing:
return errorCode 1317 and sqlState "70100", which is same as mysql

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
