### PR TITLE
[BugFix] Fix PK tablet corruption in column-mode partial update (issue #67364)

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4073,7 +4073,7 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     // decrease kv num and usage, the value in add_usage_and_size is less than 0
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() != NullIndexValue) {
-            _size--;
+            if (_size > 0) _size--;
             _usage -= keys[i].size + kIndexValueSize;
             int64_t len = keys[i].size > kFixedMaxKeySize ? 0 : keys[i].size;
             add_usage_and_size[len].first -= keys[i].size + kIndexValueSize;

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -436,6 +436,10 @@ void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<u
                 // skip in this round
                 continue;
             }
+            if (each.first < container->start_rowid) {
+                // skip invalid rowid to prevent unsigned underflow
+                continue;
+            }
             // append to sorted_source_rowids and unsorted_upt_rowids
             // Align rowid
             sorted_source_rowids->push_back(each.first - container->start_rowid);


### PR DESCRIPTION
## Why I'm doing:

Primary Key tables become corrupted when column-mode partial update is performed. The BE crashes with `std::length_error: vector::_M_range_insert`, affecting all replicas simultaneously. Root cause is an unsigned integer underflow (`size_t`) in `PersistentIndex::erase()`.

Fixes #67364

## What I'm doing:

**Fix 1 — `be/src/storage/persistent_index.cpp`** (root cause)

`PersistentIndex::erase()` unconditionally does `_size--` on a `size_t` field. When `_size == 0`, this underflows to `18446744073709551516` (= 2^64 - 100), which matches exactly the value observed in the issue reporter's logs. The corrupted `_size` causes subsequent index lookups to return garbage rowids, which eventually flow into `split_rowid_pairs()` → `append_selective()` → crash.

Guard the decrement against underflow:
```cpp
- _size--;
+ if (_size > 0) _size--;
```

**Fix 2 — `be/src/storage/rowset_column_update_state.cpp`** (defense in depth)

In `split_rowid_pairs()`, add a boundary check before computing `each.first - container->start_rowid`. If garbage rowids (< `start_rowid`) somehow reach this point, the subtraction produces another unsigned underflow → enormous offset → `vector::_M_range_insert` crash.

```cpp
+ if (each.first < container->start_rowid) {
+     // skip invalid rowid to prevent unsigned underflow
+     continue;
+ }
  sorted_source_rowids->push_back(each.first - container->start_rowid);
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4