### PR TITLE
[BugFix] Fix expression analyze fail after rename partition column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -93,7 +93,7 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
         this.partitionExprs = partitionExprs;
     }
 
-    public void updateSlotRef(Map<String, Column> nameToColumn) {
+    public void updateSlotRef(Map<ColumnId, Column> idToColumn) {
         for (ColumnIdExpr columnIdExpr : partitionExprs) {
             Expr expr = columnIdExpr.getExpr();
             SlotRef slotRef = getPartitionExprSlotRef(expr);
@@ -101,13 +101,13 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
                 LOG.warn("Unknown expr type: {}", ExprToSql.toSql(expr));
                 continue;
             }
-            // FIXME: use the slot ref's column name to find the partition column which maybe not the same as the slot ref's
-            //  column name.
-            String slotRefName = slotRef.getColumnName();
-            if (!nameToColumn.containsKey(slotRefName)) {
+            // column name is the original column name before rename.
+            ColumnId columnId = slotRef.getColumnId() != null
+                    ? slotRef.getColumnId() : ColumnId.create(slotRef.getColumnName());
+            if (!idToColumn.containsKey(columnId)) {
                 continue;
             }
-            Column partitionColumn = nameToColumn.get(slotRefName);
+            Column partitionColumn = idToColumn.get(columnId);
             // analyze partition expression
             analyzePartitionExpressionExpr(slotRef, partitionColumn, expr);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1725,7 +1725,7 @@ public class OlapTable extends Table {
         }
 
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
-            ((ExpressionRangePartitionInfo) partitionInfo).updateSlotRef(nameToColumn);
+            ((ExpressionRangePartitionInfo) partitionInfo).updateSlotRef(idToColumn);
         } else if (partitionInfo instanceof ListPartitionInfo) {
             ((ListPartitionInfo) partitionInfo).updateLiteralExprValues(idToColumn);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -22,6 +22,7 @@ import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
@@ -532,6 +533,96 @@ public class ExpressionRangePartitionInfoTest {
         Function fn = ((FunctionCallExpr) readPartitionExprs.get(0)).getFn();
         Assertions.assertNotNull(fn);
         starRocksAssert.dropTable("table_hitcount");
+    }
+
+    @Test
+    public void testUpdateSlotRefAfterColumnRename() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test_rename_partition_col (\n" +
+                "k1 varchar(200) NULL,\n" +
+                "dt date NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_rename_partition_col");
+
+        // Rename the partition column: dt -> event_date
+        table.renameColumn("dt", "event_date");
+
+        // Serialize and deserialize to trigger gsonPostProcess -> updateSlotRef
+        String json = GsonUtils.GSON.toJson(table);
+        OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+
+        // After deserialization, the partition expression should still be properly analyzed
+        // even though the column has been renamed.
+        ExpressionRangePartitionInfo partInfo =
+                (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
+        List<Expr> exprs = partInfo.getPartitionExprs(readTable.getIdToColumn());
+        Assertions.assertTrue(exprs.get(0) instanceof FunctionCallExpr);
+        FunctionCallExpr fn = (FunctionCallExpr) exprs.get(0);
+        // The function should have been resolved by analyzePartitionExpr
+        Assertions.assertNotNull(fn.getFn(),
+                "Partition expression should be analyzed after column rename");
+        // The slot ref column name should be updated to the new name
+        SlotRef slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(fn);
+        Assertions.assertNotNull(slotRef);
+        Assertions.assertEquals("event_date", slotRef.getColumnName());
+
+        starRocksAssert.dropTable("test_rename_partition_col");
+    }
+
+    @Test
+    public void testUpdateSlotRefAfterColumnRenameSlotRefPartition() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test_rename_slotref_base (\n" +
+                "k1 varchar(200) NULL,\n" +
+                "dt date NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+
+        starRocksAssert.withMaterializedView("create materialized view test_mv_rename_slotref " +
+                " DISTRIBUTED BY HASH(dt) BUCKETS 1\n" +
+                " PARTITION BY dt\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")\n" +
+                " as select dt, k1 from test_rename_slotref_base");
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_mv_rename_slotref");
+
+        // Rename the partition column: dt -> event_date
+        table.renameColumn("dt", "event_date");
+
+        // Serialize and deserialize
+        String json = GsonUtils.GSON.toJson(table);
+        OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+
+        ExpressionRangePartitionInfo partInfo =
+                (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
+        List<Expr> exprs = partInfo.getPartitionExprs(readTable.getIdToColumn());
+        Assertions.assertTrue(exprs.get(0) instanceof SlotRef);
+        SlotRef slotRef = (SlotRef) exprs.get(0);
+        // The type should have been set correctly (not INVALID)
+        Assertions.assertFalse(slotRef.getType().isInvalid(),
+                "SlotRef type should be resolved after column rename");
+        Assertions.assertTrue(slotRef.getType().isDateType());
+        // The column name should be updated to the new name
+        Assertions.assertEquals("event_date", slotRef.getColumnName());
+
+        starRocksAssert.dropMaterializedView("test_mv_rename_slotref");
+        starRocksAssert.dropTable("test_rename_slotref_base");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
After renaming partition column with date_trunc，the partition expression maybe unanalyzed after FE restart and make the load fail. Because the partition expression still use old column name but not the new one.

## What I'm doing:
Use ColumnId instead

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
