### PR TITLE
[Feature] Support iceberg v3 row lineage.

### DIFF
--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -128,7 +128,8 @@ Status HdfsScanner::_build_scanner_context() {
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto* slot = _scanner_params.materialize_slots[i];
         if (slot->col_name() == ICEBERG_ROW_ID || slot->col_name() == "_row_source_id" ||
-            slot->col_name() == "_scan_range_id" || slot->col_name() == ICEBERG_ROW_POSITION) {
+            slot->col_name() == "_scan_range_id" || slot->col_name() == ICEBERG_ROW_POSITION ||
+            slot->col_name() == ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
             ctx.reserved_field_slots.emplace_back(slot);
         } else {
             HdfsScannerContext::ColumnInfo column;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -507,7 +507,12 @@ protected:
 
 public:
     static constexpr const char* ICEBERG_ROW_ID = "_row_id";
+    static constexpr const char* ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
     static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
+    // Iceberg v3 spec reserved field IDs for row lineage columns.
+    // See: https://iceberg.apache.org/spec/#reserved-field-ids
+    static constexpr int32_t ICEBERG_ROW_ID_COLUMN_ID = 2147483540;
+    static constexpr int32_t ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID = 2147483539;
 };
 
 } // namespace starrocks

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -272,6 +272,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.file_size = _file_size;
     _group_reader_param.datacache_options = &_datacache_options;
     _group_reader_param.scan_range_id = fd_scanner_ctx.scan_range_id;
+    _group_reader_param.scan_range = fd_scanner_ctx.scan_range;
 
     int64_t row_group_first_row_id = _scanner_ctx->scan_range->first_row_id;
     int64_t row_group_first_row = 0;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -338,7 +338,7 @@ StatusOr<size_t> GroupReader::_read_range_round_by_round(const Range<uint64_t>& 
 }
 
 StatusOr<ColumnReaderPtr> GroupReader::_create_reserved_iceberg_column_reader(const SlotDescriptor* slot,
-                                                                               int32_t field_id) {
+                                                                              int32_t field_id) {
     // Try to find the physical column in the Parquet file by Iceberg spec field ID first (canonical),
     // then fall back to column name lookup for compatibility.
     int32_t field_idx = _param.file_metadata->schema().get_field_idx_by_field_id(field_id);
@@ -427,22 +427,21 @@ Status GroupReader::_create_column_readers() {
         for (const auto* slot : *_param.reserved_field_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
                 // Iceberg v3 row lineage: try physical column first (post-compaction files),
-                // fall back to computed row_id (firstRowId + position) for non-compacted files,
-                // or NULL when first_row_id is unavailable (e.g. late materialization on pre-v3 files).
-                ASSIGN_OR_RETURN(auto reader, _create_reserved_iceberg_column_reader(
-                                                      slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
+                // fall back to computed row_id (firstRowId + position) for non-compacted files.
+                // FE guarantees firstRowId is present when _row_id is requested.
+                ASSIGN_OR_RETURN(auto reader,
+                                 _create_reserved_iceberg_column_reader(slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
                 if (reader != nullptr) {
                     _column_readers.emplace(slot->id(), std::move(reader));
-                } else if (_param.scan_range != nullptr && !_param.scan_range->__isset.first_row_id) {
-                    _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(kNullDatum));
                 } else {
                     _column_readers.emplace(slot->id(), std::make_unique<IcebergRowIdReader>(_row_group_first_row_id));
                 }
             } else if (slot->col_name() == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
                 // Iceberg v3 row lineage: try physical column first (post-compaction files),
                 // fall back to file-level dataSequenceNumber passed via extended_columns from FE.
-                ASSIGN_OR_RETURN(auto reader, _create_reserved_iceberg_column_reader(
-                                                      slot, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID));
+                ASSIGN_OR_RETURN(auto reader,
+                                 _create_reserved_iceberg_column_reader(
+                                         slot, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID));
                 if (reader != nullptr) {
                     _column_readers.emplace(slot->id(), std::move(reader));
                 } else {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -41,6 +41,7 @@
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
+#include "gen_cpp/Exprs_types.h"
 #include "gutil/strings/substitute.h"
 #include "storage/chunk_helper.h"
 #include "types/type_descriptor.h"
@@ -336,6 +337,53 @@ StatusOr<size_t> GroupReader::_read_range_round_by_round(const Range<uint64_t>& 
     return hit_count;
 }
 
+StatusOr<ColumnReaderPtr> GroupReader::_create_reserved_iceberg_column_reader(const SlotDescriptor* slot,
+                                                                               int32_t field_id) {
+    // Try to find the physical column in the Parquet file by Iceberg spec field ID first (canonical),
+    // then fall back to column name lookup for compatibility.
+    int32_t field_idx = _param.file_metadata->schema().get_field_idx_by_field_id(field_id);
+    if (field_idx < 0) {
+        field_idx = _param.file_metadata->schema().get_field_idx_by_column_name(slot->col_name());
+    }
+    if (field_idx < 0) {
+        return ColumnReaderPtr(nullptr);
+    }
+
+    const auto* schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(field_idx);
+    GroupReaderParam::Column column{};
+    column.idx_in_parquet = field_idx;
+    column.type_in_parquet = schema_node->physical_type;
+    column.slot_desc = const_cast<SlotDescriptor*>(slot);
+    column.t_lake_schema_field = nullptr;
+    column.decode_needed = true;
+    return _create_column_reader(column);
+}
+
+StatusOr<int64_t> GroupReader::_get_extended_bigint_value(SlotId slot_id) const {
+    if (_param.scan_range == nullptr || !_param.scan_range->__isset.extended_columns) {
+        return Status::NotFound(strings::Substitute("Cannot find extended column for slot $0", slot_id));
+    }
+
+    const auto& extended_columns = _param.scan_range->extended_columns;
+    auto it = extended_columns.find(slot_id);
+    if (it == extended_columns.end()) {
+        return Status::NotFound(strings::Substitute("Cannot find extended column value for slot $0", slot_id));
+    }
+
+    const auto& expr = it->second;
+    if (expr.nodes.empty()) {
+        return Status::InvalidArgument(strings::Substitute("Invalid extended column expression for slot $0", slot_id));
+    }
+
+    const auto& node = expr.nodes[0];
+    if (node.node_type != TExprNodeType::INT_LITERAL || !node.__isset.int_literal) {
+        return Status::InvalidArgument(
+                strings::Substitute("Unsupported extended column expression for slot $0", slot_id));
+    }
+
+    return node.int_literal.value;
+}
+
 Status GroupReader::_create_column_readers() {
     SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
     // ColumnReaderOptions is used by all column readers in one row group
@@ -378,7 +426,30 @@ Status GroupReader::_create_column_readers() {
     if (_param.reserved_field_slots != nullptr && !_param.reserved_field_slots->empty()) {
         for (const auto* slot : *_param.reserved_field_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
-                _column_readers.emplace(slot->id(), std::make_unique<IcebergRowIdReader>(_row_group_first_row_id));
+                // Iceberg v3 row lineage: try physical column first (post-compaction files),
+                // fall back to computed row_id (firstRowId + position) for non-compacted files,
+                // or NULL when first_row_id is unavailable (e.g. late materialization on pre-v3 files).
+                ASSIGN_OR_RETURN(auto reader, _create_reserved_iceberg_column_reader(
+                                                      slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
+                if (reader != nullptr) {
+                    _column_readers.emplace(slot->id(), std::move(reader));
+                } else if (_param.scan_range != nullptr && !_param.scan_range->__isset.first_row_id) {
+                    _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(kNullDatum));
+                } else {
+                    _column_readers.emplace(slot->id(), std::make_unique<IcebergRowIdReader>(_row_group_first_row_id));
+                }
+            } else if (slot->col_name() == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
+                // Iceberg v3 row lineage: try physical column first (post-compaction files),
+                // fall back to file-level dataSequenceNumber passed via extended_columns from FE.
+                ASSIGN_OR_RETURN(auto reader, _create_reserved_iceberg_column_reader(
+                                                      slot, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID));
+                if (reader != nullptr) {
+                    _column_readers.emplace(slot->id(), std::move(reader));
+                } else {
+                    ASSIGN_OR_RETURN(auto sequence_number, _get_extended_bigint_value(slot->id()));
+                    _column_readers.emplace(slot->id(),
+                                            std::make_unique<FixedValueColumnReader>(Datum(sequence_number)));
+                }
             } else if (slot->col_name() == "_row_source_id") {
                 if (auto opt = get_backend_id(); opt.has_value()) {
                     _column_readers.emplace(slot->id(), std::make_unique<RowSourceReader>(opt.value()));

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -42,6 +42,7 @@ class RandomAccessFile;
 struct HdfsScanStats;
 class ExprContext;
 class TIcebergSchemaField;
+class THdfsScanRange;
 
 namespace parquet {
 class FileMetaData;
@@ -113,6 +114,7 @@ struct GroupReaderParam {
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
 
     int32_t scan_range_id = -1;
+    const THdfsScanRange* scan_range = nullptr;
 };
 
 class GroupReader {
@@ -156,6 +158,8 @@ private:
     Status _fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk);
 
     Status _create_column_readers();
+    StatusOr<ColumnReaderPtr> _create_reserved_iceberg_column_reader(const SlotDescriptor* slot, int32_t field_id);
+    StatusOr<int64_t> _get_extended_bigint_value(SlotId slot_id) const;
     StatusOr<ColumnReaderPtr> _create_column_reader(const GroupReaderParam::Column& column);
     Status _prepare_column_readers() const;
     ChunkPtr _create_read_chunk(const std::vector<int>& column_indices, bool ignore_reserved_field = false);

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -23,21 +23,13 @@
 namespace starrocks::parquet {
 
 Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
+    // Ignore filter and output all rows in range, consistent with other reserved column readers
+    // (FixedValueColumnReader, RowSourceReader, ParquetPosReader). The caller (GroupReader)
+    // applies chunk->filter_range() uniformly across all columns after reading.
     Column* dst_col = dst->as_mutable_raw_ptr();
-    if (filter == nullptr) {
-        for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            int64_t row_id = _first_row_id + i;
-            dst_col->append_datum(Datum(row_id));
-        }
-    } else {
-        DCHECK_EQ(filter->size(), range.span_size()) << "Filter size must match range size";
-        for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            size_t filter_index = i - range.begin();
-            if ((*filter)[filter_index]) {
-                int64_t row_id = _first_row_id + i;
-                dst_col->append_datum(Datum(row_id));
-            }
-        }
+    for (uint64_t i = range.begin(); i < range.end(); ++i) {
+        int64_t row_id = _first_row_id + i;
+        dst_col->append_datum(Datum(row_id));
     }
     return Status::OK();
 }
@@ -64,7 +56,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
     SparseRange<int64_t> row_id_range(_first_row_id + rg_first_row, _first_row_id + rg_first_row + rg_num_rows);
 
     if (pred_relation == CompoundNodeType::AND) {
-        // AND: intersect all predicate ranges sequentially
+        // For AND relation, apply all predicates sequentially with intersection
         for (const auto& pred : predicates) {
             SparseRange<int64_t> pred_range;
             StatusOr<bool> result = _apply_single_predicate(pred, pred_range);
@@ -72,15 +64,18 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
                 return result.status();
             }
             if (!result.value()) {
+                // Predicate not supported, can't apply filtering
                 return false;
             }
             row_id_range &= pred_range;
+
+            // Early exit if range becomes empty
             if (row_id_range.empty()) {
                 break;
             }
         }
     } else if (pred_relation == CompoundNodeType::OR) {
-        // OR: union all predicate ranges, then intersect with row group range
+        // For OR relation, apply all predicates and take union
         SparseRange<int64_t> union_range;
         bool has_valid_predicate = false;
 
@@ -98,6 +93,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
         }
 
         if (!has_valid_predicate) {
+            // No supported predicates, can't apply filtering
             return false;
         }
 
@@ -110,7 +106,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
         return false;
     }
 
-    // Convert row_id ranges back to row-group-relative row ranges
+    // Convert row_id range to row ranges
     for (size_t i = 0; i < row_id_range.size(); i++) {
         Range<int64_t> range = row_id_range[i];
         row_ranges->add(Range<uint64_t>(range.begin() - _first_row_id, range.end() - _first_row_id));
@@ -125,11 +121,13 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
                                                            SparseRange<int64_t>& result_range) {
     switch (pred->type()) {
     case PredicateType::kEQ: {
+        // Equal: [value, value]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value, value + 1);
         return true;
     }
     case PredicateType::kNE: {
+        // Not Equal: [0, value) | (value, max]
         int64_t value = pred->value().get_int64();
         if (value > 0) {
             result_range.add(Range<int64_t>(0, value));
@@ -140,28 +138,34 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kGT: {
+        // Greater Than: (value, max]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value + 1, std::numeric_limits<int64_t>::max());
         return true;
     }
     case PredicateType::kGE: {
+        // Greater Equal: [value, max]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value, std::numeric_limits<int64_t>::max());
         return true;
     }
     case PredicateType::kLT: {
+        // Less Than: [0, value)
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(0, value);
         return true;
     }
     case PredicateType::kLE: {
+        // Less Equal: [0, value]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(0, value + 1);
         return true;
     }
     case PredicateType::kInList: {
+        // In List: union of all values
         const auto& values = pred->values();
         if (values.empty()) {
+            // Empty IN list means no rows match
             result_range = SparseRange<int64_t>();
             return true;
         }
@@ -172,28 +176,39 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kNotInList: {
-        // Start with full range, then subtract each excluded value
+        // Not In List: complement of union of all values
         const auto& values = pred->values();
         if (values.empty()) {
+            // Empty NOT IN list means all rows match
             result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
             return true;
         }
+        // Start with full range
         result_range.add(Range<int64_t>(0, std::numeric_limits<int64_t>::max()));
+
+        // Subtract each value from the range
         for (const auto& value : values) {
             int64_t int_value = value.get_int64();
             SparseRange<int64_t> temp_range;
+
+            // For each range in result_range, subtract the excluded value
             for (size_t i = 0; i < result_range.size(); i++) {
                 const auto& range = result_range[i];
                 if (range.begin() < int_value && range.end() > int_value + 1) {
+                    // Range spans the excluded value, split into two parts
                     temp_range.add(Range<int64_t>(range.begin(), int_value));
                     temp_range.add(Range<int64_t>(int_value + 1, range.end()));
                 } else if (range.begin() < int_value && range.end() > int_value) {
+                    // Range ends at or after excluded value
                     temp_range.add(Range<int64_t>(range.begin(), int_value));
                 } else if (range.begin() < int_value + 1 && range.end() > int_value + 1) {
+                    // Range starts before excluded value ends
                     temp_range.add(Range<int64_t>(int_value + 1, range.end()));
                 } else if (range.begin() >= int_value && range.end() <= int_value + 1) {
+                    // Range is completely within excluded value, skip it
                     continue;
                 } else {
+                    // Range is outside excluded value, keep it
                     temp_range.add(range);
                 }
             }
@@ -202,15 +217,18 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kIsNull: {
+        // IS NULL: no rows match for row_id column (it's always not null)
         result_range = SparseRange<int64_t>();
         return true;
     }
     case PredicateType::kNotNull: {
+        // IS NOT NULL: all rows match for row_id column (it's always not null)
         result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
         return true;
     }
     default: {
         DLOG(WARNING) << "Unsupported predicate type for row_id filtering: " << pred->type();
+        // For unsupported types, we can't apply filtering
         return false;
     }
     }

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -25,19 +25,15 @@ namespace starrocks::parquet {
 Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
     Column* dst_col = dst->as_mutable_raw_ptr();
     if (filter == nullptr) {
-        // No filter, generate row ids for all rows in the range
         for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            // Generate row id based on the first row id and the current row index.
             int64_t row_id = _first_row_id + i;
             dst_col->append_datum(Datum(row_id));
         }
     } else {
-        // Apply filter, only generate row ids for selected rows
         DCHECK_EQ(filter->size(), range.span_size()) << "Filter size must match range size";
         for (uint64_t i = range.begin(); i < range.end(); ++i) {
             size_t filter_index = i - range.begin();
             if ((*filter)[filter_index]) {
-                // Generate row id based on the first row id and the current row index.
                 int64_t row_id = _first_row_id + i;
                 dst_col->append_datum(Datum(row_id));
             }
@@ -49,15 +45,6 @@ Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter
 Status IcebergRowIdReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
     dst->as_mutable_raw_ptr()->swap_column(*(src->as_mutable_raw_ptr()));
     return Status::OK();
-}
-
-void IcebergRowIdReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
-                                                 int64_t* end_offset, ColumnIOTypeFlags types, bool active) {
-    // No IO ranges to collect for row id reader.
-}
-
-void IcebergRowIdReader::select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) {
-    // No offset index selection needed for row id reader.
 }
 
 StatusOr<bool> IcebergRowIdReader::row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
@@ -77,7 +64,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
     SparseRange<int64_t> row_id_range(_first_row_id + rg_first_row, _first_row_id + rg_first_row + rg_num_rows);
 
     if (pred_relation == CompoundNodeType::AND) {
-        // For AND relation, apply all predicates sequentially with intersection
+        // AND: intersect all predicate ranges sequentially
         for (const auto& pred : predicates) {
             SparseRange<int64_t> pred_range;
             StatusOr<bool> result = _apply_single_predicate(pred, pred_range);
@@ -85,18 +72,15 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
                 return result.status();
             }
             if (!result.value()) {
-                // Predicate not supported, can't apply filtering
                 return false;
             }
             row_id_range &= pred_range;
-
-            // Early exit if range becomes empty
             if (row_id_range.empty()) {
                 break;
             }
         }
     } else if (pred_relation == CompoundNodeType::OR) {
-        // For OR relation, apply all predicates and take union
+        // OR: union all predicate ranges, then intersect with row group range
         SparseRange<int64_t> union_range;
         bool has_valid_predicate = false;
 
@@ -114,7 +98,6 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
         }
 
         if (!has_valid_predicate) {
-            // No supported predicates, can't apply filtering
             return false;
         }
 
@@ -127,7 +110,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
         return false;
     }
 
-    // Convert row_id range to row ranges
+    // Convert row_id ranges back to row-group-relative row ranges
     for (size_t i = 0; i < row_id_range.size(); i++) {
         Range<int64_t> range = row_id_range[i];
         row_ranges->add(Range<uint64_t>(range.begin() - _first_row_id, range.end() - _first_row_id));
@@ -136,17 +119,17 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
     return true;
 }
 
+// Convert a single predicate on _row_id into a SparseRange of matching row_id values.
+// Returns true if the predicate was converted, false if unsupported.
 StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate* pred,
                                                            SparseRange<int64_t>& result_range) {
     switch (pred->type()) {
     case PredicateType::kEQ: {
-        // Equal: [value, value]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value, value + 1);
         return true;
     }
     case PredicateType::kNE: {
-        // Not Equal: [0, value) | (value, max]
         int64_t value = pred->value().get_int64();
         if (value > 0) {
             result_range.add(Range<int64_t>(0, value));
@@ -157,34 +140,28 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kGT: {
-        // Greater Than: (value, max]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value + 1, std::numeric_limits<int64_t>::max());
         return true;
     }
     case PredicateType::kGE: {
-        // Greater Equal: [value, max]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(value, std::numeric_limits<int64_t>::max());
         return true;
     }
     case PredicateType::kLT: {
-        // Less Than: [0, value)
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(0, value);
         return true;
     }
     case PredicateType::kLE: {
-        // Less Equal: [0, value]
         int64_t value = pred->value().get_int64();
         result_range = SparseRange<int64_t>(0, value + 1);
         return true;
     }
     case PredicateType::kInList: {
-        // In List: union of all values
         const auto& values = pred->values();
         if (values.empty()) {
-            // Empty IN list means no rows match
             result_range = SparseRange<int64_t>();
             return true;
         }
@@ -195,39 +172,28 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kNotInList: {
-        // Not In List: complement of union of all values
+        // Start with full range, then subtract each excluded value
         const auto& values = pred->values();
         if (values.empty()) {
-            // Empty NOT IN list means all rows match
             result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
             return true;
         }
-        // Start with full range
         result_range.add(Range<int64_t>(0, std::numeric_limits<int64_t>::max()));
-
-        // Subtract each value from the range
         for (const auto& value : values) {
             int64_t int_value = value.get_int64();
             SparseRange<int64_t> temp_range;
-
-            // For each range in result_range, subtract the excluded value
             for (size_t i = 0; i < result_range.size(); i++) {
                 const auto& range = result_range[i];
                 if (range.begin() < int_value && range.end() > int_value + 1) {
-                    // Range spans the excluded value, split into two parts
                     temp_range.add(Range<int64_t>(range.begin(), int_value));
                     temp_range.add(Range<int64_t>(int_value + 1, range.end()));
                 } else if (range.begin() < int_value && range.end() > int_value) {
-                    // Range ends at or after excluded value
                     temp_range.add(Range<int64_t>(range.begin(), int_value));
                 } else if (range.begin() < int_value + 1 && range.end() > int_value + 1) {
-                    // Range starts before excluded value ends
                     temp_range.add(Range<int64_t>(int_value + 1, range.end()));
                 } else if (range.begin() >= int_value && range.end() <= int_value + 1) {
-                    // Range is completely within excluded value, skip it
                     continue;
                 } else {
-                    // Range is outside excluded value, keep it
                     temp_range.add(range);
                 }
             }
@@ -236,18 +202,15 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return true;
     }
     case PredicateType::kIsNull: {
-        // IS NULL: no rows match for row_id column (it's always not null)
         result_range = SparseRange<int64_t>();
         return true;
     }
     case PredicateType::kNotNull: {
-        // IS NOT NULL: all rows match for row_id column (it's always not null)
         result_range = SparseRange<int64_t>(0, std::numeric_limits<int64_t>::max());
         return true;
     }
     default: {
         DLOG(WARNING) << "Unsupported predicate type for row_id filtering: " << pred->type();
-        // For unsupported types, we can't apply filtering
         return false;
     }
     }

--- a/be/src/formats/parquet/iceberg_row_id_reader.h
+++ b/be/src/formats/parquet/iceberg_row_id_reader.h
@@ -34,9 +34,11 @@ public:
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
+    // No IO ranges to collect for row id reader.
     void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                                  ColumnIOTypeFlags types, bool active) override {}
 
+    // No offset index selection needed for row id reader.
     void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
 
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,

--- a/be/src/formats/parquet/iceberg_row_id_reader.h
+++ b/be/src/formats/parquet/iceberg_row_id_reader.h
@@ -23,6 +23,7 @@ public:
     explicit IcebergRowIdReader(int64_t first_row_id) : ColumnReader(nullptr), _first_row_id(first_row_id) {
         _cur_row_id = _first_row_id;
     }
+
     ~IcebergRowIdReader() override = default;
 
     Status prepare() override { return Status::OK(); }
@@ -34,9 +35,9 @@ public:
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
 
     void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
-                                 ColumnIOTypeFlags types, bool active) override;
+                                 ColumnIOTypeFlags types, bool active) override {}
 
-    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override;
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
 
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -234,6 +234,7 @@ set(EXEC_FILES
         ./formats/parquet/parquet_ut_base.cpp
         ./formats/parquet/parquet_variant_test.cpp
         ./formats/parquet/parquet_pos_reader_test.cpp
+        ./formats/parquet/iceberg_row_id_reader_test.cpp
         ./formats/parquet/page_index_test.cpp
         ./formats/parquet/dict_encoding_test.cpp
         ./formats/disk_range_test.cpp

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -1799,4 +1799,433 @@ TEST_F(GroupReaderTest, StructColumnReaderFillDstColumnMissingSubfieldReader) {
     ASSERT_TRUE(st.is_internal_error());
 }
 
+// ==================== Iceberg v3 Row Lineage Tests ====================
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNullScanRange) {
+    auto* param = _create_group_reader_param();
+    param->scan_range = nullptr;
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(0);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNoExtendedColumns) {
+    auto* param = _create_group_reader_param();
+    param->scan_range = _pool.add(new THdfsScanRange());
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(0);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueSlotNotFound) {
+    auto* param = _create_group_reader_param();
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(std::map<int32_t, TExpr>());
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(999);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueEmptyNodes) {
+    auto* param = _create_group_reader_param();
+
+    std::map<int32_t, TExpr> extended_columns;
+    TExpr expr;
+    expr.nodes = std::vector<TExprNode>();
+    extended_columns[0] = expr;
+
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(extended_columns);
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(0);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_invalid_argument());
+}
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueWrongNodeType) {
+    auto* param = _create_group_reader_param();
+
+    std::map<int32_t, TExpr> extended_columns;
+    TExpr expr;
+    TExprNode node;
+    node.node_type = TExprNodeType::BOOL_LITERAL;
+    expr.nodes.push_back(node);
+    extended_columns[0] = expr;
+
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(extended_columns);
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(0);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_invalid_argument());
+}
+
+TEST_F(GroupReaderTest, TestGetExtendedBigIntValueSuccess) {
+    auto* param = _create_group_reader_param();
+
+    std::map<int32_t, TExpr> extended_columns;
+    TExpr expr;
+    TExprNode node;
+    node.node_type = TExprNodeType::INT_LITERAL;
+    TIntLiteral int_literal;
+    int_literal.value = 42;
+    node.__set_int_literal(int_literal);
+    expr.nodes.push_back(node);
+    extended_columns[0] = expr;
+
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(extended_columns);
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    auto result = group_reader->_get_extended_bigint_value(0);
+    ASSERT_OK(result);
+    ASSERT_EQ(result.value(), 42);
+}
+
+TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderNotFound) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    SlotDescriptor slot(0, "_row_id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+    auto result = group_reader->_create_reserved_iceberg_column_reader(&slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID);
+    ASSERT_OK(result);
+    ASSERT_EQ(result.value(), nullptr);
+}
+
+TEST_F(GroupReaderTest, TestIcebergRowIdColumnReaderCreation) {
+    auto* param = _create_group_reader_param();
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
+                                                     TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(row_id_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+    ASSERT_NE(group_reader->_column_readers[100], nullptr);
+    delete group_reader;
+}
+
+TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation) {
+    auto* param = _create_group_reader_param();
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
+                                                  TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(seq_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    std::map<int32_t, TExpr> extended_columns;
+    TExpr expr;
+    TExprNode node;
+    node.node_type = TExprNodeType::INT_LITERAL;
+    TIntLiteral int_literal;
+    int_literal.value = 100;
+    node.__set_int_literal(int_literal);
+    expr.nodes.push_back(node);
+    extended_columns[101] = expr;
+
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(extended_columns);
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+    ASSERT_NE(group_reader->_column_readers[101], nullptr);
+    delete group_reader;
+}
+
+// Helper to build a tparquet::FileMetaData that includes the standard 6 read_cols
+// PLUS extra iceberg reserved columns (_row_id and/or _last_updated_sequence_number)
+// with proper field_ids so that get_field_idx_by_field_id returns a valid index.
+static tparquet::FileMetaData build_t_filemeta_with_iceberg_columns(ObjectPool* pool, const GroupReaderParam* param,
+                                                                    bool include_row_id, bool include_seq_num) {
+    tparquet::FileMetaData t_file_meta;
+
+    // Count total columns
+    size_t num_read_cols = param->read_cols.size();
+    size_t extra_cols = (include_row_id ? 1 : 0) + (include_seq_num ? 1 : 0);
+    size_t total_cols = num_read_cols + extra_cols;
+
+    // Build schema elements
+    std::vector<tparquet::SchemaElement> schema_elements;
+
+    // Root element
+    tparquet::SchemaElement root;
+    root.__set_num_children(static_cast<int32_t>(total_cols));
+    schema_elements.push_back(root);
+
+    // Standard read_cols
+    for (size_t i = 0; i < num_read_cols; i++) {
+        tparquet::SchemaElement elem;
+        elem.__set_type(param->read_cols[i].type_in_parquet);
+        elem.__set_name("c" + std::to_string(i));
+        elem.__set_num_children(0);
+        schema_elements.push_back(elem);
+    }
+
+    // _row_id column with ICEBERG_ROW_ID_COLUMN_ID field_id
+    if (include_row_id) {
+        tparquet::SchemaElement elem;
+        elem.__set_type(tparquet::Type::INT64);
+        elem.__set_name(HdfsScanner::ICEBERG_ROW_ID);
+        elem.__set_num_children(0);
+        elem.__set_field_id(HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID);
+        schema_elements.push_back(elem);
+    }
+
+    // _last_updated_sequence_number column
+    if (include_seq_num) {
+        tparquet::SchemaElement elem;
+        elem.__set_type(tparquet::Type::INT64);
+        elem.__set_name(HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER);
+        elem.__set_num_children(0);
+        elem.__set_field_id(HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID);
+        schema_elements.push_back(elem);
+    }
+
+    // Build row groups (2 row groups, each with column chunks for all columns)
+    std::vector<tparquet::RowGroup> row_groups;
+    for (size_t rg = 0; rg < 2; rg++) {
+        tparquet::RowGroup row_group;
+        std::vector<tparquet::ColumnChunk> cols;
+        for (size_t i = 0; i < total_cols; i++) {
+            tparquet::ColumnChunk col;
+            col.__set_file_path("c" + std::to_string(i));
+            col.file_offset = 0;
+            col.meta_data.data_page_offset = 4;
+            cols.push_back(col);
+        }
+        row_group.__set_columns(cols);
+        row_group.__set_num_rows(12);
+        row_groups.push_back(row_group);
+    }
+
+    t_file_meta.__set_version(0);
+    t_file_meta.__set_row_groups(row_groups);
+    t_file_meta.__set_schema(schema_elements);
+    return t_file_meta;
+}
+
+TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderFound) {
+    auto* param = _create_group_reader_param();
+
+    // Build file metadata with _row_id physical column
+    auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
+                                                             /*include_row_id=*/true, /*include_seq_num=*/false);
+    auto* file_meta = _pool.add(new FileMetaData());
+    ASSERT_OK(file_meta->init(t_file_meta, true));
+
+    auto* file = _pool.add(new RandomAccessFile(std::make_shared<MockInputStream>(), "mock"));
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+    param->timezone = "UTC";
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    SlotDescriptor slot(200, HdfsScanner::ICEBERG_ROW_ID, TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+    auto result = group_reader->_create_reserved_iceberg_column_reader(&slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID);
+    ASSERT_OK(result);
+    // Physical column found -> non-null reader
+    ASSERT_NE(result.value(), nullptr);
+}
+
+TEST_F(GroupReaderTest, TestIcebergRowIdPhysicalColumnReaderCreation) {
+    auto* param = _create_group_reader_param();
+
+    // Set up reserved_field_slots with _row_id
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
+                                                     TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(row_id_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    // Build file metadata WITH physical _row_id column (field_id matches)
+    auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
+                                                             /*include_row_id=*/true, /*include_seq_num=*/false);
+    auto* file_meta = _pool.add(new FileMetaData());
+    ASSERT_OK(file_meta->init(t_file_meta, true));
+
+    auto* file = _pool.add(new RandomAccessFile(std::make_shared<MockInputStream>(), "mock"));
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+    // The _row_id column reader should be created from the physical column (not IcebergRowIdReader)
+    ASSERT_NE(group_reader->_column_readers[100], nullptr);
+    delete group_reader;
+}
+
+TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation) {
+    auto* param = _create_group_reader_param();
+
+    // Set up reserved_field_slots with _last_updated_sequence_number
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
+                                                  TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(seq_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    // Build file metadata WITH physical _last_updated_sequence_number column (field_id matches)
+    auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
+                                                             /*include_row_id=*/false, /*include_seq_num=*/true);
+    auto* file_meta = _pool.add(new FileMetaData());
+    ASSERT_OK(file_meta->init(t_file_meta, true));
+
+    auto* file = _pool.add(new RandomAccessFile(std::make_shared<MockInputStream>(), "mock"));
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+    // The _last_updated_sequence_number reader should be created from the physical column
+    ASSERT_NE(group_reader->_column_readers[101], nullptr);
+    delete group_reader;
+}
+
+TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
+    auto* param = _create_group_reader_param();
+
+    // Set up reserved_field_slots with both _row_id and _last_updated_sequence_number
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
+                                                     TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
+                                                  TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(row_id_slot);
+    reserved_slots->push_back(seq_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    // Build file metadata with both physical iceberg columns
+    auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
+                                                             /*include_row_id=*/true, /*include_seq_num=*/true);
+    auto* file_meta = _pool.add(new FileMetaData());
+    ASSERT_OK(file_meta->init(t_file_meta, true));
+
+    auto* file = _pool.add(new RandomAccessFile(std::make_shared<MockInputStream>(), "mock"));
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+    // Both physical column readers should be created
+    ASSERT_NE(group_reader->_column_readers[100], nullptr);
+    ASSERT_NE(group_reader->_column_readers[101], nullptr);
+    delete group_reader;
+}
+
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/iceberg_row_id_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_row_id_reader_test.cpp
@@ -1,0 +1,438 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/iceberg_row_id_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "formats/parquet/column_reader.h"
+#include "formats/parquet/scalar_column_reader.h"
+#include "storage/column_predicate.h"
+#include "storage/range.h"
+#include "types/datum.h"
+
+namespace starrocks::parquet {
+
+class IcebergRowIdReaderTest : public testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    ObjectPool _pool;
+};
+
+// ==================== Basic read_range tests ====================
+
+TEST_F(IcebergRowIdReaderTest, TestReadRangeWithoutFilter) {
+    IcebergRowIdReader reader(1000);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 5);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 5);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 1000 + i);
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestReadRangeIgnoresFilter) {
+    // IcebergRowIdReader ignores filter and outputs all rows (consistent with other reserved
+    // column readers). The caller applies chunk->filter_range() uniformly afterwards.
+    IcebergRowIdReader reader(500);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 5);
+    Filter filter = {true, false, true, false, true};
+
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+
+    ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
+    // All 5 rows should be output regardless of filter
+    ASSERT_EQ(column->size(), 5);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 500 + i);
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestReadRangeWithOffset) {
+    // Simulate reading from a row group that doesn't start at row 0
+    IcebergRowIdReader reader(1000);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    // Range [10, 15) means rows 10..14 within the row group
+    Range<uint64_t> range(10, 15);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 5);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 1010 + i);
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestReadEmptyRange) {
+    IcebergRowIdReader reader(0);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(5, 5);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 0);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestFillDstColumn) {
+    IcebergRowIdReader reader(100);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 3);
+    ColumnPtr src = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    ASSERT_TRUE(reader.read_range(range, nullptr, src).ok());
+
+    ColumnPtr dst = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    ASSERT_TRUE(reader.fill_dst_column(dst, src).ok());
+    ASSERT_EQ(dst->size(), 3);
+    ASSERT_EQ(dst->get(0).get_int64(), 100);
+    ASSERT_EQ(dst->get(1).get_int64(), 101);
+    ASSERT_EQ(dst->get(2).get_int64(), 102);
+}
+
+// ==================== No-op method tests ====================
+
+TEST_F(IcebergRowIdReaderTest, TestNoOpMethods) {
+    IcebergRowIdReader reader(0);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    level_t* def_levels = nullptr;
+    level_t* rep_levels = nullptr;
+    size_t num_levels = 0;
+    reader.get_levels(&def_levels, &rep_levels, &num_levels);
+    reader.set_need_parse_levels(true);
+
+    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+    int64_t end_offset = 0;
+    reader.collect_column_io_range(&ranges, &end_offset, ColumnIOType::PAGES, true);
+    ASSERT_TRUE(ranges.empty());
+
+    SparseRange<uint64_t> sparse_range;
+    reader.select_offset_index(sparse_range, 100);
+}
+
+// ==================== Zone map filter tests ====================
+
+TEST_F(IcebergRowIdReaderTest, TestRowGroupZoneMapFilterEQ) {
+    // first_row_id=1000, row_group starts at row 0, 100 rows
+    // zone map: [1000, 1099]
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // EQ predicate matching within range
+    Datum eq_val(static_cast<int64_t>(1050));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto result = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    // Should NOT be filtered out (predicate falls within zone map)
+    ASSERT_FALSE(result.value());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestRowGroupZoneMapFilterOutOfRange) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // EQ predicate outside range: row_ids are [1000,1099], predicate is 2000
+    Datum eq_val(static_cast<int64_t>(2000));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto result = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    // Should be filtered out
+    ASSERT_TRUE(result.value());
+}
+
+// ==================== Page index zone map filter tests ====================
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterEQ) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // EQ _row_id = 1005
+    Datum eq_val(static_cast<int64_t>(1005));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    ASSERT_TRUE(result.value());
+    // Should produce a single range [5, 6)
+    ASSERT_EQ(row_ranges.size(), 1);
+    ASSERT_EQ(row_ranges[0].begin(), 5);
+    ASSERT_EQ(row_ranges[0].end(), 6);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterGE) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // GE _row_id >= 1090
+    Datum ge_val(static_cast<int64_t>(1090));
+    ColumnPredicate* ge_pred = _pool.add(new_column_ge_predicate_from_datum(type_info, 0, ge_val));
+    std::vector<const ColumnPredicate*> predicates = {ge_pred};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    ASSERT_TRUE(result.value());
+    // Should produce range [90, 100)
+    ASSERT_EQ(row_ranges.size(), 1);
+    ASSERT_EQ(row_ranges[0].begin(), 90);
+    ASSERT_EQ(row_ranges[0].end(), 100);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterLT) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // LT _row_id < 1003
+    Datum lt_val(static_cast<int64_t>(1003));
+    ColumnPredicate* lt_pred = _pool.add(new_column_lt_predicate_from_datum(type_info, 0, lt_val));
+    std::vector<const ColumnPredicate*> predicates = {lt_pred};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    ASSERT_TRUE(result.value());
+    // Should produce range [0, 3)
+    ASSERT_EQ(row_ranges.size(), 1);
+    ASSERT_EQ(row_ranges[0].begin(), 0);
+    ASSERT_EQ(row_ranges[0].end(), 3);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterNoFilteringWhenAllRowsMatch) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // GE _row_id >= 0 — all rows match, no filtering possible
+    Datum ge_val(static_cast<int64_t>(0));
+    ColumnPredicate* ge_pred = _pool.add(new_column_ge_predicate_from_datum(type_info, 0, ge_val));
+    std::vector<const ColumnPredicate*> predicates = {ge_pred};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    // Returns false when all rows match (no filtering benefit)
+    ASSERT_FALSE(result.value());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterAND) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // AND: _row_id >= 1010 AND _row_id < 1020
+    Datum ge_val(static_cast<int64_t>(1010));
+    ColumnPredicate* ge_pred = _pool.add(new_column_ge_predicate_from_datum(type_info, 0, ge_val));
+    Datum lt_val(static_cast<int64_t>(1020));
+    ColumnPredicate* lt_pred = _pool.add(new_column_lt_predicate_from_datum(type_info, 0, lt_val));
+    std::vector<const ColumnPredicate*> predicates = {ge_pred, lt_pred};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    ASSERT_TRUE(result.value());
+    // Should produce range [10, 20)
+    ASSERT_EQ(row_ranges.size(), 1);
+    ASSERT_EQ(row_ranges[0].begin(), 10);
+    ASSERT_EQ(row_ranges[0].end(), 20);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterOR) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // OR: _row_id = 1005 OR _row_id = 1010
+    Datum val1(static_cast<int64_t>(1005));
+    ColumnPredicate* eq1 = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, val1));
+    Datum val2(static_cast<int64_t>(1010));
+    ColumnPredicate* eq2 = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, val2));
+    std::vector<const ColumnPredicate*> predicates = {eq1, eq2};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::OR, 0, 100);
+    ASSERT_TRUE(result.ok());
+    ASSERT_TRUE(result.value());
+    // Should produce two ranges: [5, 6) and [10, 11)
+    ASSERT_EQ(row_ranges.size(), 2);
+    ASSERT_EQ(row_ranges[0].begin(), 5);
+    ASSERT_EQ(row_ranges[0].end(), 6);
+    ASSERT_EQ(row_ranges[1].begin(), 10);
+    ASSERT_EQ(row_ranges[1].end(), 11);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterIsNull) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // IS NULL: _row_id is never null, so no rows match -> AND with empty range = empty
+    ColumnPredicate* is_null = _pool.add(new_column_null_predicate(type_info, 0, true));
+    std::vector<const ColumnPredicate*> predicates = {is_null};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    // Empty intersection means filtering happened, but no rows left
+    ASSERT_TRUE(result.value());
+    ASSERT_TRUE(row_ranges.empty());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterIsNotNull) {
+    IcebergRowIdReader reader(1000);
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+
+    // IS NOT NULL: all rows match for _row_id
+    ColumnPredicate* is_not_null = _pool.add(new_column_null_predicate(type_info, 0, false));
+    std::vector<const ColumnPredicate*> predicates = {is_not_null};
+
+    SparseRange<uint64_t> row_ranges;
+    auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 100);
+    ASSERT_TRUE(result.ok());
+    // All rows match, no filtering benefit
+    ASSERT_FALSE(result.value());
+}
+
+// ==================== FixedValueColumnReader for row lineage fallback ====================
+
+TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderForNullRowId) {
+    // When first_row_id is unavailable (late materialization on pre-v3 files),
+    // a FixedValueColumnReader with kNullDatum is used.
+    auto reader = std::make_unique<FixedValueColumnReader>(kNullDatum);
+    ASSERT_TRUE(reader->prepare().ok());
+
+    Range<uint64_t> range(0, 5);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+
+    ASSERT_TRUE(reader->read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 5);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_TRUE(column->get(i).is_null());
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderForSequenceNumber) {
+    // When the Parquet file has no physical _last_updated_sequence_number column,
+    // a FixedValueColumnReader with the file-level dataSequenceNumber is used.
+    int64_t sequence_number = 42;
+    auto reader = std::make_unique<FixedValueColumnReader>(Datum(sequence_number));
+    ASSERT_TRUE(reader->prepare().ok());
+
+    Range<uint64_t> range(0, 5);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+
+    ASSERT_TRUE(reader->read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 5);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 42);
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderWithFilter) {
+    int64_t sequence_number = 99;
+    auto reader = std::make_unique<FixedValueColumnReader>(Datum(sequence_number));
+    ASSERT_TRUE(reader->prepare().ok());
+
+    Range<uint64_t> range(0, 4);
+    Filter filter = {true, false, true, false};
+
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+
+    ASSERT_TRUE(reader->read_range(range, &filter, column).ok());
+    // FixedValueColumnReader fills all rows in range (filter is applied later by caller)
+    ASSERT_EQ(column->size(), 4);
+    for (size_t i = 0; i < column->size(); i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 99);
+    }
+}
+
+// ==================== Simulating post-compaction scenario ====================
+// After compaction, _row_id and _last_updated_sequence_number are physical columns.
+// This is handled by the standard parquet ColumnReader (created via _create_reserved_iceberg_column_reader).
+// Here we verify the fallback readers produce distinct per-row values (IcebergRowIdReader)
+// vs. constant values (FixedValueColumnReader).
+
+TEST_F(IcebergRowIdReaderTest, TestRowIdReaderVsFixedValueDifferentBehavior) {
+    // IcebergRowIdReader: generates distinct row_id per row (first_row_id + position)
+    IcebergRowIdReader row_id_reader(5000);
+    ASSERT_TRUE(row_id_reader.prepare().ok());
+
+    Range<uint64_t> range(0, 3);
+    ColumnPtr row_id_col =
+            ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    ASSERT_TRUE(row_id_reader.read_range(range, nullptr, row_id_col).ok());
+
+    // FixedValueColumnReader: returns the same value for every row
+    auto seq_reader = std::make_unique<FixedValueColumnReader>(Datum(static_cast<int64_t>(10)));
+    ASSERT_TRUE(seq_reader->prepare().ok());
+
+    ColumnPtr seq_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_TRUE(seq_reader->read_range(range, nullptr, seq_col).ok());
+
+    ASSERT_EQ(row_id_col->size(), 3);
+    ASSERT_EQ(seq_col->size(), 3);
+
+    // Row IDs should be distinct and increasing
+    ASSERT_EQ(row_id_col->get(0).get_int64(), 5000);
+    ASSERT_EQ(row_id_col->get(1).get_int64(), 5001);
+    ASSERT_EQ(row_id_col->get(2).get_int64(), 5002);
+
+    // Sequence numbers should all be the same (file-level constant)
+    ASSERT_EQ(seq_col->get(0).get_int64(), 10);
+    ASSERT_EQ(seq_col->get(1).get_int64(), 10);
+    ASSERT_EQ(seq_col->get(2).get_int64(), 10);
+}
+
+// ==================== Large first_row_id (post-compaction) ====================
+
+TEST_F(IcebergRowIdReaderTest, TestLargeFirstRowId) {
+    // After compaction, first_row_id can be very large
+    int64_t large_first_row_id = 1000000000000LL;
+    IcebergRowIdReader reader(large_first_row_id);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 3);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+
+    ASSERT_EQ(column->size(), 3);
+    ASSERT_EQ(column->get(0).get_int64(), large_first_row_id);
+    ASSERT_EQ(column->get(1).get_int64(), large_first_row_id + 1);
+    ASSERT_EQ(column->get(2).get_int64(), large_first_row_id + 2);
+}
+
+} // namespace starrocks::parquet

--- a/docs/en/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -40,7 +40,8 @@ SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]t
 :::note
 
 - The `_row_id` column requires data files to have `firstRowId` metadata. If a data file is missing `firstRowId`, the query will fail with an error.
-- The `_last_updated_sequence_number` column returns the data sequence number (`dataSequenceNumber`) of the data file.
+- For newly inserted data, `_row_id` is computed as `firstRowId + row_position` and `_last_updated_sequence_number` is the file-level `dataSequenceNumber`.
+- After compaction (e.g., Iceberg OPTIMIZE / rewrite-data-files), if the compactor writes `_row_id` and `_last_updated_sequence_number` as physical columns in the data files (as required by the Iceberg v3 spec), StarRocks reads the per-row values from the physical columns, preserving row lineage across compaction.
 - These metadata columns are only available for Iceberg v3 tables (format-version = 3).
 
 :::

--- a/docs/en/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -22,6 +22,29 @@ Currently, StarRocks supports the following Iceberg metadata tables:
 | `files`                | Shows details about the data files and delete files in the current snapshot of the table. |
 | `refs`                 | Shows details about the Iceberg references, including branches and tags. |
 
+## Iceberg v3 Row Lineage Metadata Columns
+
+From v4.1 onwards, for Iceberg v3 tables (format-version = 3), StarRocks supports querying the following Row Lineage metadata columns:
+
+| Metadata Column                 | Description                                                                                    |
+| :------------------------------ | :--------------------------------------------------------------------------------------------- |
+| `_row_id`                       | Unique row identifier within the table (BIGINT). Format: `firstRowId + row_position`.          |
+| `_last_updated_sequence_number` | The commit sequence number when the row was last updated (BIGINT).                             |
+
+Usage:
+
+```SQL
+SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]table;
+```
+
+:::note
+
+- The `_row_id` column requires data files to have `firstRowId` metadata. If a data file is missing `firstRowId`, the query will fail with an error.
+- The `_last_updated_sequence_number` column returns the data sequence number (`dataSequenceNumber`) of the data file.
+- These metadata columns are only available for Iceberg v3 tables (format-version = 3).
+
+:::
+
 ## `history` table
 
 Usage:

--- a/docs/ja/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -22,6 +22,29 @@ displayed_sidebar: docs
 | `files`                | テーブルの現在のスナップショット内のデータファイルと削除ファイルの詳細を表示します。 |
 | `refs`                 | Iceberg の参照に関する詳細を表示し、ブランチやタグを含みます。 |
 
+## Iceberg v3 Row Lineage メタデータ列
+
+バージョン v4.1 以降、Iceberg v3 テーブル（format-version = 3）の場合、StarRocks は以下の Row Lineage メタデータ列のクエリをサポートしています：
+
+| メタデータ列                      | 説明                                                                                           |
+| :-------------------------------- | :--------------------------------------------------------------------------------------------- |
+| `_row_id`                         | テーブル内で一意の行識別子（BIGINT）。形式：`firstRowId + row_position`。                       |
+| `_last_updated_sequence_number`   | 行が最後に更新されたコミットシーケンス番号（BIGINT）。                                          |
+
+使用法：
+
+```SQL
+SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]table;
+```
+
+:::note
+
+- `_row_id` 列には、データファイルに `firstRowId` メタデータが必要です。データファイルに `firstRowId` がない場合、クエリはエラーで失敗します。
+- `_last_updated_sequence_number` 列は、データファイルのデータシーケンス番号（`dataSequenceNumber`）を返します。
+- これらのメタデータ列は Iceberg v3 テーブル（format-version = 3）でのみ使用可能です。
+
+:::
+
 ## `history` テーブル
 
 使用法:

--- a/docs/ja/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -40,7 +40,8 @@ SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]t
 :::note
 
 - `_row_id` 列には、データファイルに `firstRowId` メタデータが必要です。データファイルに `firstRowId` がない場合、クエリはエラーで失敗します。
-- `_last_updated_sequence_number` 列は、データファイルのデータシーケンス番号（`dataSequenceNumber`）を返します。
+- 新規挿入データの場合、`_row_id` は `firstRowId + row_position` で計算され、`_last_updated_sequence_number` はファイルレベルの `dataSequenceNumber` になります。
+- コンパクション（Iceberg OPTIMIZE / rewrite-data-files など）後、コンパクターが Iceberg v3 仕様に従って `_row_id` と `_last_updated_sequence_number` をデータファイルの物理列として書き込んだ場合、StarRocks は各行の物理列値を読み取り、コンパクション後も行リネージ情報を保持します。
 - これらのメタデータ列は Iceberg v3 テーブル（format-version = 3）でのみ使用可能です。
 
 :::

--- a/docs/zh/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -40,7 +40,8 @@ SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]t
 :::note
 
 - `_row_id` 列需要数据文件具备 `firstRowId` 元信息。如果数据文件缺失 `firstRowId`，查询将失败并报错。
-- `_last_updated_sequence_number` 列返回该数据文件的数据序列号（`dataSequenceNumber`）。
+- 对于新写入的数据，`_row_id` 通过 `firstRowId + row_position` 计算，`_last_updated_sequence_number` 取文件级别的 `dataSequenceNumber`。
+- 在 compaction（如 Iceberg OPTIMIZE / rewrite-data-files）后，如果 compactor 按照 Iceberg v3 规范将 `_row_id` 和 `_last_updated_sequence_number` 写入数据文件的物理列中，StarRocks 会读取每行的物理列值，从而在 compaction 后保留行血缘信息。
 - 这些元数据列仅对 Iceberg v3 表（format-version = 3）可用。
 
 :::

--- a/docs/zh/data_source/catalog/iceberg/iceberg_meta_table.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_meta_table.md
@@ -22,6 +22,29 @@ displayed_sidebar: docs
 | `files`                | 显示当前快照中数据文件（Data File）和删除文件（Delete File）的详细信息。 |
 | `refs`                 | 显示关于 Iceberg 引用（Reference）的详细信息，包括分支和标签。 |
 
+## Iceberg v3 Row Lineage 元数据列
+
+从 v4.1 开始，对于 Iceberg v3 表（format-version = 3），StarRocks 支持查询以下行血缘（Row Lineage）相关的元数据列：
+
+| 元数据列                     | 描述                                                                                       |
+| :--------------------------- | :----------------------------------------------------------------------------------------- |
+| `_row_id`                    | 表内唯一的行标识符（BIGINT）。格式：`firstRowId + row_position`。                          |
+| `_last_updated_sequence_number` | 该行最后更新时的提交序列号（BIGINT）。                                                  |
+
+使用方法：
+
+```SQL
+SELECT _row_id, _last_updated_sequence_number, * FROM [<catalog>.][<database>.]table;
+```
+
+:::note
+
+- `_row_id` 列需要数据文件具备 `firstRowId` 元信息。如果数据文件缺失 `firstRowId`，查询将失败并报错。
+- `_last_updated_sequence_number` 列返回该数据文件的数据序列号（`dataSequenceNumber`）。
+- 这些元数据列仅对 Iceberg v3 表（format-version = 3）可用。
+
+:::
+
 ## `history` 表
 
 用法：

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -107,11 +107,12 @@ public class IcebergTable extends Table {
     public static final String SPEC_ID = "$spec_id";
     public static final String EQUALITY_DELETE_TABLE_COMMENT = "equality_delete_table_comment";
     public static final String ROW_ID = "_row_id";
+    public static final String LAST_UPDATED_SEQUENCE_NUMBER = "_last_updated_sequence_number";
     public static final String FILE_PATH = MetadataColumns.FILE_PATH.name();
     public static final String ROW_POSITION = MetadataColumns.ROW_POSITION.name();
 
     public static final Set<String> ICEBERG_META_COLUMNS = Set.of(
-            DATA_SEQUENCE_NUMBER, SPEC_ID, ROW_ID, FILE_PATH, ROW_POSITION
+            DATA_SEQUENCE_NUMBER, SPEC_ID, ROW_ID, LAST_UPDATED_SEQUENCE_NUMBER, FILE_PATH, ROW_POSITION
     );
 
     private String catalogName;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -325,6 +325,13 @@ public class IcebergApiConverter {
                     column.setIsHidden(true);
                     fullSchema.add(column);
                 }
+                boolean hasLastUpdatedSequenceNumber = fullSchema.stream()
+                        .anyMatch(column -> column.getName().equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER));
+                if (!hasLastUpdatedSequenceNumber) {
+                    Column column = new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, IntegerType.BIGINT, true);
+                    column.setIsHidden(true);
+                    fullSchema.add(column);
+                }
             }
         }
         return fullSchema;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -359,10 +359,17 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         List<SlotDescriptor> slots = desc.getSlots();
         Map<Integer, TExpr> extendedColumns = new HashMap<>();
         boolean hasRowIdColumn = false;
+        // Late materialization adds _row_source_id and _scan_range_id along with _row_id.
+        // We need to distinguish between user-requested _row_id and late materialization internal use.
+        boolean hasLateMaterializationColumns = false;
         for (SlotDescriptor slot : slots) {
             String name = slot.getColumn().getName();
             if (name.equalsIgnoreCase(ROW_ID)) {
                 hasRowIdColumn = true;
+                continue;
+            }
+            if (name.equalsIgnoreCase("_row_source_id") || name.equalsIgnoreCase("_scan_range_id")) {
+                hasLateMaterializationColumns = true;
                 continue;
             }
             LiteralExpr value;
@@ -398,11 +405,17 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
 
         if (hasRowIdColumn) {
-            if (task.file() == null || task.file().firstRowId() == null) {
-                throw new StarRocksConnectorException(
-                        "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
+            // Only throw exception if user explicitly requested _row_id (not from late materialization)
+            if (!hasLateMaterializationColumns) {
+                if (task.file() == null || task.file().firstRowId() == null) {
+                    throw new StarRocksConnectorException(
+                            "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
+                }
             }
-            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
+            // Set first_row_id if available (for both user-requested and late materialization cases)
+            if (task.file() != null && task.file().firstRowId() != null) {
+                hdfsScanRange.setFirst_row_id(task.file().firstRowId());
+            }
         } else if (task.file() != null && task.file().firstRowId() != null) {
             hdfsScanRange.setFirst_row_id(task.file().firstRowId());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -364,6 +364,9 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         boolean hasLateMaterializationColumns = false;
         for (SlotDescriptor slot : slots) {
             String name = slot.getColumn().getName();
+            // _row_id is handled as a reserved field in BE (not an extended column).
+            // It is computed as firstRowId + row_position, or read from the physical Parquet column
+            // if present (after compaction).
             if (name.equalsIgnoreCase(ROW_ID)) {
                 hasRowIdColumn = true;
                 continue;
@@ -378,7 +381,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 setExtendedColumns(slot, extendedColumns, value);
             } else if (name.equalsIgnoreCase(LAST_UPDATED_SEQUENCE_NUMBER)) {
                 value = LiteralExprFactory.create(String.valueOf(file.dataSequenceNumber()), IntegerType.BIGINT);
-                setExtendedColumns(slot, extendedColumns, value);
+                setExtendedColumns(slot, extendedColumns, value, false);
             } else if (name.equalsIgnoreCase(SPEC_ID)) {
                 value = LiteralExprFactory.create(String.valueOf(file.specId()), IntegerType.INT);
                 setExtendedColumns(slot, extendedColumns, value);
@@ -406,13 +409,13 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
         if (hasRowIdColumn) {
             // Only throw exception if user explicitly requested _row_id (not from late materialization)
+            // and the file has no firstRowId metadata.
             if (!hasLateMaterializationColumns) {
                 if (task.file() == null || task.file().firstRowId() == null) {
                     throw new StarRocksConnectorException(
                             "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
                 }
             }
-            // Set first_row_id if available (for both user-requested and late materialization cases)
             if (task.file() != null && task.file().firstRowId() != null) {
                 hdfsScanRange.setFirst_row_id(task.file().firstRowId());
             }
@@ -424,8 +427,19 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     }
 
     private void setExtendedColumns(SlotDescriptor slot, Map<Integer, TExpr> extendedColumns, LiteralExpr value) {
+        setExtendedColumns(slot, extendedColumns, value, true);
+    }
+
+    /**
+     * Puts the value into the extended_columns map for BE to access.
+     * When registerExtendedSlot is false, the slot is NOT added to extendedColumnSlotIds,
+     * so BE treats it as a reserved field and can attempt physical column read first
+     * (e.g. _last_updated_sequence_number after compaction), falling back to the extended value.
+     */
+    private void setExtendedColumns(SlotDescriptor slot, Map<Integer, TExpr> extendedColumns, LiteralExpr value,
+                                    boolean registerExtendedSlot) {
         extendedColumns.put(slot.getId().asInt(), ExprToThrift.treeToThrift(value));
-        if (!extendedColumnSlotIds.contains(slot.getId().asInt())) {
+        if (registerExtendedSlot && !extendedColumnSlotIds.contains(slot.getId().asInt())) {
             extendedColumnSlotIds.add(slot.getId().asInt());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -85,6 +85,8 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
 import static com.starrocks.catalog.IcebergTable.FILE_PATH;
+import static com.starrocks.catalog.IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER;
+import static com.starrocks.catalog.IcebergTable.ROW_ID;
 import static com.starrocks.catalog.IcebergTable.SPEC_ID;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.iceberg.IcebergUtil.checkFileFormatSupportedDelete;
@@ -356,10 +358,18 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         // fill extended column value
         List<SlotDescriptor> slots = desc.getSlots();
         Map<Integer, TExpr> extendedColumns = new HashMap<>();
+        boolean hasRowIdColumn = false;
         for (SlotDescriptor slot : slots) {
             String name = slot.getColumn().getName();
+            if (name.equalsIgnoreCase(ROW_ID)) {
+                hasRowIdColumn = true;
+                continue;
+            }
             LiteralExpr value;
             if (name.equalsIgnoreCase(DATA_SEQUENCE_NUMBER)) {
+                value = LiteralExprFactory.create(String.valueOf(file.dataSequenceNumber()), IntegerType.BIGINT);
+                setExtendedColumns(slot, extendedColumns, value);
+            } else if (name.equalsIgnoreCase(LAST_UPDATED_SEQUENCE_NUMBER)) {
                 value = LiteralExprFactory.create(String.valueOf(file.dataSequenceNumber()), IntegerType.BIGINT);
                 setExtendedColumns(slot, extendedColumns, value);
             } else if (name.equalsIgnoreCase(SPEC_ID)) {
@@ -387,7 +397,13 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             hdfsScanRange.setMin_max_values(tExprMinMaxValueMap);
         }
 
-        if (task.file() != null && task.file().firstRowId() != null) {
+        if (hasRowIdColumn) {
+            if (task.file() == null || task.file().firstRowId() == null) {
+                throw new StarRocksConnectorException(
+                        "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
+            }
+            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
+        } else if (task.file() != null && task.file().firstRowId() != null) {
             hdfsScanRange.setFirst_row_id(task.file().firstRowId());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -359,9 +359,6 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         List<SlotDescriptor> slots = desc.getSlots();
         Map<Integer, TExpr> extendedColumns = new HashMap<>();
         boolean hasRowIdColumn = false;
-        // Late materialization adds _row_source_id and _scan_range_id along with _row_id.
-        // We need to distinguish between user-requested _row_id and late materialization internal use.
-        boolean hasLateMaterializationColumns = false;
         for (SlotDescriptor slot : slots) {
             String name = slot.getColumn().getName();
             // _row_id is handled as a reserved field in BE (not an extended column).
@@ -372,7 +369,6 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 continue;
             }
             if (name.equalsIgnoreCase("_row_source_id") || name.equalsIgnoreCase("_scan_range_id")) {
-                hasLateMaterializationColumns = true;
                 continue;
             }
             LiteralExpr value;
@@ -408,17 +404,16 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
 
         if (hasRowIdColumn) {
-            // Only throw exception if user explicitly requested _row_id (not from late materialization)
-            // and the file has no firstRowId metadata.
-            if (!hasLateMaterializationColumns) {
-                if (task.file() == null || task.file().firstRowId() == null) {
-                    throw new StarRocksConnectorException(
-                            "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
-                }
+            // Always validate firstRowId when _row_id is requested, regardless of whether
+            // late materialization columns are present. The optimizer may reuse a user-requested
+            // _row_id while also adding _row_source_id/_scan_range_id, so we cannot assume
+            // _row_id is purely internal. Without firstRowId, BE would produce NULL _row_id
+            // which violates the lookup path's non-null assumption (lookup_request.cpp).
+            if (task.file() == null || task.file().firstRowId() == null) {
+                throw new StarRocksConnectorException(
+                        "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
             }
-            if (task.file() != null && task.file().firstRowId() != null) {
-                hdfsScanRange.setFirst_row_id(task.file().firstRowId());
-            }
+            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
         } else if (task.file() != null && task.file().firstRowId() != null) {
             hdfsScanRange.setFirst_row_id(task.file().firstRowId());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -171,7 +171,8 @@ public class ScalarOperatorToIcebergExpr {
                     type = type.asStructType().fieldType(path);
                 }
             }
-            if (qualifiedName.equals(IcebergTable.ROW_ID)) {
+            if (qualifiedName.equals(IcebergTable.ROW_ID)
+                    || qualifiedName.equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER)) {
                 type = new Types.LongType();
             }
             return type;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -210,10 +210,13 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         long partitionId = scanRangeSource.addPartition(fileScanTask);
         THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
 
+        // _last_updated_sequence_number is passed as an extended column (with dataSequenceNumber value)
+        // but NOT registered as an extended slot (so BE treats it as a reserved field).
         Assertions.assertTrue(
                 hdfsScanRange.getExtended_columns().containsKey(lastUpdatedSequenceNumberSlot.getId().asInt()));
-        Assertions.assertTrue(
-                scanRangeSource.getExtendedColumnSlotIds().contains(lastUpdatedSequenceNumberSlot.getId().asInt()));
+        // It should NOT be in the extendedColumnSlotIds list
+        Assertions.assertFalse(scanRangeSource.getExtendedColumnSlotIds().contains(
+                lastUpdatedSequenceNumberSlot.getId().asInt()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -20,11 +20,13 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.thrift.THdfsScanRange;
 import org.apache.iceberg.FileScanTask;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.starrocks.type.IntegerType.BIGINT;
 import static com.starrocks.type.IntegerType.INT;
 import static com.starrocks.type.VarcharType.VARCHAR;
 
@@ -152,6 +155,138 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
             long partitionId2 = scanRangeSource2.addPartition(fileScanTask);
             Assertions.assertEquals(partitionId1, partitionId2, "Partition IDs should " +
                     "be the same for the same partition keys and values");
+        }
+    }
+
+    @Test
+    public void testToFullSchemasContainsV3RowLineageColumns() {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3", 3);
+        List<Column> fullSchema = IcebergApiConverter.toFullSchemas(
+                mockedNativeTableV3.schema(), mockedNativeTableV3);
+
+        Assertions.assertTrue(fullSchema.stream().anyMatch(
+                column -> column.getName().equals(IcebergTable.ROW_ID) && column.isHidden()));
+        Assertions.assertTrue(fullSchema.stream().anyMatch(
+                column -> column.getName().equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER) && column.isHidden()));
+    }
+
+    @Test
+    public void testToFullSchemasV2NotContainsLastUpdatedSequenceNumber() {
+        List<Column> fullSchema = IcebergApiConverter.toFullSchemas(
+                mockedNativeTableA.schema(), mockedNativeTableA);
+
+        Assertions.assertFalse(fullSchema.stream().anyMatch(
+                column -> column.getName().equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER)));
+    }
+
+    @Test
+    public void testBuildScanRangeContainsLastUpdatedSequenceNumberExtendedColumn() throws Exception {
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(2));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        SlotDescriptor lastUpdatedSequenceNumberSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        lastUpdatedSequenceNumberSlot.setType(BIGINT);
+        lastUpdatedSequenceNumberSlot.setColumn(new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, BIGINT));
+        localTupleDescriptor.addSlot(lastUpdatedSequenceNumberSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+
+        Assertions.assertTrue(
+                hdfsScanRange.getExtended_columns().containsKey(lastUpdatedSequenceNumberSlot.getId().asInt()));
+        Assertions.assertTrue(
+                scanRangeSource.getExtendedColumnSlotIds().contains(lastUpdatedSequenceNumberSlot.getId().asInt()));
+    }
+
+    @Test
+    public void testBuildScanRangeFailFastWhenRowIdWithoutFirstRowId() throws Exception {
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(3));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+        Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
+    }
+
+    @Test
+    public void testBuildScanRangeWithRowIdWhenFirstRowIdPresent() throws Exception {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_rowid", 3);
+
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(4));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        mockedNativeTableV3.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v3", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableV3, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        if (fileScanTask.file().firstRowId() != null) {
+            THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                    fileScanTask, fileScanTask.file(), partitionId);
+            Assertions.assertTrue(hdfsScanRange.isSetFirst_row_id());
+            Assertions.assertEquals(fileScanTask.file().firstRowId().longValue(),
+                    hdfsScanRange.getFirst_row_id());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -289,4 +289,166 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
                     hdfsScanRange.getFirst_row_id());
         }
     }
+
+    /**
+     * Test that when late materialization adds _row_id along with _row_source_id and _scan_range_id,
+     * and the file doesn't have firstRowId, the scan range building should NOT throw exception.
+     * This is because the _row_id is for internal use by late materialization, not user-requested.
+     */
+    @Test
+    public void testBuildScanRangeWithLateMaterializationColumnsNotThrows() throws Exception {
+        // Use v2 table which doesn't have firstRowId in files
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(5));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        // _row_id added by late materialization
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        // _row_source_id - indicates late materialization is active
+        SlotDescriptor rowSourceIdSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
+        rowSourceIdSlot.setType(INT);
+        rowSourceIdSlot.setColumn(new Column("_row_source_id", INT));
+        localTupleDescriptor.addSlot(rowSourceIdSlot);
+
+        // _scan_range_id - indicates late materialization is active
+        SlotDescriptor scanRangeIdSlot = new SlotDescriptor(new SlotId(5), localTupleDescriptor);
+        scanRangeIdSlot.setType(INT);
+        scanRangeIdSlot.setColumn(new Column("_scan_range_id", INT));
+        localTupleDescriptor.addSlot(scanRangeIdSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        // Should NOT throw exception because late materialization columns are present
+        // The file from v2 table doesn't have firstRowId
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertNotNull(hdfsScanRange);
+    }
+
+    /**
+     * Test that when late materialization adds _row_id along with _row_source_id and _scan_range_id,
+     * and the file has firstRowId (v3 table), the scan range should include first_row_id.
+     */
+    @Test
+    public void testBuildScanRangeWithLateMaterializationColumnsSetsFirstRowIdWhenPresent() throws Exception {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_late", 3);
+
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(6));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        // _row_id added by late materialization
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        // _row_source_id - indicates late materialization is active
+        SlotDescriptor rowSourceIdSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
+        rowSourceIdSlot.setType(INT);
+        rowSourceIdSlot.setColumn(new Column("_row_source_id", INT));
+        localTupleDescriptor.addSlot(rowSourceIdSlot);
+
+        // _scan_range_id - indicates late materialization is active
+        SlotDescriptor scanRangeIdSlot = new SlotDescriptor(new SlotId(5), localTupleDescriptor);
+        scanRangeIdSlot.setType(INT);
+        scanRangeIdSlot.setColumn(new Column("_scan_range_id", INT));
+        localTupleDescriptor.addSlot(scanRangeIdSlot);
+
+        mockedNativeTableV3.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v3_late", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableV3, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        if (fileScanTask.file().firstRowId() != null) {
+            THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                    fileScanTask, fileScanTask.file(), partitionId);
+            Assertions.assertTrue(hdfsScanRange.isSetFirst_row_id());
+            Assertions.assertEquals(fileScanTask.file().firstRowId().longValue(),
+                    hdfsScanRange.getFirst_row_id());
+        }
+    }
+
+    /**
+     * Test that when only _row_source_id is present (partial late materialization columns),
+     * it's still recognized as late materialization and won't throw exception.
+     */
+    @Test
+    public void testBuildScanRangeWithOnlyRowSourceIdNotThrows() throws Exception {
+        // Use v2 table which doesn't have firstRowId in files
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(7));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        // _row_id added by late materialization
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        // Only _row_source_id - should still be recognized as late materialization
+        SlotDescriptor rowSourceIdSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
+        rowSourceIdSlot.setType(INT);
+        rowSourceIdSlot.setColumn(new Column("_row_source_id", INT));
+        localTupleDescriptor.addSlot(rowSourceIdSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_partial", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        // Should NOT throw exception because _row_source_id indicates late materialization
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertNotNull(hdfsScanRange);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -295,11 +295,13 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
     /**
      * Test that when late materialization adds _row_id along with _row_source_id and _scan_range_id,
-     * and the file doesn't have firstRowId, the scan range building should NOT throw exception.
-     * This is because the _row_id is for internal use by late materialization, not user-requested.
+     * and the file doesn't have firstRowId, the scan range building MUST throw exception.
+     * The optimizer may reuse a user-requested _row_id while also adding late materialization columns,
+     * so we cannot assume _row_id is purely internal. Allowing NULL _row_id would violate the
+     * lookup path's non-null assumption (lookup_request.cpp DCHECK).
      */
     @Test
-    public void testBuildScanRangeWithLateMaterializationColumnsNotThrows() throws Exception {
+    public void testBuildScanRangeWithLateMaterializationColumnsThrowsWhenNoFirstRowId() throws Exception {
         // Use v2 table which doesn't have firstRowId in files
         TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(5));
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
@@ -342,11 +344,9 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
         long partitionId = scanRangeSource.addPartition(fileScanTask);
 
-        // Should NOT throw exception because late materialization columns are present
-        // The file from v2 table doesn't have firstRowId
-        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
-                fileScanTask, fileScanTask.file(), partitionId);
-        Assertions.assertNotNull(hdfsScanRange);
+        // Must throw: _row_id requires firstRowId regardless of late materialization columns
+        Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
     }
 
     /**
@@ -408,11 +408,187 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     }
 
     /**
-     * Test that when only _row_source_id is present (partial late materialization columns),
-     * it's still recognized as late materialization and won't throw exception.
+     * Test that when both _row_id and _last_updated_sequence_number are requested (full row lineage query),
+     * the scan range contains both: first_row_id is set, and _last_updated_sequence_number is in extended_columns
+     * but not in extendedColumnSlotIds (so BE handles it as a reserved field that checks for physical column first).
      */
     @Test
-    public void testBuildScanRangeWithOnlyRowSourceIdNotThrows() throws Exception {
+    public void testBuildScanRangeWithFullRowLineageColumns() throws Exception {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_full_lineage", 3);
+
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(10));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+        localTupleDescriptor.addSlot(dataSlot);
+
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        SlotDescriptor seqSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
+        seqSlot.setType(BIGINT);
+        seqSlot.setColumn(new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, BIGINT));
+        localTupleDescriptor.addSlot(seqSlot);
+
+        mockedNativeTableV3.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v3_full", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableV3, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        if (fileScanTask.file().firstRowId() != null) {
+            THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                    fileScanTask, fileScanTask.file(), partitionId);
+
+            // _row_id: first_row_id should be set in scan range
+            Assertions.assertTrue(hdfsScanRange.isSetFirst_row_id());
+            Assertions.assertEquals(fileScanTask.file().firstRowId().longValue(),
+                    hdfsScanRange.getFirst_row_id());
+
+            // _last_updated_sequence_number: should be in extended_columns (fallback for BE)
+            Assertions.assertTrue(
+                    hdfsScanRange.getExtended_columns().containsKey(seqSlot.getId().asInt()));
+            // But NOT registered as an extended slot (so BE treats it as reserved field)
+            Assertions.assertFalse(
+                    scanRangeSource.getExtendedColumnSlotIds().contains(seqSlot.getId().asInt()));
+
+            // _row_id should NOT be in extended columns (it's a reserved field, not extended)
+            Assertions.assertFalse(
+                    hdfsScanRange.getExtended_columns().containsKey(rowIdSlot.getId().asInt()));
+        }
+    }
+
+    /**
+     * Test that _last_updated_sequence_number extended column value matches the file's dataSequenceNumber.
+     * This is the fallback value used by BE when the physical column is not present (non-compacted files).
+     */
+    @Test
+    public void testLastUpdatedSequenceNumberValueMatchesDataSequenceNumber() throws Exception {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_seq_val", 3);
+
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(11));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor seqSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        seqSlot.setType(BIGINT);
+        seqSlot.setColumn(new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, BIGINT));
+        localTupleDescriptor.addSlot(seqSlot);
+
+        mockedNativeTableV3.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v3_seqval", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableV3, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                fileScanTask, fileScanTask.file(), partitionId);
+
+        // The extended column value should contain the file's dataSequenceNumber
+        Assertions.assertTrue(
+                hdfsScanRange.getExtended_columns().containsKey(seqSlot.getId().asInt()));
+
+        // Verify the actual value: the TExpr should have an INT_LITERAL node
+        // with the file's dataSequenceNumber
+        var texpr = hdfsScanRange.getExtended_columns().get(seqSlot.getId().asInt());
+        Assertions.assertFalse(texpr.getNodes().isEmpty());
+        long expectedSeqNum = fileScanTask.file().dataSequenceNumber();
+        Assertions.assertEquals(expectedSeqNum, texpr.getNodes().get(0).getInt_literal().getValue());
+    }
+
+    /**
+     * Test that _row_id and _last_updated_sequence_number with late materialization columns
+     * on a V3 table correctly sets first_row_id and passes sequence number as extended column.
+     * This simulates what happens when StarRocks queries a V3 table that has been compacted
+     * (the BE will check for physical columns first, then fall back to these values).
+     */
+    @Test
+    public void testBuildScanRangeV3WithLateMaterializationAndRowLineage() throws Exception {
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_late_lineage", 3);
+
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(12));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        // _row_id
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        // _last_updated_sequence_number
+        SlotDescriptor seqSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        seqSlot.setType(BIGINT);
+        seqSlot.setColumn(new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, BIGINT));
+        localTupleDescriptor.addSlot(seqSlot);
+
+        // Late materialization columns
+        SlotDescriptor rowSourceIdSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
+        rowSourceIdSlot.setType(INT);
+        rowSourceIdSlot.setColumn(new Column("_row_source_id", INT));
+        localTupleDescriptor.addSlot(rowSourceIdSlot);
+
+        SlotDescriptor scanRangeIdSlot = new SlotDescriptor(new SlotId(5), localTupleDescriptor);
+        scanRangeIdSlot.setType(INT);
+        scanRangeIdSlot.setColumn(new Column("_scan_range_id", INT));
+        localTupleDescriptor.addSlot(scanRangeIdSlot);
+
+        mockedNativeTableV3.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_v3_late_lin", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableV3, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        // Should not throw even with late materialization columns
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
+                fileScanTask, fileScanTask.file(), partitionId);
+
+        if (fileScanTask.file().firstRowId() != null) {
+            Assertions.assertTrue(hdfsScanRange.isSetFirst_row_id());
+        }
+
+        // _last_updated_sequence_number should be in extended_columns but NOT in extendedColumnSlotIds
+        Assertions.assertTrue(
+                hdfsScanRange.getExtended_columns().containsKey(seqSlot.getId().asInt()));
+        Assertions.assertFalse(
+                scanRangeSource.getExtendedColumnSlotIds().contains(seqSlot.getId().asInt()));
+    }
+
+    /**
+     * Test that when _row_id is present with only _row_source_id (partial late materialization),
+     * and the file has no firstRowId, it must throw exception.
+     * Late materialization presence does not exempt the firstRowId requirement.
+     */
+    @Test
+    public void testBuildScanRangeWithOnlyRowSourceIdThrowsWhenNoFirstRowId() throws Exception {
         // Use v2 table which doesn't have firstRowId in files
         TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(7));
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
@@ -431,7 +607,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
         localTupleDescriptor.addSlot(rowIdSlot);
 
-        // Only _row_source_id - should still be recognized as late materialization
+        // Only _row_source_id
         SlotDescriptor rowSourceIdSlot = new SlotDescriptor(new SlotId(4), localTupleDescriptor);
         rowSourceIdSlot.setType(INT);
         rowSourceIdSlot.setColumn(new Column("_row_source_id", INT));
@@ -449,9 +625,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
         long partitionId = scanRangeSource.addPartition(fileScanTask);
 
-        // Should NOT throw exception because _row_source_id indicates late materialization
-        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(
-                fileScanTask, fileScanTask.file(), partitionId);
-        Assertions.assertNotNull(hdfsScanRange);
+        // Must throw: _row_id requires firstRowId regardless of late materialization columns
+        Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
@@ -89,6 +90,8 @@ public class IcebergExprVisitorTest {
     private static final SubfieldOperator K15 = new SubfieldOperator(K10, StringType.STRING, ImmutableList.of("k15"));
     private static final SubfieldOperator K16 = new SubfieldOperator(K10, FloatType.FLOAT, ImmutableList.of("k16"));
     private static final ColumnRefOperator K17 = new ColumnRefOperator(17, FloatType.DOUBLE, "k17.double", true, false);
+    private static final ColumnRefOperator LAST_UPDATED_SEQUENCE_NUMBER = new ColumnRefOperator(
+            18, IntegerType.BIGINT, IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, true, false);
 
     @Test
     public void testToIcebergExpression() {
@@ -445,6 +448,18 @@ public class IcebergExprVisitorTest {
         CastOperator cast = new CastOperator(VarcharType.VARCHAR, K17);
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.LT, cast, value)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
+    }
+
+    @Test
+    public void testConvertLastUpdatedSequenceNumberPredicate() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        Expression convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, LAST_UPDATED_SEQUENCE_NUMBER,
+                        ConstantOperator.createBigint(1))),
+                context);
         Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -135,6 +135,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
@@ -960,6 +961,96 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(fileSize, dataFile.fileSizeInBytes());
         Assertions.assertEquals(4, dataFile.splitOffsets().get(0).longValue());
         Assertions.assertEquals(111L, dataFile.valueCounts().get(1).longValue());
+    }
+
+    @Test
+    public void testFinishSinkV3RowLineageAutoMaintenance() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        TestTables.TestTable mockedNativeTableV3 = create(SCHEMA_A, SPEC_A, "tv3_lineage", 3);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableV3, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        String partitionPath = mockedNativeTableV3.location() + "/data/data_bucket=0/";
+        long initialNextRowId = ((BaseTable) mockedNativeTableV3).operations().current().nextRowId();
+        String firstPath = partitionPath + "c1.parquet";
+        long firstRecordCount = 10;
+        TSinkCommitInfo firstCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile firstDataFile = new TIcebergDataFile();
+        firstDataFile.setPath(firstPath);
+        firstDataFile.setFormat("parquet");
+        firstDataFile.setRecord_count(firstRecordCount);
+        firstDataFile.setFile_size_in_bytes(1024);
+        firstDataFile.setPartition_path(partitionPath);
+        firstDataFile.setSplit_offsets(Lists.newArrayList(4L));
+        firstDataFile.setPartition_null_fingerprint("0");
+        firstCommitInfo.setIs_overwrite(false);
+        firstCommitInfo.setIceberg_data_file(firstDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(firstCommitInfo), null);
+        mockedNativeTableV3.refresh();
+
+        Snapshot firstSnapshot = mockedNativeTableV3.currentSnapshot();
+        Assertions.assertNotNull(firstSnapshot);
+        Assertions.assertNotNull(firstSnapshot.firstRowId());
+        Assertions.assertEquals(initialNextRowId, firstSnapshot.firstRowId().longValue());
+        Assertions.assertEquals(initialNextRowId + firstRecordCount,
+                ((BaseTable) mockedNativeTableV3).operations().current().nextRowId());
+        ManifestFile firstManifest = firstSnapshot.dataManifests(mockedNativeTableV3.io()).get(0);
+        Assertions.assertNotNull(firstManifest.firstRowId());
+        Assertions.assertEquals(initialNextRowId, firstManifest.firstRowId().longValue());
+
+        List<FileScanTask> firstFileScanTasks = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles());
+        Assertions.assertEquals(1, firstFileScanTasks.size());
+        DataFile firstCommittedFile = firstFileScanTasks.get(0).file();
+        Assertions.assertNotNull(firstCommittedFile.firstRowId());
+        Assertions.assertEquals(initialNextRowId, firstCommittedFile.firstRowId().longValue());
+        Assertions.assertNotNull(firstCommittedFile.dataSequenceNumber());
+        Assertions.assertEquals(firstSnapshot.sequenceNumber(), firstCommittedFile.dataSequenceNumber().longValue());
+
+        long secondStartRowId = ((BaseTable) mockedNativeTableV3).operations().current().nextRowId();
+        String secondPath = partitionPath + "c2.parquet";
+        long secondRecordCount = 15;
+        TSinkCommitInfo secondCommitInfo = new TSinkCommitInfo();
+        TIcebergDataFile secondDataFile = new TIcebergDataFile();
+        secondDataFile.setPath(secondPath);
+        secondDataFile.setFormat("parquet");
+        secondDataFile.setRecord_count(secondRecordCount);
+        secondDataFile.setFile_size_in_bytes(2048);
+        secondDataFile.setPartition_path(partitionPath);
+        secondDataFile.setSplit_offsets(Lists.newArrayList(4L));
+        secondDataFile.setPartition_null_fingerprint("0");
+        secondCommitInfo.setIs_overwrite(false);
+        secondCommitInfo.setIceberg_data_file(secondDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(secondCommitInfo), null);
+        mockedNativeTableV3.refresh();
+
+        Snapshot secondSnapshot = mockedNativeTableV3.currentSnapshot();
+        Assertions.assertNotNull(secondSnapshot);
+        Assertions.assertNotNull(secondSnapshot.firstRowId());
+        Assertions.assertEquals(secondStartRowId, secondSnapshot.firstRowId().longValue());
+        Assertions.assertEquals(secondStartRowId + secondRecordCount,
+                ((BaseTable) mockedNativeTableV3).operations().current().nextRowId());
+
+        List<FileScanTask> secondFileScanTasks = Lists.newArrayList(mockedNativeTableV3.newScan().planFiles());
+        Assertions.assertEquals(2, secondFileScanTasks.size());
+        Map<String, Long> firstRowIdByPath = new HashMap<>();
+        for (FileScanTask task : secondFileScanTasks) {
+            firstRowIdByPath.put(task.file().path().toString(), task.file().firstRowId());
+        }
+        Assertions.assertEquals(initialNextRowId, firstRowIdByPath.get(firstPath).longValue());
+        Assertions.assertEquals(secondStartRowId, firstRowIdByPath.get(secondPath).longValue());
     }
 
     @Test

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -439,6 +439,9 @@ struct THdfsScanRange {
     // mapping transformed bucket id, used to schedule scan range
     36: optional i32 bucket_id;
 
+    // Iceberg v3 row lineage: first row id of the data file, used to compute _row_id
+    // as first_row_id + row_position for non-compacted files.
+    // The _last_updated_sequence_number fallback value is passed via the extended_columns map.
     37: optional i64 first_row_id;
 }
 

--- a/test/sql/test_iceberg/R/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/R/test_iceberg_row_lineage
@@ -309,3 +309,119 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uu
 0
 
 -- !result
+-- name: test_iceberg_v3_row_lineage_compaction
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_rl_compact_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (1, 'alice'), (2, 'bob');
+-- result:
+-- !result
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (3, 'charlie'), (4, 'david');
+-- result:
+-- !result
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (5, 'eve'), (6, 'frank');
+-- result:
+-- !result
+select count(*) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact$files;
+-- result:
+3
+-- !result
+create table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot (
+    id int,
+    name string,
+    row_id_before bigint,
+    seq_num_before bigint
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot
+    select id, name, _row_id, _last_updated_sequence_number
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+-- !result
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+6	6
+-- !result
+[UC]ALTER TABLE iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728");
+-- result:
+-- !result
+refresh external table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+-- !result
+select s.id, s.name, s.row_id_before, t._row_id as row_id_after
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot s
+    join iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact t on s.id = t.id
+    where s.row_id_before != t._row_id
+    order by s.id;
+-- result:
+-- !result
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+6	6
+-- !result
+select id, name from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact order by id;
+-- result:
+1	alice
+2	bob
+3	charlie
+4	david
+5	eve
+6	frank
+-- !result
+select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+1
+-- !result
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (7, 'grace'), (8, 'henry');
+-- result:
+-- !result
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+8	8
+-- !result
+select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+2
+-- !result
+drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot;
+-- result:
+-- !result
+drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+-- result:
+-- !result
+drop database iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_rl_compact_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/R/test_iceberg_row_lineage
@@ -1,0 +1,311 @@
+-- name: test_iceberg_v3_row_lineage_read
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_rl_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 values (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+select _row_id, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+-- result:
+0	1	alice
+1	2	bob
+2	3	charlie
+-- !result
+select _last_updated_sequence_number, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+-- result:
+1	1	alice
+1	2	bob
+1	3	charlie
+-- !result
+select _row_id, _last_updated_sequence_number, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+-- result:
+0	1	1	alice
+1	1	2	bob
+2	1	3	charlie
+-- !result
+drop table iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3;
+-- result:
+-- !result
+drop database iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_rl_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: test_iceberg_v3_row_lineage_write_insert
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_rl_w_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write values (1, 100), (2, 200), (3, 300);
+-- result:
+-- !result
+select _row_id, _last_updated_sequence_number, id, value from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write order by _row_id;
+-- result:
+0	1	1	100
+1	1	2	200
+2	1	3	300
+-- !result
+insert into iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write values (4, 400), (5, 500);
+-- result:
+-- !result
+select _row_id, _last_updated_sequence_number, id, value from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write order by _row_id;
+-- result:
+0	1	1	100
+1	1	2	200
+2	1	3	300
+3	2	4	400
+4	2	5	500
+-- !result
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids, min(_row_id) as min_row_id, max(_row_id) as max_row_id from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write;
+-- result:
+5	5	0	4
+-- !result
+drop table iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write;
+-- result:
+-- !result
+drop database iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_rl_w_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: test_iceberg_v3_row_lineage_write_insert_select
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_rl_ins_sel_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source values (1, 'a'), (2, 'b'), (3, 'c');
+-- result:
+-- !result
+create table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target select * from iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source;
+-- result:
+-- !result
+select _row_id, _last_updated_sequence_number, id, name from iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target order by _row_id;
+-- result:
+0	1	1	a
+1	1	2	b
+2	1	3	c
+-- !result
+drop table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target;
+-- result:
+-- !result
+drop table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source;
+-- result:
+-- !result
+drop database iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_rl_ins_sel_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: test_iceberg_v3_row_lineage_predicate_pushdown
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_rl_pred_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50);
+-- result:
+-- !result
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id = 0;
+-- result:
+0	1	10
+-- !result
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id >= 2 order by _row_id;
+-- result:
+2	3	30
+3	4	40
+4	5	50
+-- !result
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id in (1, 3) order by _row_id;
+-- result:
+1	2	20
+3	4	40
+-- !result
+drop table iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred;
+-- result:
+-- !result
+drop database iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_rl_pred_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: test_iceberg_v2_vs_v3_row_lineage
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `iceberg_v2v3_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 (
+    id int,
+    name string
+) properties (
+    "format-version" = "2"
+);
+-- result:
+-- !result
+create table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+-- result:
+-- !result
+insert into iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 values (1, 'v2_data');
+-- result:
+-- !result
+insert into iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 values (1, 'v3_data');
+-- result:
+-- !result
+select _row_id, id, name from iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 order by _row_id;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column '_row_id' cannot be resolved.")
+-- !result
+select _row_id, _last_updated_sequence_number, id, name from iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 order by _row_id;
+-- result:
+0	1	1	v3_data
+-- !result
+drop table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2;
+-- result:
+-- !result
+drop table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3;
+-- result:
+-- !result
+drop database iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_v2v3_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/T/test_iceberg_row_lineage
@@ -213,3 +213,92 @@ drop database iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0};
 drop catalog iceberg_v2v3_${uuid0};
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+-- name: test_iceberg_v3_row_lineage_compaction
+-- Test that _row_id is preserved for each data row after compaction.
+-- The core invariant: the same row should have the same _row_id before and after compaction.
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_rl_compact_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0};
+
+-- Create v3 table
+create table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert data in 3 batches to create 3 data files
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (1, 'alice'), (2, 'bob');
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (3, 'charlie'), (4, 'david');
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (5, 'eve'), (6, 'frank');
+
+-- Verify 3 data files exist
+select count(*) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact$files;
+
+-- Save pre-compaction _row_id and _last_updated_sequence_number into a snapshot table
+create table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot (
+    id int,
+    name string,
+    row_id_before bigint,
+    seq_num_before bigint
+) properties (
+    "format-version" = "3"
+);
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot
+    select id, name, _row_id, _last_updated_sequence_number
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Verify pre-compaction: _row_id unique, 6 rows
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Trigger compaction
+[UC]ALTER TABLE iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728");
+
+-- Refresh metadata cache
+refresh external table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Core check: compare _row_id before vs after compaction for each row (should be identical)
+-- If any row's _row_id changed, this query returns rows with mismatches
+select s.id, s.name, s.row_id_before, t._row_id as row_id_after
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot s
+    join iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact t on s.id = t.id
+    where s.row_id_before != t._row_id
+    order by s.id;
+
+-- Verify _row_id is still unique after compaction
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Verify data integrity
+select id, name from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact order by id;
+
+-- Verify _last_updated_sequence_number is consistent after compaction (all same seq num)
+select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Insert more data after compaction (mixed: compacted file + new non-compacted file)
+insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (7, 'grace'), (8, 'henry');
+
+-- Verify _row_id uniqueness across mixed compacted + non-compacted files
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Verify new rows have different _last_updated_sequence_number from compacted rows
+select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+
+-- Cleanup
+drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot;
+drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
+drop database iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0};
+drop catalog iceberg_rl_compact_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_compact/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/T/test_iceberg_row_lineage
@@ -1,0 +1,215 @@
+-- name: test_iceberg_v3_row_lineage_read
+-- Test reading _row_id and _last_updated_sequence_number from Iceberg v3 table
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_rl_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0};
+
+-- Create v3 table with row lineage support
+create table iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert test data
+insert into iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 values (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+-- Verify _row_id can be read
+select _row_id, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+
+-- Verify _last_updated_sequence_number can be read
+select _last_updated_sequence_number, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+
+-- Verify both columns together
+select _row_id, _last_updated_sequence_number, id, name from iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3 order by _row_id;
+
+drop table iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0}.t_v3;
+drop database iceberg_rl_${uuid0}.iceberg_rl_db_${uuid0};
+drop catalog iceberg_rl_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+-- name: test_iceberg_v3_row_lineage_write_insert
+-- Test that _row_id and _last_updated_sequence_number are properly maintained during INSERT
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_rl_w_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0};
+
+create table iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+
+-- First insert: 3 rows
+insert into iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write values (1, 100), (2, 200), (3, 300);
+
+-- Check row lineage after first insert
+select _row_id, _last_updated_sequence_number, id, value from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write order by _row_id;
+
+-- Second insert: add more rows
+insert into iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write values (4, 400), (5, 500);
+
+-- Check row lineage after second insert - new rows should have higher _row_id
+select _row_id, _last_updated_sequence_number, id, value from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write order by _row_id;
+
+-- Verify _row_id is unique and monotonically increasing
+select count(*) as total_rows, count(distinct _row_id) as unique_row_ids, min(_row_id) as min_row_id, max(_row_id) as max_row_id from iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write;
+
+drop table iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0}.t_write;
+drop database iceberg_rl_w_${uuid0}.iceberg_rl_w_db_${uuid0};
+drop catalog iceberg_rl_w_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_write/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+-- name: test_iceberg_v3_row_lineage_write_insert_select
+-- Test row lineage maintenance during INSERT ... SELECT
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_rl_ins_sel_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0};
+
+-- Source table
+create table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+insert into iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source values (1, 'a'), (2, 'b'), (3, 'c');
+
+-- Target table
+create table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+-- Insert from source to target
+insert into iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target select * from iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source;
+
+-- Verify row lineage in target table
+select _row_id, _last_updated_sequence_number, id, name from iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target order by _row_id;
+
+drop table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_target;
+drop table iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0}.t_source;
+drop database iceberg_rl_ins_sel_${uuid0}.iceberg_rl_ins_sel_db_${uuid0};
+drop catalog iceberg_rl_ins_sel_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_ins_sel/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+-- name: test_iceberg_v3_row_lineage_predicate_pushdown
+-- Test predicate pushdown on _row_id column
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_rl_pred_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0};
+
+create table iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred (
+    id int,
+    value int
+) properties (
+    "format-version" = "3"
+);
+
+insert into iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50);
+
+-- Test predicate on _row_id
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id = 0;
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id >= 2 order by _row_id;
+select _row_id, id, value from iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred where _row_id in (1, 3) order by _row_id;
+
+drop table iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0}.t_pred;
+drop database iceberg_rl_pred_${uuid0}.iceberg_rl_pred_db_${uuid0};
+drop catalog iceberg_rl_pred_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_row_lineage_pred/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+-- name: test_iceberg_v2_vs_v3_row_lineage
+-- Compare row lineage behavior between v2 and v3 tables
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `iceberg_v2v3_${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0}",
+"aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0};
+
+-- V2 table
+create table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 (
+    id int,
+    name string
+) properties (
+    "format-version" = "2"
+);
+
+-- V3 table
+create table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 (
+    id int,
+    name string
+) properties (
+    "format-version" = "3"
+);
+
+insert into iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 values (1, 'v2_data');
+insert into iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 values (1, 'v3_data');
+
+-- V2 table: _row_id should be available, _last_updated_sequence_number should NOT
+select _row_id, id, name from iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2 order by _row_id;
+
+-- V3 table: both _row_id and _last_updated_sequence_number should be available
+select _row_id, _last_updated_sequence_number, id, name from iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3 order by _row_id;
+
+drop table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v2;
+drop table iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0}.t_v3;
+drop database iceberg_v2v3_${uuid0}.iceberg_v2v3_db_${uuid0};
+drop catalog iceberg_v2v3_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_v2_v3/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
Iceberg v3 introduced Row Lineage feature that provides unique row identifiers (`_row_id`) and row-level update tracking (`_last_updated_sequence_number`). 
- `_row_id`: Unique row identifier within the table. Format: `firstRowId + row_position`
- `_last_updated_sequence_number`: The commit sequence number when the row was last update

StarRocks needs to support querying these metadata columns to enable users to track data lineage and implement change data capture patterns.

## What I'm doing:
This pull request introduces support for Iceberg v3 row lineage metadata columns in StarRocks, specifically `_row_id` and `_last_updated_sequence_number`, enabling users to query row-level lineage information for Iceberg tables with format-version 3. The implementation ensures these columns are available both as computed values (for newly inserted data) and as physical columns (for post-compaction files), with proper handling in the Parquet file reader and scanner logic. Documentation and test coverage are also updated to reflect these new features.

### Changes
**Iceberg v3 Row Lineage Metadata Support**

* Added support for the reserved metadata columns `_row_id` and `_last_updated_sequence_number` for Iceberg v3 tables, including their recognition and handling in both the FE (frontend) and BE (backend) code. These columns are now part of the set of recognized Iceberg metadata columns in `IcebergTable` and are included in schema conversion logic.

* Implemented logic in the Parquet `GroupReader` to read these columns from either physical columns (if present, as per Iceberg v3 spec after compaction) or to compute them from file metadata (for new data or if physical columns are absent). This includes new helper methods for column reader creation and fallback mechanisms.

**Improvements to Parquet Reader and Scanner**

* Updated the scanner and file reader context to properly pass and recognize scan range and extended column information, ensuring correct computation and retrieval of metadata columns.

* Refactored the `IcebergRowIdReader` to simplify its logic, always outputting row IDs for the full range (with filtering applied uniformly later), and documented its behavior for clarity. 

**Documentation and Test Coverage**

* Added comprehensive documentation in English, Japanese, and Chinese describing how to use the new row lineage columns, their semantics, and caveats for users.
* Included a new unit test for `iceberg_row_id_reader` to ensure correct behavior.

 ### Usage Example
```
  -- Query row lineage columns from Iceberg v3 table
  SELECT _row_id, _last_updated_sequence_number, * FROM iceberg_catalog.db.table;
```

 ### Notes
  - These columns are only available for Iceberg v3 tables (`format-version = 3`).
  - This PR does not handle the active writing of row lineage information during compaction; we will address this separately in a future PR.


Fixes https://github.com/StarRocks/starrocks/issues/69847

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
