### PR TITLE
[BugFix] Fix use-after-free race in AsyncDeltaWriter close/finish lifecycle

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -170,7 +170,11 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
     auto async_writer = static_cast<AsyncDeltaWriterImpl*>(meta);
     auto delta_writer = async_writer->_writer.get();
     if (iter.is_queue_stopped()) {
-        delta_writer->close();
+        // Do NOT call delta_writer->close() here. A MergeBlockTask may still be
+        // running in the merge thread pool and accessing writer state (e.g.,
+        // _mem_table_sink, _flush_token). Closing the writer here would destroy
+        // that state and cause use-after-free. The writer will be closed in
+        // AsyncDeltaWriterImpl::close() after all tasks have been drained.
         return 0;
     }
     int num_tasks = 0;
@@ -352,21 +356,20 @@ inline void AsyncDeltaWriterImpl::close() {
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
+        // Shutdown (but do NOT reset) _block_merge_token to drain any running merge tasks.
+        // This must happen BEFORE execution_queue_stop() to ensure all merge tasks
+        // (which access writer state like _mem_table_sink) complete before the queue
+        // is torn down. The token remains allocated (not null) so if execute() is still
+        // running and calls _block_merge_token->submit(), it gets a ServiceUnavailable
+        // error instead of SIGSEGV.
+        if (_block_merge_token != nullptr) {
+            _block_merge_token->shutdown();
+        }
+
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.
         int r = bthread::execution_queue_stop(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to stop execution queue";
-
-        // Shutdown (but do NOT reset) _block_merge_token to drain any running merge tasks.
-        // This must happen BEFORE execution_queue_join() because the join triggers the
-        // is_queue_stopped() handler which calls delta_writer->close(), and we need all
-        // merge tasks (which call finish_with_txnlog()) to complete before that.
-        // The token remains allocated (not null) so if execute() is still running and
-        // calls _block_merge_token->submit(), it gets a ServiceUnavailable error instead
-        // of SIGSEGV.
-        if (_block_merge_token != nullptr) {
-            _block_merge_token->shutdown();
-        }
 
         // Wait for all running tasks completed.
         r = bthread::execution_queue_join(old_id);
@@ -374,6 +377,12 @@ inline void AsyncDeltaWriterImpl::close() {
 
         // Safe to destroy token now since both execution queue and merge tasks are done.
         _block_merge_token.reset();
+
+        // Close the writer AFTER all tasks (execution queue + merge tasks) have completed.
+        // Previously delta_writer->close() was called in the execution queue's stop handler,
+        // which could race with a still-running MergeBlockTask or external profile readers,
+        // destroying _mem_table_sink/_flush_token while they were still being accessed.
+        _writer->close();
     }
 }
 

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -831,6 +831,73 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger_without_input_profile) {
     do_block_merger(false);
 }
 
+// Regression test: close() used to trigger the stop handler which called delta_writer->close(),
+// destroying _mem_table_sink while a MergeBlockTask was still running merge_blocks_to_segments().
+// This caused use-after-free (SIGSEGV in LoadChunkSpiller::empty() or heap-use-after-free on
+// _flush_token). The fix defers delta_writer->close() until after all tasks are drained.
+TEST_F(LakeAsyncDeltaWriterTest, test_close_does_not_destroy_writer_during_merge) {
+    static const int kChunkSize = 128;
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    StorageEngine::instance()->load_spill_block_merge_executor()->refresh_max_thread_num();
+    CountDownLatch flush_latch(10);
+    // flush multiple times to generate spill blocks
+    int64_t old_val = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .set_immutable_tablet_size(10000000)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    for (int i = 0; i < 10; i++) {
+        delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& st) { ASSERT_OK(st); });
+        delta_writer->flush([&](const Status& st) {
+            ASSERT_OK(st);
+            flush_latch.count_down();
+        });
+    }
+    flush_latch.wait();
+    config::write_buffer_size = old_val;
+
+    // Pause inside merge_blocks_to_segments() so the merge task is actively using
+    // _mem_table_sink when close() is called.
+    CountDownLatch merge_entered(1);
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("SpillMemTableSink::merge_blocks_to_segments", [&](void* arg) {
+        merge_entered.count_down();
+        // Wait long enough for close() to stop the execution queue and trigger the
+        // stop handler. Before the fix, the stop handler would call delta_writer->close()
+        // and destroy _mem_table_sink while we're still here.
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+    });
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Submit finish — this will spawn a MergeBlockTask that enters merge_blocks_to_segments()
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {});
+
+    // Wait until merge task is inside merge_blocks_to_segments()
+    merge_entered.wait();
+
+    // Now close. Before the fix this would SIGSEGV or trigger ASAN heap-use-after-free.
+    // After the fix, close() waits for the merge task to complete before destroying writer state.
+    delta_writer->close();
+}
+
 // Test that write tasks are rejected after finish task completes
 TEST_F(LakeAsyncDeltaWriterTest, test_write_after_finish) {
     // Prepare data for writing


### PR DESCRIPTION
## Why I'm doing:

The execution queue's stop handler in `AsyncDeltaWriterImpl::execute()` calls `delta_writer->close()` when `is_queue_stopped()` returns true. This destroys internal writer state (`_mem_table_sink`, `_flush_token`, etc.) while concurrent tasks may still be accessing it:

1. **MergeBlockTask race**: A `MergeBlockTask` running in the merge thread pool accesses `_mem_table_sink` via `SpillMemTableSink::merge_blocks_to_segments()` → `LoadChunkSpiller::empty()`. If the stop handler fires concurrently, it resets `_mem_table_sink`, causing SIGSEGV.

2. **Profile reader race**: `LakeTabletsChannel::_update_tablet_profile()` reads `_flush_token` from a brpc worker thread. If the stop handler concurrently destroys `_flush_token`, this causes heap-use-after-free (ASAN crash in https://github.com/StarRocks/StarRocksTest/issues/11076).

The bad interleaving:
```
Merge Thread Pool              Execution Queue Thread         Caller Thread
─────────────────              ──────────────────────         ─────────────
MergeBlockTask::run()
→ finish_with_txnlog()
→ merge_blocks_to_segments()
→ accessing _mem_table_sink                                   close() called
                                                              execution_queue_stop()
                               Stop handler fires
                               delta_writer->close()
                               _mem_table_sink.reset() ← DESTROY
                                                              _block_merge_token->shutdown()
Accesses destroyed state → CRASH
```

## What I'm doing:

1. **Remove `delta_writer->close()` from the stop handler** — the stop handler no longer destroys writer state.
2. **Move `_writer->close()` to after all tasks are drained** — in `AsyncDeltaWriterImpl::close()`, the writer is closed only after `_block_merge_token->shutdown()` (drains merge tasks) and `execution_queue_join()` (waits for stop handler) both complete.

This guarantees `_mem_table_sink`, `_flush_token`, and other writer internals remain alive until no concurrent task can access them.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11076

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4