### PR TITLE
[BugFix] Fix race condition missing write transaction finished editlog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2213,13 +2213,26 @@ public class DatabaseTransactionMgr {
                 } finally {
                     writeUnlock();
                 }
-                stateBatch.afterVisible(TransactionStatus.VISIBLE, txnOperated);
+
+                // Persist VISIBLE state to edit log BEFORE afterVisible callbacks.
+                // This ensures that even if callbacks block or fail, the VISIBLE state is already
+                // persisted. Otherwise, getMinActiveTxnId() may return a value higher than
+                // the txn id (since unprotectSetTransactionStateBatch already removed it from
+                // idToRunningTransactionState), causing autovacuum to prematurely delete the
+                // txn log. If FE restarts before the edit log is written, the txn replays as
+                // COMMITTED and re-publish fails with "NoSuchKey".
                 long start = System.currentTimeMillis();
                 editLog.logInsertTransactionStateBatch(stateBatch);
                 LOG.debug("insert txn state visible for txnIds batch {}, cost: {}ms",
                         stateBatch.getTxnIds(), System.currentTimeMillis() - start);
 
                 updateCatalogAfterVisibleBatch(stateBatch, db);
+
+                try {
+                    stateBatch.afterVisible(TransactionStatus.VISIBLE, txnOperated);
+                } catch (Throwable t) {
+                    LOG.warn("afterVisible callback failed for transaction batch {}", stateBatch.getTxnIds(), t);
+                }
             } finally {
                 stateBatch.writeUnlock();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -100,7 +100,12 @@ public class TransactionStateBatch implements Writable {
                         .getCallbackFactory().getCallback(callbackId);
                 if (callback != null) {
                     if (Objects.requireNonNull(transactionStatus) == TransactionStatus.VISIBLE) {
-                        callback.afterVisible(transactionState, txnOperated);
+                        try {
+                            callback.afterVisible(transactionState, txnOperated);
+                        } catch (Throwable t) {
+                            LOG.warn("afterVisible callback failed for txn {}, callbackId {}",
+                                    transactionState.getTransactionId(), callbackId, t);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -76,10 +76,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1058,5 +1060,184 @@ public class DatabaseTransactionMgrTest {
                     Config.finish_transaction_default_lock_timeout_ms);
             Assertions.assertTrue(result);
         });
+    }
+
+    @Test
+    public void testFinishTransactionBatchPersistVisibleStateBeforeAfterVisible() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        List<TransactionState> states = getDefaultBatchTxnStates(masterDbTransMgr);
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        class InspectPersistedBatch extends TransactionStateBatch {
+            private boolean persistedWhenAfterVisible = false;
+
+            InspectPersistedBatch(List<TransactionState> transactionStates) {
+                super(transactionStates);
+            }
+
+            @Override
+            public void afterVisible(TransactionStatus transactionStatus, boolean txnOperated) {
+                long txnId = getTransactionStates().get(0).getTransactionId();
+                persistedWhenAfterVisible = fakeEditLog.getTransaction(txnId) != null;
+                super.afterVisible(transactionStatus, txnOperated);
+            }
+
+            boolean isPersistedWhenAfterVisible() {
+                return persistedWhenAfterVisible;
+            }
+        }
+
+        InspectPersistedBatch stateBatch = new InspectPersistedBatch(states);
+        masterTransMgr.finishTransactionBatch(GlobalStateMgrTestUtil.testDbId1, stateBatch, null);
+        assertTrue(stateBatch.isPersistedWhenAfterVisible());
+    }
+
+    @Test
+    public void testFinishTransactionBatchSwallowsBatchAfterVisibleException() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        List<TransactionState> states = getDefaultBatchTxnStates(masterDbTransMgr);
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        class ThrowingBatch extends TransactionStateBatch {
+            ThrowingBatch(List<TransactionState> transactionStates) {
+                super(transactionStates);
+            }
+
+            @Override
+            public void afterVisible(TransactionStatus transactionStatus, boolean txnOperated) {
+                throw new RuntimeException("mock afterVisible failure");
+            }
+        }
+
+        TransactionStateBatch stateBatch = new ThrowingBatch(states);
+        Assertions.assertDoesNotThrow(
+                () -> masterTransMgr.finishTransactionBatch(GlobalStateMgrTestUtil.testDbId1, stateBatch, null));
+        for (TransactionState state : states) {
+            assertEquals(TransactionStatus.VISIBLE, state.getTransactionStatus());
+            assertNotNull(fakeEditLog.getTransaction(state.getTransactionId()));
+        }
+    }
+
+    @Test
+    public void testFinishTransactionBatchAfterVisibleCallbackFailureIsolation() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        List<TransactionState> states = getDefaultBatchTxnStates(masterDbTransMgr);
+        AtomicInteger callbackInvokeCount = new AtomicInteger(0);
+
+        long failedCallbackId = 90001L;
+        long normalCallbackId = 90002L;
+        states.get(0).addCallbackId(failedCallbackId);
+        states.get(1).addCallbackId(normalCallbackId);
+        masterTransMgr.getCallbackFactory().addCallback(
+                new TestTxnStateChangeCallback(failedCallbackId, true, callbackInvokeCount));
+        masterTransMgr.getCallbackFactory().addCallback(
+                new TestTxnStateChangeCallback(normalCallbackId, false, callbackInvokeCount));
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        TransactionStateBatch stateBatch = new TransactionStateBatch(states);
+        Assertions.assertDoesNotThrow(
+                () -> masterTransMgr.finishTransactionBatch(GlobalStateMgrTestUtil.testDbId1, stateBatch, null));
+
+        assertEquals(2, callbackInvokeCount.get());
+        for (TransactionState state : states) {
+            assertEquals(TransactionStatus.VISIBLE, state.getTransactionStatus());
+        }
+    }
+
+    private List<TransactionState> getDefaultBatchTxnStates(DatabaseTransactionMgr masterDbTransMgr) {
+        long txnId6 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable6);
+        TransactionState transactionState6 = masterDbTransMgr.getTransactionState(txnId6);
+        long txnId7 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable7);
+        TransactionState transactionState7 = masterDbTransMgr.getTransactionState(txnId7);
+        long txnId8 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable8);
+        TransactionState transactionState8 = masterDbTransMgr.getTransactionState(txnId8);
+        return Lists.newArrayList(transactionState6, transactionState7, transactionState8);
+    }
+
+    private static class TestTxnStateChangeCallback implements TxnStateChangeCallback {
+        private final long id;
+        private final boolean throwInAfterVisible;
+        private final AtomicInteger callbackInvokeCount;
+
+        private TestTxnStateChangeCallback(long id, boolean throwInAfterVisible, AtomicInteger callbackInvokeCount) {
+            this.id = id;
+            this.throwInAfterVisible = throwInAfterVisible;
+            this.callbackInvokeCount = callbackInvokeCount;
+        }
+
+        @Override
+        public long getId() {
+            return id;
+        }
+
+        @Override
+        public void beforeCommitted(TransactionState txnState) throws TransactionException {
+        }
+
+        @Override
+        public void beforeAborted(TransactionState txnState) throws TransactionException {
+        }
+
+        @Override
+        public void afterCommitted(TransactionState txnState, boolean txnOperated) throws StarRocksException {
+        }
+
+        @Override
+        public void replayOnCommitted(TransactionState txnState) {
+        }
+
+        @Override
+        public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
+                throws StarRocksException {
+        }
+
+        @Override
+        public void replayOnAborted(TransactionState txnState) {
+        }
+
+        @Override
+        public void afterVisible(TransactionState txnState, boolean txnOperated) {
+            callbackInvokeCount.incrementAndGet();
+            if (throwInAfterVisible) {
+                throw new RuntimeException("mock callback failure");
+            }
+        }
+
+        @Override
+        public void replayOnVisible(TransactionState txnState) {
+        }
+
+        @Override
+        public void beforePrepared(TransactionState txnState) throws TransactionException {
+        }
+
+        @Override
+        public void afterPrepared(TransactionState txnState, boolean txnOperated) throws StarRocksException {
+        }
+
+        @Override
+        public void replayOnPrepared(TransactionState txnState) {
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

In finishTransactionBatch, unprotectSetTransactionStateBatch removes the transaction from idToRunningTransactionState inside writeLock, but the editlog write (logInsertTransactionStateBatch) was placed AFTER stateBatch.afterVisible(). If afterVisible blocks or fails, the VISIBLE state is never persisted while getMinActiveTxnId() (called by AutovacuumDaemon in a different thread) already sees the transaction as finished, leading to premature txn log deletion by vacuum_txn_log.

## What I'm doing:
Fix #69934 

- Move editLog.logInsertTransactionStateBatch and updateCatalogAfterVisibleBatch BEFORE stateBatch.afterVisible() to minimize the window between in-memory state update and WAL persistence.
- Add try-catch(Throwable) around stateBatch.afterVisible() in DatabaseTransactionMgr to ensure callback failures don't affect the already-persisted transaction state.
- Add try-catch(Throwable) around individual callback.afterVisible() in TransactionStateBatch to isolate failures between transactions in the same batch.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
