### PR TITLE
[BugFix] Fix segment_idx offset missing in batch_apply for delete-then-insert transaction

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -846,7 +846,8 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
             if (i >= first_segment_metas_size) {
                 _pending_rowset_data.rowset_pb.add_segment_metas();
             }
-            _pending_rowset_data.rowset_pb.mutable_segment_metas(i)->set_segment_idx(get_segment_idx(rowset_pb, i));
+            _pending_rowset_data.rowset_pb.mutable_segment_metas(i)->set_segment_idx(
+                    _pending_rowset_data.assigned_segment_idx + get_segment_idx(rowset_pb, i));
         }
     } else {
         // Merge segments


### PR DESCRIPTION
## Why I'm doing:
In MetaFileBuilder::add_rowset, the if-branch (CopyFrom path) did not include assigned_segment_idx when setting segment_idx, while the else-branch (merge path) correctly included it. This caused rssid mismatch between publish_primary_key_tablet and update_num_del_stat when a delete-only op_write (0 segments) preceded insert op_writes in a multi-statement transaction batch apply.

## What I'm doing:
The fix adds the assigned_segment_idx offset in the if-branch, consistent with the else-branch behavior.

Bug was introduced in #68996 (Support sparse segment idx).

Fixes https://github.com/StarRocks/StarRocksTest/issues/11074

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
