### PR TITLE
[BugFix] Gate lake capture_tablet_and_rowsets behind experimental config

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1535,6 +1535,10 @@ CONF_mInt32(pindex_rebuild_load_wait_seconds, "20");
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");
 
+// Experimental internal switch: whether to enable lake capture_tablet_and_rowsets for query cache stale entries.
+// This config is temporary and may be removed after the related lake capture implementation is fixed.
+CONF_mBool(experimental_enable_lake_capture_tablet_and_rowsets, "false");
+
 // When query cache enabled, the operators in the drivers contains cache operator are multilane
 // operators, if the number of lanes is big, Fragment Instance would spend too much time to prepare
 // operators since the number of operators scale up with the number of lanes.

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1424,7 +1424,11 @@ void TabletManager::stop() {
 
 StatusOr<TabletAndRowsets> TabletManager::capture_tablet_and_rowsets(int64_t tablet_id, int64_t from_version,
                                                                      int64_t to_version) {
+    if (!config::experimental_enable_lake_capture_tablet_and_rowsets) {
+        return Status::NotSupported("capture_tablet_and_rowsets is disabled");
+    }
     DCHECK(from_version <= to_version);
+
     auto tablet_ptr = std::make_shared<Tablet>(this, tablet_id);
     std::vector<std::shared_ptr<BaseRowset>> rowsets;
 

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1431,6 +1431,12 @@ TEST_F(LakeTabletManagerTest, test_get_output_rorwset_schema) {
 }
 
 TEST_F(LakeTabletManagerTest, capture_tablet_and_rowsets) {
+    auto old_capture_tablet_and_rowsets_config = config::experimental_enable_lake_capture_tablet_and_rowsets;
+    DeferOp defer([old_capture_tablet_and_rowsets_config]() {
+        config::experimental_enable_lake_capture_tablet_and_rowsets = old_capture_tablet_and_rowsets_config;
+    });
+    config::experimental_enable_lake_capture_tablet_and_rowsets = true;
+
     starrocks::TabletMetadata metadata;
     auto schema = metadata.mutable_schema();
     schema->set_id(1);
@@ -1481,6 +1487,53 @@ TEST_F(LakeTabletManagerTest, capture_tablet_and_rowsets) {
         EXPECT_TRUE(res.ok());
         auto& [tablet, rowsets] = res.value();
         ASSERT_EQ(1, rowsets.size());
+    }
+}
+
+TEST_F(LakeTabletManagerTest, capture_tablet_and_rowsets_capture_delta_versions_disabled) {
+    auto old_capture_tablet_and_rowsets_config = config::experimental_enable_lake_capture_tablet_and_rowsets;
+    DeferOp defer([old_capture_tablet_and_rowsets_config]() {
+        config::experimental_enable_lake_capture_tablet_and_rowsets = old_capture_tablet_and_rowsets_config;
+    });
+    config::experimental_enable_lake_capture_tablet_and_rowsets = false;
+
+    starrocks::TabletMetadata metadata;
+    auto schema = metadata.mutable_schema();
+    schema->set_id(1);
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(1);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    metadata.set_version(2);
+    auto rowset_meta_pb2 = metadata.add_rowsets();
+    rowset_meta_pb2->set_id(2);
+    rowset_meta_pb2->set_overlapped(false);
+    rowset_meta_pb2->set_data_size(1024);
+    rowset_meta_pb2->set_num_rows(5);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    metadata.set_version(3);
+    auto rowset_meta_pb3 = metadata.add_rowsets();
+    rowset_meta_pb3->set_id(3);
+    rowset_meta_pb3->set_overlapped(false);
+    rowset_meta_pb3->set_data_size(1024);
+    rowset_meta_pb3->set_num_rows(5);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    {
+        auto res = _tablet_manager->capture_tablet_and_rowsets(tablet_id, 1, 3);
+        EXPECT_TRUE(res.status().is_not_supported());
+    }
+
+    {
+        auto res = _tablet_manager->capture_tablet_and_rowsets(tablet_id, 2, 3);
+        EXPECT_TRUE(res.status().is_not_supported());
+    }
+
+    {
+        auto res = _tablet_manager->capture_tablet_and_rowsets(tablet_id, 0, 3);
+        EXPECT_TRUE(res.status().is_not_supported());
     }
 }
 


### PR DESCRIPTION
  ## Why I'm doing:
  `capture_tablet_and_rowsets` in shared-data mode has implementation issues that can affect query cache stale-entry handling. May cause query failed with dat file not found.

  ## What I'm doing:
  - Add a new BE config `experimental_enable_lake_capture_tablet_and_rowsets` with default `false`.
  - Rename the previous temporary config name to `experimental_enable_lake_capture_tablet_and_rowsets`.
  - Add an early guard at the beginning of `TabletManager::capture_tablet_and_rowsets`:
    - If the config is disabled, return `Status::NotSupported`.
  - Keep existing behavior when the config is enabled.
  - Update BE unit tests:
    - Existing test explicitly enables the config and verifies normal capture behavior.
    - Add/adjust disabled-config test to verify `NotSupported` is returned for capture calls.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
