### PR TITLE
[Enhancement] Default to PK_ENCODING_TYPE_V2 for new cloud-native PK tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -269,6 +269,11 @@ public class OlapTable extends Table {
     @SerializedName(value = "maxIndexId")
     protected long maxIndexId = -1;
 
+    // Persisted primary key encoding type. null means the table was created before this field was introduced,
+    // in which case we fall back to the legacy computed logic in getPrimaryKeyEncodingType().
+    @SerializedName(value = "primaryKeyEncodingType")
+    private TPrimaryKeyEncodingType primaryKeyEncodingType = null;
+
     // the id of the session that created this table, only used in temporary table
     @SerializedName(value = "sessionId")
     protected UUID sessionId = null;
@@ -431,6 +436,7 @@ public class OlapTable extends Table {
         // Shallow copy shared data to check whether the copied table has changed or not.
         olapTable.lastSchemaUpdateTime = this.lastSchemaUpdateTime;
         olapTable.sessionId = this.sessionId;
+        olapTable.primaryKeyEncodingType = this.primaryKeyEncodingType;
 
         if (this.bfColumns != null) {
             olapTable.bfColumns = Sets.newHashSet(this.bfColumns);
@@ -3383,11 +3389,21 @@ public class OlapTable extends Table {
         return defaultDistributionInfo instanceof RangeDistributionInfo;
     }
 
+    public void setPrimaryKeyEncodingType(TPrimaryKeyEncodingType type) {
+        this.primaryKeyEncodingType = type;
+    }
+
     public TPrimaryKeyEncodingType getPrimaryKeyEncodingType() {
         if (getKeysType() != KeysType.PRIMARY_KEYS) {
             return TPrimaryKeyEncodingType.PK_ENCODING_TYPE_NONE;
         }
 
+        // Use persisted value if available (new tables created after this field was introduced)
+        if (primaryKeyEncodingType != null) {
+            return primaryKeyEncodingType;
+        }
+
+        // Legacy fallback for tables created before primaryKeyEncodingType was persisted
         if (!isCloudNativeTableOrMaterializedView()) {
             return TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -77,6 +77,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPersistentIndexType;
+import com.starrocks.thrift.TPrimaryKeyEncodingType;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -373,6 +374,11 @@ public class OlapTableFactory implements AbstractTableFactory {
                     throw new DdlException("In-Memory index is not supported, please create table with persistent index");
                 } else {
                     table.setEnablePersistentIndex(enablePersistentIndex);
+                }
+                if (table.isCloudNativeTableOrMaterializedView()) {
+                    table.setPrimaryKeyEncodingType(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V2);
+                } else {
+                    table.setPrimaryKeyEncodingType(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V1);
                 }
             }
             if (table.isCloudNativeTable() && table.getKeysType() == KeysType.PRIMARY_KEYS) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -641,6 +641,36 @@ public class OlapTableTest {
         };
         Assertions.assertEquals(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V2,
                 primaryKeyCloudRangeTable.getPrimaryKeyEncodingType());
+
+        // Test persisted primaryKeyEncodingType overrides computed value
+        OlapTable cloudHashTableWithPersistedV2 = new OlapTable() {
+            @Override
+            public KeysType getKeysType() {
+                return KeysType.PRIMARY_KEYS;
+            }
+
+            @Override
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Override
+            public boolean isRangeDistribution() {
+                return false;
+            }
+        };
+        // Without persisted value, cloud hash table returns V1 (legacy fallback)
+        Assertions.assertEquals(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V1,
+                cloudHashTableWithPersistedV2.getPrimaryKeyEncodingType());
+        // After setting persisted value to V2, it should return V2
+        cloudHashTableWithPersistedV2.setPrimaryKeyEncodingType(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V2);
+        Assertions.assertEquals(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V2,
+                cloudHashTableWithPersistedV2.getPrimaryKeyEncodingType());
+
+        // Non-PK table should always return NONE regardless of persisted value
+        nonPrimaryKeyTable.setPrimaryKeyEncodingType(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_V2);
+        Assertions.assertEquals(TPrimaryKeyEncodingType.PK_ENCODING_TYPE_NONE,
+                nonPrimaryKeyTable.getPrimaryKeyEncodingType());
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, newly created cloud-native (shared-data) primary key tables with hash distribution default to `PK_ENCODING_TYPE_V1`, while only range-distributed tables use `PK_ENCODING_TYPE_V2`. V2 encoding provides better support and should be the default for all new cloud-native PK tables.

## What I'm doing:
- Persist `primaryKeyEncodingType` as an immutable field in `OlapTable` (set once at creation, never altered)
- New cloud-native PK tables default to `PK_ENCODING_TYPE_V2` regardless of distribution type
- New non-cloud-native PK tables explicitly persist `PK_ENCODING_TYPE_V1`
- Existing tables (created before this change) have `primaryKeyEncodingType = null` and fall back to the legacy computed logic for full backward compatibility:
  - Cloud-native + hash → V1
  - Cloud-native + range → V2
  - Non-cloud-native → V1

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4