### PR TITLE
[BugFix] Fix the AsyncFlushOutputStream use-after-free

### DIFF
--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -93,7 +93,6 @@ protected:
 };
 
 struct ConnectorChunkSinkContext {
-public:
     virtual ~ConnectorChunkSinkContext() = default;
 };
 

--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -32,6 +32,8 @@
 
 namespace starrocks::connector {
 
+DEFINE_FAIL_POINT(parquet_chunk_writer_init_failed);
+
 namespace {
 
 FieldPtr build_field_from_type_desc(const TypeDescriptor& type_desc, const std::string& name, int32_t id,
@@ -107,6 +109,10 @@ Status PartitionChunkWriter::create_file_writer_if_needed() {
         _file_writer = std::move(new_writer_and_stream.writer);
         _out_stream = std::move(new_writer_and_stream.stream);
         RETURN_IF_ERROR(_file_writer->init());
+
+        FAIL_POINT_TRIGGER_EXECUTE(parquet_chunk_writer_init_failed, {
+            return Status::InternalError("Create file writer failed due to fail point");
+        });
         _io_poller->enqueue(_out_stream);
     }
     return Status::OK();

--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -110,9 +110,8 @@ Status PartitionChunkWriter::create_file_writer_if_needed() {
         _out_stream = std::move(new_writer_and_stream.stream);
         RETURN_IF_ERROR(_file_writer->init());
 
-        FAIL_POINT_TRIGGER_EXECUTE(parquet_chunk_writer_init_failed, {
-            return Status::InternalError("Create file writer failed due to fail point");
-        });
+        FAIL_POINT_TRIGGER_EXECUTE(parquet_chunk_writer_init_failed,
+                                   { return Status::InternalError("Create file writer failed due to fail point"); });
         _io_poller->enqueue(_out_stream);
     }
     return Status::OK();

--- a/be/src/connector/partition_chunk_writer.h
+++ b/be/src/connector/partition_chunk_writer.h
@@ -107,8 +107,8 @@ protected:
     bool _is_default_partition = false;
     AsyncFlushStreamPoller* _io_poller = nullptr;
 
-    // The destruction of _filter_writer triggers a flush of _out_stream.
-    // Therefore, we must ensure _filter_writer is destroyed first, followed by _out_stream.
+    // The destruction of _file_writer triggers a flush of _out_stream.
+    // Therefore, we must ensure _file_writer is destroyed first, followed by _out_stream.
     // Failing to do so will result in a use-after-free error for _out_stream.
     // TODO: Refactor the file writer and output stream to make them more robust and user-friendly.
     std::shared_ptr<io::AsyncFlushOutputStream> _out_stream;

--- a/be/src/connector/partition_chunk_writer.h
+++ b/be/src/connector/partition_chunk_writer.h
@@ -107,8 +107,12 @@ protected:
     bool _is_default_partition = false;
     AsyncFlushStreamPoller* _io_poller = nullptr;
 
-    std::shared_ptr<formats::FileWriter> _file_writer;
+    // The destruction of _filter_writer triggers a flush of _out_stream.
+    // Therefore, we must ensure _filter_writer is destroyed first, followed by _out_stream.
+    // Failing to do so will result in a use-after-free error for _out_stream.
+    // TODO: Refactor the file writer and output stream to make them more robust and user-friendly.
     std::shared_ptr<io::AsyncFlushOutputStream> _out_stream;
+    std::shared_ptr<formats::FileWriter> _file_writer;
     CommitFunc _commit_callback;
     std::string _commit_extra_data;
     ErrorHandleFunc _error_handler = nullptr;

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -239,8 +239,8 @@ StatusOr<WriterAndStream> CSVFileWriterFactory::create(const std::string& path) 
                                                   std::move(column_evaluators), _parsed_options, rollback_action);
     cleanup_on_failure.cancel(); // Prevent cleanup on success
     return WriterAndStream{
-            .writer = std::move(writer),
             .stream = std::move(async_output_stream),
+            .writer = std::move(writer),
     };
 }
 

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -69,8 +69,8 @@ public:
 };
 
 struct WriterAndStream {
-    std::unique_ptr<FileWriter> writer;
     std::unique_ptr<io::AsyncFlushOutputStream> stream;
+    std::unique_ptr<FileWriter> writer;
 };
 
 class FileWriterFactory {

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -511,8 +511,8 @@ StatusOr<WriterAndStream> ORCFileWriterFactory::create(const string& path) const
             std::make_unique<ORCFileWriter>(path, orc_output_stream, _column_names, types, std::move(column_evaluators),
                                             _compression_type, _parsed_options, rollback_action);
     return WriterAndStream{
-            .writer = std::move(writer),
             .stream = std::move(async_output_stream),
+            .writer = std::move(writer),
     };
 }
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -367,8 +367,8 @@ StatusOr<WriterAndStream> ParquetFileWriterFactory::create(const std::string& pa
                                                       std::move(column_evaluators), _compression_type, _parsed_options,
                                                       rollback_action, _nullable);
     return WriterAndStream{
-            .writer = std::move(writer),
             .stream = std::move(async_output_stream),
+            .writer = std::move(writer),
     };
 }
 

--- a/test/sql/test_sink/R/test_file_sink_commit_failed
+++ b/test/sql/test_sink/R/test_file_sink_commit_failed
@@ -56,6 +56,21 @@ insert into files(
 admin disable failpoint 'parquet_writer_rowgroup_write_failed';
 -- result:
 -- !result
+admin enable failpoint 'parquet_chunk_writer_init_failed';
+-- result:
+-- !result
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+-- result:
+[REGEX].*Create file writer failed due to fail point.*
+-- !result
+admin disable failpoint 'parquet_chunk_writer_init_failed';
+-- result:
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -65,4 +80,5 @@ CLEANUP {
     admin disable failpoint 'parquet_writer_close_failed';
     admin disable failpoint 'parquet_writer_throw_exception';
     admin disable failpoint 'parquet_writer_rowgroup_write_failed';
+    admin disable failpoint 'parquet_chunk_writer_init_failed';
 } END CLEANUP

--- a/test/sql/test_sink/T/test_file_sink_commit_failed
+++ b/test/sql/test_sink/T/test_file_sink_commit_failed
@@ -39,10 +39,22 @@ insert into files(
 
 admin disable failpoint 'parquet_writer_rowgroup_write_failed';
 
+admin enable failpoint 'parquet_chunk_writer_init_failed';
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+
+admin disable failpoint 'parquet_chunk_writer_init_failed';
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 
 CLEANUP {
     admin disable failpoint 'parquet_writer_close_failed';
     admin disable failpoint 'parquet_writer_throw_exception';
     admin disable failpoint 'parquet_writer_rowgroup_write_failed';
+    admin disable failpoint 'parquet_chunk_writer_init_failed';
 } END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

The destruction of _filter_writer triggers a flush of _out_stream. Therefore, we must ensure _filter_writer is destroyed first, followed by _out_stream. Failing to do so will result in a use-after-free error for _out_stream.

```
PC: @          0xd5a81ed starrocks::io::AsyncFlushOutputStream::write(unsigned char const*, long)
*** SIGSEGV (@0x0) received by PID 76996 (TID 0x14bbe3cd6640) LWP(77375) from PID 0; stack trace: ***
    @     0x14bc0e41bee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x14ac8d46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14bc0e3c4520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0xd5a81ed starrocks::io::AsyncFlushOutputStream::write(unsigned char const*, long)
    @          0xd5696c8 starrocks::parquet::AsyncParquetOutputStream::Write(void const*, long)
    @         0x1615e7f6 parquet::FileMetaData::FileMetaDataImpl::WriteTo(arrow::io::OutputStream*, std::shared_ptr<parquet::Encryptor> const&) const
    @         0x160d650e parquet::WriteFileMetaData(parquet::FileMetaData const&, arrow::io::OutputStream*) [clone .localalias]
    @         0x160d96aa parquet::FileSerializer::Close()
    @         0x160d6d40 parquet::ParquetFileWriter::Close() [clone .localalias]
    @         0x160d6e8f parquet::ParquetFileWriter::~ParquetFileWriter()
    @          0xd33b8da std::_Sp_counted_deleter<parquet::ParquetFileWriter*, std::default_delete<parquet::ParquetFileWriter>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    @          0xa5b5f9a std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
    @          0xd336ee8 starrocks::formats::ParquetFileWriter::~ParquetFileWriter()
    @          0xd337061 starrocks::formats::ParquetFileWriter::~ParquetFileWriter()
    @          0xa5b5f9a std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
    @          0xc6e9b38 std::_Sp_counted_ptr_inplace<starrocks::connector::BufferPartitionChunkWriter, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    @          0xa5b5f9a std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
    @          0xc6f9b29 starrocks::connector::ConnectorChunkSink::write_partition_chunk(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<signed char, std::allocator<signed char> > const&, std::shared_ptr<starrocks::Chunk> const&)@
    @          0xc6fa222 starrocks::connector::ConnectorChunkSink::add(std::shared_ptr<starrocks::Chunk> const&)
    @          0xfd4e805 starrocks::pipeline::ConnectorSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xc5f40ff starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xc669dd1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x11034ebb starrocks::ThreadPool::dispatch_thread()
    @         0x1102beef starrocks::Thread::supervise_thread(void*)
    @     0x14bc0e416ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x14bc0e4a88d0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268cf)
```

## What I'm doing:

Fix the AsyncFlushOutputStream use-after-free

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
