### PR TITLE
[Tool] Avoid full checkout in Clang-Format CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -307,39 +307,20 @@ jobs:
         if: needs.be-checker.outputs.be_change == 'true' || needs.be-checker.outputs.pre_format_conclusion != 'success'
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-
-      - name: BRANCH INFO
-        id: branch
-        if: steps.checkout_code.outcome == 'success'
-        run: |
-          echo ${{github.base_ref}}
-          echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
-
-      - name: Checkout PR
-        id: checkout_pr
-        if: steps.checkout_code.outcome == 'success'
-        run: |
-          BRANCH=${{steps.branch.outputs.branch}}
-          git config --global user.name "wanpengfei-git";
-          git config --global user.email "wanpengfei91@163.com";
-          git checkout $BRANCH;
-          git pull;
-          BRANCH_NAME="${BRANCH}-${PR_NUMBER}";
-          git fetch origin pull/${PR_NUMBER}/head:${BRANCH_NAME};
-          git checkout $BRANCH_NAME;
-          git checkout -b merge_pr;
-          git merge --squash --no-edit ${BRANCH} || (echo "::error::Merge conflict, please check." && exit -1);
+          # A shallow checkout of the PR merge ref avoids fetching every branch
+          # and tag in the repository while keeping the merged tree for linting.
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 1
 
       - name: Run Clang-Format
         id: run_clang_format
-        if: steps.checkout_pr.outcome == 'success'
+        if: steps.checkout_code.outcome == 'success'
         run: |
           export PATH=/var/lib/llvm/bin:$PATH
           bash build-support/check-format.sh
 
       - name: Run Common Config Header Guardrail
-        if: steps.checkout_pr.outcome == 'success'
+        if: steps.checkout_code.outcome == 'success'
         run: |
           bash build-support/check_common_config_header_includes.sh
 


### PR DESCRIPTION
## Why I'm doing:

The `Clang-Format` job currently uses `actions/checkout@v6` with `fetch-depth: 0` on a `pull_request` workflow. On StarRocks this expands into a full fetch of every branch and tag, which keeps the job in `Checkout Code` for a long time before it reaches the formatting scripts.

## What I'm doing:

- shallow-check out the PR merge ref directly in `Clang-Format`
- remove the extra `BRANCH INFO` and `Checkout PR` git plumbing from that job
- run the format and guardrail scripts directly on the checked-out merge tree

Fixes: N/A (no linked issue)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Validation:

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-pipeline.yml")'