### PR TITLE
[Enhancement] modify sink DOP handling for unpartitioned Iceberg table delete behavior

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -180,4 +180,8 @@ public class IcebergDeleteSink extends DataSink {
     public com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra getSinkExtraInfo() {
         return sinkExtraInfo;
     }
+
+    public boolean isUnpartitionedTable() {
+        return !icebergTable.isPartitioned();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -26,6 +26,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.TableFunctionTableSink;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.ExplainBuilder;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.system.ComputeNode;
@@ -355,13 +356,24 @@ public class FragmentInstance {
 
         DataSink dataSink = fragment.getSink();
         int dop = fragment.getPipelineDop();
+        ConnectContext connectContext = ConnectContext.get();
+        SessionVariable sessionVariable = connectContext != null ? connectContext.getSessionVariable() : null;
         if (!(dataSink instanceof IcebergTableSink 
                 || dataSink instanceof IcebergDeleteSink
                 || dataSink instanceof HiveTableSink
                 || dataSink instanceof TableFunctionTableSink)) {
             return dop;
+        } else if (dataSink instanceof IcebergDeleteSink icebergDeleteSink && icebergDeleteSink.isUnpartitionedTable()) {
+            if (sessionVariable == null) {
+                return dop;
+            }
+            int sinkDop = sessionVariable.getPipelineSinkDop();
+            if (sinkDop > 0) {
+                return sinkDop;
+            }
+            return sessionVariable.getSinkDegreeOfParallelism(connectContext.getCurrentWarehouseId());
         } else {
-            return ConnectContext.get().getSessionVariable().getPipelineSinkDop();
+            return sessionVariable.getPipelineSinkDop();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
@@ -221,6 +221,34 @@ public class IcebergDeleteSinkTest {
     }
 
     @Test
+    public void testIsUnpartitionedTable() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+
+        when(icebergTable.isPartitioned()).thenReturn(false);
+        IcebergDeleteSink unpartitionedSink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        assertTrue(unpartitionedSink.isUnpartitionedTable());
+
+        when(icebergTable.isPartitioned()).thenReturn(true);
+        IcebergDeleteSink partitionedSink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        assertFalse(partitionedSink.isUnpartitionedTable());
+    }
+
+    @Test
     public void testCompressionTypePriority() {
         // Create a valid tuple descriptor
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
@@ -20,13 +20,18 @@ import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TPartitionType;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -110,6 +115,69 @@ public class DeletePlanTest extends PlanTestBase {
         assertTrue(execPlan.getOutputExprs().size() >= 2, "Should output _file and _pos");
         assertTrue(execPlan.getOutputExprs().get(0).debugString().contains("_file"));
         assertTrue(execPlan.getOutputExprs().get(1).debugString().contains("_pos"));
+    }
+
+    @Test
+    public void testUnpartitionedIcebergDeleteUsesExplicitPipelineSinkDop() throws Exception {
+        int previousSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
+        try {
+            connectContext.getSessionVariable().setPipelineSinkDop(8);
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+            FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
+            Assertions.assertEquals(8, instance.getTableSinkDop());
+        } finally {
+            connectContext.getSessionVariable().setPipelineSinkDop(previousSinkDop);
+        }
+    }
+
+    @Test
+    public void testUnpartitionedIcebergDeleteUsesSinkDefaultDopWhenPipelineSinkDopUnset() throws Exception {
+        int previousSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
+        int previousPipelineDop = connectContext.getSessionVariable().getPipelineDop();
+        try {
+            new MockUp<com.starrocks.system.BackendResourceStat>() {
+                @Mock
+                public int getAvgNumCoresOfBe(long warehouseId) {
+                    return 18;
+                }
+            };
+            connectContext.getSessionVariable().setPipelineSinkDop(0);
+            connectContext.getSessionVariable().setPipelineDop(0);
+
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+            FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
+            Assertions.assertEquals(6, instance.getTableSinkDop());
+        } finally {
+            connectContext.getSessionVariable().setPipelineSinkDop(previousSinkDop);
+            connectContext.getSessionVariable().setPipelineDop(previousPipelineDop);
+        }
+    }
+
+    @Test
+    public void testPartitionedIcebergDeleteKeepsOriginalPipelineSinkDopBehavior() throws Exception {
+        int previousSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
+        try {
+            connectContext.getSessionVariable().setPipelineSinkDop(0);
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.partitioned_db.t1 where id = 1");
+            FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
+            Assertions.assertEquals(0, instance.getTableSinkDop());
+        } finally {
+            connectContext.getSessionVariable().setPipelineSinkDop(previousSinkDop);
+        }
+    }
+
+    @Test
+    public void testIcebergDeleteFallsBackToFragmentDopWhenConnectContextIsMissing() throws Exception {
+        ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+        FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
+        int fragmentDop = execPlan.getTopFragment().getPipelineDop();
+
+        try {
+            ConnectContext.remove();
+            Assertions.assertEquals(fragmentDop, instance.getTableSinkDop());
+        } finally {
+            connectContext.setThreadLocalInfo();
+        }
     }
 
     @Test
@@ -205,5 +273,11 @@ public class DeletePlanTest extends PlanTestBase {
     private static String getDeleteExecPlanString(String originStmt) throws Exception {
         ExecPlan execPlan = getDeleteExecPlan(originStmt);
         return execPlan.getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private static FragmentInstance createFragmentInstance(PlanFragment fragment) {
+        connectContext.setThreadLocalInfo();
+        ExecutionFragment execFragment = new ExecutionFragment(null, fragment, 0);
+        return new FragmentInstance(null, execFragment);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
 #66944

## What I'm doing:
This pull request updates how the degree of parallelism (DOP) is determined for Iceberg delete operations, particularly for unpartitioned tables. The main logic change ensures that unpartitioned Iceberg delete sinks use the session's explicit pipeline sink DOP or a calculated default, rather than always inheriting the fragment's DOP. Additional unit tests are added to verify the new behavior and edge cases.

**Improvements to Iceberg Delete Sink DOP logic:**

* Modified `FragmentInstance.getTableSinkDop()` to check if the sink is an unpartitioned `IcebergDeleteSink`, and if so, use the session variable's pipeline sink DOP or a default value based on warehouse resources; otherwise, it falls back to the previous logic.
* Added `isUnpartitionedTable()` method to `IcebergDeleteSink` to support the new DOP logic.

**Testing enhancements:**

* Added unit tests in `DeletePlanTest` to verify that unpartitioned Iceberg deletes use the correct DOP, including cases for explicit session DOP, default DOP calculation, partitioned tables, and missing `ConnectContext`.
* Added a unit test for the new `isUnpartitionedTable()` method in `IcebergDeleteSinkTest`.
* Added a utility method to create `FragmentInstance` objects for testing.

**Dependency and import updates:**

* Added necessary imports for new classes and mocking in test files. [[1]](diffhunk://#diff-93b1997f01fa02114d4bf4b69f027aecb9a5ae96366f9e796fe6930f7ef0a787R29) [[2]](diffhunk://#diff-460a9555f3fda1aa039fd794451029290f599cd630b95f4a87517035b5d342a6R23-R34)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
