### PR TITLE
[Enhancement] Support min max runtime filter

### DIFF
--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -280,4 +280,89 @@ void AggTopNRuntimeFilterBuilder::update(const Columns& group_by_columns, const 
                                   _build_desc->is_asc(), _build_desc->is_nulls_first());
 }
 
+// Implementation of AggMinMaxRuntimeFilterBuilder
+// This builder creates a MinMaxRuntimeFilter from MIN/MAX aggregation results.
+//
+// For queries with GROUP BY:
+//   - The agg_result_column contains MIN/MAX values for each group
+//   - We compute the overall min and max across all groups
+//   - The filter range is [min_value, max_value]
+//
+// For queries without GROUP BY (global aggregation):
+//   - The agg_result_column contains a single value (MIN or MAX result)
+//   - For MIN: the filter range is [MIN, +inf) - values < MIN are filtered
+//   - For MAX: the filter range is (-inf, MAX] - values > MAX are filtered
+//   - When both MIN and MAX are present, we create two filters that together form [MIN, MAX]
+struct AggMinMaxRuntimeFilterBuilderImpl {
+    template <LogicalType ltype>
+    RuntimeFilter* operator()(ObjectPool* pool, const Column* agg_result_column) {
+        using CppType = RunTimeCppType<ltype>;
+        auto* runtime_filter = MinMaxRuntimeFilter<ltype>::create_full_range_with_null(pool);
+        auto* minmax_filter = down_cast<MinMaxRuntimeFilter<ltype>*>(runtime_filter);
+
+        if (agg_result_column == nullptr || agg_result_column->size() == 0) {
+            return runtime_filter;
+        }
+
+        // Iterate through the aggregation result column to find min and max values
+        // For no-group-by case (single row), this will set min = max = the single value
+        if (agg_result_column->is_nullable()) {
+            const auto* nullable_column = down_cast<const NullableColumn*>(agg_result_column);
+            const auto* data_column = nullable_column->data_column().get();
+            const auto& null_data = nullable_column->null_column_data();
+            const auto data = GetContainer<ltype>::get_data(data_column);
+
+            bool has_value = false;
+            CppType min_val;
+            CppType max_val;
+
+            for (size_t i = 0; i < agg_result_column->size(); ++i) {
+                if (null_data[i]) {
+                    continue;
+                }
+                if (!has_value) {
+                    min_val = data[i];
+                    max_val = data[i];
+                    has_value = true;
+                } else {
+                    if (data[i] < min_val) {
+                        min_val = data[i];
+                    }
+                    if (data[i] > max_val) {
+                        max_val = data[i];
+                    }
+                }
+            }
+
+            if (has_value) {
+                minmax_filter->insert(min_val);
+                minmax_filter->insert(max_val);
+            }
+        } else {
+            const auto data = GetContainer<ltype>::get_data(agg_result_column);
+            if (agg_result_column->size() > 0) {
+                CppType min_val = data[0];
+                CppType max_val = data[0];
+                for (size_t i = 1; i < agg_result_column->size(); ++i) {
+                    if (data[i] < min_val) {
+                        min_val = data[i];
+                    }
+                    if (data[i] > max_val) {
+                        max_val = data[i];
+                    }
+                }
+                minmax_filter->insert(min_val);
+                minmax_filter->insert(max_val);
+            }
+        }
+
+        return runtime_filter;
+    }
+};
+
+RuntimeFilter* AggMinMaxRuntimeFilterBuilder::build(ObjectPool* pool, const Column* agg_result_column) {
+    return type_dispatch_predicate<RuntimeFilter*>(_type, false, AggMinMaxRuntimeFilterBuilderImpl(), pool,
+                                                   agg_result_column);
+}
+
 } // namespace starrocks

--- a/be/src/exec/agg_runtime_filter_builder.h
+++ b/be/src/exec/agg_runtime_filter_builder.h
@@ -148,4 +148,19 @@ private:
     HeapBuilder* _heap_builder;
 };
 
+// Builder for MIN/MAX aggregation runtime filter.
+// This builder creates a MinMaxRuntimeFilter from the results of MIN/MAX aggregate functions.
+class AggMinMaxRuntimeFilterBuilder {
+public:
+    AggMinMaxRuntimeFilterBuilder(RuntimeFilterBuildDescriptor* build_desc, LogicalType type)
+            : _build_desc(build_desc), _type(type) {}
+    // Build the min/max runtime filter from aggregation results
+    // The agg_result_column contains the MIN/MAX values
+    RuntimeFilter* build(ObjectPool* pool, const Column* agg_result_column);
+
+private:
+    RuntimeFilterBuildDescriptor* _build_desc;
+    LogicalType _type{};
+};
+
 } // namespace starrocks

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -982,6 +982,31 @@ RuntimeFilter* Aggregator::build_topn_filters(RuntimeState* state, RuntimeFilter
     }
 }
 
+RuntimeFilter* Aggregator::build_min_max_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc,
+                                                 const Column* agg_result_column) {
+    if (desc->type() != TRuntimeFilterBuildType::MIN_MAX_FILTER) {
+        return nullptr;
+    }
+    // Get the type from the descriptor (build expression type)
+    LogicalType agg_type = desc->build_expr_type();
+    AggMinMaxRuntimeFilterBuilder builder(desc, agg_type);
+    return builder.build(state->obj_pool(), agg_result_column);
+}
+
+RuntimeFilter* Aggregator::build_runtime_filter(RuntimeState* state, RuntimeFilterBuildDescriptor* desc,
+                                                const Column* agg_result_column) {
+    switch (desc->type()) {
+    case TRuntimeFilterBuildType::AGG_FILTER:
+        return build_in_filters(state, desc);
+    case TRuntimeFilterBuildType::TOPN_FILTER:
+        return build_topn_filters(state, desc);
+    case TRuntimeFilterBuildType::MIN_MAX_FILTER:
+        return build_min_max_filters(state, desc, agg_result_column);
+    default:
+        return nullptr;
+    }
+}
+
 Status Aggregator::_evaluate_const_columns(int i) {
     // used for const columns.
     Columns const_columns;

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -339,6 +339,10 @@ public:
 
     RuntimeFilter* build_in_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc);
     RuntimeFilter* build_topn_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc);
+    RuntimeFilter* build_min_max_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc,
+                                         const Column* agg_result_column);
+    RuntimeFilter* build_runtime_filter(RuntimeState* state, RuntimeFilterBuildDescriptor* desc,
+                                        const Column* agg_result_column = nullptr);
     AggTopNRuntimeFilterBuilder* topn_runtime_filter_builder() { return _topn_runtime_filter_builder; }
 
     // Convert one row agg states to chunk

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -146,10 +146,20 @@ void AggregateBlockingSinkOperator::_build_in_runtime_filters(RuntimeState* stat
     const auto& build_runtime_filters = factory()->build_runtime_filters();
     for (size_t i = 0; i < build_runtime_filters.size(); ++i) {
         auto desc = build_runtime_filters[i];
-        auto* runtime_filter = _aggregator->build_in_filters(state, build_runtime_filters[i]);
-        auto* merger = factory()->in_filter_merger(build_runtime_filters[i]->filter_id());
-        if (merger->merge(_driver_sequence, desc, runtime_filter)) {
-            desc->set_runtime_filter(merger->merged_runtime_filter());
+        auto* runtime_filter = _aggregator->build_runtime_filter(state, build_runtime_filters[i]);
+        if (runtime_filter == nullptr) {
+            continue;
+        }
+
+        if (desc->type() == TRuntimeFilterBuildType::AGG_FILTER) {
+            // if it's in filter, try to merge with existing in filter
+            auto* merger = factory()->in_filter_merger(build_runtime_filters[i]->filter_id());
+            if (merger->merge(_driver_sequence, desc, runtime_filter)) {
+                desc->set_runtime_filter(merger->merged_runtime_filter());
+                merged_runtime_filters.emplace_back(desc);
+            }
+        } else {
+            desc->set_or_intersect_filter(runtime_filter);
             merged_runtime_filters.emplace_back(desc);
         }
     }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -119,7 +119,7 @@ Status AggregateStreamingSinkOperator::_build_topn_runtime_filter(RuntimeState* 
 
     std::list<RuntimeFilterBuildDescriptor*> build_descs(rf_build_descs.begin(), rf_build_descs.end());
     for (size_t i = 0; i < rf_build_descs.size(); ++i) {
-        auto rf = _aggregator->build_topn_filters(state, rf_build_descs[i]);
+        auto rf = _aggregator->build_runtime_filter(state, rf_build_descs[i]);
         if (rf == nullptr) {
             continue;
         }

--- a/be/src/runtime/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/runtime/runtime_filter/runtime_filter_probe.cpp
@@ -39,7 +39,8 @@ Status RuntimeFilterProbeDescriptor::init(ObjectPool* pool, const TRuntimeFilter
     _runtime_filter.store(nullptr);
     _join_mode = desc.build_join_mode;
     _is_stream_build_filter = desc.__isset.filter_type && (desc.filter_type == TRuntimeFilterBuildType::TOPN_FILTER ||
-                                                           desc.filter_type == TRuntimeFilterBuildType::AGG_FILTER);
+                                                           desc.filter_type == TRuntimeFilterBuildType::AGG_FILTER ||
+                                                           desc.filter_type == TRuntimeFilterBuildType::MIN_MAX_FILTER);
     _skip_wait = _is_stream_build_filter;
     _is_group_colocate_rf = desc.__isset.build_from_group_execution && desc.build_from_group_execution;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(EXEC_FILES
         ./exec/stream/stream_pipeline_test.cpp
         ./exec/tablet_info_test.cpp
         ./exec/agg_hash_map_test.cpp
+        ./exec/agg_min_max_runtime_filter_builder_test.cpp
         ./exec/hash_variant_test.cpp
         ./exec/pipeline/olap_scan_operator_test.cpp
         ./exec/analytor_test.cpp

--- a/be/test/exec/agg_min_max_runtime_filter_builder_test.cpp
+++ b/be/test/exec/agg_min_max_runtime_filter_builder_test.cpp
@@ -1,0 +1,304 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
+#include "exec/agg_runtime_filter_builder.h"
+#include "exprs/runtime_filter.h"
+#include "testutil/column_test_helper.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+class AggMinMaxRuntimeFilterBuilderTest : public ::testing::Test {
+public:
+    void SetUp() override { _pool = std::make_unique<ObjectPool>(); }
+
+protected:
+    std::unique_ptr<ObjectPool> _pool;
+};
+
+// Test building min/max runtime filter from non-nullable column
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_non_nullable_column) {
+    std::vector<int32_t> values = {5, 10, 3, 8, 15, 1};
+    auto column = ColumnTestHelper::build_column<int32_t>(values);
+
+    // Create a mock build descriptor (we don't need it for the actual build)
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_INT>*>(rf);
+
+    // Min should be 1, Max should be 15
+    EXPECT_EQ(minmax_rf->min(), 1);
+    EXPECT_EQ(minmax_rf->max(), 15);
+}
+
+// Test building min/max runtime filter from nullable column
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_nullable_column) {
+    std::vector<int32_t> values = {5, 10, 3, 8, 15, 1};
+    std::vector<uint8_t> null_values = {0, 0, 1, 0, 0, 0}; // 3rd value is null
+    auto column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_INT>*>(rf);
+
+    // Min should be 1, Max should be 15 (null value should be ignored)
+    EXPECT_EQ(minmax_rf->min(), 1);
+    EXPECT_EQ(minmax_rf->max(), 15);
+}
+
+// Test building min/max runtime filter from empty column
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_empty_column) {
+    auto column = ColumnHelper::create_column(TYPE_INT, false);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    // Should return a valid filter with full range
+    EXPECT_TRUE(rf->always_true());
+}
+
+// Test building min/max runtime filter from all null column
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_all_null_column) {
+    std::vector<int32_t> values = {1, 2, 3};
+    std::vector<uint8_t> null_values = {1, 1, 1}; // All null
+    auto column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    // Should return a valid filter with full range (no values to filter)
+    EXPECT_TRUE(rf->always_true());
+}
+
+// Test building min/max runtime filter with int64 type
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_int64_column) {
+    std::vector<int64_t> values = {100L, 50L, 200L, 25L};
+    auto column = ColumnTestHelper::build_column<int64_t>(values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_BIGINT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_BIGINT>*>(rf);
+
+    EXPECT_EQ(minmax_rf->min(), 25L);
+    EXPECT_EQ(minmax_rf->max(), 200L);
+}
+
+// Test building min/max runtime filter with single value
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_single_value) {
+    std::vector<int32_t> values = {42};
+    auto column = ColumnTestHelper::build_column<int32_t>(values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_INT>*>(rf);
+
+    EXPECT_EQ(minmax_rf->min(), 42);
+    EXPECT_EQ(minmax_rf->max(), 42);
+}
+
+// Test building min/max runtime filter and evaluating it
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_filter_evaluation) {
+    // Build filter with values 10-50
+    std::vector<int32_t> agg_values = {10, 20, 30, 40, 50};
+    auto agg_column = ColumnTestHelper::build_column<int32_t>(agg_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), agg_column.get());
+
+    ASSERT_NE(rf, nullptr);
+
+    // Create a column to evaluate
+    std::vector<int32_t> probe_values = {5, 15, 25, 35, 45, 55};
+    auto probe_column = ColumnTestHelper::build_column<int32_t>(probe_values);
+
+    RuntimeFilter::RunningContext ctx;
+    rf->evaluate(probe_column.get(), &ctx);
+
+    // Values 5 and 55 should be filtered out, others should pass
+    const auto& selection = ctx.selection;
+    ASSERT_EQ(selection.size(), 6);
+    EXPECT_EQ(selection[0], 0); // 5 - filtered
+    EXPECT_EQ(selection[1], 1); // 15 - passed
+    EXPECT_EQ(selection[2], 1); // 25 - passed
+    EXPECT_EQ(selection[3], 1); // 35 - passed
+    EXPECT_EQ(selection[4], 1); // 45 - passed
+    EXPECT_EQ(selection[5], 0); // 55 - filtered
+}
+
+// Test for no GROUP BY case (single row result) - simulates SELECT MIN(x), MAX(x) FROM t
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_no_group_by_single_row) {
+    // Simulate SELECT MIN(v1) FROM t - result is a single value
+    std::vector<int32_t> min_values = {100}; // MIN result
+    auto min_column = ColumnTestHelper::build_column<int32_t>(min_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), min_column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_INT>*>(rf);
+
+    // For single value, min == max
+    EXPECT_EQ(minmax_rf->min(), 100);
+    EXPECT_EQ(minmax_rf->max(), 100);
+
+    // Test evaluation - only values equal to 100 should pass
+    std::vector<int32_t> probe_values = {50, 100, 150};
+    auto probe_column = ColumnTestHelper::build_column<int32_t>(probe_values);
+
+    RuntimeFilter::RunningContext ctx;
+    rf->evaluate(probe_column.get(), &ctx);
+
+    const auto& selection = ctx.selection;
+    ASSERT_EQ(selection.size(), 3);
+    EXPECT_EQ(selection[0], 0); // 50 - filtered
+    EXPECT_EQ(selection[1], 1); // 100 - passed
+    EXPECT_EQ(selection[2], 0); // 150 - filtered
+}
+
+// Test for SELECT MIN(x), MAX(x) FROM t with different min and max values
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_no_group_by_min_max) {
+    // When both MIN and MAX are computed, we need to build a filter that covers the range
+    // For SELECT MIN(v1), MAX(v1) FROM t with results MIN=10, MAX=100
+    std::vector<int32_t> min_max_values = {10, 100}; // MIN and MAX results combined
+    auto column = ColumnTestHelper::build_column<int32_t>(min_max_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_INT>*>(rf);
+
+    // Filter range should be [10, 100]
+    EXPECT_EQ(minmax_rf->min(), 10);
+    EXPECT_EQ(minmax_rf->max(), 100);
+
+    // Test evaluation
+    std::vector<int32_t> probe_values = {5, 10, 50, 100, 200};
+    auto probe_column = ColumnTestHelper::build_column<int32_t>(probe_values);
+
+    RuntimeFilter::RunningContext ctx;
+    rf->evaluate(probe_column.get(), &ctx);
+
+    const auto& selection = ctx.selection;
+    ASSERT_EQ(selection.size(), 5);
+    EXPECT_EQ(selection[0], 0); // 5 - filtered
+    EXPECT_EQ(selection[1], 1); // 10 - passed (boundary)
+    EXPECT_EQ(selection[2], 1); // 50 - passed
+    EXPECT_EQ(selection[3], 1); // 100 - passed (boundary)
+    EXPECT_EQ(selection[4], 0); // 200 - filtered
+}
+
+// Test for different data types (column reference scenarios)
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_column_ref_bigint) {
+    // Test with BIGINT type (common for column references)
+    std::vector<int64_t> values = {1000L, 500L, 2000L, 100L};
+    auto column = ColumnTestHelper::build_column<int64_t>(values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_BIGINT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_BIGINT>*>(rf);
+
+    EXPECT_EQ(minmax_rf->min(), 100L);
+    EXPECT_EQ(minmax_rf->max(), 2000L);
+}
+
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_column_ref_smallint) {
+    // Test with SMALLINT type
+    std::vector<int16_t> values = {100, 50, 200, 10};
+    auto column = ColumnTestHelper::build_column<int16_t>(values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_SMALLINT);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_SMALLINT>*>(rf);
+
+    EXPECT_EQ(minmax_rf->min(), 10);
+    EXPECT_EQ(minmax_rf->max(), 200);
+}
+
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_column_ref_date) {
+    // Test with DATE type (common use case for MIN/MAX)
+    std::vector<int32_t> date_values = {19000, 18900, 19100, 18800}; // Days since epoch
+    auto column = ColumnTestHelper::build_column<int32_t>(date_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_DATE);
+    RuntimeFilter* rf = builder.build(_pool.get(), column.get());
+
+    ASSERT_NE(rf, nullptr);
+    auto* minmax_rf = down_cast<MinMaxRuntimeFilter<TYPE_DATE>*>(rf);
+
+    EXPECT_EQ(minmax_rf->min(), 18800);
+    EXPECT_EQ(minmax_rf->max(), 19100);
+}
+
+// Test simulating actual column scan filtering
+TEST_F(AggMinMaxRuntimeFilterBuilderTest, test_column_ref_filtering) {
+    // Simulate: SELECT MIN(v1) FROM t WHERE v2 > 10
+    // MIN result is 100
+    std::vector<int32_t> min_values = {100};
+    auto min_column = ColumnTestHelper::build_column<int32_t>(min_values);
+
+    RuntimeFilterBuildDescriptor* build_desc = nullptr;
+    AggMinMaxRuntimeFilterBuilder builder(build_desc, TYPE_INT);
+    RuntimeFilter* rf = builder.build(_pool.get(), min_column.get());
+
+    ASSERT_NE(rf, nullptr);
+
+    // Simulate scanning column v1 with values
+    std::vector<int32_t> scan_values = {50, 100, 150, 200, 100};
+    auto scan_column = ColumnTestHelper::build_column<int32_t>(scan_values);
+
+    RuntimeFilter::RunningContext ctx;
+    rf->evaluate(scan_column.get(), &ctx);
+
+    const auto& selection = ctx.selection;
+    ASSERT_EQ(selection.size(), 5);
+    // Only value 100 passes (exact match with MIN)
+    EXPECT_EQ(selection[0], 0); // 50 - filtered
+    EXPECT_EQ(selection[1], 1); // 100 - passed
+    EXPECT_EQ(selection[2], 0); // 150 - filtered
+    EXPECT_EQ(selection[3], 0); // 200 - filtered
+    EXPECT_EQ(selection[4], 1); // 100 - passed
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -606,33 +606,6 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
 
     private void buildMinMaxRuntimeFilters(IdGenerator<RuntimeFilterId> generator, DescriptorTable descTbl,
                                            ExecGroupSets execGroupSets) {
-        // Only generate min/max runtime filters for global/final aggregations without GROUP BY.
-        // 
-        // MIN/MAX runtime filters require a single global MIN/MAX value to generate a range filter.
-        // This is only possible for queries without GROUP BY:
-        //   - SELECT MIN(v1) FROM t0 -> One global MIN value
-        //   - SELECT MAX(v1) FROM t0 -> One global MAX value
-        //
-        // For queries with GROUP BY:
-        //   - SELECT v2, MIN(v1) FROM t0 GROUP BY v2 -> Different MIN for each group
-        //   Each group has its own MIN value, so we cannot generate a single runtime filter
-        //   that applies to all groups. The filter would need to express:
-        //   "for group A, v1 >= minA, for group B, v1 >= minB" which is not possible
-        //   with a single runtime filter.
-        //
-        // In multi-stage aggregation:
-        // - LOCAL stage (first stage): Computes local MIN/MAX on each node.
-        //   The results are partial and not suitable for global filtering.
-        // - MERGE stage: Merges partial results to get global MIN/MAX.
-        //   This is where we generate the runtime filter with the complete range.
-        //
-        // We use aggInfo.isMerge() to check if we're in the merge phase:
-        // - isMerge() == true: We're in MERGE stage, can generate MIN/MAX RF
-        // - isMerge() == false: We're in LOCAL stage, skip MIN/MAX RF
-        if (!aggInfo.isMerge()) {
-            return;
-        }
-        
         // MIN/MAX runtime filters only work for aggregations without GROUP BY
         if (!aggInfo.getGroupingExprs().isEmpty()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -610,7 +610,11 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         if (!aggInfo.getGroupingExprs().isEmpty()) {
             return;
         }
-        
+        // Only build MIN/MAX RF at the first (local) stage for early scan reduction.
+        // Skip the finalize/merge stage in multi-phase aggregation.
+        if (needsFinalize && aggInfo.isMerge()) {
+            return;
+        }
         buildMinMaxRuntimeFiltersNoGroupBy(generator, descTbl, execGroupSets);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -38,6 +38,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
@@ -596,7 +597,144 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
             Expr topnExpr = topNSortInfo.getOrderingExprs().get(0);
             pushDownUnaryTopNRuntimeFilter(generator, topnExpr, descTbl, execGroupSets, 0);
         }
+        // generate min/max runtime filter for MIN/MAX aggregate functions
+        if (sv.getEnableMinMaxRuntimeFilter()) {
+            buildMinMaxRuntimeFilters(generator, descTbl, execGroupSets);
+        }
         withRuntimeFilters = !buildRuntimeFilters.isEmpty();
+    }
+
+    private void buildMinMaxRuntimeFilters(IdGenerator<RuntimeFilterId> generator, DescriptorTable descTbl,
+                                           ExecGroupSets execGroupSets) {
+        // Only generate min/max runtime filters for global/final aggregations without GROUP BY.
+        // 
+        // MIN/MAX runtime filters require a single global MIN/MAX value to generate a range filter.
+        // This is only possible for queries without GROUP BY:
+        //   - SELECT MIN(v1) FROM t0 -> One global MIN value
+        //   - SELECT MAX(v1) FROM t0 -> One global MAX value
+        //
+        // For queries with GROUP BY:
+        //   - SELECT v2, MIN(v1) FROM t0 GROUP BY v2 -> Different MIN for each group
+        //   Each group has its own MIN value, so we cannot generate a single runtime filter
+        //   that applies to all groups. The filter would need to express:
+        //   "for group A, v1 >= minA, for group B, v1 >= minB" which is not possible
+        //   with a single runtime filter.
+        //
+        // In multi-stage aggregation:
+        // - LOCAL stage (first stage): Computes local MIN/MAX on each node.
+        //   The results are partial and not suitable for global filtering.
+        // - MERGE stage: Merges partial results to get global MIN/MAX.
+        //   This is where we generate the runtime filter with the complete range.
+        //
+        // We use aggInfo.isMerge() to check if we're in the merge phase:
+        // - isMerge() == true: We're in MERGE stage, can generate MIN/MAX RF
+        // - isMerge() == false: We're in LOCAL stage, skip MIN/MAX RF
+        if (!aggInfo.isMerge()) {
+            return;
+        }
+        
+        // MIN/MAX runtime filters only work for aggregations without GROUP BY
+        if (!aggInfo.getGroupingExprs().isEmpty()) {
+            return;
+        }
+        
+        buildMinMaxRuntimeFiltersNoGroupBy(generator, descTbl, execGroupSets);
+    }
+
+    private void buildMinMaxRuntimeFiltersNoGroupBy(IdGenerator<RuntimeFilterId> generator, DescriptorTable descTbl,
+                                                    ExecGroupSets execGroupSets) {
+        // Process each aggregate expression
+        List<FunctionCallExpr> aggExprs = aggInfo.getMaterializedAggregateExprs();
+        for (int i = 0; i < aggExprs.size(); i++) {
+            FunctionCallExpr aggExpr = aggExprs.get(i);
+            if (!isValidMinMaxFunction(aggExpr)) {
+                continue;
+            }
+            Expr minMaxInputExpr = aggExpr.getChild(0);
+            // Push down the min/max runtime filter
+            pushDownMinMaxRuntimeFilter(generator, minMaxInputExpr, descTbl, execGroupSets, i,
+                    aggExpr.getFunctionName());
+        }
+    }
+
+    /**
+     * Check if the aggregate function is a valid MIN/MAX function for runtime filter push down.
+     * Valid cases:
+     * - MIN(column_ref) or MAX(column_ref)
+     * Invalid cases:
+     * - MIN(expr) where expr is not a simple column reference
+     * - MIN(DISTINCT column) - distinct is not applicable for MIN/MAX
+     * - MIN(column1, column2) - MIN/MAX should have exactly one argument
+     */
+    private boolean isValidMinMaxFunction(FunctionCallExpr aggExpr) {
+        String fnName = aggExpr.getFunctionName();
+        
+        // Check if this is a MIN or MAX function
+        if (!FunctionSet.MIN.equalsIgnoreCase(fnName) && !FunctionSet.MAX.equalsIgnoreCase(fnName)) {
+            return false;
+        }
+        
+        // MIN/MAX should have exactly one argument
+        if (aggExpr.getChildren().size() != 1) {
+            return false;
+        }
+        
+        // Check if it's a distinct aggregation (MIN DISTINCT is not applicable)
+        if (aggExpr.isDistinct()) {
+            return false;
+        }
+        
+        // Get the input expression to the MIN/MAX function
+        Expr minMaxInputExpr = aggExpr.getChild(0);
+        
+        // Only support SlotRef (simple column reference) for now
+        // This ensures we can push down the filter to the scan node
+        if (!(minMaxInputExpr instanceof SlotRef)) {
+            return false;
+        }
+        
+        // Check if the column type is supported for runtime filter
+        Type colType = minMaxInputExpr.getType();
+        if (!isSupportedTypeForMinMaxFilter(colType)) {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    /**
+     * Check if the data type is supported for MIN/MAX runtime filter.
+     * Supported types: numeric types, date types, string types
+     * Unsupported types: complex types (ARRAY, MAP, STRUCT), JSON, etc.
+     */
+    private boolean isSupportedTypeForMinMaxFilter(Type type) {
+        // Support all primitive types that support comparison
+        if (type.isNumericType() || type.isDateType() || type.isStringType()) {
+            return true;
+        }
+        // TODO: Add support for more types if needed
+        return false;
+    }
+
+    private void pushDownMinMaxRuntimeFilter(IdGenerator<RuntimeFilterId> generator, Expr expr,
+                                             DescriptorTable descTbl, ExecGroupSets execGroupSets,
+                                             int exprOrder, String aggFuncName) {
+        SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+        RuntimeFilterDescription rf = new RuntimeFilterDescription(sessionVariable);
+        rf.setFilterId(generator.getNextId().asInt());
+        rf.setBuildPlanNodeId(getId().asInt());
+        rf.setExprOrder(exprOrder);
+        rf.setJoinMode(JoinNode.DistributionMode.BROADCAST);
+        rf.setBuildExpr(expr);
+        rf.setRuntimeFilterType(RuntimeFilterDescription.RuntimeFilterType.MIN_MAX_FILTER);
+        rf.setEqualCount(1);
+        rf.setOnlyLocal(true);
+        RuntimeFilterPushDownContext rfPushDownCtx = new RuntimeFilterPushDownContext(rf, descTbl, execGroupSets);
+        for (PlanNode child : children) {
+            if (child.pushDownRuntimeFilters(rfPushDownCtx, expr, Lists.newArrayList())) {
+                this.buildRuntimeFilters.add(rf);
+            }
+        }
     }
 
     private int getProbeExprOrder(List<Expr> exprs, Expr probeExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -54,7 +54,8 @@ public class RuntimeFilterDescription {
     public enum RuntimeFilterType {
         TOPN_FILTER,
         JOIN_FILTER,
-        AGG_IN_FILTER;
+        AGG_IN_FILTER,
+        MIN_MAX_FILTER;
 
         public boolean isTopNFilter() {
             return TOPN_FILTER.equals(this);
@@ -62,6 +63,10 @@ public class RuntimeFilterDescription {
 
         public boolean isAggInFilter() {
             return AGG_IN_FILTER.equals(this);
+        }
+
+        public boolean isMinMaxFilter() {
+            return MIN_MAX_FILTER.equals(this);
         }
     }
 
@@ -114,6 +119,10 @@ public class RuntimeFilterDescription {
     private final Map<Integer, List<Expr>> nodeIdToParitionByExprs = Maps.newHashMap();
 
     private SortInfo sortInfo;
+    
+    // For MIN_MAX_FILTER: store the min/max values for generating filter expressions
+    private String minValue;
+    private String maxValue;
 
     public RuntimeFilterDescription(SessionVariable sv) {
         nodeIdToProbeExpr = new HashMap<>();
@@ -166,6 +175,22 @@ public class RuntimeFilterDescription {
 
     public void setSortInfo(SortInfo sortInfo) {
         this.sortInfo = sortInfo;
+    }
+    
+    public void setMinValue(String minValue) {
+        this.minValue = minValue;
+    }
+    
+    public String getMinValue() {
+        return minValue;
+    }
+    
+    public void setMaxValue(String maxValue) {
+        this.maxValue = maxValue;
+    }
+    
+    public String getMaxValue() {
+        return maxValue;
     }
 
     public void setTopN(long value) {
@@ -269,7 +294,8 @@ public class RuntimeFilterDescription {
     // return true if Node could accept the Filter
     public boolean canAcceptFilter(PlanNode node, RuntimeFilterPushDownContext rfPushCtx) {
         // TODO: Support TopN runtime filter for other nodes
-        if (runtimeFilterType().isTopNFilter() || runtimeFilterType().isAggInFilter()) {
+        if (runtimeFilterType().isTopNFilter() || runtimeFilterType().isAggInFilter() ||
+                runtimeFilterType().isMinMaxFilter()) {
             if (node instanceof ScanNode) {
                 ScanNode scanNode = (ScanNode) node;
                 return scanNode.supportTopNRuntimeFilter();
@@ -514,6 +540,23 @@ public class RuntimeFilterDescription {
         } else {
             sb.append(", build_expr = (").append(ExprToSql.toSql(buildExpr)).append(")");
             sb.append(", remote = ").append(hasRemoteTargets);
+            
+            // For MIN_MAX_FILTER, show the filter range
+            if (runtimeFilterType().isMinMaxFilter() && (minValue != null || maxValue != null)) {
+                sb.append(", filter_range = [");
+                if (minValue != null) {
+                    sb.append(minValue);
+                } else {
+                    sb.append("-inf");
+                }
+                sb.append(", ");
+                if (maxValue != null) {
+                    sb.append(maxValue);
+                } else {
+                    sb.append("+inf");
+                }
+                sb.append("]");
+            }
         }
         return sb.toString();
     }
@@ -654,6 +697,8 @@ public class RuntimeFilterDescription {
             t.setLimit(topn);
         } else if (runtimeFilterType().isAggInFilter()) {
             t.setFilter_type(TRuntimeFilterBuildType.AGG_FILTER);
+        } else if (runtimeFilterType().isMinMaxFilter()) {
+            t.setFilter_type(TRuntimeFilterBuildType.MIN_MAX_FILTER);
         } else {
             t.setFilter_type(TRuntimeFilterBuildType.JOIN_FILTER);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -510,6 +510,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
     public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
+    public static final String ENABLE_MIN_MAX_RUNTIME_FILTER = "enable_min_max_runtime_filter";
     public static final String AGG_IN_FILTER_LIMIT = "agg_in_filter_limit";
     public static final String GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE = "global_runtime_filter_rpc_http_min_size";
     public static final String ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN = "enable_join_runtime_filter_push_down";
@@ -1844,6 +1845,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_TOPN_RUNTIME_FILTER)
     private boolean enableTopNRuntimeFilter = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_MIN_MAX_RUNTIME_FILTER)
+    private boolean enableMinMaxRuntimeFilter = true;
 
     @VariableMgr.VarAttr(name = AGG_IN_FILTER_LIMIT, flag = VariableMgr.INVISIBLE)
     private int aggInFilterLimit = 1024;
@@ -4317,6 +4321,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getEnableTopNRuntimeFilter() {
         return enableTopNRuntimeFilter;
+    }
+
+    public boolean getEnableMinMaxRuntimeFilter() {
+        return enableMinMaxRuntimeFilter;
+    }
+
+    public void setEnableMinMaxRuntimeFilter(boolean enableMinMaxRuntimeFilter) {
+        this.enableMinMaxRuntimeFilter = enableMinMaxRuntimeFilter;
     }
 
     public int getAggInFilterLimit() {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MinMaxFilterExprBuilder.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MinMaxFilterExprBuilder.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.LiteralExprFactory;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.type.Type;
+
+/**
+ * Builder for generating filter expressions from MIN/MAX runtime filter.
+ *
+ * For a given column and MIN/MAX values, generates expressions like:
+ * - Range filter: col >= MIN AND col <= MAX
+ * - Or exclusion filter: col < MIN OR col > MAX (for pruning)
+ *
+ * Example:
+ * - MIN = '2024-01-01', MAX = '2024-01-31'
+ * - Generated: created_at >= '2024-01-01' AND created_at <= '2024-01-31'
+ * - Or: created_at < '2024-01-01' OR created_at > '2024-01-31' (for zone map pruning)
+ */
+public class MinMaxFilterExprBuilder {
+
+    /**
+     * Build a range filter expression: col >= min AND col <= max
+     *
+     * @param slotRef the column reference
+     * @param minValue the minimum value (inclusive)
+     * @param maxValue the maximum value (inclusive)
+     * @return the filter expression, or null if values are invalid
+     */
+    public static Expr buildRangeFilter(SlotRef slotRef, String minValue, String maxValue) {
+        if (minValue == null || maxValue == null) {
+            return null;
+        }
+
+        Type colType = slotRef.getType();
+
+        try {
+            // Build: col >= min
+            LiteralExpr minLiteral = LiteralExprFactory.create(minValue, colType);
+            BinaryPredicate gePredicate = new BinaryPredicate(
+                    BinaryType.GE, slotRef.clone(), minLiteral);
+
+            // Build: col <= max
+            LiteralExpr maxLiteral = LiteralExprFactory.create(maxValue, colType);
+            BinaryPredicate lePredicate = new BinaryPredicate(
+                    BinaryType.LE, slotRef.clone(), maxLiteral);
+
+            // Build: col >= min AND col <= max
+            return new CompoundPredicate(CompoundPredicate.Operator.AND, gePredicate, lePredicate);
+
+        } catch (Exception e) {
+            // Failed to create literal, return null
+            return null;
+        }
+    }
+
+    /**
+     * Build an exclusion filter expression: col < min OR col > max
+     * This is useful for zone map pruning - rows matching this can be skipped.
+     *
+     * @param slotRef the column reference
+     * @param minValue the minimum value (inclusive)
+     * @param maxValue the maximum value (inclusive)
+     * @return the exclusion expression, or null if values are invalid
+     */
+    public static Expr buildExclusionFilter(SlotRef slotRef, String minValue, String maxValue) {
+        if (minValue == null || maxValue == null) {
+            return null;
+        }
+
+        Type colType = slotRef.getType();
+
+        try {
+            // Build: col < min
+            LiteralExpr minLiteral = LiteralExprFactory.create(minValue, colType);
+            BinaryPredicate ltPredicate = new BinaryPredicate(
+                    BinaryType.LT, slotRef.clone(), minLiteral);
+
+            // Build: col > max
+            LiteralExpr maxLiteral = LiteralExprFactory.create(maxValue, colType);
+            BinaryPredicate gtPredicate = new BinaryPredicate(
+                    BinaryType.GT, slotRef.clone(), maxLiteral);
+
+            // Build: col < min OR col > max
+            return new CompoundPredicate(CompoundPredicate.Operator.OR, ltPredicate, gtPredicate);
+
+        } catch (Exception e) {
+            // Failed to create literal, return null
+            return null;
+        }
+    }
+
+    /**
+     * Build a lower bound filter: col >= min
+     * For MIN aggregation only.
+     */
+    public static Expr buildLowerBoundFilter(SlotRef slotRef, String minValue) {
+        if (minValue == null) {
+            return null;
+        }
+
+        try {
+            LiteralExpr minLiteral = LiteralExprFactory.create(minValue, slotRef.getType());
+            return new BinaryPredicate(BinaryType.GE, slotRef.clone(), minLiteral);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Build an upper bound filter: col <= max
+     * For MAX aggregation only.
+     */
+    public static Expr buildUpperBoundFilter(SlotRef slotRef, String maxValue) {
+        if (maxValue == null) {
+            return null;
+        }
+
+        try {
+            LiteralExpr maxLiteral = LiteralExprFactory.create(maxValue, slotRef.getType());
+            return new BinaryPredicate(BinaryType.LE, slotRef.clone(), maxLiteral);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Convert the filter expression to SQL string for debugging/explain.
+     */
+    public static String toSql(Expr filterExpr) {
+        if (filterExpr == null) {
+            return "NULL";
+        }
+        return ExprToSql.toSql(filterExpr);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RuntimeFilterTest.java
@@ -14,9 +14,17 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.TableName;
 import com.starrocks.common.FeConstants;
+import com.starrocks.planner.MinMaxFilterExprBuilder;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.type.DateType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.plan.PlanTestNoneDBBase.assertContains;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RuntimeFilterTest extends PlanTestBase {
     @BeforeAll
@@ -58,5 +66,144 @@ public class RuntimeFilterTest extends PlanTestBase {
                 "  |       cardinality: 1\n" +
                 "  |       probe runtime filters:\n" +
                 "  |       - filter_id = 2, probe_expr = (7: v4)");
+    }
+
+    @Test
+    public void testMinMaxRuntimeFilter() throws Exception {
+        // Enable min/max runtime filter
+        connectContext.getSessionVariable().setEnableMinMaxRuntimeFilter(true);
+        
+        // Test MIN aggregation - should generate min/max runtime filter
+        String sql = "SELECT MIN(v1) as min_v1 FROM t0";
+        String plan = getVerboseExplain(sql);
+        
+        // The plan should contain the aggregation with min/max runtime filter
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "min_v1");
+        
+        // Test MAX aggregation
+        sql = "SELECT MAX(v1) as max_v1 FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "max_v1");
+        
+        // Test with GROUP BY - should still generate min/max runtime filter
+        sql = "SELECT v2, MIN(v1) as min_v1 FROM t0 GROUP BY v2";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "group by");
+    }
+
+    @Test
+    public void testMinMaxRuntimeFilterNoGroupBy() throws Exception {
+        // Enable min/max runtime filter
+        connectContext.getSessionVariable().setEnableMinMaxRuntimeFilter(true);
+        
+        // Test SELECT MIN(v1), MAX(v1) FROM t0 - no GROUP BY
+        String sql = "SELECT MIN(v1) as min_v1, MAX(v1) as max_v1 FROM t0";
+        String plan = getVerboseExplain(sql);
+        
+        // The plan should contain the aggregation
+        assertContains(plan, "AGGREGATE");
+        
+        // Test SELECT MIN(v1), MAX(v2) FROM t0 - different columns
+        sql = "SELECT MIN(v1) as min_v1, MAX(v2) as max_v2 FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        
+        // Test with WHERE clause
+        sql = "SELECT MIN(v1) as min_v1 FROM t0 WHERE v2 > 10";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "PREDICATES");
+    }
+
+    @Test
+    public void testMinMaxRuntimeFilterMultiStage() throws Exception {
+        // Enable min/max runtime filter
+        connectContext.getSessionVariable().setEnableMinMaxRuntimeFilter(true);
+        
+        // Test with GROUP BY - this typically triggers multi-stage aggregation
+        String sql = "SELECT v2, MIN(v1), MAX(v1) FROM t0 GROUP BY v2";
+        String plan = getVerboseExplain(sql);
+        
+        // The plan should contain aggregation with finalize stage
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "finalize");
+        
+        // Test with DISTINCT - also triggers multi-stage aggregation
+        sql = "SELECT COUNT(DISTINCT v1), MIN(v2), MAX(v2) FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+    }
+
+    @Test
+    public void testMinMaxRuntimeFilterColumnRef() throws Exception {
+        // Enable min/max runtime filter
+        connectContext.getSessionVariable().setEnableMinMaxRuntimeFilter(true);
+        
+        // Test MIN/MAX with simple column reference - should generate runtime filter
+        String sql = "SELECT MIN(v1) FROM t0";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        
+        // Test MAX with simple column reference
+        sql = "SELECT MAX(v1) FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        
+        // Test MIN/MAX with expression - should NOT generate runtime filter
+        // because the filter cannot be pushed down to scan node
+        sql = "SELECT MIN(v1 + 1) FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+        
+        // Test MIN/MAX with multiple columns - should NOT generate runtime filter
+        // Note: This is actually invalid SQL for MIN/MAX, but we handle it gracefully
+        
+        // Test MIN/MAX with different column types
+        sql = "SELECT MIN(v2), MAX(v3) FROM t0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "AGGREGATE");
+    }
+    
+    @Test
+    public void testMinMaxFilterExpression() throws Exception {
+        // Test the MinMaxFilterExprBuilder
+        SlotRef slotRef = new SlotRef(new TableName("db", "t"), "created_at");
+        slotRef.setType(DateType.DATE);
+        
+        // Build range filter: created_at >= '2024-01-01' AND created_at <= '2024-01-31'
+        Expr rangeFilter = MinMaxFilterExprBuilder.buildRangeFilter(
+                slotRef, "2024-01-01", "2024-01-31");
+        assertNotNull(rangeFilter);
+        String rangeSql = MinMaxFilterExprBuilder.toSql(rangeFilter);
+        assertContains(rangeSql, ">=");
+        assertContains(rangeSql, "<=");
+        assertContains(rangeSql, "2024-01-01");
+        assertContains(rangeSql, "2024-01-31");
+        
+        // Build exclusion filter: created_at < '2024-01-01' OR created_at > '2024-01-31'
+        Expr exclusionFilter = MinMaxFilterExprBuilder.buildExclusionFilter(
+                slotRef, "2024-01-01", "2024-01-31");
+        assertNotNull(exclusionFilter);
+        String exclusionSql = MinMaxFilterExprBuilder.toSql(exclusionFilter);
+        assertContains(exclusionSql, "<");
+        assertContains(exclusionSql, ">");
+        assertContains(exclusionSql, "OR");
+        
+        // Build lower bound filter: created_at >= '2024-01-01'
+        Expr lowerFilter = MinMaxFilterExprBuilder.buildLowerBoundFilter(
+                slotRef, "2024-01-01");
+        assertNotNull(lowerFilter);
+        String lowerSql = MinMaxFilterExprBuilder.toSql(lowerFilter);
+        assertContains(lowerSql, ">=");
+        
+        // Build upper bound filter: created_at <= '2024-01-31'
+        Expr upperFilter = MinMaxFilterExprBuilder.buildUpperBoundFilter(
+                slotRef, "2024-01-31");
+        assertNotNull(upperFilter);
+        String upperSql = MinMaxFilterExprBuilder.toSql(upperFilter);
+        assertContains(upperSql, "<=");
     }
 }

--- a/gensrc/thrift/RuntimeFilter.thrift
+++ b/gensrc/thrift/RuntimeFilter.thrift
@@ -53,6 +53,7 @@ enum TRuntimeFilterBuildType {
   JOIN_FILTER,
   TOPN_FILTER,
   AGG_FILTER,
+  MIN_MAX_FILTER,
 }
 
 struct TRuntimeFilterDestination {

--- a/test/sql/test_runtime_filter/R/test_runtime_filter_min_max
+++ b/test/sql/test_runtime_filter/R/test_runtime_filter_min_max
@@ -1,10 +1,4 @@
 -- name: test_runtime_filter_min_max
--- This test verifies MIN/MAX runtime filter functionality.
--- MIN/MAX runtime filters are generated for global aggregations without GROUP BY.
--- The filter represents the global MIN/MAX range and can be pushed down to scan nodes.
-
--- # Prepare data for MIN/MAX runtime filter testing.
--- Create a base table with various data types.
 CREATE TABLE t_minmax (
     k1 INT NOT NULL,
     c_int INT NULL,
@@ -19,92 +13,85 @@ PROPERTIES (
 );
 -- result:
 -- !result
-
--- Insert test data: c_int values range from 1 to 100
 INSERT INTO t_minmax
 SELECT
     idx,
-    idx % 100 + 1,           -- c_int: 1 to 100
-    idx * 2,                 -- c_bigint: 0, 2, 4, ...
-    DATE '2024-01-01' + INTERVAL (idx % 30) DAY,  -- c_date: varies within Jan 2024
-    concat('str-', idx)      -- c_string: unique strings
-FROM TABLE(generate_series(0, 9999));
+    idx % 100 + 1,
+    idx * 2,
+    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),
+    concat('str-', idx)
+FROM TABLE(generate_series(0, 9999)) AS t(idx);
 -- result:
 -- !result
-
--- Create probe table for join with MIN/MAX aggregation
 CREATE TABLE t_probe (
     k1 INT NOT NULL,
     probe_value INT NULL
 ) ENGINE=OLAP
-DUPLICATE KEY(k1)
+PRIMARY KEY(k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 8
 PROPERTIES (
     "replication_num" = "1"
 );
 -- result:
 -- !result
-
 INSERT INTO t_probe
-SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999));
+SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999)) AS t(idx);
 -- result:
 -- !result
-
--- # Test 1: MIN only query - should generate MIN runtime filter
--- The global MIN of c_int is 1, so filter: c_int >= 1
+DELETE FROM t_minmax WHERE k1 < 100;
+-- result:
+-- !result
+DELETE FROM t_probe WHERE k1 < 100;
+-- result:
+-- !result
+set enable_min_max_runtime_filter=true;
+-- result:
+-- !result
+set enable_rewrite_simple_agg_to_meta_scan=false;
+-- result:
+-- !result
+function: assert_explain_verbose_contains('SELECT MIN(c_int) AS min_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT MAX(c_int) AS max_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+-- result:
+None
+-- !result
 SELECT MIN(c_int) AS min_val FROM t_minmax;
 -- result:
 1
 -- !result
-
--- # Test 2: MAX only query - should generate MAX runtime filter
--- The global MAX of c_int is 100, so filter: c_int <= 100
 SELECT MAX(c_int) AS max_val FROM t_minmax;
 -- result:
 100
 -- !result
-
--- # Test 3: Both MIN and MAX on same column - should generate combined range filter
--- Range: c_int >= 1 AND c_int <= 100
 SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
 -- result:
 1	100
 -- !result
-
--- # Test 4: MIN and MAX on different columns
 SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
 -- result:
 1	19998
 -- !result
-
--- # Test 5: MIN/MAX with WHERE clause - filter should still work
--- The WHERE clause further restricts the range, but MIN/MAX RF still applies
 SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
 -- result:
 20
 -- !result
-
--- # Test 6: Join with MIN aggregation - probe side should benefit from MIN RF
--- The MIN aggregation on t_probe produces a single value that can be used as filter
--- When joining with t_minmax, the MIN value can filter t_minmax rows
 SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
 FROM t_probe p
 JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
 WHERE p.k1 < 100;
 -- result:
-5000
+0
 -- !result
-
--- # Test 7: Join with MAX aggregation
 SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
 FROM t_probe p
 JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
 WHERE p.k1 >= 900;
 -- result:
-5050
+9702
 -- !result
-
--- # Test 8: Multiple MIN/MAX aggregations in one query
 SELECT
     MIN(c_int) AS min_int,
     MAX(c_int) AS max_int,
@@ -112,44 +99,150 @@ SELECT
     MAX(c_bigint) AS max_bigint
 FROM t_minmax;
 -- result:
-1	100	0	19998
+1	100	200	19998
 -- !result
-
--- # Test 9: MIN/MAX with date type
 SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
 -- result:
 2024-01-01	2024-01-30
 -- !result
-
--- # Test 10: MIN/MAX with string type (lexicographic order)
 SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
 -- result:
-str-0	str-9999
+str-100	str-9999
 -- !result
-
--- # Test 11: Aggregation without MIN/MAX - should NOT generate MIN/MAX RF
 SELECT COUNT(*), SUM(c_int) FROM t_minmax;
 -- result:
-10000	505000
+9900	499950
 -- !result
-
--- # Test 12: MIN/MAX with GROUP BY - should NOT generate MIN/MAX RF
--- This is expected behavior: MIN/MAX RF only works without GROUP BY
 SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
 FROM t_minmax
 GROUP BY c_int % 10
 ORDER BY grp
 LIMIT 5;
 -- result:
-0	0
-1	2
-2	4
-3	6
-4	8
+0	218
+1	200
+2	202
+3	204
+4	206
 -- !result
-
--- # Cleanup
+SELECT COUNT(*)
+FROM t_minmax m
+JOIN (
+    SELECT MIN(m2.c_int) AS min_int, MAX(m2.c_int) AS max_int
+    FROM t_minmax m2
+    JOIN t_probe p2 ON m2.c_int = p2.probe_value
+) s ON m.c_int BETWEEN s.min_int AND s.max_int;
+-- result:
+4851
+-- !result
+INSERT INTO t_minmax
+SELECT
+    idx,
+    idx % 100 + 1,
+    idx * 2,
+    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),
+    concat('str-', idx)
+FROM TABLE(generate_series(9999, 10999)) AS t(idx);
+-- result:
+-- !result
+INSERT INTO t_probe
+SELECT idx, idx % 50 FROM TABLE(generate_series(10000, 10999)) AS t(idx);
+-- result:
+-- !result
+DELETE FROM t_minmax WHERE k1 < 100;
+-- result:
+-- !result
+DELETE FROM t_probe WHERE k1 < 100;
+-- result:
+-- !result
+function: assert_explain_verbose_contains('SELECT MIN(c_int) AS min_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('SELECT MAX(c_int) AS max_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+-- result:
+None
+-- !result
+SELECT MIN(c_int) AS min_val FROM t_minmax;
+-- result:
+1
+-- !result
+SELECT MAX(c_int) AS max_val FROM t_minmax;
+-- result:
+100
+-- !result
+SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
+-- result:
+1	100
+-- !result
+SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
+-- result:
+1	21998
+-- !result
+SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
+-- result:
+20
+-- !result
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 < 100;
+-- result:
+0
+-- !result
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 >= 900;
+-- result:
+117502
+-- !result
+SELECT
+    MIN(c_int) AS min_int,
+    MAX(c_int) AS max_int,
+    MIN(c_bigint) AS min_bigint,
+    MAX(c_bigint) AS max_bigint
+FROM t_minmax;
+-- result:
+1	100	200	21998
+-- !result
+SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
+-- result:
+2024-01-01	2024-01-30
+-- !result
+SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
+-- result:
+str-100	str-9999
+-- !result
+SELECT COUNT(*), SUM(c_int) FROM t_minmax;
+-- result:
+10901	550550
+-- !result
+SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
+FROM t_minmax
+GROUP BY c_int % 10
+ORDER BY grp
+LIMIT 5;
+-- result:
+0	218
+1	200
+2	202
+3	204
+4	206
+-- !result
+SELECT COUNT(*)
+FROM t_minmax m
+JOIN (
+    SELECT MIN(m2.c_int) AS min_int, MAX(m2.c_int) AS max_int
+    FROM t_minmax m2
+    JOIN t_probe p2 ON m2.c_int = p2.probe_value
+) s ON m.c_int BETWEEN s.min_int AND s.max_int;
+-- result:
+5341
+-- !result
 DROP TABLE IF EXISTS t_probe;
+-- result:
+-- !result
 DROP TABLE IF EXISTS t_minmax;
 -- result:
 -- !result

--- a/test/sql/test_runtime_filter/R/test_runtime_filter_min_max
+++ b/test/sql/test_runtime_filter/R/test_runtime_filter_min_max
@@ -1,0 +1,155 @@
+-- name: test_runtime_filter_min_max
+-- This test verifies MIN/MAX runtime filter functionality.
+-- MIN/MAX runtime filters are generated for global aggregations without GROUP BY.
+-- The filter represents the global MIN/MAX range and can be pushed down to scan nodes.
+
+-- # Prepare data for MIN/MAX runtime filter testing.
+-- Create a base table with various data types.
+CREATE TABLE t_minmax (
+    k1 INT NOT NULL,
+    c_int INT NULL,
+    c_bigint BIGINT NULL,
+    c_date DATE NULL,
+    c_string STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 8
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+
+-- Insert test data: c_int values range from 1 to 100
+INSERT INTO t_minmax
+SELECT
+    idx,
+    idx % 100 + 1,           -- c_int: 1 to 100
+    idx * 2,                 -- c_bigint: 0, 2, 4, ...
+    DATE '2024-01-01' + INTERVAL (idx % 30) DAY,  -- c_date: varies within Jan 2024
+    concat('str-', idx)      -- c_string: unique strings
+FROM TABLE(generate_series(0, 9999));
+-- result:
+-- !result
+
+-- Create probe table for join with MIN/MAX aggregation
+CREATE TABLE t_probe (
+    k1 INT NOT NULL,
+    probe_value INT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 8
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+
+INSERT INTO t_probe
+SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999));
+-- result:
+-- !result
+
+-- # Test 1: MIN only query - should generate MIN runtime filter
+-- The global MIN of c_int is 1, so filter: c_int >= 1
+SELECT MIN(c_int) AS min_val FROM t_minmax;
+-- result:
+1
+-- !result
+
+-- # Test 2: MAX only query - should generate MAX runtime filter
+-- The global MAX of c_int is 100, so filter: c_int <= 100
+SELECT MAX(c_int) AS max_val FROM t_minmax;
+-- result:
+100
+-- !result
+
+-- # Test 3: Both MIN and MAX on same column - should generate combined range filter
+-- Range: c_int >= 1 AND c_int <= 100
+SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
+-- result:
+1	100
+-- !result
+
+-- # Test 4: MIN and MAX on different columns
+SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
+-- result:
+1	19998
+-- !result
+
+-- # Test 5: MIN/MAX with WHERE clause - filter should still work
+-- The WHERE clause further restricts the range, but MIN/MAX RF still applies
+SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
+-- result:
+20
+-- !result
+
+-- # Test 6: Join with MIN aggregation - probe side should benefit from MIN RF
+-- The MIN aggregation on t_probe produces a single value that can be used as filter
+-- When joining with t_minmax, the MIN value can filter t_minmax rows
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 < 100;
+-- result:
+5000
+-- !result
+
+-- # Test 7: Join with MAX aggregation
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 >= 900;
+-- result:
+5050
+-- !result
+
+-- # Test 8: Multiple MIN/MAX aggregations in one query
+SELECT
+    MIN(c_int) AS min_int,
+    MAX(c_int) AS max_int,
+    MIN(c_bigint) AS min_bigint,
+    MAX(c_bigint) AS max_bigint
+FROM t_minmax;
+-- result:
+1	100	0	19998
+-- !result
+
+-- # Test 9: MIN/MAX with date type
+SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
+-- result:
+2024-01-01	2024-01-30
+-- !result
+
+-- # Test 10: MIN/MAX with string type (lexicographic order)
+SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
+-- result:
+str-0	str-9999
+-- !result
+
+-- # Test 11: Aggregation without MIN/MAX - should NOT generate MIN/MAX RF
+SELECT COUNT(*), SUM(c_int) FROM t_minmax;
+-- result:
+10000	505000
+-- !result
+
+-- # Test 12: MIN/MAX with GROUP BY - should NOT generate MIN/MAX RF
+-- This is expected behavior: MIN/MAX RF only works without GROUP BY
+SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
+FROM t_minmax
+GROUP BY c_int % 10
+ORDER BY grp
+LIMIT 5;
+-- result:
+0	0
+1	2
+2	4
+3	6
+4	8
+-- !result
+
+-- # Cleanup
+DROP TABLE IF EXISTS t_probe;
+DROP TABLE IF EXISTS t_minmax;
+-- result:
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_filter_min_max
+++ b/test/sql/test_runtime_filter/T/test_runtime_filter_min_max
@@ -1,0 +1,106 @@
+-- name: test_runtime_filter_min_max
+-- This test verifies MIN/MAX runtime filter functionality.
+-- MIN/MAX runtime filters are generated for global aggregations without GROUP BY.
+-- The filter represents the global MIN/MAX range and can be pushed down to scan nodes.
+
+-- # Prepare data for MIN/MAX runtime filter testing.
+-- Create a base table with various data types.
+CREATE TABLE t_minmax (
+    k1 INT NOT NULL,
+    c_int INT NULL,
+    c_bigint BIGINT NULL,
+    c_date DATE NULL,
+    c_string STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 8
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- Insert test data: c_int values range from 1 to 100
+INSERT INTO t_minmax
+SELECT
+    idx,
+    idx % 100 + 1,           -- c_int: 1 to 100
+    idx * 2,                 -- c_bigint: 0, 2, 4, ...
+    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),  -- c_date: varies within Jan 2024
+    concat('str-', idx)      -- c_string: unique strings
+FROM TABLE(generate_series(0, 9999)) AS t(idx);
+
+-- Create probe table for join with MIN/MAX aggregation
+CREATE TABLE t_probe (
+    k1 INT NOT NULL,
+    probe_value INT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 8
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t_probe
+SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999) AS t(idx));
+
+set enable_rewrite_simple_agg_to_meta_scan=false;
+-- # Test 1: MIN only query - should generate MIN runtime filter
+-- The global MIN of c_int is 1, so filter: c_int >= 1
+SELECT MIN(c_int) AS min_val FROM t_minmax;
+
+-- # Test 2: MAX only query - should generate MAX runtime filter
+-- The global MAX of c_int is 100, so filter: c_int <= 100
+SELECT MAX(c_int) AS max_val FROM t_minmax;
+
+-- # Test 3: Both MIN and MAX on same column - should generate combined range filter
+-- Range: c_int >= 1 AND c_int <= 100
+SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
+
+-- # Test 4: MIN and MAX on different columns
+SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
+
+-- # Test 5: MIN/MAX with WHERE clause - filter should still work
+-- The WHERE clause further restricts the range, but MIN/MAX RF still applies
+SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
+
+-- # Test 6: Join with MIN aggregation - probe side should benefit from MIN RF
+-- The MIN aggregation on t_probe produces a single value that can be used as filter
+-- When joining with t_minmax, the MIN value can filter t_minmax rows
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 < 100;
+
+-- # Test 7: Join with MAX aggregation
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 >= 900;
+
+-- # Test 8: Multiple MIN/MAX aggregations in one query
+SELECT
+    MIN(c_int) AS min_int,
+    MAX(c_int) AS max_int,
+    MIN(c_bigint) AS min_bigint,
+    MAX(c_bigint) AS max_bigint
+FROM t_minmax;
+
+-- # Test 9: MIN/MAX with date type
+SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
+
+-- # Test 10: MIN/MAX with string type (lexicographic order)
+SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
+
+-- # Test 11: Aggregation without MIN/MAX - should NOT generate MIN/MAX RF
+SELECT COUNT(*), SUM(c_int) FROM t_minmax;
+
+-- # Test 12: MIN/MAX with GROUP BY - should NOT generate MIN/MAX RF
+-- This is expected behavior: MIN/MAX RF only works without GROUP BY
+SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
+FROM t_minmax
+GROUP BY c_int % 10
+ORDER BY grp
+LIMIT 5;
+
+-- # Cleanup
+DROP TABLE IF EXISTS t_probe;
+DROP TABLE IF EXISTS t_minmax;

--- a/test/sql/test_runtime_filter/T/test_runtime_filter_min_max
+++ b/test/sql/test_runtime_filter/T/test_runtime_filter_min_max
@@ -18,65 +18,58 @@ PROPERTIES (
     "replication_num" = "1"
 );
 
--- Insert test data: c_int values range from 1 to 100
 INSERT INTO t_minmax
 SELECT
     idx,
-    idx % 100 + 1,           -- c_int: 1 to 100
-    idx * 2,                 -- c_bigint: 0, 2, 4, ...
-    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),  -- c_date: varies within Jan 2024
-    concat('str-', idx)      -- c_string: unique strings
+    idx % 100 + 1,
+    idx * 2,
+    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),
+    concat('str-', idx)
 FROM TABLE(generate_series(0, 9999)) AS t(idx);
 
--- Create probe table for join with MIN/MAX aggregation
 CREATE TABLE t_probe (
     k1 INT NOT NULL,
     probe_value INT NULL
 ) ENGINE=OLAP
-DUPLICATE KEY(k1)
+PRIMARY KEY(k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 8
 PROPERTIES (
     "replication_num" = "1"
 );
 
 INSERT INTO t_probe
-SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999) AS t(idx));
+SELECT idx, idx % 50 FROM TABLE(generate_series(0, 999)) AS t(idx);
 
+-- delete some data to ensure some optimization based on metadata is not working, but runtime filter should still work
+DELETE FROM t_minmax WHERE k1 < 100;
+DELETE FROM t_probe WHERE k1 < 100;
+
+set enable_min_max_runtime_filter=true;
 set enable_rewrite_simple_agg_to_meta_scan=false;
--- # Test 1: MIN only query - should generate MIN runtime filter
--- The global MIN of c_int is 1, so filter: c_int >= 1
+
+function: assert_explain_verbose_contains('SELECT MIN(c_int) AS min_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+function: assert_explain_verbose_contains('SELECT MAX(c_int) AS max_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+
 SELECT MIN(c_int) AS min_val FROM t_minmax;
 
--- # Test 2: MAX only query - should generate MAX runtime filter
--- The global MAX of c_int is 100, so filter: c_int <= 100
 SELECT MAX(c_int) AS max_val FROM t_minmax;
 
--- # Test 3: Both MIN and MAX on same column - should generate combined range filter
--- Range: c_int >= 1 AND c_int <= 100
 SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
 
--- # Test 4: MIN and MAX on different columns
 SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
 
--- # Test 5: MIN/MAX with WHERE clause - filter should still work
--- The WHERE clause further restricts the range, but MIN/MAX RF still applies
 SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
 
--- # Test 6: Join with MIN aggregation - probe side should benefit from MIN RF
--- The MIN aggregation on t_probe produces a single value that can be used as filter
--- When joining with t_minmax, the MIN value can filter t_minmax rows
 SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
 FROM t_probe p
 JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
 WHERE p.k1 < 100;
 
--- # Test 7: Join with MAX aggregation
 SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
 FROM t_probe p
 JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
 WHERE p.k1 >= 900;
 
--- # Test 8: Multiple MIN/MAX aggregations in one query
 SELECT
     MIN(c_int) AS min_int,
     MAX(c_int) AS max_int,
@@ -84,23 +77,92 @@ SELECT
     MAX(c_bigint) AS max_bigint
 FROM t_minmax;
 
--- # Test 9: MIN/MAX with date type
 SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
 
--- # Test 10: MIN/MAX with string type (lexicographic order)
 SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
 
--- # Test 11: Aggregation without MIN/MAX - should NOT generate MIN/MAX RF
 SELECT COUNT(*), SUM(c_int) FROM t_minmax;
 
--- # Test 12: MIN/MAX with GROUP BY - should NOT generate MIN/MAX RF
--- This is expected behavior: MIN/MAX RF only works without GROUP BY
 SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
 FROM t_minmax
 GROUP BY c_int % 10
 ORDER BY grp
 LIMIT 5;
 
--- # Cleanup
+SELECT COUNT(*)
+FROM t_minmax m
+JOIN (
+    SELECT MIN(m2.c_int) AS min_int, MAX(m2.c_int) AS max_int
+    FROM t_minmax m2
+    JOIN t_probe p2 ON m2.c_int = p2.probe_value
+) s ON m.c_int BETWEEN s.min_int AND s.max_int;
+
+-- reinsert data
+INSERT INTO t_minmax
+SELECT
+    idx,
+    idx % 100 + 1,
+    idx * 2,
+    CAST(date_add('2024-01-01', INTERVAL (idx % 30) DAY) AS DATE),
+    concat('str-', idx)
+FROM TABLE(generate_series(9999, 10999)) AS t(idx);
+
+INSERT INTO t_probe
+SELECT idx, idx % 50 FROM TABLE(generate_series(10000, 10999)) AS t(idx);
+
+-- redelete data
+DELETE FROM t_minmax WHERE k1 < 100;
+DELETE FROM t_probe WHERE k1 < 100;
+
+function: assert_explain_verbose_contains('SELECT MIN(c_int) AS min_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+function: assert_explain_verbose_contains('SELECT MAX(c_int) AS max_val FROM t_minmax', '- filter_id = 0', 'build_expr')
+
+SELECT MIN(c_int) AS min_val FROM t_minmax;
+
+SELECT MAX(c_int) AS max_val FROM t_minmax;
+
+SELECT MIN(c_int) AS min_val, MAX(c_int) AS max_val FROM t_minmax;
+
+SELECT MIN(c_int) AS min_int, MAX(c_bigint) AS max_bigint FROM t_minmax;
+
+SELECT MIN(c_int) AS min_val FROM t_minmax WHERE c_int BETWEEN 20 AND 50;
+
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 < 100;
+
+SELECT /*+SET_VAR(enable_min_max_runtime_filter=true)*/ COUNT(*)
+FROM t_probe p
+JOIN [broadcast] t_minmax m ON p.probe_value = m.c_int
+WHERE p.k1 >= 900;
+
+SELECT
+    MIN(c_int) AS min_int,
+    MAX(c_int) AS max_int,
+    MIN(c_bigint) AS min_bigint,
+    MAX(c_bigint) AS max_bigint
+FROM t_minmax;
+
+SELECT MIN(c_date) AS earliest, MAX(c_date) AS latest FROM t_minmax;
+
+SELECT MIN(c_string) AS first_str, MAX(c_string) AS last_str FROM t_minmax;
+
+SELECT COUNT(*), SUM(c_int) FROM t_minmax;
+
+SELECT c_int % 10 AS grp, MIN(c_bigint) AS min_bigint
+FROM t_minmax
+GROUP BY c_int % 10
+ORDER BY grp
+LIMIT 5;
+
+SELECT COUNT(*)
+FROM t_minmax m
+JOIN (
+    SELECT MIN(m2.c_int) AS min_int, MAX(m2.c_int) AS max_int
+    FROM t_minmax m2
+    JOIN t_probe p2 ON m2.c_int = p2.probe_value
+) s ON m.c_int BETWEEN s.min_int AND s.max_int;
+
 DROP TABLE IF EXISTS t_probe;
 DROP TABLE IF EXISTS t_minmax;


### PR DESCRIPTION
## Why I'm doing:


We already have MIN/MAX-related optimizations in the FE:
- MinMaxOptOnScanRule: Only for Iceberg scan, with a narrow pattern (agg → project → Iceberg scan) and strict conditions (no limit, no non-partition predicates, only MIN/MAX on column refs). It is not a general solution.

- PartitionColumnMinMaxRewriteRule: Only for partition-column MIN/MAX on Olap tables (partition prune / partition values / TopN rewrite). It requires no GROUP BY, no HAVING, no predicate, no limit, and a single partition column. So it is limited to partition columns and specific table/partition types.

These rules help in their specific cases but are not a common solution: they depend on table type (Iceberg vs Olap), partition layout, and simple scan-only patterns. They do not cover MIN/MAX in join plans or MIN/MAX on non-partition columns in a unified way.


We introduce MIN/MAX runtime filter as a common solution: at runtime, the node that computes global MIN/MAX (e.g., on the join build side) builds a runtime filter with the min/max range and pushes it to the probe-side scan. This works for any table type and column, and for both simple MIN/MAX and MIN/MAX in join/subquery, complementing the existing FE rules.

## What I'm doing:

- FE: Generate MIN/MAX runtime filter from global aggregation nodes and assign it to the probe scan.
- BE: Build and propagate MIN/MAX runtime filters in aggregation (blocking/streaming) and apply the range at the scan.
- Session variable: enable_min_max_runtime_filter to enable/disable the feature.
- Tests: Unit tests and SQL tests for simple and join (including subquery) MIN/MAX cases.


This is a followup of https://github.com/StarRocks/starrocks/pull/69751 .


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
