### PR TITLE
[BugFix] Fix duplicated CSV compression suffix in file sink output names

### DIFF
--- a/be/src/connector/file_chunk_sink.cpp
+++ b/be/src/connector/file_chunk_sink.cpp
@@ -26,7 +26,6 @@
 #include "formats/parquet/parquet_file_writer.h"
 #include "formats/utils.h"
 #include "fs/fs_factory.h"
-#include "util/compression/compression_utils.h"
 #include "utils.h"
 
 namespace starrocks::connector {
@@ -56,30 +55,23 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> FileChunkSinkProvider::create_chun
             FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)).value();
     auto column_evaluators = ColumnEvaluator::clone(ctx->column_evaluators);
 
-    // Add compression extension for compressed CSV files.
-    // Note: Parquet and ORC are self-contained formats with compression info in metadata,
-    // so they don't need compression extensions. CSV is plain text and needs extensions
-    // (e.g., .csv.gz) to indicate the content is compressed.
-    std::string file_suffix = boost::to_lower_copy(ctx->format);
-    if (boost::iequals(ctx->format, formats::CSV)) {
-        ASSIGN_OR_RETURN(std::string compression_suffix, CompressionUtils::to_compression_ext(ctx->compression_type));
-        file_suffix += compression_suffix;
-    }
+    auto normalized_format = normalize_format_name(ctx->format);
+    ASSIGN_OR_RETURN(std::string file_suffix, build_canonical_file_suffix(normalized_format, ctx->compression_type));
 
     auto location_provider = std::make_shared<connector::LocationProvider>(
             ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id, file_suffix);
 
     std::shared_ptr<formats::FileWriterFactory> file_writer_factory;
-    if (boost::iequals(ctx->format, formats::PARQUET)) {
+    if (normalized_format == formats::PARQUET) {
         file_writer_factory = std::make_shared<formats::ParquetFileWriterFactory>(
                 fs, ctx->compression_type, ctx->options, ctx->column_names,
                 std::make_shared<std::vector<std::unique_ptr<ColumnEvaluator>>>(std::move(column_evaluators)),
                 std::nullopt, ctx->executor, runtime_state);
-    } else if (boost::iequals(ctx->format, formats::ORC)) {
+    } else if (normalized_format == formats::ORC) {
         file_writer_factory = std::make_shared<formats::ORCFileWriterFactory>(
                 fs, ctx->compression_type, ctx->options, ctx->column_names, std::move(column_evaluators), ctx->executor,
                 runtime_state);
-    } else if (boost::iequals(ctx->format, formats::CSV)) {
+    } else if (normalized_format == formats::CSV) {
         file_writer_factory = std::make_shared<formats::CSVFileWriterFactory>(
                 fs, ctx->compression_type, ctx->options, ctx->column_names, std::move(column_evaluators), ctx->executor,
                 runtime_state);

--- a/be/src/connector/utils.cpp
+++ b/be/src/connector/utils.cpp
@@ -14,6 +14,8 @@
 
 #include "connector/utils.h"
 
+#include <boost/algorithm/string.hpp>
+
 #include "arrow/util/decimal.h"
 #include "base/url_coding.h"
 #include "base/utility/integer_util.h"
@@ -24,8 +26,33 @@
 #include "exprs/expr.h"
 #include "formats/parquet/parquet_file_writer.h"
 #include "types/datum.h"
+#include "util/compression/compression_utils.h"
 
 namespace starrocks::connector {
+
+std::string normalize_format_name(std::string format) {
+    boost::algorithm::trim(format);
+    boost::algorithm::to_lower(format);
+    boost::algorithm::trim_left_if(format, boost::is_any_of("."));
+
+    // Strip any accidental extension chain like "csv.gz.csv" to keep format canonical.
+    auto dot = boost::algorithm::find_first(format, ".");
+    if (!dot.empty()) {
+        format.erase(dot.begin(), format.end());
+    }
+    return format;
+}
+
+StatusOr<std::string> build_canonical_file_suffix(const std::string& format, TCompressionType::type compression_type) {
+    if (format.empty()) {
+        return Status::InvalidArgument("file format is empty");
+    }
+    if (format == formats::CSV) {
+        ASSIGN_OR_RETURN(std::string compression_suffix, CompressionUtils::to_compression_ext(compression_type));
+        return format + compression_suffix;
+    }
+    return format;
+}
 
 StatusOr<std::string> HiveUtils::make_partition_name(
         const std::vector<std::string>& column_names,

--- a/be/src/connector/utils.h
+++ b/be/src/connector/utils.h
@@ -85,6 +85,16 @@ public:
     }
 };
 
+// Normalize a raw format string (e.g. "csv.gz.csv", "  .Csv  ") to a canonical
+// lowercase base name (e.g. "csv").
+std::string normalize_format_name(std::string format);
+
+// Build canonical output file suffix for connector file sinks.
+// Expects a normalized format name (from normalize_format_name).
+// For CSV, append compression suffix (e.g. csv.gz); for self-describing formats
+// like parquet/orc, keep the format suffix only.
+StatusOr<std::string> build_canonical_file_suffix(const std::string& format, TCompressionType::type compression_type);
+
 // Location provider provides file location for every output file. The name format depends on if the write is partitioned or not.
 class LocationProvider {
 public:

--- a/be/test/connector_sink/file_chunk_sink_test.cpp
+++ b/be/test/connector_sink/file_chunk_sink_test.cpp
@@ -59,6 +59,46 @@ public:
     MOCK_METHOD(StatusOr<formats::WriterAndStream>, create, (const std::string&), (const override));
 };
 
+struct FileSuffixTestCase {
+    std::string format;
+    TCompressionType::type compression;
+    std::string expected_suffix;
+};
+
+class FileSuffixBuilderTest : public ::testing::TestWithParam<FileSuffixTestCase> {};
+
+TEST_P(FileSuffixBuilderTest, test_build_canonical_file_suffix) {
+    auto test_case = GetParam();
+    auto normalized = normalize_format_name(test_case.format);
+    ASSIGN_OR_ABORT(auto suffix, build_canonical_file_suffix(normalized, test_case.compression));
+    ASSERT_EQ(test_case.expected_suffix, suffix);
+    ASSERT_EQ(std::string::npos, suffix.find(".csv.csv"));
+}
+
+INSTANTIATE_TEST_SUITE_P(FileChunkSinkSuffix, FileSuffixBuilderTest,
+                         ::testing::Values(FileSuffixTestCase{formats::CSV, TCompressionType::NO_COMPRESSION, "csv"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::GZIP, "csv.gz"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::ZSTD, "csv.zst"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::LZ4, "csv.lz4"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::LZ4_FRAME, "csv.lz4"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::SNAPPY, "csv.snappy"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::DEFLATE, "csv.deflate"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::ZLIB, "csv.zlib"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::BZIP2, "csv.bz2"},
+                                           FileSuffixTestCase{formats::CSV, TCompressionType::DEFAULT_COMPRESSION,
+                                                              "csv"},
+                                           FileSuffixTestCase{formats::PARQUET, TCompressionType::GZIP, "parquet"},
+                                           FileSuffixTestCase{formats::ORC, TCompressionType::ZSTD, "orc"},
+                                           FileSuffixTestCase{"csv.gz.csv", TCompressionType::GZIP, "csv.gz"},
+                                           FileSuffixTestCase{"CSV.LZ4.CSV", TCompressionType::LZ4, "csv.lz4"},
+                                           FileSuffixTestCase{"  .Csv.zst.csv  ", TCompressionType::ZSTD, "csv.zst"}));
+
+TEST(FileSuffixBuilder, test_invalid_empty_format) {
+    auto normalized = normalize_format_name("   ");
+    auto st = build_canonical_file_suffix(normalized, TCompressionType::GZIP);
+    ASSERT_FALSE(st.ok());
+}
+
 TEST_F(FileChunkSinkTest, test_callback) {
     {
         std::vector<std::string> partition_column_names = {"k1"};


### PR DESCRIPTION
## Why I'm doing:
When unloading CSV data to object storage with compression enabled (for example `GZIP`), output files may get duplicated suffixes like `csv.gz.csv` instead of `csv.gz`. This is user-visible and causes incorrect file naming semantics.

## What I'm doing:
- Keep suffix generation centralized in `build_canonical_file_suffix`.
- Normalize raw format strings before suffix generation (trim, lowercase, remove leading dots, strip accidental extension chain like `csv.gz.csv`).
- Keep CSV-specific compression suffix appending in the same builder (`csv` + compression ext).
- Keep non-CSV formats (for example `parquet`, `orc`) as format-only suffixes.
- Refactor helper functions to use `static` instead of anonymous namespace.
- Replace manual string processing with existing string algorithm utilities (Boost algorithms).
- Optimize normalization path to reduce temporary string copies (single by-value copy + in-place transform).
- Add regression tests for all CSV compression codecs and dirty-format inputs.
- Keep existing `FileChunkSinkTest` coverage passing.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
