### PR TITLE
[BugFix] Fix use-after-free crash in AsyncDeltaWriter::close

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -352,20 +352,28 @@ inline void AsyncDeltaWriterImpl::close() {
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
-        // Wait for block merge finished.
-        if (_block_merge_token != nullptr) {
-            _block_merge_token->shutdown();
-            _block_merge_token.reset();
-        }
-
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.
         int r = bthread::execution_queue_stop(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to stop execution queue";
 
+        // Shutdown (but do NOT reset) _block_merge_token to drain any running merge tasks.
+        // This must happen BEFORE execution_queue_join() because the join triggers the
+        // is_queue_stopped() handler which calls delta_writer->close(), and we need all
+        // merge tasks (which call finish_with_txnlog()) to complete before that.
+        // The token remains allocated (not null) so if execute() is still running and
+        // calls _block_merge_token->submit(), it gets a ServiceUnavailable error instead
+        // of SIGSEGV.
+        if (_block_merge_token != nullptr) {
+            _block_merge_token->shutdown();
+        }
+
         // Wait for all running tasks completed.
         r = bthread::execution_queue_join(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to join execution queue";
+
+        // Safe to destroy token now since both execution queue and merge tasks are done.
+        _block_merge_token.reset();
     }
 }
 

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -764,6 +764,63 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger_running_while_close) {
     delta_writer->close();
 }
 
+// Regression test: close() used to destroy _block_merge_token before joining the execution
+// queue, causing SIGSEGV when execute() called _block_merge_token->submit() for a finish
+// task with spill blocks.
+TEST_F(LakeAsyncDeltaWriterTest, test_close_race_with_finish_submit_merge_task) {
+    static const int kChunkSize = 128;
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    StorageEngine::instance()->load_spill_block_merge_executor()->refresh_max_thread_num();
+    CountDownLatch latch(10);
+    // flush multiple times to generate spill blocks
+    int64_t old_val = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .set_immutable_tablet_size(10000000)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    for (int i = 0; i < 10; i++) {
+        delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& st) { ASSERT_OK(st); });
+        delta_writer->flush([&](const Status& st) {
+            ASSERT_OK(st);
+            latch.count_down();
+        });
+    }
+    latch.wait();
+    config::write_buffer_size = old_val;
+
+    // Ensure close() starts right when execute() begins processing the finish task.
+    // This maximizes the window for close() to race with execute()'s _block_merge_token->submit().
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->LoadDependency({{"AsyncDeltaWriterImpl::execute:1", "AsyncDeltaWriterImpl::close:1"}});
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Submit finish task (non-blocking). execute() will call _block_merge_token->submit()
+    // because there are spill blocks.
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {});
+
+    // Close concurrently. Before the fix, close() could destroy _block_merge_token while
+    // execute() was about to call _block_merge_token->submit(), causing SIGSEGV.
+    delta_writer->close();
+}
+
 TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
     do_block_merger(true);
 }


### PR DESCRIPTION
## Why I'm doing:

When disk becomes full ("No space left on device"), BE crashes with SIGSEGV in `ThreadPoolToken::submit()` called from `AsyncDeltaWriterImpl::execute()`. The crash is caused by a race condition in `AsyncDeltaWriterImpl::close()` — `_block_merge_token` was reset to null before the execution queue was joined, so an in-flight `execute()` task dereferences a null pointer when calling `_block_merge_token->submit()`.

**Crash stack:**
```
SIGSEGV (@0x8) received
@ starrocks::ThreadPoolToken::submit(...)
@ starrocks::lake::AsyncDeltaWriterImpl::execute(...)
@ bthread::ExecutionQueueBase::_execute(...)
```

## What I'm doing:

Reorder the cleanup sequence in `AsyncDeltaWriterImpl::close()` to fix the race condition.

**Before (buggy order):**
1. `_block_merge_token->shutdown()` + `reset()` ← token destroyed while execute() may still access it
2. `execution_queue_stop()`
3. `execution_queue_join()`

**After (fixed order):**
1. `execution_queue_stop()` ← stop accepting new tasks
2. `_block_merge_token->shutdown()` ← drain running merge tasks (token stays allocated, not null). If execute() calls `submit()` on a shutdown token, it returns `ServiceUnavailable` error which is handled gracefully (line 232-235). Also ensures merge tasks (`finish_with_txnlog()`) complete before `execution_queue_join()` triggers the `is_queue_stopped()` handler which calls `delta_writer->close()`.
3. `execution_queue_join()` ← wait for all execute() tasks and `is_queue_stopped()` handler to finish
4. `_block_merge_token.reset()` ← safe to destroy, everything is done

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4