### PR TITLE
[BugFix] Fix incorrect LIKE pattern matching with backslash escape sequences

### DIFF
--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -38,10 +38,10 @@ static const RE2 STARTS_WITH_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)(?:\.\*)*
 // A regex to match any regex pattern which is equivalent to a constant string match.
 static const RE2 EQUALS_RE(R"(\^([^\.\^\{\[\(\|\)\]\}\+\*\?\$\\]*)\$)", re2::RE2::Quiet);
 
-static const re2::RE2 LIKE_SUBSTRING_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
-static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
-static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|([^%_]))+)(?:%+))", re2::RE2::Quiet);
-static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|([^%_]))+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_SUBSTRING_RE(R"((?:%+)(((\\%)|(\\_)|(\\\\)|([^%_\\]))+)(?:%+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_ENDS_WITH_RE(R"((?:%+)(((\\%)|(\\_)|(\\\\)|([^%_\\]))+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|(\\\\)|([^%_\\]))+)(?:%+))", re2::RE2::Quiet);
+static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|(\\\\)|([^%_\\]))+))", re2::RE2::Quiet);
 static const char* PROMPT_INFO = " so we switch to use re2.";
 
 bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
@@ -458,26 +458,38 @@ enum class FastPathType {
 };
 
 FastPathType extract_fast_path(const Slice& pattern) {
-    if (pattern.empty() || pattern.size < 2) {
+    if (pattern.empty()) {
         return FastPathType::REGEX;
     }
 
-    if (pattern.data[0] == '_' || pattern.data[pattern.size - 1] == '_') {
-        return FastPathType::REGEX;
-    }
+    bool is_end_with = (pattern.data[0] == '%');
+    bool is_start_with = false;
+    size_t start = is_end_with ? 1 : 0;
 
-    bool is_end_with = pattern.data[0] == '%';
-    bool is_start_with = pattern.data[pattern.size - 1] == '%';
-
-    for (size_t i = 1; i < pattern.size - 1;) {
-        if (pattern.data[i] == '\\') {
+    for (size_t i = start; i < pattern.size;) {
+        if (pattern.data[i] == '\\' && i + 1 < pattern.size) {
             i += 2;
-        } else {
-            if (pattern.data[i] == '%' || pattern.data[i] == '_') {
+        } else if (pattern.data[i] == '%') {
+            if (i == pattern.size - 1) {
+                is_start_with = true;
+            } else {
                 return FastPathType::REGEX;
             }
             i++;
+        } else if (pattern.data[i] == '_') {
+            return FastPathType::REGEX;
+        } else {
+            i++;
         }
+    }
+
+    size_t content_start = is_end_with ? 1 : 0;
+    size_t content_end = is_start_with ? pattern.size - 1 : pattern.size;
+    if (content_start >= content_end) {
+        if (is_end_with && is_start_with) {
+            return FastPathType::SUBSTRING;
+        }
+        return FastPathType::REGEX;
     }
 
     if (is_end_with && is_start_with) {
@@ -673,8 +685,7 @@ void LikePredicate::remove_escape_character(std::string* search_string) {
     tmp_search_string.swap(*search_string);
     int len = tmp_search_string.length();
     for (int i = 0; i < len;) {
-        if (tmp_search_string[i] == '\\' && i + 1 < len &&
-            (tmp_search_string[i + 1] == '%' || tmp_search_string[i + 1] == '_')) {
+        if (tmp_search_string[i] == '\\' && i + 1 < len) {
             search_string->append(1, tmp_search_string[i + 1]);
             i += 2;
         } else {

--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -660,6 +660,226 @@ TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
                         .ok());
 }
 
+TEST_F(LikeTest, backslashEscapeConstSubstring) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    // pattern: %\\%  => LIKE substring match for literal backslash
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("%\\\\%", 1);
+
+    str->append("abc\\def");
+    str->append("abcdef");
+    str->append("star\\");
+    str->append("\\start");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);  // abc\def matches %\\%
+    ASSERT_FALSE(v->get_data()[1]); // abcdef does not match
+    ASSERT_TRUE(v->get_data()[2]);  // star\ matches
+    ASSERT_TRUE(v->get_data()[3]);  // \start matches
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, backslashEscapeConstEndsWith) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    // pattern: %\\asdf  => LIKE ends-with match for literal "\asdf"
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("%\\\\asdf", 1);
+
+    str->append("test\\asdf");
+    str->append("\\asdf");
+    str->append("testasdf");
+    str->append("test\\asdx");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);
+    ASSERT_TRUE(v->get_data()[1]);
+    ASSERT_FALSE(v->get_data()[2]);
+    ASSERT_FALSE(v->get_data()[3]);
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, backslashEscapeConstStartsWith) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    // pattern: star\\%  => LIKE starts-with match for literal "star\"
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("star\\\\%", 1);
+
+    str->append("star\\test");
+    str->append("star\\");
+    str->append("startest");
+    str->append("xstar\\");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);
+    ASSERT_TRUE(v->get_data()[1]);
+    ASSERT_FALSE(v->get_data()[2]);
+    ASSERT_FALSE(v->get_data()[3]);
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, backslashEscapeConstEquals) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    // pattern: star\\  => LIKE equals match for literal "star\"
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("star\\\\", 1);
+
+    str->append("star\\");
+    str->append("star\\\\");
+    str->append("star");
+    str->append("star\\x");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);
+    ASSERT_FALSE(v->get_data()[1]);
+    ASSERT_FALSE(v->get_data()[2]);
+    ASSERT_FALSE(v->get_data()[3]);
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, backslashEscapeConstEqualsEscapedPercent) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    // pattern: star\%  => LIKE equals match for literal "star%"
+    auto pattern = ColumnHelper::create_const_column<TYPE_VARCHAR>("star\\%", 1);
+
+    str->append("star%");
+    str->append("starrocks");
+    str->append("star\\%");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pattern));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);
+    ASSERT_FALSE(v->get_data()[1]);
+    ASSERT_FALSE(v->get_data()[2]);
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
+TEST_F(LikeTest, backslashEscapeRowPattern) {
+    auto context = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx(context);
+    Columns columns;
+
+    auto str = BinaryColumn::create();
+    auto pat = BinaryColumn::create();
+
+    // row 0: "abc\def" LIKE "%\\%" -> true (substring backslash)
+    str->append("abc\\def");
+    pat->append("%\\\\%");
+
+    // row 1: "star\" LIKE "star\\" -> true (equals backslash)
+    str->append("star\\");
+    pat->append("star\\\\");
+
+    // row 2: "star%" LIKE "star\%" -> true (equals literal %)
+    str->append("star%");
+    pat->append("star\\%");
+
+    // row 3: "test\asdf" LIKE "%\\asdf" -> true (ends-with)
+    str->append("test\\asdf");
+    pat->append("%\\\\asdf");
+
+    // row 4: "starrocks" LIKE "star%" -> true (starts-with)
+    str->append("starrocks");
+    pat->append("star%");
+
+    // row 5: "abcdef" LIKE "%\\%" -> false (no backslash)
+    str->append("abcdef");
+    pat->append("%\\\\%");
+
+    // row 6: "ab" LIKE "a\b" -> true (non-wildcard escape: \b unescapes to b)
+    str->append("ab");
+    pat->append("a\\b");
+
+    // row 7: "a\\b" LIKE "a\b" -> false (\b means literal b, not backslash+b)
+    str->append("a\\b");
+    pat->append("a\\b");
+
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pat));
+
+    context->set_constant_columns(columns);
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = LikePredicate::like_fn(context, columns).value();
+    auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
+
+    ASSERT_TRUE(v->get_data()[0]);
+    ASSERT_TRUE(v->get_data()[1]);
+    ASSERT_TRUE(v->get_data()[2]);
+    ASSERT_TRUE(v->get_data()[3]);
+    ASSERT_TRUE(v->get_data()[4]);
+    ASSERT_FALSE(v->get_data()[5]);
+    ASSERT_TRUE(v->get_data()[6]);  // "ab" matches "a\b"
+    ASSERT_FALSE(v->get_data()[7]); // "a\b" does not match "a\b" pattern
+
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                        .ok());
+}
+
 TEST_F(LikeTest, splitLikePatternIntoNgramSet) {
     // pattern contains special characters
     std::string pattern = "abc%_abccc\\%e\\\\\\\\";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -430,9 +430,9 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return predicate;
         }
 
-        // make sure it didn't contain '%' and '_' both
+        // make sure it didn't contain '%', '_', or '\' (LIKE escape character)
         String likeString =  ((ConstantOperator) predicate.getChild(1)).getVarchar();
-        if (likeString.contains("%") || likeString.contains("_")) {
+        if (likeString.contains("%") || likeString.contains("_") || likeString.contains("\\")) {
             return predicate;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
@@ -203,7 +203,7 @@ public class SelectStmtWithMultiLikeTest {
                 {"region like '\\\\b%' or region like '\\\\d%' or region like '\\\\S+'",
                         "region LIKE '\\\\b%'",
                         "region LIKE '\\\\d%'",
-                        "region = '\\\\S+'"
+                        "region LIKE '\\\\S+'"
                 }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleTest.java
@@ -120,6 +120,18 @@ public class SimplifiedPredicateRuleTest extends PlanTestBase {
                 ConstantOperator.createBoolean(false));
         result = rule.apply(operator, null);
         assertEquals(OperatorType.LIKE, result.getOpType());
+
+        // pattern with backslash escape should NOT be simplified to EQ,
+        // because LIKE treats '\\' as an escaped literal '\', while EQ treats it as two backslashes
+        operator = new LikePredicateOperator(new ColumnRefOperator(1, VarcharType.VARCHAR, "name", true),
+                ConstantOperator.createVarchar("star\\\\"));
+        result = rule.apply(operator, null);
+        assertEquals(OperatorType.LIKE, result.getOpType());
+
+        operator = new LikePredicateOperator(new ColumnRefOperator(1, VarcharType.VARCHAR, "name", true),
+                ConstantOperator.createVarchar("abc\\\\def"));
+        result = rule.apply(operator, null);
+        assertEquals(OperatorType.LIKE, result.getOpType());
     }
 
     @Test

--- a/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
+++ b/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
@@ -1,0 +1,76 @@
+-- name: test_like_escape_backslash
+-- result:
+DROP TABLE IF EXISTS t_like_escape;
+-- result:
+CREATE TABLE IF NOT EXISTS t_like_escape (
+    c0 INT NOT NULL,
+    c1 VARCHAR(200) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+INSERT INTO t_like_escape (c0, c1) VALUES
+(1, 'abc'),
+(2, 'abc\\def'),
+(3, 'star\\'),
+(4, 'star%'),
+(5, 'starrocks'),
+(6, '\\asdf'),
+(7, 'test\\asdf'),
+(8, 'star\\test'),
+(9, 'abc_def');
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
+-- result:
+2	abc\def
+3	star\
+6	\asdf
+7	test\asdf
+8	star\test
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\asdf' ORDER BY c0;
+-- result:
+6	\asdf
+7	test\asdf
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\%' ORDER BY c0;
+-- result:
+3	star\
+8	star\test
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\' ORDER BY c0;
+-- result:
+3	star\
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\%' ORDER BY c0;
+-- result:
+4	star%
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
+-- result:
+2	abc\def
+3	star\
+6	\asdf
+7	test\asdf
+8	star\test
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE like(c1, 'star\\\\') ORDER BY c0;
+-- result:
+3	star\
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER BY c0;
+-- result:
+2	abc\def
+3	star\
+4	star%
+5	starrocks
+6	\asdf
+7	test\asdf
+8	star\test
+-- result:
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'abc\\_def' ORDER BY c0;
+-- result:
+9	abc_def
+-- result:
+DROP TABLE t_like_escape;

--- a/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
+++ b/test/sql/test_like_escape_backslash/R/test_like_escape_backslash
@@ -1,7 +1,8 @@
 -- name: test_like_escape_backslash
--- result:
 DROP TABLE IF EXISTS t_like_escape;
 -- result:
+-- !result
+
 CREATE TABLE IF NOT EXISTS t_like_escape (
     c0 INT NOT NULL,
     c1 VARCHAR(200) NOT NULL
@@ -10,6 +11,8 @@ DUPLICATE KEY(c0)
 DISTRIBUTED BY HASH(c0) BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 -- result:
+-- !result
+
 INSERT INTO t_like_escape (c0, c1) VALUES
 (1, 'abc'),
 (2, 'abc\\def'),
@@ -21,6 +24,8 @@ INSERT INTO t_like_escape (c0, c1) VALUES
 (8, 'star\\test'),
 (9, 'abc_def');
 -- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
 -- result:
 2	abc\def
@@ -28,25 +33,30 @@ SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
 6	\asdf
 7	test\asdf
 8	star\test
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\asdf' ORDER BY c0;
 -- result:
 6	\asdf
 7	test\asdf
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\%' ORDER BY c0;
 -- result:
 3	star\
 8	star\test
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\' ORDER BY c0;
 -- result:
 3	star\
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\%' ORDER BY c0;
 -- result:
 4	star%
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
 -- result:
 2	abc\def
@@ -54,11 +64,13 @@ SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
 6	\asdf
 7	test\asdf
 8	star\test
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE like(c1, 'star\\\\') ORDER BY c0;
 -- result:
 3	star\
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER BY c0;
 -- result:
 2	abc\def
@@ -68,9 +80,13 @@ SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER
 6	\asdf
 7	test\asdf
 8	star\test
--- result:
+-- !result
+
 SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'abc\\_def' ORDER BY c0;
 -- result:
 9	abc_def
--- result:
+-- !result
+
 DROP TABLE t_like_escape;
+-- result:
+-- !result

--- a/test/sql/test_like_escape_backslash/T/test_like_escape_backslash
+++ b/test/sql/test_like_escape_backslash/T/test_like_escape_backslash
@@ -1,0 +1,51 @@
+-- name: test_like_escape_backslash
+
+DROP TABLE IF EXISTS t_like_escape;
+
+CREATE TABLE IF NOT EXISTS t_like_escape (
+    c0 INT NOT NULL,
+    c1 VARCHAR(200) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_like_escape (c0, c1) VALUES
+(1, 'abc'),
+(2, 'abc\\def'),
+(3, 'star\\'),
+(4, 'star%'),
+(5, 'starrocks'),
+(6, '\\asdf'),
+(7, 'test\\asdf'),
+(8, 'star\\test'),
+(9, 'abc_def');
+
+-- Test 1: substring match for literal backslash  (%\\%)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' ORDER BY c0;
+
+-- Test 2: ends-with match for literal "\asdf"  (%\\asdf)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\asdf' ORDER BY c0;
+
+-- Test 3: starts-with match for literal "star\"  (star\\%)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\%' ORDER BY c0;
+
+-- Test 4: equals match for literal "star\"  (star\\)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\\\' ORDER BY c0;
+
+-- Test 5: equals match for literal "star%"  (star\%)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'star\\%' ORDER BY c0;
+
+-- Test 6: using like() function form - substring backslash
+SELECT c0, c1 FROM t_like_escape WHERE like(c1, '%\\\\%') ORDER BY c0;
+
+-- Test 7: using like() function form - equals backslash
+SELECT c0, c1 FROM t_like_escape WHERE like(c1, 'star\\\\') ORDER BY c0;
+
+-- Test 8: combined - rows containing backslash OR starting with "star"
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE '%\\\\%' OR c1 LIKE 'star%' ORDER BY c0;
+
+-- Test 9: equals match for literal "abc_def"  (abc\_def)
+SELECT c0, c1 FROM t_like_escape WHERE c1 LIKE 'abc\\_def' ORDER BY c0;
+
+DROP TABLE t_like_escape;


### PR DESCRIPTION
## Why I'm doing:

The `LIKE` predicate produces incorrect results when the pattern contains backslash escape sequences (e.g., `\\` for a literal `\`, `\%` for a literal `%`).

**Reproduction:**
```
-- Table data: row (3, 'star\')

-- Expected: return row 3, because pattern 'star\\' means "equals star\"
-- Actual: returns empty
SELECT c0, c1 FROM t WHERE c1 LIKE 'star\\';

-- Expected: return 1 (true), because 'abc\def' contains a literal backslash
-- Actual: returns 0
SELECT like('abc\def', '%\\%');
```
There are three root causes:
### Bug 1: FE SimplifiedPredicateRule incorrectly rewrites LIKE to EQ
`SimplifiedPredicateRule.visitLikePredicateOperator` checks whether the pattern contains `% `or `_ `to decide if it can be simplified to an equality `(=)`. However, it does not check for `\` (the LIKE escape character).
When the pattern is star\\ (two backslashes after FE string literal escaping):
In LIKE semantics: `star\\` means "match the literal string `star\"` (one backslash)
In EQ semantics: `star\\` is compared as-is (two backslashes)
The optimizer rewrites `c1 LIKE 'star\\' → c1 = 'star\\'`, changing the semantics and causing the query to return no results.
### Bug 2: BE remove_escape_character does not handle \\ → \
The function only unescapes `\% → % and \_ → _,` but misses` \\ → \`. When a fast-path match `(EQUALS, STARTS_WITH, ENDS_WITH, SUBSTRING) `is used, the search string retains the double backslash, causing the comparison to fail.
### Bug 3: BE fast-path regex definitions match \ as a regular character
The regex patterns `LIKE_SUBSTRING_RE, LIKE_ENDS_WITH_RE, LIKE_STARTS_WITH_RE`, and `LIKE_EQUALS_RE` use `[^%_]` to match non-wildcard characters. This incorrectly allows a bare \ to be matched as a regular character instead of being recognized as the start of an escape sequence. Additionally, extract_fast_path does not properly handle escaped characters at pattern boundaries.

## What I'm doing:
### FE fix
Add `likeString.contains("\\")` check in SimplifiedPredicateRule. If the pattern contains any backslash, preserve the LIKE predicate instead of rewriting to EQ, because backslash escape sequences alter the matching semantics.
### BE fixes
remove_escape_character: Add `tmp_search_string[i + 1] == '\\'` to the condition so that `\\ `is correctly unescaped to `\`  in the search string used for fast-path matching.
Fast-path regexes: Add `(\\\\) `as an explicit alternative and change `[^%_] `to `[^%_\\]` to prevent bare backslashes from being silently consumed as regular characters.
extract_fast_path: Rewrite the logic to correctly track escape state when scanning the pattern, ensuring that escaped characters at boundaries (e.g., `star\\ `where the last `\` is escaped, not a trailing wildcard) are handled properly.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
