### PR TITLE
[BugFix] Support fetching tablet infos based on run mode in SchemaBeTabletsScanner

### DIFF
--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -98,36 +98,44 @@ Status SchemaBeTabletsScanner::start(RuntimeState* state) {
     auto o_id = get_backend_id();
     _be_id = o_id.has_value() ? o_id.value() : -1;
     _infos.clear();
-    // shared-nothing
-    auto manager = StorageEngine::instance()->tablet_manager();
-    manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos,
-                                     &authorized_table_ids);
-#ifndef __APPLE__
-    // shared-data
-    auto lake_manager = ExecEnv::GetInstance()->lake_tablet_manager();
-    if (lake_manager != nullptr) {
-        std::unordered_map<int64_t, int64_t> partition_versions;
-        int64_t table_id_offset = 0;
-        while (true) {
-            TGetPartitionsMetaRequest partitions_meta_req;
-            partitions_meta_req.__set_auth_info(auth_info);
-            partitions_meta_req.__set_start_table_id_offset(table_id_offset);
-            TGetPartitionsMetaResponse partitions_meta_response;
-            RETURN_IF_ERROR(
-                    SchemaHelper::get_partitions_meta(_ss_state, partitions_meta_req, &partitions_meta_response));
-            for (const auto& info : partitions_meta_response.partitions_meta_infos) {
-                partition_versions.emplace(info.partition_id, info.visible_version);
-            }
-            table_id_offset = partitions_meta_response.next_table_id_offset;
-            if (!table_id_offset) {
-                break;
-            }
-        }
 
-        lake_manager->get_tablets_basic_info(_param->table_id, _param->partition_id, _param->tablet_id,
-                                             authorized_table_ids, partition_versions, _infos);
+    auto run_mode = get_master_run_mode();
+    if (!run_mode.has_value() || run_mode.value() == TRunMode::SHARED_NOTHING) {
+        // shared-nothing
+        auto manager = StorageEngine::instance()->tablet_manager();
+        manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos,
+                                         &authorized_table_ids);
+    }
+
+#ifndef __APPLE__
+    if (!run_mode.has_value() || run_mode.value() == TRunMode::SHARED_DATA) {
+        // shared-data
+        auto lake_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+        if (lake_manager != nullptr) {
+            std::unordered_map<int64_t, int64_t> partition_versions;
+            int64_t table_id_offset = 0;
+            while (true) {
+                TGetPartitionsMetaRequest partitions_meta_req;
+                partitions_meta_req.__set_auth_info(auth_info);
+                partitions_meta_req.__set_start_table_id_offset(table_id_offset);
+                TGetPartitionsMetaResponse partitions_meta_response;
+                RETURN_IF_ERROR(
+                        SchemaHelper::get_partitions_meta(_ss_state, partitions_meta_req, &partitions_meta_response));
+                for (const auto& info : partitions_meta_response.partitions_meta_infos) {
+                    partition_versions.emplace(info.partition_id, info.visible_version);
+                }
+                table_id_offset = partitions_meta_response.next_table_id_offset;
+                if (!table_id_offset) {
+                    break;
+                }
+            }
+
+            lake_manager->get_tablets_basic_info(_param->table_id, _param->partition_id, _param->tablet_id,
+                                                 authorized_table_ids, partition_versions, _infos);
+        }
     }
 #endif // __APPLE__
+
     LOG(INFO) << strings::Substitute("get_tablets_basic_infos table_id:$0 partition:$1 tablet:$2 #info:$3",
                                      _param->table_id, _param->partition_id, _param->tablet_id, _infos.size());
     _cur_idx = 0;


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

Currently, `SchemaBeTabletsScanner` fetches tablet infos from both shared-nothing and shared-data tablet managers unconditionally. We should only fetch tablet infos from the tablet manager that matches the current cluster's run mode to avoid unnecessary RPCs and metadata queries.

https://github.com/StarRocks/starrocks/pull/64623

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
