### PR TITLE
[Tool] Add CLEANUP block to SQL-tester for reliable per-case teardown (backport #63068)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -475,3 +475,28 @@ CONCURRENCY {
 
 } END CONCURRENCY
 ```
+
+### 10. CLEANUP
+
+Custom cleanup statements that run in tearDown for each case, regardless of pass/fail. This is useful for deleting objects (tables/databases/catalogs) or removing external side-effects.
+
+* Usage:
+
+```sql
+-- name: ${case name}
+...
+
+CLEANUP {
+  -- SQL statements must end with ';'
+  DROP TABLE IF EXISTS t1;
+  DROP DATABASE IF EXISTS db_${uuid0};
+
+  -- You can also run shell or function statements
+  shell: echo "cleanup ${uuid0}"
+  function: your_python_helper("arg1")
+} END CLEANUP
+```
+
+* Notes:
+* The framework's built-in cleanup (dropping parsed DATABASE/RESOURCE) still runs; CLEANUP is an addition for fine-grained or external cleanup.
+* Results in CLEANUP are not validated; failures will be logged but do not block other cleanup steps.

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -44,6 +44,10 @@ PROPERTY_FLAG = "PROPERTY: "
 CONCURRENCY_FLAG = "CONCURRENCY"
 END_CONCURRENCY_FLAG = "END CONCURRENCY"
 
+# cleanup -- end cleanup
+CLEANUP_FLAG = "CLEANUP"
+END_CLEANUP_FLAG = "END CLEANUP"
+
 
 def close_conn(conn, conn_type):
     log.info(f"Try to close {conn_type} connection...")

--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -45,7 +45,7 @@ LOG_FILTERED_WARN = "You can use `--log_filtered` to show the details..."
 
 class ChooseCase(object):
     class CaseTR(object):
-        def __init__(self, ctx, name, file, sql, result, info, tags=None):
+        def __init__(self, ctx, name, file, sql, result, info, tags=None, cleanup=None):
             """init"""
             super().__init__()
             self.ctx = ctx
@@ -57,6 +57,8 @@ class ChooseCase(object):
             self.result: List = result
             # case tags (e.g., @arrow_flight_sql, @sequential)
             self.tags: List = tags or []
+            # custom cleanup commands
+            self.cleanup: List = cleanup or []
 
             # # get db from lines
             # self.db = set()
@@ -179,6 +181,9 @@ class ChooseCase(object):
                     tools.assert_in("thread", each_stat, "CONCURRENCY THREAD FORMAT ERROR!")
                     for each_thread in each_stat["thread"]:
                         _case_sqls.extend(each_thread["cmd"])
+                elif isinstance(each_stat, dict) and each_stat.get("type", "") == CLEANUP_FLAG:
+                    tools.assert_in("cmd", each_stat, "CLEANUP STATEMENT FORMAT ERROR!")
+                    _case_sqls.extend(each_stat["cmd"])
                 else:
                     tools.ok_(False, "Init data error!")
 
@@ -257,6 +262,9 @@ class ChooseCase(object):
                     tools.assert_in("thread", each_stat, "CONCURRENCY THREAD FORMAT ERROR!")
                     for each_thread in each_stat["thread"]:
                         _case_sqls.extend(each_thread["cmd"])
+                elif isinstance(each_stat, dict) and each_stat.get("type", "") == CLEANUP_FLAG:
+                    tools.assert_in("cmd", each_stat, "CLEANUP STATEMENT FORMAT ERROR!")
+                    _case_sqls.extend(each_stat["cmd"])
                 else:
                     tools.ok_(False, "Init data error!")
 
@@ -377,6 +385,8 @@ class ChooseCase(object):
         in_loop_flag = False
 
         tmp_con_stat = []
+        # cleanup blocks for current case
+        tmp_cleanup_stat = []
 
         while line_id < len(f_lines):
             line_content = f_lines[line_id].rstrip("\n")
@@ -414,6 +424,7 @@ class ChooseCase(object):
                                 copy.deepcopy(tmp_res),
                                 info,
                                 tags=copy.deepcopy(tags),
+                                cleanup=copy.deepcopy(tmp_cleanup_stat),
                             )
                         )
 
@@ -425,6 +436,7 @@ class ChooseCase(object):
 
                 tmp_sql.clear()
                 tmp_res.clear()
+                tmp_cleanup_stat.clear()
 
                 line_id += 1
                 continue
@@ -556,6 +568,33 @@ class ChooseCase(object):
                     "thread": concurrency_t_list
                 })
 
+            elif line_content.startswith(CLEANUP_FLAG):
+                # CLEANUP { ... } END CLEANUP
+                tools.ok_(not in_loop_flag, "CLEANUP block must not be inside LOOP!")
+                tools.assert_true(
+                    re.compile(f'{CLEANUP_FLAG}(\\s)*{{(\\s)*').fullmatch(line_content) is not None,
+                    f"Cleanup struct illegal: file: {file}, line: {line_id}"
+                )
+                l_cleanup_line = line_id
+                line_id += 1
+                # read cleanup statements (no result expected)
+                tmp_cleanup_lines = []
+                while line_id < len(f_lines) and not re.compile(f'}}(\\s)*{END_CLEANUP_FLAG}').fullmatch(f_lines[line_id].strip()):
+                    line_content = f_lines[line_id].strip()
+                    line_id = __read_single_stat_and_result(line_content, line_id, tmp_cleanup_lines, [])
+                tools.assert_less(line_id, len(f_lines), "CLEANUP FORMAT ERROR!")
+                r_cleanup_line = line_id
+                # collect for execution in tearDown
+                tmp_cleanup_stat.extend(tmp_cleanup_lines)
+                # also keep position for recording into R at the same place
+                tmp_sql.append({
+                    "type": CLEANUP_FLAG,
+                    "cmd": tmp_cleanup_lines,
+                    "ori": f_lines[l_cleanup_line: r_cleanup_line + 1]
+                })
+                tmp_res.append(None)
+                line_id += 1
+
             else:
                 # 1st line of command, SQL/SHELL/FUNCTION
                 line_id = __read_single_stat_and_result(line_content, line_id, tmp_sql, tmp_res, in_loop_flag)
@@ -582,6 +621,7 @@ class ChooseCase(object):
                         copy.deepcopy(tmp_res),
                         info,
                         tags=copy.deepcopy(tags),
+                        cleanup=copy.deepcopy(tmp_cleanup_stat),
                     )
                 )
 

--- a/test/sql/test_profile/R/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/R/test_load_brpc_reached_timeout
@@ -122,9 +122,7 @@ shell: env mysql_cmd="${mysql_cmd} -Ddb_${uuid0}" label="label_${uuid2}" bash ${
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
-admin disable failpoint "node_channel_set_brpc_timeout";
--- result:
--- !result
-admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
--- result:
--- !result
+CLEANUP {
+    admin disable failpoint "node_channel_set_brpc_timeout";
+    admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+} END CLEANUP

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -59,6 +59,11 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${roo
 Analyze profile succeeded
 Analyze profile succeeded
 -- !result
+CLEANUP {
+  function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+  function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
+} END CLEANUP
+
 function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
 -- result:
 None
@@ -83,12 +88,4 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${roo
 0
 Analyze profile succeeded
 Analyze profile succeeded
--- !result
-function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
--- result:
-None
--- !result
-function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
--- result:
-None
 -- !result

--- a/test/sql/test_profile/T/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/T/test_load_brpc_reached_timeout
@@ -59,5 +59,7 @@ function: wait_load_finish("label_${uuid2}")
 select instr(error_msg, '[E1008]Reached timeout=2000ms') > 0 from information_schema.loads where label="label_${uuid2}";
 shell: env mysql_cmd="${mysql_cmd} -Ddb_${uuid0}" label="label_${uuid2}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
 
-admin disable failpoint "node_channel_set_brpc_timeout";
-admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+CLEANUP {
+    admin disable failpoint "node_channel_set_brpc_timeout";
+    admin disable failpoint "tablets_channel_add_chunk_wait_write_block";
+} END CLEANUP

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -41,12 +41,14 @@ SET enable_async_profile=false;
 INSERT INTO test_load_channel_profile WITH LABEL label_${uuid0} SELECT * FROM test_load_channel_profile;
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid0}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
 
+CLEANUP {
+  function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
+  function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)
+} END CLEANUP
+
 function: enable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
 function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 1)
 
 alter table test_load_channel_profile set('enable_load_profile'='true');
 shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label: "label_${uuid1}"" -H "column_separator: ," -d '1,2,3' -X PUT ${url}/api/${db[0]}/test_load_channel_profile/_stream_load
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" label="label_${uuid1}" bash ${root_path}/sql/test_profile/T/test_load_profile_analysis.sh
-
-function: disable_fe_verbose_log(["com.starrocks.qe.QeProcessorImpl", "com.starrocks.qe.scheduler.QueryRuntimeProfile", "com.starrocks.load.streamload.StreamLoadTask", "com.starrocks.common.util.ProfileManager"])
-function: set_vlog_level_for_all_be(["fragment_mgr*", "plan_fragment_executor*"], 0)

--- a/test/test_sql_cases.py
+++ b/test/test_sql_cases.py
@@ -137,6 +137,16 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
         super().tearDown()
 
         log.info("[TearDown begin]: %s" % self.case_info.name)
+        # run custom cleanup (always)
+        try:
+            if hasattr(self.case_info, "cleanup"):
+                for stmt in self.case_info.cleanup:
+                    try:
+                        self.execute_single_statement(stmt, -1, False)
+                    except Exception as e:
+                        log.warning(f"cleanup stmt error: {e}")
+        except Exception as e:
+            log.warning(f"cleanup error: {e}")
 
         for each_db in self.db:
             self.drop_database(each_db)
@@ -201,6 +211,15 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
                         resource_name = self._get_resource_name(each_cmd)
                         if len(resource_name) > 0:
                             self.resource.append(resource_name)
+            elif isinstance(sql, dict) and sql.get("type", "") == CLEANUP_FLAG:
+                tools.assert_in("cmd", sql, "CLEANUP STATEMENT FORMAT ERROR!")
+                for each_cmd in sql["cmd"]:
+                    db_name = self._get_db_name(each_cmd)
+                    if len(db_name) > 0:
+                        self.db.append(db_name)
+                    resource_name = self._get_resource_name(each_cmd)
+                    if len(resource_name) > 0:
+                        self.resource.append(resource_name)
             else:
                 tools.ok_(False, "Init data error!")
 
@@ -253,6 +272,12 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
                             db_name = self._get_db_name(each_cmd)
                             if len(db_name) > 0:
                                 all_db_dict.setdefault(db_name, set()).add(case.name)
+                elif isinstance(sql, dict) and sql.get("type", "") == CLEANUP_FLAG:
+                    tools.assert_in("cmd", sql, "CLEANUP STATEMENT FORMAT ERROR!")
+                    for each_cmd in sql["cmd"]:
+                        db_name = self._get_db_name(each_cmd)
+                        if len(db_name) > 0:
+                            all_db_dict.setdefault(db_name, set()).add(case.name)
                 else:
                     tools.ok_(False, "Check db uniqueness error!")
 
@@ -290,6 +315,13 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
                         for each_uuid in uuid_vars:
                             if each_uuid not in variable_dict:
                                 variable_dict[each_uuid] = uuid.uuid4().hex
+            elif isinstance(sql, dict) and sql.get("type", "") == CLEANUP_FLAG:
+                tools.assert_in("cmd", sql, "CLEANUP STATEMENT FORMAT ERROR!")
+                for each_cmd in sql["cmd"]:
+                    uuid_vars = re.findall(r"\${(uuid[0-9]*)}", each_cmd)
+                    for each_uuid in uuid_vars:
+                        if each_uuid not in variable_dict:
+                            variable_dict[each_uuid] = uuid.uuid4().hex
 
             else:
                 tools.ok_(False, "Replace uuid error!")
@@ -320,6 +352,16 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
                         tmp_cmd.append(each_cmd)
                     each_thread["cmd"] = tmp_cmd
 
+                ret.append(_sql)
+            elif isinstance(sql, dict) and sql.get("type", "") == CLEANUP_FLAG:
+                _sql = copy.deepcopy(sql)
+                tools.assert_in("cmd", _sql, "CLEANUP STATEMENT FORMAT ERROR!")
+                tmp_cmd = []
+                for each_cmd in _sql["cmd"]:
+                    for each_var in variable_dict:
+                        each_cmd = each_cmd.replace("${%s}" % each_var, variable_dict[each_var])
+                    tmp_cmd.append(each_cmd)
+                _sql["cmd"] = tmp_cmd
                 ret.append(_sql)
 
         return ret
@@ -433,6 +475,18 @@ Start to run: %s
                 self_print(f"[LOOP] Finish!\n", color=ColorEnum.BLUE, logout=True, bold=True)
                 tools.ok_(loop_check_res, f"Loop checker fail: {''.join(sql['ori'])}!")
 
+            elif isinstance(sql, dict) and sql.get("type", "") == CLEANUP_FLAG:
+                # record mode: write cleanup block in-place to res_log to keep position
+                if record_mode:
+                    if isinstance(sql.get("ori"), list):
+                        self.res_log.append("".join(sql["ori"]))
+                    else:
+                        self.res_log.append("CLEANUP {")
+                        for stmt in sql.get("cmd", []):
+                            self.res_log.append(stmt)
+                        self.res_log.append("} END CLEANUP")
+                # do nothing during execution here; cleanup executes in tearDown
+                continue
             elif isinstance(sql, dict) and sql["type"] == sr_sql_lib.CONCURRENCY_FLAG:
                 # concurrency statement
                 self_print(f"[CONCURRENCY] Start...", color=ColorEnum.CYAN, logout=True)


### PR DESCRIPTION
## Why I'm doing:
backport #63068

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

