### PR TITLE
[BugFix] Fix version anomaly in OnlineOptimizeJobV2 during concurrent ingestion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -386,17 +386,28 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
 
                 if (this.future != null) {
                     if (this.future.isDone()) {
+                        Constants.TaskRunState result;
                         try {
-                            rewriteTask.setOptimizeTaskState(future.get());
+                            result = future.get();
                         } catch (InterruptedException | ExecutionException e) {
                             LOG.warn("get rewrite task result failed", e);
-                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
+                            result = Constants.TaskRunState.FAILED;
                         }
 
-                        if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED) {
+                        if (result == Constants.TaskRunState.FAILED) {
+                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
                             this.allPartitionOptimized = false;
+                            this.future = null;
+                        } else {
+                            Partition tmpPartition = tbl.getPartition(rewriteTask.getTempPartitionName(), true);
+                            if (tmpPartition != null && hasCommittedNotVisible(tmpPartition.getId())) {
+                                LOG.info("wait committed transactions to be visible for temp partition {}, job: {}",
+                                            rewriteTask.getTempPartitionName(), jobId);
+                                return;
+                            }
+                            rewriteTask.setOptimizeTaskState(Constants.TaskRunState.SUCCESS);
+                            this.future = null;
                         }
-                        this.future = null;
                     } else {
                         LOG.info("wait rewrite task {} to be finished, optimize job: {}", rewriteTask.getName(), jobId);
                         return;
@@ -602,6 +613,11 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         } finally {
             locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
+    }
+
+    protected boolean hasCommittedNotVisible(long partitionId) {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .existCommittedTxns(dbId, tableId, partitionId);
     }
 
     // Check whether transactions of the given database which txnId is less than 'watershedTxnId' are finished.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add hasCommittedNotVisible check before replacing partition in OnlineOptimizeJobV2. When the INSERT task completes but there are committed-but-not-yet-published transactions (from double-write), wait for them to become visible before proceeding with partition replacement. This prevents FE-BE version inconsistency where FE advances the visible version while BE tablets still have pending commits that haven't been applied.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
