### PR TITLE
[BugFix] fix local partition topn crash 

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -106,22 +106,6 @@ inline AggDataPtr AllocateState<HashMapWithKey>::operator()(std::nullptr_t) {
     }
 }
 
-template <bool UseIntermediateAsOutput>
-bool AggFunctionTypes::is_result_nullable() const {
-    if constexpr (UseIntermediateAsOutput) {
-        // If using intermediate results as output, no output will be generated and only the input will be serialized.
-        // Therefore, only judge whether the input is nullable to decide whether to serialize null data.
-        return has_nullable_child || serialize_always_nullable;
-    } else {
-        // `is_nullable` means whether the output MAY be nullable. It will be false only when the output is always non-nullable.
-        // Therefore, we need to decide whether the output is really nullable case by case:
-        // 1. Same as input: `has_nullable_child` = `has_nullable_child && is_nullable(true)`.
-        // 2. Always non-nullable: `false` = `has_nullable_child && is_nullable(false)`, eg. count, count distinct, and bitmap_union_int.
-        // 3. Always nullable: `is_always_nullable_result`.
-        return (has_nullable_child && is_nullable) || is_always_nullable_result;
-    }
-}
-
 bool AggFunctionTypes::use_nullable_fn(bool use_intermediate_as_output) const {
     // The non-nullable version functions assume that both the input and output are non-nullable, while the nullable version
     // functions support nullable input or nullable output, which will judge whether the input and output are nullable.

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -127,7 +127,20 @@ struct AggFunctionTypes {
     bool serialize_always_nullable = false;
 
     template <bool UseIntermediateAsOutput>
-    bool is_result_nullable() const;
+    bool is_result_nullable() const {
+        if constexpr (UseIntermediateAsOutput) {
+            // If using intermediate results as output, no output will be generated and only the input will be serialized.
+            // Therefore, only judge whether the input is nullable to decide whether to serialize null data.
+            return has_nullable_child || serialize_always_nullable;
+        } else {
+            // `is_nullable` means whether the output MAY be nullable. It will be false only when the output is always non-nullable.
+            // Therefore, we need to decide whether the output is really nullable case by case:
+            // 1. Same as input: `has_nullable_child` = `has_nullable_child && is_nullable(true)`.
+            // 2. Always non-nullable: `false` = `has_nullable_child && is_nullable(false)`, eg. count, count distinct, and bitmap_union_int.
+            // 3. Always nullable: `is_always_nullable_result`.
+            return (has_nullable_child && is_nullable) || is_always_nullable_result;
+        }
+    }
     bool use_nullable_fn(bool use_intermediate_as_output) const;
 };
 

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -24,15 +24,14 @@
 
 namespace starrocks::pipeline {
 
-LocalPartitionTopnContext::LocalPartitionTopnContext(const std::vector<TExpr>& t_partition_exprs, bool has_nullable_key,
-                                                     bool enable_pre_agg, const std::vector<TExpr>& t_pre_agg_exprs,
-                                                     const std::vector<TSlotId>& t_pre_agg_output_slot_id,
-                                                     const std::vector<ExprContext*>& sort_exprs,
-                                                     std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-                                                     std::string sort_keys, int64_t offset, int64_t partition_limit,
-                                                     const TTopNType::type topn_type)
+LocalPartitionTopnContext::LocalPartitionTopnContext(
+        const std::vector<TExpr>& t_partition_exprs, bool has_outer_join_child, bool enable_pre_agg,
+        const std::vector<TExpr>& t_pre_agg_exprs, const std::vector<TSlotId>& t_pre_agg_output_slot_id,
+        const std::vector<ExprContext*>& sort_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
+        std::string sort_keys, int64_t offset, int64_t partition_limit, const TTopNType::type topn_type)
         : _t_partition_exprs(t_partition_exprs),
-          _has_nullable_key(has_nullable_key),
+          _has_nullable_key(has_outer_join_child),
+          _has_outer_join_child(has_outer_join_child),
           _enable_pre_agg(enable_pre_agg),
           _sort_exprs(sort_exprs),
           _is_asc_order(std::move(is_asc_order)),
@@ -114,20 +113,23 @@ Status LocalPartitionTopnContext::prepare_pre_agg(RuntimeState* state) {
         _pre_agg->_agg_fn_ctxs[i] = FunctionContext::create_context(state, _mem_pool.get(), return_type, arg_typedescs);
         state->obj_pool()->add(_pre_agg->_agg_fn_ctxs[i]);
 
+        const bool has_nullable_child = _has_outer_join_child || desc.nodes[0].has_nullable_child;
+        AggFunctionTypes agg_fn_type = {return_type, serde_type, arg_typedescs, has_nullable_child,
+                                        desc.nodes[0].is_nullable};
         bool is_input_nullable = false;
         const AggregateFunction* func = nullptr;
-        if (fn.name.function_name == "count") {
+        const bool is_count_fn = fn.name.function_name == "count";
+        if (is_count_fn) {
             return_type.type = TYPE_BIGINT;
             arg_type.type = TYPE_BIGINT;
             serde_type.type = TYPE_BIGINT;
-            is_input_nullable = !fn.arg_types.empty() && (desc.nodes[0].has_nullable_child);
-            _pre_agg->_agg_fn_types[i] = {serde_type, false, false};
+            agg_fn_type = {return_type, serde_type, arg_typedescs, false, false};
+            // Keep count function selection consistent with Aggregator's intermediate-output path.
+            is_input_nullable = !fn.arg_types.empty() && has_nullable_child;
         } else {
-            // For nullable aggregate function(sum, max, min, avg),
-            // we should always use nullable aggregate function.
-            is_input_nullable = true;
-            _pre_agg->_agg_fn_types[i] = {serde_type, is_input_nullable, desc.nodes[0].is_nullable};
+            is_input_nullable = agg_fn_type.use_nullable_fn(true);
         }
+        _pre_agg->_agg_fn_types[i] = std::move(agg_fn_type);
 
         func = get_window_function(fn.name.function_name, arg_type.type, return_type.type, is_input_nullable,
                                    fn.binary_type, state->func_version());
@@ -288,10 +290,9 @@ StatusOr<ChunkPtr> LocalPartitionTopnContext::pull_one_chunk_from_sorters() {
 MutableColumns LocalPartitionTopnContext::_create_agg_result_columns(size_t num_rows) {
     MutableColumns agg_result_columns(_pre_agg->_agg_fn_types.size());
     for (size_t i = 0; i < _pre_agg->_agg_fn_types.size(); ++i) {
-        // For count, count distinct, bitmap_union_int such as never return null function,
-        // we need to create a not-nullable column.
-        agg_result_columns[i] = ColumnHelper::create_column(_pre_agg->_agg_fn_types[i].result_type,
-                                                            _pre_agg->_agg_fn_types[i].is_nullable);
+        const bool is_count_fn = _pre_agg->_t_pre_agg_exprs[i].nodes[0].fn.name.function_name == "count";
+        const bool is_result_nullable = is_count_fn ? false : _pre_agg->_agg_fn_types[i].is_result_nullable<true>();
+        agg_result_columns[i] = ColumnHelper::create_column(_pre_agg->_agg_fn_types[i].serde_type, is_result_nullable);
         agg_result_columns[i]->reserve(num_rows);
     }
     return agg_result_columns;

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -16,6 +16,7 @@
 
 #include <queue>
 
+#include "exec/aggregator.h"
 #include "exec/analytor.h"
 #include "exec/chunks_sorter.h"
 #include "exec/partition/chunks_partitioner.h"
@@ -23,8 +24,6 @@
 
 namespace starrocks {
 class RuntimeFilterBuildDescriptor;
-
-struct FunctionTypes;
 } // namespace starrocks
 
 namespace starrocks::pipeline {
@@ -57,7 +56,7 @@ struct PreAggState {
     std::vector<Columns> _agg_input_columns;
     //raw pointers in order to get multi-column values
     std::vector<std::vector<const Column*>> _agg_input_raw_columns;
-    std::vector<FunctionTypes> _agg_fn_types;
+    std::vector<AggFunctionTypes> _agg_fn_types;
     // every partition has one Agg State
     std::vector<ManagedFunctionStatesPtr<PreAggState>> _managed_fn_states;
 };
@@ -76,8 +75,8 @@ class LocalPartitionTopnContext {
     friend class ManagedFunctionStates<LocalPartitionTopnContext>;
 
 public:
-    LocalPartitionTopnContext(const std::vector<TExpr>& t_partition_exprs, bool has_nullable_key, bool enable_pre_agg,
-                              const std::vector<TExpr>& t_pre_agg_exprs,
+    LocalPartitionTopnContext(const std::vector<TExpr>& t_partition_exprs, bool has_outer_join_child,
+                              bool enable_pre_agg, const std::vector<TExpr>& t_pre_agg_exprs,
                               const std::vector<TSlotId>& t_pre_agg_output_slot_id,
                               const std::vector<ExprContext*>& sort_exprs, std::vector<bool> is_asc_order,
                               std::vector<bool> is_null_first, std::string sort_keys, int64_t offset,
@@ -138,6 +137,7 @@ private:
     std::vector<ExprContext*> _partition_exprs;
     std::vector<PartitionColumnType> _partition_types;
     bool _has_nullable_key = false;
+    bool _has_outer_join_child = false;
 
     // used in preagg
     std::unique_ptr<MemPool> _mem_pool = nullptr;

--- a/test/sql/test_window_function/R/test_window_pre_agg_with_rank
+++ b/test/sql/test_window_function/R/test_window_pre_agg_with_rank
@@ -110,3 +110,38 @@ WHERE rn <= 2;
 1
 1
 -- !result
+
+-- name: test_window_pre_agg_with_bitmap_union_count
+DROP TABLE IF EXISTS t_rank_bitmap_crash;
+-- result:
+-- !result
+CREATE TABLE t_rank_bitmap_crash (
+    k INT,
+    ts INT,
+    uid BIGINT NULL
+)
+DUPLICATE KEY(k, ts)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_rank_bitmap_crash VALUES
+(1, 100, 1), (1, 90, 2), (1, 80, NULL), (1, 70, 3),
+(2, 100, 4), (2, 90, NULL), (2, 80, 5);
+-- result:
+-- !result
+SELECT * FROM (
+    SELECT
+        k,
+        ts,
+        rank() OVER (PARTITION BY k ORDER BY ts DESC) AS rk,
+        bitmap_union_count(to_bitmap(uid)) OVER (PARTITION BY k) AS uv
+    FROM t_rank_bitmap_crash
+) s
+ORDER BY rk,k, ts DESC
+LIMIT 3;
+-- result:
+1	100	1	3
+2	100	1	2
+1	90	2	3
+-- !result

--- a/test/sql/test_window_function/T/test_window_pre_agg_with_rank
+++ b/test/sql/test_window_function/T/test_window_pre_agg_with_rank
@@ -87,3 +87,29 @@ FROM (
     FROM t1
 ) as x
 WHERE rn <= 2;
+
+-- name: test_window_pre_agg_with_bitmap_union_count
+DROP TABLE IF EXISTS t_rank_bitmap_crash;
+CREATE TABLE t_rank_bitmap_crash (
+    k INT,
+    ts INT,
+    uid BIGINT NULL
+)
+DUPLICATE KEY(k, ts)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t_rank_bitmap_crash VALUES
+(1, 100, 1), (1, 90, 2), (1, 80, NULL), (1, 70, 3),
+(2, 100, 4), (2, 90, NULL), (2, 80, 5);
+
+SELECT * FROM (
+    SELECT
+        k,
+        ts,
+        rank() OVER (PARTITION BY k ORDER BY ts DESC) AS rk,
+        bitmap_union_count(to_bitmap(uid)) OVER (PARTITION BY k) AS uv
+    FROM t_rank_bitmap_crash
+) s
+ORDER BY rk,k, ts DESC
+LIMIT 3;


### PR DESCRIPTION
## Why I'm doing:
right now local partition topn always choose nullable agg function(is_input_nullable always be true)
nullable agg function' serialize_to_column() assume result column is always nullable
but result column is determind by  _pre_agg->_agg_fn_types[i].is_nullable, which is from FE' FunctionCallExpr::isNullable()

if result column is not nullable, like bitmap_union_count( which is one of alwaysReturnNonNullableFunctions), then it will crash like below:
```
fragment_instance:7afc0c40-f52c-11f0-b5e3-005056856835, plan_node_id:17
*** Aborted at 1768823184 (unix time) try "date -d @1768823184" if you are using GNU date ***
PC: @          0x7b58c83 starrocks::BitmapValue::BitmapValue(starrocks::BitmapValue&&)
*** SIGSEGV (@0x0) received by PID 191023 (TID 0x2ad0821dd700) from PID 0; stack trace: ***
    @     0x2ad014bca20b __pthread_once_slow
    @          0xb5ba154 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2ad014bd3630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x7b58c83 starrocks::BitmapValue::BitmapValue(starrocks::BitmapValue&&)
    @          0x467caa9 starrocks::ObjectColumn<starrocks::BitmapValue>::append(starrocks::BitmapValue&&)
    @          0x5564554 starrocks::NullableAggregateFunctionBase<std::shared_ptr<starrocks::AggregateFunction>, starrocks::NullableAggregateFunctionState<starrocks::BitmapValue, true>, true, true, starrocks::AggNonNullPred<starrocks::BitmapValue> >::serialize_to_column(starrocks:@
    @          0x4b8994f starrocks::pipeline::LocalPartitionTopnContext::output_agg_result(starrocks::Chunk*, bool, bool)
    @          0x4b89ad7 starrocks::pipeline::LocalPartitionTopnContext::pull_one_chunk_from_sorters()
    @          0x4b89da1 starrocks::pipeline::LocalPartitionTopnContext::pull_one_chunk()
    @          0x4b82658 starrocks::pipeline::LocalPartitionTopnSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x4bc5f96 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x4f09261 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x3eb769f starrocks::ThreadPool::dispatch_thread()
    @          0x3ead500 starrocks::Thread::supervise_thread(void*)
    @     0x2ad014bcbea5 start_thread
```

## What I'm doing:

align local partition topn's nullable logic with first phase aggreator 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
