### PR TITLE
[Refactor] Remove get_proxy_data from BinaryColumn

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -344,7 +344,7 @@ public:
         return _german_strings;
     }
 
-    const BinaryDataProxyContainer& get_proxy_data() const { return _immuable_container; }
+    const ImmContainer immutable_data() const { return _immuable_container; }
 
     Bytes& get_bytes() {
         _ensure_materialized();

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -286,14 +286,14 @@ public:
     static MutableColumnPtr align_return_type(MutableColumnPtr&& old_col, const TypeDescriptor& type_desc,
                                               size_t num_rows, const bool is_nullable);
 
-    // Create a column with specified size, the column will be resized to size
+    // Create a column with a specified size, the column will be resized to size
     static MutableColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size,
                                           bool use_adaptive_nullable_column = false);
 
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline typename RunTimeColumnType<Type>::Ptr cast_to(const ColumnPtr& value) {
+    static inline RunTimeColumnType<Type>::Ptr cast_to(const ColumnPtr& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -305,7 +305,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline typename RunTimeColumnType<Type>::Ptr cast_to(ColumnPtr&& value) {
+    static inline RunTimeColumnType<Type>::Ptr cast_to(ColumnPtr&& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -317,7 +317,7 @@ public:
     // Cast MutableColumnPtr to special type MutableColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline typename RunTimeColumnType<Type>::MutablePtr cast_to(MutableColumnPtr&& value) {
+    static inline RunTimeColumnType<Type>::MutablePtr cast_to(MutableColumnPtr&& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -385,7 +385,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline typename Type::Ptr as_column(const ColumnPtr& value) {
+    static inline Type::Ptr as_column(const ColumnPtr& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(value);
 #else
@@ -399,7 +399,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline typename Type::Ptr as_column(ColumnPtr&& value) {
+    static inline Type::Ptr as_column(ColumnPtr&& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(std::move(value));
 #else
@@ -413,7 +413,7 @@ public:
     // Cast MutableColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline typename Type::MutablePtr as_column(MutableColumnPtr&& value) {
+    static inline Type::MutablePtr as_column(MutableColumnPtr&& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(std::move(value));
 #else
@@ -671,7 +671,7 @@ public:
 
 template <LogicalType ltype>
 struct GetContainer {
-    using ColumnType = typename RunTimeTypeTraits<ltype>::ColumnType;
+    using ColumnType = RunTimeTypeTraits<ltype>::ColumnType;
     static const auto get_data(const Column* column) {
         return ColumnHelper::as_raw_column<ColumnType>(column)->immutable_data();
     }
@@ -682,38 +682,5 @@ struct GetContainer {
         return ColumnHelper::as_raw_column<ColumnType>(column.get())->immutable_data();
     }
 };
-
-#define GET_CONTAINER(ltype)                                                                  \
-    template <>                                                                               \
-    struct GetContainer<ltype> {                                                              \
-        static const auto get_data(const Column* column) {                                    \
-            return ColumnHelper::as_raw_column<BinaryColumn>(column)->get_proxy_data();       \
-        }                                                                                     \
-        static const auto get_data(const ColumnPtr& column) {                                 \
-            return ColumnHelper::as_raw_column<BinaryColumn>(column)->get_proxy_data();       \
-        }                                                                                     \
-        static const auto get_data(const MutableColumnPtr& column) {                          \
-            return ColumnHelper::as_raw_column<BinaryColumn>(column.get())->get_proxy_data(); \
-        }                                                                                     \
-    };
-APPLY_FOR_ALL_STRING_TYPE(GET_CONTAINER)
-#undef GET_CONTAINER
-
-#define GET_CONTAINER(ltype)                                                          \
-    template <>                                                                       \
-    struct GetContainer<ltype> {                                                      \
-        using ColumnType = typename RunTimeTypeTraits<ltype>::ColumnType;             \
-        static const auto get_data(const Column* column) {                            \
-            return ColumnHelper::as_raw_column<ColumnType>(column)->get_data();       \
-        }                                                                             \
-        static const auto get_data(const ColumnPtr& column) {                         \
-            return ColumnHelper::as_raw_column<ColumnType>(column)->get_data();       \
-        }                                                                             \
-        static const auto get_data(const MutableColumnPtr& column) {                  \
-            return ColumnHelper::as_raw_column<ColumnType>(column.get())->get_data(); \
-        }                                                                             \
-    };
-// GET_CONTAINER(TYPE_JSON)
-#undef GET_CONTAINER
 
 } // namespace starrocks

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -293,7 +293,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline RunTimeColumnType<Type>::Ptr cast_to(const ColumnPtr& value) {
+    static inline typename RunTimeColumnType<Type>::Ptr cast_to(const ColumnPtr& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -305,7 +305,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline RunTimeColumnType<Type>::Ptr cast_to(ColumnPtr&& value) {
+    static inline typename RunTimeColumnType<Type>::Ptr cast_to(ColumnPtr&& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -317,7 +317,7 @@ public:
     // Cast MutableColumnPtr to special type MutableColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <LogicalType Type>
-    static inline RunTimeColumnType<Type>::MutablePtr cast_to(MutableColumnPtr&& value) {
+    static inline typename RunTimeColumnType<Type>::MutablePtr cast_to(MutableColumnPtr&& value) {
 #ifndef NDEBUG
         auto* result = dynamic_cast<const RunTimeColumnType<Type>*>(value.get());
         DCHECK(result) << "Cast failed for column: "
@@ -385,7 +385,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline Type::Ptr as_column(const ColumnPtr& value) {
+    static inline typename Type::Ptr as_column(const ColumnPtr& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(value);
 #else
@@ -413,7 +413,7 @@ public:
     // Cast MutableColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline Type::MutablePtr as_column(MutableColumnPtr&& value) {
+    static inline typename Type::MutablePtr as_column(MutableColumnPtr&& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(std::move(value));
 #else
@@ -671,7 +671,7 @@ public:
 
 template <LogicalType ltype>
 struct GetContainer {
-    using ColumnType = RunTimeTypeTraits<ltype>::ColumnType;
+    using ColumnType = typename RunTimeTypeTraits<ltype>::ColumnType;
     static const auto get_data(const Column* column) {
         return ColumnHelper::as_raw_column<ColumnType>(column)->immutable_data();
     }

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -399,7 +399,7 @@ public:
     // Cast ColumnPtr to special type ColumnPtr, ensure the input column is of the expected type,
     // otherwise it will throw an exception.
     template <typename Type>
-    static inline Type::Ptr as_column(ColumnPtr&& value) {
+    static inline typename Type::Ptr as_column(ColumnPtr&& value) {
 #ifdef NDEBUG
         return Type::static_pointer_cast(std::move(value));
 #else

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -239,7 +239,6 @@ public:
 
     const ImmContainer get_data() const { return immutable_data(); }
 
-    // TODO: remove this function
     const ImmContainer immutable_data() const {
         if (!_resource.empty()) {
             return _resource.span<T>();

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -100,17 +100,8 @@ using SliceAggTwoLevelHashMap =
                                       phmap::priv::Allocator<phmap::priv::Pair<const Slice, AggDataPtr>>, PHMAPN>;
 
 template <typename T>
-concept HasImmutableData = requires(T t) {
-    {t.immutable_data()};
-};
-
-template <typename T>
 auto get_immutable_data(T* obj) {
-    if constexpr (HasImmutableData<T>) {
-        return obj->immutable_data();
-    } else {
-        return obj->get_proxy_data();
-    }
+    return obj->immutable_data();
 }
 
 static_assert(sizeof(AggDataPtr) == sizeof(size_t));

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -191,7 +191,7 @@ public:
 
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
-        const auto& lhs_datas = column.get_proxy_data();
+        const auto lhs_datas = column.immutable_data();
         Slice rhs_data = _rhs_value.get<Slice>();
 
         if (_sort_order == 1) {
@@ -281,7 +281,7 @@ public:
 
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
-        auto& data = column.get_proxy_data();
+        auto data = column.immutable_data();
         ImmutableNullData null_data;
         if (_nullable_column != nullptr) {
             null_data = _nullable_column->immutable_data();

--- a/be/src/exec/sorting/merge_column.cpp
+++ b/be/src/exec/sorting/merge_column.cpp
@@ -179,10 +179,10 @@ public:
             auto& right_data = down_cast<const ColumnType*>(_right_col)->get_german_strings();
             return merge_ordinary_column<Container, GermanString>(left_data, right_data);
         } else {
-            using Container = typename BinaryColumnBase<SizeT>::BinaryDataProxyContainer;
-            auto& left_data = down_cast<const ColumnType*>(_left_col)->get_proxy_data();
-            auto& right_data = down_cast<const ColumnType*>(_right_col)->get_proxy_data();
-            return merge_ordinary_column<Container, Slice>(left_data, right_data);
+            using ImmContainer = BinaryColumnBase<SizeT>::ImmContainer;
+            auto left_data = down_cast<const ColumnType*>(_left_col)->immutable_data();
+            auto right_data = down_cast<const ColumnType*>(_right_col)->immutable_data();
+            return merge_ordinary_column<ImmContainer, Slice>(left_data, right_data);
         }
     }
 

--- a/be/src/exec/sorting/merge_column.cpp
+++ b/be/src/exec/sorting/merge_column.cpp
@@ -179,7 +179,7 @@ public:
             auto& right_data = down_cast<const ColumnType*>(_right_col)->get_german_strings();
             return merge_ordinary_column<Container, GermanString>(left_data, right_data);
         } else {
-            using ImmContainer = BinaryColumnBase<SizeT>::ImmContainer;
+            using ImmContainer = typename BinaryColumnBase<SizeT>::ImmContainer;
             auto left_data = down_cast<const ColumnType*>(_left_col)->immutable_data();
             auto right_data = down_cast<const ColumnType*>(_right_col)->immutable_data();
             return merge_ordinary_column<ImmContainer, Slice>(left_data, right_data);

--- a/be/src/exec/sorting/sort_column.cpp
+++ b/be/src/exec/sorting/sort_column.cpp
@@ -189,7 +189,7 @@ public:
                 return lhs.inline_value.compare(rhs.inline_value);
             };
 
-            auto inlined = create_inline_permutation<Slice, IS_RANGES>(_permutation, column.get_proxy_data());
+            auto inlined = create_inline_permutation<Slice, IS_RANGES>(_permutation, column.immutable_data());
             RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), inlined, _tie, cmp,
                                                 _range_or_ranges, _build_tie));
             restore_inline_permutation(inlined, _permutation);
@@ -301,16 +301,16 @@ public:
 
         if (_need_inline_value()) {
             using ItemType = CompactChunkItem<Slice>;
-            using Container = typename BinaryColumnBase<T>::BinaryDataProxyContainer;
+            using ImmContainer = BinaryColumnBase<T>::ImmContainer;
 
             auto cmp = [&](const ItemType& lhs, const ItemType& rhs) -> int {
                 return lhs.inline_value.compare(rhs.inline_value);
             };
 
-            std::vector<Container> containers;
+            std::vector<ImmContainer> containers;
             for (const auto& col : _vertical_columns) {
                 const auto real = down_cast<const ColumnType*>(col.get());
-                containers.push_back(real->get_proxy_data());
+                containers.push_back(real->immutable_data());
             }
 
             auto inlined = _create_inlined_permutation<Slice>(containers);

--- a/be/src/exec/sorting/sort_column.cpp
+++ b/be/src/exec/sorting/sort_column.cpp
@@ -301,7 +301,7 @@ public:
 
         if (_need_inline_value()) {
             using ItemType = CompactChunkItem<Slice>;
-            using ImmContainer = BinaryColumnBase<T>::ImmContainer;
+            using ImmContainer = typename BinaryColumnBase<T>::ImmContainer;
 
             auto cmp = [&](const ItemType& lhs, const ItemType& rhs) -> int {
                 return lhs.inline_value.compare(rhs.inline_value);

--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -320,7 +320,7 @@ public:
         this->init_state_if_needed(ctx, columns, state);
 
         const auto& column = down_cast<const BinaryColumn&>(*columns[0]);
-        const auto& column_data = column.get_proxy_data();
+        const auto column_data = column.immutable_data();
         // use mem_pool to hold the slice's data, otherwise after chunk is processed, the memory of slice used is gone
         size_t element_size = column_data[row_num].get_size();
         uint8_t* pos = ctx->mem_pool()->allocate(element_size);
@@ -408,7 +408,7 @@ public:
         double rate = ColumnHelper::get_const_value<TYPE_DOUBLE>(src[1]);
 
         const auto& src_column = *down_cast<const BinaryColumn*>(src[0].get());
-        const auto& src_data = src_column.get_proxy_data();
+        const auto src_data = src_column.immutable_data();
         for (auto i = 0; i < chunk_size; ++i) {
             size_t old_size = bytes.size();
             // [rate, 1, element ith size, element ith data]

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -147,8 +147,8 @@ public:
         result->resize_uninitialized(1);
         auto& r3 = result->get_data();
 
-        auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
-        auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
+        const auto r1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
+        const auto r2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
         r3[0] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[0], r2[0]);
 
         return result;

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -56,19 +56,15 @@ public:
         result->resize_uninitialized(v1->size());
         auto* data3 = result->get_data().data();
 
-        if constexpr (lt_is_string<LType> || lt_is_binary<LType>) {
-            auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->get_proxy_data();
-            auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->get_proxy_data();
+        if constexpr (lt_is_string<LType> || lt_is_binary<LType> || lt_is_object_family<LType> ||
+                      lt_is_object_family<RType>) {
+            const auto r1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
+            const auto r2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
             for (int i = 0; i < s; ++i) {
                 data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[i], r2[i]);
             }
-        } else if constexpr (lt_is_object_family<LType> || lt_is_object_family<RType>) {
-            const auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
-            const auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
-            for (int i = 0; i < s; ++i) {
-                data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1[i], data2[i]);
-            }
         } else {
+            // Use raw pointers for auto-vectorization to optimize performance with fixed-length values.
             auto* data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data().data();
             auto* data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data().data();
             for (int i = 0; i < s; ++i) {
@@ -91,20 +87,15 @@ public:
         result->resize_uninitialized(size);
         auto* data3 = result->get_data().data();
 
-        if constexpr (lt_is_string<LType> || lt_is_binary<LType>) {
-            auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->get_proxy_data()[0];
-            auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->get_proxy_data();
-            for (int i = 0; i < size; ++i) {
-                data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1, r2[i]);
-            }
-        } else if constexpr (lt_is_object_family<LType> || lt_is_object_family<RType>) {
-            const auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data()[0];
+        const auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data()[0];
+        if constexpr (lt_is_string<LType> || lt_is_binary<LType> || lt_is_object_family<LType> ||
+                      lt_is_object_family<RType>) {
             const auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
             for (int i = 0; i < size; ++i) {
                 data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1, data2[i]);
             }
         } else {
-            const auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data()[0];
+            // Use raw pointers for auto-vectorization to optimize performance with fixed-length values.
             const auto* data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data().data();
             for (int i = 0; i < size; ++i) {
                 data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1, data2[i]);
@@ -127,21 +118,16 @@ public:
         auto& r3 = result->get_data();
         auto* data3 = r3.data();
 
-        if constexpr (lt_is_string<LType> || lt_is_binary<LType>) {
-            auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->get_proxy_data();
-            auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->get_proxy_data()[0];
-            for (int i = 0; i < size; ++i) {
-                data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[i], data2);
-            }
-        } else if constexpr (lt_is_object_family<LType> || lt_is_object_family<RType>) {
+        auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data()[0];
+        if constexpr (lt_is_string<LType> || lt_is_binary<LType> || lt_is_object_family<LType> ||
+                      lt_is_object_family<RType>) {
             const auto data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
-            const auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data()[0];
             for (int i = 0; i < size; ++i) {
                 data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1[i], data2);
             }
         } else {
+            // Use raw pointers for auto-vectorization to optimize performance with fixed-length values.
             const auto* data1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data().data();
-            auto data2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data()[0];
             for (int i = 0; i < size; ++i) {
                 data3[i] = OP::template apply<LCppType, RCppType, ResultCppType>(data1[i], data2);
             }
@@ -161,15 +147,9 @@ public:
         result->resize_uninitialized(1);
         auto& r3 = result->get_data();
 
-        if constexpr (lt_is_string<LType> || lt_is_binary<LType>) {
-            auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->get_proxy_data();
-            auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->get_proxy_data();
-            r3[0] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[0], r2[0]);
-        } else {
-            auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
-            auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
-            r3[0] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[0], r2[0]);
-        }
+        auto& r1 = ColumnHelper::cast_to_raw<LType>(v1)->immutable_data();
+        auto& r2 = ColumnHelper::cast_to_raw<RType>(v2)->immutable_data();
+        r3[0] = OP::template apply<LCppType, RCppType, ResultCppType>(r1[0], r2[0]);
 
         return result;
     }

--- a/be/src/exprs/binary_functions.cpp
+++ b/be/src/exprs/binary_functions.cpp
@@ -126,7 +126,7 @@ StatusOr<ColumnPtr> BinaryFunctions::iceberg_truncate_binary(FunctionContext* co
     uint8_t* raw_null_flags = null_flags->get_data().data();
     auto col = ColumnHelper::cast_to_raw<TYPE_BINARY>(c0);
     ColumnBuilder<TYPE_BINARY> result(size);
-    auto& raw_c0 = col->get_proxy_data();
+    const auto raw_c0 = col->immutable_data();
 
 #define SLICE_SIZE_MIN(x, y) x < y ? x : y
     for (auto i = 0; i < size; i++) {

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -486,7 +486,7 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_string(FunctionContext* contex
     auto col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(c0);
     MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
     res->resize_uninitialized(size);
-    auto raw_c0 = col->get_proxy_data();
+    auto raw_c0 = col->immutable_data();
     // result column is mutable, use non-const raw pointer
     RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
             ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -347,7 +347,7 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
             const auto* nullable_column = down_cast<const NullableColumn*>(column.get());
             const auto* data_column = down_cast<const StarRocksColumnType*>(nullable_column->data_column().get());
             if constexpr (lt_is_string<LT> || lt_is_binary<LT>) {
-                const auto data = data_column->get_proxy_data();
+                const auto data = data_column->immutable_data();
                 for (auto i = start_idx; i < end_idx; ++i) {
                     if (nullable_column->is_null(i)) {
                         ARROW_RETURN_NOT_OK(builder->AppendNull());
@@ -378,13 +378,12 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
             }
         } else {
             const auto* data_column = down_cast<const StarRocksColumnType*>(column.get());
+            const auto data = data_column->immutable_data();
             if constexpr (lt_is_string<LT> || lt_is_binary<LT>) {
-                const auto data = data_column->get_proxy_data();
                 for (auto i = start_idx; i < end_idx; ++i) {
                     ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], -1, -1)));
                 }
             } else {
-                const auto data = data_column->immutable_data();
                 [[maybe_unused]] int precision = -1;
                 [[maybe_unused]] int scale = -1;
                 if constexpr (lt_is_decimal<LT>) {

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -4176,12 +4176,9 @@ TEST_F(TabletParallelCompactionManagerLargeRowsetTest, test_dup_keys_mixed_large
 
     // Check that we have both LARGE_ROWSET_PART and NORMAL subtasks
     bool has_large = false;
-    bool has_normal = false;
     for (const auto& [id, info] : state->running_subtasks) {
         if (info.type == SubtaskType::LARGE_ROWSET_PART) {
             has_large = true;
-        } else {
-            has_normal = true;
         }
     }
     EXPECT_TRUE(has_large) << "Should have LARGE_ROWSET_PART subtasks for the large rowset";


### PR DESCRIPTION
## Why I'm doing:

This is the first step for https://github.com/StarRocks/starrocks/issues/69589: remove get_proxy_data, and all columns use immutable_data() instead to retrieve only view data.

## What I'm doing:

Remove get_proxy_data from BinaryColumn

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
