### PR TITLE
[Refactor] Move CastExpr to ExprCore

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -29,6 +29,9 @@ set(EXPR_CORE_FILES
   binary_predicate.cpp
   bitmap_functions.cpp
   cast_nested.cpp
+  cast_expr.cpp
+  cast_expr_array.cpp
+  cast_expr_struct.cpp
   case_expr.cpp
   cast_expr_json.cpp
   cast_expr_map.cpp
@@ -97,9 +100,6 @@ set(EXPR_FILES
   table_function/list_rowsets.cpp
   array_functions.cpp
   arrow_function_call.cpp
-  cast_expr.cpp
-  cast_expr_array.cpp
-  cast_expr_struct.cpp
   dictmapping_expr.cpp
   find_in_set.cpp
   function_call_expr.cpp

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -14,8 +14,6 @@
 
 #include "exprs/cast_expr.h"
 
-#include "exprs/expr_factory.h"
-
 #ifdef STARROCKS_JIT_ENABLE
 #include <llvm/ADT/APInt.h>
 #include <llvm/IR/Constants.h>

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -17,6 +17,7 @@ set(EXPR_CORE_TEST_FILES
     arithmetic_expr_test.cpp
     array_expr_test.cpp
     case_expr_test.cpp
+    cast_expr_core_test.cpp
     function_context_core_test.cpp
     expr_core_test.cpp
     expr_context_core_test.cpp

--- a/be/test/exprs/cast_expr_core_test.cpp
+++ b/be/test/exprs/cast_expr_core_test.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "exprs/cast_expr.h"
+
+namespace starrocks {
+
+namespace {
+
+TExprNode make_cast_node(const TypeDescriptor& from, const TypeDescriptor& to) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::CAST_EXPR);
+    node.__set_opcode(TExprOpcode::CAST);
+    node.__set_num_children(1);
+    node.__set_is_nullable(true);
+    node.__set_type(to.to_thrift());
+    node.__set_child_type(to_thrift(from.type));
+    node.__set_child_type_desc(from.to_thrift());
+    return node;
+}
+
+TypeDescriptor make_array_type(LogicalType elem_type) {
+    TypeDescriptor array_type(TYPE_ARRAY);
+    array_type.children.emplace_back(elem_type);
+    return array_type;
+}
+
+} // namespace
+
+TEST(CastExprCoreTest, from_thrift_succeeds_for_primitive_cast) {
+    ObjectPool pool;
+    TExprNode node = make_cast_node(TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_BIGINT));
+    Expr* expr = VectorizedCastExprFactory::from_thrift(&pool, node);
+    ASSERT_NE(nullptr, expr);
+    pool.add(expr);
+    EXPECT_TRUE(expr->is_cast_expr());
+}
+
+TEST(CastExprCoreTest, from_thrift_returns_null_for_unsupported_cast) {
+    ObjectPool pool;
+    TypeDescriptor from = make_array_type(TYPE_INT);
+    TypeDescriptor to(TYPE_VARCHAR);
+    to.len = 10;
+    TExprNode node = make_cast_node(from, to);
+    Expr* expr = VectorizedCastExprFactory::from_thrift(&pool, node);
+    EXPECT_EQ(nullptr, expr);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
