### PR TITLE
[BugFix] Hash external table UUID when it exceeds primary key size limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -110,7 +110,8 @@ public class DeltaLakeTable extends Table {
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
-            return String.join(".", catalogName, dbName, tableName, Long.toString(createTime));
+            String fullUUID = String.join(".", catalogName, dbName, tableName, Long.toString(createTime));
+            return hashUUIDIfTooLong(fullUUID);
         } else {
             return Long.toString(id);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -194,7 +194,8 @@ public class HiveTable extends Table {
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
-            return String.join(".", catalogName, hiveDbName, hiveTableName, Long.toString(createTime));
+            String fullUUID = String.join(".", catalogName, hiveDbName, hiveTableName, Long.toString(createTime));
+            return hashUUIDIfTooLong(fullUUID);
         } else {
             return Long.toString(id);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -163,7 +163,8 @@ public class HudiTable extends Table {
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
-            return String.join(".", catalogName, hiveDbName, hiveTableName, Long.toString(createTime));
+            String fullUUID = String.join(".", catalogName, hiveDbName, hiveTableName, Long.toString(createTime));
+            return hashUUIDIfTooLong(fullUUID);
         } else {
             return Long.toString(id);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -169,8 +169,9 @@ public class IcebergTable extends Table {
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
             String uuid = ((BaseTable) getNativeTable()).operations().current().uuid();
-            return String.join(".", catalogName, catalogDBName, catalogTableName,
+            String fullUUID = String.join(".", catalogName, catalogDBName, catalogTableName,
                     uuid == null ? "" : uuid);
+            return hashUUIDIfTooLong(fullUUID);
         } else {
             return Long.toString(id);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -65,6 +65,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -254,6 +257,38 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
      */
     public String getUUID() {
         return Long.toString(id);
+    }
+
+    /**
+     * Hash the UUID string using MD5 if it exceeds the maximum length.
+     * This prevents "primary key size exceed the limit" errors when storing
+     * table UUIDs in statistics tables (e.g. external_column_statistics),
+     * where the UUID is part of the primary key and the total PK size is
+     * bounded by the BE config `primary_key_limit_size` (default 128 bytes).
+     *
+     * Connector tables construct their UUID as "{catalog}.{db}.{table}.{extra}",
+     * which can easily exceed 128 bytes when catalog / db / table names are long.
+     * Hashing caps the UUID at 32 chars (MD5 hex) while preserving uniqueness.
+     *
+     * @param uuid the original UUID string
+     * @return the original UUID if length <= 64, otherwise its lower-case MD5 hex string
+     */
+    protected static String hashUUIDIfTooLong(String uuid) {
+        if (uuid.length() <= 64) {
+            return uuid;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] hashBytes = digest.digest(uuid.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(32);
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // MD5 is guaranteed to be available in every Java implementation
+            return uuid;
+        }
     }
 
     public void setId(long id) {


### PR DESCRIPTION
## Why I'm doing:

Fixes #68992

When external catalog tables (Iceberg, Hive, DeltaLake, Hudi) have long catalog/db/table names, the UUID string `{catalog}.{db}.{table}.{extra}` can exceed the BE config `primary_key_limit_size` (default 128 bytes), causing the following error when collecting statistics:

```
DdlException: primary key size exceed the limit.
```

This happens because `external_column_statistics` is a Primary Key table, and `table_uuid` is part of its composite primary key (together with `partition_name` and `column_name`). In test environments or setups with long catalog/db/table names (e.g. including UUID suffixes), the concatenated UUID string easily exceeds the 128-byte limit.

## What I'm doing:

Add a protected static helper `hashUUIDIfTooLong()` to the `Table` base class:
- If the UUID string is **≤ 64 chars**, return it as-is (no behavioral change for existing deployments with short names)
- If the UUID string **> 64 chars**, return its **MD5 hex string** (fixed 32 chars), ensuring the total primary key size stays well within the 128-byte limit

Apply this in `getUUID()` for all affected connector table types: **IcebergTable**, **HiveTable**, **DeltaLakeTable**, **HudiTable**.

The 64-char threshold is chosen conservatively so the remaining budget is comfortably shared by `partition_name` and `column_name` columns in the statistics table primary key.

> **Note on backward compatibility:** Existing statistics data stored with the old long UUID will no longer match on lookup (the WHERE clause will use the new MD5 UUID). This causes a one-time statistics cache miss, after which fresh stats are re-collected automatically — an acceptable trade-off since statistics data is always best-effort cached data.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [x] Miscellaneous: existing statistics for external tables with long names will be invalidated once and re-collected

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation
- [x] This is NOT a backport pr