### PR TITLE
[BugFix] Wait for journal replay in changeCatalogDb on follower FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1628,8 +1628,32 @@ public class ConnectContext {
         dbName = normalizeName(dbName);
 
         if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
-            LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);
-            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            // On a follower FE, the database may have been created on the leader but the
+            // corresponding journal entry has not been replayed locally yet. Wait for the
+            // local replayer to catch up to the latest committed journal before giving up.
+            // This avoids spurious "Unknown database" errors when DDL statements are issued
+            // immediately after CREATE DATABASE hits a different FE pod.
+            if (!globalStateMgr.isLeader()) {
+                try {
+                    // Fetch the leader's current max journal ID via a lightweight forward RPC.
+                    // Using the local journal.getMaxJournalId() is insufficient because BDBJE
+                    // replication itself may not have delivered the latest entries to the local
+                    // BDB database yet. The leader's value is authoritative and guaranteed to be
+                    // >= any journal ID written before this USE/COM_INIT_DB arrived.
+                    long leaderMaxJournalId = LeaderOpExecutor.fetchLeaderMaxJournalId(this);
+                    if (leaderMaxJournalId > 0) {
+                        int timeoutMs = (int) (getSessionVariable().getQueryTimeoutS() * 1000L);
+                        globalStateMgr.getJournalObservable().waitOn(leaderMaxJournalId, timeoutMs);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to wait for journal replay in changeCatalogDb, db={}: {}",
+                            dbName, e.getMessage());
+                }
+            }
+            if (metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
+                LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
         }
 
         // Here we check the request permission that sent by the mysql client or jdbc.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -268,6 +268,49 @@ public class LeaderOpExecutor {
         this.result = result;
     }
 
+    /**
+     * Makes a lightweight Thrift call to the leader FE to retrieve its current maximum
+     * journal ID. This is used by followers to determine what journal position they need
+     * to wait for before validating metadata that was recently written by the leader.
+     * <p>
+     * A minimal {@code SELECT 1} statement is forwarded; the leader always sets
+     * {@code maxJournalId} in the response regardless of whether the query succeeds.
+     *
+     * @return the leader's current max journal ID, or -1 if the value is unavailable
+     */
+    public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+        try {
+            Pair<String, Integer> leaderAddr =
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getLeaderIpAndRpcPort();
+            if (leaderAddr == null) {
+                return -1;
+            }
+            TNetworkAddress thriftAddr = new TNetworkAddress(leaderAddr.first, leaderAddr.second);
+
+            TMasterOpRequest params = new TMasterOpRequest();
+            params.setCluster(SystemInfoService.DEFAULT_CLUSTER);
+            params.setSql("SELECT 1");
+            params.setStmtIdx(0);
+            params.setUser(ctx.getQualifiedUser() != null ? ctx.getQualifiedUser() : "");
+            params.setCatalog(ctx.getCurrentCatalog());
+            params.setDb(ctx.getDatabase() != null ? ctx.getDatabase() : "");
+            params.setStmt_id(ctx.getStmtId());
+            params.setForward_times(1);
+            params.setConnectionId(ctx.getConnectionId());
+
+            int timeoutMs = ctx.getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
+            TMasterOpResult leaderResult = ThriftRPCRequestExecutor.call(
+                    ThriftConnectionPool.frontendPool,
+                    thriftAddr,
+                    timeoutMs,
+                    client -> client.forward(params));
+            return leaderResult != null && leaderResult.isSetMaxJournalId() ? leaderResult.maxJournalId : -1;
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch leader max journal id: {}", e.getMessage());
+            return -1;
+        }
+    }
+
     public TMasterOpRequest createTMasterOpRequest(ConnectContext ctx, int forwardTimes) {
         TMasterOpRequest params = new TMasterOpRequest();
         params.setCluster(SystemInfoService.DEFAULT_CLUSTER);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -35,6 +35,9 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -43,8 +46,10 @@ import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.QueryStatement;
@@ -695,5 +700,187 @@ public class ConnectContextTest {
 
         // Should not throw exception even if getting CN group name fails
         Assertions.assertDoesNotThrow(() -> ctx.onQueryFinished());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for changeCatalogDb() journal-replay wait on follower FE
+    // -----------------------------------------------------------------------
+
+    /**
+     * On a follower FE, if the database is not found locally on the first check
+     * (journal not yet replayed), the follower fetches the leader's max journal ID,
+     * waits for local replay, and retries. If the database exists after the wait,
+     * changeCatalogDb() should succeed.
+     */
+    @Test
+    public void testChangeCatalogDb_followerWaitsForJournalAndSucceeds(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        Database mockDb = new Database(1L, "testdb");
+
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                // First call (outer condition): null  → enter wait block
+                // Second call (inner condition): mockDb → no error thrown
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                returns(null, mockDb);
+
+                // Simulate a successful journal replay (no-op)
+                journalObservable.waitOn(100L, anyInt);
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext ctx, String catalog, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertDoesNotThrow(() -> ctx.changeCatalogDb("testdb"));
+        Assertions.assertEquals("testdb", ctx.getDatabase());
+    }
+
+    /**
+     * On a follower FE, if the database is still missing after journal replay wait
+     * (the database genuinely does not exist), changeCatalogDb() should throw ERR_BAD_DB_ERROR.
+     */
+    @Test
+    public void testChangeCatalogDb_followerThrowsWhenDbStillMissingAfterWait(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                // Both calls return null: db genuinely does not exist
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                journalObservable.waitOn(100L, anyInt);
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("nonexistent"));
+    }
+
+    /**
+     * On the leader FE, changeCatalogDb() should throw immediately without fetching
+     * the leader journal ID or waiting for journal replay.
+     */
+    @Test
+    public void testChangeCatalogDb_leaderDoesNotWaitForJournal(
+            @Mocked MetadataMgr metadataMgr) {
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = true;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                // getJournalObservable must never be called on the leader
+                globalStateMgr.getJournalObservable();
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("somedb"));
+    }
+
+    /**
+     * On a follower FE, if the journal replay wait times out (DdlException from waitOn),
+     * the exception is swallowed and the inner db check still runs, throwing ERR_BAD_DB_ERROR.
+     */
+    @Test
+    public void testChangeCatalogDb_followerThrowsDbErrorAfterJournalWaitTimeout(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws DdlException {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                // Both calls return null: db does not appear even after wait
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                // Simulate journal replay timeout
+                journalObservable.waitOn(100L, anyInt);
+                result = new DdlException("journal replay timeout");
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        // The timeout exception is caught internally; ERR_BAD_DB_ERROR is still thrown
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("nonexistent"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -807,6 +807,107 @@ public class ConnectContextTest {
     }
 
     /**
+     * On a follower FE, if fetchLeaderMaxJournalId returns -1 (leader unavailable),
+     * the waitOn call is skipped entirely. The inner db check still runs and throws
+     * ERR_BAD_DB_ERROR if the database is not found.
+     */
+    @Test
+    public void testChangeCatalogDb_followerSkipsWaitWhenLeaderJournalIdNegative(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return -1L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                // Both calls return null: db not found
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                // waitOn must never be called when journalId <= 0
+                journalObservable.waitOn(anyLong, anyInt);
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("missingdb"));
+    }
+
+    /**
+     * On a follower FE, if fetchLeaderMaxJournalId returns -1 but the database
+     * actually exists on the second check (e.g. replayed in the meantime),
+     * changeCatalogDb() should succeed without calling waitOn.
+     */
+    @Test
+    public void testChangeCatalogDb_followerSucceedsWithoutWaitWhenDbAppearsAfterFetchFails(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        Database mockDb = new Database(2L, "latedb");
+
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return -1L;
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext ctx, String catalog, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                // First call: null (enter wait block), second call: found
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                returns(null, mockDb);
+
+                journalObservable.waitOn(anyLong, anyInt);
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertDoesNotThrow(() -> ctx.changeCatalogDb("latedb"));
+        Assertions.assertEquals("latedb", ctx.getDatabase());
+    }
+
+    /**
      * On the leader FE, changeCatalogDb() should throw immediately without fetching
      * the leader journal ID or waiting for journal replay.
      */

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -770,7 +770,7 @@ public class ConnectContextTest {
     @Test
     public void testChangeCatalogDb_followerThrowsWhenDbStillMissingAfterWait(
             @Mocked MetadataMgr metadataMgr,
-            @Mocked JournalObservable journalObservable) {
+            @Mocked JournalObservable journalObservable) throws Exception {
         new MockUp<LeaderOpExecutor>() {
             @Mock
             public static long fetchLeaderMaxJournalId(ConnectContext ctx) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
@@ -19,6 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.utframe.StarRocksAssert;
@@ -83,6 +84,77 @@ public class LeaderOpExecutorMockTest {
             executor.execute();
 
             Assertions.assertEquals(1, connectContext.getTxnId());
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_success() throws Exception {
+        TMasterOpResult result = new TMasterOpResult();
+        result.setMaxJournalId(200L);
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(result);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(200L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_leaderAddrNull() throws Exception {
+        try (MockedStatic<GlobalStateMgr> gsmMock = Mockito.mockStatic(GlobalStateMgr.class)) {
+            GlobalStateMgr mockGsm = Mockito.mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = Mockito.mock(NodeMgr.class);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            Mockito.when(mockGsm.getNodeMgr()).thenReturn(mockNodeMgr);
+            Mockito.when(mockNodeMgr.getLeaderIpAndRpcPort()).thenReturn(null);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_resultWithoutMaxJournalId() throws Exception {
+        TMasterOpResult result = new TMasterOpResult();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(result);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_rpcException() throws Exception {
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenThrow(new RuntimeException("RPC failed"));
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_nullResult() throws Exception {
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(null);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

In a multi-FE deployment (e.g., Kubernetes with multiple FE pods), `USE database` / `COM_INIT_DB` fails with **"Unknown database"** on a follower FE immediately after `CREATE DATABASE` is issued through a different FE pod.

`USE database` and `COM_INIT_DB` are handled locally on the follower (`RedirectStatus.NO_FORWARD`). Both call `ConnectContext.changeCatalogDb()`, which validates the database against **local metadata only** with no forwarding to the leader and no journal replay wait. When a connection pool routes `CREATE DATABASE` and `USE database` to different FE pods, the follower fails with "Unknown database" because of two compounding delays:

1. **BDBJE replication lag** — the journal entry for CREATE DATABASE may not yet have been delivered to the follower's local BDB database.
2. **Replayer lag** — even if BDB has the entry, the StarRocks replayer thread may not have applied it to in-memory metadata yet.

Note: `CREATE TABLE` (DdlStmt) does **not** have this issue — it skips local analysis on followers and forwards directly to the leader. The failure always happens at the `USE` / `COM_INIT_DB` step.

## What I'm doing:

**`LeaderOpExecutor.fetchLeaderMaxJournalId(ConnectContext)`** — a new static helper that forwards a lightweight `SELECT 1` to the leader via the existing Thrift `forward()` RPC. The leader always sets `maxJournalId` in the response (even on query failure), providing an **authoritative journal ID** that is guaranteed to be >= any entry written before this request arrived. This correctly handles both lags above, since it goes past the local BDB entirely.

**`ConnectContext.changeCatalogDb()`** — when the database is not found locally on a follower, call `fetchLeaderMaxJournalId()` to get the leader's current journal ID, then call `JournalObservable.waitOn()` to block until the local replayer catches up, and retry the lookup. This is the same **FORWARD_WITH_SYNC** mechanism already used for DDL statements, scoped to the failure path only.

```
USE mydb on follower (db not found locally)
  → LeaderOpExecutor.fetchLeaderMaxJournalId()
      → forward("SELECT 1") to leader via Thrift RPC
      ← result.maxJournalId  (leader's authoritative journal ID)
  → JournalObservable.waitOn(maxJournalId, queryTimeoutMs)
      (waits for BOTH BDB replication AND replayer to catch up)
  → retry metadataMgr.getDb()
  → if still null → ERR_BAD_DB_ERROR  (db genuinely missing)
  → else → proceed normally
```

**Key properties:**
- **Normal path** (db already exists locally): zero overhead — the wait block is never entered.
- **Failure path on follower**: one lightweight Thrift RPC + `waitOn()`, reusing the same infrastructure as `LeaderOpExecutor`.
- **Leader**: `isLeader()` guard skips the entire block, no behavior change.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4