### PR TITLE
[Refactor] Rename misleading partitionColNames variables to partition Names where they actually hold partition names

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -314,7 +314,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
             PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
             List<String> partitionNames;
             if (partitionDesc instanceof RangePartitionDesc) {
-                partitionNames = ((RangePartitionDesc) partitionDesc).getPartitionColNames();
+                partitionNames = ((RangePartitionDesc) partitionDesc).getPartitionNames();
             } else {
                 throw new DdlException("Unsupported partitionDesc");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -351,16 +351,16 @@ public class InsertOverwriteJobRunner {
             throw new RuntimeException(ex);
         }
         PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
-        List<String> partitionColNames;
+        List<String> partitionNames;
         if (partitionDesc instanceof RangePartitionDesc) {
-            partitionColNames = ((RangePartitionDesc) partitionDesc).getPartitionColNames();
+            partitionNames = ((RangePartitionDesc) partitionDesc).getPartitionNames();
         } else if (partitionDesc instanceof ListPartitionDesc) {
-            partitionColNames = ((ListPartitionDesc) partitionDesc).getPartitionColNames();
+            partitionNames = ((ListPartitionDesc) partitionDesc).getPartitionNames();
         } else {
             throw new RuntimeException("Unsupported partitionDesc");
         }
-        for (String partitionColName : partitionColNames) {
-            Partition partition = olapTable.getPartition(partitionColName);
+        for (String partitionName : partitionNames) {
+            Partition partition = olapTable.getPartition(partitionName);
             if (!sourcePartitionIds.contains(partition.getId())) {
                 sourcePartitionIds.add(partition.getId());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -1467,10 +1467,10 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             properties.putAll(clauseProperties);
         }
 
-        List<String> rangePartitionColNames = null;
+        List<String> rangePartitionNames = null;
         if (addPartitionClause.getPartitionDesc() instanceof RangePartitionDesc) {
-            rangePartitionColNames =
-                    ((RangePartitionDesc) addPartitionClause.getPartitionDesc()).getPartitionColNames();
+            rangePartitionNames =
+                    ((RangePartitionDesc) addPartitionClause.getPartitionDesc()).getPartitionNames();
         }
 
         Iterator<PartitionDesc> iterator = partitionDescs.iterator();
@@ -1500,11 +1500,11 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                                 addPartitionClause.isTempPartition());
                         if (enclosingId >= 0) {
                             Partition enclosingPartition = olapTable.getPartition(enclosingId);
-                            if (enclosingPartition != null && rangePartitionColNames != null) {
-                                int idx = rangePartitionColNames.indexOf(
+                            if (enclosingPartition != null && rangePartitionNames != null) {
+                                int idx = rangePartitionNames.indexOf(
                                         singleRangePartitionDesc.getPartitionName());
                                 if (idx >= 0) {
-                                    rangePartitionColNames.set(idx, enclosingPartition.getName());
+                                    rangePartitionNames.set(idx, enclosingPartition.getName());
                                 }
                             }
                             iterator.remove();
@@ -1540,10 +1540,10 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             }
         }
 
-        if (rangePartitionColNames != null) {
-            LinkedHashSet<String> deduped = new LinkedHashSet<>(rangePartitionColNames);
-            rangePartitionColNames.clear();
-            rangePartitionColNames.addAll(deduped);
+        if (rangePartitionNames != null) {
+            LinkedHashSet<String> deduped = new LinkedHashSet<>(rangePartitionNames);
+            rangePartitionNames.clear();
+            rangePartitionNames.addAll(deduped);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1468,7 +1468,7 @@ public class AnalyzerUtils {
 
             // table partitions for check
             PCellSortedSet tablePartitions = olapTable.getListPartitionItems();
-            Set<String> partitionColNameSet = Sets.newHashSet();
+            Set<String> partitionNameSet = Sets.newHashSet();
             List<PartitionDesc> partitionDescs = Lists.newArrayList();
             for (List<String> partitionValue : partitionValues) {
                 List<String> formattedPartitionValue = Lists.newArrayList();
@@ -1488,7 +1488,7 @@ public class AnalyzerUtils {
                     }
                     partitionName = partitionNamePrefix + PARTITION_NAME_PREFIX_SPLIT + partitionName;
                 }
-                if (!partitionColNameSet.contains(partitionName)) {
+                if (!partitionNameSet.contains(partitionName)) {
                     List<List<String>> partitionItems = Collections.singletonList(partitionValue);
                     PListCell cell = new PListCell(partitionItems);
                     partitionName = calculateUniquePartitionName(partitionName, cell, tablePartitions);
@@ -1496,14 +1496,15 @@ public class AnalyzerUtils {
                             partitionName, partitionItems, partitionProperties);
                     multiItemListPartitionDesc.setSystem(true);
                     partitionDescs.add(multiItemListPartitionDesc);
-                    partitionColNameSet.add(partitionName);
+                    partitionNameSet.add(partitionName);
 
                     // update table partition
                     tablePartitions.add(partitionName, cell);
                 }
             }
-            List<String> partitionColNames = Lists.newArrayList(partitionColNameSet);
-            ListPartitionDesc listPartitionDesc = new ListPartitionDesc(partitionColNames, partitionDescs);
+            List<String> partitionNames = Lists.newArrayList(partitionNameSet);
+            ListPartitionDesc listPartitionDesc = new ListPartitionDesc(Lists.newArrayList(), partitionDescs);
+            listPartitionDesc.setPartitionNames(partitionNames);
             listPartitionDesc.setSystem(true);
             return new AddPartitionClause(listPartitionDesc, distributionDesc,
                     partitionProperties, isTemp);
@@ -1573,7 +1574,7 @@ public class AnalyzerUtils {
         Map<String, String> partitionProperties = ImmutableMap.of("replication_num", String.valueOf(replicationNum));
 
         List<PartitionDesc> partitionDescs = Lists.newArrayList();
-        List<String> partitionColNames = Lists.newArrayList();
+        List<String> partitionNames = Lists.newArrayList();
         for (List<String> partitionValue : partitionValues) {
             if (partitionValue.size() != 1) {
                 throw new AnalysisException("automatic partition only support single column for range partition.");
@@ -1630,19 +1631,20 @@ public class AnalyzerUtils {
                     partitionName = partitionPrefix + PARTITION_NAME_PREFIX_SPLIT + partitionName;
                 }
 
-                if (!partitionColNames.contains(partitionName)) {
+                if (!partitionNames.contains(partitionName)) {
                     SingleRangePartitionDesc singleRangePartitionDesc =
                             new SingleRangePartitionDesc(true, partitionName, partitionKeyDesc, partitionProperties);
                     singleRangePartitionDesc.setSystem(true);
                     partitionDescs.add(singleRangePartitionDesc);
-                    partitionColNames.add(partitionName);
+                    partitionNames.add(partitionName);
                 }
             } catch (AnalysisException e) {
                 LOG.warn("failed to analyse partition value", e);
                 throw new AnalysisException(String.format("failed to analyse partition value:%s", partitionValue));
             }
         }
-        RangePartitionDesc rangePartitionDesc = new RangePartitionDesc(partitionColNames, partitionDescs);
+        RangePartitionDesc rangePartitionDesc = new RangePartitionDesc(Lists.newArrayList(), partitionDescs);
+        rangePartitionDesc.setPartitionNames(partitionNames);
         rangePartitionDesc.setSystem(true);
         return new AddPartitionClause(rangePartitionDesc, distributionDesc, partitionProperties, isTemp);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -37,6 +37,7 @@ public class ListPartitionDesc extends PartitionDesc {
     private final List<MultiItemListPartitionDesc> multiListPartitionDescs;
 
     private final List<String> partitionColNames;
+    private List<String> partitionNames = Lists.newArrayList();
 
     // for automatic partition table is ture. otherwise is false
     protected boolean isAutoPartitionTable = false;
@@ -94,6 +95,14 @@ public class ListPartitionDesc extends PartitionDesc {
 
     public List<String> getPartitionColNames() {
         return partitionColNames;
+    }
+
+    public List<String> getPartitionNames() {
+        return partitionNames;
+    }
+
+    public void setPartitionNames(List<String> partitionNames) {
+        this.partitionNames = partitionNames;
     }
 
     public List<String> findAllPartitionNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangePartitionDesc.java
@@ -27,6 +27,7 @@ public class RangePartitionDesc extends PartitionDesc {
     private final List<String> partitionColNames;
     private final List<SingleRangePartitionDesc> singleRangePartitionDescs;
     private final List<MultiRangePartitionDesc> multiRangePartitionDescs;
+    private List<String> partitionNames = Lists.newArrayList();
     // for automatic partition table is ture. otherwise is false
     protected boolean isAutoPartitionTable = false;
     // For automatically created partitioned tables, the partition column type and expression type may be inconsistent.
@@ -65,7 +66,13 @@ public class RangePartitionDesc extends PartitionDesc {
         return partitionColNames;
     }
 
+    public List<String> getPartitionNames() {
+        return partitionNames;
+    }
 
+    public void setPartitionNames(List<String> partitionNames) {
+        this.partitionNames = partitionNames;
+    }
 
     public void setAutoPartitionTable(boolean autoPartitionTable) {
         this.isAutoPartitionTable = autoPartitionTable;


### PR DESCRIPTION
## Why I'm doing:
In AnalyzerUtils.getAddPartitionClauseFromPartitionValues and getAddPartitionClauseForRangePartition, the partitionColNames variables actually store partition names (e.g. p20230101, p_beijing), not partition column names (e.g. dt, city). This naming inconsistency propagated to all call sites including AlterTableClauseAnalyzer, FrontendServiceImpl, and InsertOverwriteJobRunner.


## What I'm doing:
Rename the local variables and parameters at these call sites to partitionNames/partitionNameSet to accurately reflect their actual content. No logic changes.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
