### PR TITLE
[BugFix] Fix reflection for nested column with comments

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -1,6 +1,10 @@
 Version history
 ===============
 
+**Unreleased**
+
+- Fix parsing of reflected nested `STRUCT` / `ARRAY` / `MAP` column types when inline field comments are present (#69817)
+
 **1.3.3**
 
 - Add back support for SQLAlchemy 1.4 (#65976 by @rad-pat)

--- a/contrib/starrocks-python-client/starrocks/drivers/parsers.py
+++ b/contrib/starrocks-python-client/starrocks/drivers/parsers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
+import re
 from typing import Any, List, Tuple
 
 from lark import Lark, Token, Transformer, v_args
@@ -105,6 +106,7 @@ class DataTypeTransformer(Transformer):
 _grammar_text = None
 # For singleton pattern
 _data_type_parser = None
+_TYPE_COMMENT_PATTERN = re.compile(r"\s+COMMENT\s+'(?:''|[^'])*'", flags=re.IGNORECASE)
 
 
 def _get_grammar_text() -> str:
@@ -136,7 +138,11 @@ def parse_data_type(type_str: str) -> Any:
     Returns:
         A SQLAlchemy type object.
     """
-    return get_data_type_parser().parse(type_str)
+    # Reflection can return nested types with inline SQL field comments
+    # (e.g. `... value varchar COMMENT '' ...`), which are not part of the
+    # datatype grammar and would otherwise break parsing.
+    normalized_type_str = _TYPE_COMMENT_PATTERN.sub("", type_str)
+    return get_data_type_parser().parse(normalized_type_str)
 
 
 # --- Materialized View Refresh Clause Parser ---

--- a/contrib/starrocks-python-client/test/unit/test_parser.py
+++ b/contrib/starrocks-python-client/test/unit/test_parser.py
@@ -144,6 +144,33 @@ class TestDataTypeParser:
     def test_nested_complex_types(self, type_str, expected_type):
         assert repr(parse_data_type(type_str)) == repr(expected_type)
 
+    def test_nested_complex_types_with_inline_comments(self):
+        type_str = (
+            "struct<"
+            "headers array<struct<key varchar(65533) COMMENT '', value varchar(65533) COMMENT ''>> COMMENT '', "
+            "payload struct<event_id bigint COMMENT '', labels map<string, string> COMMENT ''> COMMENT ''"
+            ">"
+        )
+        expected_type = datatype.STRUCT(
+            (
+                "headers",
+                datatype.ARRAY(
+                    datatype.STRUCT(
+                        ("key", datatype.VARCHAR(65533)),
+                        ("value", datatype.VARCHAR(65533)),
+                    )
+                ),
+            ),
+            (
+                "payload",
+                datatype.STRUCT(
+                    ("event_id", datatype.BIGINT),
+                    ("labels", datatype.MAP(datatype.STRING, datatype.STRING)),
+                ),
+            ),
+        )
+        assert repr(parse_data_type(type_str)) == repr(expected_type)
+
     @pytest.mark.parametrize(
         "type_str",
         [

--- a/contrib/starrocks-python-client/test/unit/test_parser.py
+++ b/contrib/starrocks-python-client/test/unit/test_parser.py
@@ -144,13 +144,30 @@ class TestDataTypeParser:
     def test_nested_complex_types(self, type_str, expected_type):
         assert repr(parse_data_type(type_str)) == repr(expected_type)
 
-    def test_nested_complex_types_with_inline_comments(self):
-        type_str = (
-            "struct<"
-            "headers array<struct<key varchar(65533) COMMENT '', value varchar(65533) COMMENT ''>> COMMENT '', "
-            "payload struct<event_id bigint COMMENT '', labels map<string, string> COMMENT ''> COMMENT ''"
-            ">"
-        )
+    @pytest.mark.parametrize(
+        "type_str",
+        [
+            (
+                "struct<"
+                "headers array<struct<key varchar(65533) COMMENT '', value varchar(65533) COMMENT ''>> COMMENT '', "
+                "payload struct<event_id bigint COMMENT '', labels map<string, string> COMMENT ''> COMMENT ''"
+                ">"
+            ),
+            (
+                "struct<"
+                "headers array<struct<key varchar(65533) COMMENT 'header key', value varchar(65533) COMMENT 'header value'>> COMMENT 'headers comment', "
+                "payload struct<event_id bigint COMMENT 'event id', labels map<string, string> COMMENT 'label map'> COMMENT 'payload comment'"
+                ">"
+            ),
+            (
+                "struct<"
+                "headers array<struct<key varchar(65533) COMMENT 'owner''s key', value varchar(65533) COMMENT 'has \"double\" quotes'>> COMMENT 'headers \"meta\"', "
+                "payload struct<event_id bigint COMMENT 'id', labels map<string, string> COMMENT 'labels'> COMMENT 'payload''s comment'"
+                ">"
+            ),
+        ],
+    )
+    def test_nested_complex_types_with_inline_comments(self, type_str):
         expected_type = datatype.STRUCT(
             (
                 "headers",


### PR DESCRIPTION
## Why I'm doing:

DataHub ingestion through SQLAlchemy with `platform: starrocks` fails to properly reflect nested StarRocks column types when `COLUMN_TYPE` contains inline field comments (for example `COMMENT ''` inside `STRUCT/ARRAY/MAP`).  
This causes parse warnings and prevents downstream nested schema extraction from working correctly.
I  got this error when tried to ingest delta table metadata from starrocs to datahub via datahub cli ingestion which uses sqlalchemy.

## What I'm doing:

- Normalize reflected StarRocks `COLUMN_TYPE` strings in reflection by removing inline `COMMENT '...'` fragments before datatype parsing.
- Keep datatype parser strict (no fallback normalization inside `parse_data_type`).
- Add/adjust unit test coverage in reflection path to verify nested complex types with inline comments are parsed correctly.

Fixes #<issue-number>

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4