### PR TITLE
[Enhancement] add column-level dictionary encoding configuration

### DIFF
--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <future>
+#include <unordered_map>
 
 #include "base/url_coding.h"
 #include "column/column_helper.h"
@@ -303,6 +304,13 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_
     auto file_writer_factory = std::make_shared<formats::ParquetFileWriterFactory>(
             fs, ctx->compression_type, ctx->options, column_names, column_evaluators, file_column_ids, ctx->executor,
             runtime_state, nullable);
+
+    // Configure column-level dictionary encoding for position delete files
+    // Disable dictionary encoding for 'pos' column (monotonically increasing, poor dict compression)
+    // Keep dictionary encoding for 'file_path' column (high repetition, good dict compression)
+    std::unordered_map<std::string, bool> column_dict_config;
+    column_dict_config["pos"] = false;
+    file_writer_factory->set_column_dictionary_enabled(std::move(column_dict_config));
 
     // Initialize sort ordering for position delete files (required by Iceberg spec)
     // Sort by: file_path ASC, then pos ASC

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -26,6 +26,8 @@
 
 #include <future>
 #include <ostream>
+#include <sstream>
+#include <string>
 #include <utility>
 
 #include "base/failpoint/fail_point.h"
@@ -287,16 +289,26 @@ Status ParquetFileWriter::init() {
     }
 
     ASSIGN_OR_RETURN(auto compression, parquet::ParquetBuildHelper::convert_compression_type(_compression_type));
-    _properties = std::make_unique<::parquet::WriterProperties::Builder>()
-                          ->version(_writer_options->version)
-                          ->enable_write_page_index()
-                          ->data_pagesize(_writer_options->page_size)
-                          ->write_batch_size(_writer_options->write_batch_size)
-                          ->dictionary_pagesize_limit(_writer_options->dictionary_pagesize)
-                          ->compression(compression)
-                          ->created_by(fmt::format("{} starrocks-{}", CREATED_BY_VERSION, get_short_version()))
-                          ->memory_pool(&_memory_pool)
-                          ->build();
+    ::parquet::WriterProperties::Builder builder;
+    builder.version(_writer_options->version)
+            ->enable_write_page_index()
+            ->data_pagesize(_writer_options->page_size)
+            ->write_batch_size(_writer_options->write_batch_size)
+            ->dictionary_pagesize_limit(_writer_options->dictionary_pagesize)
+            ->compression(compression)
+            ->created_by(fmt::format("{} starrocks-{}", CREATED_BY_VERSION, get_short_version()))
+            ->memory_pool(&_memory_pool);
+
+    // Apply column-level dictionary encoding configuration
+    for (const auto& [col_name, enabled] : _writer_options->column_dictionary_enabled) {
+        if (enabled) {
+            builder.enable_dictionary(col_name);
+        } else {
+            builder.disable_dictionary(col_name);
+        }
+    }
+
+    _properties = builder.build();
 
     _writer = ::parquet::ParquetFileWriter::Open(_output_stream, _schema, _properties);
     return Status::OK();
@@ -347,6 +359,8 @@ Status ParquetFileWriterFactory::init() {
 #ifndef BE_TEST
     _parsed_options->time_zone = _runtime_state->timezone();
 #endif
+    // Apply column-level dictionary encoding configuration set via setter
+    _parsed_options->column_dictionary_enabled = std::move(_column_dictionary_enabled);
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -40,6 +40,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -92,6 +93,11 @@ struct ParquetWriterOptions : FileWriterOptions {
     bool use_legacy_decimal_encoding = false;
     bool use_int96_timestamp_encoding = false;
     ::parquet::ParquetVersion::type version = ::parquet::ParquetVersion::PARQUET_2_6;
+
+    // Column-level dictionary encoding configuration
+    // key: column name, value: whether to enable dictionary encoding
+    // Columns not in this map use the global default behavior
+    std::unordered_map<std::string, bool> column_dictionary_enabled;
 
     inline static std::string USE_LEGACY_DECIMAL_ENCODING = "use_legacy_decimal_encoding";
     inline static std::string USE_INT96_TIMESTAMP_ENCODING = "use_int96_timestamp_encoding";
@@ -160,6 +166,12 @@ public:
 
     StatusOr<WriterAndStream> create(const std::string& path) const override;
 
+    // Set column-level dictionary encoding configuration
+    // Must be called before init()
+    void set_column_dictionary_enabled(std::unordered_map<std::string, bool> config) {
+        _column_dictionary_enabled = std::move(config);
+    }
+
 private:
     std::shared_ptr<FileSystem> _fs;
     TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
@@ -172,6 +184,9 @@ private:
     PriorityThreadPool* _executors = nullptr;
     RuntimeState* _runtime_state = nullptr;
     std::vector<bool> _nullable;
+
+    // Column-level dictionary encoding configuration
+    std::unordered_map<std::string, bool> _column_dictionary_enabled;
 };
 
 } // namespace starrocks::formats

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -15,6 +15,8 @@
 #include "formats/parquet/parquet_file_writer.h"
 
 #include <gtest/gtest.h>
+#include <parquet/file_reader.h>
+#include <parquet/metadata.h>
 
 #include <filesystem>
 #include <memory>
@@ -934,6 +936,158 @@ TEST_F(ParquetFileWriterTest, TestIcebergDeleteFileColumnsRequired) {
         EXPECT_EQ(repetition, tparquet::FieldRepetitionType::REQUIRED)
                 << "Column " << field->name << " should be REQUIRED for Iceberg delete files but is " << repetition;
     }
+}
+
+TEST_F(ParquetFileWriterTest, TestColumnDictionaryEncodingDisabled) {
+    // Test that disabling dictionary encoding for specific column works correctly
+    // This test verifies the fix for Iceberg position delete file compression issue
+    std::vector type_descs{TYPE_VARCHAR_DESC, TYPE_BIGINT_DESC};
+    std::vector<std::string> column_names = {"file_path", "pos"};
+
+    auto column_evaluators = std::make_shared<std::vector<std::unique_ptr<ColumnEvaluator>>>(
+            ColumnSlotIdEvaluator::from_types(type_descs));
+    // Use a unique file path for this test to avoid conflicts with _file_path
+    std::string file_path = "/test_dict_disabled.parquet";
+    auto fs = std::shared_ptr<MemoryFileSystem>(&_fs, [](MemoryFileSystem*) {});
+    auto factory = ParquetFileWriterFactory(fs, TCompressionType::NO_COMPRESSION, {}, column_names, column_evaluators,
+                                            std::nullopt, nullptr, _runtime_state);
+
+    // Disable dictionary encoding for "pos" column (simulating Iceberg delete file optimization)
+    std::unordered_map<std::string, bool> column_dict_config;
+    column_dict_config["pos"] = false;
+    factory.set_column_dictionary_enabled(std::move(column_dict_config));
+
+    ASSERT_OK(factory.init());
+
+    auto maybe_writer = factory.create(file_path);
+    ASSERT_OK(maybe_writer.status());
+
+    auto writer = std::move(maybe_writer.value().writer);
+    ASSERT_OK(writer->init());
+
+    // Write monotonically increasing pos values (typical for position delete files)
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // file_path column - repeated values (good for dictionary encoding)
+        auto col0 = ColumnTestHelper::build_column<Slice>({"s3://bucket/table/data/file1.parquet",
+                                                           "s3://bucket/table/data/file1.parquet",
+                                                           "s3://bucket/table/data/file1.parquet"});
+        chunk->append_column(std::move(col0), 0);
+
+        // pos column - monotonically increasing (poor for dictionary encoding, should use PLAIN)
+        auto col1 = ColumnTestHelper::build_column<int64_t>({100, 200, 300});
+        chunk->append_column(std::move(col1), 1);
+    }
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 3);
+
+    // Verify encoding using StarRocks parquet FileReader
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    ASSERT_EQ(file_metadata->t_metadata().row_groups.size(), 1);
+
+    // Check row group 0
+    const auto& row_group = file_metadata->t_metadata().row_groups[0];
+
+    // file_path column (index 0) - should use dictionary encoding
+    const auto& file_path_col = row_group.columns[0];
+    const auto& file_path_encodings = file_path_col.meta_data.encodings;
+    bool has_dict_encoding_file_path = false;
+    for (const auto& enc : file_path_encodings) {
+        if (enc == tparquet::Encoding::RLE_DICTIONARY || enc == tparquet::Encoding::PLAIN_DICTIONARY) {
+            has_dict_encoding_file_path = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_dict_encoding_file_path) << "file_path column should use dictionary encoding (repeated values)";
+
+    // pos column (index 1) - should NOT use dictionary encoding (disabled)
+    const auto& pos_col = row_group.columns[1];
+    const auto& pos_encodings = pos_col.meta_data.encodings;
+    bool has_dict_encoding_pos = false;
+    for (const auto& enc : pos_encodings) {
+        if (enc == tparquet::Encoding::RLE_DICTIONARY || enc == tparquet::Encoding::PLAIN_DICTIONARY) {
+            has_dict_encoding_pos = true;
+            break;
+        }
+    }
+    EXPECT_FALSE(has_dict_encoding_pos) << "pos column should NOT use dictionary encoding (configured to disable)";
+
+    // Verify pos column uses PLAIN encoding
+    bool has_plain_encoding = false;
+    for (const auto& enc : pos_encodings) {
+        if (enc == tparquet::Encoding::PLAIN) {
+            has_plain_encoding = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_plain_encoding) << "pos column should use PLAIN encoding";
+}
+
+TEST_F(ParquetFileWriterTest, TestColumnDictionaryEncodingEnabledByDefault) {
+    // Test that dictionary encoding is enabled by default when not explicitly disabled
+    std::vector type_descs{TYPE_BIGINT_DESC};
+    std::vector<std::string> column_names = {"col1"};
+
+    auto column_evaluators = std::make_shared<std::vector<std::unique_ptr<ColumnEvaluator>>>(
+            ColumnSlotIdEvaluator::from_types(type_descs));
+    // Use a unique file path for this test to avoid conflicts with _file_path
+    std::string file_path = "/test_dict_default.parquet";
+    auto fs = std::shared_ptr<MemoryFileSystem>(&_fs, [](MemoryFileSystem*) {});
+    auto factory = ParquetFileWriterFactory(fs, TCompressionType::NO_COMPRESSION, {}, column_names, column_evaluators,
+                                            std::nullopt, nullptr, _runtime_state);
+
+    // Do NOT call set_column_dictionary_enabled - should use default (enabled)
+    ASSERT_OK(factory.init());
+
+    auto maybe_writer = factory.create(file_path);
+    ASSERT_OK(maybe_writer.status());
+
+    auto writer = std::move(maybe_writer.value().writer);
+    ASSERT_OK(writer->init());
+
+    // Write repeated values (good for dictionary encoding)
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto col = ColumnTestHelper::build_column<int64_t>({100, 100, 100, 100, 100});
+        chunk->append_column(std::move(col), 0);
+    }
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+    ASSERT_OK(result.io_status);
+
+    // Verify encoding using StarRocks parquet FileReader
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    const auto& row_group = file_metadata->t_metadata().row_groups[0];
+    const auto& col_chunk = row_group.columns[0];
+    const auto& encodings = col_chunk.meta_data.encodings;
+
+    // Should have dictionary encoding (default behavior)
+    bool has_dict_encoding = false;
+    for (const auto& enc : encodings) {
+        if (enc == tparquet::Encoding::RLE_DICTIONARY || enc == tparquet::Encoding::PLAIN_DICTIONARY) {
+            has_dict_encoding = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(has_dict_encoding) << "Column should use dictionary encoding by default";
 }
 
 } // namespace starrocks::formats


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces support for configuring column-level dictionary encoding in Parquet file writing, allowing more granular control over which columns use dictionary encoding. This is particularly useful for optimizing storage and performance, such as disabling dictionary encoding for monotonically increasing columns (like `pos` in Iceberg position delete files) while keeping it enabled for highly repetitive columns (like `file_path`). The changes also include comprehensive tests to verify the new functionality.

**Column-level dictionary encoding support:**

* Added a `column_dictionary_enabled` configuration to `ParquetWriterOptions`, allowing users to specify per-column dictionary encoding settings. Columns not specified use the global default. (`be/src/formats/parquet/parquet_file_writer.h` [be/src/formats/parquet/parquet_file_writer.hR97-R101](diffhunk://#diff-158f580d05a58e2ae64c72b15455c6bc01f9d7043dd3245095d8aed986c96d49R97-R101))
* Implemented a setter method `set_column_dictionary_enabled` in `ParquetFileWriterFactory` to apply these settings before initialization. (`be/src/formats/parquet/parquet_file_writer.h` 
* Modified the Parquet file writer initialization to apply the per-column dictionary encoding configuration when building writer properties. (`be/src/formats/parquet/parquet_file_writer.cpp` 

**Integration and usage:**

* Updated Iceberg position delete file writing to disable dictionary encoding for the `pos` column (monotonically increasing) and keep it enabled for the `file_path` column (high repetition), improving compression and performance for these files. (`be/src/connector/iceberg_delete_sink.cpp` 

**Testing and validation:**

* Added new tests to verify that dictionary encoding can be disabled for specific columns and is enabled by default otherwise, ensuring correct behavior and encoding in the resulting Parquet files. (`be/test/formats/parquet/parquet_file_writer_test.cpp` 

These changes collectively provide fine-grained control over Parquet encoding, enabling better optimization for different data patterns and use cases.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
