### PR TITLE
[BugFix] Fix lake_compaction_max_parallel in SHOW CREATE TABLE and use FE config

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3604,6 +3604,14 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The number of recent successful Compaction task records to keep in the memory of the Leader FE node in a shared-data cluster. You can view recent successful Compaction task records using the `SHOW PROC '/compactions'` command. Note that the Compaction history is stored in the FE process memory, and it will be lost if the FE process is restarted.
 - Introduced in: v3.1.0
 
+##### `lake_compaction_max_parallel_default`
+
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Default max parallel compaction subtasks per tablet when `lake_compaction_max_parallel` is not specified in table properties. `0` means disable parallel compaction. This config is used as the default value for the table property `lake_compaction_max_parallel`.
+
 ##### `lake_compaction_max_tasks`
 
 - Default: -1

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -3604,6 +3604,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: 共有データクラスターのリーダー FE ノードのメモリに保持される最近の成功したコンパクションタスクレコードの数。`SHOW PROC '/compactions'` コマンドを使用して、最近の成功したコンパクションタスクレコードを表示できます。コンパクション履歴は FE プロセスメモリに格納され、FE プロセスが再起動されると失われることに注意してください。
 - Introduced in: v3.1.0
 
+##### `lake_compaction_max_parallel_default`
+
+- 默认值: 3
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: 当建表时未指定 `lake_compaction_max_parallel` 表属性时，每个 tablet 的默认最大并行 Compaction 子任务数。`0` 表示禁用并行 Compaction。此配置作为表属性 `lake_compaction_max_parallel` 的默认值。
+
 ##### `lake_compaction_max_tasks`
 
 - Default: -1
@@ -3766,6 +3774,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: ブローカーを使用しない HDFS またはオブジェクトストレージへの直接書き込みに使用される HDFS 書き込みバッファサイズ (KB 単位) を設定します。FE はこの値をバイト (`<< 10`) に変換し、`HdfsFsManager` でローカル書き込みバッファを初期化します。また、Thrift リクエスト (例: TUploadReq、TExportSink、シンクオプション) に伝播され、バックエンド/エージェントが同じバッファサイズを使用するようにします。この値を増やすと、大きなシーケンシャル書き込みのスループットが向上しますが、ライターごとのメモリが増加します。減らすと、ストリームごとのメモリ使用量が減少し、小さな書き込みのレイテンシーが低下する可能性があります。`hdfs_read_buffer_size_kb` と並行して調整し、利用可能なメモリと同時ライターを考慮してください。
 - Introduced in: v3.2.0
+
+
+##### `lake_enable_drop_tablet_cache`
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: shared-data モードで、実データが削除される前に BE/CN 上のキャッシュをクリーンアップします。
+- 導入バージョン: v4.0
+
 
 
 ##### `lake_enable_drop_tablet_cache`

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -3603,6 +3603,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 在共享数据集群中，Leader FE 内存中保留的最近成功 Compaction 任务记录数。您可以使用 `SHOW PROC '/compactions'` 命令查看最近成功的 Compaction 任务记录。请注意，Compaction 历史记录存储在 FE 进程内存中，如果 FE 进程重启，它将丢失。
 - 引入版本: v3.1.0
 
+##### `lake_compaction_max_parallel_default`
+
+- 默认值: 3
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: 当建表时未指定 `lake_compaction_max_parallel` 表属性时，每个 tablet 的默认最大并行 Compaction 子任务数。`0` 表示禁用并行 Compaction。此配置作为表属性 `lake_compaction_max_parallel` 的默认值。
+
 ##### `lake_compaction_max_tasks`
 
 - 默认值: -1

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3002,6 +3002,15 @@ public class OlapTable extends Table {
                     TableProperty.compactionStrategyToString(getCompactionStrategy()));
         }
 
+        // lake_compaction_max_parallel (only for cloud native table, only show when not default)
+        if (isCloudNativeTable()) {
+            int lakeCompactionMaxParallel = getLakeCompactionMaxParallel();
+            if (lakeCompactionMaxParallel != Config.lake_compaction_max_parallel_default) {
+                properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL,
+                        String.valueOf(lakeCompactionMaxParallel));
+            }
+        }
+
         Map<String, String> tableProperties = tableProperty != null ? tableProperty.getProperties() : Maps.newLinkedHashMap();
 
         // table query timeout (only show if explicitly set, not default)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3212,6 +3212,10 @@ public class Config extends ConfigBase {
             "will disable compaction.")
     public static int lake_compaction_max_tasks = -1;
 
+    @ConfField(mutable = true, comment = "Default max parallel compaction subtasks per tablet when not specified in " +
+            "table properties. 0 means disable parallel compaction.")
+    public static int lake_compaction_max_parallel_default = 3;
+
     @ConfField(mutable = true)
     public static int lake_compaction_history_size = 20;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1668,10 +1668,11 @@ public class PropertyAnalyzer {
         return TCompactionStrategy.DEFAULT;
     }
 
-    // Analyze lake_compaction_max_parallel property
-    // Returns the max parallel value (default 3, 0 means disabled)
+    // Analyze lake_compaction_max_parallel table property.
+    // Returns the max parallel value (default from Config.lake_compaction_max_parallel_default;
+    // 0 means parallel lake compaction is disabled).
     public static int analyzeLakeCompactionMaxParallel(Map<String, String> properties) throws AnalysisException {
-        int defaultValue = 3;
+        int defaultValue = Config.lake_compaction_max_parallel_default;
         if (properties != null && properties.containsKey(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)) {
             String value = properties.get(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
             properties.remove(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeCompactionMaxParallelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeCompactionMaxParallelTest.java
@@ -18,15 +18,18 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -474,6 +477,71 @@ public class LakeCompactionMaxParallelTest extends StarRocksTestBase {
                 "PROPERTIES('lake_compaction_max_parallel' = '9')", DB_NAME, tableName);
         LakeTable table = createTable(createSql);
         Assertions.assertEquals(9, table.getLakeCompactionMaxParallel());
+    }
+
+    // ===========================================
+    // Tests for SHOW CREATE TABLE - lake_compaction_max_parallel visibility
+    // Only show when value differs from Config.lake_compaction_max_parallel_default
+    // ===========================================
+
+    @Test
+    public void testShowCreateTableWithNonDefaultLakeCompactionMaxParallel() throws Exception {
+        int nonDefaultValue = Config.lake_compaction_max_parallel_default + 1;
+        String tableName = "t_show_create_non_default";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '%d')", DB_NAME, tableName, nonDefaultValue);
+        createTable(createSql);
+
+        ShowCreateTableStmt showStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "SHOW CREATE TABLE " + tableName, connectContext);
+        ShowResultSet resultSet = GlobalStateMgr.getCurrentState().getShowExecutor().execute(showStmt, connectContext);
+        String createTableSql = resultSet.getResultRows().get(0).get(1);
+
+        Assertions.assertTrue(createTableSql.contains("\"lake_compaction_max_parallel\" = \"" + nonDefaultValue + "\""),
+                "SHOW CREATE TABLE should show lake_compaction_max_parallel when it is not default: " + createTableSql);
+    }
+
+    @Test
+    public void testShowCreateTableWithDefaultLakeCompactionMaxParallel() throws Exception {
+        int defaultValue = Config.lake_compaction_max_parallel_default;
+        String tableName = "t_show_create_default";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '%d')", DB_NAME, tableName, defaultValue);
+        createTable(createSql);
+
+        ShowCreateTableStmt showStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "SHOW CREATE TABLE " + tableName, connectContext);
+        ShowResultSet resultSet = GlobalStateMgr.getCurrentState().getShowExecutor().execute(showStmt, connectContext);
+        String createTableSql = resultSet.getResultRows().get(0).get(1);
+
+        Assertions.assertFalse(createTableSql.contains("lake_compaction_max_parallel"),
+                "SHOW CREATE TABLE should NOT show lake_compaction_max_parallel when it equals default ("
+                        + defaultValue + "): " + createTableSql);
+    }
+
+    @Test
+    public void testShowCreateTableWithZeroLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_show_create_zero";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '0')", DB_NAME, tableName);
+        createTable(createSql);
+
+        ShowCreateTableStmt showStmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "SHOW CREATE TABLE " + tableName, connectContext);
+        ShowResultSet resultSet = GlobalStateMgr.getCurrentState().getShowExecutor().execute(showStmt, connectContext);
+        String createTableSql = resultSet.getResultRows().get(0).get(1);
+
+        Assertions.assertTrue(createTableSql.contains("\"lake_compaction_max_parallel\" = \"0\""),
+                "SHOW CREATE TABLE should show lake_compaction_max_parallel when it is 0 (disabled): " + createTableSql);
     }
 }
 

--- a/test/sql/test_parallel_compaction/R/test_parallel_compaction
+++ b/test/sql/test_parallel_compaction/R/test_parallel_compaction
@@ -641,6 +641,7 @@ PROPERTIES (
 "enable_async_write_back" = "false",
 "enable_persistent_index" = "true",
 "file_bundling" = "true",
+"lake_compaction_max_parallel" = "2",
 "persistent_index_type" = "CLOUD_NATIVE",
 "replication_num" = "1",
 "storage_volume" = "builtin_storage_volume"
@@ -667,6 +668,7 @@ PROPERTIES (
 "enable_async_write_back" = "false",
 "enable_persistent_index" = "true",
 "file_bundling" = "true",
+"lake_compaction_max_parallel" = "5",
 "persistent_index_type" = "CLOUD_NATIVE",
 "replication_num" = "1",
 "storage_volume" = "builtin_storage_volume"
@@ -693,6 +695,7 @@ PROPERTIES (
 "enable_async_write_back" = "false",
 "enable_persistent_index" = "true",
 "file_bundling" = "true",
+"lake_compaction_max_parallel" = "0",
 "persistent_index_type" = "CLOUD_NATIVE",
 "replication_num" = "1",
 "storage_volume" = "builtin_storage_volume"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Add lake_compaction_max_parallel to SHOW CREATE TABLE for cloud native tables
- Only display when value differs from default for maximum compatibility
- Change default value to FE config lake_compaction_max_parallel_default (default: 3)
- Add unit tests and update test_parallel_compaction expected results
- Add documentation for lake_compaction_max_parallel_default in FE_configuration.md

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4