### PR TITLE
[BugFix] clear corrupted cache for PK sst table (backport #69693)

### DIFF
--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -17,6 +17,7 @@
 #include <butil/time.h> // NOLINT
 
 #include "fs/fs.h"
+#include "fs/key_cache.h"
 #include "storage/lake/utils.h"
 #include "storage/sstable/table_builder.h"
 #include "testutil/sync_point.h"
@@ -24,6 +25,29 @@
 #include "util/trace.h"
 
 namespace starrocks::lake {
+
+namespace {
+
+Status drop_corrupted_sstable_cache(const std::string& path) {
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    if (!config::lake_clear_corrupted_cache_data) {
+        return Status::NotSupported("lake_clear_corrupted_cache_data is turned off");
+    }
+    auto fs_or = FileSystem::CreateSharedFromString(path);
+    if (!fs_or.ok()) {
+        LOG(INFO) << "clear corrupted cache for " << path << ", error:" << fs_or.status();
+        return fs_or.status();
+    }
+    auto drop_status = (*fs_or)->drop_local_cache(path);
+    TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::drop_corrupted_cache", &drop_status);
+    LOG(INFO) << "clear corrupted cache for " << path << ", error:" << drop_status;
+    return drop_status;
+#else
+    return Status::NotSupported("clear corrupted cache is only supported in shared-data mode");
+#endif
+}
+
+} // namespace
 
 Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const PersistentIndexSstablePB& sstable_pb,
                                     Cache* cache, bool need_filter) {
@@ -36,6 +60,21 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
     sstable::Table* table;
     auto open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table);
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_error", &open_st);
+    if (open_st.is_corruption()) {
+        auto sst_path = rf->filename();
+        auto drop_status = drop_corrupted_sstable_cache(sst_path);
+        if (drop_status.ok()) {
+            delete table;
+            RandomAccessFileOptions opts;
+            if (!sstable_pb.encryption_meta().empty()) {
+                ASSIGN_OR_RETURN(auto info, KeyCache::instance().unwrap_encryption_meta(sstable_pb.encryption_meta()));
+                opts.encryption_info = std::move(info);
+            }
+            ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, sst_path));
+            open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table);
+            TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_retry_error", &open_st);
+        }
+    }
     if (!open_st.ok()) {
         StarRocksMetrics::instance()->pk_index_sst_read_error_total.increment(1);
         LOG(WARNING) << "Failed to open PersistentIndex SST file: " << sstable_pb.filename() << ", error: " << open_st;
@@ -81,6 +120,13 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     auto multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
     auto end_ts = butil::gettimeofday_us();
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::multi_get:error", &multiget_st);
+    if (multiget_st.is_corruption()) {
+        auto drop_status = drop_corrupted_sstable_cache(_rf->filename());
+        if (drop_status.ok()) {
+            multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
+            TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::multi_get:retry_error", &multiget_st);
+        }
+    }
     if (!multiget_st.ok()) {
         StarRocksMetrics::instance()->pk_index_sst_read_error_total.increment(1);
         LOG(WARNING) << "Failed to multi_get from PersistentIndex SST file: " << _sstable_pb.filename()

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -527,6 +527,41 @@ TEST_F(PersistentIndexSstableTest, test_metric_sst_open_read_error) {
     ASSERT_EQ(before + 1, StarRocksMetrics::instance()->pk_index_sst_read_error_total.value());
 }
 
+TEST_F(PersistentIndexSstableTest, test_sst_open_retry_after_clear_corrupted_cache) {
+    const std::string filename = "open_retry_corrupted_cache.sst";
+    const std::string path = lake::join_path(kTestDir, filename);
+    uint64_t filesize = 0;
+    build_test_sst(path, &filesize);
+
+    bool old = config::lake_clear_corrupted_cache_data;
+    config::lake_clear_corrupted_cache_data = true;
+
+    bool injected = false;
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::init:table_open_error", [&](void* arg) {
+        if (!injected) {
+            injected = true;
+            *(Status*)arg = Status::Corruption("inject_open_corruption");
+        }
+    });
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache",
+                                          [](void* arg) { *(Status*)arg = Status::OK(); });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename(filename);
+    sstable_pb.set_filesize(filesize);
+    auto st = sst->init(std::move(rf), sstable_pb, nullptr);
+
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::init:table_open_error");
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+    SyncPoint::GetInstance()->DisableProcessing();
+    config::lake_clear_corrupted_cache_data = old;
+
+    ASSERT_OK(st);
+}
+
 TEST_F(PersistentIndexSstableTest, test_metric_sst_multiget_read_error) {
     const std::string path = lake::join_path(kTestDir, "metric_multiget_error.sst");
     uint64_t filesize = 0;
@@ -558,6 +593,46 @@ TEST_F(PersistentIndexSstableTest, test_metric_sst_multiget_read_error) {
 
     ASSERT_ERROR(st);
     ASSERT_EQ(before + 1, StarRocksMetrics::instance()->pk_index_sst_read_error_total.value());
+}
+
+TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cache) {
+    const std::string path = lake::join_path(kTestDir, "multiget_retry_corrupted_cache.sst");
+    uint64_t filesize = 0;
+    build_test_sst(path, &filesize);
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    std::unique_ptr<Cache> cache(new_lru_cache(1024));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename("multiget_retry_corrupted_cache.sst");
+    sstable_pb.set_filesize(filesize);
+    ASSERT_OK(sst->init(std::move(rf), sstable_pb, cache.get()));
+
+    bool old = config::lake_clear_corrupted_cache_data;
+    config::lake_clear_corrupted_cache_data = true;
+
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::multi_get:error",
+                                          [](void* arg) { *(Status*)arg = Status::Corruption("inject_corruption"); });
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache",
+                                          [](void* arg) { *(Status*)arg = Status::OK(); });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    std::string key_str = fmt::format("key_{:04d}", 0);
+    Slice key(key_str);
+    KeyIndexSet key_indexes{0};
+    std::vector<IndexValue> values(1, IndexValue(NullIndexValue));
+    KeyIndexSet found;
+    auto st = sst->multi_get(&key, key_indexes, -1, values.data(), &found);
+
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::multi_get:error");
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+    SyncPoint::GetInstance()->DisableProcessing();
+    config::lake_clear_corrupted_cache_data = old;
+
+    ASSERT_OK(st);
+    ASSERT_EQ(1, found.size());
+    ASSERT_TRUE(found.contains(0));
+    ASSERT_EQ(IndexValue(0), values[0]);
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

