### PR TITLE
[BugFix] Fix metadata null error when sampling keys from SSTable with delvec

### DIFF
--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -381,8 +381,7 @@ Status LakePersistentIndexParallelCompactMgr::sample_keys_from_sstable(const Per
         ASSIGN_OR_RETURN(auto sstable,
                          PersistentIndexSstable::new_sstable(
                                  sstable_pb, _tablet_mgr->sst_location(metadata->id(), sstable_pb.filename()),
-                                 block_cache ? block_cache->cache() : nullptr, false, nullptr, metadata,
-                                 _tablet_mgr));
+                                 block_cache ? block_cache->cache() : nullptr, false, nullptr, metadata, _tablet_mgr));
         RETURN_IF_ERROR(sstable->sample_keys(sample_keys, config::pk_index_sstable_sample_interval_bytes));
     }
     return Status::OK();

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -381,7 +381,8 @@ Status LakePersistentIndexParallelCompactMgr::sample_keys_from_sstable(const Per
         ASSIGN_OR_RETURN(auto sstable,
                          PersistentIndexSstable::new_sstable(
                                  sstable_pb, _tablet_mgr->sst_location(metadata->id(), sstable_pb.filename()),
-                                 block_cache ? block_cache->cache() : nullptr, false));
+                                 block_cache ? block_cache->cache() : nullptr, false, nullptr, metadata,
+                                 _tablet_mgr));
         RETURN_IF_ERROR(sstable->sample_keys(sample_keys, config::pk_index_sstable_sample_interval_bytes));
     }
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:
When `sample_keys_from_sstable` opens an SSTable for key sampling during parallel compaction, it calls `PersistentIndexSstable::new_sstable` without passing `metadata` and `tablet_mgr`. If the SSTable has delvec data, `init()` tries to load the delvec from file but fails with `"metadata is null when loading delvec from file"`, causing the sampling to fall back to using only the start_key as boundary, which degrades parallel compaction splitting quality.

## What I'm doing:
Pass `metadata` and `_tablet_mgr` to the `new_sstable` call in `sample_keys_from_sstable`, so delvec can be properly loaded when the SSTable contains delvec data.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4