### PR TITLE
[Enhancement] Support EXPLAIN for query queue visibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1068,6 +1068,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_DESENSITIZE_EXPLAIN = "enable_desensitize_explain";
 
+    /**
+     * When true, EXPLAIN output may include extended sections (e.g. query queue info at COSTS/VERBOSE level).
+     * Extensible for future explain-related features. Default false to preserve original explain output.
+     */
+    public static final String ENABLE_EXTENDED_EXPLAIN = "enable_extended_explain";
+
     public static final String ENABLE_FULL_SORT_USE_GERMAN_STRING = "enable_full_sort_use_german_string";
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
@@ -1245,6 +1251,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Toggle ANSI color in explain output
     @VariableMgr.VarAttr(name = COLOR_EXPLAIN_OUTPUT)
     private boolean colorExplainOutput = true;
+
+    // When true, EXPLAIN may include extended sections (e.g. query queue info). Extensible for other features.
+    @VariableMgr.VarAttr(name = ENABLE_EXTENDED_EXPLAIN)
+    private boolean enableExtendedExplain = false;
 
     @VariableMgr.VarAttr(name = ENABLE_METADATA_PROFILE)
     private boolean enableMetadataProfile = false;
@@ -3663,6 +3673,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getColorExplainOutput() {
         return colorExplainOutput;
+    }
+
+    public boolean isEnableExtendedExplain() {
+        return enableExtendedExplain;
+    }
+
+    public void setEnableExtendedExplain(boolean enableExtendedExplain) {
+        this.enableExtendedExplain = enableExtendedExplain;
     }
 
     public boolean isEnableLoadProfile() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -136,6 +136,12 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.FeExecuteCoordinator;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
+import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.qe.scheduler.slot.BaseSlotManager;
+import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
+import com.starrocks.qe.scheduler.slot.LogicalSlot;
+import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
+import com.starrocks.qe.scheduler.slot.SlotEstimatorFactory;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.GracefulExitFlag;
 import com.starrocks.server.WarehouseManager;
@@ -253,6 +259,7 @@ import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TUniqueId;
@@ -2549,12 +2556,117 @@ public class StmtExecutor {
             if (optimizedRecord != null) {
                 explainString += optimizedRecord.getExplainString();
             }
+            if (context.getSessionVariable().isEnableExtendedExplain() && execPlan != null
+                    && (explainLevel == StatementBase.ExplainLevel.COSTS
+                    || explainLevel == StatementBase.ExplainLevel.VERBOSE)) {
+                explainString += buildQueryQueueExplainString(execPlan, context, queryType);
+            }
             if (execPlan != null) {
                 explainString += execPlan.getExplainString(explainLevel);
             }
         }
 
         return explainString;
+    }
+
+    private static String buildQueryQueueExplainString(ExecPlan execPlan, ConnectContext context,
+                                                       ResourceGroupClassifier.QueryType queryType) {
+        if (execPlan == null || context == null) {
+            return "";
+        }
+
+        BaseSlotManager slotManager = GlobalStateMgr.getCurrentState().getSlotManager();
+        if (slotManager == null) {
+            return "";
+        }
+
+        try {
+            TQueryType tQueryType = queryType == ResourceGroupClassifier.QueryType.INSERT
+                    ? TQueryType.LOAD
+                    : TQueryType.SELECT;
+            JobSpec jobSpec = JobSpec.Factory.fromQuerySpec(context, execPlan.getFragments(),
+                    execPlan.getScanNodes(), execPlan.getDescTbl().toThrift(), tQueryType, execPlan);
+
+            long warehouseId = context.getCurrentWarehouseId();
+            BaseSlotTracker slotTracker = slotManager.getSlotTracker(warehouseId);
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv(warehouseId);
+
+            boolean enableQueue = jobSpec.isEnableQueue();
+            boolean needQueued = jobSpec.isNeedQueued();
+            boolean queryQueueEnabled = enableQueue && needQueued;
+
+            int estimatedSlots = SlotEstimatorFactory.estimateSlotsForExplain(opts, context, execPlan);
+            TWorkGroup resourceGroup = CoordinatorPreprocessor.prepareResourceGroup(context, queryType);
+            long groupId = resourceGroup == null ? LogicalSlot.ABSENT_GROUP_ID : resourceGroup.getId();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("QUERY QUEUE\n");
+            sb.append("  Enabled: ").append(queryQueueEnabled);
+            if (!enableQueue) {
+                sb.append(" (disabled by config/session)");
+            } else if (!needQueued) {
+                sb.append(" (query not subject to queue)");
+            }
+            sb.append("\n");
+            sb.append("  Version: ").append(opts.isEnableQueryQueueV2() ? "v2" : "v1").append("\n");
+            sb.append("  Estimated slots: ").append(queryQueueEnabled ? estimatedSlots : "N/A").append("\n");
+            sb.append("  Warehouse: ").append(warehouseId);
+            if (slotTracker != null) {
+                String warehouseName = slotTracker.getWarehouseName();
+                if (!warehouseName.isEmpty()) {
+                    sb.append(" (").append(warehouseName).append(")");
+                }
+            }
+            sb.append("\n");
+            if (opts.isEnableQueryQueueV2()) {
+                sb.append("  Capacity: total_slots=").append(opts.v2().getTotalSlots())
+                        .append(", total_small_slots=").append(opts.v2().getTotalSmallSlots())
+                        .append(", num_workers=").append(opts.v2().getNumWorkers()).append("\n");
+            } else {
+                int concurrencyLimit = slotManager.getQueryQueueConcurrencyLimit(warehouseId);
+                sb.append("  Capacity: concurrency_limit=")
+                        .append(concurrencyLimit < 0 ? "unlimited" : concurrencyLimit)
+                        .append("\n");
+            }
+            if (slotTracker != null) {
+                sb.append("  Load: running_queries=").append(slotTracker.getCurrentCurrency())
+                        .append(", running_slots=").append(slotTracker.getNumAllocatedSlots())
+                        .append(", pending_queries=").append(slotTracker.getQueuePendingLength());
+                if (opts.isEnableQueryQueueV2()) {
+                    slotTracker.getSumRequiredSlots().ifPresent(sum -> sb.append(", pending_slots=").append(sum));
+                    slotTracker.getMaxRequiredSlots().ifPresent(max -> sb.append(", max_pending_slots=").append(max));
+                }
+                sb.append("\n");
+                if (opts.isEnableQueryQueueV2()) {
+                    int remaining = Math.max(0, opts.v2().getTotalSlots() - slotTracker.getNumAllocatedSlots());
+                    sb.append("  Remaining slots: ").append(remaining).append("\n");
+                } else {
+                    int concurrencyLimit = slotManager.getQueryQueueConcurrencyLimit(warehouseId);
+                    if (concurrencyLimit >= 0) {
+                        int remaining = Math.max(0, concurrencyLimit - slotTracker.getCurrentCurrency());
+                        sb.append("  Remaining slots: ").append(remaining).append("\n");
+                    }
+                }
+            }
+            sb.append("  Limits: max_queued_queries=").append(slotManager.getQueryQueueMaxQueuedQueries(warehouseId))
+                    .append(", pending_timeout_s=").append(slotManager.getQueryQueuePendingTimeoutSecond(warehouseId))
+                    .append("\n");
+            sb.append("  Resource overloaded: global=")
+                    .append(slotManager.getResourceUsageMonitor().isGlobalResourceOverloaded());
+            if (groupId != LogicalSlot.ABSENT_GROUP_ID) {
+                sb.append(", group=").append(slotManager.getResourceUsageMonitor().isGroupResourceOverloaded(groupId));
+            }
+            sb.append("\n");
+            if (opts.isEnableQueryQueueV2()) {
+                sb.append("  Schedule policy: ").append(opts.getPolicy()).append("\n");
+            }
+            sb.append("\n");
+
+            return sb.toString();
+        } catch (Exception e) {
+            LOG.warn("Failed to build query queue explain info.", e);
+            return "";
+        }
     }
 
     private void handleDdlStmt() throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
@@ -25,6 +25,7 @@ import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.sql.optimizer.cost.feature.CostPredictor;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import org.apache.commons.lang3.EnumUtils;
@@ -81,6 +82,167 @@ public class SlotEstimatorFactory {
             policy = EstimatorPolicy.createDefault();
         }
         return policy.createEstimator();
+    }
+
+    /**
+     * Estimate slots for EXPLAIN output when we only have ExecPlan (not DefaultCoordinator).
+     * This is used for query queue information in EXPLAIN.
+     */
+    public static int estimateSlotsForExplain(QueryQueueOptions opts, ConnectContext context, ExecPlan execPlan) {
+        if (!opts.isEnableQueryQueueV2()) {
+            return 1;
+        }
+
+        EstimatorPolicy policy = EstimatorPolicy.create(Config.query_queue_slots_estimator_strategy);
+        if (policy == null) {
+            policy = EstimatorPolicy.createDefault();
+        }
+
+        // For explain, we use a simplified estimation based on ExecPlan
+        // Memory-based estimation uses audit event costs (fallback path)
+        // Parallelism-based estimation uses fragments from ExecPlan
+        return estimateSlotsFromExecPlan(opts, context, execPlan, policy);
+    }
+
+    private static int estimateSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context, ExecPlan execPlan,
+                                                  EstimatorPolicy policy) {
+        int memBasedSlots = estimateMemoryBasedSlotsFromExecPlan(opts, context);
+        int parallelBasedSlots = estimateParallelismBasedSlotsFromExecPlan(opts, context, execPlan);
+
+        switch (policy) {
+            case MBE:
+                return memBasedSlots;
+            case PBE:
+                return parallelBasedSlots;
+            case MIN:
+                return Math.min(memBasedSlots, parallelBasedSlots);
+            case MAX:
+            default:
+                return Math.max(memBasedSlots, parallelBasedSlots);
+        }
+    }
+
+    private static int estimateMemoryBasedSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context) {
+        // Use audit event costs as fallback (same as MemoryBasedSlotsEstimator without predicted cost)
+        long memCost = (long) Math.max(context.getAuditEventBuilder().build().planMemCosts,
+                context.getAuditEventBuilder().build().planCpuCosts);
+        long numSlotsPerWorker = memCost / opts.v2().getMemBytesPerSlot();
+        numSlotsPerWorker = Math.max(numSlotsPerWorker, 0);
+        numSlotsPerWorker = computeMinGEPower2((int) numSlotsPerWorker);
+
+        long numSlots = numSlotsPerWorker * opts.v2().getNumWorkers();
+        numSlots = Math.max(numSlots, 1);
+        numSlots = Math.min(numSlots, opts.v2().getTotalSlots());
+
+        return (int) numSlots;
+    }
+
+    private static int estimateParallelismBasedSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context,
+                                                                  ExecPlan execPlan) {
+        List<PlanFragment> fragments = execPlan.getFragments();
+        if (fragments == null || fragments.isEmpty()) {
+            return 1;
+        }
+
+        PlanFragment rootFragment = fragments.get(0);
+        PlanNode rootNode = rootFragment.getPlanRoot();
+        Map<PlanFragmentId, FragmentContext> contexts = Maps.newHashMap();
+        collectFragmentSourceNodes(rootNode, contexts);
+        calculateFragmentWorkers(opts, rootFragment, contexts);
+
+        int numSlots = contexts.values().stream()
+                .mapToInt(fragmentContext -> estimateFragmentSlots(opts, fragmentContext))
+                .max().orElse(1);
+
+        // Apply CPU-cost clamp like ParallelismBasedSlotsEstimator does
+        final int numWorkers = contexts.values().stream()
+                .mapToInt(fragmentContext -> fragmentContext.numWorkers)
+                .max().orElse(1);
+        final long planCpuCosts = (long) context.getAuditEventBuilder().build().planCpuCosts;
+        int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getCpuCostsPerSlot());
+        numSlotsByCpuCosts = Math.max(1, numSlotsByCpuCosts / numWorkers) * numWorkers;
+
+        // Restrict numSlotsByCpuCosts to be within [numSlots / 2, numSlots].
+        return Math.min(Math.max(numSlots / 2, numSlotsByCpuCosts), numSlots);
+    }
+
+    private static int estimateFragmentSlots(QueryQueueOptions opts, FragmentContext context) {
+        int numSlots = 1;
+        for (PlanNode sourceNode : context.sourceNodes) {
+            int curNumSlots = estimateNumSlotsBySourceNode(opts, sourceNode);
+
+            curNumSlots /= context.numWorkers;
+            curNumSlots = Math.max(curNumSlots, 1);
+            curNumSlots = Math.min(curNumSlots, context.fragment.getPipelineDop());
+
+            curNumSlots *= context.numWorkers;
+            curNumSlots = Math.min(curNumSlots, opts.v2().getTotalSlots());
+
+            numSlots = Math.max(numSlots, curNumSlots);
+        }
+        return numSlots;
+    }
+
+    private static int estimateNumSlotsBySourceNode(QueryQueueOptions opts, PlanNode sourceNode) {
+        if (sourceNode instanceof OlapScanNode) {
+            OlapScanNode olapScanNode = (OlapScanNode) sourceNode;
+            List<TScanRangeLocations> locations = olapScanNode.getScanRangeLocations(0);
+            if (locations != null) {
+                return locations.size();
+            }
+        }
+
+        return (int) (sourceNode.getCardinality() / opts.v2().getNumRowsPerSlot());
+    }
+
+    private static void collectFragmentSourceNodes(PlanNode node, Map<PlanFragmentId, FragmentContext> contexts) {
+        PlanFragmentId fragmentId = node.getFragmentId();
+        if (node.getChildren().isEmpty() || !fragmentId.equals(node.getChildren().get(0).getFragmentId())) {
+            contexts.computeIfAbsent(fragmentId, k -> new FragmentContext(node.getFragment()))
+                    .sourceNodes.add(node);
+        }
+
+        node.getChildren().forEach(child -> collectFragmentSourceNodes(child, contexts));
+    }
+
+    private static void calculateFragmentWorkers(QueryQueueOptions opts, PlanFragment fragment,
+                                                 Map<PlanFragmentId, FragmentContext> contexts) {
+        fragment.getChildren().forEach(child -> calculateFragmentWorkers(opts, child, contexts));
+
+        FragmentContext context = contexts.get(fragment.getFragmentId());
+        if (context == null) {
+            return;
+        }
+
+        PlanNode leftMostNode = fragment.getLeftMostNode();
+        if (leftMostNode instanceof OlapScanNode) {
+            OlapScanNode scanNode = (OlapScanNode) leftMostNode;
+            context.numWorkers = scanNode.getScanRangeLocations(0).stream()
+                    .flatMap(locations -> locations.getLocations().stream())
+                    .map(TScanRangeLocation::getBackend_id)
+                    .collect(Collectors.toSet())
+                    .size();
+        } else if (leftMostNode instanceof ScanNode && ((ScanNode) leftMostNode).isConnectorScanNode()) {
+            // TODO: get the actual number of files for connector scan nodes.
+            int numWorkers = (int) leftMostNode.getCardinality() / opts.v2().getNumRowsPerSlot();
+            context.numWorkers = Math.max(1, Math.min(numWorkers, opts.v2().getNumWorkers()));
+        } else if (fragment.isGatherFragment()) {
+            context.numWorkers = 1;
+        } else {
+            context.numWorkers = fragment.getChildren().stream()
+                    .mapToInt(child -> contexts.get(child.getFragmentId()).numWorkers)
+                    .max().orElse(1);
+        }
+    }
+
+    private static class FragmentContext {
+        private final PlanFragment fragment;
+        private final List<PlanNode> sourceNodes = Lists.newArrayList();
+        private int numWorkers = 1;
+
+        public FragmentContext(PlanFragment fragment) {
+            this.fragment = fragment;
+        }
     }
 
     public static class DefaultSlotEstimator implements SlotEstimator {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
@@ -323,6 +323,9 @@ public class SlotEstimatorTest extends SchedulerTestBase {
         // Set cardinality on scan nodes in the exec plan
         setNodeCardinalityInExecPlan(execPlan, 1, numWorkers * numRowsPerWorker * dop);
 
+        // Set planCpuCosts high enough to not be clamped by the CPU-cost clamp
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
+
         int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
         assertThat(slots).isEqualTo(dop * numWorkers);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
@@ -15,12 +15,15 @@
 package com.starrocks.qe.scheduler.slot;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.scheduler.SchedulerTestBase;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -212,6 +215,9 @@ public class SlotEstimatorTest extends SchedulerTestBase {
 
     @Test
     public void testCreate() {
+        // Reset to default policy to ensure test isolation
+        Config.query_queue_slots_estimator_strategy = SlotEstimatorFactory.EstimatorPolicy.createDefault().name();
+
         QueryQueueOptions opts = new QueryQueueOptions(false, new QueryQueueOptions.V2());
         assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.DefaultSlotEstimator.class);
 
@@ -268,6 +274,118 @@ public class SlotEstimatorTest extends SchedulerTestBase {
             Config.query_queue_slots_estimator_strategy = "BAD_SET";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
             assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MaxSlotsEstimator.class);
+        }
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithV1() {
+        // V1 should always return 1
+        QueryQueueOptions opts = new QueryQueueOptions(false, new QueryQueueOptions.V2());
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, null);
+        assertThat(slots).isEqualTo(1);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithMemoryBasedPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "MBE";
+        final int numWorkers = 3;
+        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
+        QueryQueueOptions opts =
+                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(3);
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers);
+        slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(opts.v2().getTotalSlots());
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithParallelBasedPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "PBE";
+        final int numWorkers = 3;
+        final int numCoresPerWorker = 16;
+        final int numRowsPerWorker = 4096;
+        final int dop = numCoresPerWorker / 2;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, numCoresPerWorker, 64L * 1024 * 1024 * 1024, numRowsPerWorker, 100));
+
+        String sql = "SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
+                "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey";
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        ExecPlan execPlan = planPair.second;
+
+        // Set cardinality on scan nodes in the exec plan
+        setNodeCardinalityInExecPlan(execPlan, 1, numWorkers * numRowsPerWorker * dop);
+
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(dop * numWorkers);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithMaxPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "MAX";
+        final int numWorkers = 3;
+        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
+        QueryQueueOptions opts =
+                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        // Memory-based will return 3, parallelism-based will return different value
+        // MAX should return the larger of the two
+        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithMinPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "MIN";
+        final int numWorkers = 3;
+        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
+        QueryQueueOptions opts =
+                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        // MIN should return the smaller of memory-based and parallelism-based
+        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithEmptyFragments() {
+        // Test with empty fragments
+        Config.query_queue_slots_estimator_strategy = "PBE";
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        // Create an exec plan with no fragments
+        ExecPlan emptyExecPlan = new ExecPlan();
+        
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, emptyExecPlan);
+        assertThat(slots).isEqualTo(1);
+    }
+
+    private static void setNodeCardinalityInExecPlan(ExecPlan execPlan, int nodeId, long cardinality) {
+        if (execPlan.getFragments() == null || execPlan.getFragments().isEmpty()) {
+            return;
+        }
+        PlanNode rootNode = execPlan.getFragments().get(0).getPlanRoot();
+        PlanNode node = findPlanNodeById(rootNode, nodeId);
+        if (node != null) {
+            Statistics statistics = Statistics.builder().setOutputRowCount(cardinality).build();
+            node.computeStatistics(statistics);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

After this patch, we can display `query queue` information for each query:
```
set enable_extended_explain= true;

mysql> explain costs select * from t1;
+-------------------------------------------------------------------+
| Explain String                                                    |
+-------------------------------------------------------------------+
| QUERY QUEUE                                                       |
|   Enabled: false (disabled by config/session)                     |
|   Version: v2                                                     |
|   Estimated slots: N/A                                            |
|   Warehouse: 0 (default_warehouse)                                |
|   Capacity: total_slots=416, total_small_slots=104, num_workers=1 |
|   Load: running_queries=0, running_slots=0, pending_queries=0     |
|   Remaining slots: 416                                            |
|   Limits: max_queued_queries=1024, pending_timeout_s=300          |
|   Resource overloaded: global=false, group=false                  |
|   Schedule policy: SWRR                                           |
|                                                                   |
| PLAN COST                                                         |
|   CPU: 36.0                                                       |
|   Memory: 0.0                                                     |
|                                                                   |
| PLAN FRAGMENT 0(F01)                                              |
|   Output Exprs:1: k1 | 2: k2 | 3: k3                              |
|   Input Partition: UNPARTITIONED                                  |
|   RESULT SINK                                                     |
|                                                                   |
|   1:EXCHANGE                                                      |
|      cardinality: 3                                               |
|                                                                   |
| PLAN FRAGMENT 1(F00)                                              |
|                                                                   |
|   Input Partition: RANDOM                                         |
|   OutPut Partition: UNPARTITIONED                                 |
|   OutPut Exchange Id: 01                                          |
|                                                                   |
|   0:OlapScanNode                                                  |
|      table: t1, rollup: t1                                        |
|      preAggregation: on                                           |
|      partitionsRatio=1/35, tabletsRatio=3/3                       |
|      tabletList=38152,38154,38156                                 |
|      actualRows=3, avgRowSize=3.0                                 |
|      cardinality: 3                                               |
|      column statistics:                                           |
|      * k1-->[1.6040736E9, 1.6053696E9, 0.0, 1.0, 1.0] UNKNOWN     |
|      * k2-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN          |
|      * k3-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN          |
+-------------------------------------------------------------------+
41 rows in set (0.01 sec)



mysql> set global enable_query_queue_select=true;
Query OK, 0 rows affected (0.02 sec)


mysql> explain costs select * from t1;
+-------------------------------------------------------------------+
| Explain String                                                    |
+-------------------------------------------------------------------+
| QUERY QUEUE                                                       |
|   Enabled: true                                                   |
|   Version: v2                                                     |
|   Estimated slots: 3                                              |
|   Warehouse: 0 (default_warehouse)                                |
|   Capacity: total_slots=416, total_small_slots=104, num_workers=1 |
|   Load: running_queries=0, running_slots=0, pending_queries=0     |
|   Remaining slots: 416                                            |
|   Limits: max_queued_queries=1024, pending_timeout_s=300          |
|   Resource overloaded: global=false, group=false                  |
|   Schedule policy: SWRR                                           |
|                                                                   |
| PLAN COST                                                         |
|   CPU: 36.0                                                       |
|   Memory: 0.0                                                     |
|                                                                   |
| PLAN FRAGMENT 0(F01)                                              |
|   Output Exprs:1: k1 | 2: k2 | 3: k3                              |
|   Input Partition: UNPARTITIONED                                  |
|   RESULT SINK                                                     |
|                                                                   |
|   1:EXCHANGE                                                      |
|      cardinality: 3                                               |
|                                                                   |
| PLAN FRAGMENT 1(F00)                                              |
|                                                                   |
|   Input Partition: RANDOM                                         |
|   OutPut Partition: UNPARTITIONED                                 |
|   OutPut Exchange Id: 01                                          |
|                                                                   |
|   0:OlapScanNode                                                  |
|      table: t1, rollup: t1                                        |
|      preAggregation: on                                           |
|      partitionsRatio=1/35, tabletsRatio=3/3                       |
|      tabletList=38152,38154,38156                                 |
|      actualRows=3, avgRowSize=12.0                                |
|      cardinality: 3                                               |
|      column statistics:                                           |
|      * k1-->[1.6040736E9, 1.6053696E9, 0.0, 4.0, 3.0] ESTIMATE    |
|      * k2-->[1.0, 3.0, 0.0, 4.0, 3.0] ESTIMATE                    |
|      * k3-->[1.0, 3.0, 0.0, 4.0, 3.0] ESTIMATE                    |
+-------------------------------------------------------------------+
41 rows in set (0.01 sec)

```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
