### PR TITLE
[BugFix] Hide expression partition generated columns in DESC/SHOW CREATE TABLE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexSchemaProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexSchemaProcNode.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.SchemaConstants;
 import org.apache.commons.lang.StringUtils;
 
@@ -78,6 +79,10 @@ public class IndexSchemaProcNode implements ProcNodeInterface {
         result.setNames(TITLE_NAMES);
 
         for (Column column : schema) {
+            // Filter out expression partition generated columns in DESC
+            if (column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                continue;
+            }
             // Extra string (aggregation and bloom filter)
             List<String> extras = Lists.newArrayList();
             if (column.getAggregationType() != null && !isHideAggregateTypeName) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -91,6 +91,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.DuplicatedRequestException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
@@ -912,6 +913,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (Column column : table.getBaseSchema()) {
             if (column.isHidden()) {
+                continue;
+            }
+            // Filter out expression partition generated columns in DESC and information_schema.columns.
+            // SHOW CREATE TABLE also filters them in AstToStringBuilder to display user-created DDL.
+            if (column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
                 continue;
             }
             final TColumnDesc desc =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MysqlTable;
@@ -40,6 +41,7 @@ import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.sql.ast.KeysType;
@@ -146,6 +148,10 @@ public class AstToStringBuilder {
         sb.append("`").append(table.getName()).append("` (\n");
         int idx = 0;
         for (Column column : table.getBaseSchema()) {
+            // Skip expression partition generated columns to show user-created DDL
+            if (column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                continue;
+            }
             if (idx++ != 0) {
                 sb.append(",\n");
             }
@@ -196,7 +202,14 @@ public class AstToStringBuilder {
                 partitionId = Lists.newArrayList();
             }
             if (partitionInfo.isRangePartition() || partitionInfo.getType() == PartitionType.LIST) {
-                sb.append("\n").append(partitionInfo.toSql(olapTable, partitionId));
+                // Use expression (not generated column name) for user-created DDL display
+                if (partitionInfo instanceof ListPartitionInfo) {
+                    ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+                    sb.append("\n").append(listPartitionInfo.toSql(olapTable,
+                            listPartitionInfo.isAutomaticPartition(), false));
+                } else {
+                    sb.append("\n").append(partitionInfo.toSql(olapTable, partitionId));
+                }
             }
 
             // distribution

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -29,6 +29,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.SchemaConstants;
 import com.starrocks.common.proc.ExternalTableProcDir;
 import com.starrocks.common.proc.TableProcDir;
@@ -404,6 +405,9 @@ public class ShowStmtAnalyzer {
                                         .equalsIgnoreCase(node.getTableName())) {
                                     List<Column> columns = olapTable.getSchemaByIndexMetaId(mvMeta.getIndexMetaId());
                                     for (Column column : columns) {
+                                        if (column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                                            continue;
+                                        }
                                         // Extra string (aggregation and bloom filter)
                                         List<String> extras = Lists.newArrayList();
                                         if (column.getAggregationType() != null &&
@@ -474,7 +478,9 @@ public class ShowStmtAnalyzer {
                             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
                             for (int j = 0; j < columns.size(); ++j) {
                                 Column column = columns.get(j);
-
+                                if (column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                                    continue;
+                                }
                                 // Extra string (aggregation and bloom filter)
                                 List<String> extras = Lists.newArrayList();
                                 if (column.getAggregationType() != null &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.TableOperation;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -371,8 +372,15 @@ public class MetaUtils {
         return columnIds;
     }
 
+    /**
+     * Convert partition column to SQL representation for SHOW CREATE TABLE etc.
+     * Only internal expression partition columns (__generated_partition_column_*) are expanded to
+     * their expression form; user-defined generated columns retain their column names to preserve
+     * DDL round-trippability.
+     */
     public static String getPartitionColumnToSql(Column column) {
-        if (column.isGeneratedColumn()) {
+        if (column.isGeneratedColumn()
+                && column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
             return column.generatedColumnExprToString();
         } else {
             return "`" + column.getName() + "`";

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -260,6 +260,18 @@ public class FrontendServiceImplTest {
                                 "PROPERTIES (\n" +
                                 "\"replication_num\" = \"1\"\n" +
                                 ");")
+                    .withTable("CREATE TABLE site_access_multi_expr (\n" +
+                                "    event_day DATETIME,\n" +
+                                "    site_id INT DEFAULT '10',\n" +
+                                "    city_code VARCHAR(100),\n" +
+                                "    pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code)\n" +
+                                "PARTITION BY site_id, date_trunc('day', event_day)\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");")
                     .withTable("CREATE TABLE site_access_day (\n" +
                                 "    event_day DATE,\n" +
                                 "    site_id INT DEFAULT '10',\n" +
@@ -852,7 +864,7 @@ public class FrontendServiceImplTest {
         params.setCurrent_user_ident(tUserIdentity);
 
         TGetTablesResult result = impl.getTableNames(params);
-        Assertions.assertEquals(18, result.tables.size());
+        Assertions.assertEquals(19, result.tables.size());
     }
 
     @Test
@@ -1087,6 +1099,82 @@ public class FrontendServiceImplTest {
         Assertions.assertEquals(2, testDefaultValue.size());
         Assertions.assertEquals("CURRENT_TIMESTAMP", testDefaultValue.get(0).getColumnDesc().getColumnDefault());
         Assertions.assertEquals("2", testDefaultValue.get(1).getColumnDesc().getColumnDefault());
+    }
+
+    @Test
+    public void testDescribeTableAndShowCreateTableExpressionPartition() throws Exception {
+        // site_access_hour: PARTITION BY date_trunc - ExpressionRangePartitionInfo, no generated column in schema.
+        // Verify DESC never shows __generated_partition_column_, SHOW CREATE TABLE shows partition expr.
+        starRocksAssert.useDatabase("test");
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TDescribeTableParams request = new TDescribeTableParams();
+        request.setDb("test");
+        request.setTable_name("site_access_hour");
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("root");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        request.setCurrent_user_ident(userIdentity);
+
+        TDescribeTableResult response = impl.describeTable(request);
+        List<String> columnNames = response.getColumns().stream()
+                .map(c -> c.getColumnDesc().getColumnName())
+                .collect(Collectors.toList());
+        Assertions.assertFalse(columnNames.stream().anyMatch(
+                        name -> name.startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)),
+                "DESC should not contain expression partition generated columns: " + columnNames);
+        Assertions.assertTrue(columnNames.contains("event_day"));
+
+        // SHOW CREATE TABLE: show user-created form with partition expression, not generated column
+        com.starrocks.sql.ast.ShowCreateTableStmt stmt =
+                (com.starrocks.sql.ast.ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                        "show create table site_access_hour", connectContext);
+        String createTableSql = GlobalStateMgr.getCurrentState().getShowExecutor().execute(stmt, connectContext)
+                .getResultRows().get(0).get(1);
+        Assertions.assertFalse(createTableSql.contains(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX),
+                "SHOW CREATE TABLE should not contain internal generated partition columns: " + createTableSql);
+        Assertions.assertTrue(createTableSql.contains("date_trunc"),
+                "SHOW CREATE TABLE should show partition expression: " + createTableSql);
+        Assertions.assertTrue(
+                java.util.regex.Pattern.compile("PARTITION BY\\s+date_trunc\\s*\\([^)]*event_day[^)]*\\)")
+                        .matcher(createTableSql).find(),
+                "SHOW CREATE TABLE partition clause should explicitly use expression form: " + createTableSql);
+    }
+
+    @Test
+    public void testDescribeTableHidesGeneratedPartitionColumnsMultiExpr() throws Exception {
+        starRocksAssert.useDatabase("test");
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TDescribeTableParams request = new TDescribeTableParams();
+        request.setDb("test");
+        request.setTable_name("site_access_multi_expr");
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("root");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        request.setCurrent_user_ident(userIdentity);
+
+        TDescribeTableResult response = impl.describeTable(request);
+        List<String> columnNames = response.getColumns().stream()
+                .map(c -> c.getColumnDesc().getColumnName())
+                .collect(Collectors.toList());
+        Assertions.assertFalse(columnNames.stream().anyMatch(
+                        name -> name.startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)),
+                "DESC should not show generated partition columns: " + columnNames);
+        Assertions.assertTrue(columnNames.contains("event_day"));
+        Assertions.assertTrue(columnNames.contains("site_id"));
+
+        com.starrocks.sql.ast.ShowCreateTableStmt showStmt =
+                (com.starrocks.sql.ast.ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                        "show create table site_access_multi_expr", connectContext);
+        String ddl = GlobalStateMgr.getCurrentState().getShowExecutor().execute(showStmt, connectContext)
+                .getResultRows().get(0).get(1);
+        Assertions.assertFalse(ddl.contains(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX),
+                "SHOW CREATE TABLE should not contain generated partition columns: " + ddl);
+        Assertions.assertTrue(ddl.contains("date_trunc"),
+                "SHOW CREATE TABLE should show partition expression: " + ddl);
+        Assertions.assertFalse(ddl.contains("__generated_partition_column"),
+                "Column definitions should not include generated partition columns: " + ddl);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/DescribeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/DescribeStmtTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.ast;
 
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
@@ -68,7 +69,18 @@ public class DescribeStmtTest {
                         " AS\n" +
                         "SELECT store_id, SUM(sale_amt) as sale_amt\n" +
                         "FROM sales_records\n" +
-                        "GROUP BY store_id;");
+                        "GROUP BY store_id;")
+                .withTable("CREATE TABLE expr_part_tbl (\n" +
+                        "    event_day DATETIME,\n" +
+                        "    site_id INT,\n" +
+                        "    pv BIGINT DEFAULT '0'\n" +
+                        ")\n" +
+                        "DUPLICATE KEY(event_day, site_id)\n" +
+                        "PARTITION BY site_id, date_trunc('day', event_day)\n" +
+                        "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ");");
     }
 
     @AfterAll
@@ -236,6 +248,39 @@ public class DescribeStmtTest {
         Assertions.assertEquals("sale_amt", resultRows.get(1).get(2));
         Assertions.assertEquals("bigint", resultRows.get(1).get(3));
         Assertions.assertEquals("YES", resultRows.get(1).get(4));
+    }
+
+    @Test
+    public void testDescExprPartitionTableHidesGeneratedColumns() throws Exception {
+        String sql = "desc expr_part_tbl";
+        DescribeStmt describeStmt = (DescribeStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                starRocksAssert.getCtx());
+        ShowResultSet result = ShowExecutor.execute(describeStmt, connectContext);
+        List<List<String>> rows = result.getResultRows();
+        for (List<String> row : rows) {
+            Assertions.assertFalse(row.get(0).startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX),
+                    "DESC should not show generated partition column: " + row.get(0));
+        }
+        Assertions.assertEquals(3, rows.size());
+        Assertions.assertEquals("event_day", rows.get(0).get(0));
+        Assertions.assertEquals("site_id", rows.get(1).get(0));
+        Assertions.assertEquals("pv", rows.get(2).get(0));
+    }
+
+    @Test
+    public void testDescAllExprPartitionTableHidesGeneratedColumns() throws Exception {
+        String sql = "desc expr_part_tbl all";
+        DescribeStmt describeStmt = (DescribeStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                starRocksAssert.getCtx());
+        ShowResultSet result = ShowExecutor.execute(describeStmt, connectContext);
+        List<List<String>> rows = result.getResultRows();
+        for (List<String> row : rows) {
+            String fieldName = row.get(2);
+            if (fieldName != null && !fieldName.isEmpty()) {
+                Assertions.assertFalse(fieldName.startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX),
+                        "DESC ALL should not show generated partition column: " + fieldName);
+            }
+        }
     }
 
     @Test

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -404,11 +404,10 @@ show create table multi_level_expr_par_tbl_1;
 multi_level_expr_par_tbl_1	CREATE TABLE `multi_level_expr_par_tbl_1` (
   `c1` bigint(20) NOT NULL COMMENT "",
   `c2` varchar(1048576) NULL COMMENT "",
-  `c3` date NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS from_unixtime(c1) COMMENT ""
+  `c3` date NULL COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`c1`)
-PARTITION BY (`__generated_partition_column_0`)
+PARTITION BY (from_unixtime(c1))
 DISTRIBUTED BY HASH(`c1`) BUCKETS 3 
 PROPERTIES (
 "compression" = "LZ4",
@@ -459,13 +458,11 @@ multi_level_expr_par_tbl_2	CREATE TABLE `multi_level_expr_par_tbl_2` (
   `k10` largeint(40) NULL COMMENT "",
   `k11` decimal(38, 9) NULL COMMENT "",
   `k12` decimal(38, 9) NULL COMMENT "",
-  `k13` decimal(27, 9) NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS substring(k4, 1, 5) COMMENT "",
-  `__generated_partition_column_1` date NULL AS date_trunc('month', k1) COMMENT ""
+  `k13` decimal(27, 9) NULL COMMENT ""
 ) ENGINE=OLAP 
 PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
 COMMENT "OLAP"
-PARTITION BY (`__generated_partition_column_0`,`k3`,`__generated_partition_column_1`)
+PARTITION BY (substring(k4, 1, 5),`k3`,date_trunc('month', k1))
 DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
 PROPERTIES (
 "compression" = "LZ4",
@@ -599,13 +596,11 @@ base_tbl	CREATE TABLE `base_tbl` (
   `k10` largeint(40) NULL COMMENT "",
   `k11` float NULL COMMENT "",
   `k12` double NULL COMMENT "",
-  `k13` decimal(27, 9) NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS substring(`k4`, 1, 5) COMMENT "",
-  `__generated_partition_column_1` date NULL AS date_trunc('month', `k1`) COMMENT ""
+  `k13` decimal(27, 9) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
 COMMENT "OLAP"
-PARTITION BY (`__generated_partition_column_0`,`k3`,`__generated_partition_column_1`)
+PARTITION BY (substring(k4, 1, 5),`k3`,date_trunc('month', k1))
 DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
 PROPERTIES (
 "compression" = "LZ4",
@@ -632,13 +627,11 @@ t1	CREATE TABLE `t1` (
   `k10` largeint(40) NULL COMMENT "",
   `k11` float NULL COMMENT "",
   `k12` double NULL COMMENT "",
-  `k13` decimal(27, 9) NULL COMMENT "",
-  `__generated_partition_column_0` varchar(1048576) NULL AS substring(`k4`, 1, 5) COMMENT "",
-  `__generated_partition_column_1` date NULL AS date_trunc('month', `k1`) COMMENT ""
+  `k13` decimal(27, 9) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
 COMMENT "OLAP"
-PARTITION BY (`__generated_partition_column_0`,`k3`,`__generated_partition_column_1`)
+PARTITION BY (substring(k4, 1, 5),`k3`,date_trunc('month', k1))
 DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
 PROPERTIES (
 "compression" = "LZ4",

--- a/test/sql/test_automatic_partition/R/test_partition_ttl
+++ b/test/sql/test_automatic_partition/R/test_partition_ttl
@@ -59,11 +59,10 @@ show create table ss;
 -- result:
 ss	CREATE TABLE `ss` (
   `event_day` datetime NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` datetime NULL AS date_trunc('day', `event_day`) COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`, `pv`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,date_trunc('day', event_day))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -80,11 +79,10 @@ show create table ss1;
 -- result:
 ss1	CREATE TABLE `ss1` (
   `event_day` datetime NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` datetime NULL AS date_trunc('day', `event_day`) COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`, `pv`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,date_trunc('day', event_day))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -126,11 +124,10 @@ show create table ss1;
 -- result:
 ss1	CREATE TABLE `ss1` (
   `event_day` datetime NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` datetime NULL AS date_trunc('day', `event_day`) COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`, `pv`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,date_trunc('day', event_day))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -165,11 +162,10 @@ show create table ss1;
 -- result:
 ss1	CREATE TABLE `ss1` (
   `event_day` datetime NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` datetime NULL AS date_trunc('day', `event_day`) COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`, `pv`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,date_trunc('day', event_day))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -202,11 +198,10 @@ show create table ss;
 -- result:
 ss	CREATE TABLE `ss` (
   `event_day` varchar(65533) NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` date NULL AS date_trunc('day', str2date(`event_day`, '%Y-%m-%d')) COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,date_trunc('day', str2date(event_day, '%Y-%m-%d')))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -244,11 +239,10 @@ show create table ss;
 -- result:
 ss	CREATE TABLE `ss` (
   `event_day` varchar(65533) NULL COMMENT "",
-  `pv` bigint(20) NULL COMMENT "",
-  `__generated_partition_column_0` date NULL AS str2date(`event_day`, '%Y-%m-%d') COMMENT ""
+  `pv` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`event_day`)
-PARTITION BY (`pv`,`__generated_partition_column_0`)
+PARTITION BY (`pv`,str2date(event_day, '%Y-%m-%d'))
 DISTRIBUTED BY HASH(`event_day`)
 PROPERTIES (
 "compression" = "LZ4",

--- a/test/sql/test_partition_by_expr/R/test_expr_partition_generated_column_visibility
+++ b/test/sql/test_partition_by_expr/R/test_expr_partition_generated_column_visibility
@@ -1,0 +1,39 @@
+-- name: test_expr_partition_desc_filter_generated_column
+-- Multi-column expression partition creates __generated_partition_column_
+-- DESC/information_schema.columns should filter it, SHOW CREATE TABLE should show user DDL form
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+-- Multi-column list partition: (k1, date_trunc('month', dt)) creates __generated_partition_column_0
+create table t1 (
+    k1 int,
+    dt datetime
+)
+duplicate key(k1, dt)
+partition by (k1, date_trunc('month', dt))
+distributed by hash(k1) buckets 1
+properties("replication_num" = "1");
+-- result:
+-- !result
+desc t1;
+-- result:
+[REGEX](?s)^k1\t.*\ndt\t.*$
+-- !result
+show create table t1;
+-- result:
+[REGEX](?s).*date_trunc\s*\(\s*['"]month['"]\s*,\s*`?dt`?\).*
+-- !result
+select COLUMN_NAME from information_schema.columns where table_schema = 'db_${uuid0}' and table_name = 't1' order by ORDINAL_POSITION;
+-- result:
+k1
+dt
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_partition_generated_column_visibility
+++ b/test/sql/test_partition_by_expr/T/test_expr_partition_generated_column_visibility
@@ -1,0 +1,25 @@
+-- name: test_expr_partition_desc_filter_generated_column
+-- Multi-column expression partition creates __generated_partition_column_
+-- DESC/information_schema.columns should filter it, SHOW CREATE TABLE should show user DDL form
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Multi-column list partition: (k1, date_trunc('month', dt)) creates __generated_partition_column_0
+create table t1 (
+    k1 int,
+    dt datetime
+)
+duplicate key(k1, dt)
+partition by (k1, date_trunc('month', dt))
+distributed by hash(k1) buckets 1
+properties("replication_num" = "1");
+
+desc t1;
+
+show create table t1;
+
+select COLUMN_NAME from information_schema.columns where table_schema = 'db_${uuid0}' and table_name = 't1' order by ORDINAL_POSITION;
+
+drop table t1;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Filter out internal generated partition columns (prefixed with
GENERATED_PARTITION_COLUMN_PREFIX) from the following outputs:
- DESC table (IndexSchemaProcNode and ShowStmtAnalyzer)
- information_schema.columns (FrontendServiceImpl.describeTable)
- SHOW CREATE TABLE (AstToStringBuilder)

For SHOW CREATE TABLE, ListPartitionInfo now renders the original
partition expression instead of the generated column name, so the
displayed DDL matches the user-created form.

```
mysql> create table t3(k1 string) partition by str_to_date(k1, '%Y%m%d');
Query OK, 0 rows affected (0.04 sec)

mysql> show create table t3;
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t3    | CREATE TABLE `t3` (
  `k1` varchar(65533) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
COMMENT "OLAP"
PARTITION BY (str_to_date(k1, '%Y%m%d'))
DISTRIBUTED BY RANDOM
PROPERTIES (
"bucket_size" = "1073741824",
"cloud_native_fast_schema_evolution_v2" = "true",
"compression" = "LZ4",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"file_bundling" = "true",
"replication_num" = "1",
"storage_volume" = "builtin_storage_volume"
); |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> desc t3;
+-------+----------------+------+------+---------+-------+
| Field | Type           | Null | Key  | Default | Extra |
+-------+----------------+------+------+---------+-------+
| k1    | varchar(65533) | YES  | true | NULL    |       |
+-------+----------------+------+------+---------+-------+
1 row in set (0.00 sec)

mysql> select COLUMN_NAME from information_schema.columns where table_schema = 'd' and table_name = 't3' order by ORDINAL_POSITION;
+-------------+
| COLUMN_NAME |
+-------------+
| k1          |
+-------------+
1 row in set (0.01 sec)


mysql> show create table t1;
+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `k1` int(11) NULL COMMENT "",
  `dt` datetime NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`, `dt`)
COMMENT "OLAP"
PARTITION BY (`k1`,date_trunc('month', dt))
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"cloud_native_fast_schema_evolution_v2" = "true",
"compression" = "LZ4",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"file_bundling" = "true",
"replication_num" = "1",
"storage_volume" = "builtin_storage_volume"
); |
+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> desc t1;
+-------+----------+------+------+---------+-------+
| Field | Type     | Null | Key  | Default | Extra |
+-------+----------+------+------+---------+-------+
| k1    | int      | YES  | true | NULL    |       |
| dt    | datetime | YES  | true | NULL    |       |
+-------+----------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> select COLUMN_NAME from information_schema.columns where table_schema = 'd' and table_name = 't1' order by ORDINAL_POSITION;
+-------------+
| COLUMN_NAME |
+-------------+
| k1          |
| dt          |
+-------------+
2 rows in set (0.02 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
