### PR TITLE
[BugFix] Fix use-after-free crash in AsyncDeltaWriter::close

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -346,20 +346,23 @@ inline void AsyncDeltaWriterImpl::close() {
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
-        // Wait for block merge finished.
-        if (_block_merge_token != nullptr) {
-            _block_merge_token->shutdown();
-            _block_merge_token.reset();
-        }
-
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.
         int r = bthread::execution_queue_stop(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to stop execution queue";
 
         // Wait for all running tasks completed.
+        // Must join execution queue BEFORE destroying _block_merge_token, because a running
+        // execute() task may still submit to _block_merge_token in kFinishTask handler.
         r = bthread::execution_queue_join(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to join execution queue";
+
+        // Wait for block merge finished. Safe to destroy now since the execution queue has
+        // been joined and no new merge tasks can be submitted.
+        if (_block_merge_token != nullptr) {
+            _block_merge_token->shutdown();
+            _block_merge_token.reset();
+        }
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

When disk becomes full ("No space left on device"), BE crashes with SIGSEGV in `ThreadPoolToken::submit()` called from `AsyncDeltaWriterImpl::execute()`. The crash is caused by a race condition between `execute()` and `close()` — `_block_merge_token` is destroyed before the execution queue is joined, so an in-flight `execute()` task dereferences a null pointer.

**Crash stack:**
```
SIGSEGV (@0x8) received
@ starrocks::ThreadPoolToken::submit(...)
@ starrocks::lake::AsyncDeltaWriterImpl::execute(...)
@ bthread::ExecutionQueueBase::_execute(...)
```

## What I'm doing:

Move `_block_merge_token` shutdown/reset to **after** `execution_queue_join()` in `AsyncDeltaWriterImpl::close()`. This ensures all in-flight `execute()` tasks complete before the token is destroyed.

**Before (buggy order):**
1. `_block_merge_token->shutdown()` + `reset()` ← token destroyed while execute() may still use it
2. `execution_queue_stop()`
3. `execution_queue_join()`

**After (fixed order):**
1. `execution_queue_stop()`
2. `execution_queue_join()` ← all in-flight execute() tasks finish first
3. `_block_merge_token->shutdown()` + `reset()` ← safe to destroy

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport PR

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the PR will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
