### PR TITLE
[BugFix] Fix NPE in StreamLoadMultiStmtTask.cancelAfterRestart after deserialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -768,8 +768,6 @@ public class StreamLoadMgr implements MemoryTrackable {
         long currentMs = System.currentTimeMillis();
         for (Class<? extends AbstractStreamLoadTask> clazz : PERSISTENT_TASK_TYPES) {
             reader.readCollection(clazz, loadTask -> {
-                loadTask.init();
-                // discard expired task right away
                 if (loadTask.checkNeedRemove(currentMs, false)) {
                     LOG.info("discard expired task, type: {}, label: {}", clazz.getSimpleName(), loadTask.getLabel());
                     return;

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -690,6 +690,7 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     @Override
     public void gsonPostProcess() throws IOException {
         loadId = new TUniqueId(loadIdHi, loadIdLo);
+        init();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1664,6 +1664,7 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
     @Override
     public void gsonPostProcess() throws IOException {
         loadId = new TUniqueId(loadIdHi, loadIdLo);
+        init();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TUniqueId;
@@ -551,5 +552,13 @@ public class StreamLoadMultiStmtTaskTest {
     public void testCancelAfterRestartWithNoTxnId() {
         multiTask.cancelAfterRestart();
         Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+    }
+
+    @Test
+    public void testCancelAfterRestartOnDeserializedTask() {
+        String json = GsonUtils.GSON.toJson(multiTask);
+        StreamLoadMultiStmtTask deserialized = GsonUtils.GSON.fromJson(json, StreamLoadMultiStmtTask.class);
+        Assertions.assertDoesNotThrow(deserialized::cancelAfterRestart);
+        Assertions.assertEquals("CANCELLED", deserialized.getStateName());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
The lock field (ReentrantReadWriteLock) in StreamLoadMultiStmtTask is not annotated with @SerializedName, so it is null after Gson deserialization. During leader transfer replay, cancelUnDurableTaskAfterRestart() calls cancelAfterRestart() -> tryRollbackNow() -> writeLock() which dereferences the null lock, causing NPE.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
