### PR TITLE
[BugFix] Fix  possible PartitionColumnMinMaxRewriteRule bugs caused by Partition.hasStorageData

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -642,7 +642,7 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         // The fe unit test need to check the selected index id without any data.
         // So if set FeConstants.runningUnitTest, we can ensure that the number of partitions is not empty,
         // And the test case can continue to execute the logic of 'select best roll up'
-        return ((visibleVersion != PARTITION_INIT_VERSION)
+        return ((dataVersion != PARTITION_INIT_VERSION)
                 || FeConstants.runningUnitTest);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -642,7 +642,7 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         // The fe unit test need to check the selected index id without any data.
         // So if set FeConstants.runningUnitTest, we can ensure that the number of partitions is not empty,
         // And the test case can continue to execute the logic of 'select best roll up'
-        return ((dataVersion != PARTITION_INIT_VERSION)
+        return ((dataVersion != PARTITION_INIT_VERSION && visibleVersion != PARTITION_INIT_VERSION)
                 || FeConstants.runningUnitTest);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -187,6 +187,7 @@ public abstract class StarRocksHttpTestCase {
         Partition partition = new Partition(testPartitionId, testPhysicalPartitionId,
                 "testPartition", baseIndex, distributionInfo);
         partition.getDefaultPhysicalPartition().updateVisibleVersion(testStartVersion);
+        partition.getDefaultPhysicalPartition().setDataVersion(testStartVersion);
         partition.getDefaultPhysicalPartition().setNextVersion(testStartVersion + 1);
 
         // table
@@ -244,6 +245,7 @@ public abstract class StarRocksHttpTestCase {
         Partition partition = new Partition(testPartitionId, testPhysicalPartitionId,
                 "testPartition", baseIndex, distributionInfo);
         partition.getDefaultPhysicalPartition().updateVisibleVersion(testStartVersion);
+        partition.getDefaultPhysicalPartition().setDataVersion(testStartVersion);
         partition.getDefaultPhysicalPartition().setNextVersion(testStartVersion + 1);
 
         // table

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -730,13 +730,18 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
             MaterializedView mv = starRocksAssert.getMv("test", "test_loose_mv");
             mv.getPartition("p19910330").getDefaultPhysicalPartition()
                     .setVisibleVersion(Partition.PARTITION_INIT_VERSION, System.currentTimeMillis());
+            mv.getPartition("p19910330").getDefaultPhysicalPartition()
+                    .setDataVersion(Partition.PARTITION_INIT_VERSION);
             String query5 = "select id_date, sum(t1b) from table_with_day_partition" +
                     " where id_date >= '1991-03-30' and id_date < '1991-04-03' group by id_date";
-            FeConstants.runningUnitTest = false;
-            String plan = getFragmentPlan(query5);
-            FeConstants.runningUnitTest = true;
-            PlanTestBase.assertContains(plan, "test_loose_mv", "partitions=3/4",
-                    "table_with_day_partition", "partitions=1/4", "UNION");
+            try {
+                FeConstants.runningUnitTest = false;
+                String plan = getFragmentPlan(query5);
+                PlanTestBase.assertContains(plan, "test_loose_mv", "partitions=3/4",
+                        "table_with_day_partition", "partitions=1/4", "UNION");
+            } finally {
+                FeConstants.runningUnitTest = true;
+            }
             dropMv("test", "test_loose_mv");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -354,8 +354,11 @@ public class StatisticsCalculatorTest {
         Partition partition3 = partitions.get(2);
         // mock one empty partition
         partition1.getDefaultPhysicalPartition().setVisibleVersion(Partition.PARTITION_INIT_VERSION, System.currentTimeMillis());
+        partition1.getDefaultPhysicalPartition().setDataVersion(Partition.PARTITION_INIT_VERSION);
         partition2.getDefaultPhysicalPartition().setVisibleVersion(2, System.currentTimeMillis());
+        partition2.getDefaultPhysicalPartition().setDataVersion(2);
         partition3.getDefaultPhysicalPartition().setVisibleVersion(2, System.currentTimeMillis());
+        partition3.getDefaultPhysicalPartition().setDataVersion(2);
         List<Long> partitionIds = partitions.stream().filter(partition -> !(partition.getName().equalsIgnoreCase("p1"))).
                     mapToLong(Partition::getId).boxed().collect(Collectors.toList());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -266,6 +266,7 @@ public class ExternalTableTest extends PlanTestBase {
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "jointest");
         for (Partition partition : tbl.getPartitions()) {
             partition.getDefaultPhysicalPartition().updateVisibleVersion(2);
+            partition.getDefaultPhysicalPartition().setDataVersion(2);
             for (MaterializedIndex mIndex : partition.getDefaultPhysicalPartition()
                     .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
                 mIndex.setRowCount(10000);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -633,11 +633,15 @@ public class PartitionPruneTest extends PlanTestBase {
                 "    \"replication_num\" = \"1\"\n" +
                 ");");
         starRocksAssert.getCtx().executeSql("insert into t4_range_minmax values('2025-04-29', 1, 'bar')");
-        FeConstants.runningUnitTest = false;
-        starRocksAssert.getTable("test", "t4_range_minmax")
-                .getPartition("p20250428").getDefaultPhysicalPartition().updateVisibleVersion(1);
-        starRocksAssert.query("select min(dt), max(dt) from t4_range_minmax").explainContains("partitions=1/2");
-        FeConstants.runningUnitTest = true;
-
+        try {
+            FeConstants.runningUnitTest = false;
+            starRocksAssert.getTable("test", "t4_range_minmax")
+                    .getPartition("p20250428").getDefaultPhysicalPartition().updateVisibleVersion(1);
+            starRocksAssert.getTable("test", "t4_range_minmax")
+                    .getPartition("p20250428").getDefaultPhysicalPartition().setDataVersion(1);
+            starRocksAssert.query("select min(dt), max(dt) from t4_range_minmax").explainContains("partitions=1/2");
+        } finally {
+            FeConstants.runningUnitTest = true;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1351,6 +1351,7 @@ public class UtFrameUtils {
 
     public static void setPartitionVersion(Partition partition, long version) {
         partition.getDefaultPhysicalPartition().setVisibleVersion(version, System.currentTimeMillis());
+        partition.getDefaultPhysicalPartition().setDataVersion(version);
         MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
         List<Tablet> tablets = baseIndex.getTablets();
         for (Tablet tablet : tablets) {

--- a/test/sql/test_partition_storage_data/R/test_minmax_partition_column_rewrite.sql
+++ b/test/sql/test_partition_storage_data/R/test_minmax_partition_column_rewrite.sql
@@ -1,0 +1,220 @@
+-- name: test_minmax_partition_column_rewrite
+DROP DATABASE IF EXISTS test_minmax_partition_column_rewrite;
+-- result:
+-- !result
+CREATE DATABASE test_minmax_partition_column_rewrite;
+-- result:
+-- !result
+USE test_minmax_partition_column_rewrite;
+-- result:
+-- !result
+CREATE TABLE `t1_partial_empty` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1_partial_empty VALUES('2025-02-15', 1, 100);
+-- result:
+-- !result
+SELECT MIN(dt) FROM t1_partial_empty;
+-- result:
+2025-02-15
+-- !result
+SELECT MAX(dt) FROM t1_partial_empty;
+-- result:
+2025-02-15
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_partial_empty;
+-- result:
+2025-02-15	2025-02-15
+-- !result
+CREATE TABLE `t2_schema_change_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2_schema_change_minmax VALUES('2025-01-15', 1);
+-- result:
+-- !result
+INSERT INTO t2_schema_change_minmax VALUES('2025-02-15', 2);
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+ALTER TABLE t2_schema_change_minmax ADD COLUMN new_col INT NULL DEFAULT "0";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+INSERT INTO t2_schema_change_minmax VALUES('2025-01-20', 3, 100);
+-- result:
+-- !result
+INSERT INTO t2_schema_change_minmax VALUES('2025-02-20', 4, 200);
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+-- result:
+2025-01-15	2025-02-20
+-- !result
+CREATE TABLE `t3_list_minmax` (
+    `c1` int NOT NULL,
+    `c2` int,
+    `c3` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2', '3'),
+    PARTITION p2 VALUES IN ('4', '5', '6'),
+    PARTITION p3 VALUES IN ('7', '8', '9')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t3_list_minmax VALUES(1, 100, 'a'), (5, 200, 'b'), (9, 300, 'c');
+-- result:
+-- !result
+SELECT MIN(c1), MAX(c1) FROM t3_list_minmax;
+-- result:
+1	9
+-- !result
+ALTER TABLE t3_list_minmax ADD COLUMN new_col DOUBLE NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(c1), MAX(c1) FROM t3_list_minmax;
+-- result:
+1	9
+-- !result
+CREATE TABLE `t4_prune_with_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01")),
+    PARTITION p202504 VALUES [("2025-04-01"), ("2025-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t4_prune_with_minmax VALUES('2025-01-15', 1);
+-- result:
+-- !result
+INSERT INTO t4_prune_with_minmax VALUES('2025-02-15', 2);
+-- result:
+-- !result
+INSERT INTO t4_prune_with_minmax VALUES('2025-03-15', 3);
+-- result:
+-- !result
+INSERT INTO t4_prune_with_minmax VALUES('2025-04-15', 4);
+-- result:
+-- !result
+SELECT MIN(dt) FROM t4_prune_with_minmax;
+-- result:
+2025-01-15
+-- !result
+SELECT MAX(dt) FROM t4_prune_with_minmax;
+-- result:
+2025-04-15
+-- !result
+ALTER TABLE t4_prune_with_minmax ADD COLUMN col1 STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt) FROM t4_prune_with_minmax;
+-- result:
+2025-01-15
+-- !result
+SELECT MAX(dt) FROM t4_prune_with_minmax;
+-- result:
+2025-04-15
+-- !result
+CREATE TABLE `t5_filter_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t5_filter_minmax VALUES('2025-01-15', 1, 100);
+-- result:
+-- !result
+INSERT INTO t5_filter_minmax VALUES('2025-02-15', 2, 200);
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t5_filter_minmax;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+ALTER TABLE t5_filter_minmax ADD COLUMN col1 INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t5_filter_minmax;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+DROP DATABASE IF EXISTS test_minmax_partition_column_rewrite;
+-- result:
+-- !result

--- a/test/sql/test_partition_storage_data/R/test_partition_storage_data_schema_change.sql
+++ b/test/sql/test_partition_storage_data/R/test_partition_storage_data_schema_change.sql
@@ -1,0 +1,316 @@
+-- name: test_partition_storage_data_schema_change
+DROP DATABASE IF EXISTS test_partition_storage_data_schema_change;
+-- result:
+-- !result
+CREATE DATABASE test_partition_storage_data_schema_change;
+-- result:
+-- !result
+USE test_partition_storage_data_schema_change;
+-- result:
+-- !result
+CREATE TABLE `t1_range_basic` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `name` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`, `name`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p20250428 VALUES [("2025-04-28"), ("2025-04-29")),
+    PARTITION p20250429 VALUES [("2025-04-29"), ("2025-04-30"))
+)
+DISTRIBUTED BY HASH(`id`, `name`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1_range_basic VALUES('2025-04-29', 1, 'bar');
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+-- result:
+2025-04-29	2025-04-29
+-- !result
+ALTER TABLE t1_range_basic ADD COLUMN new_col INT NULL DEFAULT "0";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+-- result:
+2025-04-29	2025-04-29
+-- !result
+INSERT INTO t1_range_basic VALUES('2025-04-29', 2, 'baz', 100);
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+-- result:
+2025-04-29	2025-04-29
+-- !result
+CREATE TABLE `t2_list_rollup` (
+    `c1` int,
+    `c2` int,
+    `c3` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2'),
+    PARTITION p2 VALUES IN ('3', '4'),
+    PARTITION p3 VALUES IN ('5', '6')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2_list_rollup VALUES(1, 100, 'a'), (3, 200, 'b'), (5, 300, 'c');
+-- result:
+-- !result
+SELECT MIN(c1), MAX(c1) FROM t2_list_rollup;
+-- result:
+1	6
+-- !result
+ALTER TABLE t2_list_rollup ADD ROLLUP r1(c1, c2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(c1), MAX(c1) FROM t2_list_rollup;
+-- result:
+1	6
+-- !result
+CREATE TABLE `t3_range_empty` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t3_range_empty VALUES('2025-02-15', 1, 100), ('2025-02-20', 2, 200);
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t3_range_empty;
+-- result:
+2025-02-15	2025-02-20
+-- !result
+ALTER TABLE t3_range_empty ADD COLUMN new_value DOUBLE NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t3_range_empty;
+-- result:
+2025-02-15	2025-02-20
+-- !result
+CREATE TABLE `t4_prune_after_alter` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `name` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01")),
+    PARTITION p202504 VALUES [("2025-04-01"), ("2025-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t4_prune_after_alter VALUES
+('2025-01-15', 1, 'jan'),
+('2025-02-15', 2, 'feb'),
+('2025-03-15', 3, 'mar'),
+('2025-04-15', 4, 'apr');
+-- result:
+-- !result
+SELECT * FROM t4_prune_after_alter WHERE dt >= '2025-02-01' AND dt < '2025-04-01' ORDER BY dt;
+-- result:
+2025-02-15	2	feb
+2025-03-15	3	mar
+-- !result
+ALTER TABLE t4_prune_after_alter ADD COLUMN description STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t4_prune_after_alter WHERE dt >= '2025-02-01' AND dt < '2025-04-01' ORDER BY dt;
+-- result:
+2025-02-15	2	feb	None
+2025-03-15	3	mar	None
+-- !result
+CREATE TABLE `t5_multi_alter` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t5_multi_alter VALUES('2025-01-15', 1), ('2025-02-15', 2);
+-- result:
+-- !result
+ALTER TABLE t5_multi_alter ADD COLUMN col1 INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+ALTER TABLE t5_multi_alter ADD COLUMN col2 STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+INSERT INTO t5_multi_alter VALUES('2025-01-20', 3, 100, 'test');
+-- result:
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+CREATE TABLE `t6_explain_check` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t6_explain_check VALUES('2025-02-15', 1);
+-- result:
+-- !result
+EXPLAIN SELECT MIN(dt), MAX(dt) FROM t6_explain_check;
+-- result:
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:6: min | 7: max
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  3:AGGREGATE (merge finalize)
+  |  output: min(6: min), max(7: max)
+  |  group by: 
+  |  
+  2:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    UNPARTITIONED
+
+  1:AGGREGATE (update serialize)
+  |  output: min(1: dt), max(1: dt)
+  |  group by: 
+  |  
+  0:OlapScanNode
+     TABLE: t6_explain_check
+     PREAGGREGATION: ON
+     partitions=1/2
+     rollup: t6_explain_check
+     tabletRatio=2/2
+     tabletList=11425,11427
+     cardinality=1
+     avgRowSize=4.0
+-- !result
+ALTER TABLE t6_explain_check ADD COLUMN new_col BIGINT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+EXPLAIN SELECT MIN(dt), MAX(dt) FROM t6_explain_check;
+-- result:
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:7: min | 8: max
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  3:AGGREGATE (merge finalize)
+  |  output: min(7: min), max(8: max)
+  |  group by: 
+  |  
+  2:EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 02
+    UNPARTITIONED
+
+  1:AGGREGATE (update serialize)
+  |  output: min(1: dt), max(1: dt)
+  |  group by: 
+  |  
+  0:OlapScanNode
+     TABLE: t6_explain_check
+     PREAGGREGATION: ON
+     partitions=1/2
+     rollup: t6_explain_check
+     tabletRatio=2/2
+     tabletList=11425,11427
+     cardinality=1
+     avgRowSize=4.0
+-- !result
+DROP DATABASE IF EXISTS test_partition_storage_data_schema_change;
+-- result:
+-- !result

--- a/test/sql/test_partition_storage_data/R/test_schema_change_empty_partition.sql
+++ b/test/sql/test_partition_storage_data/R/test_schema_change_empty_partition.sql
@@ -1,0 +1,241 @@
+-- name: test_schema_change_empty_partition
+DROP DATABASE IF EXISTS test_schema_change_empty_partition;
+-- result:
+-- !result
+CREATE DATABASE test_schema_change_empty_partition;
+-- result:
+-- !result
+USE test_schema_change_empty_partition;
+-- result:
+-- !result
+CREATE TABLE `t1_alter_with_data` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1_alter_with_data VALUES('2025-01-15', 1, 100);
+-- result:
+-- !result
+INSERT INTO t1_alter_with_data VALUES('2025-02-15', 2, 200);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t1_alter_with_data;
+-- result:
+2
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_alter_with_data;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+ALTER TABLE t1_alter_with_data ADD COLUMN new_col INT NULL DEFAULT "0";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t1_alter_with_data;
+-- result:
+2
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t1_alter_with_data;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+CREATE TABLE `t2_multi_alter` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p1 VALUES [("2025-01-01"), ("2025-02-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2_multi_alter VALUES('2025-01-15', 1);
+-- result:
+-- !result
+ALTER TABLE t2_multi_alter ADD COLUMN col1 INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t2_multi_alter;
+-- result:
+1
+-- !result
+ALTER TABLE t2_multi_alter ADD COLUMN col2 STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t2_multi_alter;
+-- result:
+1
+-- !result
+ALTER TABLE t2_multi_alter ADD COLUMN col3 DOUBLE NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t2_multi_alter;
+-- result:
+1
+-- !result
+SELECT * FROM t2_multi_alter;
+-- result:
+2025-01-15	1	None	None	None
+-- !result
+CREATE TABLE `t3_alter_then_insert` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t3_alter_then_insert VALUES('2025-01-15', 1);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t3_alter_then_insert;
+-- result:
+1
+-- !result
+ALTER TABLE t3_alter_then_insert ADD COLUMN new_col INT NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+INSERT INTO t3_alter_then_insert VALUES('2025-01-20', 2, 100);
+-- result:
+-- !result
+INSERT INTO t3_alter_then_insert VALUES('2025-02-15', 3, 200);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t3_alter_then_insert;
+-- result:
+3
+-- !result
+SELECT MIN(dt), MAX(dt) FROM t3_alter_then_insert;
+-- result:
+2025-01-15	2025-02-15
+-- !result
+CREATE TABLE `t4_query_after_alter` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t4_query_after_alter VALUES
+('2025-01-15', 1, 100),
+('2025-02-15', 2, 200),
+('2025-03-15', 3, 300);
+-- result:
+-- !result
+SELECT * FROM t4_query_after_alter WHERE dt >= '2025-02-01' ORDER BY dt;
+-- result:
+2025-02-15	2	200
+2025-03-15	3	300
+-- !result
+ALTER TABLE t4_query_after_alter ADD COLUMN col1 STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t4_query_after_alter WHERE dt >= '2025-02-01' ORDER BY dt;
+-- result:
+2025-02-15	2	200	None
+2025-03-15	3	300	None
+-- !result
+SELECT COUNT(*) FROM t4_query_after_alter;
+-- result:
+3
+-- !result
+CREATE TABLE `t5_list_alter` (
+    `c1` int NOT NULL,
+    `c2` int
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2'),
+    PARTITION p2 VALUES IN ('3', '4')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t5_list_alter VALUES(1, 100), (3, 200);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t5_list_alter;
+-- result:
+2
+-- !result
+ALTER TABLE t5_list_alter ADD COLUMN col1 STRING NULL;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT COUNT(*) FROM t5_list_alter;
+-- result:
+2
+-- !result
+SELECT MIN(c1), MAX(c1) FROM t5_list_alter;
+-- result:
+1	4
+-- !result
+DROP DATABASE IF EXISTS test_schema_change_empty_partition;
+-- result:
+-- !result

--- a/test/sql/test_partition_storage_data/T/test_minmax_partition_column_rewrite.sql
+++ b/test/sql/test_partition_storage_data/T/test_minmax_partition_column_rewrite.sql
@@ -1,0 +1,150 @@
+-- name: test_minmax_partition_column_rewrite
+
+DROP DATABASE IF EXISTS test_minmax_partition_column_rewrite;
+CREATE DATABASE test_minmax_partition_column_rewrite;
+USE test_minmax_partition_column_rewrite;
+
+CREATE TABLE `t1_partial_empty` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1_partial_empty VALUES('2025-02-15', 1, 100);
+
+SELECT MIN(dt) FROM t1_partial_empty;
+
+SELECT MAX(dt) FROM t1_partial_empty;
+
+SELECT MIN(dt), MAX(dt) FROM t1_partial_empty;
+
+CREATE TABLE `t2_schema_change_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t2_schema_change_minmax VALUES('2025-01-15', 1);
+INSERT INTO t2_schema_change_minmax VALUES('2025-02-15', 2);
+
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+
+ALTER TABLE t2_schema_change_minmax ADD COLUMN new_col INT NULL DEFAULT "0";
+
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+
+INSERT INTO t2_schema_change_minmax VALUES('2025-01-20', 3, 100);
+INSERT INTO t2_schema_change_minmax VALUES('2025-02-20', 4, 200);
+
+SELECT MIN(dt), MAX(dt) FROM t2_schema_change_minmax;
+
+CREATE TABLE `t3_list_minmax` (
+    `c1` int NOT NULL,
+    `c2` int,
+    `c3` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2', '3'),
+    PARTITION p2 VALUES IN ('4', '5', '6'),
+    PARTITION p3 VALUES IN ('7', '8', '9')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t3_list_minmax VALUES(1, 100, 'a'), (5, 200, 'b'), (9, 300, 'c');
+
+SELECT MIN(c1), MAX(c1) FROM t3_list_minmax;
+
+ALTER TABLE t3_list_minmax ADD COLUMN new_col DOUBLE NULL;
+
+function: wait_alter_table_finish()
+
+SELECT MIN(c1), MAX(c1) FROM t3_list_minmax;
+
+CREATE TABLE `t4_prune_with_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01")),
+    PARTITION p202504 VALUES [("2025-04-01"), ("2025-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t4_prune_with_minmax VALUES('2025-01-15', 1);
+INSERT INTO t4_prune_with_minmax VALUES('2025-02-15', 2);
+INSERT INTO t4_prune_with_minmax VALUES('2025-03-15', 3);
+INSERT INTO t4_prune_with_minmax VALUES('2025-04-15', 4);
+
+SELECT MIN(dt) FROM t4_prune_with_minmax;
+
+SELECT MAX(dt) FROM t4_prune_with_minmax;
+
+ALTER TABLE t4_prune_with_minmax ADD COLUMN col1 STRING NULL;
+
+function: wait_alter_table_finish()
+
+SELECT MIN(dt) FROM t4_prune_with_minmax;
+SELECT MAX(dt) FROM t4_prune_with_minmax;
+
+CREATE TABLE `t5_filter_minmax` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t5_filter_minmax VALUES('2025-01-15', 1, 100);
+INSERT INTO t5_filter_minmax VALUES('2025-02-15', 2, 200);
+
+SELECT MIN(dt), MAX(dt) FROM t5_filter_minmax;
+
+ALTER TABLE t5_filter_minmax ADD COLUMN col1 INT NULL;
+
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t5_filter_minmax;
+
+DROP DATABASE IF EXISTS test_minmax_partition_column_rewrite;

--- a/test/sql/test_partition_storage_data/T/test_partition_storage_data_schema_change.sql
+++ b/test/sql/test_partition_storage_data/T/test_partition_storage_data_schema_change.sql
@@ -1,0 +1,177 @@
+-- name: test_partition_storage_data_schema_change
+
+DROP DATABASE IF EXISTS test_partition_storage_data_schema_change;
+CREATE DATABASE test_partition_storage_data_schema_change;
+USE test_partition_storage_data_schema_change;
+
+CREATE TABLE `t1_range_basic` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `name` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`, `name`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p20250428 VALUES [("2025-04-28"), ("2025-04-29")),
+    PARTITION p20250429 VALUES [("2025-04-29"), ("2025-04-30"))
+)
+DISTRIBUTED BY HASH(`id`, `name`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1_range_basic VALUES('2025-04-29', 1, 'bar');
+
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+
+ALTER TABLE t1_range_basic ADD COLUMN new_col INT NULL DEFAULT "0";
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+
+INSERT INTO t1_range_basic VALUES('2025-04-29', 2, 'baz', 100);
+
+SELECT MIN(dt), MAX(dt) FROM t1_range_basic;
+
+CREATE TABLE `t2_list_rollup` (
+    `c1` int,
+    `c2` int,
+    `c3` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2'),
+    PARTITION p2 VALUES IN ('3', '4'),
+    PARTITION p3 VALUES IN ('5', '6')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t2_list_rollup VALUES(1, 100, 'a'), (3, 200, 'b'), (5, 300, 'c');
+
+SELECT MIN(c1), MAX(c1) FROM t2_list_rollup;
+
+ALTER TABLE t2_list_rollup ADD ROLLUP r1(c1, c2);
+
+function: wait_alter_table_finish()
+
+SELECT MIN(c1), MAX(c1) FROM t2_list_rollup;
+
+CREATE TABLE `t3_range_empty` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t3_range_empty VALUES('2025-02-15', 1, 100), ('2025-02-20', 2, 200);
+
+SELECT MIN(dt), MAX(dt) FROM t3_range_empty;
+
+ALTER TABLE t3_range_empty ADD COLUMN new_value DOUBLE NULL;
+
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t3_range_empty;
+
+CREATE TABLE `t4_prune_after_alter` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `name` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `id`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01")),
+    PARTITION p202504 VALUES [("2025-04-01"), ("2025-05-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t4_prune_after_alter VALUES
+('2025-01-15', 1, 'jan'),
+('2025-02-15', 2, 'feb'),
+('2025-03-15', 3, 'mar'),
+('2025-04-15', 4, 'apr');
+
+SELECT * FROM t4_prune_after_alter WHERE dt >= '2025-02-01' AND dt < '2025-04-01' ORDER BY dt;
+
+ALTER TABLE t4_prune_after_alter ADD COLUMN description STRING NULL;
+
+function: wait_alter_table_finish()
+
+SELECT * FROM t4_prune_after_alter WHERE dt >= '2025-02-01' AND dt < '2025-04-01' ORDER BY dt;
+
+CREATE TABLE `t5_multi_alter` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t5_multi_alter VALUES('2025-01-15', 1), ('2025-02-15', 2);
+
+ALTER TABLE t5_multi_alter ADD COLUMN col1 INT NULL;
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+
+ALTER TABLE t5_multi_alter ADD COLUMN col2 STRING NULL;
+function: wait_alter_table_finish()
+
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+
+INSERT INTO t5_multi_alter VALUES('2025-01-20', 3, 100, 'test');
+
+SELECT MIN(dt), MAX(dt) FROM t5_multi_alter;
+
+CREATE TABLE `t6_explain_check` (
+    `dt` date NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t6_explain_check VALUES('2025-02-15', 1);
+
+EXPLAIN SELECT MIN(dt), MAX(dt) FROM t6_explain_check;
+
+ALTER TABLE t6_explain_check ADD COLUMN new_col BIGINT NULL;
+function: wait_alter_table_finish()
+
+EXPLAIN SELECT MIN(dt), MAX(dt) FROM t6_explain_check;
+
+DROP DATABASE IF EXISTS test_partition_storage_data_schema_change;

--- a/test/sql/test_partition_storage_data/T/test_schema_change_empty_partition.sql
+++ b/test/sql/test_partition_storage_data/T/test_schema_change_empty_partition.sql
@@ -1,0 +1,156 @@
+-- name: test_schema_change_empty_partition
+
+DROP DATABASE IF EXISTS test_schema_change_empty_partition;
+CREATE DATABASE test_schema_change_empty_partition;
+USE test_schema_change_empty_partition;
+
+CREATE TABLE `t1_alter_with_data` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1_alter_with_data VALUES('2025-01-15', 1, 100);
+INSERT INTO t1_alter_with_data VALUES('2025-02-15', 2, 200);
+
+SELECT COUNT(*) FROM t1_alter_with_data;
+
+SELECT MIN(dt), MAX(dt) FROM t1_alter_with_data;
+
+ALTER TABLE t1_alter_with_data ADD COLUMN new_col INT NULL DEFAULT "0";
+function: wait_alter_table_finish()
+
+SELECT COUNT(*) FROM t1_alter_with_data;
+
+SELECT MIN(dt), MAX(dt) FROM t1_alter_with_data;
+
+CREATE TABLE `t2_multi_alter` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p1 VALUES [("2025-01-01"), ("2025-02-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t2_multi_alter VALUES('2025-01-15', 1);
+
+ALTER TABLE t2_multi_alter ADD COLUMN col1 INT NULL;
+function: wait_alter_table_finish()
+
+SELECT COUNT(*) FROM t2_multi_alter;
+
+ALTER TABLE t2_multi_alter ADD COLUMN col2 STRING NULL;
+function: wait_alter_table_finish()
+
+SELECT COUNT(*) FROM t2_multi_alter;
+
+ALTER TABLE t2_multi_alter ADD COLUMN col3 DOUBLE NULL;
+function: wait_alter_table_finish()
+
+SELECT COUNT(*) FROM t2_multi_alter;
+
+SELECT * FROM t2_multi_alter;
+
+CREATE TABLE `t3_alter_then_insert` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t3_alter_then_insert VALUES('2025-01-15', 1);
+
+SELECT COUNT(*) FROM t3_alter_then_insert;
+
+ALTER TABLE t3_alter_then_insert ADD COLUMN new_col INT NULL;
+function: wait_alter_table_finish()
+
+INSERT INTO t3_alter_then_insert VALUES('2025-01-20', 2, 100);
+INSERT INTO t3_alter_then_insert VALUES('2025-02-15', 3, 200);
+
+SELECT COUNT(*) FROM t3_alter_then_insert;
+
+SELECT MIN(dt), MAX(dt) FROM t3_alter_then_insert;
+
+CREATE TABLE `t4_query_after_alter` (
+    `dt` date NOT NULL COMMENT "",
+    `id` int(11) NULL COMMENT "",
+    `value` bigint NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p202501 VALUES [("2025-01-01"), ("2025-02-01")),
+    PARTITION p202502 VALUES [("2025-02-01"), ("2025-03-01")),
+    PARTITION p202503 VALUES [("2025-03-01"), ("2025-04-01"))
+)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t4_query_after_alter VALUES
+('2025-01-15', 1, 100),
+('2025-02-15', 2, 200),
+('2025-03-15', 3, 300);
+
+SELECT * FROM t4_query_after_alter WHERE dt >= '2025-02-01' ORDER BY dt;
+
+ALTER TABLE t4_query_after_alter ADD COLUMN col1 STRING NULL;
+function: wait_alter_table_finish()
+
+SELECT * FROM t4_query_after_alter WHERE dt >= '2025-02-01' ORDER BY dt;
+
+SELECT COUNT(*) FROM t4_query_after_alter;
+
+CREATE TABLE `t5_list_alter` (
+    `c1` int NOT NULL,
+    `c2` int
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+PARTITION BY LIST(`c1`)
+(
+    PARTITION p1 VALUES IN ('1', '2'),
+    PARTITION p2 VALUES IN ('3', '4')
+)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t5_list_alter VALUES(1, 100), (3, 200);
+
+SELECT COUNT(*) FROM t5_list_alter;
+
+ALTER TABLE t5_list_alter ADD COLUMN col1 STRING NULL;
+function: wait_alter_table_finish()
+
+SELECT COUNT(*) FROM t5_list_alter;
+
+SELECT MIN(c1), MAX(c1) FROM t5_list_alter;
+
+DROP DATABASE IF EXISTS test_schema_change_empty_partition;


### PR DESCRIPTION
## Why I'm doing:

Currently, PartitionColumnMinMaxRewriteRule and other some components (e.g., Materialized View refresh logic) rely on the assumption that if a partition's visibleVersion is greater than PARTITION_INIT_VERSION, it implies the partition has data (storageRowCount() > 0). However, this assumption is flawed and can lead to incorrect behaviors, such as MV refresh incorrectly skipping partitions that are actually empty.

The divergence between visibleVersion and actual row count happens in two main scenarios:

- Schema Changes: Operations like adding a column, creating a rollup, or altering metadata can advance the visibleVersion without writing any new data rows. A new shadow index is published and becomes visible with empty or copied metadata, incrementing the version while the row count remains at zero.

- Shared-data (Lake) Mode: In Lake mode, this mismatch is even more highly probable. Alter or rollup jobs update the version directly, but tablet statistics are updated asynchronously. This creates a wider time window where visibleVersion > PARTITION_INIT_VERSION is true, but storageRowCount() == 0.

Fix bugs cuased by: https://github.com/StarRocks/starrocks/pull/49942/

## What I'm doing:
- Add `dataVersion` to check.

TODO:
- Support more common optimizations for `min/max` partitions to compute.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
