### PR TITLE
[Enhancement] Add `MemtableIOSpeed` metric

### DIFF
--- a/be/src/common/runtime_profile.h
+++ b/be/src/common/runtime_profile.h
@@ -790,6 +790,8 @@ private:
             RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::MERGE_ALL, threshold), parent)
 #define ADD_CHILD_TIMER(profile, name, parent) \
     (profile)->add_child_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS), parent)
+#define ADD_DERIVED_COUNTER(profile, name, type, parent, ...) \
+    (profile)->add_derived_counter(name, type, __VA_ARGS__, parent)
 #define SCOPED_TIMER(c) ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c)
 #define CANCEL_SAFE_SCOPED_TIMER(c, is_cancelled) \
     ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c, is_cancelled)
@@ -821,6 +823,7 @@ private:
 #define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) (RuntimeProfile::Counter*)NULL
 #define ADD_CHILD_COUNTER_SKIP_MIN_MAX(profile, name, type, min_max_type, parent) (RuntimeProfile::Counter*)NULL
 #define ADD_CHILD_TIMER(profile, name, parent) (RuntimeProfile::Counter*)NULL
+#define ADD_DERIVED_COUNTER(profile, name, type, parent, ...) (RuntimeProfile::DerivedCounter*)NULL
 #define ADD_THREAD_COUNTERS(profile, prefix) (RuntimeProfile::ThreadCounters*)NULL
 #define ADD_CHILD_TIMER_THESHOLD(profile, name, parent, threshold) (RuntimeProfile::Counter*)NULL
 #define SCOPED_THREAD_COUNTER_MEASUREMENT(c)

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -1023,15 +1023,17 @@ void LakeTabletsChannel::_update_tablet_profile(const DeltaWriter* writer, Runti
                       DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.agg_time_ns.load(), 0));
     ADD_AND_SET_TIMER(profile, "MemtableFlushTime",
                       DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_time_ns.load(), 0));
-    ADD_AND_SET_TIMER(profile, "MemtableIOTime",
-                      DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.io_time_ns.load(), 0));
-    ADD_AND_SET_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND,
-        DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_disk_size.load() /
-            flush_stat->memtable_stats.io_time_ns.load(), 0));
     ADD_AND_SET_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES,
                         DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_memory_size.load(), 0));
-    ADD_AND_SET_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES,
-                        DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_disk_size.load(), 0));
+    auto* memtable_disk_size_counter = ADD_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES);
+    COUNTER_SET(memtable_disk_size_counter, flush_stat->memtable_stats.flush_disk_size.load());
+    auto* memtable_io_time_counter = ADD_TIMER(profile, "MemtableIOTime");
+    COUNTER_SET(memtable_io_time_counter, flush_stat->memtable_stats.io_time_ns.load());
+    ADD_DERIVED_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND, "",
+                        [memtable_disk_size_counter, memtable_io_time_counter] {
+                            return RuntimeProfile::units_per_second(memtable_disk_size_counter,
+                                                                    memtable_io_time_counter);
+                        });
 }
 
 std::shared_ptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, lake::TabletManager* tablet_manager,

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -1025,6 +1025,9 @@ void LakeTabletsChannel::_update_tablet_profile(const DeltaWriter* writer, Runti
                       DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_time_ns.load(), 0));
     ADD_AND_SET_TIMER(profile, "MemtableIOTime",
                       DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.io_time_ns.load(), 0));
+    ADD_AND_SET_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND,
+        DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_disk_size.load() /
+            flush_stat->memtable_stats.io_time_ns.load(), 0));
     ADD_AND_SET_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES,
                         DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_memory_size.load(), 0));
     ADD_AND_SET_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES,

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -1026,9 +1026,10 @@ void LakeTabletsChannel::_update_tablet_profile(const DeltaWriter* writer, Runti
     ADD_AND_SET_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES,
                         DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_memory_size.load(), 0));
     auto* memtable_disk_size_counter = ADD_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES);
-    COUNTER_SET(memtable_disk_size_counter, flush_stat->memtable_stats.flush_disk_size.load());
+    COUNTER_SET(memtable_disk_size_counter,
+                DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.flush_disk_size.load(), 0));
     auto* memtable_io_time_counter = ADD_TIMER(profile, "MemtableIOTime");
-    COUNTER_SET(memtable_io_time_counter, flush_stat->memtable_stats.io_time_ns.load());
+    COUNTER_SET(memtable_io_time_counter, DEFAULT_IF_NULL(flush_stat, flush_stat->memtable_stats.io_time_ns.load(), 0));
     ADD_DERIVED_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND, "",
                         [memtable_disk_size_counter, memtable_io_time_counter] {
                             return RuntimeProfile::units_per_second(memtable_disk_size_counter,

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -1189,11 +1189,16 @@ void LocalTabletsChannel::_update_peer_replica_profile(DeltaWriter* writer, Runt
     ADD_AND_SET_COUNTER(profile, "MemtableAggCount", TUnit::UNIT, memtable_stat.agg_count.load());
     ADD_AND_SET_TIMER(profile, "MemtableAggTime", memtable_stat.agg_time_ns.load());
     ADD_AND_SET_TIMER(profile, "MemtableFlushTime", memtable_stat.flush_time_ns.load());
-    ADD_AND_SET_TIMER(profile, "MemtableIOTime", memtable_stat.io_time_ns.load());
-    ADD_AND_SET_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND,
-        memtable_stat.flush_disk_size.load() / memtable_stat.io_time_ns.load());
     ADD_AND_SET_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES, memtable_stat.flush_memory_size.load());
-    ADD_AND_SET_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES, memtable_stat.flush_disk_size.load());
+    auto* memtable_disk_size_counter = ADD_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES);
+    COUNTER_SET(memtable_disk_size_counter, memtable_stat.flush_disk_size.load());
+    auto* memtable_io_time_counter = ADD_TIMER(profile, "MemtableIOTime");
+    COUNTER_SET(memtable_io_time_counter, memtable_stat.io_time_ns.load());
+    ADD_DERIVED_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND, "",
+                        [memtable_disk_size_counter, memtable_io_time_counter] {
+                            return RuntimeProfile::units_per_second(memtable_disk_size_counter,
+                                                                    memtable_io_time_counter);
+                        });
 }
 
 void LocalTabletsChannel::_update_primary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile) {

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -1190,6 +1190,8 @@ void LocalTabletsChannel::_update_peer_replica_profile(DeltaWriter* writer, Runt
     ADD_AND_SET_TIMER(profile, "MemtableAggTime", memtable_stat.agg_time_ns.load());
     ADD_AND_SET_TIMER(profile, "MemtableFlushTime", memtable_stat.flush_time_ns.load());
     ADD_AND_SET_TIMER(profile, "MemtableIOTime", memtable_stat.io_time_ns.load());
+    ADD_AND_SET_COUNTER(profile, "MemtableIOSpeed", TUnit::BYTES_PER_SECOND,
+        memtable_stat.flush_disk_size.load() / memtable_stat.io_time_ns.load());
     ADD_AND_SET_COUNTER(profile, "MemtableMemorySize", TUnit::BYTES, memtable_stat.flush_memory_size.load());
     ADD_AND_SET_COUNTER(profile, "MemtableDiskSize", TUnit::BYTES, memtable_stat.flush_disk_size.load());
 }


### PR DESCRIPTION
## Why I'm doing:

- We want to be able to detect that a particular backend node in the cluster is much slower than the others due to e.g. its disk failing.   
- Currently, Starrocks reports metrics such as `MemtableDiskSize` and `MemTableIOTime` in a query profile.
- Physical disk IO throughput cannot reliably determined by looking at these metrics because their values are already aggregated independently across all backend nodes, and do not necessarily correspond to the values reported from the same backend node.
- A new dedicated metric `MemTableIOSpeed` must be added before the aggregation without losing the per-memtable information.

## What I'm doing:

This pull request adds the `MemtableIOSpeed` metric.

- I used a derived metric as in [`sink_buffer.cpp#L201-L211`](https://github.com/StarRocks/starrocks/blob/9ada1d9de57be324ae93309a5a0be385a74c1005/be/src/exec/pipeline/exchange/sink_buffer.cpp#L201-L211)
- I added a new macro `ADD_DERIVED_METRIC` which respects the `ENABLE_COUNTERS` definition.

## Test

I tested the new metric with the following simple scenario:
- Start up 3 local backend instances and throttle the disk IO speed of the third node to 64 KiB/s. 
- Create a table distributed intro 3 buckets.
- Execute an INSERT operation such that the slowest node receives only the 1/10 of the total rows.

The results are as follows:

```
 - RowCount: 3.000M (3000000)
  - __MAX_OF_RowCount: 1.500M (1500000)
  - __MIN_OF_RowCount: 300.000K (300000)
- TabletsNum: 3
  - __MAX_OF_TabletsNum: 1
  - __MIN_OF_TabletsNum: 1
- MemtableDiskSize: 432.702 MB
  - __MAX_OF_MemtableDiskSize: 216.351 MB
  - __MIN_OF_MemtableDiskSize: 43.270 MB  
- MemtableIOTime: 3m58s
  - __MAX_OF_MemtableIOTime: 11m54s
  - __MIN_OF_MemtableIOTime: 115.276ms
- MemtableIOSpeed: 2.897 GB/sec
  - __MAX_OF_MemtableIOSpeed: 1.466 GB/sec
  - __MIN_OF_MemtableIOSpeed: 62.005 KB/sec
```
- All nodes received a tablet and worked on it.
- The slowest node received the least amount of work (43 MB) and wrote to disk with a speed of 62 KB/s in 12 mins.
- The fastest of the other nodes wrote with 1.4 GB/s, and the most physical write work for a node was 216 MB.
- The new metric `MemtableIOSpeed` gives the throughputs of the fastest and slowest backend nodes correctly.

The query I executed to get these results and [the complete query profile can be found here.](https://gist.github.com/arin-mirza/51d419d984689480fa1976901f41f766)

### Test setup
- I used a usb flash drive and `systemd-run` to simulate a slow disk and throttle the IO speed.
  - Throttling does not work if your computer's disk is encrypted. (e.g. `nvme0n1p3_crypt`)
  - Throttling does not work if a usb disk is formatted as anything else than `ext4` format.
    - Moreover, other disk formats are not ACID compliant and will *lie* about the write being physically written, which gives extremely high IO speeds even though the data is not `fsync`ed.
  - Runs where throttling does not work properly might be slow or fast, and are not reproducible.
- I ran the test multiple times and the results are reproducible.
  - Running `ls be3/storage` in bash while the SQL query is running will stall until the query has finished. This is expected, as a read operation can only be sequentially ordered after the write has been completed and synced.

If you want to run this experiment yourself, you can find the steps I used below (Ubuntu). 
```bash
# Get the device mapping information 
# My flash drive was mapped to device sdb1 under /media/amirza/test-usb
lsblk

# unmount the device
sudo umount /media/amirza/test-usb 

# format it using ext4 format
sudo mkfs.ext4 /dev/sdb1

# mount it back
sudo mount /dev/sdb1 /media/amirza/test-usb

# fix the permissions (replace amirza with your username)
sudo chown -R amirza:amirza /media/amirza/test-usb/slow-storage

# bind the slow-storage folder to the storage folder of the 3rd backend node
sudo mount --bind /media/amirza/test-usb/slow-storage ./output/be3/storage

# run the fe, be1 and be2 normally
./output/fe/bin/start_fe.sh --daemon
./output/be1/bin/start_be.sh --daemon
./output/be2/bin/start_be.sh --daemon

# start the 3rd be node with throttling (not as a daemon!)
sudo systemd-run --scope -p IOWriteBandwidthMax="/dev/sdb1 64K"./output/be3/bin/start_be.sh
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
