### PR TITLE
[Enhancement] Improve repair table and show tablet status

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -46,7 +45,6 @@ import com.starrocks.proto.TabletMetadataEntry;
 import com.starrocks.proto.TabletMetadataPB;
 import com.starrocks.proto.TabletMetadataRepairStatus;
 import com.starrocks.proto.TabletResult;
-import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
@@ -56,7 +54,6 @@ import com.starrocks.sql.ast.LakeTabletStatus;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatusCode;
-import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,18 +73,6 @@ public class TabletRepairHelper {
 
     private static final long BATCH_VERSION_NUM = 5L;
     private static final String SST_FILE_SUFFIX = ".sst";
-
-    private static ShowResultSetMetaData DRY_RUN_REPAIR_RESULT_META_DATA;
-
-    static {
-        ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        builder.addColumn(new Column("PartitionId", TypeFactory.createVarcharType(20)));
-        builder.addColumn(new Column("VisibleVersion", TypeFactory.createVarcharType(20)));
-        builder.addColumn(new Column("RepairStatus", TypeFactory.createVarcharType(60)));
-        builder.addColumn(new Column("TabletRecoverInfo", TypeFactory.createVarcharType(65535)));
-        builder.addColumn(new Column("ErrorMsg", TypeFactory.createVarcharType(65535)));
-        DRY_RUN_REPAIR_RESULT_META_DATA = builder.build();
-    }
 
     // the version range [minVersion, maxVersion] is used to find valid tablet metadatas, both are included
     record PhysicalPartitionInfo(
@@ -357,6 +342,9 @@ public class TabletRepairHelper {
         // only missing pk index sst files, clear sstableMeta
         if (checkOnlySstFilesMissing(missingFiles)) {
             metadata.sstableMeta = null;
+            // set version to negative to indicate the metadata is missing some files but still can be repaired,
+            // and the real version will be set in repairTabletMetadata()
+            metadata.version = -1 * metadata.version;
             return metadata;
         }
 
@@ -731,10 +719,6 @@ public class TabletRepairHelper {
                             partitionErrorsSize, partitionErrorsSize > 1 ? "s" : "",
                             errorMsgsSize, errorMsgsSize > 1 ? "s" : "", Joiner.on(", ").join(errorMsgs)));
         }
-    }
-
-    public static ShowResultSetMetaData getDryRunRepairResultMetaData() {
-        return DRY_RUN_REPAIR_RESULT_META_DATA;
     }
 
     private static class TabletRecoverInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -873,7 +873,7 @@ public class DDLStmtExecutor {
             });
 
             if (isDryRun) {
-                return new ShowResultSet(TabletRepairHelper.getDryRunRepairResultMetaData(), result);
+                return new ShowResultSet(new ShowResultMetaFactory().getMetadata(stmt), result);
             } else {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -33,6 +33,7 @@ import com.starrocks.common.proc.ProcService;
 import com.starrocks.common.proc.RollupProcDir;
 import com.starrocks.common.proc.SchemaChangeProcDir;
 import com.starrocks.common.proc.TransProcDir;
+import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
@@ -132,6 +133,7 @@ import com.starrocks.sql.ast.warehouse.ShowNodesStmt;
 import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
 import com.starrocks.type.TypeFactory;
 
 import java.util.List;
@@ -405,7 +407,18 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .addColumn(new Column("Version", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("Status", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("MissingDataFileCount", TypeFactory.createVarcharType(30)))
-                .addColumn(new Column("MissingDataFiles", TypeFactory.createVarcharType(65535)))
+                .addColumn(new Column("MissingDataFiles", StringType.STRING))
+                .build();
+    }
+
+    @Override
+    public ShowResultSetMetaData visitAdminRepairTableStatement(AdminRepairTableStmt statement, Void context) {
+        return ShowResultSetMetaData.builder()
+                .addColumn(new Column("PartitionId", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("VisibleVersion", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("RepairStatus", TypeFactory.createVarcharType(30)))
+                .addColumn(new Column("TabletRecoverInfo", StringType.STRING))
+                .addColumn(new Column("ErrorMsg", StringType.STRING))
                 .build();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -425,7 +425,7 @@ public class TabletRepairHelperTest {
             TabletMetadataPB metadata = Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry);
             Assertions.assertNotNull(metadata);
             Assertions.assertEquals(tabletId11, metadata.id);
-            Assertions.assertEquals(maxVersion, metadata.version);
+            Assertions.assertEquals(-1 * maxVersion, metadata.version);
             Assertions.assertNull(metadata.sstableMeta); // sstableMeta should be cleared
         }
 
@@ -619,7 +619,7 @@ public class TabletRepairHelperTest {
             Assertions.assertEquals(2, tabletToValidMetadata.size());
             Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
             // Should pick maxVersion - 1 because maxVersion has invalid missing files
-            Assertions.assertEquals(maxVersion - 1, tabletToValidMetadata.get(tabletId11).version);
+            Assertions.assertEquals(-1 * (maxVersion - 1), tabletToValidMetadata.get(tabletId11).version);
             Assertions.assertNull(tabletToValidMetadata.get(tabletId11).sstableMeta); // should be cleared
 
             Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/AdminShowTabletStatusStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/AdminShowTabletStatusStmtTest.java
@@ -45,7 +45,7 @@ public class AdminShowTabletStatusStmtTest {
     @Test
     public void testWithPartitionAndProperties() {
         String sql = "ADMIN SHOW TABLET STATUS FROM db1.tbl1 PARTITION (p1, p2) " +
-                "PROPERTIES ('max_missing_data_files_to_show'='10') WHERE STATUS = 'MISSING_DATA'";
+                "WHERE STATUS = 'MISSING_DATA' PROPERTIES ('max_missing_data_files_to_show'='10')";
         AdminShowTabletStatusStmt stmt = (AdminShowTabletStatusStmt) AnalyzeTestUtil.analyzeSuccess(sql);
         Assertions.assertEquals("db1", stmt.getDbName());
         Assertions.assertEquals("tbl1", stmt.getTblName());

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -794,7 +794,7 @@ adminShowReplicaStatusStatement
     ;
 
 adminShowTabletStatusStatement
-    : ADMIN SHOW TABLET STATUS FROM qualifiedName partitionNames? properties? showPredicateClauses
+    : ADMIN SHOW TABLET STATUS FROM qualifiedName partitionNames? showPredicateClauses properties?
     ;
 
 adminRepairTableStatement

--- a/test/sql/test_repair_table/R/test_repair_table
+++ b/test/sql/test_repair_table/R/test_repair_table
@@ -1,0 +1,29 @@
+-- name: test_repair_table @cloud
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int) distributed by hash(k1) buckets 1;
+-- result:
+-- !result
+insert into t1 values(1);
+-- result:
+-- !result
+insert into t1 values(2);
+-- result:
+-- !result
+
+admin repair table t1 partition (t1) properties("dry_run" = "true");
+-- result:
+[REGEX].*3	NORMAL.*
+-- !result
+
+admin repair table t1 partition (t1);
+-- result:
+-- !result
+
+admin show tablet status from t1 where status = "normal";
+-- result:
+[REGEX].*3	NORMAL	0.*
+-- !result
+

--- a/test/sql/test_repair_table/T/test_repair_table
+++ b/test/sql/test_repair_table/T/test_repair_table
@@ -1,0 +1,15 @@
+-- name: test_repair_table @cloud
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int) distributed by hash(k1) buckets 1;
+insert into t1 values(1);
+insert into t1 values(2);
+
+admin repair table t1 partition (t1) properties("dry_run" = "true");
+
+admin repair table t1 partition (t1);
+
+admin show tablet status from t1 where status = "normal";
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces several improvements to the repair table logic and tablet status display:
1. Fix missing files detection logic: When a tablet metadata is missing some SST files but can still be repaired (only missing PK index files), its version is temporarily set to a negative value (`-1 * version`) as an indicator. The real version will be recovered later in `repairTabletMetadata()`.
2. Refactor `AdminRepairTableStmt` execution to use `ShowResultMetaFactory` for result metadata generation instead of a hardcoded static field in `TabletRepairHelper`.
3. Improve grammar for `ADMIN SHOW TABLET STATUS` to allow `PROPERTIES` after the `WHERE` clause (`showPredicateClauses`), which is more intuitive.
4. Update the column types for `MissingDataFiles`, `TabletRecoverInfo`, and `ErrorMsg` from `VARCHAR(65535)` to `STRING` in the show result metadata.
5. Add SQL integration tests for `ADMIN REPAIR TABLE` and `ADMIN SHOW TABLET STATUS`.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
