### PR TITLE
[Enhancement] Add a build slice interface to BinaryColumn, allowing callers to invoke it on demand.

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -440,6 +440,21 @@ void BinaryColumnBase<T>::append_value_multiple_times(const void* value, size_t 
 }
 
 template <typename T>
+void BinaryColumnBase<T>::build_slices(Container& slices) const {
+    if constexpr (std::is_same_v<T, uint32_t>) {
+        DCHECK_LT(_total_bytes(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
+    }
+
+    DCHECK(_offsets.size() > 0);
+
+    slices.resize(_offsets.size() - 1);
+    const uint8_t* data_ptr = _data_base();
+    for (size_t i = 0; i < _offsets.size() - 1; ++i) {
+        slices[i] = {data_ptr + _offsets[i], _offsets[i + 1] - _offsets[i]};
+    }
+}
+
+template <typename T>
 void BinaryColumnBase<T>::_build_slices() const {
     if constexpr (std::is_same_v<T, uint32_t>) {
         DCHECK_LT(_total_bytes(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -406,6 +406,8 @@ public:
 
     Status capacity_limit_reached() const override;
 
+    void build_slices(Container& slices) const;
+
 private:
     void _build_slices() const;
     void _build_german_strings() const;

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -570,6 +570,10 @@ public:
             return reinterpret_cast<const ColumnType*>(column);
         }
     }
+    template <LogicalType LT>
+    static const RunTimeColumnType<LT>* get_data_column_by_type(const ColumnPtr& column) {
+        return get_data_column_by_type<LT>(column.get());
+    }
 
     static const NullColumn* get_null_column(const Column* column) {
         if (column->only_null()) {
@@ -595,6 +599,7 @@ public:
             return column;
         }
     }
+    static const Column* get_data_column(const ColumnPtr& column) { return get_data_column(column.get()); }
 
     static BinaryColumn* get_binary_column(Column* column) { return down_cast<BinaryColumn*>(get_data_column(column)); }
 

--- a/be/src/exec/join/join_key_constructor.h
+++ b/be/src/exec/join/join_key_constructor.h
@@ -43,7 +43,7 @@ public:
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 
     static void prepare(RuntimeState* state, JoinHashTableItems* table_items) {}
-    static void build_key(RuntimeState* state, JoinHashTableItems* table_items) {}
+    static void build_key(RuntimeState* state, JoinHashTableItems* table_items);
     static size_t get_key_column_bytes(const JoinHashTableItems& table_items) {
         return table_items.key_columns[0]->byte_size();
     }

--- a/be/src/exec/join/join_key_constructor.hpp
+++ b/be/src/exec/join/join_key_constructor.hpp
@@ -25,24 +25,29 @@ namespace starrocks {
 // KeyConstructorForOneKey
 // ------------------------------------------------------------------------------------
 
+
+template <LogicalType LT>
+void BuildKeyConstructorForOneKey<LT>::build_key(RuntimeState* state, JoinHashTableItems* table_items) {
+    // TODO: Going forward, if system testing verifies: the slice cache has no impact on join performance on all scene,
+    // we will ultimately avoid building the slice cache. According to the current simple benchmark results,
+    // it only has a minor performance optimization in mid-cardinality scenarios.
+    if constexpr (lt_is_string<LT>) {
+        const auto* data_column = ColumnHelper::get_data_column(table_items->key_columns[0]);
+        if (UNLIKELY(data_column->is_large_binary())) {
+            ColumnHelper::as_raw_column<LargeBinaryColumn>(data_column)->build_slices(table_items->build_slice);
+        } else {
+            ColumnHelper::as_raw_column<BinaryColumn>(data_column)->build_slices(table_items->build_slice);
+        }
+    }
+}
+
 template <LogicalType LT>
 auto BuildKeyConstructorForOneKey<LT>::get_key_data(const JoinHashTableItems& table_items) -> const ImmBuffer<CppType> {
-    ColumnPtr data_column;
-    if (table_items.key_columns[0]->is_nullable()) {
-        auto* null_column = ColumnHelper::as_raw_column<NullableColumn>(table_items.key_columns[0]);
-        data_column = null_column->data_column();
-    } else {
-        data_column = table_items.key_columns[0];
-    }
-
     if constexpr (lt_is_string<LT>) {
-        if (UNLIKELY(data_column->is_large_binary())) {
-            return ColumnHelper::as_raw_column<LargeBinaryColumn>(data_column)->get_data();
-        } else {
-            return ColumnHelper::as_raw_column<BinaryColumn>(data_column)->get_data();
-        }
+        return table_items.build_slice;
     } else {
-        return ColumnHelper::as_raw_column<ColumnType>(data_column)->get_data();
+        const auto* data_column = ColumnHelper::get_data_column(table_items.key_columns[0]);
+        return ColumnHelper::as_raw_column<ColumnType>(data_column)->immutable_data();
     }
 }
 
@@ -67,17 +72,21 @@ void ProbeKeyConstructorForOneKey<LT>::build_key(const JoinHashTableItems& table
     } else {
         probe_state->null_array = std::nullopt;
     }
+    if constexpr (lt_is_string<LT>) {
+        const auto* data_column = ColumnHelper::get_data_column_by_type<LT>((*probe_state.key_columns)[0]);
+        data_column->build_slices(probe_state->probe_slice);
+    }
 }
 
 template <LogicalType LT>
 auto ProbeKeyConstructorForOneKey<LT>::get_key_data(const HashTableProbeState& probe_state)
         -> const ImmBuffer<CppType> {
-    if ((*probe_state.key_columns)[0]->is_nullable()) {
-        auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state.key_columns)[0]);
-        return ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
+    if constexpr(lt_is_string<LT>) {
+        return probe_state.probe_slice;
+    } else {
+        const auto* data_column = ColumnHelper::get_data_column_by_type<LT>((*probe_state.key_columns)[0]);
+        return data_column->get_data();
     }
-
-    return ColumnHelper::as_raw_column<ColumnType>((*probe_state.key_columns)[0])->get_data();
 }
 
 // ------------------------------------------------------------------------------------

--- a/be/src/exec/join/join_key_constructor.hpp
+++ b/be/src/exec/join/join_key_constructor.hpp
@@ -27,9 +27,9 @@ namespace starrocks {
 
 template <LogicalType LT>
 void BuildKeyConstructorForOneKey<LT>::build_key(RuntimeState* state, JoinHashTableItems* table_items) {
-    // TODO: Going forward, if system testing verifies: the slice cache has no impact on join performance on all scene,
-    // we will ultimately avoid building the slice cache. According to the current simple benchmark results,
-    // it only has a minor performance optimization in mid-cardinality scenarios.
+    // TODO: Going forward, if system testing verifies that the slice cache has no impact on join performance
+    // in all scenarios, we will ultimately avoid building the slice cache. According to current simple benchmark
+    // results, it provides only minor performance benefits in medium-cardinality scenarios.
     if constexpr (lt_is_string<LT>) {
         const auto* data_column = ColumnHelper::get_data_column(table_items->key_columns[0]);
         if (UNLIKELY(data_column->is_large_binary())) {

--- a/be/src/exec/join/join_key_constructor.hpp
+++ b/be/src/exec/join/join_key_constructor.hpp
@@ -25,7 +25,6 @@ namespace starrocks {
 // KeyConstructorForOneKey
 // ------------------------------------------------------------------------------------
 
-
 template <LogicalType LT>
 void BuildKeyConstructorForOneKey<LT>::build_key(RuntimeState* state, JoinHashTableItems* table_items) {
     // TODO: Going forward, if system testing verifies: the slice cache has no impact on join performance on all scene,
@@ -81,7 +80,7 @@ void ProbeKeyConstructorForOneKey<LT>::build_key(const JoinHashTableItems& table
 template <LogicalType LT>
 auto ProbeKeyConstructorForOneKey<LT>::get_key_data(const HashTableProbeState& probe_state)
         -> const ImmBuffer<CppType> {
-    if constexpr(lt_is_string<LT>) {
+    if constexpr (lt_is_string<LT>) {
         return probe_state.probe_slice;
     } else {
         const auto* data_column = ColumnHelper::get_data_column_by_type<LT>((*probe_state.key_columns)[0]);

--- a/be/src/exec/join/join_key_constructor.hpp
+++ b/be/src/exec/join/join_key_constructor.hpp
@@ -72,7 +72,7 @@ void ProbeKeyConstructorForOneKey<LT>::build_key(const JoinHashTableItems& table
         probe_state->null_array = std::nullopt;
     }
     if constexpr (lt_is_string<LT>) {
-        const auto* data_column = ColumnHelper::get_data_column_by_type<LT>((*probe_state.key_columns)[0]);
+        const auto* data_column = ColumnHelper::get_data_column_by_type<LT>((*probe_state->key_columns)[0]);
         data_column->build_slices(probe_state->probe_slice);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

This is the 4st for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

* Add a build slice interface to BinaryColumn, allowing callers to invoke it on demand.
* Hash join key use the interface to build slice cache outside of BinaryColumn.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
