### PR TITLE
[Enhancement] Add fine-grained trace counters for lake persistent index publish

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -955,6 +955,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
     auto chunk = chunk_shared_ptr.get();
     auto rowsets = Rowset::get_rowsets(tablet_mgr, metadata);
+    int64_t get_next_cost_us = 0;
+    int64_t pk_encode_cost_us = 0;
+    int64_t build_values_cost_us = 0;
     // Rowset whose version is between max_sstable_version and base_version should be recovered.
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
@@ -987,7 +990,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             while (true) {
                 chunk->reset();
                 rowids.clear();
+                int64_t t1 = GetCurrentTimeMicros();
                 auto st = itr->get_next(chunk, &rowids);
+                get_next_cost_us += GetCurrentTimeMicros() - t1;
                 if (st.is_end_of_file()) {
                     break;
                 } else if (!st.ok()) {
@@ -995,13 +1000,16 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                 } else {
                     Column* pkc = nullptr;
                     if (pk_column) {
+                        int64_t t2 = GetCurrentTimeMicros();
                         pk_column->reset_column();
                         PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
                                                   pk_encoding_type);
+                        pk_encode_cost_us += GetCurrentTimeMicros() - t2;
                         pkc = pk_column.get();
                     } else {
                         pkc = const_cast<Column*>(chunk->columns()[0].get());
                     }
+                    int64_t t3 = GetCurrentTimeMicros();
                     uint64_t base = ((uint64_t)rssid) << 32;
                     std::vector<IndexValue> values;
                     values.reserve(pkc->size());
@@ -1009,6 +1017,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                     for (uint32_t i = 0; i < pkc->size(); i++) {
                         values.emplace_back(base + rowids[i]);
                     }
+                    build_values_cost_us += GetCurrentTimeMicros() - t3;
                     if (values.back().get_value() <= rebuild_rss_rowid_point) {
                         // lower AND equal than rebuild point, skip
                         continue;
@@ -1036,6 +1045,11 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
         }
     }
+    TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
+    TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);
+    TRACE_COUNTER_INCREMENT("rebuild_build_values_cost_us", build_values_cost_us);
+    TRACE_COUNTER_INCREMENT("segment_io_local_disk_us", stats.io_ns_read_local_disk / 1000);
+    TRACE_COUNTER_INCREMENT("segment_io_remote_us", stats.io_ns_remote / 1000);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -473,6 +473,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
                                                                                       int64_t version,
                                                                                       const MetaFileBuilder* builder,
                                                                                       OlapReaderStatistics* stats) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_iterator_with_delvec_us");
     std::vector<SegmentPtr> segments;
     RETURN_IF_ERROR(load_segments(&segments, false));
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -195,6 +195,8 @@ public:
 
     static StatusOr<bool> file_exist(const std::string& full_path);
 
+    const OlapReaderStatistics& stats() const { return _stats; }
+
 private:
     // Load segment state
     Status _do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -494,6 +494,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     TRACE_COUNTER_INCREMENT("total_del", total_del);
     TRACE_COUNTER_INCREMENT("upsert_rows", op_write.rowset().num_rows());
     TRACE_COUNTER_INCREMENT("base_version", base_version);
+    TRACE_COUNTER_INCREMENT("segment_io_local_disk_us", state.stats().io_ns_read_local_disk / 1000);
+    TRACE_COUNTER_INCREMENT("segment_io_remote_us", state.stats().io_ns_remote / 1000);
     VLOG(1) << strings::Substitute(
             "[publish_pk_tablet][end] tablet:$0 txn:$1 rowset_id:$2 upsert_segments:$3 dels:$4 new_del:$5 total_del:$6 "
             "upsert_rows:$7 base_version:$8 new_version:$9",

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -249,6 +249,9 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // only use state entry once, remove it when publish finish or fail
     DeferOp remove_state_entry([&] { _update_state_cache.remove(state_entry); });
     auto& state = state_entry->value();
+    // Snapshot IO stats before publish to exclude preload IO from trace counters.
+    const int64_t io_local_disk_ns_before = state.stats().io_ns_read_local_disk;
+    const int64_t io_remote_ns_before = state.stats().io_ns_remote;
 
     std::vector<FileMetaPB> orphan_files;
     std::map<int, FileInfo> replace_segments;
@@ -494,8 +497,9 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     TRACE_COUNTER_INCREMENT("total_del", total_del);
     TRACE_COUNTER_INCREMENT("upsert_rows", op_write.rowset().num_rows());
     TRACE_COUNTER_INCREMENT("base_version", base_version);
-    TRACE_COUNTER_INCREMENT("segment_io_local_disk_us", state.stats().io_ns_read_local_disk / 1000);
-    TRACE_COUNTER_INCREMENT("segment_io_remote_us", state.stats().io_ns_remote / 1000);
+    TRACE_COUNTER_INCREMENT("segment_io_local_disk_us",
+                            (state.stats().io_ns_read_local_disk - io_local_disk_ns_before) / 1000);
+    TRACE_COUNTER_INCREMENT("segment_io_remote_us", (state.stats().io_ns_remote - io_remote_ns_before) / 1000);
     VLOG(1) << strings::Substitute(
             "[publish_pk_tablet][end] tablet:$0 txn:$1 rowset_id:$2 upsert_segments:$3 dels:$4 new_del:$5 total_del:$6 "
             "upsert_rows:$7 base_version:$8 new_version:$9",


### PR DESCRIPTION
## Why I'm doing:

When investigating performance issues during PK persistent index publish, the existing `rebuild_index_segment_cost_us` trace is too coarse-grained to pinpoint which specific operation is the bottleneck. We also lack visibility into whether segment IO latency comes from local disk cache or remote S3 storage.

## What I'm doing:

Add detailed trace counters to help diagnose performance bottlenecks during PK persistent index operations:

**Rebuild path** (`lake_persistent_index.cpp`):
- `rebuild_get_next_cost_us`: segment iterator `get_next` time
- `rebuild_pk_encode_cost_us`: primary key encoding time
- `rebuild_build_values_cost_us`: IndexValue array construction time

**Segment IO breakdown** (`lake_persistent_index.cpp` + `update_manager.cpp`):
- `segment_io_local_disk_us`: segment IO time hitting local disk cache (publish-phase only, excluding preload)
- `segment_io_remote_us`: segment IO time from remote storage (S3) (publish-phase only, excluding preload)

**Iterator creation** (`rowset.cpp`):
- `get_each_segment_iterator_with_delvec_us`: iterator creation time including delvec loading

The rebuild path counters use local `int64_t` variables to accumulate across loop iterations, writing to trace only once at the end to minimize overhead. Segment IO stats come from `OlapReaderStatistics`. In `update_manager.cpp`, IO stats are snapshotted at the start of `publish_primary_key_tablet()` and only the delta is emitted, so that preload IO accumulated in `RowsetUpdateState._stats` is excluded.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4