### PR TITLE
[Enhancement] Support show cloud native tablet status

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -290,6 +290,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY = "allow_empty_tablet_recovery";
     // If true, just return the repair plan without executing it
     public static final String PROPERTIES_DRY_RUN = "dry_run";
+    // Show at most `limit` missing data files per tablet
+    public static final String PROPERTIES_MAX_MISSING_DATA_FILES_TO_SHOW = "max_missing_data_files_to_show";
 
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -52,6 +52,8 @@ import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
+import com.starrocks.sql.ast.LakeTabletStatus;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.type.TypeFactory;
@@ -59,6 +61,7 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -668,10 +671,10 @@ public class TabletRepairHelper {
      * It handles different repair strategies based on `enforceConsistentVersion` and `allowEmptyTabletRecovery`
      * and aggregates errors from failed partition repairs.
      *
-     * @param stmt The AdminRepairTableStmt containing repair parameters.
-     * @param db The Database containing the table to be repaired.
-     * @param table The OlapTable whose tablets are to be repaired.
-     * @param partitionNames A list of partition names to repair. If empty, all partitions are repaired.
+     * @param stmt            The AdminRepairTableStmt containing repair parameters.
+     * @param db              The Database containing the table to be repaired.
+     * @param table           The OlapTable whose tablets are to be repaired.
+     * @param partitionNames  A list of partition names to repair. If empty, all partitions are repaired.
      * @param computeResource The compute resource used for assigning compute nodes.
      * @throws StarRocksException If any tablet repair fails or if there are issues during the process.
      */
@@ -809,6 +812,95 @@ public class TabletRepairHelper {
 
             result.add(Lists.newArrayList(String.valueOf(physicalPartitionId), String.valueOf(visibleVersion),
                     repairStatus.name(), gson.toJson(tabletRecoverInfos), errorMsg));
+        }
+
+        return result;
+    }
+
+    private static boolean matchTablet(LakeTabletStatus status, BinaryType op, LakeTabletStatus statusFilter) {
+        boolean match = true;
+        if (statusFilter != null && op != null) {
+            if (op == BinaryType.EQ && status != statusFilter) {
+                match = false;
+            } else if (op == BinaryType.NE && status == statusFilter) {
+                match = false;
+            }
+        }
+        return match;
+    }
+
+    private static List<String> limitMissingFiles(List<String> missingFiles, int limit) {
+        if (missingFiles == null || missingFiles.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        int fileCount = missingFiles.size();
+        if (limit >= 0 && fileCount > limit) {
+            List<String> result = new ArrayList<>(limit + 1);
+            if (limit > 0) {
+                result.addAll(missingFiles.subList(0, limit));
+            }
+            result.add("... " + (fileCount - limit) + " more");
+            return result;
+        }
+
+        return Lists.newArrayList(missingFiles);
+    }
+
+    /**
+     * Return the tablet status for specified partitions of a table.
+     * Whether meta and data files are missing.
+     */
+    public static List<List<String>> getTabletStatus(Database db, OlapTable table, @NotNull List<String> partitionNames,
+                                                     LakeTabletStatus statusFilter, BinaryType op, int maxMissingDataFilesToShow,
+                                                     ComputeResource computeResource) throws Exception {
+        // get physical partition ids in db table read lock
+        List<Long> physicalPartitionIds = getPhysicalPartitionIds(db, table, partitionNames);
+
+        List<List<String>> result = Lists.newArrayList();
+        for (Long physicalPartitionId : physicalPartitionIds) {
+            PhysicalPartitionInfo info = getPhysicalPartitionInfo(db, table, physicalPartitionId, true, computeResource);
+
+            // get visible version metadata for all tablets in the partition
+            long version = info.maxVersion;
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = getTabletMetadatas(info, version, version);
+
+            // check the tablet status for each tablet in the partition
+            for (long tabletId : info.allTablets) {
+                LakeTabletStatus status = LakeTabletStatus.NORMAL;
+                List<String> missingFiles = null;
+                int missingFileCount = 0;
+
+                Map<Long, TabletMetadataEntry> versionToMetadataEntry = tabletToVersionMetadataEntry.get(tabletId);
+                if (versionToMetadataEntry == null || versionToMetadataEntry.isEmpty() ||
+                        !versionToMetadataEntry.containsKey(version)) {
+                    status = LakeTabletStatus.MISSING_META;
+                } else {
+                    TabletMetadataEntry metadataEntry = versionToMetadataEntry.get(version);
+                    if (metadataEntry.missingFiles != null && !metadataEntry.missingFiles.isEmpty()) {
+                        status = LakeTabletStatus.MISSING_DATA;
+                        missingFiles = metadataEntry.missingFiles;
+                        missingFileCount = missingFiles.size();
+                    }
+                }
+
+                // filter by status
+                if (!matchTablet(status, op, statusFilter)) {
+                    continue;
+                }
+
+                // limit the number of missing data files to show
+                List<String> limitMissingFiles = limitMissingFiles(missingFiles, maxMissingDataFilesToShow);
+
+                List<String> row = Lists.newArrayList();
+                row.add(String.valueOf(tabletId));
+                row.add(String.valueOf(physicalPartitionId));
+                row.add(String.valueOf(version));
+                row.add(status.name());
+                row.add(String.valueOf(missingFileCount));
+                row.add(limitMissingFiles.toString());
+                result.add(row);
+            }
         }
 
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
 import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
@@ -744,6 +745,15 @@ public class RedirectStatus {
 
         @Override
         public RedirectStatus visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, Void context) {
+            if (ConnectContext.get().getSessionVariable().getForwardToLeader()) {
+                return RedirectStatus.FORWARD_NO_SYNC;
+            } else {
+                return RedirectStatus.NO_FORWARD;
+            }
+        }
+
+        @Override
+        public RedirectStatus visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, Void context) {
             if (ConnectContext.get().getSessionVariable().getForwardToLeader()) {
                 return RedirectStatus.FORWARD_NO_SYNC;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Enums;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -113,6 +114,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.datacache.DataCacheMgr;
+import com.starrocks.lake.TabletRepairHelper;
 import com.starrocks.load.DeleteMgr;
 import com.starrocks.load.ExportJob;
 import com.starrocks.load.ExportMgr;
@@ -152,11 +154,13 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.DescStorageVolumeStmt;
 import com.starrocks.sql.ast.DescribeStmt;
 import com.starrocks.sql.ast.HelpStmt;
 import com.starrocks.sql.ast.ImportColumnDesc;
+import com.starrocks.sql.ast.LakeTabletStatus;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.OrderByPair;
 import com.starrocks.sql.ast.PartitionRef;
@@ -230,6 +234,7 @@ import com.starrocks.sql.ast.ShowVariablesStmt;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.LikePredicate;
@@ -275,6 +280,7 @@ import com.starrocks.thrift.TTableInfo;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -2347,6 +2353,57 @@ public class ShowExecutor {
             try {
                 results = MetadataViewer.getTabletStatus(statement, context);
             } catch (DdlException e) {
+                throw new SemanticException(e.getMessage());
+            }
+            return new ShowResultSet(showResultMetaFactory.getMetadata(statement), results);
+        }
+
+        @Override
+        public ShowResultSet visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, ConnectContext context) {
+            // Check db table partition
+            String dbName = statement.getDbName() != null ? statement.getDbName() : context.getDatabase();
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            if (db == null) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
+
+            String tableName = statement.getTblName();
+            Table table = db.getTable(tableName);
+            if (table == null) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+            }
+
+            if (!table.isCloudNativeTableOrMaterializedView()) {
+                throw new SemanticException("Only support show tablet status for cloud native table or materialized view");
+            }
+
+            PartitionRef partitionRef = statement.getPartitionRef();
+            List<String> partitionNames = partitionRef != null ? partitionRef.getPartitionNames() : Lists.newArrayList();
+
+            // Check status filter
+            LakeTabletStatus statusFilter = null;
+            BinaryType op = null;
+            Expr where = statement.getWhere();
+            if (where instanceof BinaryPredicate binaryPredicate) {
+                op = binaryPredicate.getOp();
+                Expr leftChild = binaryPredicate.getChild(0);
+                Expr rightChild = binaryPredicate.getChild(1);
+                String leftKey = ((SlotRef) leftChild).getColumnName();
+                if (rightChild instanceof StringLiteral && leftKey.equalsIgnoreCase("status")) {
+                    statusFilter = Enums.getIfPresent(
+                            LakeTabletStatus.class, ((StringLiteral) rightChild).getStringValue().toUpperCase()).orNull();
+                }
+            }
+
+            // Get tablet status
+            int maxMissingDataFilesToShow = statement.getMaxMissingDataFilesToShow();
+            ComputeResource computeResource = context.getCurrentComputeResource();
+            List<List<String>> results;
+            try {
+                results = TabletRepairHelper.getTabletStatus(
+                        db, (OlapTable) table, partitionNames, statusFilter, op, maxMissingDataFilesToShow, computeResource);
+            } catch (Exception e) {
+                LOG.warn("Failed to get tablet status", e);
                 throw new SemanticException(e.getMessage());
             }
             return new ShowResultSet(showResultMetaFactory.getMetadata(statement), results);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.DescStorageVolumeStmt;
 import com.starrocks.sql.ast.DescribeStmt;
@@ -393,6 +394,18 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .addColumn(new Column("IsSetBadForce", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("State", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("Status", TypeFactory.createVarcharType(30)))
+                .build();
+    }
+
+    @Override
+    public ShowResultSetMetaData visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, Void context) {
+        return ShowResultSetMetaData.builder()
+                .addColumn(new Column("TabletId", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("PartitionId", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("Version", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("MissingDataFileCount", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("MissingDataFiles", TypeFactory.createVarcharType(65535)))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 import com.google.common.base.Enums;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.CatalogUtils;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -30,7 +31,9 @@ import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
 import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
+import com.starrocks.sql.ast.LakeTabletStatus;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.Property;
 import com.starrocks.sql.ast.ReplicaStatus;
@@ -141,10 +144,52 @@ public class AdminStmtAnalyzer {
                 }
             }
 
-            if (!analyzeWhere(adminShowReplicaStatusStmt)) {
-                Expr where = adminShowReplicaStatusStmt.getWhere();
+            Expr where = adminShowReplicaStatusStmt.getWhere();
+            if (!analyzeWhere(where, ReplicaStatus.class)) {
                 throw new SemanticException(PARSER_ERROR_MSG.invalidWhereExpr("status =|!= " +
                         "'OK'|'DEAD'|'VERSION_ERROR'|'SCHEMA_ERROR'|'MISSING'"),
+                        where.getPos());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt adminShowTabletStatusStmt,
+                                                        ConnectContext session) {
+            String dbName = adminShowTabletStatusStmt.getDbName();
+            NodePosition pos = adminShowTabletStatusStmt.getPos();
+            if (Strings.isNullOrEmpty(dbName)) {
+                if (Strings.isNullOrEmpty(session.getDatabase())) {
+                    throw new SemanticException(PARSER_ERROR_MSG.noDbSelected(), pos);
+                }
+            }
+
+            PartitionRef partitionRef = adminShowTabletStatusStmt.getPartitionRef();
+            if (partitionRef != null) {
+                if (partitionRef.isTemp()) {
+                    throw new SemanticException(PARSER_ERROR_MSG.unsupportedOpWithInfo("temporary partitions"), pos);
+                }
+            }
+
+            Map<String, String> properties = adminShowTabletStatusStmt.getProperties();
+            if (!properties.isEmpty()) {
+                try {
+                    int maxMissingDataFilesToShow = PropertyAnalyzer.analyzeIntProp(
+                            properties, PropertyAnalyzer.PROPERTIES_MAX_MISSING_DATA_FILES_TO_SHOW, 5);
+                    adminShowTabletStatusStmt.setMaxMissingDataFilesToShow(maxMissingDataFilesToShow);
+                } catch (AnalysisException e) {
+                    throw new SemanticException(e.getMessage());
+                }
+
+                if (!properties.isEmpty()) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_PROPERTY, properties);
+                }
+            }
+
+            Expr where = adminShowTabletStatusStmt.getWhere();
+            if (!analyzeWhere(where, LakeTabletStatus.class)) {
+                throw new SemanticException(PARSER_ERROR_MSG.invalidWhereExpr("status =|!= " +
+                        "'NORMAL'|'MISSING_META'|'MISSING_DATA'"),
                         where.getPos());
             }
             return null;
@@ -234,9 +279,7 @@ public class AdminStmtAnalyzer {
             return null;
         }
 
-        private boolean analyzeWhere(AdminShowReplicaStatusStmt adminShowReplicaStatusStmt) {
-            Expr where = adminShowReplicaStatusStmt.getWhere();
-
+        private <T extends Enum<T>> boolean analyzeWhere(Expr where, Class<T> enumClass) {
             // analyze where clause if not null
             if (where == null) {
                 return true;
@@ -262,9 +305,9 @@ public class AdminStmtAnalyzer {
             if (!leftKey.equalsIgnoreCase("status")) {
                 return false;
             }
-            ReplicaStatus statusFilter = Enums.getIfPresent(ReplicaStatus.class,
-                    ((StringLiteral) rightChild).getStringValue().toUpperCase()).orNull();
-            return statusFilter != null;
+
+            String name = ((StringLiteral) rightChild).getStringValue().toUpperCase();
+            return Enums.getIfPresent(enumClass, name).isPresent();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
 import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
@@ -283,6 +284,12 @@ public class Analyzer {
 
         @Override
         public Void visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, ConnectContext session) {
+            AdminStmtAnalyzer.analyze(statement, session);
+            return null;
+        }
+
+        @Override
+        public Void visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, ConnectContext session) {
             AdminStmtAnalyzer.analyze(statement, session);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
@@ -2209,6 +2210,19 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
 
     @Override
     public Void visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, ConnectContext context) {
+        try {
+            Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, ConnectContext context) {
         try {
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -78,6 +78,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AlterClause;
@@ -2884,6 +2885,31 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 new AdminShowReplicaDistributionStmt(tableRef, createPos(context));
         visitShowPredicateClauses(context.showPredicateClauses(), adminShowReplicaDistributionStmt);
         return adminShowReplicaDistributionStmt;
+    }
+
+    @Override
+    public ParseNode visitAdminShowTabletStatusStatement(
+            com.starrocks.sql.parser.StarRocksParser.AdminShowTabletStatusStatementContext context) {
+        Token start = context.qualifiedName().start;
+        Token stop = context.qualifiedName().stop;
+        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
+
+        PartitionRef partitionRef = null;
+        if (context.partitionNames() != null) {
+            stop = context.partitionNames().stop;
+            PartitionRef partitionNames = (PartitionRef) visit(context.partitionNames());
+            partitionRef = new PartitionRef(partitionNames.getPartitionNames(), partitionNames.isTemp(), partitionNames.getPos());
+        }
+
+        TableRef tableRef = new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop));
+        Map<String, String> properties = getCaseSensitiveProperties(context.properties());
+        AdminShowTabletStatusStmt adminShowTabletStatusStmt =
+                new AdminShowTabletStatusStmt(tableRef, where, properties, createPos(context));
+        adminShowTabletStatusStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, adminShowTabletStatusStmt);
+        return adminShowTabletStatusStmt;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -45,9 +45,11 @@ import com.starrocks.rpc.LakeServiceWithMetrics;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
+import com.starrocks.sql.ast.LakeTabletStatus;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStorageMedium;
@@ -1209,4 +1211,85 @@ public class TabletRepairHelperTest {
 
         Assertions.assertEquals("ERROR: rpc exception", row.get(4)); // ErrorMsg
     }
+    @Test
+    public void testGetTabletStatus() throws Exception {
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                return node;
+            }
+        };
+
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                GetTabletMetadatasResponse response = new GetTabletMetadatasResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 0;
+
+                // tablet1 with valid metadata
+                TabletResult tr1 = new TabletResult();
+                tr1.tabletId = tabletId11;
+                tr1.status = new StatusPB();
+                tr1.status.statusCode = 0;
+                tr1.metadataEntries = Lists.newArrayList();
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, maxVersion, null));
+
+                // tablet2 with missing data files
+                TabletResult tr2 = new TabletResult();
+                tr2.tabletId = tabletId12;
+                tr2.status = new StatusPB();
+                tr2.status.statusCode = 0;
+                tr2.metadataEntries = Lists.newArrayList();
+                tr2.metadataEntries.add(createTabletMetadataEntry(
+                        tabletId12, maxVersion, Lists.newArrayList("file1.dat", "file2.dat", "file3.dat")));
+
+                response.tabletResults = Lists.newArrayList(tr1, tr2);
+
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        // case 1: no filter
+        List<List<String>> result = TabletRepairHelper.getTabletStatus(
+                db, table, Lists.newArrayList("p1"), null, null, 2, WarehouseComputeResource.DEFAULT);
+
+        Assertions.assertEquals(2, result.size());
+
+        List<String> row1 = result.get(0);
+        Assertions.assertEquals("11", row1.get(0)); // tabletId
+        Assertions.assertEquals("4", row1.get(1)); // partitionId
+        Assertions.assertEquals("8", row1.get(2)); // version
+        Assertions.assertEquals("NORMAL", row1.get(3)); // status
+        Assertions.assertEquals("0", row1.get(4)); // missingFileCount
+        Assertions.assertEquals("[]", row1.get(5)); // missingFiles
+
+        List<String> row2 = result.get(1);
+        Assertions.assertEquals("12", row2.get(0));
+        Assertions.assertEquals("4", row2.get(1));
+        Assertions.assertEquals("8", row2.get(2));
+        Assertions.assertEquals("MISSING_DATA", row2.get(3));
+        Assertions.assertEquals("3", row2.get(4));
+        Assertions.assertEquals("[file1.dat, file2.dat, ... 1 more]", row2.get(5));
+
+        // case 2: filter by NORMAL
+        result = TabletRepairHelper.getTabletStatus(
+                db, table, Lists.newArrayList("p1"), LakeTabletStatus.NORMAL, BinaryType.EQ, 5, WarehouseComputeResource.DEFAULT);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("11", result.get(0).get(0));
+
+        // case 3: filter by MISSING_DATA
+        result = TabletRepairHelper.getTabletStatus(db, table, Lists.newArrayList("p1"), LakeTabletStatus.MISSING_DATA,
+                BinaryType.EQ, 5, WarehouseComputeResource.DEFAULT);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("12", result.get(0).get(0));
+        Assertions.assertEquals("[file1.dat, file2.dat, file3.dat]", result.get(0).get(5)); // check limit=5 works
+        
+        // case 4: filter != NORMAL
+        result = TabletRepairHelper.getTabletStatus(
+                db, table, Lists.newArrayList("p1"), LakeTabletStatus.NORMAL, BinaryType.NE, 5, WarehouseComputeResource.DEFAULT);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("12", result.get(0).get(0));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/ShowExecutorTest.java
@@ -14,17 +14,32 @@
 
 package com.starrocks.lake.qe;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.TabletRepairHelper;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.LakeTabletStatus;
+import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -32,6 +47,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 public class ShowExecutorTest {
     private static ConnectContext ctx;
@@ -110,6 +128,54 @@ public class ShowExecutorTest {
         Assertions.assertTrue(resultSet.next());
         Assertions.assertEquals("testDb1", resultSet.getString(0));
         Assertions.assertEquals("CREATE DATABASE `testDb1`", resultSet.getString(1));
+        Assertions.assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testAdminShowTabletStatusStmt() throws Exception {
+        ctx.setGlobalStateMgr(globalStateMgr);
+        ctx.setQualifiedUser("testUser");
+
+        Database db = globalStateMgr.getLocalMetastore().getDb("testDb");
+        new Expectations(db) {
+            {
+                db.getTable("testTbl");
+                minTimes = 0;
+                result = new LakeTable(1L, "testTbl", Lists.newArrayList(), KeysType.DUP_KEYS, null, null);
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+            }
+        };
+
+        TableRef tableRef = new TableRef(QualifiedName.of(Lists.newArrayList("testDb", "testTbl")), null, NodePosition.ZERO);
+        BinaryPredicate where = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "status"), new StringLiteral("NORMAL"));
+        AdminShowTabletStatusStmt stmt =
+                new AdminShowTabletStatusStmt(tableRef, where, Collections.emptyMap(), NodePosition.ZERO);
+
+        new MockUp<TabletRepairHelper>() {
+            @Mock
+            public List<List<String>> getTabletStatus(Database db, OlapTable table, List<String> partitionNames,
+                                                      LakeTabletStatus statusFilter, BinaryType op, int maxMissingDataFilesToShow,
+                                                      ComputeResource computeResource) {
+                List<List<String>> results = Lists.newArrayList();
+                results.add(Lists.newArrayList("1", "2", "10", "NORMAL", "0", "[]"));
+                return results;
+            }
+        };
+
+        ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
+        Assertions.assertTrue(resultSet.next());
+        Assertions.assertEquals("1", resultSet.getString(0));
+        Assertions.assertEquals("2", resultSet.getString(1));
+        Assertions.assertEquals("10", resultSet.getString(2));
+        Assertions.assertEquals("NORMAL", resultSet.getString(3));
+        Assertions.assertEquals("0", resultSet.getString(4));
+        Assertions.assertEquals("[]", resultSet.getString(5));
         Assertions.assertFalse(resultSet.next());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
 import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
@@ -726,6 +727,12 @@ public class RedirectStatusTest {
         QualifiedName qualifiedName = QualifiedName.of(Lists.newArrayList("test_table"));
         TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
         AdminShowReplicaStatusStmt stmt = new AdminShowReplicaStatusStmt(tableRef, null, NodePosition.ZERO);
+        Assertions.assertEquals(RedirectStatus.NO_FORWARD, RedirectStatus.getRedirectStatus(stmt));
+    }
+
+    @Test
+    public void testAdminShowTabletStatusStmt() {
+        AdminShowTabletStatusStmt stmt = new AdminShowTabletStatusStmt(null, null, null, NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.NO_FORWARD, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -70,6 +70,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.ShowColumnStmt;
@@ -645,5 +646,20 @@ public class ShowExecutorTest {
         ShowIndexStmt stmt = new ShowIndexStmt(tableRef);
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assertions.assertEquals(0, resultSet.getResultRows().size());
+    }
+
+    @Test
+    public void testAdminShowTabletStatusStmt() throws Exception {
+        TableRef tableRef = new TableRef(QualifiedName.of(Lists.newArrayList("testDb", "testTbl")),
+                null, NodePosition.ZERO);
+        AdminShowTabletStatusStmt stmt = new AdminShowTabletStatusStmt(tableRef, null, Collections.emptyMap(), NodePosition.ZERO);
+
+        ctx.setGlobalStateMgr(globalStateMgr);
+        ctx.setQualifiedUser("testUser");
+
+        // Use assertThrows to check if it throws exception when table is not cloud native
+        assertThrows(SemanticException.class, () -> {
+            ShowExecutor.execute(stmt, ctx);
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowTabletStatusStmt;
 import com.starrocks.sql.ast.LabelName;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.SetType;
@@ -949,6 +950,19 @@ public class ShowStmtMetaTest {
         Assertions.assertEquals("IsSetBadForce", metaData.getColumn(10).getName());
         Assertions.assertEquals("State", metaData.getColumn(11).getName());
         Assertions.assertEquals("Status", metaData.getColumn(12).getName());
+    }
+
+    @Test
+    public void testAdminShowTabletStatusStmt() {
+        AdminShowTabletStatusStmt stmt = new AdminShowTabletStatusStmt(null, null, null, NodePosition.ZERO);
+        ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
+        Assertions.assertEquals(6, metaData.getColumnCount());
+        Assertions.assertEquals("TabletId", metaData.getColumn(0).getName());
+        Assertions.assertEquals("PartitionId", metaData.getColumn(1).getName());
+        Assertions.assertEquals("Version", metaData.getColumn(2).getName());
+        Assertions.assertEquals("Status", metaData.getColumn(3).getName());
+        Assertions.assertEquals("MissingDataFileCount", metaData.getColumn(4).getName());
+        Assertions.assertEquals("MissingDataFiles", metaData.getColumn(5).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/AdminShowTabletStatusStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/AdminShowTabletStatusStmtTest.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AdminShowTabletStatusStmtTest {
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        ctx = AnalyzeTestUtil.getConnectContext();
+    }
+
+    @Test
+    public void testNormal() {
+        String sql = "ADMIN SHOW TABLET STATUS FROM db1.tbl1 WHERE STATUS = 'NORMAL'";
+        AdminShowTabletStatusStmt stmt = (AdminShowTabletStatusStmt) AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertEquals("db1", stmt.getDbName());
+        Assertions.assertEquals("tbl1", stmt.getTblName());
+        Assertions.assertNull(stmt.getPartitionRef());
+        Assertions.assertNotNull(stmt.getWhere());
+        Assertions.assertTrue(stmt.getProperties().isEmpty());
+    }
+
+    @Test
+    public void testWithPartitionAndProperties() {
+        String sql = "ADMIN SHOW TABLET STATUS FROM db1.tbl1 PARTITION (p1, p2) " +
+                "PROPERTIES ('max_missing_data_files_to_show'='10') WHERE STATUS = 'MISSING_DATA'";
+        AdminShowTabletStatusStmt stmt = (AdminShowTabletStatusStmt) AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertEquals("db1", stmt.getDbName());
+        Assertions.assertEquals("tbl1", stmt.getTblName());
+        Assertions.assertNotNull(stmt.getPartitionRef());
+        Assertions.assertEquals(2, stmt.getPartitionRef().getPartitionNames().size());
+        Assertions.assertNotNull(stmt.getWhere());
+        Assertions.assertEquals(10, stmt.getMaxMissingDataFilesToShow());
+    }
+
+    @Test
+    public void testInvalidStatus() {
+        String sql = "ADMIN SHOW TABLET STATUS FROM db1.tbl1 WHERE STATUS = 'UNKNOWN'";
+        AnalyzeTestUtil.analyzeFail(sql, "status =|!= 'NORMAL'|'MISSING_META'|'MISSING_DATA'");
+    }
+}

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -123,6 +123,7 @@ statement
     | adminShowAutomatedSnapshotStatement
     | adminShowReplicaDistributionStatement
     | adminShowReplicaStatusStatement
+    | adminShowTabletStatusStatement
     | adminRepairTableStatement
     | adminCancelRepairTableStatement
     | adminCheckTabletsStatement
@@ -790,6 +791,10 @@ adminShowReplicaDistributionStatement
 
 adminShowReplicaStatusStatement
     : ADMIN SHOW REPLICA STATUS FROM qualifiedName partitionNames? showPredicateClauses
+    ;
+
+adminShowTabletStatusStatement
+    : ADMIN SHOW TABLET STATUS FROM qualifiedName partitionNames? properties? showPredicateClauses
     ;
 
 adminRepairTableStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminShowTabletStatusStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminShowTabletStatusStmt.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Map;
+
+// ADMIN SHOW TABLET STATUS FROM db.table PARTITION (p1) PROPERTIES ('key'='value') where status != "NORMAL";
+public class AdminShowTabletStatusStmt extends ShowStmt {
+    private final TableRef tblRef;
+    private final Expr where;
+    private final Map<String, String> properties;
+
+    // default value is 5, means show at most 5 missing data files per tablet
+    private int maxMissingDataFilesToShow = 5;
+
+    public AdminShowTabletStatusStmt(TableRef tblRef, Expr where, Map<String, String> properties, NodePosition pos) {
+        super(pos);
+        this.tblRef = tblRef;
+        this.where = where;
+        this.properties = properties;
+    }
+
+    public String getDbName() {
+        return tblRef.getDbName();
+    }
+
+    public String getTblName() {
+        return tblRef.getTableName();
+    }
+
+    public PartitionRef getPartitionRef() {
+        return tblRef.getPartitionDef();
+    }
+
+    public Expr getWhere() {
+        return where;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public int getMaxMissingDataFilesToShow() {
+        return maxMissingDataFilesToShow;
+    }
+
+    public void setMaxMissingDataFilesToShow(int maxMissingDataFilesToShow) {
+        this.maxMissingDataFilesToShow = maxMissingDataFilesToShow;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAdminShowTabletStatusStatement(this, context);
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -182,6 +182,10 @@ public interface AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    default R visitAdminShowTabletStatusStatement(AdminShowTabletStatusStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     default R visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, C context) {
         return visitShowStatement(statement, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/LakeTabletStatus.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/LakeTabletStatus.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+public enum LakeTabletStatus {
+    NORMAL,       // health
+    MISSING_META, // missing meta file
+    MISSING_DATA  // missing data file
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request adds support for the new `ADMIN SHOW TABLET STATUS` statement, which allows users to query the status of tablets in cloud native tables or materialized views, including filtering by status and limiting the number of missing data files shown per tablet.

```
mysql> admin show tablet status from t1 where status = "xxx" properties("max_missing_data_files_to_show" = "1");
+----------+-------------+---------+--------------+----------------------+-------------------------------------------------------------------------+
| TabletId | PartitionId | Version | Status       | MissingDataFileCount | MissingDataFiles                                                        |
+----------+-------------+---------+--------------+----------------------+-------------------------------------------------------------------------+
| 246101   | 246100      | 4       | NORMAL       | 0                    | []                                                                      |
| 246102   | 246100      | 4       | MISSING_META | 0                    | []                                                                      |
| 246103   | 246100      | 4       | MISSING_DATA | 2                    | [000000000003b990_5f7e4cbb-e331-41e0-ad8b-0421e3e9fdc9.dat, ... 1 more] |
+----------+-------------+---------+--------------+----------------------+-------------------------------------------------------------------------+
3 rows in set (0.03 sec)
```

https://github.com/StarRocks/starrocks/issues/66015


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
