### PR TITLE
[BugFix] Fix invalid date check bypass in INSERT VALUES clause when FORBID_INVALID_DATE is enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -159,6 +160,14 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
 
     @Override
     public OptExpression visitLogicalValues(OptExpression optExpression, Void context) {
+        if (needValidate) {
+            LogicalValuesOperator valuesOperator = (LogicalValuesOperator) optExpression.getOp();
+            for (List<ScalarOperator> row : valuesOperator.getRows()) {
+                for (ScalarOperator scalarOperator : row) {
+                    validateScalarOperator(scalarOperator);
+                }
+            }
+        }
         return commonValidate(optExpression);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ValidatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ValidatePlanTest.java
@@ -71,6 +71,20 @@ class ValidatePlanTest extends PlanTestBase {
         sqlList.add("select * from test_all_type where id_date > '2021-11-30' or id_date < " +
                 "cast(str_to_date('2021-11-31', 'yyyy-MM-dd') as int)");
         sqlList.add("select *, cast(20211131 as date) from t1 union all select *, cast(20211130 as date) from t2");
+
+        // insert values with invalid date
+        sqlList.add("insert into test_all_type(id_date) values (date('2025-11-35'))");
+        sqlList.add("insert into test_all_type(id_date) values (to_date('2025-11-35'))");
+        sqlList.add("insert into test_all_type(id_date) values (cast('2025-11-35' as date))");
+        sqlList.add("insert into test_all_type(id_date) values (str_to_date('2025-11-35', '%Y-%m-%d'))");
+        sqlList.add("insert into test_all_type(id_date) values (str2date('2025-11-35', '%Y-%m-%d'))");
+
+        // insert select with invalid date
+        sqlList.add("insert into test_all_type(id_date) select date('2025-11-35')");
+        sqlList.add("insert into test_all_type(id_date) select to_date('2025-11-35')");
+        sqlList.add("insert into test_all_type(id_date) select cast('2025-11-35' as date)");
+        sqlList.add("insert into test_all_type(id_date) select str_to_date('2025-11-35', '%Y-%m-%d')");
+        sqlList.add("insert into test_all_type(id_date) select str2date('2025-11-35', '%Y-%m-%d')");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 


### PR DESCRIPTION

## Why I'm doing:

When `sql_mode` contains `FORBID_INVALID_DATE`, queries with invalid date strings (e.g. `SELECT TO_DATE('2025-11-35')`) should fail in the FE validation phase and throw an `ERR_INVALID_DATE_ERROR` exception.
However, `INSERT INTO ... VALUES (..., TO_DATE('2025-11-35'))` bypasses this validation and executes silently (producing NULLs) unless `ALLOW_THROW_EXCEPTION` is also set (which will cause a BE execution error).
This happens because `OptExpressionValidator` in the FE optimizer fails to traverse and validate the internal expressions (`rows`) contained within the `LogicalValuesOperator`.

## What I'm doing:

Explicitly iterate over all the `ScalarOperator` instances inside the `rows` of `LogicalValuesOperator` to perform validation (`validateScalarOperator`)

Behavior change:
`insert into invalid date values` returns error when `sql_mode` is `FORBID_INVALID_DATE`.
Old behavior is successful insert with null value.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
