### PR TITLE
[Enhancement] reduce memory usage for RemoveOrphanFilesProcedure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -173,6 +173,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
             ManifestFile.schema().select(
                     "manifest_path",
                     "manifest_length",
+                    "content",
                     "partition_spec_id",
                     "added_snapshot_id",
                     "deleted_data_files_count");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -29,11 +29,17 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.GenericManifestFile;
+import org.apache.iceberg.InternalData;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,19 +130,23 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
                 validFileNames.add(fileName(snapshot.manifestListLocation()));
             }
 
-            for (ManifestFile manifest : snapshot.allManifests(table.io())) {
-                if (!processedManifestFilePaths.add(manifest.path())) {
-                    continue;
-                }
-
-                validFileNames.add(fileName(manifest.path()));
-                try (ManifestReader<? extends ContentFile<?>> manifestReader = readerForManifest(table, manifest)) {
-                    for (ContentFile<?> contentFile : manifestReader) {
-                        validFileNames.add(fileName(contentFile.location()));
+            try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot, table.io())) {
+                for (ManifestFile manifest : manifests) {
+                    if (!processedManifestFilePaths.add(manifest.path())) {
+                        continue;
                     }
-                } catch (IOException e) {
-                    throw new StarRocksConnectorException("Unable to list manifest file content from " + manifest.path(), e);
+
+                    validFileNames.add(fileName(manifest.path()));
+                    try (ManifestReader<? extends ContentFile<?>> manifestReader = readerForManifest(table, manifest)) {
+                        for (ContentFile<?> contentFile : manifestReader) {
+                            validFileNames.add(fileName(contentFile.location()));
+                        }
+                    } catch (IOException e) {
+                        throw new StarRocksConnectorException("Unable to list manifest file content from " + manifest.path(), e);
+                    }
                 }
+            } catch (IOException e) {
+                throw new StarRocksConnectorException("Unable to read manifests for snapshot " + snapshot.snapshotId(), e);
             }
         }
 
@@ -152,6 +162,32 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
         scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.hdfsEnvironment());
         return null;
+    }
+
+    /**
+     * Reads manifest files for a snapshot. When the snapshot has a manifest list file,
+     * reads from it directly (AVRO) for better efficiency; otherwise falls back to
+     * snapshot.allManifests(). Aligned with Iceberg FileCleanupStrategy.readManifests().
+     */
+    private static final Schema MANIFEST_PROJECTION =
+            ManifestFile.schema().select(
+                    "manifest_path",
+                    "manifest_length",
+                    "partition_spec_id",
+                    "added_snapshot_id",
+                    "deleted_data_files_count");
+
+    private static CloseableIterable<ManifestFile> readManifests(Snapshot snapshot, FileIO fileIO) {
+        if (snapshot.manifestListLocation() != null) {
+            return InternalData.read(
+                            FileFormat.AVRO, fileIO.newInputFile(snapshot.manifestListLocation()))
+                    .setRootType(GenericManifestFile.class)
+                    .project(MANIFEST_PROJECTION)
+                    .reuseContainers()
+                    .build();
+        } else {
+            return CloseableIterable.withNoopClose(snapshot.allManifests(fileIO));
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -21,23 +21,42 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.InternalData;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RemoveOrphanFilesProcedureTest {
 
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    private static final String TABLE_LOCATION = "s3://bucket/table";
+    private static final String MANIFEST_LIST_LOCATION = "s3://bucket/table/metadata/snap-123-manifest-list.avro";
 
     @Test
     void testTableLocationEmptyThrows() {
@@ -239,6 +258,125 @@ public class RemoveOrphanFilesProcedureTest {
         assertTrue(ex.getMessage().contains("invalid argument value"));
         assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
         assertTrue(ex.getMessage().contains("must be a subdirectory of"));
+    }
+
+    /**
+     * When snapshot has no manifest list (manifestListLocation is null), the procedure uses
+     * the fallback path: readManifests returns CloseableIterable.withNoopClose(snapshot.allManifests(io)).
+     * This test verifies that snapshot.allManifests(any()) is invoked, i.e. the fallback path is used.
+     */
+    @Test
+    void testExecuteWithSnapshotsWithoutManifestListUsesAllManifestsFallback() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(null);
+        when(snapshot.allManifests(any(FileIO.class))).thenReturn(Collections.emptyList());
+
+        FileIO fileIO = Mockito.mock(FileIO.class);
+        Table table = Mockito.mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<org.apache.iceberg.ReachableFileUtil> reachableUtil =
+                        mockStatic(org.apache.iceberg.ReachableFileUtil.class);
+                MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.metadataFileLocations(any(Table.class), eq(false)))
+                    .thenReturn(Collections.emptySet());
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.statisticsFilesLocations(any(Table.class)))
+                    .thenReturn(Collections.emptyList());
+
+            FileSystem mockFs = Mockito.mock(FileSystem.class);
+            RemoteIterator<LocatedFileStatus> emptyIterator = new RemoteIterator<LocatedFileStatus>() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public LocatedFileStatus next() {
+                    throw new java.util.NoSuchElementException();
+                }
+            };
+            when(mockFs.listFiles(any(Path.class), eq(true))).thenReturn(emptyIterator);
+            fsStatic.when(() -> FileSystem.get(any(), any())).thenReturn(mockFs);
+
+            IcebergTableProcedureContext context = createContext(table);
+
+            assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+            verify(snapshot).allManifests(any(FileIO.class));
+        }
+    }
+
+    /**
+     * When snapshot has a manifest list location, the procedure reads manifests from the AVRO file
+     * via InternalData.read(...).build() instead of snapshot.allManifests(). This test mocks
+     * InternalData.read() to return an empty iterable and verifies the AVRO path is taken
+     * (allManifests is not called, and newInputFile(manifestListLocation) is called).
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteWithManifestListLocationReadsFromAvroPath() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(MANIFEST_LIST_LOCATION);
+
+        InputFile mockInputFile = mock(InputFile.class);
+        FileIO fileIO = mock(FileIO.class);
+        when(fileIO.newInputFile(MANIFEST_LIST_LOCATION)).thenReturn(mockInputFile);
+
+        InternalData.ReadBuilder mockBuilder = mock(InternalData.ReadBuilder.class);
+        when(mockBuilder.setRootType(any(Class.class))).thenReturn(mockBuilder);
+        when(mockBuilder.project(any(org.apache.iceberg.Schema.class))).thenReturn(mockBuilder);
+        when(mockBuilder.reuseContainers()).thenReturn(mockBuilder);
+        when(mockBuilder.build()).thenReturn(CloseableIterable.withNoopClose(Collections.emptyList()));
+
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<InternalData> internalDataMock = mockStatic(InternalData.class);
+                MockedStatic<org.apache.iceberg.ReachableFileUtil> reachableUtil =
+                        mockStatic(org.apache.iceberg.ReachableFileUtil.class);
+                MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+
+            internalDataMock.when(() -> InternalData.read(any(org.apache.iceberg.FileFormat.class), any(InputFile.class)))
+                    .thenReturn(mockBuilder);
+
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.metadataFileLocations(any(Table.class), eq(false)))
+                    .thenReturn(Collections.emptySet());
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.statisticsFilesLocations(any(Table.class)))
+                    .thenReturn(Collections.emptyList());
+
+            FileSystem mockFs = mock(FileSystem.class);
+            RemoteIterator<LocatedFileStatus> emptyIterator = new RemoteIterator<LocatedFileStatus>() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public LocatedFileStatus next() {
+                    throw new java.util.NoSuchElementException();
+                }
+            };
+            when(mockFs.listFiles(any(Path.class), eq(true))).thenReturn(emptyIterator);
+            fsStatic.when(() -> FileSystem.get(any(), any())).thenReturn(mockFs);
+
+            IcebergTableProcedureContext context = createContext(table);
+
+            assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+            verify(fileIO).newInputFile(MANIFEST_LIST_LOCATION);
+            verify(snapshot, never()).allManifests(any(FileIO.class));
+        }
     }
 
     private IcebergTableProcedureContext createContext(Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -25,16 +25,23 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.InternalData;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +52,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -376,6 +385,168 @@ public class RemoveOrphanFilesProcedureTest {
 
             verify(fileIO).newInputFile(MANIFEST_LIST_LOCATION);
             verify(snapshot, never()).allManifests(any(FileIO.class));
+        }
+    }
+
+    /**
+     * Covers: one snapshot with one manifest containing one content file;
+     * procedure iterates manifests, adds manifest path, opens ManifestReader and adds content file location,
+     * then calls metadataFileLocations and statisticsFilesLocations.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteWithManifestContainingContentFile_addsContentFileToValidNames() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        ManifestFile manifest = mock(ManifestFile.class);
+        when(manifest.path()).thenReturn("s3://bucket/table/metadata/m1.avro");
+        when(manifest.content()).thenReturn(ManifestContent.DATA);
+
+        DataFile dataFile = mock(DataFile.class);
+        when(dataFile.location()).thenReturn("s3://bucket/table/data/file.parquet");
+
+        ManifestReader<DataFile> manifestReader = mock(ManifestReader.class);
+        when(manifestReader.iterator()).thenReturn(
+                CloseableIterable.withNoopClose(Collections.singletonList(dataFile)).iterator());
+
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(null);
+        when(snapshot.allManifests(any(FileIO.class))).thenReturn(Collections.singletonList(manifest));
+
+        FileIO fileIO = mock(FileIO.class);
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<ManifestFiles> mfStatic = mockStatic(ManifestFiles.class);
+                MockedStatic<org.apache.iceberg.ReachableFileUtil> reachableUtil =
+                        mockStatic(org.apache.iceberg.ReachableFileUtil.class);
+                MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+            mfStatic.when(() -> ManifestFiles.read(any(ManifestFile.class), any(FileIO.class)))
+                    .thenReturn(manifestReader);
+
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.metadataFileLocations(any(Table.class), eq(false)))
+                    .thenReturn(Collections.emptySet());
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.statisticsFilesLocations(any(Table.class)))
+                    .thenReturn(Collections.emptyList());
+
+            FileSystem mockFs = mock(FileSystem.class);
+            RemoteIterator<LocatedFileStatus> emptyIterator = new RemoteIterator<LocatedFileStatus>() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public LocatedFileStatus next() {
+                    throw new java.util.NoSuchElementException();
+                }
+            };
+            when(mockFs.listFiles(any(Path.class), eq(true))).thenReturn(emptyIterator);
+            fsStatic.when(() -> FileSystem.get(any(), any())).thenReturn(mockFs);
+
+            IcebergTableProcedureContext context = createContext(table);
+            assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+        }
+    }
+
+    /**
+     * Covers: when ManifestReader throws IOException on close(), procedure throws
+     * StarRocksConnectorException with "Unable to list manifest file content from".
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteWhenManifestReaderThrows_throwsUnableToListManifestContent() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        String manifestPath = "s3://bucket/table/metadata/m1.avro";
+        ManifestFile manifest = mock(ManifestFile.class);
+        when(manifest.path()).thenReturn(manifestPath);
+        when(manifest.content()).thenReturn(ManifestContent.DATA);
+
+        ManifestReader<DataFile> manifestReader = mock(ManifestReader.class);
+        when(manifestReader.iterator()).thenReturn(
+                CloseableIterable.withNoopClose(Collections.<DataFile>emptyList()).iterator());
+        doThrow(new IOException("simulated read failure")).when(manifestReader).close();
+
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(null);
+        when(snapshot.allManifests(any(FileIO.class))).thenReturn(Collections.singletonList(manifest));
+
+        FileIO fileIO = mock(FileIO.class);
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<ManifestFiles> mfStatic = mockStatic(ManifestFiles.class)) {
+            mfStatic.when(() -> ManifestFiles.read(any(ManifestFile.class), any(FileIO.class)))
+                    .thenReturn(manifestReader);
+
+            IcebergTableProcedureContext context = createContext(table);
+
+            StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                    () -> procedure.execute(context, Collections.emptyMap()));
+
+            assertTrue(ex.getMessage().contains("Unable to list manifest file content from"));
+            assertTrue(ex.getMessage().contains(manifestPath));
+        }
+    }
+
+    /**
+     * Covers: when reading manifests (AVRO path) throws IOException on close,
+     * procedure throws StarRocksConnectorException with "Unable to read manifests for snapshot".
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteWhenReadManifestsThrowsOnClose_throwsUnableToReadManifests() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        long snapshotId = 12345L;
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.snapshotId()).thenReturn(snapshotId);
+        when(snapshot.manifestListLocation()).thenReturn(MANIFEST_LIST_LOCATION);
+
+        CloseableIterable<ManifestFile> empty = CloseableIterable.withNoopClose(Collections.<ManifestFile>emptyList());
+        CloseableIterable<ManifestFile> iterableThatThrowsOnClose = new CloseableIterable<ManifestFile>() {
+            @Override
+            public void close() throws IOException {
+                throw new IOException("simulated close failure");
+            }
+
+            @Override
+            public CloseableIterator<ManifestFile> iterator() {
+                return empty.iterator();
+            }
+        };
+
+        InternalData.ReadBuilder mockBuilder = mock(InternalData.ReadBuilder.class);
+        when(mockBuilder.setRootType(any(Class.class))).thenReturn(mockBuilder);
+        when(mockBuilder.project(any(org.apache.iceberg.Schema.class))).thenReturn(mockBuilder);
+        when(mockBuilder.reuseContainers()).thenReturn(mockBuilder);
+        doReturn(iterableThatThrowsOnClose).when(mockBuilder).build();
+
+        InputFile mockInputFile = mock(InputFile.class);
+        FileIO fileIO = mock(FileIO.class);
+        when(fileIO.newInputFile(MANIFEST_LIST_LOCATION)).thenReturn(mockInputFile);
+
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<InternalData> internalDataMock = mockStatic(InternalData.class)) {
+            internalDataMock.when(() -> InternalData.read(any(org.apache.iceberg.FileFormat.class), any(InputFile.class)))
+                    .thenReturn(mockBuilder);
+
+            IcebergTableProcedureContext context = createContext(table);
+
+            StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                    () -> procedure.execute(context, Collections.emptyMap()));
+
+            assertTrue(ex.getMessage().contains("Unable to read manifests for snapshot"));
+            assertTrue(ex.getMessage().contains(String.valueOf(snapshotId)));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

Previously, `RemoveOrphanFilesProcedure` used `snapshot.allManifests(table.io())` to obtain the list of manifest files for each snapshot. That call loads all manifest metadata into memory at once. For Iceberg tables with many snapshots or many manifests, this can lead to high memory usage and pressure on the FE.

By aligning with the approach used in Iceberg’s `FileCleanupStrategy.readManifests()`, we can read from the manifest list AVRO file in a streaming way when it exists, so that manifest entries are consumed incrementally instead of being fully materialized in memory, thus reducing memory usage.

## What I'm doing:

- **Introduce `readManifests(snapshot, fileIO)`**  
  - When `snapshot.manifestListLocation() != null`, read manifests by opening the manifest list AVRO file and streaming via `InternalData.read(FileFormat.AVRO, fileIO.newInputFile(...)).setRootType(GenericManifestFile.class).project(MANIFEST_PROJECTION).reuseContainers().build()`, so only the needed fields are read and containers are reused.  
  - When `manifestListLocation()` is null, fall back to `CloseableIterable.withNoopClose(snapshot.allManifests(fileIO))` to keep the same behavior as before.

- **Use try-with-resources**  
  Use `try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot, table.io())) { ... }` so that the iterable (and any opened streams) is closed correctly. Catch `IOException` and rethrow as `StarRocksConnectorException` with a clear message (e.g. "Unable to read manifests for snapshot ...").

- **Unit tests**  
  - `testExecuteWithSnapshotsWithoutManifestListUsesAllManifestsFallback`: verifies that when there is no manifest list, the procedure uses the fallback path and calls `snapshot.allManifests(any(FileIO.class))`.  
  - `testExecuteWithManifestListLocationReadsFromAvroPath`: verifies that when a manifest list location exists, the procedure uses the AVRO path (`fileIO.newInputFile(manifestListLocation)` and mocked `InternalData.read()`), and does not call `snapshot.allManifests()`.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
