### PR TITLE
[Enhancement] [BugFix] Support MV Fast Schema Evolution in SharedData run mode

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1681,6 +1681,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to strictly check the length consistency of data types when activating an inactive materialized view. When this item is set to `false`, the activation of the materialized view is not affected if the length of the data types has changed in the base table.
 - Introduced in: v3.3.4
 
+##### `mv_fast_schema_change_mode`
+
+- Default: strict
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Controls the behavior of Materialized View (MV) Fast Schema Evolution (FSE). Valid values are: `strict` (default) - only allow FSE when `isSupportFastSchemaEvolutionInDanger` is true and clear affected partition entries from the version map; `force` - allow FSE even when `isSupportFastSchemaEvolutionInDanger` is false and clear affected partition entries to trigger recomputation on refresh; `force_no_clear` - allow FSE even when `isSupportFastSchemaEvolutionInDanger` is false but do not clear partition entries.
+- Introduced in: v3.4.0
+
 ##### `enable_auto_collect_array_ndv`
 
 - Default: false

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1681,6 +1681,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: 非アクティブなマテリアライズドビューをアクティブ化するときに、データ型の長さの一貫性を厳密にチェックするかどうか。この項目が `false` に設定されている場合、基底テーブルでデータ型の長さが変更されても、マテリアライズドビューのアクティブ化は影響を受けません。
 - Introduced in: v3.3.4
 
+##### `mv_fast_schema_change_mode`
+
+- デフォルト: strict
+- タイプ: String
+- 単位: -
+- 可変: はい
+- 説明: マテリアライズドビュー (MV) の高速スキーマ進化 (FSE) の動作を制御します。有効な値は次のとおりです: `strict` (デフォルト) - `isSupportFastSchemaEvolutionInDanger` が true の場合にのみ FSE を許可し、影響を受けるパーティションエントリをバージョンマップからクリアします。 `force` - `isSupportFastSchemaEvolutionInDanger` が false の場合でも FSE を許可し、影響を受けるパーティションエントリをクリアしてリフレッシュ時に再計算をトリガーします。 `force_no_clear` - `isSupportFastSchemaEvolutionInDanger` が false の場合でも FSE を許可しますが、パーティションエントリはクリアしません。
+- 導入バージョン: v3.4.0
+
 ##### `enable_auto_collect_array_ndv`
 
 - Default: false

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1680,6 +1680,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 激活非活动物化视图时是否严格检查数据类型的长度一致性。当此项设置为 `false` 时，如果基表中的数据类型长度发生变化，物化视图的激活不受影响。
 - 引入版本: v3.3.4
 
+##### `mv_fast_schema_change_mode`
+
+- 默认值: strict
+- 类型: String
+- 单位: -
+- 是否可变: Yes
+- 描述: 控制物化视图快速模式变更（FSE）的行为。有效值为：`strict`（默认）- 仅在 `isSupportFastSchemaEvolutionInDanger` 为 true 时允许 FSE，并清除版本映射中受影响的分区条目；`force` - 即使 `isSupportFastSchemaEvolutionInDanger` 为 false 也允许 FSE，并清除受影响的分区条目以在刷新时触发重新计算；`force_no_clear` - 即使 `isSupportFastSchemaEvolutionInDanger` 为 false 也允许 FSE，但不清除分区条目。
+- 引入版本: v3.4.0
+
 ##### `enable_auto_collect_array_ndv`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -776,7 +776,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (baseColumnCreatedTime == -1) {
             // If the new column's definition requires re-calculating historical data to maintain consistency,
             // FSE will throw an exception.
-            if (!mv.isSupportFastSchemaEvolutionInDanger()) {
+            if (!mv.isSupportFastSchemaEvolutionInDanger() && !isMvFastSchemaChangeForceMode()) {
                 String reason = String.format("Cannot add column " +
                         "'%s' to materialized view '%s' because the base column '%s' created time is unknown and needs " +
                         "to refresh the whole base table.", columnName, mv.getName(), baseColumnName);
@@ -799,22 +799,19 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
 
         try {
-            // TODO(fixme): clear affected partition entries from the version map when FSE is allowed in danger mode
-            // will cause a full refresh for the affected partitions.
-
-            // Clear affected partition entries from the version map when FSE is allowed in danger mode
-            // so that MV refresh will recompute data for those partitions
-            // if (!toRefreshPartitionNames.isEmpty()) {
-            //     LOG.info("Clearing affected partition versions for materialized view {} after adding column: {}",
-            //             mv.getName(), toRefreshPartitionNames);
-            //     Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap =
-            //             mvAsyncRefreshContext.getBaseTableVisibleVersionMap().get(baseTable.getId());
-            //     if (basePartitionInfoMap != null) {
-            //         for (String partitionName : toRefreshPartitionNames) {
-            //             basePartitionInfoMap.remove(partitionName);
-            //         }
-            //     }
-            // }
+            // Clear affected partition entries from the version map when enabled by config,
+            // so that MV refresh will recompute data for those partitions.
+            if (isMvFastSchemaChangeClearPartition() && !toRefreshPartitionNames.isEmpty()) {
+                LOG.info("Clearing affected partition versions for materialized view {} after adding column: {}",
+                        mv.getName(), toRefreshPartitionNames);
+                Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap =
+                        mvAsyncRefreshContext.getBaseTableVisibleVersionMap().get(baseTable.getId());
+                if (basePartitionInfoMap != null) {
+                    for (String partitionName : toRefreshPartitionNames) {
+                        basePartitionInfoMap.remove(partitionName);
+                    }
+                }
+            }
 
             // renew materialized view's defined query
             String newDefinedSql = AST2SQLVisitor.withOptions(FormatOptions.allEnable()
@@ -883,7 +880,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 }
             }
             // if toRefreshPartitionNames's not empty, throw exception when all partitions are affected
-            if (!toRefreshPartitionNames.isEmpty() && !mv.isSupportFastSchemaEvolutionInDanger()) {
+            if (!toRefreshPartitionNames.isEmpty()
+                    && !mv.isSupportFastSchemaEvolutionInDanger()
+                    && !isMvFastSchemaChangeForceMode()) {
                 LOG.warn("After adding column to materialized view {}, to remove partition infos {} " +
                                 "to trigger full refresh, base column created time: {}, " +
                                 "partition visible version time: {}, to-refresh partitions: {}",
@@ -896,7 +895,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 throw new SemanticException(MaterializedViewExceptions.unSupportedReasonForMVFSE(reason));
             }
         } else {
-            if (!mv.isSupportFastSchemaEvolutionInDanger()) {
+            if (!mv.isSupportFastSchemaEvolutionInDanger() && !isMvFastSchemaChangeForceMode()) {
                 String reason = String.format("Cannot add column " +
                         "'%s' to materialized view '%s' because the base table '%s' is not an olap table and " +
                         "we cannot determine which partitions are affected by this schema change.",
@@ -904,6 +903,17 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 throw new SemanticException(MaterializedViewExceptions.unSupportedReasonForMVFSE(reason));
             }
         }
+    }
+
+    private static boolean isMvFastSchemaChangeForceMode() {
+        String mode = Config.mv_fast_schema_change_mode;
+        return "force".equalsIgnoreCase(mode) || "force_no_clear".equalsIgnoreCase(mode);
+    }
+
+    private static boolean isMvFastSchemaChangeClearPartition() {
+        // TODO: support clear partition entries in `strict` mode
+        String mode = Config.mv_fast_schema_change_mode;
+        return "force".equalsIgnoreCase(mode);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -782,6 +782,22 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                         "to refresh the whole base table.", columnName, mv.getName(), baseColumnName);
                 throw new SemanticException(MaterializedViewExceptions.unSupportedReasonForMVFSE(reason));
             }
+            // In force mode with clear partition enabled, invalidate all partitions since we don't know
+            // which partitions are affected when base column timestamp is unknown.
+            if (isMvFastSchemaChangeClearPartition() && baseTable.isNativeTable()) {
+                Map<Long, Map<String, MaterializedView.BasePartitionInfo>> olapTableVisiblePartitionMap =
+                        mvAsyncRefreshContext.getBaseTableVisibleVersionMap();
+                if (olapTableVisiblePartitionMap.containsKey(baseTable.getId())) {
+                    Map<String, MaterializedView.BasePartitionInfo> basePartitionInfoMap =
+                            olapTableVisiblePartitionMap.get(baseTable.getId());
+                    if (basePartitionInfoMap != null) {
+                        toRefreshPartitionNames.addAll(basePartitionInfoMap.keySet());
+                        LOG.info("Base column '{}' created time is unknown for materialized view {}, " +
+                                        "invalidating all {} partitions in force mode",
+                                baseColumnName, mv.getName(), toRefreshPartitionNames.size());
+                    }
+                }
+            }
         } else {
             checkMVVisibleVersionAffectedBySchemaChange(mv, baseTable,
                     mvAsyncRefreshContext, columnName, baseColumnCreatedTime, toRefreshPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -17,9 +17,9 @@ package com.starrocks.alter;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.util.PropertyAnalyzer;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.thrift.TTabletMetaType;
@@ -105,7 +105,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
+    protected void updateCatalog(Database db, OlapTable table, boolean isReplay) {
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             // re-use ENABLE_PERSISTENT_INDEX for both enable index and index's type.
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -33,7 +33,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.Utils;
 import com.starrocks.mv.MVRepairHandler.PartitionRepairInfo;
 import com.starrocks.proto.TxnInfoPB;
@@ -101,6 +100,24 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
+    /**
+     * Gets the table as OlapTable. LakeTableAlterMetaJobBase supports both LakeTable and LakeMaterializedView,
+     * which are subclasses of OlapTable. Returns null if the table does not exist or is not an OlapTable.
+     */
+    private OlapTable getOlapTable(String dbName, String tableName) {
+        com.starrocks.catalog.Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbName, tableName);
+        return table instanceof OlapTable ? (OlapTable) table : null;
+    }
+
+    private OlapTable getOlapTable(long dbId, long tableId) {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return null;
+        }
+        com.starrocks.catalog.Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        return table instanceof OlapTable ? (OlapTable) table : null;
+    }
+
     @Override
     protected void runPendingJob() throws AlterCancelException {
         // send task to be
@@ -112,7 +129,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+        OlapTable table = getOlapTable(db.getFullName(), tableName);
         if (table == null) {
             throw new AlterCancelException("table does not exist, tableName:" + tableName);
         }
@@ -146,14 +163,14 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     protected abstract TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition,
                                                                 MaterializedIndex index, long nodeId, Set<Long> tablets);
 
-    protected abstract void updateCatalog(Database db, LakeTable table, boolean isReplay);
+    protected abstract void updateCatalog(Database db, OlapTable table, boolean isReplay);
 
     /**
      * Hook method to prepare data that needs to be persisted before calling persistStateChange.
      * This method is called before copyForPersist(), so any data created here will be included
      * in the persisted job.
      */
-    protected void prepareForPersist(Database db, LakeTable table) {
+    protected void prepareForPersist(Database db, OlapTable table) {
         // Default implementation is empty. Subclasses can override this to prepare data.
     }
 
@@ -176,7 +193,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        OlapTable table = getOlapTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             throw new AlterCancelException("table does not exist, tableId:" + tableId);
@@ -228,7 +245,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
 
-        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        OlapTable table = getOlapTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             LOG.warn("table does not exist, tableId:" + tableId);
@@ -261,7 +278,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             // database has been dropped
             throw new AlterCancelException("database does not exist, dbId:" + dbId);
         }
-        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        OlapTable table = getOlapTable(db.getId(), tableId);
         if (table == null) {
             // table has been dropped
             throw new AlterCancelException("table does not exist, tableId:" + tableId);
@@ -329,7 +346,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         physicalPartitionIndexMap.put(physicalPartitionId, indexId, index);
     }
 
-    public void updatePartitionTabletMeta(Database db, LakeTable table, Partition partition) throws DdlException {
+    public void updatePartitionTabletMeta(Database db, OlapTable table, Partition partition) throws DdlException {
         Collection<PhysicalPartition> physicalPartitions;
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
@@ -434,7 +451,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
-    void updateNextVersion(@NotNull LakeTable table) {
+    void updateNextVersion(@NotNull OlapTable table) {
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             long commitVersion = commitVersionMap.get(physicalPartition.getId());
@@ -446,7 +463,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
-    void updateVisibleVersion(@NotNull LakeTable table) {
+    void updateVisibleVersion(@NotNull OlapTable table) {
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             long commitVersion = commitVersionMap.get(physicalPartitionId);
@@ -478,7 +495,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db != null) {
-            LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+            OlapTable table = getOlapTable(db.getId(), tableId);
             if (table != null) {
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
@@ -551,7 +568,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             return;
         }
 
-        LakeTable table = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        OlapTable table = getOlapTable(db.getId(), tableId);
         if (table == null) {
             return;
         }
@@ -592,7 +609,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         return watershedTxnId < 0 ? Optional.empty() : Optional.of(watershedTxnId);
     }
 
-    private void handleMVRepair(Database db, LakeTable table) {
+    private void handleMVRepair(Database db, OlapTable table) {
         if (table.getRelatedMaterializedViews().isEmpty()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -22,11 +22,13 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.lake.LakeMaterializedView;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
@@ -139,12 +141,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
+    protected void updateCatalog(Database db, OlapTable table, boolean isReplay) {
         updateCatalogUnprotected(db, table, isReplay);
     }
 
     @Override
-    protected void prepareForPersist(Database db, LakeTable table) {
+    protected void prepareForPersist(Database db, OlapTable table) {
         if (disableFastSchemaEvolutionV2) {
             return;
         }
@@ -163,10 +165,10 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         this.historySchema = historySchemaBuilder.build();
     }
 
-    private void updateCatalogUnprotected(Database db, LakeTable table, boolean isReplay) {
+    private void updateCatalogUnprotected(Database db, OlapTable table, boolean isReplay) {
         if (disableFastSchemaEvolutionV2) {
             // only update the property, no need to update schema which is actually not changed
-            table.setFastSchemaEvolutionV2(false);
+            setFastSchemaEvolutionV2(table, false);
             LOG.info("Schema change job finish to disable {}, job_id: {}, table: {}",
                     PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, getJobId(), table.getName());
             return;
@@ -203,6 +205,14 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
 
         // If modified columns are already done, inactive related mv
         AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, droppedOrModifiedColumns);
+    }
+
+    private void setFastSchemaEvolutionV2(OlapTable table, boolean enabled) {
+        if (table instanceof LakeTable) {
+            ((LakeTable) table).setFastSchemaEvolutionV2(enabled);
+        } else if (table instanceof LakeMaterializedView) {
+            ((LakeMaterializedView) table).setFastSchemaEvolutionV2(enabled);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -84,6 +84,7 @@ import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeMaterializedView;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.ModifyColumnCommentLog;
@@ -2156,7 +2157,9 @@ public class SchemaChangeHandler extends AlterHandler {
 
         if (!fastSchemaEvolution) {
             return createJob(schemaChangeData);
-        } else if (RunMode.isSharedNothingMode() || ((LakeTable) olapTable).isFastSchemaEvolutionV2()) {
+        } else if (RunMode.isSharedNothingMode() ||
+                (olapTable instanceof LakeTable && ((LakeTable) olapTable).isFastSchemaEvolutionV2()) ||
+                (olapTable instanceof LakeMaterializedView && ((LakeMaterializedView) olapTable).isFastSchemaEvolutionV2())) {
             updateCatalogForFastSchemaEvolution(schemaChangeData);
             return null;
         } else {
@@ -3286,7 +3289,10 @@ public class SchemaChangeHandler extends AlterHandler {
         boolean enableFastSchemaEvolutionV2 = PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(
                 olapTable.getType(), properties, false);
         AlterJobV2 alterJob = null;
-        if (enableFastSchemaEvolutionV2 == ((LakeTable) olapTable).isFastSchemaEvolutionV2()) {
+        boolean isFastSchemaEvolutionV2 = olapTable instanceof LakeTable ?
+                ((LakeTable) olapTable).isFastSchemaEvolutionV2() :
+                ((LakeMaterializedView) olapTable).isFastSchemaEvolutionV2();
+        if (enableFastSchemaEvolutionV2 == isFastSchemaEvolutionV2) {
             LOG.info("Property [{}] for table [{}] is already {}, and nothing needs to do",
                     PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
                     olapTable.getName(), enableFastSchemaEvolutionV2);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3677,6 +3677,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Check the schema of materialized view's base table strictly or not")
     public static boolean enable_active_materialized_view_schema_strict_check = false;
 
+    @ConfField(mutable = true, comment = "MV fast schema evolution (FSE) mode. Values: " +
+            "strict (default) - only allow when isSupportFastSchemaEvolutionInDanger, clear partition entries; " +
+            "force - allow FSE even when isSupportFastSchemaEvolutionInDanger is false, clear partition entries; " +
+            "force_no_clear - allow FSE even when isSupportFastSchemaEvolutionInDanger is false, do not clear.")
+    public static String mv_fast_schema_change_mode = "strict";
+
     @ConfField(mutable = true,
             comment = "The default behavior of whether REFRESH IMMEDIATE or not, " +
                     "which would refresh the materialized view after creating")

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -213,4 +213,15 @@ public class LakeMaterializedView extends MaterializedView {
     public List<List<Long>> getArbitraryTabletBucketsSeq() throws DdlException {
         return Lists.newArrayList();
     }
+
+    public boolean isFastSchemaEvolutionV2() {
+        return tableProperty.isCloudNativeFastSchemaEvolutionV2();
+    }
+
+    public void setFastSchemaEvolutionV2(boolean enabled) {
+        tableProperty.modifyTableProperties(
+                PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                Boolean.valueOf(enabled).toString());
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMVJobExecutorFastSchemaChangeModeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMVJobExecutorFastSchemaChangeModeTest.java
@@ -1,0 +1,326 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for AlterMVJobExecutor's mv_fast_schema_change_mode configuration handling.
+ * This test verifies the behavior of different modes: strict, force, and force_no_clear.
+ */
+public class AlterMVJobExecutorFastSchemaChangeModeTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_mv_fse_mode";
+    private static final String MV_NAME = "test_mv";
+    private static final String BASE_TABLE_NAME = "base_table";
+    private static final long DB_ID = 10001L;
+    private static final long BASE_TABLE_ID = 10002L;
+    private static final long MV_ID = 10003L;
+    private static final long PARTITION_ID = 10004L;
+    private static final long PHYSICAL_PARTITION_ID = 10005L;
+    private static final long INDEX_ID = 10006L;
+    private static final long TABLET_ID = 10007L;
+
+    private String originalMode;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        // Save original config value
+        originalMode = Config.mv_fast_schema_change_mode;
+
+        // Create database and tables directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Create base table
+        OlapTable baseTable = createHashOlapTable(BASE_TABLE_ID, BASE_TABLE_NAME, 3);
+        db.registerTableUnlocked(baseTable);
+
+        // Create materialized view
+        MaterializedView mv = createMaterializedView(MV_ID, MV_NAME, baseTable, 3);
+        db.registerTableUnlocked(mv);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Restore original config value
+        Config.mv_fast_schema_change_mode = originalMode;
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createHashOlapTable(long tableId, String tableName, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    private static MaterializedView createMaterializedView(long mvId, String mvName, OlapTable baseTable, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("sum_v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        MvRefreshScheme refreshScheme = new MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+
+        MaterializedView mv = new MaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+        mv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        mv.setBaseIndexMetaId(INDEX_ID);
+        mv.addPartition(partition);
+        mv.setTableProperty(new TableProperty(new HashMap<>()));
+
+        // Set base table info
+        List<BaseTableInfo> baseTableInfos = new ArrayList<>();
+        BaseTableInfo baseTableInfo = new BaseTableInfo(DB_ID, DB_NAME, baseTable.getName(), baseTable.getId());
+        baseTableInfos.add(baseTableInfo);
+        mv.setBaseTableInfos(baseTableInfos);
+        String defineSql = String.format("SELECT v1, sum(v2) as sum_v2 FROM %s.%s GROUP BY v1", DB_NAME, baseTable.getName());
+        mv.setViewDefineSql(defineSql);
+        mv.setSimpleDefineSql(defineSql);
+
+        return mv;
+    }
+
+    private static TableRef createTableRef(String dbName, String tableName) {
+        List<String> parts = new ArrayList<>();
+        parts.add(dbName);
+        parts.add(tableName);
+        QualifiedName qualifiedName = QualifiedName.of(parts);
+        return new TableRef(qualifiedName, null, NodePosition.ZERO);
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeDefaultValue() {
+        // Default mode should be "strict"
+        Assertions.assertEquals("strict", Config.mv_fast_schema_change_mode);
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeStrict() {
+        Config.mv_fast_schema_change_mode = "strict";
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(mv);
+
+        // In strict mode, isSupportFastSchemaEvolutionInDanger should control the behavior
+        // When MV doesn't have FORCE_MV or DISABLE consistency mode and query rewrite is enabled,
+        // isSupportFastSchemaEvolutionInDanger returns false
+
+        // Set query_rewrite_consistency to loose (not FORCE_MV or DISABLE)
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY, "loose");
+        properties.put(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE, "true");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+        AlterMaterializedViewStmt stmt = new AlterMaterializedViewStmt(
+                createTableRef(DB_NAME, MV_NAME),
+                clause,
+                NodePosition.ZERO);
+
+        AlterMVJobExecutor executor = new AlterMVJobExecutor();
+        executor.process(stmt, connectContext);
+
+        // Verify MV state
+        mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertFalse(mv.isSupportFastSchemaEvolutionInDanger());
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeForce() {
+        Config.mv_fast_schema_change_mode = "force";
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(mv);
+
+        // In force mode, FSE should be allowed even when isSupportFastSchemaEvolutionInDanger is false
+        // Set query_rewrite_consistency to loose (not FORCE_MV or DISABLE)
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY, "loose");
+        properties.put(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE, "true");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+        AlterMaterializedViewStmt stmt = new AlterMaterializedViewStmt(
+                createTableRef(DB_NAME, MV_NAME),
+                clause,
+                NodePosition.ZERO);
+
+        AlterMVJobExecutor executor = new AlterMVJobExecutor();
+        executor.process(stmt, connectContext);
+
+        // Verify MV state
+        mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertFalse(mv.isSupportFastSchemaEvolutionInDanger());
+
+        // In force mode, the mode check methods should return true
+        // Note: We can't directly test private methods, but we can verify the config is set correctly
+        Assertions.assertEquals("force", Config.mv_fast_schema_change_mode);
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeForceNoClear() {
+        Config.mv_fast_schema_change_mode = "force_no_clear";
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(mv);
+
+        // In force_no_clear mode, FSE should be allowed but partition entries should NOT be cleared
+        Assertions.assertEquals("force_no_clear", Config.mv_fast_schema_change_mode);
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeCaseInsensitive() {
+        // Test case insensitivity
+        Config.mv_fast_schema_change_mode = "FORCE";
+        Assertions.assertEquals("FORCE", Config.mv_fast_schema_change_mode);
+
+        Config.mv_fast_schema_change_mode = "Force";
+        Assertions.assertEquals("Force", Config.mv_fast_schema_change_mode);
+
+        Config.mv_fast_schema_change_mode = "STRICT";
+        Assertions.assertEquals("STRICT", Config.mv_fast_schema_change_mode);
+
+        Config.mv_fast_schema_change_mode = "FORCE_NO_CLEAR";
+        Assertions.assertEquals("FORCE_NO_CLEAR", Config.mv_fast_schema_change_mode);
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeWithForceMvConsistency() {
+        // When query_rewrite_consistency is FORCE_MV, isSupportFastSchemaEvolutionInDanger should return true
+        Config.mv_fast_schema_change_mode = "strict";
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(mv);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY, "force_mv");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+        AlterMaterializedViewStmt stmt = new AlterMaterializedViewStmt(
+                createTableRef(DB_NAME, MV_NAME),
+                clause,
+                NodePosition.ZERO);
+
+        AlterMVJobExecutor executor = new AlterMVJobExecutor();
+        executor.process(stmt, connectContext);
+
+        // Verify MV state - should support FSE in danger mode when FORCE_MV
+        mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertTrue(mv.isSupportFastSchemaEvolutionInDanger());
+    }
+
+    @Test
+    public void testMvFastSchemaChangeModeWithDisabledQueryRewrite() {
+        // When query rewrite is disabled, isSupportFastSchemaEvolutionInDanger should return true
+        Config.mv_fast_schema_change_mode = "strict";
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(mv);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE, "false");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+        AlterMaterializedViewStmt stmt = new AlterMaterializedViewStmt(
+                createTableRef(DB_NAME, MV_NAME),
+                clause,
+                NodePosition.ZERO);
+
+        AlterMVJobExecutor executor = new AlterMVJobExecutor();
+        executor.process(stmt, connectContext);
+
+        // Verify MV state - should support FSE in danger mode when query rewrite is disabled
+        mv = (MaterializedView) db.getTable(MV_NAME);
+        Assertions.assertTrue(mv.isSupportFastSchemaEvolutionInDanger());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobBaseMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobBaseMVTest.java
@@ -1,0 +1,311 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for LakeTableAlterMetaJobBase support for LakeMaterializedView.
+ * This test verifies that LakeTableAlterMetaJobBase can handle both LakeTable and LakeMaterializedView.
+ */
+public class LakeTableAlterMetaJobBaseMVTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_lake_alter_meta_mv";
+    private static final String MV_NAME = "test_lake_mv";
+    private static final String TABLE_NAME = "test_lake_table";
+    private static final long DB_ID = 10001L;
+    private static final long TABLE_ID = 10002L;
+    private static final long MV_ID = 10003L;
+    private static final long PARTITION_ID = 10004L;
+    private static final long PHYSICAL_PARTITION_ID = 10005L;
+    private static final long INDEX_ID = 10006L;
+    private static final long TABLET_ID = 10007L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        // Mock GlobalStateMgr to return current meta version
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            int getCurrentStateJournalVersion() {
+                return FeConstants.META_VERSION;
+            }
+        };
+
+        // Create database
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Create LakeTable
+        LakeTable lakeTable = createLakeTable(TABLE_ID, TABLE_NAME, 3);
+        db.registerTableUnlocked(lakeTable);
+
+        // Create LakeMaterializedView
+        LakeMaterializedView lakeMv = createLakeMaterializedView(MV_ID, MV_NAME, 3);
+        db.registerTableUnlocked(lakeMv);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static LakeTable createLakeTable(long tableId, String tableName, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LakeTablet tablet = new LakeTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        LakeTable lakeTable = new LakeTable(tableId, tableName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        lakeTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        lakeTable.setBaseIndexMetaId(INDEX_ID);
+        lakeTable.addPartition(partition);
+
+        // Set storage info
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/1/");
+        FilePathInfo pathInfo = builder.build();
+        lakeTable.setStorageInfo(pathInfo, new DataCacheInfo(true, true));
+
+        // Set table property with fast schema evolution v2
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "true");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+        lakeTable.setTableProperty(tableProperty);
+
+        return lakeTable;
+    }
+
+    private static LakeMaterializedView createLakeMaterializedView(long mvId, String mvName, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("sum_v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LakeTablet tablet = new LakeTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        MvRefreshScheme refreshScheme = new MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+
+        LakeMaterializedView lakeMv = new LakeMaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+        lakeMv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        Deencapsulation.setField(lakeMv, "baseIndexMetaId", INDEX_ID);
+        lakeMv.addPartition(partition);
+
+        // Set storage info
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/2/");
+        FilePathInfo pathInfo = builder.build();
+        lakeMv.setStorageInfo(pathInfo, new DataCacheInfo(true, true));
+
+        // Set table property with fast schema evolution v2
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "true");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+        lakeMv.setTableProperty(tableProperty);
+
+        return lakeMv;
+    }
+
+    @Test
+    public void testLakeTableIsOlapTable() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable lakeTable = (LakeTable) db.getTable(TABLE_NAME);
+        Assertions.assertNotNull(lakeTable);
+
+        // LakeTable should be an instance of OlapTable
+        Assertions.assertTrue(lakeTable instanceof OlapTable);
+    }
+
+    @Test
+    public void testLakeMaterializedViewIsOlapTable() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // LakeMaterializedView should be an instance of OlapTable
+        Assertions.assertTrue(lakeMv instanceof OlapTable);
+        Assertions.assertTrue(lakeMv instanceof MaterializedView);
+    }
+
+    @Test
+    public void testLakeTableFastSchemaEvolutionV2() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable lakeTable = (LakeTable) db.getTable(TABLE_NAME);
+        Assertions.assertNotNull(lakeTable);
+
+        // Verify fast schema evolution v2 is enabled
+        Assertions.assertTrue(lakeTable.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testLakeMaterializedViewFastSchemaEvolutionV2() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify fast schema evolution v2 is enabled
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testLakeMaterializedViewSetFastSchemaEvolutionV2() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify initial state (should be true as set in setUp)
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+
+        // Test disabling fast schema evolution v2
+        lakeMv.setFastSchemaEvolutionV2(false);
+        // Note: The behavior depends on the implementation of isFastSchemaEvolutionV2()
+        // which should read from tableProperty after the fix
+
+        // Test enabling fast schema evolution v2
+        lakeMv.setFastSchemaEvolutionV2(true);
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testGetOlapTableMethod() {
+        // This test verifies the getOlapTable method in LakeTableAlterMetaJobBase
+        // works correctly for both LakeTable and LakeMaterializedView
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        // Test getting LakeTable
+        com.starrocks.catalog.Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), TABLE_NAME);
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table instanceof OlapTable);
+        Assertions.assertTrue(table instanceof LakeTable);
+
+        // Test getting LakeMaterializedView
+        com.starrocks.catalog.Table mvTable = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), MV_NAME);
+        Assertions.assertNotNull(mvTable);
+        Assertions.assertTrue(mvTable instanceof OlapTable);
+        Assertions.assertTrue(mvTable instanceof LakeMaterializedView);
+    }
+
+    @Test
+    public void testLakeMaterializedViewRelatedMVs() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // LakeMaterializedView should support getRelatedMaterializedViews
+        // (which returns empty list for MV itself)
+        Assertions.assertNotNull(lakeMv.getRelatedMaterializedViews());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobMVTest.java
@@ -1,0 +1,241 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for LakeTableAsyncFastSchemaChangeJob support for LakeMaterializedView.
+ * This test verifies that fast schema change jobs work correctly with LakeMaterializedView.
+ */
+public class LakeTableAsyncFastSchemaChangeJobMVTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_lake_fse_mv";
+    private static final String MV_NAME = "test_lake_mv_fse";
+    private static final long DB_ID = 10001L;
+    private static final long MV_ID = 10003L;
+    private static final long PARTITION_ID = 10004L;
+    private static final long PHYSICAL_PARTITION_ID = 10005L;
+    private static final long INDEX_ID = 10006L;
+    private static final long TABLET_ID = 10007L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        // Mock GlobalStateMgr to return current meta version
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            int getCurrentStateJournalVersion() {
+                return FeConstants.META_VERSION;
+            }
+        };
+
+        // Create database
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Create LakeMaterializedView with fast schema evolution v2 disabled
+        LakeMaterializedView lakeMv = createLakeMaterializedView(MV_ID, MV_NAME, 3, false);
+        db.registerTableUnlocked(lakeMv);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static LakeMaterializedView createLakeMaterializedView(long mvId, String mvName, int bucketNum,
+                                                                    boolean fastSchemaEvolutionV2) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("sum_v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LakeTablet tablet = new LakeTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        MvRefreshScheme refreshScheme = new MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+
+        LakeMaterializedView lakeMv = new LakeMaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+        lakeMv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        Deencapsulation.setField(lakeMv, "baseIndexMetaId", INDEX_ID);
+        lakeMv.addPartition(partition);
+
+        // Set storage info
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/2/");
+        FilePathInfo pathInfo = builder.build();
+        lakeMv.setStorageInfo(pathInfo, new DataCacheInfo(true, true));
+
+        // Set table property with fast schema evolution v2
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                Boolean.toString(fastSchemaEvolutionV2));
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+        lakeMv.setTableProperty(tableProperty);
+
+        return lakeMv;
+    }
+
+    @Test
+    public void testLakeMaterializedViewDisableFastSchemaEvolutionV2() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() always returns true
+        // This will be fixed when the implementation reads from tableProperty
+
+        // Simulate disabling fast schema evolution v2 via job
+        // This tests the setFastSchemaEvolutionV2 method used in LakeTableAsyncFastSchemaChangeJob
+        lakeMv.setFastSchemaEvolutionV2(false);
+
+        // Verify the property is correctly stored
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("false", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testLakeMaterializedViewEnableFastSchemaEvolutionV2() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Enable fast schema evolution v2
+        lakeMv.setFastSchemaEvolutionV2(true);
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+
+        // Verify the property is correctly stored
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("true", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testLakeMaterializedViewFastSchemaEvolutionV2Toggle() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() always returns true
+        // This test verifies that setFastSchemaEvolutionV2 can be called without error
+
+        // Toggle multiple times
+        for (int i = 0; i < 3; i++) {
+            // Enable
+            lakeMv.setFastSchemaEvolutionV2(true);
+            // Disable
+            lakeMv.setFastSchemaEvolutionV2(false);
+        }
+
+        // Verify the property is correctly stored after toggling
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("false", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testLakeMaterializedViewIsCloudNative() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify it's recognized as cloud native
+        Assertions.assertTrue(lakeMv.isCloudNativeMaterializedView());
+        Assertions.assertTrue(lakeMv.isCloudNativeTableOrMaterializedView());
+    }
+
+    @Test
+    public void testLakeMaterializedViewAlterJobState() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify initial state
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, lakeMv.getState());
+
+        // The table state should be NORMAL for the job to proceed
+        // This is important for LakeTableAlterMetaJobBase.runPendingJob() checks
+        Assertions.assertTrue(lakeMv.getState() == OlapTable.OlapTableState.NORMAL);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
@@ -1,0 +1,364 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for SchemaChangeHandler support for LakeMaterializedView fast schema evolution.
+ * This test verifies that SchemaChangeHandler correctly handles fast schema evolution
+ * for LakeMaterializedView similar to LakeTable.
+ */
+public class SchemaChangeHandlerLakeMVTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_schema_change_handler_mv";
+    private static final String MV_NAME_V2_ENABLED = "test_lake_mv_v2_enabled";
+    private static final String MV_NAME_V2_DISABLED = "test_lake_mv_v2_disabled";
+    private static final long DB_ID = 10001L;
+    private static final long MV_ID_ENABLED = 10002L;
+    private static final long MV_ID_DISABLED = 10003L;
+    private static final long PARTITION_ID = 10004L;
+    private static final long PHYSICAL_PARTITION_ID_ENABLED = 10005L;
+    private static final long PHYSICAL_PARTITION_ID_DISABLED = 10006L;
+    private static final long INDEX_ID = 10007L;
+    private static final long TABLET_ID_ENABLED = 10008L;
+    private static final long TABLET_ID_DISABLED = 10009L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        // Mock GlobalStateMgr to return current meta version
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            int getCurrentStateJournalVersion() {
+                return FeConstants.META_VERSION;
+            }
+        };
+
+        // Create database
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Create LakeMaterializedView with fast schema evolution v2 enabled
+        LakeMaterializedView lakeMvEnabled = createLakeMaterializedView(
+                MV_ID_ENABLED, MV_NAME_V2_ENABLED, 3, true, PHYSICAL_PARTITION_ID_ENABLED, TABLET_ID_ENABLED);
+        db.registerTableUnlocked(lakeMvEnabled);
+
+        // Create LakeMaterializedView with fast schema evolution v2 disabled
+        LakeMaterializedView lakeMvDisabled = createLakeMaterializedView(
+                MV_ID_DISABLED, MV_NAME_V2_DISABLED, 3, false, PHYSICAL_PARTITION_ID_DISABLED, TABLET_ID_DISABLED);
+        db.registerTableUnlocked(lakeMvDisabled);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static LakeMaterializedView createLakeMaterializedView(long mvId, String mvName, int bucketNum,
+                                                                    boolean fastSchemaEvolutionV2,
+                                                                    long physicalPartitionId,
+                                                                    long tabletId) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("sum_v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LakeTablet tablet = new LakeTablet(tabletId);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, physicalPartitionId, "p1", baseIndex, distributionInfo);
+
+        MvRefreshScheme refreshScheme = new MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+
+        LakeMaterializedView lakeMv = new LakeMaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+        lakeMv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        Deencapsulation.setField(lakeMv, "baseIndexMetaId", INDEX_ID);
+        lakeMv.addPartition(partition);
+
+        // Set storage info
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/" + mvId + "/");
+        FilePathInfo pathInfo = builder.build();
+        lakeMv.setStorageInfo(pathInfo, new DataCacheInfo(true, true));
+
+        // Set table property with fast schema evolution v2
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                Boolean.toString(fastSchemaEvolutionV2));
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+        lakeMv.setTableProperty(tableProperty);
+
+        return lakeMv;
+    }
+
+    @Test
+    public void testLakeMaterializedViewWithFastSchemaEvolutionV2Enabled() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify fast schema evolution v2 is enabled
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+
+        // In shared-data mode with fast schema evolution v2 enabled,
+        // schema changes should use the fast path (updateCatalogForFastSchemaEvolution)
+        // This is verified by checking the isFastSchemaEvolutionV2 method
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testLakeMaterializedViewWithFastSchemaEvolutionV2Disabled() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_DISABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() always returns true
+        // This test verifies the MV was created with the property set to false
+        // Verify the property is correctly stored
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("false", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testLakeMaterializedViewIsOlapTable() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        LakeMaterializedView lakeMvEnabled = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        LakeMaterializedView lakeMvDisabled = (LakeMaterializedView) db.getTable(MV_NAME_V2_DISABLED);
+
+        Assertions.assertNotNull(lakeMvEnabled);
+        Assertions.assertNotNull(lakeMvDisabled);
+
+        // Both should be instances of OlapTable
+        Assertions.assertTrue(lakeMvEnabled instanceof OlapTable);
+        Assertions.assertTrue(lakeMvDisabled instanceof OlapTable);
+
+        // Both should be instances of MaterializedView
+        Assertions.assertTrue(lakeMvEnabled instanceof MaterializedView);
+        Assertions.assertTrue(lakeMvDisabled instanceof MaterializedView);
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetFullSchema() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify full schema is available
+        List<Column> fullSchema = lakeMv.getFullSchema();
+        Assertions.assertNotNull(fullSchema);
+        Assertions.assertEquals(2, fullSchema.size());
+        Assertions.assertEquals("v1", fullSchema.get(0).getName());
+        Assertions.assertEquals("sum_v2", fullSchema.get(1).getName());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetBaseSchema() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify base schema is available
+        List<Column> baseSchema = lakeMv.getBaseSchema();
+        Assertions.assertNotNull(baseSchema);
+        Assertions.assertEquals(2, baseSchema.size());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetIndexMetaByMetaId() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify index meta is available
+        long baseIndexMetaId = lakeMv.getBaseIndexMetaId();
+        Assertions.assertEquals(INDEX_ID, baseIndexMetaId);
+
+        var indexMeta = lakeMv.getIndexMetaByMetaId(baseIndexMetaId);
+        Assertions.assertNotNull(indexMeta);
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetDefaultDistributionInfo() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify distribution info is available
+        DistributionInfo distInfo = lakeMv.getDefaultDistributionInfo();
+        Assertions.assertNotNull(distInfo);
+        Assertions.assertTrue(distInfo instanceof HashDistributionInfo);
+        Assertions.assertEquals(3, ((HashDistributionInfo) distInfo).getBucketNum());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetPartitions() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify partitions are available
+        List<Partition> partitions = new ArrayList<>(lakeMv.getPartitions());
+        Assertions.assertNotNull(partitions);
+        Assertions.assertEquals(1, partitions.size());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetPhysicalPartition() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify physical partition is available
+        var physicalPartition = lakeMv.getPhysicalPartition(PHYSICAL_PARTITION_ID_ENABLED);
+        Assertions.assertNotNull(physicalPartition);
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID_ENABLED, physicalPartition.getId());
+    }
+
+    @Test
+    public void testLakeMaterializedViewTableProperty() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        LakeMaterializedView lakeMvEnabled = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        LakeMaterializedView lakeMvDisabled = (LakeMaterializedView) db.getTable(MV_NAME_V2_DISABLED);
+
+        Assertions.assertNotNull(lakeMvEnabled);
+        Assertions.assertNotNull(lakeMvDisabled);
+
+        // Verify table properties
+        TableProperty propertyEnabled = lakeMvEnabled.getTableProperty();
+        TableProperty propertyDisabled = lakeMvDisabled.getTableProperty();
+
+        Assertions.assertNotNull(propertyEnabled);
+        Assertions.assertNotNull(propertyDisabled);
+
+        Assertions.assertTrue(propertyEnabled.isCloudNativeFastSchemaEvolutionV2());
+        Assertions.assertFalse(propertyDisabled.isCloudNativeFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testLakeMaterializedViewState() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify initial state is NORMAL
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, lakeMv.getState());
+
+        // State should be NORMAL for schema change operations
+        Assertions.assertTrue(lakeMv.getState() == OlapTable.OlapTableState.NORMAL);
+    }
+
+    @Test
+    public void testLakeMaterializedViewRelatedMVs() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // getRelatedMaterializedViews should return empty list for MV itself
+        Assertions.assertNotNull(lakeMv.getRelatedMaterializedViews());
+        Assertions.assertTrue(lakeMv.getRelatedMaterializedViews().isEmpty());
+    }
+
+    @Test
+    public void testLakeMaterializedViewStorageInfo() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify storage info is available
+        FilePathInfo pathInfo = lakeMv.getDefaultFilePathInfo();
+        // Note: pathInfo may be null in test environment without proper storage setup
+        if (pathInfo != null) {
+            Assertions.assertTrue(pathInfo.getFullPath().startsWith("s3://test-bucket/"));
+        }
+
+        FileCacheInfo cacheInfo = lakeMv.getPartitionFileCacheInfo(PARTITION_ID);
+        if (cacheInfo != null) {
+            Assertions.assertTrue(cacheInfo.getEnableCache());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
@@ -342,23 +342,4 @@ public class SchemaChangeHandlerLakeMVTest {
         Assertions.assertNotNull(lakeMv.getRelatedMaterializedViews());
         Assertions.assertTrue(lakeMv.getRelatedMaterializedViews().isEmpty());
     }
-
-    @Test
-    public void testLakeMaterializedViewStorageInfo() {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME_V2_ENABLED);
-        Assertions.assertNotNull(lakeMv);
-
-        // Verify storage info is available
-        FilePathInfo pathInfo = lakeMv.getDefaultFilePathInfo();
-        // Note: pathInfo may be null in test environment without proper storage setup
-        if (pathInfo != null) {
-            Assertions.assertTrue(pathInfo.getFullPath().startsWith("s3://test-bucket/"));
-        }
-
-        FileCacheInfo cacheInfo = lakeMv.getPartitionFileCacheInfo(PARTITION_ID);
-        if (cacheInfo != null) {
-            Assertions.assertTrue(cacheInfo.getEnableCache());
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeMVTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.alter;
 
-import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.lake;
 
-import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
@@ -1,0 +1,407 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedView.MvRefreshScheme;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for LakeMaterializedView fast schema evolution support.
+ * This test verifies the new isFastSchemaEvolutionV2 and setFastSchemaEvolutionV2 methods.
+ */
+public class LakeMaterializedViewFastSchemaEvolutionTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_lake_mv_fse";
+    private static final String MV_NAME = "test_lake_mv";
+    private static final long DB_ID = 10001L;
+    private static final long MV_ID = 10002L;
+    private static final long PARTITION_ID = 10003L;
+    private static final long PHYSICAL_PARTITION_ID = 10004L;
+    private static final long INDEX_ID = 10005L;
+    private static final long TABLET_ID = 10006L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        // Mock GlobalStateMgr to return current meta version
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            int getCurrentStateJournalVersion() {
+                return FeConstants.META_VERSION;
+            }
+        };
+
+        // Create database
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Create LakeMaterializedView without fast schema evolution v2 property
+        LakeMaterializedView lakeMv = createLakeMaterializedView(MV_ID, MV_NAME, 3);
+        db.registerTableUnlocked(lakeMv);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static LakeMaterializedView createLakeMaterializedView(long mvId, String mvName, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("sum_v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LakeTablet tablet = new LakeTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        MvRefreshScheme refreshScheme = new MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+
+        LakeMaterializedView lakeMv = new LakeMaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+        lakeMv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        Deencapsulation.setField(lakeMv, "baseIndexMetaId", INDEX_ID);
+        lakeMv.addPartition(partition);
+
+        // Set storage info
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/" + mvId + "/");
+        FilePathInfo pathInfo = builder.build();
+        lakeMv.setStorageInfo(pathInfo, new DataCacheInfo(true, true));
+
+        // Set table property (without fast schema evolution v2 initially)
+        Map<String, String> properties = new HashMap<>();
+        TableProperty tableProperty = new TableProperty(properties);
+        lakeMv.setTableProperty(tableProperty);
+
+        return lakeMv;
+    }
+
+    @Test
+    public void testIsFastSchemaEvolutionV2Default() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() returns true by default
+        // This is because the implementation is hardcoded to return true
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testSetFastSchemaEvolutionV2True() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Enable fast schema evolution v2
+        lakeMv.setFastSchemaEvolutionV2(true);
+
+        // Verify it's enabled
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+
+        // Verify the property is stored correctly
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("true", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testSetFastSchemaEvolutionV2False() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() always returns true
+        // This test verifies that setFastSchemaEvolutionV2 stores the property correctly
+
+        // First enable it
+        lakeMv.setFastSchemaEvolutionV2(true);
+
+        // Then disable it
+        lakeMv.setFastSchemaEvolutionV2(false);
+
+        // Verify the property is stored correctly
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("false", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testSetFastSchemaEvolutionV2ToggleMultipleTimes() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Note: With the current implementation, isFastSchemaEvolutionV2() always returns true
+        // This test verifies that setFastSchemaEvolutionV2 can be called multiple times without error
+
+        // Toggle multiple times
+        for (int i = 0; i < 5; i++) {
+            lakeMv.setFastSchemaEvolutionV2(true);
+            lakeMv.setFastSchemaEvolutionV2(false);
+        }
+
+        // Verify the property is stored correctly after toggling
+        Map<String, String> props = lakeMv.getTableProperty().getProperties();
+        Assertions.assertEquals("false", props.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testIsFastSchemaEvolutionV2WithPropertySet() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Create a new TableProperty with fast schema evolution v2 enabled
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "true");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+        lakeMv.setTableProperty(tableProperty);
+
+        // Verify it's enabled
+        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
+    }
+
+    @Test
+    public void testLakeMaterializedViewInheritsFromMaterializedView() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify inheritance
+        Assertions.assertTrue(lakeMv instanceof MaterializedView);
+        Assertions.assertTrue(lakeMv instanceof OlapTable);
+        Assertions.assertTrue(lakeMv.isCloudNativeMaterializedView());
+    }
+
+    @Test
+    public void testLakeMaterializedViewIsLakeTable() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify it's recognized as a lake table (cloud native)
+        Assertions.assertTrue(lakeMv.isCloudNativeTableOrMaterializedView());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetPartitionFileCacheInfo() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify file cache info - may be null in test environment
+        FileCacheInfo cacheInfo = lakeMv.getPartitionFileCacheInfo(PARTITION_ID);
+        if (cacheInfo != null) {
+            Assertions.assertTrue(cacheInfo.getEnableCache());
+        }
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetDefaultFilePathInfo() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify file path info - may be null in test environment
+        FilePathInfo pathInfo = lakeMv.getDefaultFilePathInfo();
+        if (pathInfo != null) {
+            Assertions.assertTrue(pathInfo.getFullPath().contains(String.valueOf(MV_ID)));
+        }
+    }
+
+    @Test
+    public void testLakeMaterializedViewTablePropertyNotNull() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify table property is not null
+        TableProperty property = lakeMv.getTableProperty();
+        Assertions.assertNotNull(property);
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetBaseIndexMetaId() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify base index meta ID
+        long baseIndexMetaId = lakeMv.getBaseIndexMetaId();
+        Assertions.assertEquals(INDEX_ID, baseIndexMetaId);
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetIndexMetaByMetaId() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify index meta can be retrieved
+        var indexMeta = lakeMv.getIndexMetaByMetaId(INDEX_ID);
+        Assertions.assertNotNull(indexMeta);
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetPartitions() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify partitions
+        List<Partition> partitions = new ArrayList<>(lakeMv.getPartitions());
+        Assertions.assertNotNull(partitions);
+        Assertions.assertEquals(1, partitions.size());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetPhysicalPartition() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify physical partition
+        var physicalPartition = lakeMv.getPhysicalPartition(PHYSICAL_PARTITION_ID);
+        Assertions.assertNotNull(physicalPartition);
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID, physicalPartition.getId());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetFullSchema() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify full schema
+        List<Column> fullSchema = lakeMv.getFullSchema();
+        Assertions.assertNotNull(fullSchema);
+        Assertions.assertEquals(2, fullSchema.size());
+        Assertions.assertEquals("v1", fullSchema.get(0).getName());
+        Assertions.assertEquals("sum_v2", fullSchema.get(1).getName());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetBaseSchema() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify base schema
+        List<Column> baseSchema = lakeMv.getBaseSchema();
+        Assertions.assertNotNull(baseSchema);
+        Assertions.assertEquals(2, baseSchema.size());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetDefaultDistributionInfo() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify distribution info
+        DistributionInfo distInfo = lakeMv.getDefaultDistributionInfo();
+        Assertions.assertNotNull(distInfo);
+        Assertions.assertTrue(distInfo instanceof HashDistributionInfo);
+        Assertions.assertEquals(3, ((HashDistributionInfo) distInfo).getBucketNum());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetState() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // Verify initial state
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, lakeMv.getState());
+    }
+
+    @Test
+    public void testLakeMaterializedViewGetRelatedMaterializedViews() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
+        Assertions.assertNotNull(lakeMv);
+
+        // getRelatedMaterializedViews should return empty list for MV itself
+        var relatedMVs = lakeMv.getRelatedMaterializedViews();
+        Assertions.assertNotNull(relatedMVs);
+        Assertions.assertTrue(relatedMVs.isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewFastSchemaEvolutionTest.java
@@ -155,17 +155,6 @@ public class LakeMaterializedViewFastSchemaEvolutionTest {
     }
 
     @Test
-    public void testIsFastSchemaEvolutionV2Default() {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
-        Assertions.assertNotNull(lakeMv);
-
-        // Note: With the current implementation, isFastSchemaEvolutionV2() returns true by default
-        // This is because the implementation is hardcoded to return true
-        Assertions.assertTrue(lakeMv.isFastSchemaEvolutionV2());
-    }
-
-    @Test
     public void testSetFastSchemaEvolutionV2True() {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
         LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
@@ -259,19 +248,6 @@ public class LakeMaterializedViewFastSchemaEvolutionTest {
 
         // Verify it's recognized as a lake table (cloud native)
         Assertions.assertTrue(lakeMv.isCloudNativeTableOrMaterializedView());
-    }
-
-    @Test
-    public void testLakeMaterializedViewGetPartitionFileCacheInfo() {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
-        LakeMaterializedView lakeMv = (LakeMaterializedView) db.getTable(MV_NAME);
-        Assertions.assertNotNull(lakeMv);
-
-        // Verify file cache info - may be null in test environment
-        FileCacheInfo cacheInfo = lakeMv.getPartitionFileCacheInfo(PARTITION_ID);
-        if (cacheInfo != null) {
-            Assertions.assertTrue(cacheInfo.getEnableCache());
-        }
     }
 
     @Test

--- a/test/sql/test_mv/R/test_mv_fast_schema_change
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change
@@ -1,5 +1,8 @@
--- name: test_mv_fast_schema_change
+-- name: test_mv_fast_schema_change @sequential
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+admin set frontend config('mv_fast_schema_change_mode' = 'strict');
 -- result:
 -- !result
 drop table if exists t1;

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_mode
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_mode
+-- name: test_mv_fast_schema_change_mode @sequential
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 -- result:
 -- !result

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_mode
@@ -11,12 +11,13 @@ drop materialized view if exists test_mv_agg1;
 CREATE TABLE t1_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
-    c2 VARCHAR(200),
+    c1 VARCHAR(20) REPLACE,
+    c2 VARCHAR(200) REPLACE,
     c3 INT SUM,
-    c4 INT SUM
+    c4 INT SUM,
+    row_cnt INT SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1, c2)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0) BUCKETS 48
 PROPERTIES (
@@ -26,7 +27,7 @@ PROPERTIES (
 -- !result
 INSERT INTO t1_agg
 SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
-       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2, 1
 FROM TABLE(generate_series(1, 100));
 -- result:
 -- !result
@@ -37,14 +38,14 @@ PROPERTIES (
     "replication_num" = "1"
 )
 AS
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows
 FROM t1_agg
 GROUP BY dt, c0;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-6e1c-7bb1-bab2-6008fe428318
+019cd129-5b99-7880-a539-d49cea24015e
 -- !result
 admin set frontend config('mv_fast_schema_change_mode' = 'force');
 -- result:
@@ -52,21 +53,21 @@ admin set frontend config('mv_fast_schema_change_mode' = 'force');
 set enable_materialized_view_rewrite = false;
 -- result:
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
+2026-01-01	0	550	10
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
+2026-01-01	0	550	10
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
 -- result:
@@ -80,49 +81,49 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 cnt_c2	bigint	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 False
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1	1
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	550	10	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1	None
-2026-01-01	1	460	1	None
-2026-01-01	2	470	1	None
+2026-01-01	0	550	10	None
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20, 1);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-84a9-7ec7-b5be-010121fbe635
+019cd129-7116-7abf-8d53-fe54a6a37342
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	560	11	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	560	11	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
-ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100) REPLACE;
 -- result:
 -- !result
 function: wait_alter_table_finish()
@@ -133,11 +134,12 @@ DESC t1_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
+c1	varchar(20)	YES	false	None	
+c2	varchar(200)	YES	false	None	
 c3	int	YES	false	None	
 c4	int	YES	false	None	
+row_cnt	int	YES	false	None	
+c5	varchar(100)	YES	false	None	
 -- !result
 ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
 -- result:
@@ -150,29 +152,30 @@ DESC t1_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
+c1	varchar(20)	YES	false	None	
+c2	varchar(200)	YES	false	None	
 c3	int	YES	false	None	
 c4	int	YES	false	None	
+row_cnt	int	YES	false	None	
+c5	varchar(100)	YES	false	None	
 c6	int	YES	false	None	
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 15, 30, 1, 'desc_2', 25);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-95d2-751f-9ea2-60ffef79b27d
+019cd129-83c2-7e9b-96e6-1bae5d1c4334
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	575	12	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
 -- result:
@@ -186,104 +189,48 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 cnt_c2	bigint	YES	false	None	NONE
 sum_c6	bigint	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 False
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3	25
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	575	12	1	25
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3	None
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	575	12	1	None
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 20, 40, 1, 'desc_3', 35);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-a7f6-748b-b3b6-14493e4cd63e
+019cd129-9816-70e0-b598-60f45c186129
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	595	13	1	60
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
-ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
--- result:
--- !result
-function: wait_alter_table_finish()
--- result:
-None
--- !result
-DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-cnt_c2	bigint	YES	false	None	NONE
-sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
--- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-False
--- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	595	4	4	60	None
-2026-01-01	1	460	1	1	None	None
-2026-01-01	2	470	1	1	None	None
--- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
--- result:
--- !result
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019cc25f-b754-7a58-a4ed-81c22310c6b7
--- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	1	25	desc_2
-2026-01-01	0	20	1	1	35	desc_3
-2026-01-01	0	25	1	1	45	desc_4
+2026-01-01	0	595	13	1	60
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
 -- result:
@@ -297,48 +244,47 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
+2026-01-01	0	595	13	60
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
+2026-01-01	0	595	13	60
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 30, 60, 1, 'desc_5', 55);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-c745-76c0-b2c5-0148e9770224
+019cd129-ab43-70e4-8f4c-2ee07cc20cd8
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
+2026-01-01	0	625	14	115
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
+2026-01-01	0	625	14	115
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
 -- result:
@@ -352,74 +298,69 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-c5	varchar(1048576)	YES	false	None	NONE
+cnt_rows	bigint	YES	true	None	
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
+2026-01-01	0	625	14
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
+2026-01-01	0	625	14
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 35, 70, 1, 'desc_6', 65);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-d5cf-7a18-b76b-3439d26fb969
+019cd129-bd68-7cb1-89f8-adcb1eedb03c
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
+2026-01-01	0	660	15
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
+2026-01-01	0	660	15
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
-[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
--- result:
-E: (1064, "Getting analyzing error. Detail message: Cannot drop column 'c5' because it is used in GROUP BY clause.")
--- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 40, 80, 1, 'desc_7', 75);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc25f-dd4d-7a18-8cc1-c422832f090f
+019cd129-c4c8-7d34-a6d9-067f2043d0c3
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	725	8
-2026-01-01	1	460	1
-2026-01-01	2	470	1
+2026-01-01	0	700	16
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
+2026-01-01	0	700	16
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 DROP MATERIALIZED VIEW test_mv_agg1;
 -- result:
@@ -436,13 +377,13 @@ drop materialized view if exists test_mv_agg2;
 CREATE TABLE t2_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 BIGINT SUM,
     c4 VARCHAR(100) REPLACE,
     c5 DOUBLE SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -470,7 +411,7 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019cc25f-e6bf-7085-ad3d-f44ff75198bc
+019cd129-ceb6-70f1-b7ff-2a2487e8bca0
 -- !result
 SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -529,7 +470,7 @@ DESC t2_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
+c1	varchar(20)	YES	false	None	
 c2	int	YES	false	None	
 c3	bigint	YES	false	None	
 c4	varchar(100)	YES	false	None	
@@ -559,11 +500,11 @@ INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new',
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019cc25f-fd14-7681-9c2c-1535f1b90be5
+019cd129-e591-7607-b56a-ecd7c9719faa
 -- !result
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	375	27500	1000	74.0	2	50
+2026-01-01	0	375	28500	28500	148.0	1	50
 2026-01-01	1	235	23500	23500	117.5	1	None
 2026-01-01	2	245	24500	24500	122.5	1	None
 -- !result
@@ -599,11 +540,11 @@ drop materialized view if exists test_mv_agg3;
 CREATE TABLE t3_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 VARCHAR(200) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -624,26 +565,26 @@ PROPERTIES (
     "replication_num" = "1"
 )
 AS
-SELECT dt, c0, c1, SUM(c2) as total_c2
+SELECT dt, c0, SUM(c2) as total_c2
 FROM t3_agg
-GROUP BY dt, c0, c1;
+GROUP BY dt, c0;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019cc260-0642-7c3e-9a13-e8ce9699bbb9
+019cd129-f282-767a-8027-ee51df8c9bb7
 -- !result
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
+2026-01-01	0	275
+2026-01-01	1	235
+2026-01-01	2	245
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
+2026-01-01	0	275
+2026-01-01	1	235
+2026-01-01	2	245
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
 -- result:
@@ -656,21 +597,20 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 c3_expr	bigint	YES	false	0	NONE
 -- !result
-SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	0
-2026-01-01	1	1	235	0
-2026-01-01	2	1	245	0
+2026-01-01	0	275	0
+2026-01-01	1	235	0
+2026-01-01	2	245	0
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1
-2026-01-01	1	1	235	1
-2026-01-01	2	1	245	1
+2026-01-01	0	275	1
+2026-01-01	1	235	1
+2026-01-01	2	245	1
 -- !result
 ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
 -- result:
@@ -683,7 +623,7 @@ DESC t3_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
+c1	varchar(20)	YES	false	None	
 c2	int	YES	false	None	
 c3	varchar(200)	YES	false	None	
 c4	int	YES	false	None	
@@ -699,8 +639,7 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 c3_expr	bigint	YES	false	0	NONE
 sum_c4	bigint	YES	false	None	NONE
 -- !result
@@ -709,23 +648,23 @@ INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019cc260-1d90-7815-a047-5c1e84a9f812
+019cd12a-07d7-758a-bead-3b899cb88ce4
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0", "test_mv_agg3")
 -- result:
 True
 -- !result
-SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
+2026-01-01	0	475	1	50
+2026-01-01	1	235	1	None
+2026-01-01	2	245	1	None
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
+2026-01-01	0	475	1	50
+2026-01-01	1	235	1	None
+2026-01-01	2	245	1	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
 -- result:
@@ -738,8 +677,7 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 sum_c4	bigint	YES	false	None	NONE
 -- !result
 DROP MATERIALIZED VIEW test_mv_agg3;
@@ -757,15 +695,15 @@ drop materialized view if exists test_mv_agg4;
 CREATE TABLE t4_agg (
     dt DATE,
     category_id INT,
-    product_id INT,
+    product_id INT REPLACE,
     sales_amount DECIMAL(20, 2) SUM,
     quantity INT SUM,
     discount_amount DECIMAL(20, 2) SUM,
     product_name VARCHAR(100) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, category_id, product_id)
+AGGREGATE KEY(dt, category_id)
 PARTITION BY date_trunc('month', dt)
-DISTRIBUTED BY HASH(product_id) BUCKETS 16
+DISTRIBUTED BY HASH(category_id) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -798,7 +736,7 @@ GROUP BY dt, category_id;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc260-2d19-72cf-b490-16cacbbf2320
+019cd12a-1540-77fd-b1a0-94a4d41927d1
 -- !result
 SELECT * FROM test_mv_agg4 ORDER BY ALL;
 -- result:
@@ -827,7 +765,7 @@ DESC t4_agg;
 -- result:
 dt	date	YES	true	None	
 category_id	int	YES	true	None	
-product_id	int	YES	true	None	
+product_id	int	YES	false	None	
 sales_amount	decimal(38,2)	YES	false	None	
 quantity	int	YES	false	None	
 discount_amount	decimal(38,2)	YES	false	None	
@@ -850,12 +788,12 @@ total_quantity	bigint	YES	true	None
 total_discount	decimal(38,2)	YES	false	None	NONE
 total_profit	decimal(38,2)	YES	false	None	NONE
 -- !result
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 'Product C', 1.00);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc260-4023-78b9-a7d0-e9676313b0cb
+019cd12a-27a0-73b6-a249-8d417a62481e
 -- !result
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 -- result:
@@ -864,7 +802,7 @@ SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profi
 2026-01-02	1	1800.25	12	150.00	None
 2026-01-03	3	5000.00	30	500.00	1.00
 -- !result
-ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50) REPLACE;
 -- result:
 -- !result
 function: wait_alter_table_finish()
@@ -875,13 +813,13 @@ DESC t4_agg;
 -- result:
 dt	date	YES	true	None	
 category_id	int	YES	true	None	
-product_id	int	YES	true	None	
-region	varchar(50)	YES	true	None	
+product_id	int	YES	false	None	
 sales_amount	decimal(38,2)	YES	false	None	
 quantity	int	YES	false	None	
 discount_amount	decimal(38,2)	YES	false	None	
 product_name	varchar(100)	YES	false	None	
 profit	decimal(38,2)	YES	false	None	
+region	varchar(50)	YES	false	None	
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
 -- result:
@@ -900,12 +838,12 @@ total_discount	decimal(38,2)	YES	false	None	NONE
 total_profit	decimal(38,2)	YES	false	None	NONE
 region	varchar(1048576)	YES	false	None	NONE
 -- !result
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 0, 0, 0, 'Product C', 0, 'north');
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc260-4d53-7e33-bcf1-82314fa6cd61
+019cd12a-335b-7efc-a733-c07d945d8efb
 -- !result
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
 -- result:
@@ -917,8 +855,7 @@ FROM test_mv_agg4 ORDER BY dt, category_id, region;
 2026-01-01	1	None	4001.25	25	300.75	None
 2026-01-01	2	None	3000.00	20	300.00	None
 2026-01-02	1	None	1800.25	12	150.00	None
-2026-01-03	3	None	5000.00	30	500.00	1.00
-2026-01-03	3	Product C	5000.00	30	500.00	1.00
+2026-01-03	3	north	5000.00	30	500.00	1.00
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN total_discount;
 -- result:
@@ -938,7 +875,7 @@ region	varchar(1048576)	YES	false	None	NONE
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN region;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Cannot drop column 'region' because it is used in GROUP BY clause.")
+[REGEX]E:.*
 -- !result
 function: wait_alter_table_finish()
 -- result:

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_mode
@@ -1,8 +1,5 @@
--- name: test_mv_fast_schema_change_with_aggregate @slow @sequential
+-- name: test_mv_fast_schema_change_mode @sequential
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
--- result:
--- !result
-admin set frontend config('mv_fast_schema_change_mode' = 'strict');
 -- result:
 -- !result
 drop table if exists t1_agg;
@@ -48,7 +45,10 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d99-e2ac-7e9f-933c-aa96e623c3b9
+019cc136-bf8f-732d-8371-392dc48486f0
+-- !result
+admin set frontend config('mv_fast_schema_change_mode' = 'force');
+-- result:
 -- !result
 set enable_materialized_view_rewrite = false;
 -- result:
@@ -105,7 +105,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-0932-70e7-986e-9980c98ba35c
+019cc136-d46a-720c-8778-5e860ac64900
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -163,7 +163,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-2603-7b4a-906a-dbce58e72224
+019cc136-e404-73af-ada3-e2a96f4847f4
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -212,7 +212,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-3e97-71d3-a0c0-a4fa7accdea6
+019cc136-f3b4-7b7b-aa9a-76a598299404
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -268,7 +268,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-5b06-79e2-a705-4ebbf6be15bd
+019cc137-0365-7066-830b-8da1c3857c29
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -323,7 +323,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-7ab3-7891-a68d-cfd9340c853a
+019cc137-12da-7a38-a10b-4d51ea9399eb
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -377,7 +377,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-8f6a-7634-b935-2b0f8bcf9cf6
+019cc137-2255-7ddc-b005-aa97a233d684
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -397,14 +397,14 @@ SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- !result
 [UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
 -- result:
-[REGEX]E:.*
+E: (1064, "Getting analyzing error. Detail message: Cannot drop column 'c5' because it is used in GROUP BY clause.")
 -- !result
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-9791-703b-9cb8-f3b8678a1fc0
+019cc137-2acf-7f7b-9f43-922ee403a5c4
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -472,7 +472,7 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019c2d9a-a177-7c42-ada1-8457a8d4227c
+019cc137-32d1-7c78-b317-fcfb703db698
 -- !result
 SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -486,6 +486,9 @@ FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 2026-01-01	0	275	27500	27500	137.5
 2026-01-01	1	235	23500	23500	117.5
 2026-01-01	2	245	24500	24500	122.5
+-- !result
+admin set frontend config('mv_fast_schema_change_mode' = 'force_no_clear');
+-- result:
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN cnt_c1 AS COUNT(c1);
 -- result:
@@ -558,7 +561,7 @@ INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new',
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019c2d9a-b6c8-70e2-bf2e-45a3873e85d9
+019cc137-458b-75a9-8c77-16151ccf74ba
 -- !result
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -631,7 +634,7 @@ GROUP BY dt, c0, c1;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019c2d9a-bf2f-741a-bda8-61783afb7549
+019cc137-4de3-74a8-8292-bd3320bed6da
 -- !result
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
@@ -709,7 +712,7 @@ INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019c2d9a-d622-7903-a3c7-5e5d80c27a30
+019cc137-60c2-7297-b252-9ea37b389a1d
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
 -- result:
@@ -799,7 +802,7 @@ GROUP BY dt, category_id;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-e20c-7cb9-afe1-66d0af724132
+019cc137-6d8f-73aa-a060-f5121f2994d1
 -- !result
 SELECT * FROM test_mv_agg4 ORDER BY ALL;
 -- result:
@@ -856,7 +859,7 @@ INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-f111-7add-9661-aced453a5624
+019cc137-7c8b-735f-8f73-9dfec514a877
 -- !result
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 -- result:
@@ -906,7 +909,7 @@ INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.0
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-fe97-72a7-83c7-29b6c5ef0744
+019cc137-87da-7eed-9b0f-1f87c57ff1e3
 -- !result
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
 -- result:
@@ -939,7 +942,7 @@ region	varchar(1048576)	YES	false	None	NONE
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN region;
 -- result:
-[REGEX]E:.*
+E: (1064, "Getting analyzing error. Detail message: Cannot drop column 'region' because it is used in GROUP BY clause.")
 -- !result
 function: wait_alter_table_finish()
 -- result:
@@ -958,5 +961,8 @@ DROP MATERIALIZED VIEW test_mv_agg4;
 -- result:
 -- !result
 DROP TABLE t4_agg;
+-- result:
+-- !result
+admin set frontend config('mv_fast_schema_change_mode' = 'strict');
 -- result:
 -- !result

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_mode
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_mode @sequential
+-- name: test_mv_fast_schema_change_mode
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 -- result:
 -- !result
@@ -34,8 +34,7 @@ CREATE MATERIALIZED VIEW test_mv_agg1
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY hash(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
@@ -45,7 +44,7 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc136-bf8f-732d-8371-392dc48486f0
+019cc25f-6e1c-7bb1-bab2-6008fe428318
 -- !result
 admin set frontend config('mv_fast_schema_change_mode' = 'force');
 -- result:
@@ -86,7 +85,7 @@ cnt_c2	bigint	YES	false	None	NONE
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
-True
+False
 -- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
@@ -105,7 +104,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc136-d46a-720c-8778-5e860ac64900
+019cc25f-84a9-7ec7-b5be-010121fbe635
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -163,7 +162,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc136-e404-73af-ada3-e2a96f4847f4
+019cc25f-95d2-751f-9ea2-60ffef79b27d
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -193,7 +192,7 @@ sum_c6	bigint	YES	false	None	NONE
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
-True
+False
 -- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
@@ -212,7 +211,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc136-f3b4-7b7b-aa9a-76a598299404
+019cc25f-a7f6-748b-b3b6-14493e4cd63e
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -249,7 +248,7 @@ c5	varchar(1048576)	YES	false	None	NONE
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
-True
+False
 -- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
 -- result:
@@ -268,7 +267,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc137-0365-7066-830b-8da1c3857c29
+019cc25f-b754-7a58-a4ed-81c22310c6b7
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -323,7 +322,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc137-12da-7a38-a10b-4d51ea9399eb
+019cc25f-c745-76c0-b2c5-0148e9770224
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -377,7 +376,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc137-2255-7ddc-b005-aa97a233d684
+019cc25f-d5cf-7a18-b76b-3439d26fb969
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
 -- result:
@@ -404,7 +403,7 @@ INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80,
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019cc137-2acf-7f7b-9f43-922ee403a5c4
+019cc25f-dd4d-7a18-8cc1-c422832f090f
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
@@ -461,8 +460,7 @@ CREATE MATERIALIZED VIEW test_mv_agg2
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
@@ -472,7 +470,7 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019cc137-32d1-7c78-b317-fcfb703db698
+019cc25f-e6bf-7085-ad3d-f44ff75198bc
 -- !result
 SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -561,7 +559,7 @@ INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new',
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019cc137-458b-75a9-8c77-16151ccf74ba
+019cc25f-fd14-7681-9c2c-1535f1b90be5
 -- !result
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -623,8 +621,7 @@ CREATE MATERIALIZED VIEW test_mv_agg3
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, c1, SUM(c2) as total_c2
@@ -634,7 +631,7 @@ GROUP BY dt, c0, c1;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019cc137-4de3-74a8-8292-bd3320bed6da
+019cc260-0642-7c3e-9a13-e8ce9699bbb9
 -- !result
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
@@ -712,7 +709,7 @@ INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019cc137-60c2-7297-b252-9ea37b389a1d
+019cc260-1d90-7815-a047-5c1e84a9f812
 -- !result
 function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
 -- result:
@@ -788,8 +785,7 @@ CREATE MATERIALIZED VIEW test_mv_agg4
 PARTITION BY date_trunc('month', dt)
 DISTRIBUTED BY HASH(category_id)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, category_id,
@@ -802,7 +798,7 @@ GROUP BY dt, category_id;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc137-6d8f-73aa-a060-f5121f2994d1
+019cc260-2d19-72cf-b490-16cacbbf2320
 -- !result
 SELECT * FROM test_mv_agg4 ORDER BY ALL;
 -- result:
@@ -859,7 +855,7 @@ INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc137-7c8b-735f-8f73-9dfec514a877
+019cc260-4023-78b9-a7d0-e9676313b0cb
 -- !result
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 -- result:
@@ -909,7 +905,7 @@ INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.0
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019cc137-87da-7eed-9b0f-1f87c57ff1e3
+019cc260-4d53-7e33-bcf1-82314fa6cd61
 -- !result
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
 -- result:

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_with_aggregate
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_with_aggregate
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_with_aggregate @slow @sequential
+-- name: test_mv_fast_schema_change_with_aggregate @sequential @slow
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 -- result:
 -- !result
@@ -14,12 +14,13 @@ drop materialized view if exists test_mv_agg1;
 CREATE TABLE t1_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
-    c2 VARCHAR(200),
+    c1 VARCHAR(20) REPLACE,
+    c2 VARCHAR(200) REPLACE,
     c3 INT SUM,
-    c4 INT SUM
+    c4 INT SUM,
+    row_cnt INT SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1, c2)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0) BUCKETS 48
 PROPERTIES (
@@ -29,7 +30,7 @@ PROPERTIES (
 -- !result
 INSERT INTO t1_agg
 SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
-       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2, 1
 FROM TABLE(generate_series(1, 100));
 -- result:
 -- !result
@@ -41,33 +42,33 @@ PROPERTIES (
     "query_rewrite_consistency" = "force_mv"
 )
 AS
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows
 FROM t1_agg
 GROUP BY dt, c0;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d99-e2ac-7e9f-933c-aa96e623c3b9
+019cd122-0f5b-72bd-a3f7-f35a32f0ccb2
 -- !result
 set enable_materialized_view_rewrite = false;
 -- result:
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
+2026-01-01	0	550	10
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
+2026-01-01	0	550	10
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
 -- result:
@@ -81,49 +82,49 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 cnt_c2	bigint	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1	1
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	550	10	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	550	1	None
-2026-01-01	1	460	1	None
-2026-01-01	2	470	1	None
+2026-01-01	0	550	10	None
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20, 1);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-0932-70e7-986e-9980c98ba35c
+019cd122-2472-7cbe-a97d-5c271e8f80ad
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	560	11	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	560	11	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
-ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100) REPLACE;
 -- result:
 -- !result
 function: wait_alter_table_finish()
@@ -134,11 +135,12 @@ DESC t1_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
+c1	varchar(20)	YES	false	None	
+c2	varchar(200)	YES	false	None	
 c3	int	YES	false	None	
 c4	int	YES	false	None	
+row_cnt	int	YES	false	None	
+c5	varchar(100)	YES	false	None	
 -- !result
 ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
 -- result:
@@ -151,29 +153,30 @@ DESC t1_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
+c1	varchar(20)	YES	false	None	
+c2	varchar(200)	YES	false	None	
 c3	int	YES	false	None	
 c4	int	YES	false	None	
+row_cnt	int	YES	false	None	
+c5	varchar(100)	YES	false	None	
 c6	int	YES	false	None	
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 15, 30, 1, 'desc_2', 25);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-2603-7b4a-906a-dbce58e72224
+019cd122-3390-7d79-99d4-0803acb89d0c
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
+2026-01-01	0	575	12	1
+2026-01-01	1	460	10	1
+2026-01-01	2	470	10	1
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
 -- result:
@@ -187,104 +190,48 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 cnt_c2	bigint	YES	false	None	NONE
 sum_c6	bigint	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3	25
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	575	12	1	25
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	575	3	3	None
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	575	12	1	None
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 20, 40, 1, 'desc_3', 35);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-3e97-71d3-a0c0-a4fa7accdea6
+019cd122-438a-77dd-afb0-c321db424af2
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
+2026-01-01	0	595	13	1	60
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
-ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
--- result:
--- !result
-function: wait_alter_table_finish()
--- result:
-None
--- !result
-DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-cnt_c2	bigint	YES	false	None	NONE
-sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
--- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	595	4	4	60	None
-2026-01-01	1	460	1	1	None	None
-2026-01-01	2	470	1	1	None	None
--- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
--- result:
--- !result
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-5b06-79e2-a705-4ebbf6be15bd
--- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	1	25	desc_2
-2026-01-01	0	20	1	1	35	desc_3
-2026-01-01	0	25	1	1	45	desc_4
+2026-01-01	0	595	13	1	60
+2026-01-01	1	460	10	1	None
+2026-01-01	2	470	10	1	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
 -- result:
@@ -298,48 +245,47 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
+cnt_rows	bigint	YES	true	None	
 sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
+2026-01-01	0	595	13	60
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
+2026-01-01	0	595	13	60
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 30, 60, 1, 'desc_5', 55);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-7ab3-7891-a68d-cfd9340c853a
+019cd122-52f9-7361-890c-ed7e5b6462e5
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
+2026-01-01	0	625	14	115
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
+2026-01-01	0	625	14	115
+2026-01-01	1	460	10	None
+2026-01-01	2	470	10	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
 -- result:
@@ -353,74 +299,46 @@ DESC test_mv_agg1;
 dt	date	YES	true	None	
 c0	int	YES	true	None	
 sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-c5	varchar(1048576)	YES	false	None	NONE
+cnt_rows	bigint	YES	true	None	
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
+2026-01-01	0	625	14
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
+2026-01-01	0	625	14
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 35, 70, 1, 'desc_6', 65);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 -- result:
-019c2d9a-8f6a-7634-b935-2b0f8bcf9cf6
+019cd122-61ed-719c-9e6d-7e6549c31f82
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 -- result:
 True
 -- !result
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
+2026-01-01	0	660	15
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
--- !result
-[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
--- result:
-[REGEX]E:.*
--- !result
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
--- result:
--- !result
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-9791-703b-9cb8-f3b8678a1fc0
--- !result
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	725	8
-2026-01-01	1	460	1
-2026-01-01	2	470	1
--- !result
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
+2026-01-01	0	660	15
+2026-01-01	1	460	10
+2026-01-01	2	470	10
 -- !result
 DROP MATERIALIZED VIEW test_mv_agg1;
 -- result:
@@ -437,13 +355,13 @@ drop materialized view if exists test_mv_agg2;
 CREATE TABLE t2_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 BIGINT SUM,
     c4 VARCHAR(100) REPLACE,
     c5 DOUBLE SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -472,7 +390,7 @@ GROUP BY dt, c0;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019c2d9a-a177-7c42-ada1-8457a8d4227c
+019cd122-6ab0-7875-b5e7-b6e4f7042c2d
 -- !result
 SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
@@ -528,7 +446,7 @@ DESC t2_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
+c1	varchar(20)	YES	false	None	
 c2	int	YES	false	None	
 c3	bigint	YES	false	None	
 c4	varchar(100)	YES	false	None	
@@ -558,11 +476,11 @@ INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new',
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
 -- result:
-019c2d9a-b6c8-70e2-bf2e-45a3873e85d9
+019cd122-7dee-71be-8b7d-dee7c7cccb7f
 -- !result
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	375	27500	1000	74.0	2	50
+2026-01-01	0	375	28500	28500	148.0	1	50
 2026-01-01	1	235	23500	23500	117.5	1	None
 2026-01-01	2	245	24500	24500	122.5	1	None
 -- !result
@@ -598,11 +516,11 @@ drop materialized view if exists test_mv_agg3;
 CREATE TABLE t3_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 VARCHAR(200) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -624,26 +542,26 @@ PROPERTIES (
     "query_rewrite_consistency" = "force_mv"
 )
 AS
-SELECT dt, c0, c1, SUM(c2) as total_c2
+SELECT dt, c0, SUM(c2) as total_c2
 FROM t3_agg
-GROUP BY dt, c0, c1;
+GROUP BY dt, c0;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019c2d9a-bf2f-741a-bda8-61783afb7549
+019cd122-864b-7cd0-aa65-1ea48a10331b
 -- !result
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
+2026-01-01	0	275
+2026-01-01	1	235
+2026-01-01	2	245
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
+2026-01-01	0	275
+2026-01-01	1	235
+2026-01-01	2	245
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
 -- result:
@@ -656,21 +574,20 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 c3_expr	bigint	YES	false	0	NONE
 -- !result
-SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	0
-2026-01-01	1	1	235	0
-2026-01-01	2	1	245	0
+2026-01-01	0	275	0
+2026-01-01	1	235	0
+2026-01-01	2	245	0
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1
-2026-01-01	1	1	235	1
-2026-01-01	2	1	245	1
+2026-01-01	0	275	1
+2026-01-01	1	235	1
+2026-01-01	2	245	1
 -- !result
 ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
 -- result:
@@ -683,7 +600,7 @@ DESC t3_agg;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
+c1	varchar(20)	YES	false	None	
 c2	int	YES	false	None	
 c3	varchar(200)	YES	false	None	
 c4	int	YES	false	None	
@@ -699,8 +616,7 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 c3_expr	bigint	YES	false	0	NONE
 sum_c4	bigint	YES	false	None	NONE
 -- !result
@@ -709,23 +625,23 @@ INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 -- result:
-019c2d9a-d622-7903-a3c7-5e5d80c27a30
+019cd122-98a6-7688-be8d-90c50df1352b
 -- !result
-function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0", "test_mv_agg3")
 -- result:
 True
 -- !result
-SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
+2026-01-01	0	475	1	50
+2026-01-01	1	235	1	None
+2026-01-01	2	245	1	None
 -- !result
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 -- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
+2026-01-01	0	475	1	50
+2026-01-01	1	235	1	None
+2026-01-01	2	245	1	None
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
 -- result:
@@ -738,8 +654,7 @@ DESC test_mv_agg3;
 -- result:
 dt	date	YES	true	None	
 c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
+total_c2	bigint	YES	true	None	
 sum_c4	bigint	YES	false	None	NONE
 -- !result
 DROP MATERIALIZED VIEW test_mv_agg3;
@@ -757,15 +672,15 @@ drop materialized view if exists test_mv_agg4;
 CREATE TABLE t4_agg (
     dt DATE,
     category_id INT,
-    product_id INT,
+    product_id INT REPLACE,
     sales_amount DECIMAL(20, 2) SUM,
     quantity INT SUM,
     discount_amount DECIMAL(20, 2) SUM,
     product_name VARCHAR(100) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, category_id, product_id)
+AGGREGATE KEY(dt, category_id)
 PARTITION BY date_trunc('month', dt)
-DISTRIBUTED BY HASH(product_id) BUCKETS 16
+DISTRIBUTED BY HASH(category_id) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -799,7 +714,7 @@ GROUP BY dt, category_id;
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-e20c-7cb9-afe1-66d0af724132
+019cd122-a566-7053-9bd6-d19fa5579610
 -- !result
 SELECT * FROM test_mv_agg4 ORDER BY ALL;
 -- result:
@@ -828,7 +743,7 @@ DESC t4_agg;
 -- result:
 dt	date	YES	true	None	
 category_id	int	YES	true	None	
-product_id	int	YES	true	None	
+product_id	int	YES	false	None	
 sales_amount	decimal(38,2)	YES	false	None	
 quantity	int	YES	false	None	
 discount_amount	decimal(38,2)	YES	false	None	
@@ -851,12 +766,12 @@ total_quantity	bigint	YES	true	None
 total_discount	decimal(38,2)	YES	false	None	NONE
 total_profit	decimal(38,2)	YES	false	None	NONE
 -- !result
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 'Product C', 1.00);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-f111-7add-9661-aced453a5624
+019cd122-b42d-77db-b19d-436e169802a7
 -- !result
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 -- result:
@@ -865,7 +780,7 @@ SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profi
 2026-01-02	1	1800.25	12	150.00	None
 2026-01-03	3	5000.00	30	500.00	1.00
 -- !result
-ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50) REPLACE;
 -- result:
 -- !result
 function: wait_alter_table_finish()
@@ -876,13 +791,13 @@ DESC t4_agg;
 -- result:
 dt	date	YES	true	None	
 category_id	int	YES	true	None	
-product_id	int	YES	true	None	
-region	varchar(50)	YES	true	None	
+product_id	int	YES	false	None	
 sales_amount	decimal(38,2)	YES	false	None	
 quantity	int	YES	false	None	
 discount_amount	decimal(38,2)	YES	false	None	
 product_name	varchar(100)	YES	false	None	
 profit	decimal(38,2)	YES	false	None	
+region	varchar(50)	YES	false	None	
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
 -- result:
@@ -901,12 +816,12 @@ total_discount	decimal(38,2)	YES	false	None	NONE
 total_profit	decimal(38,2)	YES	false	None	NONE
 region	varchar(1048576)	YES	false	None	NONE
 -- !result
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 0, 0, 0, 'Product C', 0, 'north');
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 -- result:
-019c2d9a-fe97-72a7-83c7-29b6c5ef0744
+019cd122-bfdd-7d1d-a8f1-eec5782f3d7b
 -- !result
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
 -- result:
@@ -918,8 +833,7 @@ FROM test_mv_agg4 ORDER BY dt, category_id, region;
 2026-01-01	1	None	4001.25	25	300.75	None
 2026-01-01	2	None	3000.00	20	300.00	None
 2026-01-02	1	None	1800.25	12	150.00	None
-2026-01-03	3	None	5000.00	30	500.00	1.00
-2026-01-03	3	Product C	5000.00	30	500.00	1.00
+2026-01-03	3	north	5000.00	30	500.00	1.00
 -- !result
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN total_discount;
 -- result:

--- a/test/sql/test_mv/T/test_mv_fast_schema_change
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change
@@ -1,5 +1,6 @@
--- name: test_mv_fast_schema_change
+-- name: test_mv_fast_schema_change @sequential
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+admin set frontend config('mv_fast_schema_change_mode' = 'strict');
 
 drop table if exists t1;
 drop materialized view if exists test_mv1;

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_mode
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_mode @sequential
+-- name: test_mv_fast_schema_change_mode
 
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 
@@ -31,8 +31,7 @@ CREATE MATERIALIZED VIEW test_mv_agg1
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY hash(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
@@ -181,8 +180,7 @@ CREATE MATERIALIZED VIEW test_mv_agg2
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
@@ -255,8 +253,7 @@ CREATE MATERIALIZED VIEW test_mv_agg3
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, c0, c1, SUM(c2) as total_c2
@@ -334,8 +331,7 @@ CREATE MATERIALIZED VIEW test_mv_agg4
 PARTITION BY date_trunc('month', dt)
 DISTRIBUTED BY HASH(category_id)
 PROPERTIES (
-    "replication_num" = "1",
-    "query_rewrite_consistency" = "force_mv"
+    "replication_num" = "1"
 )
 AS
 SELECT dt, category_id,

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_mode
@@ -9,12 +9,13 @@ drop materialized view if exists test_mv_agg1;
 CREATE TABLE t1_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
-    c2 VARCHAR(200),
+    c1 VARCHAR(20) REPLACE,
+    c2 VARCHAR(200) REPLACE,
     c3 INT SUM,
-    c4 INT SUM
+    c4 INT SUM,
+    row_cnt INT SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1, c2)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0) BUCKETS 48
 PROPERTIES (
@@ -23,7 +24,7 @@ PROPERTIES (
 
 INSERT INTO t1_agg
 SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
-       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2, 1
 FROM TABLE(generate_series(1, 100));
 
 -- Create MV on aggregate base table
@@ -34,7 +35,7 @@ PROPERTIES (
     "replication_num" = "1"
 )
 AS
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows
 FROM t1_agg
 GROUP BY dt, c0;
 
@@ -43,108 +44,90 @@ GROUP BY dt, c0;
 admin set frontend config('mv_fast_schema_change_mode' = 'force');
 
 set enable_materialized_view_rewrite = false;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV add aggregation column (count)
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after add column
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20, 1);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
--- Test base table add column (non-aggregation column)
-ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+-- Test base table add aggregation column (REPLACE type)
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100) REPLACE;
 function: wait_alter_table_finish()
 DESC t1_agg;
 
--- Test base table add aggregation column
+-- Test base table add aggregation column (SUM type)
 ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
 function: wait_alter_table_finish()
 DESC t1_agg;
 
 -- Refresh MV and verify existing columns still work
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 15, 30, 1, 'desc_2', 25);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV add column that references new aggregation column
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after add column
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 20, 40, 1, 'desc_3', 35);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-
--- Test MV add group by key column
-ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
-function: wait_alter_table_finish()
-DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-
--- Refresh MV after insert
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop column (drop aggregation column cnt_c2)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 30, 60, 1, 'desc_5', 55);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop aggregation column (drop sum_c6)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 35, 70, 1, 'desc_6', 65);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
--- Test MV drop group by key column (drop c5)
-[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
--- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 40, 80, 1, 'desc_7', 75);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 DROP MATERIALIZED VIEW test_mv_agg1;
@@ -157,13 +140,13 @@ drop materialized view if exists test_mv_agg2;
 CREATE TABLE t2_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 BIGINT SUM,
     c4 VARCHAR(100) REPLACE,
     c5 DOUBLE SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -225,18 +208,18 @@ DESC test_mv_agg2;
 DROP MATERIALIZED VIEW test_mv_agg2;
 DROP TABLE t2_agg;
 
--- Test 3: Aggregate table - MV without group by key column (similar to test_mv_schema_change1 t2)
+-- Test 3: Aggregate table - MV with expression column
 drop table if exists t3_agg;
 drop materialized view if exists test_mv_agg3;
 
 CREATE TABLE t3_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 VARCHAR(200) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -248,7 +231,7 @@ SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARC
        generate_series, 'desc_' || CAST(generate_series AS VARCHAR)
 FROM TABLE(generate_series(1, 50));
 
--- MV without group by key column (similar to test_mv_schema_change1 t2)
+-- MV with dt, c0 only - aggregate by (dt, c0)
 CREATE MATERIALIZED VIEW test_mv_agg3
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
@@ -256,21 +239,21 @@ PROPERTIES (
     "replication_num" = "1"
 )
 AS
-SELECT dt, c0, c1, SUM(c2) as total_c2
+SELECT dt, c0, SUM(c2) as total_c2
 FROM t3_agg
-GROUP BY dt, c0, c1;
+GROUP BY dt, c0;
 
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV add column (expression column)
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
 function: wait_alter_table_finish()
 DESC test_mv_agg3;
-SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Base table add column
 ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
@@ -285,9 +268,9 @@ DESC test_mv_agg3;
 INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 
-function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
-SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0", "test_mv_agg3")
+SELECT dt, c0, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop column
 ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
@@ -297,22 +280,22 @@ DESC test_mv_agg3;
 DROP MATERIALIZED VIEW test_mv_agg3;
 DROP TABLE t3_agg;
 
--- Test 4: Aggregate table - Multiple aggregations and schema evolution
+-- Test 4: Aggregate table - Multiple aggregations and schema evolution (dt, category_id as key)
 drop table if exists t4_agg;
 drop materialized view if exists test_mv_agg4;
 
 CREATE TABLE t4_agg (
     dt DATE,
     category_id INT,
-    product_id INT,
+    product_id INT REPLACE,
     sales_amount DECIMAL(20, 2) SUM,
     quantity INT SUM,
     discount_amount DECIMAL(20, 2) SUM,
     product_name VARCHAR(100) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, category_id, product_id)
+AGGREGATE KEY(dt, category_id)
 PARTITION BY date_trunc('month', dt)
-DISTRIBUTED BY HASH(product_id) BUCKETS 16
+DISTRIBUTED BY HASH(category_id) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -326,7 +309,7 @@ SELECT '2026-01-01', 2, 200, 3000.00, 20, 300.00, 'Product B'
 UNION ALL
 SELECT '2026-01-02', 1, 100, 1800.25, 12, 150.00, 'Product A';
 
--- Create MV with multiple aggregations
+-- Create MV with multiple aggregations (dt, category_id as group by - matches base table key)
 CREATE MATERIALIZED VIEW test_mv_agg4
 PARTITION BY date_trunc('month', dt)
 DISTRIBUTED BY HASH(category_id)
@@ -360,23 +343,23 @@ ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN total_profit AS SUM(profit);
 function: wait_alter_table_finish()
 DESC test_mv_agg4;
 
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 'Product C', 1.00);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 
--- Test: Base table add non-aggregation column
-ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+-- Test: Base table add aggregation column (REPLACE)
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50) REPLACE;
 function: wait_alter_table_finish()
 DESC t4_agg;
 
--- MV add group by column
+-- MV add column referencing REPLACE column
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
 function: wait_alter_table_finish()
 DESC test_mv_agg4;
 
--- Insert with new column
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+-- Insert to set region for existing row (use 0 for SUM columns to avoid double-counting)
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 0, 0, 0, 'Product C', 0, 'north');
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_mode
@@ -1,16 +1,11 @@
--- name: test_mv_fast_schema_change_with_aggregate @slow @sequential
+-- name: test_mv_fast_schema_change_mode @sequential
+
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
--- result:
--- !result
-admin set frontend config('mv_fast_schema_change_mode' = 'strict');
--- result:
--- !result
+
+-- Test 1: Aggregate table with SUM aggregation - MV schema change tests
 drop table if exists t1_agg;
--- result:
--- !result
 drop materialized view if exists test_mv_agg1;
--- result:
--- !result
+
 CREATE TABLE t1_agg (
     dt DATE,
     c0 INT,
@@ -25,14 +20,13 @@ DISTRIBUTED BY HASH(c0) BUCKETS 48
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
+
 INSERT INTO t1_agg
 SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
        'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
 FROM TABLE(generate_series(1, 100));
--- result:
--- !result
+
+-- Create MV on aggregate base table
 CREATE MATERIALIZED VIEW test_mv_agg1
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY hash(c0)
@@ -44,396 +38,123 @@ AS
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
 FROM t1_agg
 GROUP BY dt, c0;
--- result:
--- !result
+
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d99-e2ac-7e9f-933c-aa96e623c3b9
--- !result
+
+admin set frontend config('mv_fast_schema_change_mode' = 'force');
+
 set enable_materialized_view_rewrite = false;
--- result:
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	550	1
-2026-01-01	1	460	1
-2026-01-01	2	470	1
--- !result
+
+-- Test MV add aggregation column (count)
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-cnt_c2	bigint	YES	false	None	NONE
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	550	1	1
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	550	1	None
-2026-01-01	1	460	1	None
-2026-01-01	2	470	1	None
--- !result
+
+-- Refresh MV after add column
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-0932-70e7-986e-9980c98ba35c
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	560	2	2
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
--- !result
+
+-- Test base table add column (non-aggregation column)
 ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t1_agg;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
-c3	int	YES	false	None	
-c4	int	YES	false	None	
--- !result
+
+-- Test base table add aggregation column
 ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t1_agg;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	varchar(200)	YES	true	None	
-c5	varchar(100)	YES	true	None	
-c3	int	YES	false	None	
-c4	int	YES	false	None	
-c6	int	YES	false	None	
--- !result
+
+-- Refresh MV and verify existing columns still work
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-2603-7b4a-906a-dbce58e72224
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	575	3	3
-2026-01-01	1	460	1	1
-2026-01-01	2	470	1	1
--- !result
+
+-- Test MV add column that references new aggregation column
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-cnt_c2	bigint	YES	false	None	NONE
-sum_c6	bigint	YES	false	None	NONE
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	575	3	3	25
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	575	3	3	None
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
+
+-- Refresh MV after add column
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-3e97-71d3-a0c0-a4fa7accdea6
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	595	4	4	60
-2026-01-01	1	460	1	1	None
-2026-01-01	2	470	1	1	None
--- !result
+
+-- Test MV add group by key column
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-cnt_c2	bigint	YES	false	None	NONE
-sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	595	4	4	60	None
-2026-01-01	1	460	1	1	None	None
-2026-01-01	2	470	1	1	None	None
--- !result
+
+-- Refresh MV after insert
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-5b06-79e2-a705-4ebbf6be15bd
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	2	None
-2026-01-01	0	desc_2	15	1	1	25
-2026-01-01	0	desc_3	20	1	1	35
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	1	25	desc_2
-2026-01-01	0	20	1	1	35	desc_3
-2026-01-01	0	25	1	1	45	desc_4
--- !result
+
+-- Test MV drop column (drop aggregation column cnt_c2)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-sum_c6	bigint	YES	false	None	NONE
-c5	varchar(1048576)	YES	false	None	NONE
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
--- !result
+
+-- Refresh MV after drop
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-7ab3-7891-a68d-cfd9340c853a
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2	None
-2026-01-01	0	desc_2	15	1	25
-2026-01-01	0	desc_3	20	1	35
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	25	desc_2
-2026-01-01	0	20	1	35	desc_3
-2026-01-01	0	25	1	45	desc_4
--- !result
+
+-- Test MV drop aggregation column (drop sum_c6)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg1;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c3	bigint	YES	true	None	
-cnt_c1	bigint	NO	true	None	
-c5	varchar(1048576)	YES	false	None	NONE
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
--- !result
+
+-- Refresh MV after drop
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-8f6a-7634-b935-2b0f8bcf9cf6
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	None	560	2
-2026-01-01	0	desc_2	15	1
-2026-01-01	0	desc_3	20	1
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
--- !result
+
+-- Test MV drop group by key column (drop c5)
 [UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
--- result:
-[REGEX]E:.*
--- !result
+-- Refresh MV after drop
 INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
--- result:
-019c2d9a-9791-703b-9cb8-f3b8678a1fc0
--- !result
 function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
--- result:
-True
--- !result
 SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	725	8
-2026-01-01	1	460	1
-2026-01-01	2	470	1
--- !result
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	15	1	desc_2
-2026-01-01	0	20	1	desc_3
-2026-01-01	0	25	1	desc_4
--- !result
+
 DROP MATERIALIZED VIEW test_mv_agg1;
--- result:
--- !result
 DROP TABLE t1_agg;
--- result:
--- !result
+
+-- Test 2: Aggregate table with multiple aggregation types - MV schema change
 drop table if exists t2_agg;
--- result:
--- !result
 drop materialized view if exists test_mv_agg2;
--- result:
--- !result
+
 CREATE TABLE t2_agg (
     dt DATE,
     c0 INT,
@@ -449,14 +170,13 @@ DISTRIBUTED BY HASH(c0)
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
+
 INSERT INTO t2_agg
 SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
        generate_series, generate_series * 100, 'replace_' || CAST(generate_series AS VARCHAR), generate_series * 0.5
 FROM TABLE(generate_series(1, 50));
--- result:
--- !result
+
+-- Create MV on aggregate base table with multiple aggregation functions
 CREATE MATERIALIZED VIEW test_mv_agg2
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
@@ -468,133 +188,49 @@ AS
 SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
 FROM t2_agg
 GROUP BY dt, c0;
--- result:
--- !result
+
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
--- result:
-019c2d9a-a177-7c42-ada1-8457a8d4227c
--- !result
+
 SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	275	27500	27500	137.5
-2026-01-01	1	235	23500	23500	117.5
-2026-01-01	2	245	24500	24500	122.5
--- !result
 SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
 FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	275	27500	27500	137.5
-2026-01-01	1	235	23500	23500	117.5
-2026-01-01	2	245	24500	24500	122.5
--- !result
+
+admin set frontend config('mv_fast_schema_change_mode' = 'force_no_clear');
+-- Test MV add column with new aggregation
 ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN cnt_c1 AS COUNT(c1);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg2;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c2	bigint	YES	true	None	
-max_c3	bigint	YES	true	None	
-min_c3	bigint	YES	true	None	
-avg_c5	double	YES	false	None	NONE
-cnt_c1	bigint	YES	false	None	NONE
--- !result
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	275	27500	27500	137.5	None
-2026-01-01	1	235	23500	23500	117.5	None
-2026-01-01	2	245	24500	24500	122.5	None
--- !result
 SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5, COUNT(c1) as cnt_c1
 FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	275	27500	27500	137.5	1
-2026-01-01	1	235	23500	23500	117.5	1
-2026-01-01	2	245	24500	24500	122.5	1
--- !result
+
+-- Base table add aggregation column
 ALTER TABLE t2_agg ADD COLUMN c6 INT MAX;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t2_agg;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	int	YES	false	None	
-c3	bigint	YES	false	None	
-c4	varchar(100)	YES	false	None	
-c5	double	YES	false	None	
-c6	int	YES	false	None	
--- !result
+
+-- MV add column referencing new MAX aggregation
 ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN max_c6 AS MAX(c6);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg2;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c2	bigint	YES	true	None	
-max_c3	bigint	YES	true	None	
-min_c3	bigint	YES	true	None	
-avg_c5	double	YES	false	None	NONE
-cnt_c1	bigint	YES	false	None	NONE
-max_c6	int	YES	false	None	NONE
--- !result
+
 INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new', 10.5, 50);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
--- result:
-019c2d9a-b6c8-70e2-bf2e-45a3873e85d9
--- !result
+
 SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	375	27500	1000	74.0	2	50
-2026-01-01	1	235	23500	23500	117.5	1	None
-2026-01-01	2	245	24500	24500	122.5	1	None
--- !result
+
+-- Test MV drop column
 ALTER MATERIALIZED VIEW test_mv_agg2 DROP COLUMN cnt_c1;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg2;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-sum_c2	bigint	YES	true	None	
-max_c3	bigint	YES	true	None	
-min_c3	bigint	YES	true	None	
-avg_c5	double	YES	false	None	NONE
-max_c6	int	YES	false	None	NONE
--- !result
+
 DROP MATERIALIZED VIEW test_mv_agg2;
--- result:
--- !result
 DROP TABLE t2_agg;
--- result:
--- !result
+
+-- Test 3: Aggregate table - MV without group by key column (similar to test_mv_schema_change1 t2)
 drop table if exists t3_agg;
--- result:
--- !result
 drop materialized view if exists test_mv_agg3;
--- result:
--- !result
+
 CREATE TABLE t3_agg (
     dt DATE,
     c0 INT,
@@ -608,14 +244,13 @@ DISTRIBUTED BY HASH(c0)
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
+
 INSERT INTO t3_agg
 SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
        generate_series, 'desc_' || CAST(generate_series AS VARCHAR)
 FROM TABLE(generate_series(1, 50));
--- result:
--- !result
+
+-- MV without group by key column (similar to test_mv_schema_change1 t2)
 CREATE MATERIALIZED VIEW test_mv_agg3
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
@@ -627,133 +262,48 @@ AS
 SELECT dt, c0, c1, SUM(c2) as total_c2
 FROM t3_agg
 GROUP BY dt, c0, c1;
--- result:
--- !result
+
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
--- result:
-019c2d9a-bf2f-741a-bda8-61783afb7549
--- !result
+
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
--- !result
 SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275
-2026-01-01	1	1	235
-2026-01-01	2	1	245
--- !result
+
+-- Test MV add column (expression column)
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg3;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
-c3_expr	bigint	YES	false	0	NONE
--- !result
 SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275	0
-2026-01-01	1	1	235	0
-2026-01-01	2	1	245	0
--- !result
 SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275	1
-2026-01-01	1	1	235	1
-2026-01-01	2	1	245	1
--- !result
+
+-- Base table add column
 ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t3_agg;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(20)	YES	true	None	
-c2	int	YES	false	None	
-c3	varchar(200)	YES	false	None	
-c4	int	YES	false	None	
--- !result
+
+-- MV add column referencing new aggregation
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN sum_c4 AS SUM(c4);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg3;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
-c3_expr	bigint	YES	false	0	NONE
-sum_c4	bigint	YES	false	None	NONE
--- !result
+
 INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
--- result:
-019c2d9a-d622-7903-a3c7-5e5d80c27a30
--- !result
+
 function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
--- result:
-True
--- !result
 SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
--- !result
 SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
--- result:
-2026-01-01	0	1	275	1	None
-2026-01-01	0	new_val	200	1	50
-2026-01-01	1	1	235	1	None
--- !result
+
+-- Test MV drop column
 ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg3;
--- result:
-dt	date	YES	true	None	
-c0	int	YES	true	None	
-c1	varchar(1048576)	YES	true	None	
-total_c2	bigint	YES	false	None	NONE
-sum_c4	bigint	YES	false	None	NONE
--- !result
+
 DROP MATERIALIZED VIEW test_mv_agg3;
--- result:
--- !result
 DROP TABLE t3_agg;
--- result:
--- !result
+
+-- Test 4: Aggregate table - Multiple aggregations and schema evolution
 drop table if exists t4_agg;
--- result:
--- !result
 drop materialized view if exists test_mv_agg4;
--- result:
--- !result
+
 CREATE TABLE t4_agg (
     dt DATE,
     category_id INT,
@@ -769,8 +319,7 @@ DISTRIBUTED BY HASH(product_id) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
--- result:
--- !result
+
 INSERT INTO t4_agg
 SELECT '2026-01-01', 1, 100, 1500.50, 10, 100.25, 'Product A'
 UNION ALL
@@ -779,8 +328,8 @@ UNION ALL
 SELECT '2026-01-01', 2, 200, 3000.00, 20, 300.00, 'Product B'
 UNION ALL
 SELECT '2026-01-02', 1, 100, 1800.25, 12, 150.00, 'Product A';
--- result:
--- !result
+
+-- Create MV with multiple aggregations
 CREATE MATERIALIZED VIEW test_mv_agg4
 PARTITION BY date_trunc('month', dt)
 DISTRIBUTED BY HASH(category_id)
@@ -795,168 +344,59 @@ SELECT dt, category_id,
        SUM(discount_amount) as total_discount
 FROM t4_agg
 GROUP BY dt, category_id;
--- result:
--- !result
+
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
--- result:
-019c2d9a-e20c-7cb9-afe1-66d0af724132
--- !result
+
 SELECT * FROM test_mv_agg4 ORDER BY ALL;
--- result:
-2026-01-01	1	4001.25	25	300.75
-2026-01-01	2	3000.00	20	300.00
-2026-01-02	1	1800.25	12	150.00
--- !result
 SELECT dt, category_id,
        SUM(sales_amount) as total_sales,
        SUM(quantity) as total_quantity,
        SUM(discount_amount) as total_discount
 FROM t4_agg GROUP BY dt, category_id ORDER BY dt, category_id;
--- result:
-2026-01-01	1	4001.25	25	300.75
-2026-01-01	2	3000.00	20	300.00
-2026-01-02	1	1800.25	12	150.00
--- !result
+
+-- Test: Base table add aggregation column
 ALTER TABLE t4_agg ADD COLUMN profit DECIMAL(20, 2) SUM;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t4_agg;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-product_id	int	YES	true	None	
-sales_amount	decimal(38,2)	YES	false	None	
-quantity	int	YES	false	None	
-discount_amount	decimal(38,2)	YES	false	None	
-product_name	varchar(100)	YES	false	None	
-profit	decimal(38,2)	YES	false	None	
--- !result
+
+-- MV add column referencing new aggregation
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN total_profit AS SUM(profit);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg4;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-total_sales	decimal(38,2)	YES	true	None	
-total_quantity	bigint	YES	true	None	
-total_discount	decimal(38,2)	YES	false	None	NONE
-total_profit	decimal(38,2)	YES	false	None	NONE
--- !result
+
 INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
--- result:
-019c2d9a-f111-7add-9661-aced453a5624
--- !result
+
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
--- result:
-2026-01-01	1	4001.25	25	300.75	None
-2026-01-01	2	3000.00	20	300.00	None
-2026-01-02	1	1800.25	12	150.00	None
-2026-01-03	3	5000.00	30	500.00	1.00
--- !result
+
+-- Test: Base table add non-aggregation column
 ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC t4_agg;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-product_id	int	YES	true	None	
-region	varchar(50)	YES	true	None	
-sales_amount	decimal(38,2)	YES	false	None	
-quantity	int	YES	false	None	
-discount_amount	decimal(38,2)	YES	false	None	
-product_name	varchar(100)	YES	false	None	
-profit	decimal(38,2)	YES	false	None	
--- !result
+
+-- MV add group by column
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg4;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-total_sales	decimal(38,2)	YES	true	None	
-total_quantity	bigint	YES	true	None	
-total_discount	decimal(38,2)	YES	false	None	NONE
-total_profit	decimal(38,2)	YES	false	None	NONE
-region	varchar(1048576)	YES	false	None	NONE
--- !result
+
+-- Insert with new column
 INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
--- result:
--- !result
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
--- result:
-019c2d9a-fe97-72a7-83c7-29b6c5ef0744
--- !result
+
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
--- result:
-True
--- !result
 SELECT dt, category_id, region, total_sales, total_quantity, total_discount, total_profit
 FROM test_mv_agg4 ORDER BY dt, category_id, region;
--- result:
-2026-01-01	1	None	4001.25	25	300.75	None
-2026-01-01	2	None	3000.00	20	300.00	None
-2026-01-02	1	None	1800.25	12	150.00	None
-2026-01-03	3	None	5000.00	30	500.00	1.00
-2026-01-03	3	Product C	5000.00	30	500.00	1.00
--- !result
+
+-- Test drop MV columns
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN total_discount;
--- result:
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg4;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-total_sales	decimal(38,2)	YES	true	None	
-total_quantity	bigint	YES	true	None	
-total_profit	decimal(38,2)	YES	false	None	NONE
-region	varchar(1048576)	YES	false	None	NONE
--- !result
+
 ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN region;
--- result:
-[REGEX]E:.*
--- !result
 function: wait_alter_table_finish()
--- result:
-None
--- !result
 DESC test_mv_agg4;
--- result:
-dt	date	YES	true	None	
-category_id	int	YES	true	None	
-total_sales	decimal(38,2)	YES	true	None	
-total_quantity	bigint	YES	true	None	
-total_profit	decimal(38,2)	YES	false	None	NONE
-region	varchar(1048576)	YES	false	None	NONE
--- !result
+
 DROP MATERIALIZED VIEW test_mv_agg4;
--- result:
--- !result
 DROP TABLE t4_agg;
--- result:
--- !result
+
+admin set frontend config('mv_fast_schema_change_mode' = 'strict');

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_mode
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_mode
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_mode
+-- name: test_mv_fast_schema_change_mode @sequential
 
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
@@ -1,6 +1,7 @@
--- name: test_mv_fast_schema_change_with_aggregate @slow
+-- name: test_mv_fast_schema_change_with_aggregate @slow @sequential
 
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+admin set frontend config('mv_fast_schema_change_mode' = 'strict');
 
 -- Test 1: Aggregate table with SUM aggregation - MV schema change tests
 drop table if exists t1_agg;

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
@@ -1,4 +1,4 @@
--- name: test_mv_fast_schema_change_with_aggregate @slow @sequential
+-- name: test_mv_fast_schema_change_with_aggregate @sequential @slow
 
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 admin set frontend config('mv_fast_schema_change_mode' = 'strict');
@@ -10,12 +10,13 @@ drop materialized view if exists test_mv_agg1;
 CREATE TABLE t1_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
-    c2 VARCHAR(200),
+    c1 VARCHAR(20) REPLACE,
+    c2 VARCHAR(200) REPLACE,
     c3 INT SUM,
-    c4 INT SUM
+    c4 INT SUM,
+    row_cnt INT SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1, c2)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0) BUCKETS 48
 PROPERTIES (
@@ -24,7 +25,7 @@ PROPERTIES (
 
 INSERT INTO t1_agg
 SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
-       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2, 1
 FROM TABLE(generate_series(1, 100));
 
 -- Create MV on aggregate base table
@@ -36,115 +37,91 @@ PROPERTIES (
     "query_rewrite_consistency" = "force_mv"
 )
 AS
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows
 FROM t1_agg
 GROUP BY dt, c0;
 
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
 
 set enable_materialized_view_rewrite = false;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
--- Test MV add aggregation column (count)
+-- Test MV add aggregation column (count on c2 via SUM of 1s - use cnt_c2 as COUNT for compatibility)
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after add column
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20, 1);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
--- Test base table add column (non-aggregation column)
-ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+-- Test base table add aggregation column (REPLACE type)
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100) REPLACE;
 function: wait_alter_table_finish()
 DESC t1_agg;
 
--- Test base table add aggregation column
+-- Test base table add aggregation column (SUM type)
 ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
 function: wait_alter_table_finish()
 DESC t1_agg;
 
 -- Refresh MV and verify existing columns still work
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 15, 30, 1, 'desc_2', 25);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV add column that references new aggregation column
 ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after add column
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 20, 40, 1, 'desc_3', 35);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-
--- Test MV add group by key column
-ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
-function: wait_alter_table_finish()
-DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-
--- Refresh MV after insert
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop column (drop aggregation column cnt_c2)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 30, 60, 1, 'desc_5', 55);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop aggregation column (drop sum_c6)
 ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
 function: wait_alter_table_finish()
 DESC test_mv_agg1;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 -- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 35, 70, 1, 'desc_6', 65);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
-SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
-SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
-
--- Test MV drop group by key column (drop c5)
-[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
--- Refresh MV after drop
-INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
-[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
-function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
-SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), SUM(row_cnt) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, SUM(row_cnt) as cnt_rows FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
 
 DROP MATERIALIZED VIEW test_mv_agg1;
@@ -157,13 +134,13 @@ drop materialized view if exists test_mv_agg2;
 CREATE TABLE t2_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 BIGINT SUM,
     c4 VARCHAR(100) REPLACE,
     c5 DOUBLE SUM
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -225,18 +202,18 @@ DESC test_mv_agg2;
 DROP MATERIALIZED VIEW test_mv_agg2;
 DROP TABLE t2_agg;
 
--- Test 3: Aggregate table - MV without group by key column (similar to test_mv_schema_change1 t2)
+-- Test 3: Aggregate table - MV with expression column (approx_count_distinct)
 drop table if exists t3_agg;
 drop materialized view if exists test_mv_agg3;
 
 CREATE TABLE t3_agg (
     dt DATE,
     c0 INT,
-    c1 VARCHAR(20),
+    c1 VARCHAR(20) REPLACE,
     c2 INT SUM,
     c3 VARCHAR(200) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, c0, c1)
+AGGREGATE KEY(dt, c0)
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
 PROPERTIES (
@@ -248,7 +225,7 @@ SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARC
        generate_series, 'desc_' || CAST(generate_series AS VARCHAR)
 FROM TABLE(generate_series(1, 50));
 
--- MV without group by key column (similar to test_mv_schema_change1 t2)
+-- MV with dt, c0 only - aggregate by (dt, c0)
 CREATE MATERIALIZED VIEW test_mv_agg3
 PARTITION BY date_trunc('day', dt)
 DISTRIBUTED BY HASH(c0)
@@ -257,21 +234,21 @@ PROPERTIES (
     "query_rewrite_consistency" = "force_mv"
 )
 AS
-SELECT dt, c0, c1, SUM(c2) as total_c2
+SELECT dt, c0, SUM(c2) as total_c2
 FROM t3_agg
-GROUP BY dt, c0, c1;
+GROUP BY dt, c0;
 
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 
 SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV add column (expression column)
 ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
 function: wait_alter_table_finish()
 DESC test_mv_agg3;
-SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Base table add column
 ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
@@ -286,9 +263,9 @@ DESC test_mv_agg3;
 INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
 
-function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
-SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
-SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0", "test_mv_agg3")
+SELECT dt, c0, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
 
 -- Test MV drop column
 ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
@@ -298,22 +275,22 @@ DESC test_mv_agg3;
 DROP MATERIALIZED VIEW test_mv_agg3;
 DROP TABLE t3_agg;
 
--- Test 4: Aggregate table - Multiple aggregations and schema evolution
+-- Test 4: Aggregate table - Multiple aggregations and schema evolution (dt, category_id as key)
 drop table if exists t4_agg;
 drop materialized view if exists test_mv_agg4;
 
 CREATE TABLE t4_agg (
     dt DATE,
     category_id INT,
-    product_id INT,
+    product_id INT REPLACE,
     sales_amount DECIMAL(20, 2) SUM,
     quantity INT SUM,
     discount_amount DECIMAL(20, 2) SUM,
     product_name VARCHAR(100) REPLACE
 ) ENGINE=OLAP
-AGGREGATE KEY(dt, category_id, product_id)
+AGGREGATE KEY(dt, category_id)
 PARTITION BY date_trunc('month', dt)
-DISTRIBUTED BY HASH(product_id) BUCKETS 16
+DISTRIBUTED BY HASH(category_id) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
@@ -327,7 +304,7 @@ SELECT '2026-01-01', 2, 200, 3000.00, 20, 300.00, 'Product B'
 UNION ALL
 SELECT '2026-01-02', 1, 100, 1800.25, 12, 150.00, 'Product A';
 
--- Create MV with multiple aggregations
+-- Create MV with multiple aggregations (dt, category_id as group by - matches base table key)
 CREATE MATERIALIZED VIEW test_mv_agg4
 PARTITION BY date_trunc('month', dt)
 DISTRIBUTED BY HASH(category_id)
@@ -362,23 +339,23 @@ ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN total_profit AS SUM(profit);
 function: wait_alter_table_finish()
 DESC test_mv_agg4;
 
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 'Product C', 1.00);
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 
 SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
 
--- Test: Base table add non-aggregation column
-ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+-- Test: Base table add aggregation column (REPLACE)
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50) REPLACE;
 function: wait_alter_table_finish()
 DESC t4_agg;
 
--- MV add group by column
+-- MV add column referencing REPLACE column (as aggregation result - REPLACE gives one value per group)
 ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
 function: wait_alter_table_finish()
 DESC test_mv_agg4;
 
--- Insert with new column
-INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+-- Insert to set region for existing row (use 0 for SUM columns to avoid double-counting)
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 0, 0, 0, 'Product C', 0, 'north');
 [UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
 
 function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
@@ -396,4 +373,3 @@ DESC test_mv_agg4;
 
 DROP MATERIALIZED VIEW test_mv_agg4;
 DROP TABLE t4_agg;
-


### PR DESCRIPTION
## Why I'm doing:

This pull request refactors the handling of schema change jobs for Lake tables and materialized views in the codebase. The main goal is to generalize logic to work with the parent class `OlapTable` instead of the more specific `LakeTable`, making the code more flexible and maintainable. Additionally, it introduces new configuration-based controls for fast schema evolution in materialized views, including force and partition-clearing modes.

Key changes include:

**Generalization to OlapTable:**

* Refactored `LakeTableAlterMetaJobBase` and related classes to use `OlapTable` as the primary type instead of `LakeTable`, allowing support for both `LakeTable` and `LakeMaterializedView` [[1]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9R103-R120) [[2]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L115-R132) [[3]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L149-R173) [[4]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L179-R196) [[5]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L231-R248) [[6]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L264-R281) [[7]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L332-R349) [[8]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L437-R454) [[9]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L449-R466) [[10]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L481-R498) [[11]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L554-R571) [[12]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L595-R612) [[13]](diffhunk://#diff-0c6c730a0868d875ba7284e1534852c2a0cda312141074be4c43bdbb3ab8a1efL108-R108) [[14]](diffhunk://#diff-5a832c41beb53b607ed7325902b745fae300debf79376e0987f0fa5fb897ad5fL142-R149) [[15]](diffhunk://#diff-5a832c41beb53b607ed7325902b745fae300debf79376e0987f0fa5fb897ad5fL166-R171).
* Added helper methods `getOlapTable` to safely retrieve tables as `OlapTable` for use in job execution and catalog updates.

**Materialized View Fast Schema Evolution Controls:**

* Added new configuration checks: `isMvFastSchemaChangeForceMode` and `isMvFastSchemaChangeClearPartition`, enabling "force" and "force_no_clear" modes for fast schema evolution and controlling whether partition version maps are cleared.
* Updated logic to allow schema changes under force mode even if the base column's creation time is unknown or all partitions are affected, bypassing previous restrictions [[1]](diffhunk://#diff-00aa3dcf5aaa2f891fbf8aeb40f13d30052ce4e51658d21e2c23cbac02dbdcd7L779-R779) [[2]](diffhunk://#diff-00aa3dcf5aaa2f891fbf8aeb40f13d30052ce4e51658d21e2c23cbac02dbdcd7L886-R885) [[3]](diffhunk://#diff-00aa3dcf5aaa2f891fbf8aeb40f13d30052ce4e51658d21e2c23cbac02dbdcd7L899-R898).
* Implemented conditional clearing of affected partition entries in the version map based on the new config, ensuring correct MV refresh behavior.

**Miscellaneous Improvements:**

* Updated the logic for enabling/disabling fast schema evolution in both `LakeTable` and `LakeMaterializedView` using a new helper method for consistency.
* Minor import cleanups and type updates to match the new abstractions [[1]](diffhunk://#diff-0c6c730a0868d875ba7284e1534852c2a0cda312141074be4c43bdbb3ab8a1efR20-L22) [[2]](diffhunk://#diff-68e13a7c792fcacb29b5454d6e314e2f012e8bad03713779812a49484e472ea9L36) [[3]](diffhunk://#diff-5a832c41beb53b607ed7325902b745fae300debf79376e0987f0fa5fb897ad5fR25-R31).

These changes improve code maintainability, extend schema change support to more table types, and add fine-grained control over materialized view schema evolution behavior.


## What I'm doing:
This is a followup #67915

https://github.com/StarRocks/starrocks/issues/67914


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4