### PR TITLE
[BugFix] fix partition min prune with shadow partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1507,7 +1507,9 @@ public class OlapTable extends Table {
     }
 
     public List<Partition> getNonEmptyPartitions() {
-        return idToPartition.values().stream().filter(Partition::hasData).collect(Collectors.toList());
+        return idToPartition.values().stream().filter(
+                        p -> !p.getName().startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX))
+                .filter(Partition::hasData).collect(Collectors.toList());
     }
 
     public int getNumberOfPartitions() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.FeConstants;
@@ -637,6 +638,36 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.getTable("test", "t4_range_minmax")
                 .getPartition("p20250428").getDefaultPhysicalPartition().updateVisibleVersion(1);
         starRocksAssert.query("select min(dt), max(dt) from t4_range_minmax").explainContains("partitions=1/2");
+        FeConstants.runningUnitTest = true;
+
+    }
+
+    @Test
+    public void testMinMaxRangePartitionPruneWithDateTruncPartition() throws Exception {
+        UtFrameUtils.mockDML();
+        starRocksAssert.withTable("CREATE TABLE `t4_expr_range_minmax` (\n" +
+                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\",\n" +
+                "    `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`, `name`)\n" +
+                "PARTITION BY date_trunc('day', `dt`)(\n" +
+                " START (\"2025-04-28\") END (\"2025-04-30\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`, `name`)\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.getCtx().executeSql("insert into t4_expr_range_minmax values('2025-04-29', 1, 'bar')");
+        FeConstants.runningUnitTest = false;
+        starRocksAssert.getTable("test", "t4_expr_range_minmax")
+                .getPartition(ExpressionRangePartitionInfo.AUTOMATIC_SHADOW_PARTITION_NAME)
+                .getDefaultPhysicalPartition()
+                // after `alter table t4_expr_range_minmax modify column `id` varchar(11)`,
+                // visible version of shadow partition will increase
+                .updateVisibleVersion(2);
+        // min(dt) should not be affected by shadow partition
+        starRocksAssert.query("select min(dt) from t4_expr_range_minmax").explainContains("partitions=1/2");
         FeConstants.runningUnitTest = true;
 
     }


### PR DESCRIPTION
## Why I'm doing:
```sql
mysql>  select min(pt) from test_table;
+---------+
| min(pt) |
+---------+
| NULL    |
+---------+
1 row in set (0.02 sec)
```

`min(pt)` should not be `NULL`
## What I'm doing:

ignore shadow partition

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
