### PR TITLE
[Enhancement] optimize MIN/MAX on date partition column with constant partition value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -74,7 +74,7 @@ public class PartitionKey implements Comparable<PartitionKey> {
     // for hudi， it's __HIVE_DEFAULT_PARTITION__ or default
     private String nullPartitionValue = "";
 
-    public static final DateLiteral SHADOW_DATE_LITERAL = new DateLiteral(0, 0, 0);
+    private static final DateLiteral SHADOW_DATE_LITERAL = new DateLiteral(0, 0, 0);
     private static final DateLiteral SHADOW_DATETIME_LITERAL = new DateLiteral(0, 0, 0, 0, 0, 0, 0);
 
     // constructor for partition prune
@@ -494,6 +494,10 @@ public class PartitionKey implements Comparable<PartitionKey> {
             }
         }
         return Math.max(higher, 0);
+    }
+
+    public static boolean isShadowDateLiteral(DateLiteral literal) {
+        return literal.getYear() == 0 && literal.getMonth() == 0 && literal.getDay() == 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -74,7 +74,7 @@ public class PartitionKey implements Comparable<PartitionKey> {
     // for hudi， it's __HIVE_DEFAULT_PARTITION__ or default
     private String nullPartitionValue = "";
 
-    private static final DateLiteral SHADOW_DATE_LITERAL = new DateLiteral(0, 0, 0);
+    public static final DateLiteral SHADOW_DATE_LITERAL = new DateLiteral(0, 0, 0);
     private static final DateLiteral SHADOW_DATETIME_LITERAL = new DateLiteral(0, 0, 0, 0, 0, 0, 0);
 
     // constructor for partition prune

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -15,17 +15,30 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.expression.DateLiteral;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -39,17 +52,20 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import com.starrocks.type.PrimitiveType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -152,7 +168,12 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         try {
             OptExpression result = null;
             if (checkRewritePartitionValues(aggregationOperator, scanOperator, table)) {
-                result = optimizeWithPartitionValues(aggregationOperator, table, minMax);
+                result = optimizeWithPartitionValues(aggregationOperator, table,
+                        Pair.create(this::getMinListPartitionValue, this::getMaxListPartitionValue));
+            } else if (checkRewriteDateTruncDayPartition(aggregationOperator, scanOperator, table)
+                    || checkRewriteDayRangePartition(aggregationOperator, scanOperator, table)) {
+                result = optimizeWithPartitionValues(aggregationOperator, table,
+                        Pair.create(this::getRangePartitionValue, this::getRangePartitionValue));
             } else if (checkPartitionPrune(aggregationOperator, scanOperator, table)) {
                 result = optimizeWithPartitionPrune(input, aggregationOperator, scanOperator, table, minMax);
             } else if (checkRewriteTopN(aggregationOperator, scanOperator, table, minMax)) {
@@ -288,8 +309,10 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
      */
     private OptExpression optimizeWithPartitionValues(LogicalAggregationOperator aggregationOperator,
                                                       OlapTable table,
-                                                      Pair<Boolean, Boolean> hasMinMax) {
-        ListPartitionInfo partitionInfo = (ListPartitionInfo) table.getPartitionInfo();
+                                                      Pair<BiFunction<Long, PartitionInfo, ScalarOperator>,
+                                                              BiFunction<Long, PartitionInfo, ScalarOperator>>
+                                                              minMaxFunction) {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
         List<Partition> nonEmpty = table.getNonEmptyPartitions();
         Set<Long> nonEmptyPartitionIds = nonEmpty.stream().map(Partition::getId).collect(Collectors.toSet());
 
@@ -302,11 +325,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 if (CollectionUtils.isEmpty(sorted)) {
                     return null;
                 }
-                long minPartition = sorted.get(0);
-                ListPartitionInfo.ListPartitionCell partitionValues = partitionInfo.getPartitionListExpr(minPartition);
-                Preconditions.checkState(!partitionValues.isEmpty());
-                ConstantOperator minValue = partitionValues.minValue().toConstant();
-                valueRow.add(minValue);
+                valueRow.add(minMaxFunction.first.apply(sorted.get(0), partitionInfo));
                 columns.add(entry.getKey());
             } else if (isMax(entry.getValue())) {
                 List<Long> sorted = partitionInfo.getSortedPartitions(false);
@@ -314,11 +333,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 if (CollectionUtils.isEmpty(sorted)) {
                     return null;
                 }
-                long maxPartition = sorted.get(0);
-                ListPartitionInfo.ListPartitionCell partitionValues = partitionInfo.getPartitionListExpr(maxPartition);
-                Preconditions.checkState(!partitionValues.isEmpty());
-                ConstantOperator maxValue = partitionValues.maxValue().toConstant();
-                valueRow.add(maxValue);
+                valueRow.add(minMaxFunction.second.apply(sorted.get(0), partitionInfo));
                 columns.add(entry.getKey());
             }
         }
@@ -327,6 +342,148 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
                 .setColumnRefSet(columns)
                 .build();
         return OptExpression.create(values);
+    }
+
+    public ScalarOperator getMinListPartitionValue(long partitionId, PartitionInfo partitionInfo) {
+        ListPartitionInfo.ListPartitionCell partitionValues =
+                ((ListPartitionInfo) partitionInfo).getPartitionListExpr(partitionId);
+        Preconditions.checkState(!partitionValues.isEmpty());
+        return partitionValues.minValue().toConstant();
+    }
+
+    public ScalarOperator getMaxListPartitionValue(long partitionId, PartitionInfo partitionInfo) {
+        ListPartitionInfo.ListPartitionCell partitionValues =
+                ((ListPartitionInfo) partitionInfo).getPartitionListExpr(partitionId);
+        Preconditions.checkState(!partitionValues.isEmpty());
+        return partitionValues.maxValue().toConstant();
+    }
+
+    public ScalarOperator getRangePartitionValue(long partitionId, PartitionInfo partitionInfo) {
+        LiteralExpr partitionValue =
+                ((RangePartitionInfo) partitionInfo).getRange(partitionId).lowerEndpoint().getKeys().get(0);
+        return SqlToScalarOperatorTranslator.translate(partitionValue);
+    }
+
+    private boolean isRangePartitionValues(LogicalAggregationOperator aggregationOperator,
+                                           LogicalScanOperator scanOperator,
+                                           OlapTable olapTable) {
+        if (!checkPartitionPrune(aggregationOperator, scanOperator, olapTable)) {
+            return false;
+        }
+        if (!olapTable.getPartitionInfo().isRangePartition()) {
+            return false;
+        }
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
+        if (partitionInfo.getPartitionColumnsSize() > 1) {
+            return false;
+        }
+        return partitionInfo.isPartitionedBy(olapTable, PrimitiveType.DATE);
+    }
+
+    /**
+     * Apply this optimization if:
+     * 1. DUPLICATED TABLE, no delete and no filter
+     * 2. RANGE-EXPRESSION-PARTITIONED table
+     * 3. Partition by date_trunc('day', column) and column is date type
+     */
+    public boolean checkRewriteDateTruncDayPartition(LogicalAggregationOperator aggregationOperator,
+                                                     LogicalScanOperator scanOperator,
+                                                     OlapTable olapTable) {
+        if (!isRangePartitionValues(aggregationOperator, scanOperator, olapTable)) {
+            return false;
+        }
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
+        if (partitionInfo.getType() != PartitionType.EXPR_RANGE &&
+                partitionInfo.getType() != PartitionType.EXPR_RANGE_V2) {
+            return false;
+        }
+
+        List<Expr> partitionExprs;
+        if (partitionInfo instanceof ExpressionRangePartitionInfoV2) {
+            ExpressionRangePartitionInfoV2 rangePartitionInfoV2 = (ExpressionRangePartitionInfoV2) partitionInfo;
+            partitionExprs = rangePartitionInfoV2.getPartitionExprs(olapTable.getIdToColumn());
+        } else {
+            ExpressionRangePartitionInfo rangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+            partitionExprs = rangePartitionInfo.getPartitionExprs(olapTable.getIdToColumn());
+        }
+
+        if (partitionExprs.size() != 1) {
+            return false;
+        }
+
+        Expr partitionExpr = partitionExprs.get(0);
+
+        // should be date_trunc('day', column)
+        if (partitionExpr instanceof FunctionCallExpr) {
+            FunctionCallExpr funcCall = (FunctionCallExpr) partitionExpr;
+            if (FunctionSet.DATE_TRUNC.equalsIgnoreCase(funcCall.getFunctionName())) {
+                List<Expr> args = funcCall.getChildren();
+                if (args.size() == 2) {
+                    Expr timeUnit = args.get(0);
+                    Expr partitionColumn = args.get(1);
+
+                    if (timeUnit instanceof StringLiteral) {
+                        if ("day".equalsIgnoreCase(((StringLiteral) timeUnit).getValue())) {
+                            if (!(partitionColumn instanceof SlotRef
+                                    && partitionColumn.getType().getPrimitiveType() == PrimitiveType.DATE)) {
+                                return false;
+                            }
+                            return partitionInfo.getIdToRange(false).values().stream()
+                                    .allMatch(this::isDayRange);
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Apply this optimization if:
+     * 1. DUPLICATED TABLE, no delete and no filter
+     * 2. RANGE-PARTITIONED table
+     * 3. Partition by date column
+     * 4. The min/max partition range size is 86400s
+     */
+    private boolean checkRewriteDayRangePartition(LogicalAggregationOperator aggregationOperator,
+                                                  LogicalScanOperator scanOperator,
+                                                  OlapTable olapTable) {
+        if (!isRangePartitionValues(aggregationOperator, scanOperator, olapTable)) {
+            return false;
+        }
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
+        // expr partition is not handled here
+        if (partitionInfo.getType() == PartitionType.EXPR_RANGE ||
+                partitionInfo.getType() == PartitionType.EXPR_RANGE_V2) {
+            return false;
+        }
+        return partitionInfo.getIdToRange(false).values().stream().allMatch(this::isDayRange);
+    }
+
+    private boolean isDayRange(Range<PartitionKey> range) {
+        if (range.lowerBoundType() != BoundType.CLOSED
+                || range.upperBoundType() != BoundType.OPEN) {
+            return false;
+        }
+
+        PartitionKey lowerEndpoint = range.lowerEndpoint();
+        PartitionKey upperEndpoint = range.upperEndpoint();
+
+        if (lowerEndpoint.getKeys().size() != 1 || upperEndpoint.getKeys().size() != 1) {
+            return false;
+        }
+        LiteralExpr lowerBound = lowerEndpoint.getKeys().get(0);
+        LiteralExpr upperBound = upperEndpoint.getKeys().get(0);
+        if (!(lowerBound instanceof DateLiteral lowerDate) || !(upperBound instanceof DateLiteral upperDate)) {
+            return false;
+        }
+        // ignore shadow partition
+        if (lowerBound == PartitionKey.SHADOW_DATE_LITERAL) {
+            return true;
+        }
+        return upperDate.toLocalDateTime().toEpochSecond(ZoneOffset.UTC) ==
+                lowerDate.toLocalDateTime().toEpochSecond(ZoneOffset.UTC) + 86400;
     }
 
     private static boolean isMax(CallOperator call) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -457,7 +457,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
             return false;
         }
         // ignore shadow partition
-        if (lowerBound == PartitionKey.SHADOW_DATE_LITERAL) {
+        if (PartitionKey.isShadowDateLiteral(lowerDate)) {
             return true;
         }
         return upperDate.toLocalDateTime().toEpochSecond(ZoneOffset.UTC) ==

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -170,8 +170,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
             if (checkRewritePartitionValues(aggregationOperator, scanOperator, table)) {
                 result = optimizeWithPartitionValues(aggregationOperator, table,
                         Pair.create(this::getMinListPartitionValue, this::getMaxListPartitionValue));
-            } else if (checkRewriteDateTruncDayPartition(aggregationOperator, scanOperator, table)
-                    || checkRewriteDayRangePartition(aggregationOperator, scanOperator, table)) {
+            } else if (checkRewriteDayRangePartition(aggregationOperator, scanOperator, table)) {
                 result = optimizeWithPartitionValues(aggregationOperator, table,
                         Pair.create(this::getRangePartitionValue, this::getRangePartitionValue));
             } else if (checkPartitionPrune(aggregationOperator, scanOperator, table)) {
@@ -383,19 +382,20 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
     /**
      * Apply this optimization if:
      * 1. DUPLICATED TABLE, no delete and no filter
-     * 2. RANGE-EXPRESSION-PARTITIONED table
-     * 3. Partition by date_trunc('day', column) and column is date type
+     * 2. RANGE-EXPRESSION-PARTITIONED table and Partition by date_trunc('day', column) and column is date type
+     * 3. Or RANGE-PARTITIONED table and Partition by date column and the min/max partition range size is 86400s
      */
-    public boolean checkRewriteDateTruncDayPartition(LogicalAggregationOperator aggregationOperator,
-                                                     LogicalScanOperator scanOperator,
-                                                     OlapTable olapTable) {
+    public boolean checkRewriteDayRangePartition(LogicalAggregationOperator aggregationOperator,
+                                                 LogicalScanOperator scanOperator,
+                                                 OlapTable olapTable) {
         if (!isRangePartitionValues(aggregationOperator, scanOperator, olapTable)) {
             return false;
         }
         RangePartitionInfo partitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
         if (partitionInfo.getType() != PartitionType.EXPR_RANGE &&
                 partitionInfo.getType() != PartitionType.EXPR_RANGE_V2) {
-            return false;
+            // check if day range partition
+            return partitionInfo.getIdToRange(false).values().stream().allMatch(this::isDayRange);
         }
 
         List<Expr> partitionExprs;
@@ -437,28 +437,6 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         }
 
         return false;
-    }
-
-    /**
-     * Apply this optimization if:
-     * 1. DUPLICATED TABLE, no delete and no filter
-     * 2. RANGE-PARTITIONED table
-     * 3. Partition by date column
-     * 4. The min/max partition range size is 86400s
-     */
-    private boolean checkRewriteDayRangePartition(LogicalAggregationOperator aggregationOperator,
-                                                  LogicalScanOperator scanOperator,
-                                                  OlapTable olapTable) {
-        if (!isRangePartitionValues(aggregationOperator, scanOperator, olapTable)) {
-            return false;
-        }
-        RangePartitionInfo partitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
-        // expr partition is not handled here
-        if (partitionInfo.getType() == PartitionType.EXPR_RANGE ||
-                partitionInfo.getType() == PartitionType.EXPR_RANGE_V2) {
-            return false;
-        }
-        return partitionInfo.getIdToRange(false).values().stream().allMatch(this::isDayRange);
     }
 
     private boolean isDayRange(Range<PartitionKey> range) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -619,7 +619,7 @@ public class PartitionPruneTest extends PlanTestBase {
     public void testMinMaxRangePartitionPruneWithEmptyPartition() throws Exception {
         UtFrameUtils.mockDML();
         starRocksAssert.withTable("CREATE TABLE `t4_range_minmax` (\n" +
-                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `dt` datetime NULL COMMENT \"\",\n" +
                 "    `id` int(11) NULL COMMENT \"\",\n" +
                 "    `name` varchar(65533) NULL COMMENT \"\"\n" +
                 ") ENGINE=OLAP\n" +
@@ -650,7 +650,7 @@ public class PartitionPruneTest extends PlanTestBase {
     public void testMinMaxRangePartitionPruneWithDateTruncPartition() throws Exception {
         UtFrameUtils.mockDML();
         starRocksAssert.withTable("CREATE TABLE `t4_expr_range_minmax` (\n" +
-                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `dt` datetime NULL COMMENT \"\",\n" +
                 "    `id` int(11) NULL COMMENT \"\",\n" +
                 "    `name` varchar(65533) NULL COMMENT \"\"\n" +
                 ") ENGINE=OLAP\n" +
@@ -672,6 +672,112 @@ public class PartitionPruneTest extends PlanTestBase {
                 .updateVisibleVersion(2);
         // min(dt) should not be affected by shadow partition
         starRocksAssert.query("select min(dt) from t4_expr_range_minmax").explainContains("partitions=1/2");
+        FeConstants.runningUnitTest = true;
+
+    }
+
+    @Test
+    public void testMinMaxConstantWithRangePartition() throws Exception {
+        UtFrameUtils.mockDML();
+        starRocksAssert.withTable("CREATE TABLE `t4_range_minmax2` (\n" +
+                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\",\n" +
+                "    `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`, `name`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(\n" +
+                "    PARTITION p20250428 VALUES [(\"2025-04-28\"), (\"2025-04-29\")),\n" +
+                "    PARTITION p20250429 VALUES [(\"2025-04-29\"), (\"2025-04-30\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`, `name`)\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.getCtx().executeSql("insert into t4_range_minmax2 partition(p20250429) values('2025-04-29', 1, 'bar')");
+        FeConstants.runningUnitTest = false;
+        starRocksAssert.query("select min(dt) from t4_range_minmax2")
+                .explainContains("     constant exprs: \n         '2025-04-29'\n");
+        FeConstants.runningUnitTest = true;
+
+    }
+
+    @Test
+    public void testMinMaxConstantWithDateTruncPartition() throws Exception {
+        UtFrameUtils.mockDML();
+        starRocksAssert.withTable("CREATE TABLE `t4_expr_range_minmax` (\n" +
+                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\",\n" +
+                "    `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`, `name`)\n" +
+                "PARTITION BY date_trunc('day', `dt`)(\n" +
+                " START (\"2025-04-28\") END (\"2025-04-30\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`, `name`)\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.getCtx()
+                .executeSql("insert into t4_expr_range_minmax partition(p20250429) values('2025-04-29', 1, 'bar')");
+        FeConstants.runningUnitTest = false;
+        // there are 2 partitions: p20250428 and p20250429, p20250428 is empty
+        starRocksAssert.query("select min(dt) from t4_expr_range_minmax")
+                .explainContains("     constant exprs: \n         '2025-04-29'\n");
+        starRocksAssert.dropTable("t4_expr_range_minmax");
+        FeConstants.runningUnitTest = true;
+
+    }
+
+    @Test
+    public void testMinMaxConstantWithDateTruncPartition2() throws Exception {
+        UtFrameUtils.mockDML();
+        starRocksAssert.withTable("CREATE TABLE `t4_expr_range_minmax` (\n" +
+                "    `dt` date NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\",\n" +
+                "    `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`, `name`)\n" +
+                "PARTITION BY date_trunc('month', `dt`)(\n" +
+                " START (\"2025-04-01\") END (\"2025-06-01\") EVERY (INTERVAL 1 MONTH)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`, `name`)\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.getCtx().executeSql("insert into t4_expr_range_minmax values('2025-04-29', 1, 'bar')");
+        FeConstants.runningUnitTest = false;
+        starRocksAssert.getTable("test", "t4_expr_range_minmax")
+                .getPartition("p202505").getDefaultPhysicalPartition().updateVisibleVersion(1);
+        // month partition should not produce constant result
+        starRocksAssert.query("select min(dt), max(dt) from t4_expr_range_minmax").explainContains("partitions=1/2");
+        FeConstants.runningUnitTest = true;
+        starRocksAssert.dropTable("t4_expr_range_minmax");
+
+    }
+
+    @Test
+    public void testMinMaxConstantWithDateTruncPartition3() throws Exception {
+        UtFrameUtils.mockDML();
+        starRocksAssert.withTable("CREATE TABLE `t4_expr_range_minmax` (\n" +
+                "    `dt` datetime NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\",\n" +
+                "    `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`, `name`)\n" +
+                "PARTITION BY date_trunc('day', `dt`)(\n" +
+                " START (\"2025-04-28\") END (\"2025-04-30\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`, `name`)\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.getCtx()
+                .executeSql("insert into t4_expr_range_minmax partition(p20250429) values('2025-04-29', 1, 'bar')");
+        FeConstants.runningUnitTest = false;
+        // datetime partition column should not produce constant result
+        starRocksAssert.query("select min(dt), max(dt) from t4_expr_range_minmax").explainContains("partitions=1/2");
+        starRocksAssert.dropTable("t4_expr_range_minmax");
         FeConstants.runningUnitTest = true;
 
     }


### PR DESCRIPTION
## Why I'm doing:
```
select min(pt),max(pt) from t
```
this sql will actually scan 2 partitions when `t` is partitioned by date column.

## What I'm doing:
when `t` is `date_trunc('day', pt)` or `range(pt)` when `pt` is `date`, `min(pt)` can be replaced with min non-empty partition constant value, eg `2026-03-05` , also `max(pt)` as same.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
