### PR TITLE
[Enhancement] Trigger early flush in LakePersistentIndex when rebuild row count exceeds threshold

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1314,6 +1314,10 @@ CONF_mBool(lake_clear_corrupted_cache_data, "false");
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
+// The maximum number of rows which need to be rebuilt in cloud native pk index.
+// If rows which need to be rebuilt exceed this threshold, we will flush memtable immediately
+// to reduce index rebuild cost. 0 means disabled.
+CONF_mInt64(cloud_native_pk_index_rebuild_rows_threshold, "10000000");
 // if set to true, CACHE SELECT will only read file, save CPU time
 // if set to false, CACHE SELECT will behave like SELECT
 CONF_mBool(lake_cache_select_in_physical_way, "true");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -116,7 +116,8 @@ bool LakePersistentIndex::is_memtable_full() const {
 }
 
 bool LakePersistentIndex::too_many_rebuild_files() const {
-    return _need_rebuild_file_cnt >= config::cloud_native_pk_index_rebuild_files_threshold;
+    return config::cloud_native_pk_index_rebuild_files_threshold > 0 &&
+           _need_rebuild_file_cnt >= config::cloud_native_pk_index_rebuild_files_threshold;
 }
 
 bool LakePersistentIndex::too_many_rebuild_rows() const {

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -119,6 +119,11 @@ bool LakePersistentIndex::too_many_rebuild_files() const {
     return _need_rebuild_file_cnt >= config::cloud_native_pk_index_rebuild_files_threshold;
 }
 
+bool LakePersistentIndex::too_many_rebuild_rows() const {
+    return config::cloud_native_pk_index_rebuild_rows_threshold > 0 &&
+           _need_rebuild_row_cnt >= config::cloud_native_pk_index_rebuild_rows_threshold;
+}
+
 Status LakePersistentIndex::merge_sstable_into_fileset(std::unique_ptr<PersistentIndexSstable>& sstable) {
     bool need_create_new_fileset = false;
     if (_sstable_filesets.empty()) {
@@ -210,8 +215,9 @@ Status LakePersistentIndex::sync_flush_all_memtables(int64_t wait_timeout_us) {
         const uint64_t next_max_rss_rowid = _memtable->max_rss_rowid();
         _memtable = std::make_shared<PersistentIndexMemtable>(_tablet_mgr, _tablet_id, next_max_rss_rowid);
     }
-    // Reset rebuild file count, avoid useless flush.
+    // Reset rebuild file/row count, avoid useless flush.
     _need_rebuild_file_cnt = 0;
+    _need_rebuild_row_cnt = 0;
     return Status::OK();
 }
 
@@ -274,8 +280,9 @@ Status LakePersistentIndex::flush_memtable(bool force) {
         }
         const uint64_t next_max_rss_rowid = _memtable->max_rss_rowid();
         _memtable = std::make_shared<PersistentIndexMemtable>(_tablet_mgr, _tablet_id, next_max_rss_rowid);
-        // Reset rebuild file count, avoid useless flush.
+        // Reset rebuild file/row count, avoid useless flush.
         _need_rebuild_file_cnt = 0;
+        _need_rebuild_row_cnt = 0;
     }
     return Status::OK();
 }
@@ -772,8 +779,8 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
 }
 
 Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
-    if (too_many_rebuild_files() && !_memtable->empty()) {
-        // If we have too many files need to be rebuilt,
+    if ((too_many_rebuild_files() || too_many_rebuild_rows()) && !_memtable->empty()) {
+        // If we have too many files or rows need to be rebuilt,
         // we need to do flush to reduce index rebuild cost later.
         RETURN_IF_ERROR(flush_memtable(true));
     }
@@ -795,7 +802,9 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
         }
     }
     builder->finalize_sstable_meta(sstable_meta);
-    _need_rebuild_file_cnt = need_rebuild_file_cnt(*builder->tablet_meta(), sstable_meta);
+    auto [file_cnt, row_cnt] = need_rebuild_counts(*builder->tablet_meta(), sstable_meta);
+    _need_rebuild_file_cnt = file_cnt;
+    _need_rebuild_row_cnt = row_cnt;
     return Status::OK();
 }
 
@@ -873,14 +882,34 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     return Status::OK();
 }
 
-static size_t rebuild_segment_cnt(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id) {
-    size_t cnt = 0;
+// Return {segment_file_cnt, segment_row_cnt} for segments that need to rebuild in a single pass.
+// Uses exact per-segment num_rows when segment_metas is fully populated (size matches segments and
+// every entry has num_rows set). Falls back to a proportional estimate based on the rowset's total
+// num_rows if segment_metas is absent or any entry is missing num_rows (e.g. synthesized by
+// MetaFileBuilder::add_rowset which sets only segment_idx without num_rows).
+static std::pair<size_t, int64_t> rebuild_segment_counts(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id) {
+    size_t file_cnt = 0;
+    int64_t row_cnt = 0;
+    bool exact = (rowset.segment_metas_size() == rowset.segments_size());
     for (int i = 0; i < rowset.segments_size(); ++i) {
         if (get_rssid(rowset, i) >= rebuild_rss_id) {
-            ++cnt;
+            ++file_cnt;
+            if (exact) {
+                if (rowset.segment_metas(i).has_num_rows()) {
+                    row_cnt += rowset.segment_metas(i).num_rows();
+                } else {
+                    // This entry was synthesized without num_rows; give up on exact counting.
+                    exact = false;
+                    row_cnt = 0;
+                }
+            }
         }
     }
-    return cnt;
+    if (!exact && file_cnt > 0 && rowset.segments_size() > 0) {
+        // Proportional estimate when per-segment metadata is unavailable or incomplete.
+        row_cnt = rowset.num_rows() * static_cast<int64_t>(file_cnt) / rowset.segments_size();
+    }
+    return {file_cnt, row_cnt};
 }
 
 // Check if this rowset need to rebuild, return `True` means need to rebuild this rowset.
@@ -906,20 +935,23 @@ bool LakePersistentIndex::needs_rowset_rebuild(const RowsetMetadataPB& rowset, u
     return true;
 }
 
-// Return the files cnt that need to rebuild.
-size_t LakePersistentIndex::need_rebuild_file_cnt(const TabletMetadataPB& metadata,
-                                                  const PersistentIndexSstableMetaPB& sstable_meta) {
-    size_t cnt = 0;
+// Return {file_cnt, row_cnt} that need to rebuild in a single rowset traversal.
+std::pair<size_t, int64_t> LakePersistentIndex::need_rebuild_counts(const TabletMetadataPB& metadata,
+                                                                    const PersistentIndexSstableMetaPB& sstable_meta) {
+    size_t file_cnt = 0;
+    int64_t row_cnt = 0;
     const auto& sstables = sstable_meta.sstables();
     const uint32_t rebuild_rss_id = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid() >> 32;
     for (const auto& rowset : metadata.rowsets()) {
         if (!needs_rowset_rebuild(rowset, rebuild_rss_id)) {
             continue; // skip rowset
         }
-        cnt += rowset.del_files_size();
-        cnt += rebuild_segment_cnt(rowset, rebuild_rss_id);
+        file_cnt += rowset.del_files_size();
+        auto [seg_file_cnt, seg_row_cnt] = rebuild_segment_counts(rowset, rebuild_rss_id);
+        file_cnt += seg_file_cnt;
+        row_cnt += seg_row_cnt;
     }
-    return cnt;
+    return {file_cnt, row_cnt};
 }
 
 Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
@@ -932,7 +964,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     }
     auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
 
-    _need_rebuild_file_cnt = need_rebuild_file_cnt(*metadata, metadata->sstable_meta());
+    auto [file_cnt, row_cnt] = need_rebuild_counts(*metadata, metadata->sstable_meta());
+    _need_rebuild_file_cnt = file_cnt;
+    _need_rebuild_row_cnt = row_cnt;
     ASSIGN_OR_RETURN(auto pk_encoding_type, tablet_schema->primary_key_encoding_type_or_error());
 
     // Init PersistentIndex

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -141,9 +141,9 @@ public:
     // Check if this rowset need to rebuild, return `True` means need to rebuild this rowset.
     static bool needs_rowset_rebuild(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id);
 
-    // Return the files cnt that need to rebuild.
-    static size_t need_rebuild_file_cnt(const TabletMetadataPB& metadata,
-                                        const PersistentIndexSstableMetaPB& sstable_meta);
+    // Return the {file_cnt, row_cnt} that need to rebuild in a single rowset traversal.
+    static std::pair<size_t, int64_t> need_rebuild_counts(const TabletMetadataPB& metadata,
+                                                          const PersistentIndexSstableMetaPB& sstable_meta);
 
     Status flush_memtable(bool force = false);
 
@@ -153,6 +153,8 @@ private:
     bool is_memtable_full() const;
 
     bool too_many_rebuild_files() const;
+
+    bool too_many_rebuild_rows() const;
 
     // batch get
     // |n|: size of key/value array
@@ -190,6 +192,7 @@ private:
     TabletManager* _tablet_mgr{nullptr};
     int64_t _tablet_id{0};
     size_t _need_rebuild_file_cnt{0};
+    int64_t _need_rebuild_row_cnt{0};
     // Collection of sstable fileset, from old to new.
     std::vector<std::unique_ptr<PersistentIndexSstableFileset>> _sstable_filesets;
 };

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -803,4 +803,103 @@ TEST_F(LakePersistentIndexTest, test_tablet_range_infinite_bounds) {
     ASSERT_TRUE(sst_seek_range.stop_key.empty());
 }
 
+// Helper: build a RowsetMetadataPB with given id, per-segment row counts (segment_metas populated),
+// and an optional del file count.
+static RowsetMetadataPB make_rowset(uint32_t id, const std::vector<int64_t>& seg_rows, int del_file_cnt = 0) {
+    RowsetMetadataPB rowset;
+    rowset.set_id(id);
+    int64_t total_rows = 0;
+    for (int64_t r : seg_rows) {
+        rowset.add_segments("seg.dat");
+        auto* meta = rowset.add_segment_metas();
+        meta->set_num_rows(r);
+        total_rows += r;
+    }
+    rowset.set_num_rows(total_rows);
+    for (int i = 0; i < del_file_cnt; ++i) {
+        rowset.add_del_files();
+    }
+    return rowset;
+}
+
+// Helper: build a RowsetMetadataPB without segment_metas (proportional fallback path).
+static RowsetMetadataPB make_rowset_no_meta(uint32_t id, int seg_cnt, int64_t total_rows) {
+    RowsetMetadataPB rowset;
+    rowset.set_id(id);
+    for (int i = 0; i < seg_cnt; ++i) {
+        rowset.add_segments("seg.dat");
+    }
+    rowset.set_num_rows(total_rows);
+    return rowset;
+}
+
+TEST_F(LakePersistentIndexTest, test_need_rebuild_counts) {
+    TabletMetadataPB metadata;
+    PersistentIndexSstableMetaPB sstable_meta;
+
+    // Case 1: no rowsets, no SSTs → {0, 0}
+    {
+        auto [file_cnt, row_cnt] = LakePersistentIndex::need_rebuild_counts(metadata, sstable_meta);
+        EXPECT_EQ(file_cnt, 0);
+        EXPECT_EQ(row_cnt, 0);
+    }
+
+    // Case 2: three rowsets, no SSTs → all segments need rebuild, exact row count via segment_metas.
+    // Rowset layout: id=0 (100 rows), id=1 (200 rows), id=2 (150 rows), each with 1 segment.
+    {
+        metadata.Clear();
+        sstable_meta.Clear();
+        *metadata.add_rowsets() = make_rowset(0, {100});
+        *metadata.add_rowsets() = make_rowset(1, {200});
+        *metadata.add_rowsets() = make_rowset(2, {150});
+
+        auto [file_cnt, row_cnt] = LakePersistentIndex::need_rebuild_counts(metadata, sstable_meta);
+        EXPECT_EQ(file_cnt, 3u);
+        EXPECT_EQ(row_cnt, 450);
+    }
+
+    // Case 3: SST covers rowsets 0 and 1 (max_rss_rowid has rss_id=2 in high 32 bits).
+    // Only rowset 2's segment (rssid=2) needs rebuild.
+    {
+        metadata.Clear();
+        sstable_meta.Clear();
+        *metadata.add_rowsets() = make_rowset(0, {100});
+        *metadata.add_rowsets() = make_rowset(1, {200});
+        *metadata.add_rowsets() = make_rowset(2, {150});
+        auto* sst = sstable_meta.add_sstables();
+        sst->set_max_rss_rowid(static_cast<int64_t>(2LL << 32)); // rebuild_rss_id = 2
+
+        auto [file_cnt, row_cnt] = LakePersistentIndex::need_rebuild_counts(metadata, sstable_meta);
+        EXPECT_EQ(file_cnt, 1u);
+        EXPECT_EQ(row_cnt, 150);
+    }
+
+    // Case 4: proportional fallback when segment_metas is absent.
+    // Rowset id=0 has 2 segments and 200 total rows; SST covers segment 0 (rssid=0),
+    // segment 1 (rssid=1) needs rebuild → proportional estimate: 200 * 1 / 2 = 100.
+    {
+        metadata.Clear();
+        sstable_meta.Clear();
+        *metadata.add_rowsets() = make_rowset_no_meta(0, 2, 200);
+        auto* sst = sstable_meta.add_sstables();
+        sst->set_max_rss_rowid(static_cast<int64_t>(1LL << 32)); // rebuild_rss_id = 1
+
+        auto [file_cnt, row_cnt] = LakePersistentIndex::need_rebuild_counts(metadata, sstable_meta);
+        EXPECT_EQ(file_cnt, 1u);
+        EXPECT_EQ(row_cnt, 100);
+    }
+
+    // Case 5: del files are counted in file_cnt but not in row_cnt.
+    // Rowset id=0: 1 segment (100 rows) + 2 del files.
+    {
+        metadata.Clear();
+        sstable_meta.Clear();
+        *metadata.add_rowsets() = make_rowset(0, {100}, /*del_file_cnt=*/2);
+
+        auto [file_cnt, row_cnt] = LakePersistentIndex::need_rebuild_counts(metadata, sstable_meta);
+        EXPECT_EQ(file_cnt, 3u); // 1 segment + 2 del files
+        EXPECT_EQ(row_cnt, 100);
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1779,9 +1779,10 @@ TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_
             // last one, check need rebuilt file cnt
             ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
             EXPECT_EQ(new_tablet_metadata->sstable_meta().sstables_size(), 0);
-            EXPECT_EQ(LakePersistentIndex::need_rebuild_file_cnt(*new_tablet_metadata,
-                                                                 new_tablet_metadata->sstable_meta()),
-                      config::cloud_native_pk_index_rebuild_files_threshold - 1);
+            EXPECT_EQ(
+                    LakePersistentIndex::need_rebuild_counts(*new_tablet_metadata, new_tablet_metadata->sstable_meta())
+                            .first,
+                    config::cloud_native_pk_index_rebuild_files_threshold - 1);
         }
     }
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
@@ -1821,14 +1822,62 @@ TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_
             // last one, check need rebuilt file cnt
             ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
             EXPECT_EQ(new_tablet_metadata->sstable_meta().sstables_size(), 0);
-            EXPECT_EQ(LakePersistentIndex::need_rebuild_file_cnt(*new_tablet_metadata,
-                                                                 new_tablet_metadata->sstable_meta()),
-                      config::cloud_native_pk_index_rebuild_files_threshold);
+            EXPECT_EQ(
+                    LakePersistentIndex::need_rebuild_counts(*new_tablet_metadata, new_tablet_metadata->sstable_meta())
+                            .first,
+                    config::cloud_native_pk_index_rebuild_files_threshold);
         }
     }
     ASSERT_EQ(0, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     // make sure generate sst files
+    EXPECT_TRUE(new_tablet_metadata->sstable_meta().sstables_size() > 0);
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_rows) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        GTEST_SKIP() << "this case only for cloud native index";
+    }
+    // Set row threshold to kChunkSize * 2 rows: after 2 writes the pending row count equals
+    // the threshold, so the 3rd commit triggers an early flush.
+    ConfigResetGuard row_guard(&config::cloud_native_pk_index_rebuild_rows_threshold, (int64_t)kChunkSize * 2);
+    ConfigResetGuard memtable_guard(&config::pk_index_memtable_max_count, 1);
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    for (int i = 0; i < 3; i++) {
+        auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        if (i == 1) {
+            // After 2 writes, verify row count has reached the threshold and no SST yet.
+            ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+            EXPECT_EQ(new_tablet_metadata->sstable_meta().sstables_size(), 0);
+            EXPECT_EQ(
+                    LakePersistentIndex::need_rebuild_counts(*new_tablet_metadata, new_tablet_metadata->sstable_meta())
+                            .second,
+                    kChunkSize * 2);
+        }
+    }
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    // The 3rd commit must have triggered an early flush due to the row threshold.
     EXPECT_TRUE(new_tablet_metadata->sstable_meta().sstables_size() > 0);
 }
 

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2966,6 +2966,24 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ### Shared-data
 
+##### cloud_native_pk_index_rebuild_files_threshold
+
+- Default: 50
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of segment files that need to be rebuilt in cloud-native Primary Key index. If the number of files that need to be rebuilt during index recovery exceeds this threshold, StarRocks will flush the in-memory MemTable immediately to reduce the number of segments that must be replayed. Set to `0` to disable this early-flush strategy.
+- Introduced in: -
+
+##### cloud_native_pk_index_rebuild_rows_threshold
+
+- Default: 10000000
+- Type: Long
+- Unit: Rows
+- Is mutable: Yes
+- Description: The maximum number of rows that need to be rebuilt in cloud-native Primary Key index. If the number of rows that need to be rebuilt during index recovery exceeds this threshold, StarRocks will flush the in-memory MemTable immediately to reduce the rebuild overhead. Set to `0` to disable this early-flush strategy. Works in conjunction with `cloud_native_pk_index_rebuild_files_threshold`; a flush is triggered if either threshold is exceeded.
+- Introduced in: -
+
 ##### download_buffer_size
 
 - Default: 4194304

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -2446,6 +2446,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ### 共有データ
 
+##### cloud_native_pk_index_rebuild_files_threshold
+
+- デフォルト: 50
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: クラウドネイティブ主キーインデックスのリビルド時に許容される最大 Segment ファイル数。リビルドが必要なファイル数がこの閾値を超えた場合、StarRocks はメモリ内の MemTable を即座にフラッシュし、リプレイが必要な Segment 数を削減します。`0` に設定するとこの早期フラッシュ戦略は無効になります。
+- 導入バージョン: -
+
+##### cloud_native_pk_index_rebuild_rows_threshold
+
+- デフォルト: 10000000
+- タイプ: Long
+- 単位: 行
+- 変更可能: Yes
+- 説明: クラウドネイティブ主キーインデックスのリビルド時に許容される最大行数。リビルドが必要な行数がこの閾値を超えた場合、StarRocks はメモリ内の MemTable を即座にフラッシュし、インデックス再構築のコストを削減します。`0` に設定するとこの早期フラッシュ戦略は無効になります。`cloud_native_pk_index_rebuild_files_threshold` と連携して動作し、いずれかの閾値を超えるとフラッシュがトリガーされます。
+- 導入バージョン: -
+
 ##### download_buffer_size
 
 - デフォルト: 4194304

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2937,6 +2937,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ### 存算分离
 
+##### cloud_native_pk_index_rebuild_files_threshold
+
+- 默认值：50
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：云原生主键索引在恢复（Rebuild）时允许重建的最大 Segment 文件数。若需要重建的文件数超过该阈值，StarRocks 会立即将内存中的 MemTable 刷盘，以减少需要重放的 Segment 数量。设置为 `0` 则禁用此提前刷盘策略。
+- 引入版本：-
+
+##### cloud_native_pk_index_rebuild_rows_threshold
+
+- 默认值：10000000
+- 类型：Long
+- 单位：行
+- 是否动态：是
+- 描述：云原生主键索引在恢复（Rebuild）时允许重建的最大行数。若需要重建的行数超过该阈值，StarRocks 会立即将内存中的 MemTable 刷盘，以降低索引重建开销。设置为 `0` 则禁用此提前刷盘策略。与 `cloud_native_pk_index_rebuild_files_threshold` 配合使用，任一阈值超出均会触发刷盘。
+- 引入版本：-
+
 ##### download_buffer_size
 
 - 默认值：4194304


### PR DESCRIPTION
## Why I'm doing:

When recovering a Lake Primary Key index, StarRocks replays all rowset segments and del files that have not yet been checkpointed into SSTables. The existing early-flush strategy in `LakePersistentIndex::commit` only considered the **number of files** to rebuild (`too_many_rebuild_files`). A tablet with a small number of large rowsets could still accumulate millions of rows pending rebuild without triggering a flush, leading to high recovery cost (large amounts of data to read from remote storage and re-insert into the index).

## What I'm doing:

Add a complementary early-flush strategy based on **row count**: when the estimated number of rows that would need to be rebuilt exceeds a configurable threshold, `commit()` triggers a flush just like the existing file-count strategy.

**Key changes:**

- **`need_rebuild_counts()` (new, replaces two separate functions)**: Merges the old `need_rebuild_file_cnt` and `need_rebuild_row_cnt` into a single function returning `std::pair<size_t, int64_t>` so the rowset list is traversed only once. An inner helper `rebuild_segment_counts()` also performs a single segment loop to accumulate both file count and row count simultaneously.
  - Row count uses exact per-segment `num_rows` from `RowsetMetadataPB::segment_metas` when available; falls back to a proportional estimate (`rowset.num_rows * rebuild_seg_cnt / total_seg_cnt`) for older data without per-segment metadata.
  - Del files are counted in `file_cnt` only (their rows are not tracked in metadata).

- **`too_many_rebuild_rows()` (new private method)**: Returns true when `_need_rebuild_row_cnt >= cloud_native_pk_index_rebuild_rows_threshold` and the threshold is non-zero (0 disables the strategy).

- **`too_many_rebuild_files()` (updated)**: Added `> 0` guard to match `too_many_rebuild_rows()` behavior, so setting threshold to 0 correctly disables the strategy.

- **`commit()` updated**: Now checks `too_many_rebuild_files() || too_many_rebuild_rows()` before deciding to flush.

- **New config `cloud_native_pk_index_rebuild_rows_threshold` (mutable, default 10,000,000)**: Controls the row-count threshold. Setting to 0 disables the strategy.

- **Tests**:
  - `LakePersistentIndexTest::test_need_rebuild_counts`: unit test directly exercising `need_rebuild_counts` across 5 scenarios (empty, all-rebuild with segment_metas, partial SST coverage, proportional fallback, del-file handling).
  - `LakePrimaryKeyPublishTest::test_cloud_native_index_minor_compact_because_rows`: integration test that sets a low row threshold and verifies SST files are generated after the 3rd publish triggers the early flush.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport PR