### PR TITLE
[Enhancement] Remove interface get_data from BinaryColumn

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -305,19 +305,6 @@ public:
         }
     }
 
-    Container& get_data() {
-        if (!_slices_cache) {
-            _build_slices();
-        }
-        return _slices;
-    }
-    const Container& get_data() const {
-        if (!_slices_cache) {
-            _build_slices();
-        }
-        return _slices;
-    }
-
     GermanStringContainer& get_german_strings() {
         if (!_german_strings_cache) {
             _build_german_strings();

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -87,9 +87,9 @@ public:
         // @FIXME: BinaryColumn get_data() will call build_slice() to modify the column's memory data,
         // but the operator is thread-unsafe, it's will cause crash in multi-thread(OLAP_SCANNER) when
         // OLAP_SCANNER call expression.
-        // Call the get_data() when create ConstColumn is a short-term solution
+        // Call the raw_data() when create ConstColumn is a short-term solution
         if constexpr (!lt_is_object_family<Type>) {
-            ptr->get_data();
+            ptr->raw_data();
         }
         return ConstColumn::create(std::move(ptr), chunk_size);
     }

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -271,8 +271,7 @@ void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_h
                 }
             }
         } else {
-            // Use raw pointers for auto-vectorization to optimize performance with fixed-length values.
-            const auto* __restrict__ order_by_data = order_by_column->get_data().data();
+            const auto& order_by_data = order_by_column->immutable_data();
             if (sort_order_flag > 0) {
                 for (int i = 0; i < row_sz; ++i) {
                     filter_data[i] = order_by_data[i] < need_filter_data;

--- a/be/src/exprs/agg/array_union_agg.h
+++ b/be/src/exprs/agg/array_union_agg.h
@@ -84,7 +84,7 @@ struct ArrayUnionAggAggregateState {
         if (data_column.size() > 0 || size == 0) {
             return &data_column;
         }
-        data_column.get_data().reserve(size);
+        data_column.reserve(size);
         if constexpr (is_distinct) {
             if constexpr (lt_is_string<PT>) {
                 for (auto& key : set) {

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -93,7 +93,7 @@ Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, 
                 auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
                 size_t read_num = 1;
                 RETURN_IF_ERROR(_bitmap_itr->next_batch_dictionary(&read_num, column.get()));
-                Slice s = down_cast<BinaryColumn*>(column.get())->get_data()[0];
+                Slice s = down_cast<BinaryColumn*>(column.get())->immutable_data()[0];
                 return std::make_pair(cur_ordinal, s.to_string());
             }
         };

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -19,7 +19,6 @@
 #include "base/testutil/parallel_test.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
-#include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 
@@ -60,7 +59,7 @@ GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflo
     }
 
     // row size overflow
-    // the case will allocate a lot of memory, so temp remove it
+    // the case will allocate a lot of memory, so temp removes it
     count = Column::MAX_CAPACITY_LIMIT + 5;
     column = BinaryColumn::create();
     column->reserve(count);
@@ -108,7 +107,7 @@ PARALLEL_TEST(BinaryColumnTest, test_get_data) {
     for (int i = 0; i < 100; i++) {
         column->append(std::string("str:").append(std::to_string(i)));
     }
-    auto& slices = ColumnHelper::as_raw_column<BinaryColumn>(column.get())->get_data();
+    auto slices = column->immutable_data();
     for (int i = 0; i < slices.size(); ++i) {
         ASSERT_EQ(std::string("str:").append(std::to_string(i)), slices[i].to_string());
     }
@@ -142,7 +141,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter) {
     column->filter(filter);
     ASSERT_EQ(50, column->size());
 
-    const auto& slices = ColumnHelper::as_raw_column<BinaryColumn>(column.get())->get_data();
+    auto slices = column->immutable_data();
 
     for (int i = 0; i < 50; ++i) {
         ASSERT_EQ(std::to_string(i * 2 + 1), slices[i].to_string());
@@ -156,17 +155,17 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     ASSERT_TRUE(c1->append_strings(values.data(), values.size()));
     ASSERT_EQ(values.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
-        ASSERT_EQ(values[i], ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data()[i]);
+        ASSERT_EQ(values[i], c1->immutable_data()[i]);
     }
 
     std::vector<Slice> values2{{"abcd"}, {"123456"}};
     ASSERT_TRUE(c1->append_strings(values2.data(), values2.size()));
     ASSERT_EQ(values.size() + values2.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
-        ASSERT_EQ(values[i], ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data()[i]);
+        ASSERT_EQ(values[i], c1->immutable_data()[i]);
     }
     for (size_t i = 0; i < values2.size(); i++) {
-        ASSERT_EQ(values2[i], ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data()[i + 2]);
+        ASSERT_EQ(values2[i], c1->immutable_data()[i + 2]);
     }
 
     // Nullable BinaryColumn
@@ -175,7 +174,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     ASSERT_EQ(values.size(), c2->size());
     auto* c = reinterpret_cast<BinaryColumn*>(c2->data_column_raw_ptr());
     for (size_t i = 0; i < values.size(); i++) {
-        ASSERT_EQ(values[i], c->get_data()[i]);
+        ASSERT_EQ(values[i], c->immutable_data()[i]);
     }
 }
 
@@ -222,7 +221,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_defaults) {
     c1->append_default(10);
     ASSERT_EQ(10U, c1->size());
     for (int i = 0; i < 10; i++) {
-        ASSERT_EQ("", c1->get_data()[i]);
+        ASSERT_EQ("", c1->immutable_data()[i]);
     }
 
     // NullableColumn
@@ -303,8 +302,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter_range) {
 
     column->filter_range(filter, 0, 66);
 
-    auto* binary_column = ColumnHelper::as_raw_column<BinaryColumn>(column.get());
-    auto& data = binary_column->get_data();
+    auto data = column->immutable_data();
     for (size_t i = 0; i < 63; i++) {
         ASSERT_EQ(data[i], "a");
     }
@@ -361,7 +359,7 @@ PARALLEL_TEST(BinaryColumnTest, test_reset_column) {
 
     c1->reset_column();
     ASSERT_EQ(0, c1->size());
-    ASSERT_EQ(0, ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data().size());
+    ASSERT_EQ(0, c1->immutable_data().size());
     ASSERT_EQ(DEL_NOT_SATISFIED, c1->delete_state());
 }
 
@@ -377,36 +375,15 @@ PARALLEL_TEST(BinaryColumnTest, test_swap_column) {
     c1->swap_column(*c2);
 
     ASSERT_EQ(0, c1->size());
-    ASSERT_EQ(0, ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data().size());
+    ASSERT_EQ(0, c1->immutable_data().size());
     ASSERT_EQ(DEL_NOT_SATISFIED, c1->delete_state());
 
     ASSERT_EQ(3, c2->size());
-    ASSERT_EQ(3, ColumnHelper::as_raw_column<BinaryColumn>(c2.get())->get_data().size());
+    ASSERT_EQ(3, c2->immutable_data().size());
     ASSERT_EQ(DEL_PARTIAL_SATISFIED, c2->delete_state());
     ASSERT_EQ("bbb", c2->get_slice(0));
     ASSERT_EQ("bbc", c2->get_slice(1));
     ASSERT_EQ("ccc", c2->get_slice(2));
-}
-
-// NOLINTNEXTLINE
-PARALLEL_TEST(BinaryColumnTest, test_slice_cache) {
-    auto c1 = BinaryColumn::create();
-    ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data().reserve(10);
-    c1->append_default();
-    ASSERT_FALSE(c1->_slices_cache);
-    ASSERT_EQ(c1->get_offset().size(), 2);
-
-    auto c2 = BinaryColumn::create();
-    ColumnHelper::as_raw_column<BinaryColumn>(c2.get())->get_data().reserve(10);
-    c2->append_default(5);
-    ASSERT_FALSE(c2->_slices_cache);
-    ASSERT_EQ(c2->get_offset().size(), 6);
-
-    auto c3 = BinaryColumn::create();
-    ColumnHelper::as_raw_column<BinaryColumn>(c3.get())->get_data().reserve(10);
-    c3->append(Slice("1"));
-    ASSERT_FALSE(c3->_slices_cache);
-    ASSERT_EQ(c3->get_offset().size(), 2);
 }
 
 // NOLINTNEXTLINE
@@ -425,15 +402,14 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_constructor) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
     auto c2 = BinaryColumn::static_pointer_cast(c1->clone());
 
     c1.reset();
-    slices = c2->get_data();
+    slices = c2->immutable_data();
     ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -445,15 +421,14 @@ PARALLEL_TEST(BinaryColumnTest, test_move_constructor) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
     auto c2(std::move(*c1));
 
     c1.reset();
-    slices = c2.get_data();
+    slices = c2.immutable_data();
     ASSERT_EQ(2, c2.size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -465,15 +440,14 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_assignment) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
     auto c2 = BinaryColumn::static_pointer_cast(c1->clone());
 
     c1.reset();
-    slices = c2->get_data();
+    slices = c2->immutable_data();
     ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -485,16 +459,14 @@ PARALLEL_TEST(BinaryColumnTest, test_move_assignment) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
-    BinaryColumn c2;
-    c2 = std::move(*c1);
+    BinaryColumn c2 = std::move(*c1);
 
     c1.reset();
-    slices = c2.get_data();
+    slices = c2.immutable_data();
     ASSERT_EQ(2, c2.size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -506,8 +478,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
@@ -515,7 +486,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone) {
 
     c1.reset();
 
-    slices = down_cast<BinaryColumn*>(c2.get())->get_data();
+    slices = down_cast<BinaryColumn*>(c2.get())->immutable_data();
     ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -527,8 +498,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_shared) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
@@ -537,7 +507,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_shared) {
 
     c1.reset();
 
-    slices = down_cast<BinaryColumn*>(c2.get())->get_data();
+    slices = down_cast<BinaryColumn*>(c2.get())->immutable_data();
     ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
@@ -549,8 +519,7 @@ PARALLEL_TEST(BinaryColumnTest, test_clone_empty) {
     c1->append_datum("abc");
     c1->append_datum("def");
 
-    // trigger cache building.
-    auto slices = ColumnHelper::as_raw_column<BinaryColumn>(c1.get())->get_data();
+    auto slices = c1->immutable_data();
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
@@ -576,7 +545,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     c2->append_datum("rstu");
     c1->update_rows(*c2.get(), replace_idxes.data());
 
-    auto slices = c1->get_data();
+    auto slices = c1->immutable_data();
     EXPECT_EQ(5, c1->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("pq", slices[1]);
@@ -589,7 +558,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     c3->append_datum("cdef");
     c1->update_rows(*c3.get(), replace_idxes.data());
 
-    slices = c1->get_data();
+    slices = c1->immutable_data();
     EXPECT_EQ(5, c1->size());
     ASSERT_EQ("abc", slices[0]);
     EXPECT_EQ("ab", slices[1]);
@@ -603,34 +572,13 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     c4->append_datum("cdef");
     c1->update_rows(*c4.get(), new_replace_idxes.data());
 
-    slices = c1->get_data();
+    slices = c1->immutable_data();
     EXPECT_EQ(5, c1->size());
     ASSERT_EQ("ab", slices[0]);
     EXPECT_EQ("cdef", slices[1]);
     ASSERT_EQ("ghi", slices[2]);
     ASSERT_EQ("cdef", slices[3]);
     ASSERT_EQ("mno", slices[4]);
-
-#ifdef NDEBUG
-    // This case will alloc a lot of memory (16G) and run slowly,
-    // So i temp comment it and will open if i find one better solution
-    /*
-    size_t count = (1ul << 31ul) + 5;
-    auto c5 = BinaryColumn::create();
-    c5->get_bytes().resize(count);
-    c5->get_offset().resize(count + 1);
-    for (size_t i = 0; i < c5->get_offset().size(); i++) {
-        c5->get_offset()[i] = i;
-    }
-
-    auto c6 = BinaryColumn::create();
-    c6->append("22");
-
-    std::vector<uint32_t> c6_replace_idxes = {0};
-    ASSERT_TRUE(c5->update_rows(*c6, c6_replace_idxes.data()).ok());
-    ASSERT_EQ(c5->size(), count);
-    */
-#endif
 }
 
 // NOLINTNEXTLINE
@@ -660,7 +608,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
 
     auto c2 = c1->replicate(offsets).value();
 
-    auto slices = down_cast<const BinaryColumn*>(c2.get())->get_data();
+    auto slices = down_cast<const BinaryColumn*>(c2.get())->immutable_data();
     ASSERT_EQ(5, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("abc", slices[1]);

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -59,7 +59,7 @@ GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflo
     }
 
     // row size overflow
-    // the case will allocate a lot of memory, so temp removes it
+    // this case will allocate a lot of memory, so it is temporarily disabled
     count = Column::MAX_CAPACITY_LIMIT + 5;
     column = BinaryColumn::create();
     column->reserve(count);
@@ -463,7 +463,8 @@ PARALLEL_TEST(BinaryColumnTest, test_move_assignment) {
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
-    BinaryColumn c2 = std::move(*c1);
+    BinaryColumn c2;
+    c2 = std::move(*c1);
 
     c1.reset();
     slices = c2.immutable_data();

--- a/be/test/exec/chunks_sorter_heap_sort_test.cpp
+++ b/be/test/exec/chunks_sorter_heap_sort_test.cpp
@@ -236,7 +236,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(sorter.get_next(&chunk, &eos));
             auto column = chunk->get_column_by_slot_id(1);
             auto* slice_col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(column);
-            const auto& slice_data = slice_col->get_data();
+            BinaryColumn::Container slice_data;
+            slice_col->build_slices(slice_data);
             ASSERT_TRUE(std::is_sorted(slice_data.begin(), slice_data.end()));
         }
     }

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -710,7 +710,7 @@ ColumnPtr JoinHashMapTest::create_int32_nullable_column(uint32_t row_count, uint
 
 void JoinHashMapTest::check_binary_column(const ColumnPtr& column, uint32_t row_count, uint32_t start_value) {
     auto* binary_column = ColumnHelper::as_raw_column<BinaryColumn>(column);
-    auto& data = binary_column->get_data();
+    auto data = binary_column->immutable_data();
 
     for (uint32_t i = 0; i < row_count; i++) {
         std::string str = std::to_string(start_value + i);

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -39,7 +39,7 @@ public:
         _allocator.reset();
     }
 
-private:
+protected:
     FunctionUtils* utils{};
     FunctionContext* ctx{};
     std::unique_ptr<CountingAllocatorWithHook> _allocator;
@@ -1077,7 +1077,7 @@ TEST_F(AggregateTest, test_group_concat) {
     auto result_column = BinaryColumn::create();
     group_concat_function->finalize_to_column(ctx, state->state(), result_column.get());
 
-    ASSERT_EQ("starrocks0, starrocks1, starrocks2, starrocks3, starrocks4, starrocks5", result_column->get_data()[0]);
+    ASSERT_EQ("starrocks0, starrocks1, starrocks2, starrocks3, starrocks4, starrocks5", result_column->get_slice(0));
 }
 
 TEST_F(AggregateTest, test_group_concat_const_seperator) {
@@ -1122,7 +1122,7 @@ TEST_F(AggregateTest, test_group_concat_const_seperator) {
     auto result_column = BinaryColumn::create();
     group_concat_function->finalize_to_column(local_ctx.get(), state->state(), result_column.get());
 
-    ASSERT_EQ("abcbcdcdedefefgfghghihijijk", result_column->get_data()[0]);
+    ASSERT_EQ("abcbcdcdedefefgfghghihijijk", result_column->get_slice(0));
 }
 
 TEST_F(AggregateTest, test_percentile_cont) {
@@ -1672,7 +1672,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     func->finalize_to_column(ctx, state->state(), result_column1.get());
 
     const auto& expected_column1 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
-    ASSERT_EQ(expected_column1.get_data()[0], result_column1->get_data()[0]);
+    ASSERT_EQ(expected_column1.immutable_data()[0], result_column1->immutable_data()[0]);
 
     // update input column 2
     ResultColumnPtr result_column2 = ResultColumn::create();
@@ -1683,7 +1683,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     func->finalize_to_column(ctx, state2->state(), result_column2.get());
 
     const auto& expected_column2 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
-    ASSERT_EQ(expected_column2.get_data()[0], result_column2->get_data()[0]);
+    ASSERT_EQ(expected_column2.immutable_data()[0], result_column2->immutable_data()[0]);
 
     // merge column 1 and column 2
     auto final_result_column = ResultColumn::create();
@@ -1691,7 +1691,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     func->merge(ctx, final_result_column.get(), state2->state(), 0);
     func->finalize_to_column(ctx, state2->state(), final_result_column.get());
 
-    ASSERT_EQ(final_result_column->get_data()[0], result_column1->get_data()[0]);
+    ASSERT_EQ(final_result_column->immutable_data()[0], result_column1->immutable_data()[0]);
 }
 
 TEST_F(AggregateTest, test_any_value) {

--- a/be/test/exprs/agg/base_aggregate_test.h
+++ b/be/test/exprs/agg/base_aggregate_test.h
@@ -214,7 +214,7 @@ void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TRes
     const Column* row_column = column.get();
     func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state->state());
     func->finalize_to_column(ctx, aggr_state->state(), result_column.get());
-    ASSERT_EQ(update_result1, result_column->get_data()[0]);
+    ASSERT_EQ(update_result1, result_column->immutable_data()[0]);
 
     // update input column 2
     auto aggr_state2 = ManagedAggrState::create(ctx, func);
@@ -222,7 +222,7 @@ void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TRes
     row_column = column2.get();
     func->update_batch_single_state(ctx, row_column->size(), &row_column, aggr_state2->state());
     func->finalize_to_column(ctx, aggr_state2->state(), result_column.get());
-    ASSERT_EQ(update_result2, result_column->get_data()[1]);
+    ASSERT_EQ(update_result2, result_column->immutable_data()[1]);
 
     // merge column 1 and column 2
     MutableColumnPtr serde_column = BinaryColumn::create();
@@ -234,7 +234,7 @@ void test_agg_function(FunctionContext* ctx, const AggregateFunction* func, TRes
     func->serialize_to_column(ctx, aggr_state->state(), serde_column.get());
     func->merge(ctx, serde_column.get(), aggr_state2->state(), 0);
     func->finalize_to_column(ctx, aggr_state2->state(), result_column.get());
-    ASSERT_EQ(merge_result, result_column->get_data()[2]);
+    ASSERT_EQ(merge_result, result_column->immutable_data()[2]);
 }
 
 template <LogicalType LT, typename TResult = RunTimeCppType<TYPE_DECIMAL128>, typename = DecimalLTGuard<LT>>

--- a/be/test/exprs/ai_functions_test.cpp
+++ b/be/test/exprs/ai_functions_test.cpp
@@ -19,7 +19,6 @@
 
 #include "column/array_column.h"
 #include "column/binary_column.h"
-#include "column/const_column.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "exprs/mock_vectorized_expr.h"
@@ -89,12 +88,12 @@ protected:
     }
 
     // Helper method to validate sentiment analysis responses
-    void validateSentimentResponses(const ColumnPtr& result_column, size_t expected_size) {
+    static void validateSentimentResponses(const ColumnPtr& result_column, size_t expected_size) {
         ASSERT_EQ(result_column->size(), expected_size);
         const auto* binary_column = down_cast<const BinaryColumn*>(result_column.get());
 
         for (size_t i = 0; i < expected_size; ++i) {
-            std::string response = binary_column->get_data()[i].to_string();
+            std::string response = binary_column->get_slice(i).to_string();
             ASSERT_TRUE(response == "positive" || response == "negative")
                     << "Response at index " << i << " is neither 'positive' nor 'negative': " << response;
         }
@@ -273,7 +272,7 @@ TEST_F(AiFunctionsTest, AiQueryWithNullValues) {
 
         // Verify that null inputs produce some predictable output (empty string or error message)
         for (size_t i = 0; i < 2; ++i) {
-            std::string response = binary_result->get_data()[i].to_string();
+            std::string response = binary_result->get_slice(i).to_string();
             EXPECT_TRUE(response.empty() || response.find("null") != std::string::npos ||
                         response.find("error") != std::string::npos)
                     << "Row " << i << " should handle null input appropriately, got: " << response;
@@ -298,7 +297,7 @@ TEST_F(AiFunctionsTest, DISABLED_SingleSentimentAnalysisCall) {
 
     // For this specific positive test case, we expect "positive"
     const auto* binary_column = down_cast<const BinaryColumn*>(result_column.get());
-    std::string response = binary_column->get_data()[0].to_string();
+    std::string response = binary_column->get_slice(0).to_string();
     ASSERT_EQ(response, "positive");
 }
 
@@ -326,7 +325,7 @@ TEST_F(AiFunctionsTest, DISABLED_MultipleSameSentimentAnalysisCalls) {
     // For these specific positive test cases, we expect all "positive"
     const auto* binary_column = down_cast<const BinaryColumn*>(result_column.get());
     for (int i = 0; i < num_calls; ++i) {
-        std::string response = binary_column->get_data()[i].to_string();
+        std::string response = binary_column->get_slice(i).to_string();
         ASSERT_EQ(response, "positive") << "Response at index " << i << " should be positive";
     }
 }

--- a/be/test/exprs/binary_functions_test.cpp
+++ b/be/test/exprs/binary_functions_test.cpp
@@ -17,10 +17,8 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include "column/fixed_length_column.h"
 #include "exprs/math_functions.h"
 #include "exprs/mock_vectorized_expr.h"
-#include "testutil/column_test_helper.h"
 
 namespace starrocks {
 
@@ -87,9 +85,9 @@ TEST_F(BinaryFunctionsTest, TestToBinaryNormal) {
         ASSERT_TRUE(!v->is_null(0));
         ASSERT_EQ(v->size(), 1);
         if (binary_type == BinaryFormatType::HEX) {
-            ASSERT_EQ(Slice(expect).to_string(), hex_binary(v->get_data()[0]));
+            ASSERT_EQ(Slice(expect).to_string(), hex_binary(v->get_slice(0)));
         } else {
-            ASSERT_EQ(Slice(expect), v->get_data()[0]);
+            ASSERT_EQ(Slice(expect), v->get_slice(0));
         }
     }
 
@@ -104,7 +102,7 @@ TEST_F(BinaryFunctionsTest, TestToBinaryNormal) {
         auto v = ColumnHelper::as_column<BinaryColumn>(result.value());
         // TODO: Return null if input is invalid.
         ASSERT_FALSE(v->is_null(0));
-        ASSERT_EQ(Slice(""), v->get_data()[0]);
+        ASSERT_EQ(Slice(""), v->get_slice(0));
     }
 }
 
@@ -140,11 +138,11 @@ TEST_F(BinaryFunctionsTest, TestFromToBinaryNormal) {
         ASSERT_TRUE(!v->is_null(0));
         ASSERT_EQ(v->size(), 1);
 
-        auto result_vv = test_from_binary(v->get_data()[0], binary_type);
+        auto result_vv = test_from_binary(v->get_slice(0), binary_type);
         auto vv = ColumnHelper::as_column<BinaryColumn>(result_vv.value());
         ASSERT_TRUE(!vv->is_null(0));
         ASSERT_EQ(vv->size(), 1);
-        ASSERT_EQ(Slice(expect), vv->get_data()[0]);
+        ASSERT_EQ(Slice(expect), vv->get_slice(0));
     }
 }
 

--- a/be/test/exprs/case_expr_test.cpp
+++ b/be/test/exprs/case_expr_test.cpp
@@ -467,10 +467,10 @@ TEST_F(VectorizedCaseExprTest, whenNullIntCaseElse) {
             for (int j = 0; j < ptr->size(); ++j) {
                 if (j % 2) {
                     ASSERT_FALSE(ptr->is_null(j));
-                    ASSERT_EQ(s3, v->get_data()[j]);
+                    ASSERT_EQ(s3, v->get_slice(j));
                 } else {
                     ASSERT_FALSE(ptr->is_null(j));
-                    ASSERT_EQ(s2, v->get_data()[j]);
+                    ASSERT_EQ(s2, v->get_slice(j));
                 }
             }
         }

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -638,7 +638,7 @@ TEST_F(VectorizedCastExprTest, decimalCastString) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(std::string("123"), v->get_data()[j]);
+            ASSERT_EQ(std::string("123"), v->get_slice(j));
         }
 
         // error cast
@@ -668,7 +668,7 @@ TEST_F(VectorizedCastExprTest, intCastString) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(std::string("12345"), v->get_data()[j]);
+            ASSERT_EQ(std::string("12345"), v->get_slice(j));
         }
 
         // error cast
@@ -698,7 +698,7 @@ TEST_F(VectorizedCastExprTest, booleanCastString) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(std::string("1"), v->get_data()[j]);
+            ASSERT_EQ(std::string("1"), v->get_slice(j));
         }
 
         // error cast
@@ -728,7 +728,7 @@ TEST_F(VectorizedCastExprTest, timestmapCastString) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(std::string("2020-02-03 01:23:45"), v->get_data()[j]);
+            ASSERT_EQ(std::string("2020-02-03 01:23:45"), v->get_slice(j));
         }
 
         // error cast
@@ -759,7 +759,7 @@ TEST_F(VectorizedCastExprTest, stringCastInt) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(1234, v->get_data()[j]);
+            ASSERT_EQ(1234, v->immutable_data()[j]);
         }
 
         // error cast
@@ -821,7 +821,7 @@ TEST_F(VectorizedCastExprTest, stringCastDouble) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(1234.1234, v->get_data()[j]);
+            ASSERT_EQ(1234.1234, v->immutable_data()[j]);
         }
 
         // error cast
@@ -887,7 +887,7 @@ TEST_F(VectorizedCastExprTest, stringCastDecimal) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(d, v->get_data()[j]);
+            ASSERT_EQ(d, v->immutable_data()[j]);
         }
 
         // error cast
@@ -952,7 +952,7 @@ TEST_F(VectorizedCastExprTest, stringCastDate) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(DateValue::create(2023, 12, 02), v->get_data()[j]);
+            ASSERT_EQ(DateValue::create(2023, 12, 02), v->immutable_data()[j]);
         }
 
         // error cast
@@ -983,7 +983,7 @@ TEST_F(VectorizedCastExprTest, stringCastDate2) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(DateValue::create(2023, 12, 02), v->get_data()[j]);
+            ASSERT_EQ(DateValue::create(2023, 12, 02), v->immutable_data()[j]);
         }
 
         // error cast
@@ -1045,7 +1045,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->get_data()[j]);
+            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->immutable_data()[j]);
         }
 
         // error cast
@@ -1364,7 +1364,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap2) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->get_data()[j]);
+            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->immutable_data()[j]);
         }
 
         // error cast
@@ -1395,7 +1395,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap3) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->get_data()[j]);
+            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->immutable_data()[j]);
         }
 
         // error cast
@@ -1426,7 +1426,7 @@ TEST_F(VectorizedCastExprTest, stringCastTimestmap4) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->get_data()[j]);
+            ASSERT_EQ(TimestampValue::create(2022, 02, 03, 11, 23, 45), v->immutable_data()[j]);
         }
 
         // error cast
@@ -1509,7 +1509,7 @@ TEST_F(VectorizedCastExprTest, BigIntCastToInt2) {
             ASSERT_EQ(10, v->size());
 
             for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(10, v->get_data()[j]);
+                ASSERT_EQ(10, v->immutable_data()[j]);
             }
         });
     }
@@ -1534,7 +1534,7 @@ TEST_F(VectorizedCastExprTest, IntCastToBigInt3) {
 
             auto p = ColumnHelper::cast_to<TYPE_BIGINT>(ptr);
             for (int j = 0; j < p->size(); ++j) {
-                ASSERT_EQ(INT_MAX, p->get_data()[j]);
+                ASSERT_EQ(INT_MAX, p->immutable_data()[j]);
             }
         });
     }
@@ -1561,7 +1561,7 @@ TEST_F(VectorizedCastExprTest, stringCastToTime) {
         ASSERT_EQ(10, v->size());
 
         for (int j = 0; j < v->size(); ++j) {
-            ASSERT_EQ(54915, v->get_data()[j]);
+            ASSERT_EQ(54915, v->immutable_data()[j]);
         }
     }
 }
@@ -1716,7 +1716,7 @@ TEST_F(VectorizedCastExprTest, bigintToTime) {
         auto d = ColumnHelper::cast_to<TYPE_TIME>(v->data_column());
 
         ASSERT_FALSE(v->is_null(0));
-        ASSERT_EQ(12020, d->get_data()[0]);
+        ASSERT_EQ(12020, d->immutable_data()[0]);
         ASSERT_TRUE(v->is_null(1));
     }
 }
@@ -1738,8 +1738,8 @@ TEST_F(VectorizedCastExprTest, dateToTime) {
         auto d = ColumnHelper::cast_to<TYPE_TIME>(ptr);
         ASSERT_EQ(2, d->size());
 
-        ASSERT_EQ(0, d->get_data()[0]);
-        ASSERT_EQ(0, d->get_data()[1]);
+        ASSERT_EQ(0, d->immutable_data()[0]);
+        ASSERT_EQ(0, d->immutable_data()[1]);
     }
 }
 
@@ -1759,8 +1759,8 @@ TEST_F(VectorizedCastExprTest, datetimeToTime) {
         auto d = ColumnHelper::cast_to<TYPE_TIME>(ptr);
         ASSERT_EQ(2, d->size());
 
-        ASSERT_EQ(45000, d->get_data()[0]);
-        ASSERT_EQ(45000, d->get_data()[1]);
+        ASSERT_EQ(45000, d->immutable_data()[0]);
+        ASSERT_EQ(45000, d->immutable_data()[1]);
     }
 }
 
@@ -1780,8 +1780,8 @@ TEST_F(VectorizedCastExprTest, timeToInt) {
         auto d = ColumnHelper::cast_to<TYPE_INT>(ptr);
         ASSERT_EQ(2, d->size());
 
-        ASSERT_EQ(212102, d->get_data()[0]);
-        ASSERT_EQ(212102, d->get_data()[1]);
+        ASSERT_EQ(212102, d->immutable_data()[0]);
+        ASSERT_EQ(212102, d->immutable_data()[1]);
     }
 }
 
@@ -1801,8 +1801,8 @@ TEST_F(VectorizedCastExprTest, timeToVarchar) {
         auto d = ColumnHelper::cast_to<TYPE_VARCHAR>(ptr);
         ASSERT_EQ(2, d->size());
 
-        ASSERT_EQ("02:22:01", d->get_data()[0]);
-        ASSERT_EQ("02:22:01", d->get_data()[1]);
+        ASSERT_EQ("02:22:01", d->immutable_data()[0]);
+        ASSERT_EQ("02:22:01", d->immutable_data()[1]);
     }
 }
 
@@ -1872,14 +1872,14 @@ TEST_F(VectorizedCastExprTest, jsonToValue) {
     EXPECT_EQ(1.1, evaluateCastFromJson<TYPE_DOUBLE>(cast_expr, 1.1)->get_data()[0]);
     EXPECT_EQ(true, evaluateCastFromJson<TYPE_BOOLEAN>(cast_expr, true)->get_data()[0]);
     EXPECT_EQ(false, evaluateCastFromJson<TYPE_BOOLEAN>(cast_expr, false)->get_data()[0]);
-    EXPECT_EQ("a", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"a\"")->get_data()[0]);
-    EXPECT_EQ("1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"1\"")->get_data()[0]);
-    EXPECT_EQ("[1, 2, 3]", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "[1,2,3]")->get_data()[0]);
-    EXPECT_EQ("1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "1")->get_data()[0]);
-    EXPECT_EQ("1.1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "1.1")->get_data()[0]);
-    EXPECT_EQ("true", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "true")->get_data()[0]);
-    EXPECT_EQ("star", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"star\"")->get_data()[0]);
-    EXPECT_EQ("{\"a\": 1}", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "{\"a\": 1}")->get_data()[0]);
+    EXPECT_EQ("a", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"a\"")->immutable_data()[0]);
+    EXPECT_EQ("1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"1\"")->immutable_data()[0]);
+    EXPECT_EQ("[1, 2, 3]", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "[1,2,3]")->immutable_data()[0]);
+    EXPECT_EQ("1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "1")->immutable_data()[0]);
+    EXPECT_EQ("1.1", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "1.1")->immutable_data()[0]);
+    EXPECT_EQ("true", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "true")->immutable_data()[0]);
+    EXPECT_EQ("star", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "\"star\"")->immutable_data()[0]);
+    EXPECT_EQ("{\"a\": 1}", evaluateCastFromJson<TYPE_VARCHAR>(cast_expr, "{\"a\": 1}")->immutable_data()[0]);
 
     EXPECT_EQ(true, evaluateCastFromJson<TYPE_BOOLEAN>(cast_expr, "\"1123\"")->get_data()[0]);
     EXPECT_EQ(true, evaluateCastFromJson<TYPE_BOOLEAN>(cast_expr, "\"true\"")->get_data()[0]);

--- a/be/test/exprs/encryption_functions_test.cpp
+++ b/be/test/exprs/encryption_functions_test.cpp
@@ -94,7 +94,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_ECB_Test) {
         // which don't use padding. For 16-byte aligned input, PKCS#7 adds a full 16-byte padding block.
         // We verify correctness through encrypt-decrypt cycle instead of comparing encrypted output.
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_GT(encrypted_data->get_data()[0].size, 0); // Ensure encryption succeeded
+        ASSERT_GT(encrypted_data->get_slice(0).size, 0); // Ensure encryption succeeded
 
         // Decrypt
         Columns decrypt_columns;
@@ -107,7 +107,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_ECB_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string());
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string());
     }
 }
 
@@ -175,7 +175,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CBC_Test) {
         // which don't use padding. For 16-byte aligned input, PKCS#7 adds a full 16-byte padding block.
         // We verify correctness through encrypt-decrypt cycle instead of comparing encrypted output.
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_GT(encrypted_data->get_data()[0].size, 0); // Ensure encryption succeeded
+        ASSERT_GT(encrypted_data->get_slice(0).size, 0); // Ensure encryption succeeded
 
         // Decrypt
         Columns decrypt_columns;
@@ -188,7 +188,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CBC_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string());
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string());
     }
 }
 
@@ -252,7 +252,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CFB_Test) {
 
         // For stream modes (CFB), verify encrypted length equals plain length (no padding)
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_EQ(tc.plain.size(), encrypted_data->get_data()[0].size)
+        ASSERT_EQ(tc.plain.size(), encrypted_data->get_slice(0).size)
                 << "CFB mode should not add padding, encrypted length should equal plain length";
 
         // Decrypt and verify we can recover the original plaintext
@@ -266,7 +266,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CFB_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string()) << "Decrypted text should match original plaintext";
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string()) << "Decrypted text should match original plaintext";
     }
 }
 
@@ -332,7 +332,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_OFB_Test) {
 
         // For stream modes (OFB), verify encrypted length equals plain length (no padding)
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_EQ(tc.plain.size(), encrypted_data->get_data()[0].size)
+        ASSERT_EQ(tc.plain.size(), encrypted_data->get_slice(0).size)
                 << "OFB mode should not add padding, encrypted length should equal plain length";
 
         // Decrypt and verify we can recover the original plaintext
@@ -346,7 +346,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_OFB_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string()) << "Decrypted text should match original plaintext";
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string()) << "Decrypted text should match original plaintext";
     }
 }
 
@@ -412,7 +412,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CTR_Test) {
 
         // For stream modes (CTR), verify encrypted length equals plain length (no padding)
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_EQ(tc.plain.size(), encrypted_data->get_data()[0].size)
+        ASSERT_EQ(tc.plain.size(), encrypted_data->get_slice(0).size)
                 << "CTR mode should not add padding, encrypted length should equal plain length";
 
         // Decrypt and verify we can recover the original plaintext
@@ -426,7 +426,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CTR_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string()) << "Decrypted text should match original plaintext";
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string()) << "Decrypted text should match original plaintext";
     }
 }
 
@@ -536,7 +536,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_GCM_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(tc.plain, result->get_data()[0].to_string());
+        ASSERT_EQ(tc.plain, result->get_slice(0).to_string());
     }
 }
 
@@ -599,7 +599,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_GCM_with_AAD_Test) {
     ASSERT_FALSE(decrypted->is_null(0));
 
     auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-    ASSERT_EQ(plain, result->get_data()[0].to_string());
+    ASSERT_EQ(plain, result->get_slice(0).to_string());
 
     // Decrypt with wrong AAD should fail (authentication failure)
     auto wrong_aad_col = BinaryColumn::create();
@@ -638,7 +638,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_GCM_with_AAD_Test) {
     ASSERT_FALSE(decrypted_no_aad->is_null(0));
 
     auto result_no_aad = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted_no_aad);
-    ASSERT_EQ(plain, result_no_aad->get_data()[0].to_string());
+    ASSERT_EQ(plain, result_no_aad->get_slice(0).to_string());
 }
 
 // Test NULL handling
@@ -714,7 +714,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_NULL_IV_Test) {
     ASSERT_FALSE(decrypted->is_null(0));
 
     auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-    ASSERT_EQ("test data", result->get_data()[0].to_string());
+    ASSERT_EQ("test data", result->get_slice(0).to_string());
 }
 
 // Test case-insensitive mode string
@@ -758,7 +758,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_CaseInsensitive_Test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(plain, result->get_data()[0].to_string());
+        ASSERT_EQ(plain, result->get_slice(0).to_string());
     }
 }
 
@@ -803,7 +803,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_LargeData_Test) {
     ASSERT_FALSE(decrypted->is_null(0));
 
     auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-    ASSERT_EQ(plain, result->get_data()[0].to_string());
+    ASSERT_EQ(plain, result->get_slice(0).to_string());
 }
 
 // Test batch encryption with constant key/mode (optimized path)
@@ -885,7 +885,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_ECB_with_NULL_IV_Test) {
     ASSERT_FALSE(encrypted->is_null(0)) << "ECB mode should work with NULL IV";
 
     auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-    ASSERT_GT(encrypted_data->get_data()[0].size, 0);
+    ASSERT_GT(encrypted_data->get_slice(0).size, 0);
 
     // Decrypt - should also work with NULL IV
     Columns decrypt_columns;
@@ -898,7 +898,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_ECB_with_NULL_IV_Test) {
     ASSERT_FALSE(result->is_null(0));
 
     auto result_data = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-    ASSERT_EQ(plain, result_data->get_data()[0].to_string());
+    ASSERT_EQ(plain, result_data->get_slice(0).to_string());
 }
 
 // Test non-ECB mode with NULL IV (should return NULL)
@@ -942,16 +942,15 @@ TEST_F(EncryptionFunctionsTest, aes_encryptGeneralTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+    for (int j = 0; j < std::size(plains); ++j) {
         plain->append(plains[j]);
         text->append(texts[j]);
     }
 
     columns.emplace_back(std::move(plain));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
 
@@ -963,8 +962,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptGeneralTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -981,7 +980,7 @@ TEST_F(EncryptionFunctionsTest, aes_encryptSingularCasesTest) {
                              "09529C15ECF0FC27073310DCEB76FAF4", "0143DB63EE66B0CDFF9F69917680151E",
                              "0143DB63EE66B0CDFF9F69917680151E"};
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+    for (int j = 0; j < std::size(plains); ++j) {
         plain->append(plains[j]);
         if (j % 2 == 0) {
             null_column->append(DATUM_NOT_NULL);
@@ -995,9 +994,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptSingularCasesTest) {
     auto nullable_text = NullableColumn::create(std::move(text), std::move(null_column));
     columns.emplace_back(std::move(plain));
     columns.emplace_back(std::move(nullable_text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
 
@@ -1007,7 +1005,7 @@ TEST_F(EncryptionFunctionsTest, aes_encryptSingularCasesTest) {
     columns.emplace_back(std::move(result));
     result = StringFunctions::hex_string(ctx.get(), columns).value();
     ASSERT_TRUE(result->is_nullable());
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         if (j % 2 == 0) {
             ASSERT_FALSE(result->is_null(j));
             auto datum = result->get(j);
@@ -1030,16 +1028,15 @@ TEST_F(EncryptionFunctionsTest, aes_encryptBigDataTest) {
                              "9B247414C29023C0E208DD1C4914EEB1AD7912069B5F47EF7B4E1CBDDDE7551C",
                              "CB49B2B910DA7C511C559B241183471C3718BF908D1946600ED4B7CE729E2684"};
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+    for (int j = 0; j < std::size(plains); ++j) {
         plain->append(plains[j]);
         text->append(texts[j]);
     }
 
     columns.emplace_back(std::move(plain));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
 
@@ -1051,8 +1048,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptBigDataTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1068,7 +1065,7 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullPlainTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+    for (int j = 0; j < std::size(plains); ++j) {
         plain->append(plains[j]);
         plain_null->append(0);
         text->append(texts[j]);
@@ -1095,8 +1092,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullPlainTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -1113,7 +1110,7 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullTextTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
+    for (int j = 0; j < std::size(plains); ++j) {
         plain->append(plains[j]);
         text->append(texts[j]);
         text_null->append(0);
@@ -1139,8 +1136,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptNullTextTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -1161,9 +1158,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptConstTextTest) {
 
     columns.emplace_back(std::move(plain));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
 
@@ -1175,8 +1171,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptConstTextTest) {
     result = StringFunctions::hex_string(ctx.get(), columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1204,8 +1200,8 @@ TEST_F(EncryptionFunctionsTest, aes_encryptConstAllTest) {
     auto v = ColumnHelper::as_column<ConstColumn>(result);
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(v->data_column());
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], data_column->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], data_column->get_slice(j).to_string());
     }
 }
 
@@ -1220,7 +1216,7 @@ TEST_F(EncryptionFunctionsTest, aes_decryptGeneralTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         plain->append(results[j]);
         text->append(texts[j]);
     }
@@ -1232,17 +1228,16 @@ TEST_F(EncryptionFunctionsTest, aes_decryptGeneralTest) {
     columns.clear();
     columns.emplace_back(std::move(result));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
     result = EncryptionFunctions::aes_decrypt_with_mode(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        ASSERT_EQ(plains[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(plains); ++j) {
+        ASSERT_EQ(plains[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1258,7 +1253,7 @@ TEST_F(EncryptionFunctionsTest, aes_decryptBigDataTest) {
                              "9B247414C29023C0E208DD1C4914EEB1AD7912069B5F47EF7B4E1CBDDDE7551C",
                              "CB49B2B910DA7C511C559B241183471C3718BF908D1946600ED4B7CE729E2684"};
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         plain->append(results[j]);
         text->append(texts[j]);
     }
@@ -1270,17 +1265,16 @@ TEST_F(EncryptionFunctionsTest, aes_decryptBigDataTest) {
     columns.clear();
     columns.emplace_back(std::move(result));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
     result = EncryptionFunctions::aes_decrypt_with_mode(ctx.get(), columns).value();
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        ASSERT_EQ(plains[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(plains); ++j) {
+        ASSERT_EQ(plains[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1296,7 +1290,7 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullPlainTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         plain->append(results[j]);
         plain_null->append(0);
         text->append(texts[j]);
@@ -1322,8 +1316,8 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullPlainTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        ASSERT_EQ(plains[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(plains); ++j) {
+        ASSERT_EQ(plains[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -1340,7 +1334,7 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullTextTest) {
     std::string results[] = {"CEF5BE724B7B98B63216C95A7BD681C9", "424B4E9B042FC5274A77A82BB4BB9826",
                              "09529C15ECF0FC27073310DCEB76FAF4"};
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         plain->append(results[j]);
         text->append(texts[j]);
         text_null->append(0);
@@ -1366,8 +1360,8 @@ TEST_F(EncryptionFunctionsTest, aes_decryptNullTextTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        ASSERT_EQ(plains[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(plains); ++j) {
+        ASSERT_EQ(plains[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -1393,9 +1387,8 @@ TEST_F(EncryptionFunctionsTest, aes_decryptConstTextTest) {
     columns.clear();
     columns.emplace_back(std::move(result));
     columns.emplace_back(std::move(text));
-    auto iv_col = ColumnHelper::create_const_null_column(sizeof(plains) / sizeof(plains[0]));
-    auto mode_col =
-            ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), sizeof(plains) / sizeof(plains[0]));
+    auto iv_col = ColumnHelper::create_const_null_column(std::size(plains));
+    auto mode_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("AES_128_ECB"), std::size(plains));
     columns.emplace_back(std::move(iv_col));
     columns.emplace_back(std::move(mode_col));
 
@@ -1403,8 +1396,8 @@ TEST_F(EncryptionFunctionsTest, aes_decryptConstTextTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(plains) / sizeof(plains[0]); ++j) {
-        ASSERT_EQ(plains[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(plains); ++j) {
+        ASSERT_EQ(plains[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1434,8 +1427,8 @@ TEST_F(EncryptionFunctionsTest, aes_decryptConstAllTest) {
 
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(v->data_column());
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], data_column->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], data_column->get_slice(j).to_string());
     }
 }
 
@@ -1464,7 +1457,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_basic_test) {
         ASSERT_FALSE(encrypted->is_null(0));
 
         auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted);
-        ASSERT_GT(encrypted_data->get_data()[0].size, 0);
+        ASSERT_GT(encrypted_data->get_slice(0).size, 0);
 
         // Decrypt with 2 parameters
         Columns decrypt_columns;
@@ -1475,7 +1468,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_basic_test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(plaintext, result->get_data()[0].to_string());
+        ASSERT_EQ(plaintext, result->get_slice(0).to_string());
     }
 
     // Test case 2: Binary data
@@ -1504,7 +1497,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_basic_test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(plaintext, result->get_data()[0].to_string());
+        ASSERT_EQ(plaintext, result->get_slice(0).to_string());
     }
 
     // Test case 3: Empty string
@@ -1533,7 +1526,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_basic_test) {
         ASSERT_FALSE(decrypted->is_null(0));
 
         auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
-        ASSERT_EQ(plaintext, result->get_data()[0].to_string());
+        ASSERT_EQ(plaintext, result->get_slice(0).to_string());
     }
 }
 
@@ -1631,7 +1624,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_batch_test) {
     auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted);
     for (size_t i = 0; i < plaintexts.size(); ++i) {
         ASSERT_FALSE(decrypted->is_null(i));
-        ASSERT_EQ(plaintexts[i], result->get_data()[i].to_string());
+        ASSERT_EQ(plaintexts[i], result->get_slice(i).to_string());
     }
 }
 
@@ -1685,11 +1678,11 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_mixed_null_test) {
     auto result = down_cast<const BinaryColumn*>(nullable_result->data_column().get());
 
     ASSERT_FALSE(decrypted->is_null(0));
-    ASSERT_EQ("data1", result->get_data()[0].to_string());
+    ASSERT_EQ("data1", result->get_slice(0).to_string());
     ASSERT_TRUE(decrypted->is_null(1));
     ASSERT_TRUE(decrypted->is_null(2));
     ASSERT_FALSE(decrypted->is_null(3));
-    ASSERT_EQ("data4", result->get_data()[3].to_string());
+    ASSERT_EQ("data4", result->get_slice(3).to_string());
 }
 
 // Test 2-parameter version with constant columns (optimization path)
@@ -1723,7 +1716,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_const_test) {
     auto encrypted_unpacked = ColumnHelper::unpack_and_duplicate_const_column(encrypted->size(), encrypted);
     auto encrypted_data = ColumnHelper::cast_to<TYPE_VARCHAR>(encrypted_unpacked);
     for (size_t i = 1; i < 5; ++i) {
-        ASSERT_EQ(encrypted_data->get_data()[0].to_string(), encrypted_data->get_data()[i].to_string());
+        ASSERT_EQ(encrypted_data->get_slice(0).to_string(), encrypted_data->get_slice(i).to_string());
     }
 
     // Decrypt
@@ -1738,7 +1731,7 @@ TEST_F(EncryptionFunctionsTest, aes_encrypt_decrypt_2params_const_test) {
     auto decrypted_unpacked = ColumnHelper::unpack_and_duplicate_const_column(decrypted->size(), decrypted);
     auto result = ColumnHelper::cast_to<TYPE_VARCHAR>(decrypted_unpacked);
     for (size_t i = 0; i < 5; ++i) {
-        ASSERT_EQ(plaintext, result->get_data()[i].to_string());
+        ASSERT_EQ(plaintext, result->get_slice(i).to_string());
     }
 }
 
@@ -1799,8 +1792,8 @@ TEST_F(EncryptionFunctionsTest, from_base64GeneralTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1828,8 +1821,8 @@ TEST_F(EncryptionFunctionsTest, from_base64NullTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
     result2->is_null(j);
 }
@@ -1848,8 +1841,8 @@ TEST_F(EncryptionFunctionsTest, from_base64ConstTest) {
     auto v = ColumnHelper::as_column<ConstColumn>(result);
     auto data_column = ColumnHelper::cast_to<TYPE_VARCHAR>(v->data_column());
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], data_column->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], data_column->get_slice(j).to_string());
     }
 }
 
@@ -1871,8 +1864,8 @@ TEST_F(EncryptionFunctionsTest, to_base64Test) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1900,8 +1893,8 @@ TEST_F(EncryptionFunctionsTest, to_base64NullTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -1920,8 +1913,8 @@ TEST_F(EncryptionFunctionsTest, to_base64ConstTest) {
     auto result2 = ColumnHelper::as_column<ConstColumn>(result)->data_column();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1943,8 +1936,8 @@ TEST_F(EncryptionFunctionsTest, md5GeneralTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -1972,8 +1965,8 @@ TEST_F(EncryptionFunctionsTest, md5NullTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result2->data_column());
 
     int j;
-    for (j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
     ASSERT_TRUE(result2->is_null(j));
 }
@@ -2014,8 +2007,8 @@ TEST_F(EncryptionFunctionsTest, md5sumTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -2044,8 +2037,8 @@ TEST_F(EncryptionFunctionsTest, md5sumNullTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
-        ASSERT_EQ(results[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(results); ++j) {
+        ASSERT_EQ(results[j], v->get_slice(j).to_string());
     }
 }
 
@@ -2072,7 +2065,7 @@ TEST_F(EncryptionFunctionsTest, md5sum_numericTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_LARGEINT>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         ASSERT_EQ(results[j], v->immutable_data()[j]);
     }
 }
@@ -2102,7 +2095,7 @@ TEST_F(EncryptionFunctionsTest, md5sum_numericNullTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_LARGEINT>(result);
 
-    for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
+    for (int j = 0; j < std::size(results); ++j) {
         ASSERT_EQ(results[j], v->immutable_data()[j]);
     }
 }
@@ -2143,7 +2136,7 @@ TEST_P(ShaTestFixture, test_sha2) {
         EXPECT_TRUE(result->is_null(0));
     } else {
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        EXPECT_EQ(expected, v->get_data()[0].to_string());
+        EXPECT_EQ(expected, v->get_slice(0).to_string());
     }
 
     ASSERT_TRUE(EncryptionFunctions::sha2_close(ctx.get(),

--- a/be/test/exprs/geography_functions_test.cpp
+++ b/be/test/exprs/geography_functions_test.cpp
@@ -46,7 +46,7 @@ TEST_F(geographyFunctionsTest, st_pointTest) {
         result = GeoFunctions::st_as_wkt(ctx.get(), columns).value();
 
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
-        ASSERT_EQ("POINT (24.7 56.7)", v->get_data()[0].to_string());
+        ASSERT_EQ("POINT (24.7 56.7)", v->get_slice(0).to_string());
     }
 
     {
@@ -62,7 +62,7 @@ TEST_F(geographyFunctionsTest, st_pointTest) {
         columns.emplace_back(std::move(str_2));
         ColumnPtr result = GeoFunctions::st_point(ctx.get(), columns).value();
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
-        auto str_value = v->get_data()[0];
+        auto str_value = v->get_slice(0);
 
         GeoPoint point;
         auto res = point.decode_from(str_value.data, str_value.size);
@@ -151,7 +151,7 @@ TEST_F(geographyFunctionsTest, as_wktTest) {
     auto result = GeoFunctions::st_as_wkt(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
-    ASSERT_EQ("POINT (134 63)", v->get_data()[0].to_string());
+    ASSERT_EQ("POINT (134 63)", v->get_slice(0).to_string());
 }
 
 TEST_F(geographyFunctionsTest, st_from_wktGeneralTest) {
@@ -174,7 +174,7 @@ TEST_F(geographyFunctionsTest, st_from_wktGeneralTest) {
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     GeoPoint point;
-    auto res = point.decode_from(v->get_data()[0].data, v->get_data()[0].size);
+    auto res = point.decode_from(v->get_slice(0).data, v->get_slice(0).size);
 
     ASSERT_TRUE(res);
     ASSERT_DOUBLE_EQ(10.1, point.x());
@@ -221,7 +221,7 @@ TEST_F(geographyFunctionsTest, st_lineGeneralTest) {
     auto result = GeoFunctions::st_line(ctx.get(), columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     GeoLine line_obj;
-    auto res = line_obj.decode_from(v->get_data()[0].data, v->get_data()[0].size);
+    auto res = line_obj.decode_from(v->get_slice(0).data, v->get_slice(0).size);
     ASSERT_TRUE(res);
     GeoFunctions::st_from_wkt_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
 }
@@ -259,7 +259,7 @@ TEST_F(geographyFunctionsTest, st_polygonGeneralTest) {
     auto str2 = GeoFunctions::st_polygon(ctx.get(), columns).value();
     auto result = ColumnHelper::as_column<BinaryColumn>(str2);
     ASSERT_FALSE(str2->is_null(0));
-    auto v = result->get_data()[0];
+    auto v = result->get_slice(0);
 
     GeoPolygon polygon;
     auto res = polygon.decode_from(v.data, v.size);
@@ -310,7 +310,7 @@ TEST_F(geographyFunctionsTest, st_circleGeneralTest) {
     ASSERT_FALSE(result->is_null(0));
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
-    auto cir_str = v->get_data()[0];
+    auto cir_str = v->get_slice(0);
 
     GeoCircle circle;
     auto res = circle.decode_from(cir_str.data, cir_str.size);
@@ -410,7 +410,7 @@ TEST_F(geographyFunctionsTest, st_containsWithUnexpectedInputTest) {
     auto varchar_column = ColumnHelper::cast_to<TYPE_VARCHAR>(result1);
     ASSERT_TRUE(varchar_column->size() == 1);
     ASSERT_FALSE(varchar_column->is_null(0));
-    auto value = varchar_column->get_data()[0];
+    auto value = varchar_column->get_slice(0);
     std::string string_value(value.get_data(), value.get_size());
     string_value.append("A");
     auto input_column = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(string_value), varchar_column->size());

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -121,7 +121,7 @@ TEST_F(JsonFunctionsTest, get_json_string_casting) {
                                     R"({"k11": "v11"})",
                                     R"({"k11": "v11"})"};
 
-    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+    for (int j = 0; j < std::size(values); ++j) {
         strings->append(values[j]);
         strings2->append(strs[j]);
     }
@@ -137,8 +137,8 @@ TEST_F(JsonFunctionsTest, get_json_string_casting) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-        ASSERT_EQ(length_strings[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(values); ++j) {
+        ASSERT_EQ(length_strings[j], v->get_slice(j).to_string());
     }
 
     ASSERT_TRUE(JsonFunctions::native_json_path_close(
@@ -157,7 +157,7 @@ TEST_F(JsonFunctionsTest, get_json_string_array) {
     std::string strs[] = {"$[*].key", "$.[*].key"};
     std::string length_strings[] = {"[1, 2]", "[1, 2]"};
 
-    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+    for (int j = 0; j < std::size(values); ++j) {
         strings->append(values[j]);
         strings2->append(strs[j]);
     }
@@ -173,8 +173,8 @@ TEST_F(JsonFunctionsTest, get_json_string_array) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-        ASSERT_EQ(length_strings[j], v->get_data()[j].to_string());
+    for (int j = 0; j < std::size(values); ++j) {
+        ASSERT_EQ(length_strings[j], v->get_slice(j).to_string());
     }
 
     ASSERT_TRUE(JsonFunctions::native_json_path_close(
@@ -192,7 +192,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             doubles->append(values[j]);
             doubles2->append(strs[j]);
         }
@@ -209,7 +209,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         auto v = ColumnHelper::as_column<NullableColumn>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ASSERT_TRUE(v->is_null(j));
         }
 
@@ -227,7 +227,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             str_values->append(values[j]);
             str_values2->append(strs[j]);
         }
@@ -244,7 +244,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         auto v = ColumnHelper::as_column<NullableColumn>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ASSERT_TRUE(v->is_null(j));
         }
 
@@ -262,7 +262,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"", ""};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ints->append(values[j]);
             ints2->append(strs[j]);
         }
@@ -279,7 +279,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         auto v = ColumnHelper::as_column<NullableColumn>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ASSERT_TRUE(v->is_null(j));
         }
 
@@ -297,7 +297,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
         std::string values[] = {R"({"k1":1.3, "k2":"2"})", R"({"k1":"v1", "my.key":[1.1, 2.2, 3.3]})"};
         std::string strs[] = {"$.k3", "$.k4"};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ints->append(values[j]);
             ints2->append(strs[j]);
         }
@@ -314,7 +314,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         auto v = ColumnHelper::as_column<NullableColumn>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ASSERT_TRUE(v->is_null(j));
         }
 
@@ -1131,7 +1131,10 @@ INSTANTIATE_TEST_SUITE_P(
 
 using JsonObjectTestParam = std::tuple<std::vector<std::string>, std::string>;
 
-class JsonObjectTestFixture : public ::testing::TestWithParam<JsonObjectTestParam> {};
+class JsonObjectTestFixture : public ::testing::TestWithParam<JsonObjectTestParam> {
+public:
+    ~JsonObjectTestFixture() override = default;
+};
 
 TEST_P(JsonObjectTestFixture, json_object) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -2122,7 +2125,7 @@ TEST_P(JsonPrettyTestFixture, json_pretty) {
     } else {
         ASSERT_FALSE(res_col->is_null(0));
         auto v_col = ColumnHelper::cast_to<TYPE_VARCHAR>(res_col);
-        std::string actual = v_col->get_data()[0].to_string();
+        std::string actual = v_col->get_slice(0).to_string();
 
         ASSERT_EQ(param.expected_output, actual) << "Test Description: " << param.description << "\nExpected:\n"
                                                  << param.expected_output << "\nActual:\n"

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -43,7 +43,7 @@ TEST_F(VecMathFunctionsTest, truncateTest) {
 
         double expected_res[] = {2341.23, 4999.901, 2144.2, 934.1243};
 
-        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+        for (int i = 0; i < std::size(dous); ++i) {
             c0->append(dous[i]);
             c1->append(ints[i]);
         }
@@ -56,7 +56,7 @@ TEST_F(VecMathFunctionsTest, truncateTest) {
 
         auto* raw_res = ColumnHelper::cast_to<TYPE_DOUBLE>(res)->immutable_data().data();
 
-        for (int i = 0; i < sizeof(expected_res) / sizeof(expected_res[0]); ++i) {
+        for (int i = 0; i < std::size(expected_res); ++i) {
             ASSERT_EQ(expected_res[i], raw_res[i]);
         }
     }
@@ -414,7 +414,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToTest) {
 
         double res[] = {2341.23, 4999.901, 2144.3, 934.1244};
 
-        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+        for (int i = 0; i < std::size(dous); ++i) {
             tc1->append(dous[i]);
             tc2->append(ints[i]);
         }
@@ -427,7 +427,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
 
-        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
+        for (int i = 0; i < std::size(res); ++i) {
             ASSERT_EQ(res[i], v->immutable_data()[i]);
         }
     }
@@ -445,7 +445,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithPositiveTest) {
 
         double res[] = {7.85, 7.86};
 
-        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+        for (int i = 0; i < std::size(dous); ++i) {
             tc1->append(dous[i]);
             tc2->append(ints[i]);
         }
@@ -458,7 +458,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithPositiveTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
 
-        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
+        for (int i = 0; i < std::size(res); ++i) {
             ASSERT_EQ(res[i], v->immutable_data()[i]);
         }
     }
@@ -476,7 +476,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithNegativeTest) {
 
         double res[] = {50, 40};
 
-        for (int i = 0; i < sizeof(dous) / sizeof(dous[0]); ++i) {
+        for (int i = 0; i < std::size(dous); ++i) {
             tc1->append(dous[i]);
             tc2->append(ints[i]);
         }
@@ -489,7 +489,7 @@ TEST_F(VecMathFunctionsTest, RoundUpToHalfwayCasesWithNegativeTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
 
-        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
+        for (int i = 0; i < std::size(res); ++i) {
             ASSERT_EQ(res[i], v->immutable_data()[i]);
         }
     }
@@ -516,8 +516,8 @@ TEST_F(VecMathFunctionsTest, BinTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-        for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-            ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        for (int i = 0; i < std::size(res); ++i) {
+            ASSERT_EQ(res[i], v->get_slice(i).to_string());
         }
     }
 }
@@ -528,8 +528,8 @@ TEST_F(VecMathFunctionsTest, LeastDecimalTest) {
     auto tc1 = DecimalColumn::create();
     {
         std::string str[] = {"3333333333.2222222222", "-740740740.716049"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -540,8 +540,8 @@ TEST_F(VecMathFunctionsTest, LeastDecimalTest) {
     auto tc2 = DecimalColumn::create();
     {
         std::string str[] = {"2342.111", "9866.9011"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -558,12 +558,12 @@ TEST_F(VecMathFunctionsTest, LeastDecimalTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(result);
 
     std::string result_str[] = {"2342.111", "-740740740.716049"};
-    DecimalV2Value results[sizeof(result_str) / sizeof(result_str[0])];
-    for (int i = 0; i < sizeof(result_str) / sizeof(result_str[0]); ++i) {
+    DecimalV2Value results[std::size(result_str)];
+    for (int i = 0; i < std::size(result_str); ++i) {
         results[i] = DecimalV2Value(result_str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -574,8 +574,8 @@ TEST_F(VecMathFunctionsTest, GreatestDecimalTest) {
     auto tc1 = DecimalColumn::create();
     {
         std::string str[] = {"3333333333.2222222222", "-740740740.716049"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -586,8 +586,8 @@ TEST_F(VecMathFunctionsTest, GreatestDecimalTest) {
     auto tc2 = DecimalColumn::create();
     {
         std::string str[] = {"2342.111", "9866.9011"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -604,12 +604,12 @@ TEST_F(VecMathFunctionsTest, GreatestDecimalTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(result);
 
     std::string result_str[] = {"3333333333.2222222222", "9866.9011"};
-    DecimalV2Value results[sizeof(result_str) / sizeof(result_str[0])];
-    for (int i = 0; i < sizeof(result_str) / sizeof(result_str[0]); ++i) {
+    DecimalV2Value results[std::size(result_str)];
+    for (int i = 0; i < std::size(result_str); ++i) {
         results[i] = DecimalV2Value(result_str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -620,8 +620,8 @@ TEST_F(VecMathFunctionsTest, PositiveDecimalTest) {
     auto tc1 = DecimalColumn::create();
     {
         std::string str[] = {"-3333333333.2222222222", "-740740740.716049"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -637,12 +637,12 @@ TEST_F(VecMathFunctionsTest, PositiveDecimalTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(result);
 
     std::string result_str[] = {"-3333333333.2222222222", "-740740740.716049"};
-    DecimalV2Value results[sizeof(result_str) / sizeof(result_str[0])];
-    for (int i = 0; i < sizeof(result_str) / sizeof(result_str[0]); ++i) {
+    DecimalV2Value results[std::size(result_str)];
+    for (int i = 0; i < std::size(result_str); ++i) {
         results[i] = DecimalV2Value(result_str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -653,8 +653,8 @@ TEST_F(VecMathFunctionsTest, NegativeDecimalTest) {
     auto tc1 = DecimalColumn::create();
     {
         std::string str[] = {"3333333333.2222222222", "740740740.716049"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -670,12 +670,12 @@ TEST_F(VecMathFunctionsTest, NegativeDecimalTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(result);
 
     std::string result_str[] = {"-3333333333.2222222222", "-740740740.716049"};
-    DecimalV2Value results[sizeof(result_str) / sizeof(result_str[0])];
-    for (int i = 0; i < sizeof(result_str) / sizeof(result_str[0]); ++i) {
+    DecimalV2Value results[std::size(result_str)];
+    for (int i = 0; i < std::size(result_str); ++i) {
         results[i] = DecimalV2Value(result_str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -686,8 +686,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalGeneralTest) {
     auto tc1 = DecimalColumn::create();
     {
         std::string str[] = {"3333333333.3222222222", "2342414342.132", "32413241.12342", "999234812.222"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -698,8 +698,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalGeneralTest) {
     auto tc2 = DecimalColumn::create();
     {
         std::string str[] = {"4", "3", "0", "1"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -717,12 +717,12 @@ TEST_F(VecMathFunctionsTest, ModDecimalGeneralTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
     std::string str[] = {"1.3222222222", "2.132", "0.12342", "0.222"};
-    DecimalV2Value results[sizeof(str) / sizeof(str[0])];
-    for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+    DecimalV2Value results[std::size(str)];
+    for (int i = 0; i < std::size(str); ++i) {
         results[i] = DecimalV2Value(str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -735,8 +735,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalBigTest) {
         std::string str[] = {
                 "333333099873333.322222222", "23112133142414342.132", "413241.12342", "999234812.222", "68482.48227",
                 "2413424287348.24221"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -747,8 +747,8 @@ TEST_F(VecMathFunctionsTest, ModDecimalBigTest) {
     auto tc2 = DecimalColumn::create();
     {
         std::string str[] = {"4535.3452", "7.34535", "2.91", "71.234", "34241.24114", "777982341.234234"};
-        DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-        for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+        DecimalV2Value dec_values[std::size(str)];
+        for (int i = 0; i < std::size(str); ++i) {
             dec_values[i] = DecimalV2Value(str[i]);
         }
         for (auto dec_value : dec_values) {
@@ -766,12 +766,12 @@ TEST_F(VecMathFunctionsTest, ModDecimalBigTest) {
     auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
     std::string str[] = {"163.573422222", "4.4786", "0.75342", "19.69", "34241.24113", "123064839.648342"};
-    DecimalV2Value results[sizeof(str) / sizeof(str[0])];
-    for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+    DecimalV2Value results[std::size(str)];
+    for (int i = 0; i < std::size(str); ++i) {
         results[i] = DecimalV2Value(str[i]);
     }
 
-    for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+    for (int i = 0; i < std::size(results); ++i) {
         ASSERT_EQ(results[i], v->immutable_data()[i]);
     }
 }
@@ -819,7 +819,7 @@ TEST_F(VecMathFunctionsTest, Conv_intTest) {
                                  "18446743787748822378",
                                  "-285960729238"};
 
-        for (int i = 0; i < sizeof(bigints) / sizeof(bigints[0]); ++i) {
+        for (int i = 0; i < std::size(bigints); ++i) {
             tc1->append(bigints[i]);
             tc2->append(baseints[i]);
             tc3->append(destints[i]);
@@ -834,8 +834,8 @@ TEST_F(VecMathFunctionsTest, Conv_intTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-        for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
-            ASSERT_EQ(results[i], v->get_data()[i].to_string());
+        for (int i = 0; i < std::size(results); ++i) {
+            ASSERT_EQ(results[i], v->get_slice(i).to_string());
         }
     }
 }
@@ -922,7 +922,7 @@ TEST_F(VecMathFunctionsTest, Conv_stringTest) {
                                  "10000000000000000000",
                                  "0"};
 
-        for (int i = 0; i < sizeof(bigints) / sizeof(bigints[0]); ++i) {
+        for (int i = 0; i < std::size(bigints); ++i) {
             tc1->append(bigints[i]);
             tc2->append(baseints[i]);
             tc3->append(destints[i]);
@@ -937,8 +937,8 @@ TEST_F(VecMathFunctionsTest, Conv_stringTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-        for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
-            ASSERT_EQ(results[i], v->get_data()[i].to_string());
+        for (int i = 0; i < std::size(results); ++i) {
+            ASSERT_EQ(results[i], v->get_slice(i).to_string());
         }
     }
 }
@@ -1102,7 +1102,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_SMALLINT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1112,7 +1112,6 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto tc1 = Int16Column::create();
         int16_t inputs[] = {1000, 1000, 1000, -500, -35, 35, -32768};
-        int32_t results[] = {1000, 1000, 1000, 500, 35, 35, 32768};
 
         for (short input : inputs) {
             tc1->append(input);
@@ -1125,7 +1124,8 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_INT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
+            int32_t results[] = {1000, 1000, 1000, 500, 35, 35, 32768};
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1148,7 +1148,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_BIGINT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1173,7 +1173,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_LARGEINT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1198,7 +1198,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_LARGEINT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1221,7 +1221,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1244,7 +1244,7 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
 
         auto v = ColumnHelper::cast_to<TYPE_FLOAT>(result);
 
-        for (int i = 0; i < sizeof(inputs) / sizeof(inputs[0]); ++i) {
+        for (int i = 0; i < std::size(inputs); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }
@@ -1255,8 +1255,8 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
         auto tc1 = DecimalColumn::create();
         {
             std::string str[] = {"3333333333.2222222222", "-740740740.716049"};
-            DecimalV2Value dec_values[sizeof(str) / sizeof(str[0])];
-            for (int i = 0; i < sizeof(str) / sizeof(str[0]); ++i) {
+            DecimalV2Value dec_values[std::size(str)];
+            for (int i = 0; i < std::size(str); ++i) {
                 dec_values[i] = DecimalV2Value(str[i]);
             }
             for (auto dec_value : dec_values) {
@@ -1272,12 +1272,12 @@ TEST_F(VecMathFunctionsTest, AbsTest) {
         auto v = ColumnHelper::cast_to<TYPE_DECIMALV2>(result);
 
         std::string result_str[] = {"3333333333.2222222222", "740740740.716049"};
-        DecimalV2Value results[sizeof(result_str) / sizeof(result_str[0])];
-        for (int i = 0; i < sizeof(result_str) / sizeof(result_str[0]); ++i) {
+        DecimalV2Value results[std::size(result_str)];
+        for (int i = 0; i < std::size(result_str); ++i) {
             results[i] = DecimalV2Value(result_str[i]);
         }
 
-        for (int i = 0; i < sizeof(results) / sizeof(results[0]); ++i) {
+        for (int i = 0; i < std::size(results); ++i) {
             ASSERT_EQ(results[i], v->immutable_data()[i]);
         }
     }

--- a/be/test/exprs/string_fn_concat_test.cpp
+++ b/be/test/exprs/string_fn_concat_test.cpp
@@ -66,7 +66,7 @@ TEST_F(StringFunctionConcatTest, concatNormalTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -103,7 +103,7 @@ TEST_F(StringFunctionConcatTest, concatConstTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("test" + std::to_string(k) + "_abcd_1234_道可道,非常道", v->get_data()[k].to_string());
+        ASSERT_EQ("test" + std::to_string(k) + "_abcd_1234_道可道,非常道", v->get_slice(k).to_string());
     }
 }
 
@@ -140,7 +140,7 @@ TEST_F(StringFunctionConcatTest, concatNullTest) {
         if (k % 2 == 0) {
             ASSERT_TRUE(nv->is_null(k));
         } else {
-            ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_data()[k].to_string());
+            ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_slice(k).to_string());
         }
     }
 }
@@ -177,9 +177,9 @@ TEST_F(StringFunctionConcatTest, concatWsTest) {
 
     for (int j = 0; j < 20; ++j) {
         if (j % 2) {
-            ASSERT_EQ("a|" + std::to_string(j), v->get_data()[j].to_string());
+            ASSERT_EQ("a|" + std::to_string(j), v->get_slice(j).to_string());
         } else {
-            ASSERT_EQ("a|" + std::to_string(j) + "|b", v->get_data()[j].to_string());
+            ASSERT_EQ("a|" + std::to_string(j) + "|b", v->get_slice(j).to_string());
         }
     }
 }
@@ -216,9 +216,9 @@ TEST_F(StringFunctionConcatTest, concatWs1Test) {
 
     for (int j = 0; j < 20; ++j) {
         if (j % 2) {
-            ASSERT_EQ("a-----" + std::to_string(j), v->get_data()[j].to_string());
+            ASSERT_EQ("a-----" + std::to_string(j), v->get_slice(j).to_string());
         } else {
-            ASSERT_EQ("a-----" + std::to_string(j) + "-----b", v->get_data()[j].to_string());
+            ASSERT_EQ("a-----" + std::to_string(j) + "-----b", v->get_slice(j).to_string());
         }
     }
 }

--- a/be/test/exprs/string_fn_format_bytes_test.cpp
+++ b/be/test/exprs/string_fn_format_bytes_test.cpp
@@ -52,7 +52,7 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesBasicTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int i = 0; i < test_cases.size(); ++i) {
-        ASSERT_EQ(std::get<1>(test_cases[i]), v->get_data()[i].to_string())
+        ASSERT_EQ(std::get<1>(test_cases[i]), v->get_slice(i).to_string())
                 << "Failed for input: " << std::get<0>(test_cases[i]);
     }
 }
@@ -189,7 +189,7 @@ TEST_F(StringFunctionFormatBytesTest, formatBytesPrecisionTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int i = 0; i < precision_cases.size(); ++i) {
-        ASSERT_EQ(std::get<1>(precision_cases[i]), v->get_data()[i].to_string())
+        ASSERT_EQ(std::get<1>(precision_cases[i]), v->get_slice(i).to_string())
                 << "Failed precision test for input: " << std::get<0>(precision_cases[i]);
     }
 }

--- a/be/test/exprs/string_fn_money_format_decimal_test.cpp
+++ b/be/test/exprs/string_fn_money_format_decimal_test.cpp
@@ -48,7 +48,7 @@ void test_money_format_decimal(TestArray const& test_cases, int precision, int s
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 
     for (int i = 0; i < rows_num; ++i) {
-        auto actual = v->get_data()[i].to_string();
+        auto actual = v->get_slice(i).to_string();
         auto expect = std::get<1>(test_cases[i]);
         std::cout << "decimal=" << std::get<0>(test_cases[i]) << ", actual=" << actual << ", expect=" << expect
                   << std::endl;

--- a/be/test/exprs/string_fn_pad_test.cpp
+++ b/be/test/exprs/string_fn_pad_test.cpp
@@ -18,6 +18,7 @@
 #include <random>
 #include <utility>
 
+#include "base/testutil/assert.h"
 #include "butil/time.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "exprs/string_functions.h"
@@ -249,11 +250,11 @@ void test_const_pad(size_t num_rows, TestCaseType& c) {
     columns.emplace_back(ColumnPtr(std::move(mut_columns[0])));
     columns.emplace_back(ColumnPtr(std::move(mut_columns[1])));
     columns.emplace_back(std::move(const_pad_col));
-    StringFunctions::pad_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_OK(StringFunctions::pad_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
 
     auto lpad_result = StringFunctions::lpad(ctx.get(), columns).value();
     auto rpad_result = StringFunctions::rpad(ctx.get(), columns).value();
-    StringFunctions::pad_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_OK(StringFunctions::pad_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
     ASSERT_EQ(lpad_result->size(), num_rows);
     ASSERT_EQ(rpad_result->size(), num_rows);
     auto lpad_actual = lpad_result->get(num_rows - 1);
@@ -333,11 +334,11 @@ void test_const_len_and_pad(size_t num_rows, TestCaseType& c) {
     columns.emplace_back(ColumnPtr(std::move(mut_columns[0])));
     columns.emplace_back(const_len_col);
     columns.emplace_back(std::move(const_pad_col));
-    StringFunctions::pad_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_OK(StringFunctions::pad_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
 
     auto lpad_result = StringFunctions::lpad(ctx.get(), columns).value();
     auto rpad_result = StringFunctions::rpad(ctx.get(), columns).value();
-    StringFunctions::pad_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL);
+    ASSERT_OK(StringFunctions::pad_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
     if (lpad_result->is_constant()) {
         ASSERT_EQ(lpad_result->size(), 1);
         ASSERT_EQ(rpad_result->size(), 1);
@@ -444,10 +445,10 @@ TEST_F(StringFunctionPadTest, lpadNullTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
     ASSERT_FALSE(result->is_null(0));
-    ASSERT_EQ("1231test", v->get_data()[0].to_string());
+    ASSERT_EQ("1231test", v->get_slice(0).to_string());
 
     ASSERT_TRUE(result->is_null(1));
-    ASSERT_EQ("", v->get_data()[1].to_string());
+    ASSERT_EQ("", v->get_slice(1).to_string());
 }
 
 TEST_F(StringFunctionPadTest, rpadTest) {
@@ -475,8 +476,8 @@ TEST_F(StringFunctionPadTest, rpadTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    ASSERT_EQ("test1231231", v->get_data()[0].to_string());
-    ASSERT_EQ("", v->get_data()[1].to_string());
+    ASSERT_EQ("test1231231", v->get_slice(0).to_string());
+    ASSERT_EQ("", v->get_slice(1).to_string());
 }
 
 TEST_F(StringFunctionPadTest, rpadChineseTest) {
@@ -504,8 +505,8 @@ TEST_F(StringFunctionPadTest, rpadChineseTest) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    ASSERT_EQ(Slice("我是中文字符串不，我不是不，我"), v->get_data()[0]);
-    ASSERT_EQ(Slice("我是"), v->get_data()[1]);
+    ASSERT_EQ(Slice("我是中文字符串不，我不是不，我"), v->get_slice(0));
+    ASSERT_EQ(Slice("我是"), v->get_slice(1));
 }
 
 TEST_F(StringFunctionPadTest, rpadConstTest) {
@@ -533,10 +534,10 @@ TEST_F(StringFunctionPadTest, rpadConstTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
     ASSERT_FALSE(result->is_null(0));
-    ASSERT_EQ("test1231", v->get_data()[0].to_string());
+    ASSERT_EQ("test1231", v->get_slice(0).to_string());
 
     ASSERT_TRUE(result->is_null(1));
-    ASSERT_EQ("", v->get_data()[1].to_string());
+    ASSERT_EQ("", v->get_slice(1).to_string());
 }
 
 struct PadNullableStrConstLenFillTestCase {
@@ -615,7 +616,7 @@ TEST_P(PadNullableStrConstLenFillTestFixture, pad) {
     for (int i = 0; i < num_rows; ++i) {
         ASSERT_EQ(c.rpad_expected_nulls[i], rpad_result->is_null(i)) << "Row#" << i;
         if (!c.rpad_expected_nulls[i]) {
-            ASSERT_EQ(c.rpad_expected_results[i], rpad_v->get_data()[i].to_string()) << "Row#" << i;
+            ASSERT_EQ(c.rpad_expected_results[i], rpad_v->get_slice(i).to_string()) << "Row#" << i;
         }
     }
 
@@ -633,7 +634,7 @@ TEST_P(PadNullableStrConstLenFillTestFixture, pad) {
     for (int i = 0; i < num_rows; ++i) {
         ASSERT_EQ(c.lpad_expected_nulls[i], lpad_result->is_null(i)) << "Row#" << i;
         if (!c.lpad_expected_nulls[i]) {
-            ASSERT_EQ(c.lpad_expected_results[i], lpad_v->get_data()[i].to_string()) << "Row#" << i;
+            ASSERT_EQ(c.lpad_expected_results[i], lpad_v->get_slice(i).to_string()) << "Row#" << i;
         }
     }
 }

--- a/be/test/exprs/string_fn_reverse_test.cpp
+++ b/be/test/exprs/string_fn_reverse_test.cpp
@@ -57,7 +57,7 @@ TEST_F(StringFunctionReverseTest, reverseASCIITest) {
     for (int k = 0; k < 100; ++k) {
         auto tmp_s = str->get_slice(k).to_string();
         std::string expect(tmp_s.rbegin(), tmp_s.rend());
-        ASSERT_EQ(expect, v->get_data()[k].to_string());
+        ASSERT_EQ(expect, v->get_slice(k).to_string());
     }
 }
 
@@ -85,7 +85,7 @@ TEST_F(StringFunctionReverseTest, reverseUtf8Test) {
 
     for (auto i = 0; i < str->size(); ++i) {
         auto expect = std::get<1>(cases[i]);
-        ASSERT_EQ(expect, v->get_data()[i].to_string());
+        ASSERT_EQ(expect, v->get_slice(i).to_string());
     }
 }
 

--- a/be/test/exprs/string_fn_sm3_test.cpp
+++ b/be/test/exprs/string_fn_sm3_test.cpp
@@ -31,7 +31,7 @@ TEST_F(StringFunctionSm3Test, abcA1Test) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     std::string s = "66c7f0f4 62eeedd9 d1f2d46b dc10e4e2 4167c487 5cf2f7a2 297da02b 8f4ba8e0";
-    ASSERT_EQ(s, v->get_data()[0].to_string());
+    ASSERT_EQ(s, v->get_slice(0).to_string());
 }
 
 TEST_F(StringFunctionSm3Test, abcA2Test) {
@@ -46,7 +46,7 @@ TEST_F(StringFunctionSm3Test, abcA2Test) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
-    ASSERT_EQ(s, v->get_data()[0].to_string());
+    ASSERT_EQ(s, v->get_slice(0).to_string());
 }
 
 TEST_F(StringFunctionSm3Test, abcConstTest) {
@@ -60,7 +60,7 @@ TEST_F(StringFunctionSm3Test, abcConstTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<ConstColumn>(result)->data_column());
 
     std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
-    ASSERT_EQ(s, v->get_data()[0].to_string());
+    ASSERT_EQ(s, v->get_slice(0).to_string());
 }
 
 TEST_F(StringFunctionSm3Test, abcNull1Test) {
@@ -81,7 +81,7 @@ TEST_F(StringFunctionSm3Test, abcNull1Test) {
     for (int j = 0; j < 20; ++j) {
         if (j % 2 != 0) {
             std::string s = "66c7f0f4 62eeedd9 d1f2d46b dc10e4e2 4167c487 5cf2f7a2 297da02b 8f4ba8e0";
-            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+            ASSERT_EQ(s, data_column->get_slice(0).to_string());
         } else {
             ASSERT_TRUE(nullable_column->is_null(j));
         }
@@ -106,7 +106,7 @@ TEST_F(StringFunctionSm3Test, abcNull2Test) {
     for (int j = 0; j < 20; ++j) {
         if (j % 2 != 0) {
             std::string s = "debe9ff9 2275b8a1 38604889 c18e5a4d 6fdb70e5 387e5765 293dcba3 9c0c5732";
-            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+            ASSERT_EQ(s, data_column->get_slice(0).to_string());
         } else {
             ASSERT_TRUE(nullable_column->is_null(j));
         }
@@ -131,7 +131,7 @@ TEST_F(StringFunctionSm3Test, abcNullLiteralTest) {
     for (int j = 0; j < 20; ++j) {
         if (j % 2 != 0) {
             std::string s = "";
-            ASSERT_EQ(s, data_column->get_data()[0].to_string());
+            ASSERT_EQ(s, data_column->get_slice(0).to_string());
         } else {
             ASSERT_TRUE(nullable_column->is_null(j));
         }

--- a/be/test/exprs/string_fn_space_test.cpp
+++ b/be/test/exprs/string_fn_space_test.cpp
@@ -40,7 +40,7 @@ TEST_F(StringFunctionSpaceTest, spaceTest) {
     for (int k = 0; k < 20; ++k) {
         std::string s;
         s.resize(k, ' ');
-        ASSERT_EQ(s, v->get_data()[k].to_string());
+        ASSERT_EQ(s, v->get_slice(k).to_string());
     }
 }
 

--- a/be/test/exprs/string_fn_substr_test.cpp
+++ b/be/test/exprs/string_fn_substr_test.cpp
@@ -64,7 +64,7 @@ TEST_F(StringFunctionSubstrTest, substringNormalTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -92,7 +92,7 @@ TEST_F(StringFunctionSubstrTest, substringChineseTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(Slice("中文"), v->get_data()[k]);
+        ASSERT_EQ(Slice("中文"), v->get_slice(k));
     }
 }
 
@@ -120,7 +120,7 @@ TEST_F(StringFunctionSubstrTest, substringleftTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 10; ++k) {
-        ASSERT_EQ(Slice(std::string("串") + std::to_string(k)), v->get_data()[k]);
+        ASSERT_EQ(Slice(std::string("串") + std::to_string(k)), v->get_slice(k));
     }
 }
 
@@ -308,7 +308,7 @@ TEST_F(StringFunctionSubstrTest, substringOverleftTest) {
 
     auto v = ColumnHelper::as_column<const BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("", v->get_data()[k].to_string());
+        ASSERT_EQ("", v->get_slice(k).to_string());
     }
 }
 
@@ -337,7 +337,7 @@ TEST_F(StringFunctionSubstrTest, substringConstTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -372,7 +372,7 @@ TEST_F(StringFunctionSubstrTest, substringNullTest) {
         if (k % 2 == 0) {
             ASSERT_TRUE(nv->is_null(k));
         } else {
-            ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+            ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
         }
     }
 }
@@ -399,9 +399,9 @@ TEST_F(StringFunctionSubstrTest, leftTest) {
     for (int k = 0; k < 20; ++k) {
         std::string s = std::to_string(k) + "TEST";
         if (k < s.size()) {
-            ASSERT_EQ(0, strncmp(s.c_str(), v->get_data()[k].to_string().c_str(), k));
+            ASSERT_EQ(0, strncmp(s.c_str(), v->get_slice(k).to_string().c_str(), k));
         } else {
-            ASSERT_EQ(s, v->get_data()[k].to_string());
+            ASSERT_EQ(s, v->get_slice(k).to_string());
         }
     }
 }
@@ -428,9 +428,9 @@ TEST_F(StringFunctionSubstrTest, rightTest) {
     for (int k = 0; k < 20; ++k) {
         std::string s = std::to_string(k) + "TEST";
         if (k < s.size()) {
-            ASSERT_EQ(0, strncmp(s.c_str() + s.size() - k, v->get_data()[k].to_string().c_str(), k));
+            ASSERT_EQ(0, strncmp(s.c_str() + s.size() - k, v->get_slice(k).to_string().c_str(), k));
         } else {
-            ASSERT_EQ(s, v->get_data()[k].to_string());
+            ASSERT_EQ(s, v->get_slice(k).to_string());
         }
     }
 }

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -1542,7 +1542,7 @@ PARALLEL_TEST(VecStringFunctionsTest, charTest) {
     ASSERT_EQ(6, result->size());
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-    ASSERT_EQ("[A, B, a, b, !, ~]", v->debug_string());
+    ASSERT_EQ("['A', 'B', 'a', 'b', '!', '~']", v->debug_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, inetAtonInvalidIPv4Test) {
@@ -4598,8 +4598,9 @@ PARALLEL_TEST(VecStringFunctionsTest, initcapTest) {
 
     // Fast Path Assertions
     ASSERT_EQ(
-            "[Hello World, Hello World, Hello World, Starrocks Database, 1st Place, In-The-World!,    Hello   World   "
-            ", Abc_Def.Ghi+Jkl, A, , Héllo, École, Ça Va, Café Resumé, Привет Мир, Hello-Wörld_123]",
+            "['Hello World', 'Hello World', 'Hello World', 'Starrocks Database', '1st Place', 'In-The-World!','    "
+            "Hello   World   '"
+            ", 'Abc_Def.Ghi+Jkl', 'A', '', 'Héllo', 'École', 'Ça Va', 'Café Resumé', 'Привет Мир', 'Hello-Wörld_123']",
             result->debug_string());
 
     // --- Error Path (Invalid UTF-8) ---

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -4597,11 +4597,23 @@ PARALLEL_TEST(VecStringFunctionsTest, initcapTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     // Fast Path Assertions
-    ASSERT_EQ(
-            "['Hello World', 'Hello World', 'Hello World', 'Starrocks Database', '1st Place, In-The-World!','    "
-            "Hello   World   '"
-            ", 'Abc_Def.Ghi+Jkl', 'A', '', 'Héllo', 'École', 'Ça Va', 'Café Resumé', 'Привет Мир', 'Hello-Wörld_123']",
-            result->debug_string());
+    ASSERT_EQ("Hello World", v->immutable_data()[0].to_string());
+    ASSERT_EQ("Hello World", v->immutable_data()[1].to_string());
+    ASSERT_EQ("Hello World", v->immutable_data()[2].to_string());
+    ASSERT_EQ("Starrocks Database", v->immutable_data()[3].to_string());
+    ASSERT_EQ("1st Place, In-The-World!", v->immutable_data()[4].to_string());
+    ASSERT_EQ("   Hello   World   ", v->immutable_data()[5].to_string());
+    ASSERT_EQ("Abc_Def.Ghi+Jkl", v->immutable_data()[6].to_string());
+    ASSERT_EQ("A", v->immutable_data()[7].to_string());
+    ASSERT_EQ("", v->immutable_data()[8].to_string());
+
+    // Slow Path Assertions
+    ASSERT_EQ("Héllo", v->immutable_data()[9].to_string());
+    ASSERT_EQ("École", v->immutable_data()[10].to_string());
+    ASSERT_EQ("Ça Va", v->immutable_data()[11].to_string());
+    ASSERT_EQ("Café Resumé", v->immutable_data()[12].to_string());
+    ASSERT_EQ("Привет Мир", v->immutable_data()[13].to_string());
+    ASSERT_EQ("Hello-Wörld_123", v->immutable_data()[14].to_string());
 
     // --- Error Path (Invalid UTF-8) ---
     Columns invalid_columns;

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -4598,7 +4598,7 @@ PARALLEL_TEST(VecStringFunctionsTest, initcapTest) {
 
     // Fast Path Assertions
     ASSERT_EQ(
-            "['Hello World', 'Hello World', 'Hello World', 'Starrocks Database', '1st Place', 'In-The-World!','    "
+            "['Hello World', 'Hello World', 'Hello World', 'Starrocks Database', '1st Place, In-The-World!','    "
             "Hello   World   '"
             ", 'Abc_Def.Ghi+Jkl', 'A', '', 'Héllo', 'École', 'Ça Va', 'Café Resumé', 'Привет Мир', 'Hello-Wörld_123']",
             result->debug_string());

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -69,7 +69,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNormalTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -97,7 +97,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringChineseTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(Slice("中文"), v->get_data()[k]);
+        ASSERT_EQ(Slice("中文"), v->get_slice(k));
     }
 }
 
@@ -125,7 +125,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringleftTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 10; ++k) {
-        ASSERT_EQ(Slice(std::string("串") + std::to_string(k)), v->get_data()[k]);
+        ASSERT_EQ(Slice(std::string("串") + std::to_string(k)), v->get_slice(k));
     }
 }
 
@@ -313,7 +313,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringOverleftTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("", v->get_data()[k].to_string());
+        ASSERT_EQ("", v->get_slice(k).to_string());
     }
 }
 
@@ -342,7 +342,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringConstTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -377,7 +377,7 @@ PARALLEL_TEST(VecStringFunctionsTest, substringNullTest) {
         if (k % 2 == 0) {
             ASSERT_TRUE(nv->is_null(k));
         } else {
-            ASSERT_EQ(std::to_string(k), v->get_data()[k].to_string());
+            ASSERT_EQ(std::to_string(k), v->get_slice(k).to_string());
         }
     }
 }
@@ -408,7 +408,7 @@ PARALLEL_TEST(VecStringFunctionsTest, concatNormalTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -438,7 +438,7 @@ PARALLEL_TEST(VecStringFunctionsTest, concatConstTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("test" + std::to_string(k) + "_abcd_1234_道可道,非常道", v->get_data()[k].to_string());
+        ASSERT_EQ("test" + std::to_string(k) + "_abcd_1234_道可道,非常道", v->get_slice(k).to_string());
     }
 }
 
@@ -475,7 +475,7 @@ PARALLEL_TEST(VecStringFunctionsTest, concatNullTest) {
         if (k % 2 == 0) {
             ASSERT_TRUE(nv->is_null(k));
         } else {
-            ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_data()[k].to_string());
+            ASSERT_EQ("test" + std::to_string(k) + "hello" + std::to_string(k), v->get_slice(k).to_string());
         }
     }
 }
@@ -502,7 +502,7 @@ PARALLEL_TEST(VecStringFunctionsTest, lowerNormalTest) {
 
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("test" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("test" + std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -1100,9 +1100,9 @@ PARALLEL_TEST(VecStringFunctionsTest, leftTest) {
     for (int k = 0; k < 20; ++k) {
         std::string s = std::to_string(k) + "TEST";
         if (k < s.size()) {
-            ASSERT_EQ(0, strncmp(s.c_str(), v->get_data()[k].to_string().c_str(), k));
+            ASSERT_EQ(0, strncmp(s.c_str(), v->get_slice(k).to_string().c_str(), k));
         } else {
-            ASSERT_EQ(s, v->get_data()[k].to_string());
+            ASSERT_EQ(s, v->get_slice(k).to_string());
         }
     }
 }
@@ -1129,9 +1129,9 @@ PARALLEL_TEST(VecStringFunctionsTest, rightTest) {
     for (int k = 0; k < 20; ++k) {
         std::string s = std::to_string(k) + "TEST";
         if (k < s.size()) {
-            ASSERT_EQ(0, strncmp(s.c_str() + s.size() - k, v->get_data()[k].to_string().c_str(), k));
+            ASSERT_EQ(0, strncmp(s.c_str() + s.size() - k, v->get_slice(k).to_string().c_str(), k));
         } else {
-            ASSERT_EQ(s, v->get_data()[k].to_string());
+            ASSERT_EQ(s, v->get_slice(k).to_string());
         }
     }
 }
@@ -1257,10 +1257,9 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentTest) {
     ASSERT_EQ(3, result->size());
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    ASSERT_EQ("qwer", v->get_data()[0].to_string());
-    ASSERT_EQ("qwer", v->get_data()[1].to_string());
-    ASSERT_EQ("", v->get_data()[2].to_string());
+    ASSERT_EQ("qwer", v->get_slice(0).to_string());
+    ASSERT_EQ("qwer", v->get_slice(1).to_string());
+    ASSERT_EQ("", v->get_slice(2).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentNullTest) {
@@ -1306,8 +1305,8 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8Test) {
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    ASSERT_EQ("中国a", v->get_data()[0].to_string());
-    ASSERT_EQ("北京b", v->get_data()[1].to_string());
+    ASSERT_EQ("中国a", v->get_slice(0).to_string());
+    ASSERT_EQ("北京b", v->get_slice(1).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentUTF8NullTest) {
@@ -1450,7 +1449,7 @@ PARALLEL_TEST(VecStringFunctionsTest, upperTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int k = 0; k < 20; ++k) {
-        ASSERT_EQ("ABCD" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("ABCD" + std::to_string(k), v->get_slice(k).to_string());
     }
 }
 
@@ -1543,13 +1542,7 @@ PARALLEL_TEST(VecStringFunctionsTest, charTest) {
     ASSERT_EQ(6, result->size());
 
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-
-    ASSERT_EQ("A", v->get_data()[0].to_string());
-    ASSERT_EQ("B", v->get_data()[1].to_string());
-    ASSERT_EQ("a", v->get_data()[2].to_string());
-    ASSERT_EQ("b", v->get_data()[3].to_string());
-    ASSERT_EQ("!", v->get_data()[4].to_string());
-    ASSERT_EQ("~", v->get_data()[5].to_string());
+    ASSERT_EQ("[A, B, a, b, !, ~]", v->debug_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, inetAtonInvalidIPv4Test) {
@@ -1764,9 +1757,9 @@ PARALLEL_TEST(VecStringFunctionsTest, concatWsTest) {
 
     for (int j = 0; j < 20; ++j) {
         if (j % 2) {
-            ASSERT_EQ("a|" + std::to_string(j), v->get_data()[j].to_string());
+            ASSERT_EQ("a|" + std::to_string(j), v->get_slice(j).to_string());
         } else {
-            ASSERT_EQ("a|" + std::to_string(j) + "|b", v->get_data()[j].to_string());
+            ASSERT_EQ("a|" + std::to_string(j) + "|b", v->get_slice(j).to_string());
         }
     }
 }
@@ -1803,9 +1796,9 @@ PARALLEL_TEST(VecStringFunctionsTest, concatWs1Test) {
 
     for (int j = 0; j < 20; ++j) {
         if (j % 2) {
-            ASSERT_EQ("a-----" + std::to_string(j), v->get_data()[j].to_string());
+            ASSERT_EQ("a-----" + std::to_string(j), v->get_slice(j).to_string());
         } else {
-            ASSERT_EQ("a-----" + std::to_string(j) + "-----b", v->get_data()[j].to_string());
+            ASSERT_EQ("a-----" + std::to_string(j) + "-----b", v->get_slice(j).to_string());
         }
     }
 }
@@ -1905,7 +1898,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
             ASSERT_FALSE(result->is_null(i));
         }
 
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -1982,7 +1975,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -2026,7 +2019,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -2072,7 +2065,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
     auto result = StringFunctions::regexp_replace(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
-    ASSERT_EQ(res[0], v->get_data()[0].to_string());
+    ASSERT_EQ(res[0], v->get_slice(0).to_string());
     ASSERT_TRUE(result->is_null(1));
 
     ASSERT_TRUE(
@@ -2152,7 +2145,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -2212,7 +2205,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -2254,7 +2247,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceWithEmptyPattern) {
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(
@@ -2302,9 +2295,9 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceNullablePattern) {
     const auto v =
             ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
-    EXPECT_EQ(res[0], v->get_data()[0].to_string());
+    EXPECT_EQ(res[0], v->get_slice(0).to_string());
     EXPECT_TRUE(result->is_null(1));
-    EXPECT_EQ(res[2], v->get_data()[2].to_string());
+    EXPECT_EQ(res[2], v->get_slice(2).to_string());
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -2439,7 +2432,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceConstPattern) {
     const auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
@@ -2477,7 +2470,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceConstColumn1) {
     const std::string res[] = {"a-b-c", "a+b+c"};
     const auto vv = ColumnHelper::as_column<BinaryColumn>(result);
     for (int i = 0; i < vv->size(); i++) {
-        ASSERT_EQ(res[i], vv->get_data()[i].to_string());
+        ASSERT_EQ(res[i], vv->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
@@ -2509,7 +2502,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceConstColumn2) {
     ASSERT_EQ(result->size(), 2);
     const auto v = ColumnHelper::as_column<ConstColumn>(result);
     const auto vv = ColumnHelper::as_column<BinaryColumn>(v->data_column());
-    ASSERT_EQ("a+b+c", vv->get_data()[0].to_string());
+    ASSERT_EQ("a+b+c", vv->get_slice(0).to_string());
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
                                                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -2550,7 +2543,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replace) {
     const auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
@@ -2588,7 +2581,7 @@ PARALLEL_TEST(VecStringFunctionsTest, replaceWithEmptyPattern) {
     const auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
-        ASSERT_EQ(strs[i], v->get_data()[i].to_string());
+        ASSERT_EQ(strs[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(StringFunctions::replace_close(context,
@@ -2611,7 +2604,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatDouble) {
     ColumnPtr result = StringFunctions::money_format_double(ctx.get(), columns).value();
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 
-    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_data()[i].to_string());
+    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_slice(i).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, moneyFormatBigInt) {
@@ -2629,7 +2622,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatBigInt) {
     ColumnPtr result = StringFunctions::money_format_bigint(ctx.get(), columns).value();
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 
-    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_data()[i].to_string());
+    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_slice(i).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, moneyFormatLargeInt) {
@@ -2658,7 +2651,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatLargeInt) {
     ColumnPtr result = StringFunctions::money_format_largeint(ctx.get(), columns).value();
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 
-    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_data()[i].to_string());
+    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_slice(i).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, moneyFormatDecimalV2Value) {
@@ -2682,7 +2675,7 @@ PARALLEL_TEST(VecStringFunctionsTest, moneyFormatDecimalV2Value) {
     ColumnPtr result = StringFunctions::money_format_decimalv2val(ctx.get(), columns).value();
     auto v = ColumnHelper::as_raw_column<BinaryColumn>(result);
 
-    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_data()[i].to_string());
+    for (int i = 0; i < sizeof(moneys) / sizeof(moneys[0]); ++i) ASSERT_EQ(results[i], v->get_slice(i).to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, parseUrlNullable) {
@@ -2720,8 +2713,8 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlNullable) {
     auto result = StringFunctions::parse_url(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
 
-    ASSERT_EQ("/dsfsf", v->get_data()[0].to_string());
-    ASSERT_EQ("sdfsceesvdsdvs", v->get_data()[1].to_string());
+    ASSERT_EQ("/dsfsf", v->get_slice(0).to_string());
+    ASSERT_EQ("sdfsceesvdsdvs", v->get_slice(1).to_string());
     ASSERT_TRUE(result->is_null(2));
 
     ASSERT_TRUE(StringFunctions::parse_url_close(context,
@@ -2796,7 +2789,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlForConst) {
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-            ASSERT_EQ(res[i], v->get_data()[i].to_string());
+            ASSERT_EQ(res[i], v->get_slice(i).to_string());
         }
 
         ASSERT_TRUE(StringFunctions::parse_url_close(
@@ -2835,7 +2828,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrlForConst) {
         auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-            ASSERT_EQ(res[i], v->get_data()[i].to_string());
+            ASSERT_EQ(res[i], v->get_slice(i).to_string());
         }
 
         ASSERT_TRUE(StringFunctions::parse_url_close(
@@ -2882,7 +2875,7 @@ PARALLEL_TEST(VecStringFunctionsTest, parseUrl) {
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
-        ASSERT_EQ(res[i], v->get_data()[i].to_string());
+        ASSERT_EQ(res[i], v->get_slice(i).to_string());
     }
 
     ASSERT_TRUE(StringFunctions::parse_url_close(context,
@@ -2908,7 +2901,7 @@ PARALLEL_TEST(VecStringFunctionsTest, hex_intTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-        ASSERT_EQ(strs[j], v->get_data()[j].to_string());
+        ASSERT_EQ(strs[j], v->get_slice(j).to_string());
     }
 }
 
@@ -2930,7 +2923,7 @@ PARALLEL_TEST(VecStringFunctionsTest, hex_stringTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-        ASSERT_EQ(strs[j], v->get_data()[j].to_string());
+        ASSERT_EQ(strs[j], v->get_slice(j).to_string());
     }
 }
 
@@ -2953,7 +2946,7 @@ PARALLEL_TEST(VecStringFunctionsTest, unhexTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-        ASSERT_EQ(strs[j], v->get_data()[j].to_string());
+        ASSERT_EQ(strs[j], v->get_slice(j).to_string());
     }
 }
 
@@ -4604,23 +4597,10 @@ PARALLEL_TEST(VecStringFunctionsTest, initcapTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     // Fast Path Assertions
-    ASSERT_EQ("Hello World", v->get_data()[0].to_string());
-    ASSERT_EQ("Hello World", v->get_data()[1].to_string());
-    ASSERT_EQ("Hello World", v->get_data()[2].to_string());
-    ASSERT_EQ("Starrocks Database", v->get_data()[3].to_string());
-    ASSERT_EQ("1st Place, In-The-World!", v->get_data()[4].to_string());
-    ASSERT_EQ("   Hello   World   ", v->get_data()[5].to_string());
-    ASSERT_EQ("Abc_Def.Ghi+Jkl", v->get_data()[6].to_string());
-    ASSERT_EQ("A", v->get_data()[7].to_string());
-    ASSERT_EQ("", v->get_data()[8].to_string());
-
-    // Slow Path Assertions
-    ASSERT_EQ("Héllo", v->get_data()[9].to_string());
-    ASSERT_EQ("École", v->get_data()[10].to_string());
-    ASSERT_EQ("Ça Va", v->get_data()[11].to_string());
-    ASSERT_EQ("Café Resumé", v->get_data()[12].to_string());
-    ASSERT_EQ("Привет Мир", v->get_data()[13].to_string());
-    ASSERT_EQ("Hello-Wörld_123", v->get_data()[14].to_string());
+    ASSERT_EQ(
+            "[Hello World, Hello World, Hello World, Starrocks Database, 1st Place, In-The-World!,    Hello   World   "
+            ", Abc_Def.Ghi+Jkl, A, , Héllo, École, Ça Va, Café Resumé, Привет Мир, Hello-Wörld_123]",
+            result->debug_string());
 
     // --- Error Path (Invalid UTF-8) ---
     Columns invalid_columns;

--- a/be/test/exprs/string_fn_trim_test.cpp
+++ b/be/test/exprs/string_fn_trim_test.cpp
@@ -55,7 +55,7 @@ TEST_F(StringFunctionTrimTest, trimTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int k = 0; k < 4096; ++k) {
-        ASSERT_EQ("abcd" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("abcd" + std::to_string(k), v->get_slice(k).to_string());
     }
     ASSERT_OK(StringFunctions::trim_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
 }
@@ -81,7 +81,7 @@ TEST_F(StringFunctionTrimTest, trimCharTest) {
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
     for (int k = 0; k < 4096; ++k) {
-        ASSERT_EQ("cd" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ("cd" + std::to_string(k), v->get_slice(k).to_string());
     }
 
     ASSERT_OK(StringFunctions::trim_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
@@ -101,7 +101,7 @@ TEST_F(StringFunctionTrimTest, trimCharTest) {
             ASSERT_OK(StringFunctions::trim_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
             auto maybe_result = StringFunctions::trim(ctx.get(), columns);
             ASSERT_OK(maybe_result.status());
-            Slice result = *ColumnHelper::get_cpp_data<TYPE_VARCHAR>(maybe_result.value());
+            Slice result = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(maybe_result.value())->get_slice(0);
             ASSERT_EQ("abc🐱🐷", std::string(result));
             ASSERT_OK(StringFunctions::trim_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
         }
@@ -182,7 +182,7 @@ TEST_F(StringFunctionTrimTest, ltrimTest) {
 
     for (int k = 0; k < 4096; ++k) {
         std::string spaces(k, ' ');
-        ASSERT_EQ("abcd" + std::to_string(k) + spaces, v->get_data()[k].to_string());
+        ASSERT_EQ("abcd" + std::to_string(k) + spaces, v->get_slice(k).to_string());
     }
     ASSERT_OK(StringFunctions::trim_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
 }
@@ -207,7 +207,7 @@ TEST_F(StringFunctionTrimTest, rtrimTest) {
 
     for (int k = 0; k < 4096; ++k) {
         std::string spaces(k, ' ');
-        ASSERT_EQ(spaces + "abcd" + std::to_string(k), v->get_data()[k].to_string());
+        ASSERT_EQ(spaces + "abcd" + std::to_string(k), v->get_slice(k).to_string());
     }
     ASSERT_OK(StringFunctions::trim_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
 }

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4366,7 +4366,6 @@ TEST_F(TimeFunctionsTest, unixtimeToDatetimeInvalidTimestamp) {
             auto nullable_col = ColumnHelper::as_column<NullableColumn>(result);
         }
 
-
         delete fn_ctx;
     }
 }

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -61,10 +61,9 @@ public:
         _utils = std::make_shared<FunctionUtils>(_state.get());
     }
 
-public:
     TExprNode expr_node;
 
-private:
+protected:
     std::shared_ptr<RuntimeState> _state;
     std::shared_ptr<FunctionUtils> _utils;
 };
@@ -279,7 +278,7 @@ TEST_F(TimeFunctionsTest, dayOfYearTest) {
 
     auto year_days = ColumnHelper::cast_to<TYPE_INT>(result);
 
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], year_days->get_data()[i]);
     }
 }
@@ -304,7 +303,7 @@ TEST_F(TimeFunctionsTest, weekOfYearTest) {
 
     auto year_weeks = ColumnHelper::cast_to<TYPE_INT>(result);
 
-    for (size_t i = 0; i < sizeof(weeks) / sizeof(weeks[0]); ++i) {
+    for (size_t i = 0; i < std::size(weeks); ++i) {
         ASSERT_EQ(weeks[i], year_weeks->get_data()[i]);
     }
 }
@@ -330,7 +329,7 @@ TEST_F(TimeFunctionsTest, weekOfYearIsoTest) {
     ColumnPtr result = TimeFunctions::week_of_year_iso(_utils->get_fn_ctx(), columns).value();
 
     auto year_weeks = ColumnHelper::cast_to<TYPE_INT>(result);
-    for (size_t i = 0; i < sizeof(weeks) / sizeof(weeks[0]); ++i) {
+    for (size_t i = 0; i < std::size(weeks); ++i) {
         ASSERT_EQ(weeks[i], year_weeks->get_data()[i]);
     }
 }
@@ -350,7 +349,7 @@ TEST_F(TimeFunctionsTest, weekWithDefaultModeTest) {
     ColumnPtr result = TimeFunctions::week_of_year_with_default_mode(_utils->get_fn_ctx(), columns).value();
 
     auto year_weeks = ColumnHelper::cast_to<TYPE_INT>(result);
-    for (size_t i = 0; i < sizeof(weeks) / sizeof(weeks[0]); ++i) {
+    for (size_t i = 0; i < std::size(weeks); ++i) {
         ASSERT_EQ(weeks[i], year_weeks->get_data()[i]);
     }
 }
@@ -369,7 +368,7 @@ TEST_F(TimeFunctionsTest, dayofweekisoTest) {
     ColumnPtr result = TimeFunctions::day_of_week_iso(_utils->get_fn_ctx(), columns).value();
 
     auto ret = ColumnHelper::cast_to<TYPE_INT>(result);
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], ret->get_data()[i]);
     }
 }
@@ -388,7 +387,7 @@ TEST_F(TimeFunctionsTest, weekdayTest) {
     ColumnPtr result = TimeFunctions::week_day(_utils->get_fn_ctx(), columns).value();
 
     auto ret = ColumnHelper::cast_to<TYPE_INT>(result);
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], ret->get_data()[i]);
     }
 }
@@ -423,7 +422,7 @@ TEST_F(TimeFunctionsTest, weekWithModeTest) {
     ColumnPtr result = TimeFunctions::week_of_year_with_mode(_utils->get_fn_ctx(), columns).value();
 
     auto year_weeks = ColumnHelper::cast_to<TYPE_INT>(result);
-    for (size_t i = 0; i < sizeof(weeks) / sizeof(weeks[0]); ++i) {
+    for (size_t i = 0; i < std::size(weeks); ++i) {
         ASSERT_EQ(weeks[i], year_weeks->get_data()[i]);
     }
 }
@@ -603,12 +602,7 @@ TEST_F(TimeFunctionsTest, dateAndDaysDiffTest) {
         ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_INT>(result);
-        ASSERT_EQ(6, v->get_data()[0]);
-        ASSERT_EQ(6, v->get_data()[1]);
-        ASSERT_EQ(8, v->get_data()[2]);
-        ASSERT_EQ(-1, v->get_data()[3]);
-        ASSERT_EQ(0, v->get_data()[4]);
-        ASSERT_EQ(0, v->get_data()[5]);
+        ASSERT_EQ("[6, 6, 8, -1, 0, 0]", result->debug_string());
     }
 
     // days_diff
@@ -617,12 +611,7 @@ TEST_F(TimeFunctionsTest, dateAndDaysDiffTest) {
         ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_BIGINT>(result);
-        ASSERT_EQ(5, v->get_data()[0]);
-        ASSERT_EQ(6, v->get_data()[1]);
-        ASSERT_EQ(8, v->get_data()[2]);
-        ASSERT_EQ(0, v->get_data()[3]);
-        ASSERT_EQ(0, v->get_data()[4]);
-        ASSERT_EQ(0, v->get_data()[5]);
+        ASSERT_EQ("[5, 6, 8, 0, 0, 0]", result->debug_string());
     }
 }
 
@@ -1249,9 +1238,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetime) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("2019-08-06 01:38:57", v->get_data()[0]);
-        ASSERT_EQ("2019-08-06 01:39:57", v->get_data()[1]);
-        ASSERT_EQ("2019-08-06 02:38:57", v->get_data()[2]);
+        ASSERT_EQ("[2019-08-06 01:38:57, 2019-08-06 01:39:57, 2019-08-06 02:38:57]", result->debug_string());
     }
 }
 
@@ -1282,9 +1269,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithFormat) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("1970-01-01 16:00:00", v->get_data()[0]);
-        ASSERT_EQ("1970-01-01 16:01:01", v->get_data()[1]);
-        ASSERT_EQ("1970-01-01 17:03:09", v->get_data()[2]);
+        ASSERT_EQ("[1970-01-01 16:00:00, 1970-01-01 16:01:01, 1970-01-01 17:03:09]", result->debug_string());
 
         ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -1316,9 +1301,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithConstFormat) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("1970-01-01 16:00:00", v->get_data()[0]);
-        ASSERT_EQ("1970-01-01 16:01:01", v->get_data()[1]);
-        ASSERT_EQ("1970-01-01 17:03:09", v->get_data()[2]);
+        ASSERT_EQ("[1970-01-01 16:00:00, 1970-01-01 16:01:01, 1970-01-01 17:03:09]", result->debug_string());
 
         ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -1630,7 +1613,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("01,05,2013"), v->get_data()[0]);
+        ASSERT_EQ(Slice("01,05,2013"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%d %H:%i:%s"), 1);
@@ -1645,7 +1628,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
@@ -1660,7 +1643,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("20130501"), v->get_data()[0]);
+        ASSERT_EQ(Slice("20130501"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
@@ -1675,7 +1658,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
@@ -1690,7 +1673,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%dT%H:%i:%s"), 1);
@@ -1705,7 +1688,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01T00:00:00"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01T00:00:00"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("abcdef"), 1);
@@ -1720,7 +1703,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("abcdef"), v->get_data()[0]);
+        ASSERT_EQ(Slice("abcdef"), v->get_slice(0));
     }
 
     // datetime_format
@@ -1737,7 +1720,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("25,06,2020"), v->get_data()[0]);
+        ASSERT_EQ(Slice("25,06,2020"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%d %H:%i:%s"), 1);
@@ -1754,7 +1737,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%d %H:%i:%s"), 1);
@@ -1769,7 +1752,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
@@ -1784,7 +1767,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("20200625"), v->get_data()[0]);
+        ASSERT_EQ(Slice("20200625"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
@@ -1799,7 +1782,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
@@ -1814,7 +1797,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%dT%H:%i:%s"), 1);
@@ -1829,7 +1812,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25T15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25T15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("abcdef"), 1);
@@ -1844,7 +1827,7 @@ TEST_F(TimeFunctionsTest, date_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("abcdef"), v->get_data()[0]);
+        ASSERT_EQ(Slice("abcdef"), v->get_slice(0));
     }
     {
         // stack-buffer-overflow test
@@ -1958,7 +1941,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("01,05,13"), v->get_data()[0]);
+        ASSERT_EQ(Slice("01,05,13"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
@@ -1973,7 +1956,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("20130501"), v->get_data()[0]);
+        ASSERT_EQ(Slice("20130501"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
@@ -1988,7 +1971,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
@@ -2003,7 +1986,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-ddTHH:mm:ss"), 1);
@@ -2018,7 +2001,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013-05-01T00:00:00"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013-05-01T00:00:00"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("bcfbcf"), 1);
@@ -2033,7 +2016,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("bcfbcf"), v->get_data()[0]);
+        ASSERT_EQ(Slice("bcfbcf"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("", 0), 1);
@@ -2060,7 +2043,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("AD 20 2013 2013 18 3 Wed 2013 121 5 1"), v->get_data()[0]);
+        ASSERT_EQ(Slice("AD 20 2013 2013 18 3 Wed 2013 121 5 1"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy MMM dd EEEE ee"), 1);
@@ -2075,7 +2058,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013 May 01 Wednesday 03"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013 May 01 Wednesday 03"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy MMM 'abcd'"), 1);
@@ -2090,7 +2073,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2013 May abcd"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2013 May abcd"), v->get_slice(0));
     }
 
     {
@@ -2106,7 +2089,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("abcd 201305"), v->get_data()[0]);
+        ASSERT_EQ(Slice("abcd 201305"), v->get_slice(0));
     }
 
     // datetime_format
@@ -2123,7 +2106,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("25,06,20"), v->get_data()[0]);
+        ASSERT_EQ(Slice("25,06,20"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
@@ -2138,7 +2121,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("20200625"), v->get_data()[0]);
+        ASSERT_EQ(Slice("20200625"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
@@ -2153,7 +2136,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
@@ -2168,7 +2151,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-ddTHH:mm:ss"), 1);
@@ -2183,7 +2166,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("2020-06-25T15:58:21"), v->get_data()[0]);
+        ASSERT_EQ(Slice("2020-06-25T15:58:21"), v->get_slice(0));
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("bcfbcf"), 1);
@@ -2198,7 +2181,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("bcfbcf"), v->get_data()[0]);
+        ASSERT_EQ(Slice("bcfbcf"), v->get_slice(0));
     }
     {
         // stack-buffer-overflow test
@@ -2245,7 +2228,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("PM 3 3 15 15 58 21 0"), v->get_data()[0]);
+        ASSERT_EQ(Slice("PM 3 3 15 15 58 21 0"), v->get_slice(0));
     }
 
     {
@@ -2261,7 +2244,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("PM 3 abcd"), v->get_data()[0]);
+        ASSERT_EQ(Slice("PM 3 abcd"), v->get_slice(0));
     }
 
     {
@@ -2277,7 +2260,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("abcd 202006"), v->get_data()[0]);
+        ASSERT_EQ(Slice("abcd 202006"), v->get_slice(0));
     }
 }
 
@@ -2376,8 +2359,8 @@ TEST_F(TimeFunctionsTest, daynameTest) {
     ColumnPtr result = TimeFunctions::day_name(_utils->get_fn_ctx(), columns).value();
     auto day_names = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
-        ASSERT_EQ(days[i], day_names->get_data()[i].to_string());
+    for (size_t i = 0; i < std::size(days); ++i) {
+        ASSERT_EQ(days[i], day_names->get_slice(i).to_string());
     }
 }
 
@@ -2398,8 +2381,8 @@ TEST_F(TimeFunctionsTest, monthnameTest) {
     ColumnPtr result = TimeFunctions::month_name(_utils->get_fn_ctx(), columns).value();
     auto day_names = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-    for (size_t i = 0; i < sizeof(months) / sizeof(months[0]); ++i) {
-        ASSERT_EQ(months[i], day_names->get_data()[i].to_string());
+    for (size_t i = 0; i < std::size(months); ++i) {
+        ASSERT_EQ(months[i], day_names->get_slice(i).to_string());
     }
 }
 
@@ -2442,7 +2425,7 @@ TEST_F(TimeFunctionsTest, convertTzGeneralTest) {
     ColumnPtr result = TimeFunctions::convert_tz(_utils->get_fn_ctx(), columns).value();
 
     auto day_names = ColumnHelper::cast_to<TYPE_DATETIME>(result);
-    for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) ASSERT_EQ(res[i], day_names->get_data()[i]);
+    for (int i = 0; i < std::size(res); ++i) ASSERT_EQ(res[i], day_names->get_data()[i]);
 
     ASSERT_TRUE(
             TimeFunctions::convert_tz_close(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -2483,7 +2466,7 @@ TEST_F(TimeFunctionsTest, convertTzConstTest) {
     ColumnPtr result = TimeFunctions::convert_tz(_utils->get_fn_ctx(), columns).value();
 
     auto day_names = ColumnHelper::cast_to<TYPE_DATETIME>(result);
-    for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) ASSERT_EQ(res[i], day_names->get_data()[i]);
+    for (int i = 0; i < std::size(res); ++i) ASSERT_EQ(res[i], day_names->get_data()[i]);
 
     ASSERT_TRUE(
             TimeFunctions::convert_tz_close(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -2565,7 +2548,7 @@ TEST_F(TimeFunctionsTest, hourTest) {
 
     auto year_days = ColumnHelper::cast_to<TYPE_INT>(result);
 
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], year_days->get_data()[i]);
     }
 }
@@ -2590,7 +2573,7 @@ TEST_F(TimeFunctionsTest, minuteTest) {
 
     auto year_days = ColumnHelper::cast_to<TYPE_INT>(result);
 
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], year_days->get_data()[i]);
     }
 }
@@ -2615,7 +2598,7 @@ TEST_F(TimeFunctionsTest, secondTest) {
 
     auto year_days = ColumnHelper::cast_to<TYPE_INT>(result);
 
-    for (size_t i = 0; i < sizeof(days) / sizeof(days[0]); ++i) {
+    for (size_t i = 0; i < std::size(days); ++i) {
         ASSERT_EQ(days[i], year_days->get_data()[i]);
     }
 }
@@ -2635,7 +2618,7 @@ TEST_F(TimeFunctionsTest, timestampTest) {
 
         TimestampValue check_result[] = {TimestampValue::create(2020, 1, 1, 21, 22, 51)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2678,7 +2661,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 6, 11, 54, 23), TimestampValue::create(2020, 4, 8, 9, 13, 19),
                 TimestampValue::create(2020, 5, 9, 8, 8, 16),   TimestampValue::create(2020, 11, 3, 23, 41, 37)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2711,7 +2694,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 6, 11, 54, 0), TimestampValue::create(2020, 4, 8, 9, 13, 0),
                 TimestampValue::create(2020, 5, 9, 8, 8, 0),   TimestampValue::create(2020, 11, 3, 23, 41, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2744,7 +2727,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 6, 11, 0, 0), TimestampValue::create(2020, 4, 8, 9, 0, 0),
                 TimestampValue::create(2020, 5, 9, 8, 0, 0),  TimestampValue::create(2020, 11, 3, 23, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2777,7 +2760,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 6, 0, 0, 0), TimestampValue::create(2020, 4, 8, 0, 0, 0),
                 TimestampValue::create(2020, 5, 9, 0, 0, 0), TimestampValue::create(2020, 11, 3, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2810,7 +2793,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 1, 0, 0, 0), TimestampValue::create(2020, 4, 1, 0, 0, 0),
                 TimestampValue::create(2020, 5, 1, 0, 0, 0), TimestampValue::create(2020, 11, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2843,7 +2826,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 1, 1, 0, 0, 0), TimestampValue::create(2020, 1, 1, 0, 0, 0),
                 TimestampValue::create(2020, 1, 1, 0, 0, 0), TimestampValue::create(2020, 1, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2876,7 +2859,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 3, 2, 0, 0, 0),   TimestampValue::create(2020, 4, 6, 0, 0, 0),
                 TimestampValue::create(2020, 5, 4, 0, 0, 0),   TimestampValue::create(2020, 11, 2, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -2909,7 +2892,7 @@ TEST_F(TimeFunctionsTest, datetimeTruncTest) {
                 TimestampValue::create(2020, 1, 1, 0, 0, 0), TimestampValue::create(2020, 4, 1, 0, 0, 0),
                 TimestampValue::create(2020, 4, 1, 0, 0, 0), TimestampValue::create(2020, 10, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3184,7 +3167,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 5, 6, 11, 54, 20), TimestampValue::create(2022, 7, 8, 9, 13, 15),
                 TimestampValue::create(2022, 9, 9, 8, 8, 15),   TimestampValue::create(2022, 11, 3, 23, 41, 35)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3229,7 +3212,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 5, 6, 11, 50, 0), TimestampValue::create(2022, 7, 8, 9, 10, 0),
                 TimestampValue::create(2022, 9, 9, 8, 5, 0),   TimestampValue::create(2022, 11, 3, 23, 40, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3274,7 +3257,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 5, 6, 10, 0, 0), TimestampValue::create(2022, 7, 8, 8, 0, 0),
                 TimestampValue::create(2022, 9, 9, 6, 0, 0),  TimestampValue::create(2022, 11, 3, 21, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3319,7 +3302,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 5, 6, 0, 0, 0), TimestampValue::create(2022, 7, 5, 0, 0, 0),
                 TimestampValue::create(2022, 9, 8, 0, 0, 0), TimestampValue::create(2022, 11, 2, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3364,7 +3347,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 1, 1, 0, 0, 0), TimestampValue::create(2022, 4, 1, 0, 0, 0),
                 TimestampValue::create(2022, 9, 1, 0, 0, 0), TimestampValue::create(2022, 9, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3409,7 +3392,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 1, 1, 0, 0, 0), TimestampValue::create(2021, 1, 1, 0, 0, 0),
                 TimestampValue::create(2021, 1, 1, 0, 0, 0), TimestampValue::create(2021, 1, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3454,7 +3437,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 4, 16, 0, 0, 0), TimestampValue::create(2022, 6, 20, 0, 0, 0),
                 TimestampValue::create(2022, 8, 29, 0, 0, 0), TimestampValue::create(2022, 10, 3, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3499,7 +3482,7 @@ TEST_F(TimeFunctionsTest, timeSliceFloorTest) {
                 TimestampValue::create(0001, 1, 1, 0, 0, 0), TimestampValue::create(2022, 4, 1, 0, 0, 0),
                 TimestampValue::create(2022, 4, 1, 0, 0, 0), TimestampValue::create(2022, 4, 1, 0, 0, 0)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3559,7 +3542,7 @@ TEST_F(TimeFunctionsTest, timeSliceCeilTest) {
                 TimestampValue::create(0001, 5, 6, 11, 54, 25), TimestampValue::create(2022, 7, 8, 9, 13, 20),
                 TimestampValue::create(2022, 9, 9, 8, 8, 20),   TimestampValue::create(2022, 11, 3, 23, 41, 40)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3664,7 +3647,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
                                      DateValue::create(0001, 5, 6), DateValue::create(2022, 7, 5),
                                      DateValue::create(2022, 9, 8), DateValue::create(2022, 11, 2)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3708,7 +3691,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
                                      DateValue::create(0001, 1, 1), DateValue::create(2022, 4, 1),
                                      DateValue::create(2022, 9, 1), DateValue::create(2022, 9, 1)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3752,7 +3735,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
                                      DateValue::create(0001, 1, 1), DateValue::create(2021, 1, 1),
                                      DateValue::create(2021, 1, 1), DateValue::create(2021, 1, 1)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3796,7 +3779,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
                                      DateValue::create(0001, 4, 16), DateValue::create(2022, 6, 20),
                                      DateValue::create(2022, 8, 29), DateValue::create(2022, 10, 3)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3840,7 +3823,7 @@ TEST_F(TimeFunctionsTest, DateSliceFloorTest) {
                                      DateValue::create(0001, 1, 1), DateValue::create(2022, 4, 1),
                                      DateValue::create(2022, 4, 1), DateValue::create(2022, 4, 1)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -3899,7 +3882,7 @@ TEST_F(TimeFunctionsTest, DateSliceCeilTest) {
                                      DateValue::create(0001, 5, 11), DateValue::create(2022, 7, 10),
                                      DateValue::create(2022, 9, 13), DateValue::create(2022, 11, 7)};
 
-        for (size_t i = 0; i < sizeof(check_result) / sizeof(check_result[0]); ++i) {
+        for (size_t i = 0; i < std::size(check_result); ++i) {
             ASSERT_EQ(check_result[i], datetimes->get_data()[i]);
         }
     }
@@ -4383,9 +4366,6 @@ TEST_F(TimeFunctionsTest, unixtimeToDatetimeInvalidTimestamp) {
             auto nullable_col = ColumnHelper::as_column<NullableColumn>(result);
         }
 
-        ASSERT_TRUE(
-                TimeFunctions::unixtime_to_datetime_close(fn_ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
-                        .ok());
 
         delete fn_ctx;
     }
@@ -4561,7 +4541,7 @@ TEST_F(TimeFunctionsTest, hourFromUnixTime) {
         ColumnPtr result = TimeFunctions::hour_from_unixtime(_utils->get_fn_ctx(), columns).value();
 
         auto hours = ColumnHelper::cast_to<TYPE_TINYINT>(result);
-        for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i) {
+        for (size_t i = 0; i < std::size(expected); ++i) {
             EXPECT_EQ(expected[i], hours->get_data()[i]) << "Failed for basic positive at index " << i;
         }
     }
@@ -4594,7 +4574,7 @@ TEST_F(TimeFunctionsTest, hourFromUnixTime) {
         ColumnPtr result = TimeFunctions::hour_from_unixtime(_utils->get_fn_ctx(), columns).value();
 
         auto hours = ColumnHelper::cast_to<TYPE_TINYINT>(result);
-        for (size_t i = 0; i < sizeof(expected_negative) / sizeof(expected_negative[0]); ++i) {
+        for (size_t i = 0; i < std::size(expected_negative); ++i) {
             EXPECT_EQ(expected_negative[i], hours->get_data()[i])
                     << "Failed for timezone offset at index " << i << " with value " << tc->get_data()[i];
         }
@@ -4629,7 +4609,7 @@ TEST_F(TimeFunctionsTest, hourFromUnixTime) {
         ColumnPtr result = TimeFunctions::hour_from_unixtime(_utils->get_fn_ctx(), columns).value();
 
         auto hours = ColumnHelper::cast_to<TYPE_TINYINT>(result);
-        for (size_t i = 0; i < sizeof(expected_mixed) / sizeof(expected_mixed[0]); ++i) {
+        for (size_t i = 0; i < std::size(expected_mixed); ++i) {
             EXPECT_EQ(expected_mixed[i], hours->get_data()[i])
                     << "Failed for mixed timezone offset at index " << i << " with value " << tc->get_data()[i];
         }

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1238,7 +1238,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetime) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("[2019-08-06 01:38:57, 2019-08-06 01:39:57, 2019-08-06 02:38:57]", result->debug_string());
+        ASSERT_EQ("['2019-08-06 01:38:57', '2019-08-06 01:39:57', '2019-08-06 02:38:57']", result->debug_string());
     }
 }
 
@@ -1269,7 +1269,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithFormat) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("[1970-01-01 16:00:00, 1970-01-01 16:01:01, 1970-01-01 17:03:09]", result->debug_string());
+        ASSERT_EQ("['1970-01-01 16:00:00', '1970-01-01 16:01:01', '1970-01-01 17:03:09']", result->debug_string());
 
         ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -1301,7 +1301,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithConstFormat) {
         //ASSERT_TRUE(result->is_numeric());
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ("[1970-01-01 16:00:00, 1970-01-01 16:01:01, 1970-01-01 17:03:09]", result->debug_string());
+        ASSERT_EQ("['1970-01-01 16:00:00', '1970-01-01 16:01:01', '1970-01-01 17:03:09']", result->debug_string());
 
         ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -4365,6 +4365,10 @@ TEST_F(TimeFunctionsTest, unixtimeToDatetimeInvalidTimestamp) {
         if (result->is_nullable()) {
             auto nullable_col = ColumnHelper::as_column<NullableColumn>(result);
         }
+
+        ASSERT_TRUE(
+                TimeFunctions::unixtime_to_datetime_close(fn_ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 
         delete fn_ctx;
     }

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -266,7 +266,7 @@ TEST_F(ChunkHelperTest, SegmentedChunk) {
     while (!slice.empty()) {
         auto chunk = slice.cutoff(1000);
         EXPECT_LE(chunk->num_rows(), 1000);
-        auto& slices = ColumnHelper::as_column<BinaryColumn>(chunk->get_column_by_index(1))->get_data();
+        const auto& slices = ColumnHelper::as_column<BinaryColumn>(chunk->get_column_by_index(1))->immutable_data();
         for (int i = 0; i < chunk->num_rows(); i++) {
             EXPECT_EQ(total_rows + i, chunk->get_column_by_index(0)->get(i).get_int32());
             EXPECT_EQ(fmt::format("str{}", total_rows + i + 1), slices[i].to_string());

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -297,7 +297,7 @@ TEST(ColumnAggregator, testStringMin) {
     aggregator->aggregate_values(0, 3, loops.data(), false);
 
     EXPECT_EQ(3, agg1->size());
-    ASSERT_EQ("[1000, 3000, 3003]", agg1->debug_string());
+    ASSERT_EQ("['1000', '1002', '3003']", agg1->debug_string());
 
     aggregator->update_source(src3);
 
@@ -310,7 +310,7 @@ TEST(ColumnAggregator, testStringMin) {
     aggregator->finalize();
 
     EXPECT_EQ(6, agg1->size());
-    ASSERT_EQ("[1000, 1002, 3003, 3103, 2000, 2001]", agg1->debug_string());
+    ASSERT_EQ("['1000', '1002', '3003', '3103', '2000', '2001']", agg1->debug_string());
 }
 
 TEST(ColumnAggregator, testNullBooleanMin) {

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -285,7 +285,7 @@ TEST(ColumnAggregator, testStringMin) {
     aggregator->aggregate_values(0, 2, loops.data(), false);
 
     ASSERT_EQ(1, agg1->size());
-    ASSERT_EQ("1000", agg1->get_data()[0].to_string());
+    ASSERT_EQ("1000", agg1->immutable_data()[0].to_string());
 
     aggregator->update_source(src2);
 
@@ -297,9 +297,7 @@ TEST(ColumnAggregator, testStringMin) {
     aggregator->aggregate_values(0, 3, loops.data(), false);
 
     EXPECT_EQ(3, agg1->size());
-    EXPECT_EQ("1000", agg1->get_data()[0].to_string());
-    EXPECT_EQ("1002", agg1->get_data()[1].to_string());
-    EXPECT_EQ("3003", agg1->get_data()[2].to_string());
+    ASSERT_EQ("[1000, 3000, 3003]", agg1->debug_string());
 
     aggregator->update_source(src3);
 
@@ -312,12 +310,7 @@ TEST(ColumnAggregator, testStringMin) {
     aggregator->finalize();
 
     EXPECT_EQ(6, agg1->size());
-    EXPECT_EQ("1000", agg1->get_data()[0].to_string());
-    EXPECT_EQ("1002", agg1->get_data()[1].to_string());
-    EXPECT_EQ("3003", agg1->get_data()[2].to_string());
-    EXPECT_EQ("3103", agg1->get_data()[3].to_string());
-    EXPECT_EQ("2000", agg1->get_data()[4].to_string());
-    EXPECT_EQ("2001", agg1->get_data()[5].to_string());
+    ASSERT_EQ("[1000, 1002, 3003, 3103, 2000, 2001]", agg1->debug_string());
 }
 
 TEST(ColumnAggregator, testNullBooleanMin) {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -420,7 +420,6 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range) {
 }
 
 TEST_F(LakeTabletManagerTest, create_tablet_with_range_null_values) {
-    auto fs = FileSystem::Default();
     auto tablet_id = next_id();
     auto schema_id = next_id();
 
@@ -463,7 +462,6 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_null_values) {
 }
 
 TEST_F(LakeTabletManagerTest, create_tablet_with_range_min_max_values) {
-    auto fs = FileSystem::Default();
     auto tablet_id = next_id();
     auto schema_id = next_id();
 
@@ -520,7 +518,6 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_min_max_values) {
 
 TEST_F(LakeTabletManagerTest, create_tablet_without_range) {
     // Test backward compatibility: create tablet without range
-    auto fs = FileSystem::Default();
     auto tablet_id = next_id();
     auto schema_id = next_id();
 

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -114,7 +114,7 @@ public:
         status = page_decoder.next_batch(read_range, column2.get());
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(2, column2->size());
-        ASSERT_EQ("[Hello, StarRocks]", column2->debug_string());
+        ASSERT_EQ("['Hello', 'StarRocks']", column2->debug_string());
     }
 };
 
@@ -212,7 +212,7 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
         ASSERT_EQ(1, selection[4]);
 
         ASSERT_EQ(3, column->size());
-        ASSERT_EQ("[c_300, d_400, e_500]", column->debug_string());
+        ASSERT_EQ("['c_300', 'd_400', 'e_500']", column->debug_string());
     }
 
     // Reset decoder
@@ -329,7 +329,7 @@ TEST_F(BinaryPlainPageTest, TestReadByRowids) {
     Status st = decoder.read_by_rowids(0, rowids, &num_read, column.get());
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(4, num_read);
-    ASSERT_EQ("[val_1, val_3, val_5, val_8]", column->debug_string());
+    ASSERT_EQ("['val_1', 'val_3', 'val_5', 'val_8']", column->debug_string());
 }
 
 TEST_F(BinaryPlainPageTest, TestDictFilterSelectionLargeDictSize) {

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -49,7 +49,6 @@
 #include "storage/column_predicate.h"
 #include "storage/olap_common.h"
 #include "storage/range.h"
-#include "storage/rowset/page_decoder.h"
 #include "storage/types.h"
 
 namespace starrocks {
@@ -97,9 +96,7 @@ public:
         status = page_decoder.next_batch(&size, column.get());
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(3U, size);
-        ASSERT_EQ("Hello", column->get_data()[0]);
-        ASSERT_EQ(",", column->get_data()[1]);
-        ASSERT_EQ("StarRocks", column->get_data()[2]);
+        ASSERT_EQ("['Hello', ',', 'StarRocks']", column->debug_string());
 
         size = 1024;
         auto column1 = BinaryColumn::create();
@@ -107,7 +104,7 @@ public:
         status = page_decoder.next_batch(&size, column1.get());
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(1, size);
-        ASSERT_EQ("StarRocks", column1->get_data()[0]);
+        ASSERT_EQ("StarRocks", column1->immutable_data()[0]);
 
         auto column2 = BinaryColumn::create();
         ASSERT_OK(page_decoder.seek_to_position_in_page(0));
@@ -117,8 +114,7 @@ public:
         status = page_decoder.next_batch(read_range, column2.get());
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(2, column2->size());
-        ASSERT_EQ("Hello", column2->get_data()[0]);
-        ASSERT_EQ("StarRocks", column2->get_data()[1]);
+        ASSERT_EQ("[Hello, StarRocks]", column2->debug_string());
     }
 };
 
@@ -216,9 +212,7 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
         ASSERT_EQ(1, selection[4]);
 
         ASSERT_EQ(3, column->size());
-        ASSERT_EQ("c_300", column->get_data()[0]);
-        ASSERT_EQ("d_400", column->get_data()[1]);
-        ASSERT_EQ("e_500", column->get_data()[2]);
+        ASSERT_EQ("[c_300, d_400, e_500]", column->debug_string());
     }
 
     // Reset decoder
@@ -252,9 +246,7 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
         auto nullable_col = down_cast<NullableColumn*>(column.get());
         auto binary_col = down_cast<BinaryColumn*>(nullable_col->data_column_raw_ptr());
 
-        ASSERT_EQ("c_300", binary_col->get_data()[0]);
-        ASSERT_EQ("d_400", binary_col->get_data()[1]);
-        ASSERT_EQ("e_500", binary_col->get_data()[2]);
+        ASSERT_EQ("[c_300, d_400, e_500]", binary_col->debug_string());
 
         ASSERT_EQ(3, nullable_col->null_column_raw_ptr()->size());
         ASSERT_EQ(0, nullable_col->null_column_data()[0]);
@@ -306,7 +298,7 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
         auto nullable_col = down_cast<NullableColumn*>(column.get());
         auto binary_col = down_cast<BinaryColumn*>(nullable_col->data_column_raw_ptr());
 
-        ASSERT_EQ("d_400", binary_col->get_data()[0]);
+        ASSERT_EQ("d_400", binary_col->immutable_data()[0]);
     }
 }
 
@@ -337,12 +329,7 @@ TEST_F(BinaryPlainPageTest, TestReadByRowids) {
     Status st = decoder.read_by_rowids(0, rowids, &num_read, column.get());
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(4, num_read);
-    ASSERT_EQ(4, column->size());
-
-    ASSERT_EQ("val_1", column->get_data()[0]);
-    ASSERT_EQ("val_3", column->get_data()[1]);
-    ASSERT_EQ("val_5", column->get_data()[2]);
-    ASSERT_EQ("val_8", column->get_data()[3]);
+    ASSERT_EQ("[val_1, val_3, val_5, val_8]", column->debug_string());
 }
 
 TEST_F(BinaryPlainPageTest, TestDictFilterSelectionLargeDictSize) {

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -246,7 +246,7 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
         auto nullable_col = down_cast<NullableColumn*>(column.get());
         auto binary_col = down_cast<BinaryColumn*>(nullable_col->data_column_raw_ptr());
 
-        ASSERT_EQ("[c_300, d_400, e_500]", binary_col->debug_string());
+        ASSERT_EQ("['c_300', 'd_400', 'e_500']", binary_col->debug_string());
 
         ASSERT_EQ(3, nullable_col->null_column_raw_ptr()->size());
         ASSERT_EQ(0, nullable_col->null_column_data()[0]);

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -456,7 +456,7 @@ TEST_F(BitmapIndexTest, test_seek_dictionary_by_predicate) {
             auto res = BooleanColumn::create();
             const auto& binary_col = down_cast<const BinaryColumn&>(value_column);
             for (size_t i = 0; i < binary_col.size(); ++i) {
-                Slice s = binary_col.get_data()[i];
+                Slice s = binary_col.get_slice(i);
                 res->append(s.to_string().find('a') != std::string::npos);
             }
             return res;

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -445,7 +445,6 @@ protected:
         auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, true);
         auto nc = down_cast<NullableColumn*>(col.get());
         nc->reserve(count);
-        down_cast<BinaryColumn*>(nc->data_column_raw_ptr())->get_data().reserve(s1.size() * count);
         auto v = std::vector<Slice>{s1, s2, s1, s1, s2, s2, s1, s2, s1, s1, s2, s1, s2, s1, s1, s1};
         for (size_t i = 0; i < count; i += 16) {
             CHECK(col->append_strings(v));
@@ -472,7 +471,6 @@ protected:
         size_t count = (128 * 1024 / s1.size()) / 8 * 8;
         auto nc = down_cast<NullableColumn*>(col.get());
         nc->reserve(count);
-        down_cast<BinaryColumn*>(nc->data_column_raw_ptr())->get_data().reserve(count * s1.size());
         for (size_t i = 0; i < count; i += 8) {
             (void)col->append_strings(std::vector<Slice>{s1, s2, s3, s4, s5, s6, s7, s8});
 


### PR DESCRIPTION
## Why I'm doing:

This is the 5st for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

Remove interface get_data from BinaryColumn

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
