### PR TITLE
[BugFix] Fix SST file deleted by vacuum due to parallel compaction full-contain optimization

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -320,8 +320,22 @@ void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& m
 }
 
 void MetaFileBuilder::remove_compacted_sst(const TxnLogPB_OpCompaction& op_compaction) {
-    // remove compacted sst
+    // Collect output SST filenames. Parallel compaction's "full contain" optimization
+    // may reuse input SST files as output (only changing fileset_id). Skip those files
+    // to avoid the same file appearing in both sstable_meta and orphan_files, which
+    // would cause vacuum to delete a still-referenced SST file.
+    std::unordered_set<std::string> output_sst_filenames;
+    if (op_compaction.has_output_sstable()) {
+        output_sst_filenames.insert(op_compaction.output_sstable().filename());
+    }
+    for (const auto& output_sstable : op_compaction.output_sstables()) {
+        output_sst_filenames.insert(output_sstable.filename());
+    }
+
     for (auto& input_sstable : op_compaction.input_sstables()) {
+        if (output_sst_filenames.contains(input_sstable.filename())) {
+            continue;
+        }
         FileMetaPB file_meta;
         file_meta.set_name(input_sstable.filename());
         file_meta.set_size(input_sstable.filesize());

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1092,4 +1092,126 @@ TEST_F(MetaFileTest, test_sstable_delvec_integration) {
     auto final_version_iter = final_version_to_file_map.find(version1);
     EXPECT_TRUE(final_version_iter == final_version_to_file_map.end());
 }
+// Test that remove_compacted_sst skips SST files that appear in both input and output,
+// which happens when parallel compaction's "full contain" optimization reuses input SSTs.
+TEST_F(MetaFileTest, test_remove_compacted_sst_skip_reused_sst) {
+    const int64_t tablet_id = 10010;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(110);
+    metadata->set_enable_persistent_index(true);
+    metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+    // Setup: 3 input SSTs, where "reused.sst" appears in both input and output
+    // (simulating the "full contain" optimization in parallel compaction)
+    TxnLogPB_OpCompaction op_compaction;
+
+    auto* input1 = op_compaction.add_input_sstables();
+    input1->set_filename("old1.sst");
+    input1->set_filesize(100);
+
+    auto* input2 = op_compaction.add_input_sstables();
+    input2->set_filename("reused.sst");
+    input2->set_filesize(200);
+
+    auto* input3 = op_compaction.add_input_sstables();
+    input3->set_filename("old2.sst");
+    input3->set_filesize(150);
+
+    // Output contains "reused.sst" (full contain) and a new merged file
+    auto* output1 = op_compaction.add_output_sstables();
+    output1->set_filename("reused.sst");
+    output1->set_filesize(200);
+
+    auto* output2 = op_compaction.add_output_sstables();
+    output2->set_filename("merged_new.sst");
+    output2->set_filesize(250);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    builder.remove_compacted_sst(op_compaction);
+
+    // Verify: only "old1.sst" and "old2.sst" should be in orphan_files.
+    // "reused.sst" must NOT be in orphan_files since it's also an output.
+    ASSERT_EQ(metadata->orphan_files_size(), 2);
+    std::set<std::string> orphan_names;
+    for (const auto& f : metadata->orphan_files()) {
+        orphan_names.insert(f.name());
+    }
+    EXPECT_TRUE(orphan_names.count("old1.sst") > 0);
+    EXPECT_TRUE(orphan_names.count("old2.sst") > 0);
+    EXPECT_TRUE(orphan_names.count("reused.sst") == 0);
+}
+
+// Test that remove_compacted_sst also handles output_sstable (singular, from major_compact)
+TEST_F(MetaFileTest, test_remove_compacted_sst_skip_reused_sst_singular_output) {
+    const int64_t tablet_id = 10011;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(110);
+    metadata->set_enable_persistent_index(true);
+    metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+    TxnLogPB_OpCompaction op_compaction;
+
+    auto* input1 = op_compaction.add_input_sstables();
+    input1->set_filename("reused_single.sst");
+    input1->set_filesize(100);
+
+    auto* input2 = op_compaction.add_input_sstables();
+    input2->set_filename("old.sst");
+    input2->set_filesize(200);
+
+    // Singular output_sstable reuses one of the input files
+    op_compaction.mutable_output_sstable()->set_filename("reused_single.sst");
+    op_compaction.mutable_output_sstable()->set_filesize(100);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    builder.remove_compacted_sst(op_compaction);
+
+    ASSERT_EQ(metadata->orphan_files_size(), 1);
+    EXPECT_EQ(metadata->orphan_files(0).name(), "old.sst");
+}
+
+// Test that when no SSTs are reused, all inputs go to orphan_files (original behavior)
+TEST_F(MetaFileTest, test_remove_compacted_sst_no_reuse) {
+    const int64_t tablet_id = 10012;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(110);
+    metadata->set_enable_persistent_index(true);
+    metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+    TxnLogPB_OpCompaction op_compaction;
+
+    auto* input1 = op_compaction.add_input_sstables();
+    input1->set_filename("a.sst");
+    input1->set_filesize(100);
+
+    auto* input2 = op_compaction.add_input_sstables();
+    input2->set_filename("b.sst");
+    input2->set_filesize(200);
+
+    auto* output = op_compaction.add_output_sstables();
+    output->set_filename("c.sst");
+    output->set_filesize(300);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    builder.remove_compacted_sst(op_compaction);
+
+    // All inputs should be orphaned since output is a new file
+    ASSERT_EQ(metadata->orphan_files_size(), 2);
+    std::set<std::string> orphan_names;
+    for (const auto& f : metadata->orphan_files()) {
+        orphan_names.insert(f.name());
+    }
+    EXPECT_TRUE(orphan_names.count("a.sst") > 0);
+    EXPECT_TRUE(orphan_names.count("b.sst") > 0);
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

When parallel compaction's "full contain" optimization reuses input SST files as output (only changing `fileset_id`), `remove_compacted_sst()` blindly adds **all** input SSTs to `orphan_files`. This causes the same file to appear in both `sstable_meta` (as output) and `orphan_files` (as input). When vacuum runs `collect_garbage_files`, it deletes files in `orphan_files` without checking `sstable_meta`, resulting in:

```
load primary index failed: Not found: starlet err Object ... .sst does not exist
```

The "full contain" optimization was introduced in PR #66522 as part of the large tablet support feature (#66457), so this issue only affects 4.1 and does not exist in 4.0.

### Root Cause

In `LakePersistentIndexParallelCompactTask::do_run()` (`lake_persistent_index_parallel_compact_mgr.cpp:164-179`), when a single fileset's SSTs are fully contained within the seek range, the input SST PBs are directly copied as output (only `fileset_id` is changed):

```cpp
if (full_contain) {
    for (const auto& sst : sstables) {
        _output_sstables.push_back(sst->sstable_pb());
        _output_sstables.back().mutable_fileset_id()->CopyFrom(_output_fileset_id.to_proto());
    }
    return Status::OK();
}
```

Later in `MetaFileBuilder::remove_compacted_sst()`, all input SSTs are added to `orphan_files` for garbage collection — including the ones that were reused as output. Vacuum then deletes these files, breaking the persistent index.

## What I'm doing:

In `remove_compacted_sst()`, collect output SST filenames first, and skip any input SST whose filename also appears in the output. This prevents reused SST files from being added to `orphan_files`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4