### PR TITLE
[Enhancement] Optimize Iceberg read performance with position delete

### DIFF
--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -27,6 +27,12 @@ namespace starrocks {
 static const std::string kParquetProfileSectionPrefix = "Parquet";
 
 Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    if (scanner_params.split_context != nullptr) {
+        auto split_ctx = down_cast<const parquet::SplitContext*>(scanner_params.split_context);
+        _skip_rows_ctx = split_ctx->skip_rows_ctx;
+        return Status::OK();
+    }
+
     if (!scanner_params.deletes.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
         auto iceberg_delete_builder =
@@ -47,11 +53,6 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
                 new PaimonDeleteFileBuilder(scanner_params.fs, _skip_rows_ctx));
         RETURN_IF_ERROR(paimon_delete_file_builder->build(scanner_params.paimon_deletion_file.get()));
     } else if (scanner_params.deletion_vector_descriptor != nullptr) {
-        if (scanner_params.split_context != nullptr) {
-            auto split_ctx = down_cast<const parquet::SplitContext*>(scanner_params.split_context);
-            _skip_rows_ctx = split_ctx->skip_rows_ctx;
-            return Status::OK();
-        }
         SCOPED_RAW_TIMER(&_app_stats.deletion_vector_build_ns);
         std::unique_ptr<DeletionVector> dv = std::make_unique<DeletionVector>(scanner_params);
         RETURN_IF_ERROR(dv->fill_row_indexes(_skip_rows_ctx));
@@ -62,9 +63,11 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile* root = profile->runtime_profile;
+    ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::NONE);
     // deletion vector build only in the first task which used for split sub-tasks,
     // and do not need to re-build in sub io tasks.
     do_update_deletion_vector_build_counter(root);
+    do_update_iceberg_v2_counter(root, kParquetProfileSectionPrefix);
     // if we have split tasks, we don't need to update counter
     // and we will update those counters in sub io tasks.
     if (has_split_tasks()) {
@@ -121,7 +124,6 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* bloom_filter_tried_counter = nullptr;
     RuntimeProfile::Counter* bloom_filter_success_counter = nullptr;
 
-    ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::NONE);
     request_bytes_read = ADD_CHILD_COUNTER(root, "RequestBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
     request_bytes_read_uncompressed =
             ADD_CHILD_COUNTER(root, "RequestBytesReadUncompressed", TUnit::BYTES, kParquetProfileSectionPrefix);
@@ -208,7 +210,6 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
     COUNTER_SET(group_min_round_cost, _app_stats.group_min_round_cost);
-    do_update_iceberg_v2_counter(root, kParquetProfileSectionPrefix);
     do_update_deletion_vector_filter_counter(root);
     COUNTER_UPDATE(rows_before_page_index, _app_stats.rows_before_page_index);
     COUNTER_UPDATE(page_index_timer, _app_stats.page_index_ns);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1284,52 +1284,178 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             private void ensureOpen() {
                 if (fileScanTaskIterator == null) {
-                    fileScanTaskIterable = TableScanUtil.splitFiles(tableScan.planFiles(), tableScan.targetSplitSize());
-                    fileScanTaskIterator = fileScanTaskIterable.iterator();
+                    openPlannedTaskIterator(tableScan);
                 }
-                if (!fileScanTaskIterator.hasNext()) {
-                    try {
-                        fileScanTaskIterable.close();
-                        fileScanTaskIterator.close();
-                    } catch (Exception e) {
-                        // ignore
-                    } finally {
-                        //record scan metrics profile
-                        if (tableScan instanceof StarRocksIcebergTableScan) {
-                            IcebergMetricsReporter metricsReporter =
-                                    ((StarRocksIcebergTableScan) tableScan).getMetricsReporter();
-                            if (metricsReporter.getScanReport() != null) {
-                                String name = "ICEBERG.ScanMetrics." +
-                                        ((StarRocksIcebergTableScan) tableScan).getIcebergTableName().toString();
-                                String value = metricsReporter.getScanReport().toString();
-                                Tracers.record(Tracers.Module.EXTERNAL, name, value);
-                            }
-                        }
-                    }
-                    hasMore = false;
+                if (fileScanTaskIterator.hasNext()) {
+                    return;
                 }
+                closePlannedTaskIterator();
+                recordScanMetrics(tableScan);
+                hasMore = false;
+            }
+
+            private void openPlannedTaskIterator(Scan tableScan) {
+                fileScanTaskIterable = normalizePlannedTaskIterable(tableScan.planFiles());
+                fileScanTaskIterator = buildSplitFileScanTaskIterator(
+                        fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize());
+            }
+
+            private void closePlannedTaskIterator() {
+                closeQuietly(fileScanTaskIterator);
+                closeQuietly(fileScanTaskIterable);
+                fileScanTaskIterator = null;
+                fileScanTaskIterable = null;
             }
 
             @Override
             public void close() {
-                try {
-                    if (fileScanTaskIterator != null) {
-                        fileScanTaskIterator.close();
-                    }
-                } catch (Exception ignore) {
-                }
-
-                try {
-                    if (fileScanTaskIterable != null) {
-                        fileScanTaskIterable.close();
-                    }
-                } catch (Exception ignore) {
-                } finally {
-                    fileScanTaskIterator = null;
-                    fileScanTaskIterable = null;
-                }
+                closePlannedTaskIterator();
             }
         };
+    }
+
+    private boolean hasPositionDeletes(FileScanTask task) {
+        for (DeleteFile deleteFile : task.deletes()) {
+            if (deleteFile.content() == FileContent.POSITION_DELETES) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private CloseableIterable<FileScanTask> splitFileScanTask(FileScanTask task, long targetSplitSize) {
+        if (!hasPositionDeletes(task)) {
+            return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(task), targetSplitSize);
+        }
+
+        List<FileScanTask> splitTasks = Lists.newArrayList(task.split(targetSplitSize));
+        if (splitTasks.size() <= 1) {
+            return CloseableIterable.withNoopClose(task);
+        }
+
+        return CloseableIterable.withNoopClose(coalesceSplitTasks(task, splitTasks, targetSplitSize));
+    }
+
+    private List<FileScanTask> coalesceSplitTasks(FileScanTask task, List<FileScanTask> splitTasks, long targetSplitSize) {
+        List<FileScanTask> coalescedTasks = new ArrayList<>();
+        long currentOffset = -1;
+        long currentLength = 0;
+        long currentEnd = -1;
+        for (FileScanTask splitTask : splitTasks) {
+            if (currentOffset < 0) {
+                currentOffset = splitTask.start();
+                currentLength = splitTask.length();
+                currentEnd = splitTask.start() + splitTask.length();
+                continue;
+            }
+
+            if (currentLength < targetSplitSize && currentEnd == splitTask.start()) {
+                currentLength += splitTask.length();
+                currentEnd += splitTask.length();
+                continue;
+            }
+
+            coalescedTasks.add(buildCoalescedSplitTask(task, currentOffset, currentLength));
+            currentOffset = splitTask.start();
+            currentLength = splitTask.length();
+            currentEnd = splitTask.start() + splitTask.length();
+        }
+        coalescedTasks.add(buildCoalescedSplitTask(task, currentOffset, currentLength));
+        return coalescedTasks;
+    }
+
+    private FileScanTask buildCoalescedSplitTask(FileScanTask task, long offset, long length) {
+        if (offset == task.start() && length == task.length()) {
+            return task;
+        }
+        return new IcebergSplitScanTask(offset, length, task);
+    }
+
+    private CloseableIterator<FileScanTask> buildSplitFileScanTaskIterator(
+            CloseableIterable<FileScanTask> plannedTaskIterable,
+            CloseableIterator<FileScanTask> plannedTaskIterator,
+            long targetSplitSize) {
+        return new CloseableIterator<>() {
+            private CloseableIterable<FileScanTask> currentTaskIterable = CloseableIterable.empty();
+            private CloseableIterator<FileScanTask> currentTaskIterator = CloseableIterator.empty();
+
+            @Override
+            public void close() throws IOException {
+                currentTaskIterator.close();
+                currentTaskIterable.close();
+                plannedTaskIterator.close();
+                plannedTaskIterable.close();
+            }
+
+            @Override
+            public boolean hasNext() {
+                while (!currentTaskIterator.hasNext() && plannedTaskIterator.hasNext()) {
+                    openNextTask();
+                }
+                return currentTaskIterator.hasNext();
+            }
+
+            @Override
+            public FileScanTask next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return currentTaskIterator.next();
+            }
+
+            private void openNextTask() {
+                closeCurrentTask();
+                FileScanTask task = plannedTaskIterator.next();
+                currentTaskIterable = splitFileScanTask(task, targetSplitSize);
+                currentTaskIterator = currentTaskIterable.iterator();
+            }
+
+            private void closeCurrentTask() {
+                closeUnchecked(currentTaskIterator);
+                closeUnchecked(currentTaskIterable);
+                currentTaskIterator = CloseableIterator.empty();
+                currentTaskIterable = CloseableIterable.empty();
+            }
+        };
+    }
+
+    private CloseableIterable<FileScanTask> normalizePlannedTaskIterable(CloseableIterable<FileScanTask> plannedTasks) {
+        return plannedTasks != null ? plannedTasks : CloseableIterable.empty();
+    }
+
+    private void recordScanMetrics(Scan tableScan) {
+        if (!(tableScan instanceof StarRocksIcebergTableScan)) {
+            return;
+        }
+
+        IcebergMetricsReporter metricsReporter = ((StarRocksIcebergTableScan) tableScan).getMetricsReporter();
+        if (metricsReporter.getScanReport() == null) {
+            return;
+        }
+
+        String name = "ICEBERG.ScanMetrics." + ((StarRocksIcebergTableScan) tableScan).getIcebergTableName();
+        String value = metricsReporter.getScanReport().toString();
+        Tracers.record(EXTERNAL, name, value);
+    }
+
+    private void closeUnchecked(AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception ignore) {
+        }
     }
 
     public Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.HistoricalNodeMgr;
 import com.starrocks.thrift.THdfsScanRange;
+import com.starrocks.thrift.TIcebergDeleteFile;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
@@ -220,7 +221,7 @@ public class HDFSBackendSelector implements BackendSelector {
         }
 
         ComputeNode node = null;
-        long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
+        long addedScans = computeScanRangeWeight(scanRangeLocations);
         for (ComputeNode backend : backends) {
             long assignedScanRanges = assignedBytesPerComputeNode.get(backend);
             if (assignedScanRanges + addedScans < avgNodeScanRangeBytes * kMaxImbalanceRatio) {
@@ -268,7 +269,7 @@ public class HDFSBackendSelector implements BackendSelector {
     private long computeTotalSize() {
         long size = 0;
         for (TScanRangeLocations scanRangeLocations : locations) {
-            size += scanRangeLocations.scan_range.hdfs_scan_range.getLength();
+            size += computeScanRangeWeight(scanRangeLocations);
         }
         return size;
     }
@@ -384,7 +385,7 @@ public class HDFSBackendSelector implements BackendSelector {
         workerProvider.selectWorker(worker.getId());
 
         // update statistic
-        long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
+        long addedScans = computeScanRangeWeight(scanRangeLocations);
         assignedBytesPerComputeNode.put(worker, assignedBytesPerComputeNode.get(worker) + addedScans);
         // the fist item in backends will be assigned if there is no re-balance, we compute re-balance bytes
         // if the worker is not the first item in backends.
@@ -402,6 +403,21 @@ public class HDFSBackendSelector implements BackendSelector {
         assignment.put(worker.getId(), scanNode.getId().asInt(), scanRangeParams);
         assignedScanRangesPerComputeNode.put(worker,
                 assignedScanRangesPerComputeNode.get(worker) + 1);
+    }
+
+    private long computeScanRangeWeight(TScanRangeLocations scanRangeLocations) {
+        THdfsScanRange hdfsScanRange = scanRangeLocations.scan_range.hdfs_scan_range;
+        long weight = hdfsScanRange.getLength();
+        if (!hdfsScanRange.isSetDelete_files()) {
+            return weight;
+        }
+
+        for (TIcebergDeleteFile deleteFile : hdfsScanRange.getDelete_files()) {
+            if (deleteFile.isSetLength()) {
+                weight += deleteFile.getLength();
+            }
+        }
+        return weight;
     }
 
     private void recordScanRangeStatistic() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -133,6 +133,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.NullOrder;
@@ -150,13 +151,18 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.TableScanUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -2983,5 +2989,78 @@ public class IcebergMetadataTest extends TableTestBase {
         // Verify a new snapshot was created after metadata delete
         org.apache.iceberg.Snapshot latestSnapshot = mockedNativeTableB.currentSnapshot();
         Assertions.assertNotNull(latestSnapshot, "Latest snapshot should exist after metadata delete");
+    }
+
+    @Test
+    public void testSplitFileScanTaskCoalescesPositionDeleteTasks() throws Exception {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        DeleteFile deleteFile = Mockito.mock(DeleteFile.class);
+        Mockito.when(deleteFile.content()).thenReturn(FileContent.POSITION_DELETES);
+        Mockito.when(task.deletes()).thenReturn(List.of(deleteFile));
+        Mockito.when(task.start()).thenReturn(0L);
+        Mockito.when(task.length()).thenReturn(180L);
+
+        FileScanTask splitTask1 = Mockito.mock(FileScanTask.class);
+        Mockito.when(splitTask1.start()).thenReturn(0L);
+        Mockito.when(splitTask1.length()).thenReturn(64L);
+
+        FileScanTask splitTask2 = Mockito.mock(FileScanTask.class);
+        Mockito.when(splitTask2.start()).thenReturn(64L);
+        Mockito.when(splitTask2.length()).thenReturn(64L);
+
+        FileScanTask splitTask3 = Mockito.mock(FileScanTask.class);
+        Mockito.when(splitTask3.start()).thenReturn(128L);
+        Mockito.when(splitTask3.length()).thenReturn(52L);
+
+        Mockito.when(task.split(128L)).thenReturn(List.of(splitTask1, splitTask2, splitTask3));
+
+        Method splitMethod = IcebergMetadata.class.getDeclaredMethod("splitFileScanTask",
+                FileScanTask.class, long.class);
+        splitMethod.setAccessible(true);
+
+        CloseableIterable<FileScanTask> iterable =
+                (CloseableIterable<FileScanTask>) splitMethod.invoke(metadata, task, 128L);
+        List<FileScanTask> actualTasks = Lists.newArrayList(iterable);
+
+        Assertions.assertEquals(2, actualTasks.size());
+        Assertions.assertEquals(0L, actualTasks.get(0).start());
+        Assertions.assertEquals(128L, actualTasks.get(0).length());
+        Assertions.assertEquals(128L, actualTasks.get(1).start());
+        Assertions.assertEquals(52L, actualTasks.get(1).length());
+        Assertions.assertSame(task.deletes(), actualTasks.get(0).deletes());
+        Assertions.assertSame(task.deletes(), actualTasks.get(1).deletes());
+    }
+
+    @Test
+    public void testSplitFileScanTaskUsesTableScanUtilForNonPositionDeleteTasks() throws Exception {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        DeleteFile deleteFile = Mockito.mock(DeleteFile.class);
+        Mockito.when(deleteFile.content()).thenReturn(FileContent.EQUALITY_DELETES);
+        Mockito.when(task.deletes()).thenReturn(List.of(deleteFile));
+
+        CloseableIterable<FileScanTask> expectedIterable = CloseableIterable.withNoopClose(List.of(task));
+        Method splitMethod = IcebergMetadata.class.getDeclaredMethod("splitFileScanTask",
+                FileScanTask.class, long.class);
+        splitMethod.setAccessible(true);
+
+        try (MockedStatic<TableScanUtil> tableScanUtilMock = Mockito.mockStatic(TableScanUtil.class)) {
+            tableScanUtilMock.when(() -> TableScanUtil.splitFiles(Mockito.any(), Mockito.eq(128L)))
+                    .thenReturn(expectedIterable);
+
+            CloseableIterable<FileScanTask> actualIterable =
+                    (CloseableIterable<FileScanTask>) splitMethod.invoke(metadata, task, 128L);
+
+            Assertions.assertSame(expectedIterable, actualIterable);
+            tableScanUtilMock.verify(() -> TableScanUtil.splitFiles(Mockito.any(), Mockito.eq(128L)),
+                    Mockito.times(1));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
optimize read performace when read iceberg table with position delete 
## What I'm doing:
IcebergMetadata optimizes FE-side split planning. Tasks with POSITION_DELETES are no longer split too finely by row group; instead, they are coalesced using connector_huge_file_size, which reduces repeated reads and repeated bitmap builds for position delete files.

HdfsParquetScanner optimizes delete bitmap reuse for BE Parquet split tasks. Parquet split subtasks now reuse the parent task's skip_rows_ctx, avoiding repeated Iceberg position delete bitmap construction for the same data file inside BE split execution. 

HDFSBackendSelector optimizes FE scheduling weight calculation. Scan range weight is no longer based only on data length; it now also includes delete_files size, so tasks with position deletes are weighted closer to their real execution cost. 


**Iceberg File Scan Task Splitting and Coalescing:**

* Refactored the logic for splitting `FileScanTask` instances, introducing methods to coalesce adjacent split tasks for position delete files, ensuring more efficient scan task grouping and reducing overhead. Added helper methods for resource management and metrics recording, and improved iterator management for planned scan tasks (`IcebergMetadata.java`).
* Added comprehensive unit tests to verify that the new split and coalescing logic for position delete and non-position delete tasks works as expected (`IcebergMetadataTest.java`).

**HDFS Parquet Scanner Initialization and Profiling:**

* Adjusted the initialization logic in `HdfsParquetScanner` to set the skip rows context earlier when a split context is provided, and simplified the handling of deletion vectors. Updated the profiling logic to ensure counters are added and updated in the correct order, and to avoid redundant updates 

**Scan Range Assignment and Load Balancing:**

* Refined the logic for calculating scan range weights to include the size of associated Iceberg delete files, leading to a more accurate distribution of scan ranges across compute nodes and improved load balancing (`HDFSBackendSelector.java`). 

**Test and Dependency Updates:**

* Added necessary imports and dependencies to support new logic and tests, including Mockito and Iceberg utility classes (`IcebergMetadataTest.java`). 

These changes collectively improve the efficiency, correctness, and maintainability of Parquet and Iceberg scan task processing and assignment.

Fixes #issue

## performance
lineorder_100g_parquet_zstd table has 600 million rows，delete 50% data, 
delete sql 
```
DELETE FROM lineorder_100g_parquet_zstd WHERE lo_orderkey % 2 = 0
```
query sql 
```
SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue FROM lineorder_100g_parquet_zstd;
```
The query execution time has been reduced from over **10** seconds to the current **2.3** seconds.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
