### PR TITLE
[Doc] Update Ubuntu build guide for latest Ubuntu compatibility and JDK 17

### DIFF
--- a/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
+++ b/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
@@ -10,16 +10,14 @@ This topic describes how to compile StarRocks on the Ubuntu operating system. St
 
 ### Install Dependencies
 
-Run the following commands to update the package list and install necessary dependencies.
-
-> **Note:** For Ubuntu 24.04 and newer, `libbinutils-dev` is required to resolve linker dependencies.
+Run the following commands to install necessary dependencies:
 
 ```bash
 sudo apt update
 ```
 
 ```bash
-sudo apt install build-essential automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 libbinutils-dev git -y
+sudo apt install build-essential automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
 ```
 
 ### Install Compiler
@@ -96,7 +94,7 @@ Q-2: Building StarRocks fails on Ubuntu 24.04 or GCC 12+ with strict warning err
 
 A: To prevent build failures in third-party libraries, export the following flag before building:
 
-```Bash
+```bash
 export DISABLE_WARNING_AS_ERROR=1
 ./build.sh
 ```

--- a/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
+++ b/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
@@ -10,14 +10,16 @@ This topic describes how to compile StarRocks on the Ubuntu operating system. St
 
 ### Install Dependencies
 
-Run the following commands to install necessary dependencies:
+Run the following commands to update the package list and install necessary dependencies.
+
+> **Note:** For Ubuntu 24.04 and newer, `libbinutils-dev` is required to resolve linker dependencies.
 
 ```bash
-sudo apt-get update
+sudo apt update
 ```
 
-```
-sudo apt-get install automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
+```bash
+sudo apt install build-essential automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 libbinutils-dev git -y
 ```
 
 ### Install Compiler
@@ -25,7 +27,7 @@ sudo apt-get install automake bison byacc ccache flex libiberty-dev libtool mave
 If you are using Ubuntu 22.04 or later, run the following command to install the tools and compilers:
 
 ```bash
-sudo apt-get install cmake gcc g++ default-jdk -y
+sudo apt install cmake gcc g++ openjdk-17-jdk -y
 ```
 
 If you are using an Ubuntu version earlier than 22.04, run the following commands to check the versions of tools and compilers:
@@ -45,7 +47,7 @@ If you are using an Ubuntu version earlier than 22.04, run the following command
    java --version
    ```
 
-   OpenJDK version must be 8 or later. If you are using an earlier version, [click here to install OpenJDK](https://openjdk.org/install).
+   OpenJDK version must be 17 or later. If you are using an earlier version, [click here to install OpenJDK](https://openjdk.org/install).
 
 3. Check CMake version:
 
@@ -56,6 +58,17 @@ If you are using an Ubuntu version earlier than 22.04, run the following command
    CMake version must be 3.20.1 or later. If you are using an earlier version, [click here to install CMake](https://cmake.org/download).
 
 ## Compile StarRocks
+
+### Download Source Code
+
+Run the following command to clone the StarRocks repository and navigate into the directory:
+
+```bash
+git clone https://github.com/StarRocks/starrocks.git
+cd starrocks
+```
+
+### Build StarRocks
 
 Run the following command to start the compilation:
 
@@ -75,6 +88,15 @@ The following example uses 24 CPU cores for compilation:
 
 ## FAQ
 
-Q: Building `aws_cpp_sdk` fails on Ubuntu 20.04 with the error "Error: undefined reference to pthread_create". How can I resolve this?
+Q-1: Building `aws_cpp_sdk` fails on Ubuntu 20.04 with the error "Error: undefined reference to pthread_create". How can I resolve this?
 
 A: This error occurs due to a lower version of CMake. Please upgrade CMake to version 3.20.1 or above.
+
+Q-2: Building StarRocks fails on Ubuntu 24.04 or GCC 12+ with strict warning errors. How can I resolve this?
+
+A: To prevent build failures in third-party libraries, export the following flag before building:
+
+```Bash
+export DISABLE_WARNING_AS_ERROR=1
+./build.sh
+```


### PR DESCRIPTION
## Why I'm doing:
The current Ubuntu compilation documentation is slightly outdated and lacks critical details for modern environments. Specifically, it misses dependencies required for Ubuntu 24.04 (`libbinutils-dev`), uses an outdated JDK version (JDK 8 instead of 17 for v3.5+), misses the source code cloning step, and doesn't address the strict compiler warnings introduced in GCC 12+. This leads to build failures and confusion for new contributors.

## What I'm doing:
- Updated package manager commands from `apt-get` to modern `apt`.
- Added missing essential build dependencies (`build-essential`, `libbinutils-dev`, `git`).
- Updated the required Java version from JDK 8 to `openjdk-17-jdk` (required for StarRocks v3.5+).
- Added the missing `git clone` step before the build execution.
- Added a new FAQ entry providing the `DISABLE_WARNING_AS_ERROR=1` workaround for GCC 12+ and Ubuntu 24.04 strict warning errors.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4