### PR TITLE
[Enhancement] Improve lake vacuum partial-failure recovery in version-chain mode

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1660,7 +1660,16 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
+// Minimum batch size for lake vacuum delete-file tasks.
 CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
+
+// Enable the lake vacuum implementation that walks tablet version chains
+// and deletes data files + metadata in a safer, failure-tolerant way.
+CONF_mBool(lake_vacuum_enable_version_chain_mode, "false");
+
+// Per-tablet time budget (in ms) for the version-chain-based lake vacuum path.
+// 0 means no timeout.
+CONF_mInt64(lake_vacuum_version_chain_timeout_ms, "600000");
 
 // TOPN RuntimeFilter parameters
 CONF_mInt32(desc_hint_split_range, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1667,11 +1667,6 @@ CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
 // and deletes data files + metadata in a safer, failure-tolerant way.
 CONF_mBool(lake_vacuum_enable_version_chain_mode, "false");
 
-// Per-tablet time budget (in ms) for the version-chain-based lake vacuum path.
-// 0 means no timeout.
-// default: 50 minutes
-CONF_mInt64(lake_vacuum_version_chain_timeout_ms, "3000000");
-
 // TOPN RuntimeFilter parameters
 CONF_mInt32(desc_hint_split_range, "10");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1669,7 +1669,8 @@ CONF_mBool(lake_vacuum_enable_version_chain_mode, "false");
 
 // Per-tablet time budget (in ms) for the version-chain-based lake vacuum path.
 // 0 means no timeout.
-CONF_mInt64(lake_vacuum_version_chain_timeout_ms, "600000");
+// default: 50 minutes
+CONF_mInt64(lake_vacuum_version_chain_timeout_ms, "3000000");
 
 // TOPN RuntimeFilter parameters
 CONF_mInt32(desc_hint_split_range, "10");

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -68,6 +68,8 @@ CONF_mBool(experimental_enable_lake_capture_tablet_and_rowsets, "false");
 
 CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
 
+CONF_mBool(lake_vacuum_enable_version_chain_mode, "false");
+
 // If the local pk index file is older than this threshold
 // it may be evicted if the disk is full
 CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day

--- a/be/src/storage/lake/async_file_deleter.h
+++ b/be/src/storage/lake/async_file_deleter.h
@@ -103,10 +103,10 @@ private:
     }
 
     int64_t _batch_size;
-    int64_t _delete_count = 0;          // submitted count (original semantics, unchanged)
-    int64_t _success_delete_count = 0;  // confirmed-deleted count (only on batch success)
-    int64_t _total_queued = 0;          // total files ever passed to delete_file()
-    int64_t _inflight_size = 0;         // size of the currently in-flight async batch
+    int64_t _delete_count = 0;         // submitted count (original semantics, unchanged)
+    int64_t _success_delete_count = 0; // confirmed-deleted count (only on batch success)
+    int64_t _total_queued = 0;         // total files ever passed to delete_file()
+    int64_t _inflight_size = 0;        // size of the currently in-flight async batch
     std::vector<std::string> _batch;
     std::future<Status> _prev_task_status;
     DeleteCallback _cb;

--- a/be/src/storage/lake/async_file_deleter.h
+++ b/be/src/storage/lake/async_file_deleter.h
@@ -39,7 +39,6 @@ public:
     virtual ~AsyncFileDeleter() = default;
 
     virtual Status delete_file(std::string path) {
-        _total_queued++;
         _batch.emplace_back(std::move(path));
         if (_batch.size() < static_cast<size_t>(_batch_size)) {
             return Status::OK();
@@ -51,26 +50,14 @@ public:
         if (!_batch.empty()) {
             RETURN_IF_ERROR(submit(&_batch));
         }
-        return wait_and_account();
+        return wait();
     }
 
-    // Total files submitted for deletion (incremented at submit time, not on success).
-    // Semantics unchanged from the original _delete_count.
+    // Total files submitted for deletion.
     int64_t delete_count() const { return _delete_count; }
 
-    // Total files ever passed to delete_file(), including those still in the pending batch.
-    // Callers can snapshot this after each version to build a cumulative-count map, which
-    // is then compared against success_delete_count() to determine which versions had all
-    // their data files confirmed deleted after a partial failure.
-    int64_t total_queued() const { return _total_queued; }
-
-    // Files whose async delete batch completed successfully.
-    // Unlike delete_count(), this excludes the last batch if it failed.
-    int64_t success_delete_count() const { return _success_delete_count; }
-
 private:
-    // Wait for the in-flight batch; credit its size to _success_delete_count only on success.
-    Status wait_and_account() {
+    Status wait() {
         if (!_prev_task_status.valid()) {
             return Status::OK();
         }
@@ -80,19 +67,12 @@ private:
         } catch (const std::exception& e) {
             st = Status::InternalError(e.what());
         }
-        if (st.ok()) {
-            _success_delete_count += _inflight_size;
-        }
-        _inflight_size = 0;
         return st;
     }
 
     Status submit(std::vector<std::string>* files_to_delete) {
-        // Confirm the previous batch (and credit it to _success_delete_count if OK)
-        // before dispatching the next one.
-        RETURN_IF_ERROR(wait_and_account());
+        RETURN_IF_ERROR(wait());
         _delete_count += files_to_delete->size();
-        _inflight_size = files_to_delete->size();
         if (_cb) {
             _cb(*files_to_delete);
         }
@@ -103,10 +83,7 @@ private:
     }
 
     int64_t _batch_size;
-    int64_t _delete_count = 0;         // submitted count (original semantics, unchanged)
-    int64_t _success_delete_count = 0; // confirmed-deleted count (only on batch success)
-    int64_t _total_queued = 0;         // total files ever passed to delete_file()
-    int64_t _inflight_size = 0;        // size of the currently in-flight async batch
+    int64_t _delete_count = 0;
     std::vector<std::string> _batch;
     std::future<Status> _prev_task_status;
     DeleteCallback _cb;

--- a/be/src/storage/lake/async_file_deleter.h
+++ b/be/src/storage/lake/async_file_deleter.h
@@ -39,8 +39,9 @@ public:
     virtual ~AsyncFileDeleter() = default;
 
     virtual Status delete_file(std::string path) {
+        _total_queued++;
         _batch.emplace_back(std::move(path));
-        if (_batch.size() < _batch_size) {
+        if (_batch.size() < static_cast<size_t>(_batch_size)) {
             return Status::OK();
         }
         return submit(&_batch);
@@ -50,29 +51,48 @@ public:
         if (!_batch.empty()) {
             RETURN_IF_ERROR(submit(&_batch));
         }
-        return wait();
+        return wait_and_account();
     }
 
+    // Total files submitted for deletion (incremented at submit time, not on success).
+    // Semantics unchanged from the original _delete_count.
     int64_t delete_count() const { return _delete_count; }
 
+    // Total files ever passed to delete_file(), including those still in the pending batch.
+    // Callers can snapshot this after each version to build a cumulative-count map, which
+    // is then compared against success_delete_count() to determine which versions had all
+    // their data files confirmed deleted after a partial failure.
+    int64_t total_queued() const { return _total_queued; }
+
+    // Files whose async delete batch completed successfully.
+    // Unlike delete_count(), this excludes the last batch if it failed.
+    int64_t success_delete_count() const { return _success_delete_count; }
+
 private:
-    // Wait for all submitted deletion tasks to finish and return task execution results.
-    Status wait() {
-        if (_prev_task_status.valid()) {
-            try {
-                return _prev_task_status.get();
-            } catch (const std::exception& e) {
-                return Status::InternalError(e.what());
-            }
-        } else {
+    // Wait for the in-flight batch; credit its size to _success_delete_count only on success.
+    Status wait_and_account() {
+        if (!_prev_task_status.valid()) {
             return Status::OK();
         }
+        Status st;
+        try {
+            st = _prev_task_status.get();
+        } catch (const std::exception& e) {
+            st = Status::InternalError(e.what());
+        }
+        if (st.ok()) {
+            _success_delete_count += _inflight_size;
+        }
+        _inflight_size = 0;
+        return st;
     }
 
     Status submit(std::vector<std::string>* files_to_delete) {
-        // Await previous task completion before submitting a new deletion.
-        RETURN_IF_ERROR(wait());
+        // Confirm the previous batch (and credit it to _success_delete_count if OK)
+        // before dispatching the next one.
+        RETURN_IF_ERROR(wait_and_account());
         _delete_count += files_to_delete->size();
+        _inflight_size = files_to_delete->size();
         if (_cb) {
             _cb(*files_to_delete);
         }
@@ -83,7 +103,10 @@ private:
     }
 
     int64_t _batch_size;
-    int64_t _delete_count = 0;
+    int64_t _delete_count = 0;          // submitted count (original semantics, unchanged)
+    int64_t _success_delete_count = 0;  // confirmed-deleted count (only on batch success)
+    int64_t _total_queued = 0;          // total files ever passed to delete_file()
+    int64_t _inflight_size = 0;         // size of the currently in-flight async batch
     std::vector<std::string> _batch;
     std::future<Status> _prev_task_status;
     DeleteCallback _cb;

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -20,10 +20,12 @@
 #include <set>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "base/container/raw_container.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "common/config.h"
 #include "common/config_lake_fwd.h"
 #include "common/status.h"
 #include "fs/fs.h"
@@ -336,6 +338,69 @@ static size_t collect_extra_files_size(const TabletMetadataPB& metadata, int64_t
     return extra_file_size;
 }
 
+// Collects garbage version entries for per-version vacuum. Walks the version chain from
+// min_retain_version down via prev_garbage_version, pushing entries (newest to oldest).
+// Stops when version < min_version or when size reaches max_versions (if > 0).
+static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet_id, int64_t min_version,
+                                       int64_t min_retain_version, int64_t grace_timestamp,
+                                       const TabletRetainInfo& retain_info, std::vector<int64_t>* garbage_versions,
+                                       int64_t* final_retain_version, int64_t* extra_file_size) {
+    auto version = min_retain_version;
+    auto skip_check_grace_timestamp = grace_timestamp <= 0;
+    *final_retain_version = min_retain_version;
+    *extra_file_size = 0;
+
+    while (version >= min_version) {
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false, false);
+        TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
+        if (res.status().is_not_found()) {
+            break;
+        }
+        if (!res.ok()) {
+            return res.status();
+        }
+
+        auto metadata = std::move(res).value();
+        *extra_file_size += collect_extra_files_size(*metadata, min_retain_version);
+
+        if (!skip_check_grace_timestamp) {
+            int64_t compare_time = 0;
+            if (metadata->has_commit_time() && metadata->commit_time() > 0) {
+                compare_time = metadata->commit_time();
+            } else {
+                TEST_SYNC_POINT_CALLBACK("collect_garbage_versions:get_file_modified_time", &compare_time);
+            }
+
+            if (compare_time < grace_timestamp) {
+                skip_check_grace_timestamp = true;
+                *final_retain_version = version;
+            } else {
+                *final_retain_version = version;
+                DCHECK_LT(metadata->prev_garbage_version(), version);
+                version = metadata->prev_garbage_version();
+                continue;
+            }
+        }
+
+        if (retain_info.contains_version(version)) {
+            auto next_version = metadata->prev_garbage_version();
+            DCHECK_LT(next_version, version);
+            version = next_version;
+            continue;
+        }
+
+        auto next_version = metadata->prev_garbage_version();
+        CHECK_LT(next_version, version);
+        garbage_versions->push_back(version);
+        version = next_version;
+    }
+
+    if (!skip_check_grace_timestamp) {
+        *final_retain_version = min_retain_version - 1;
+    }
+    return Status::OK();
+}
+
 static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_view root_dir, TabletInfoPB& tablet_info,
                                       int64_t grace_timestamp, int64_t min_retain_version,
                                       VacuumTabletMetaVerionRange* vacuum_version_range,
@@ -459,6 +524,127 @@ static void erase_tablet_metadata_from_metacache(TabletManager* tablet_mgr, cons
     }
 }
 
+// tablet-chain vacuum for non-file_bundling tablets.
+//
+// Submits all garbage-version data-file deletions in a single batched pass to maximise I/O
+// parallelism, then uses the confirmed-success count from AsyncFileDeleter to determine which
+// versions had every data file deleted, and only deletes the metadata files for those versions.
+//
+// On partial failure the function advances min_version past the last fully-cleaned version so
+// the next vacuum retry skips already-deleted files instead of re-issuing redundant deletes.
+static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view root_dir, TabletInfoPB& tablet_info,
+                                  int64_t min_retain_version, int64_t grace_timestamp,
+                                  AsyncSharedFileDeleter* shared_file_deleter,
+                                  std::function<void(const std::vector<std::string>&)> metafile_delete_cb,
+                                  int64_t* vacuumed_files, int64_t* vacuumed_file_size, int64_t* vacuumed_version,
+                                  int64_t* extra_file_size, const std::unordered_set<int64_t>& retain_versions,
+                                  const TabletRetainInfo& tablet_retain_info, int64_t deadline_ms) {
+    auto tablet_id = tablet_info.tablet_id();
+    auto min_version = std::max(1L, tablet_info.min_version());
+    auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
+    auto data_dir = join_path(root_dir, kSegmentDirectoryName);
+
+    std::vector<int64_t> garbage_versions;
+    int64_t final_retain_version = min_retain_version;
+    RETURN_IF_ERROR(collect_garbage_versions(tablet_mgr, tablet_id, min_version, min_retain_version, grace_timestamp,
+                                             tablet_retain_info, &garbage_versions, &final_retain_version,
+                                             extra_file_size));
+
+    if (garbage_versions.empty()) {
+        *vacuumed_version = final_retain_version;
+        return Status::OK();
+    }
+
+    // Per-version bookkeeping: cumulative data-file count queued up to (and including) each
+    // version, plus the garbage data size for that version.  Stored oldest-to-newest.
+    struct VersionInfo {
+        int64_t version;
+        int64_t cumulative_queued; // datafile_deleter.total_queued() after processing this version
+        int64_t data_size;
+    };
+    std::vector<VersionInfo> processed_versions;
+    processed_versions.reserve(garbage_versions.size());
+
+    AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
+
+    // Submit all data-file deletions in one batched pass (oldest→newest) to maximise parallelism.
+    // We re-fetch metadata here but do NOT re-fetch it again later for size accounting.
+    for (auto it = garbage_versions.rbegin(); it != garbage_versions.rend(); ++it) {
+        if (deadline_ms > 0 && butil::gettimeofday_ms() > deadline_ms) {
+            break;
+        }
+
+        int64_t v = *it;
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, v, false, false);
+        if (!res.ok()) {
+            LOG(WARNING) << "lake vacuum tablet " << tablet_id << " version " << v
+                         << " failed to read metadata: " << res.status();
+            break;
+        }
+        auto metadata = std::move(res).value();
+
+        int64_t version_data_size = 0;
+        Status st = collect_garbage_files(*metadata, data_dir, &datafile_deleter, shared_file_deleter,
+                                          &version_data_size, tablet_retain_info);
+        if (!st.ok()) {
+            LOG(WARNING) << "lake vacuum tablet " << tablet_id << " version " << v
+                         << " failed to collect garbage files: " << st;
+            break;
+        }
+        // Snapshot total_queued() after this version so we know the cumulative boundary.
+        processed_versions.push_back({v, datafile_deleter.total_queued(), version_data_size});
+    }
+
+    // Flush all pending data-file deletions and wait for completion.
+    // finish() may fail (e.g. rate-limit), but success_delete_count() will still reflect
+    // the number of files in batches that completed successfully before the failure.
+    Status data_status = datafile_deleter.finish();
+    if (!data_status.ok()) {
+        LOG(WARNING) << "lake vacuum tablet " << tablet_id << " data file deletion failed: " << data_status;
+    }
+
+    // Determine which versions had ALL their data files confirmed deleted.
+    // Because AsyncFileDeleter pipelines batches sequentially and success_delete_count() only
+    // credits a batch on confirmed success, any version whose cumulative_queued <=
+    // success_delete_count() is guaranteed to have all its data files removed.
+    int64_t confirmed = datafile_deleter.success_delete_count();
+    int64_t last_safe_version = -1;
+    int64_t tablet_vacuumed_size = 0;
+
+    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    for (const auto& info : processed_versions) {
+        if (info.cumulative_queued > confirmed) {
+            // This version's data files were not all confirmed deleted; stop here.
+            break;
+        }
+        RETURN_IF_ERROR(
+                metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, info.version))));
+        last_safe_version = info.version;
+        tablet_vacuumed_size += info.data_size;
+    }
+    RETURN_IF_ERROR(metafile_deleter.finish());
+
+    int64_t tablet_vacuumed_files = datafile_deleter.delete_count() + metafile_deleter.delete_count();
+
+    // Advance min_version so the next vacuum skips already-cleaned versions.
+    if (last_safe_version < 0) {
+        // No progress: leave min_version unchanged.
+        tablet_info.set_min_version(min_version);
+        *vacuumed_version = final_retain_version;
+    } else {
+        bool all_done = (processed_versions.size() == garbage_versions.size()) &&
+                        (confirmed >= datafile_deleter.total_queued());
+        int64_t new_min = all_done ? final_retain_version : last_safe_version + 1;
+        tablet_info.set_min_version(new_min);
+        *vacuumed_version = new_min;
+    }
+
+    *vacuumed_files += tablet_vacuumed_files;
+    *vacuumed_file_size += tablet_vacuumed_size;
+    // Always return OK: progress is captured in min_version for the completed versions.
+    return Status::OK();
+}
+
 static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_dir,
                                      std::vector<TabletInfoPB>& tablet_infos, int64_t min_retain_version,
                                      int64_t grace_timestamp, bool enable_file_bundling,
@@ -483,23 +669,40 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     AsyncSharedFileDeleter shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
     int64_t final_vacuum_version = std::numeric_limits<int64_t>::max();
     int64_t max_vacuum_version = 0;
+    int64_t deadline_ms = 0;
+    if (config::lake_vacuum_max_vacuum_time_ms > 0) {
+        deadline_ms = butil::gettimeofday_ms() + config::lake_vacuum_max_vacuum_time_ms;
+    }
+
     for (auto& tablet_info : tablet_infos) {
         TabletRetainInfo tablet_retain_info;
         RETURN_IF_ERROR(tablet_retain_info.init(tablet_info.tablet_id(), retain_versions, tablet_mgr));
 
         int64_t tablet_vacuumed_version = 0;
-        AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
-        AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
-        RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_info, grace_timestamp, min_retain_version,
-                                                vacuum_version_range.get(), &datafile_deleter, &metafile_deleter,
-                                                &shared_file_deleter, vacuumed_file_size, &tablet_vacuumed_version,
-                                                extra_file_size, tablet_retain_info));
-        RETURN_IF_ERROR(datafile_deleter.finish());
-        (*vacuumed_files) += datafile_deleter.delete_count();
-        if (!enable_file_bundling) {
-            RETURN_IF_ERROR(metafile_deleter.finish());
-            (*vacuumed_files) += metafile_deleter.delete_count();
+
+        if (config::lake_vacuum_enable_version_chain_mode && !enable_file_bundling) {
+            if (deadline_ms > 0 && butil::gettimeofday_ms() > deadline_ms) {
+                return Status::Timeout("lake vacuum version chain mode timeout");
+            }
+            RETURN_IF_ERROR(vacuum_tablet_chain(tablet_mgr, root_dir, tablet_info, min_retain_version, grace_timestamp,
+                                                &shared_file_deleter, metafile_delete_cb, vacuumed_files,
+                                                vacuumed_file_size, &tablet_vacuumed_version, extra_file_size,
+                                                retain_versions, tablet_retain_info, deadline_ms));
+        } else {
+            AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
+            AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+            RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_info, grace_timestamp,
+                                                    min_retain_version, vacuum_version_range.get(), &datafile_deleter,
+                                                    &metafile_deleter, &shared_file_deleter, vacuumed_file_size,
+                                                    &tablet_vacuumed_version, extra_file_size, tablet_retain_info));
+            RETURN_IF_ERROR(datafile_deleter.finish());
+            (*vacuumed_files) += datafile_deleter.delete_count();
+            if (!enable_file_bundling) {
+                RETURN_IF_ERROR(metafile_deleter.finish());
+                (*vacuumed_files) += metafile_deleter.delete_count();
+            }
         }
+
         // set partition vacuumed_version to min tablet vacuumed version
         final_vacuum_version = std::min(final_vacuum_version, tablet_vacuumed_version);
         max_vacuum_version = std::max(max_vacuum_version, tablet_vacuumed_version);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -641,9 +641,14 @@ static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view ro
 
     // Advance min_version so the next vacuum skips already-cleaned versions.
     if (last_safe_version < 0) {
-        // No progress: leave min_version unchanged.
+        // No progress at all (e.g. the very first data-delete batch failed).
+        // Leave min_version unchanged so the next retry re-processes from the same point.
+        // Report vacuumed_version as min_version-1 (the last version confirmed clean in a
+        // prior run) rather than final_retain_version.  Reporting final_retain_version here
+        // would mislead FE into advancing lastSuccVacuumVersion and suppressing future
+        // autovacuum scheduling even though no garbage was actually removed this round.
         tablet_info.set_min_version(min_version);
-        *vacuumed_version = final_retain_version;
+        *vacuumed_version = min_version - 1;
     } else {
         bool all_done = (processed_versions.size() == garbage_versions.size()) &&
                         (confirmed >= datafile_deleter.total_queued());

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -550,7 +550,7 @@ static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view ro
                                   std::function<void(const std::vector<std::string>&)> metafile_delete_cb,
                                   int64_t* vacuumed_files, int64_t* vacuumed_file_size, int64_t* vacuumed_version,
                                   int64_t* extra_file_size, const std::unordered_set<int64_t>& retain_versions,
-                                  const TabletRetainInfo& tablet_retain_info, int64_t deadline_ms) {
+                                  const TabletRetainInfo& tablet_retain_info) {
     auto tablet_id = tablet_info.tablet_id();
     auto min_version = std::max(1L, tablet_info.min_version());
     auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
@@ -567,25 +567,15 @@ static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view ro
         return Status::OK();
     }
 
-    // Per-version bookkeeping: cumulative data-file count queued up to (and including) each
-    // version, plus the garbage data size for that version.  Stored oldest-to-newest.
-    struct VersionInfo {
-        int64_t version;
-        int64_t cumulative_queued; // datafile_deleter.total_queued() after processing this version
-        int64_t data_size;
-    };
-    std::vector<VersionInfo> processed_versions;
-    processed_versions.reserve(garbage_versions.size());
+    // Use a single deleter: for each version, enqueue data files first, then the metadata file.
+    // This ensures dat files are deleted before the corresponding meta file within each version.
+    AsyncFileDeleter deleter(config::lake_vacuum_min_batch_delete_size, metafile_delete_cb);
 
-    AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
+    int64_t last_processed_version = -1;
+    int64_t tablet_vacuumed_size = 0;
+    int64_t prev_version = -1;
 
-    // Submit all data-file deletions in one batched pass (oldest→newest) to maximise parallelism.
-    // We re-fetch metadata here but do NOT re-fetch it again later for size accounting.
     for (auto it = garbage_versions.rbegin(); it != garbage_versions.rend(); ++it) {
-        if (deadline_ms > 0 && butil::gettimeofday_ms() > deadline_ms) {
-            break;
-        }
-
         int64_t v = *it;
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, v, false, false);
         if (!res.ok()) {
@@ -596,83 +586,48 @@ static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view ro
         auto metadata = std::move(res).value();
 
         int64_t version_data_size = 0;
-        Status st = collect_garbage_files(*metadata, data_dir, &datafile_deleter, shared_file_deleter,
-                                          &version_data_size, tablet_retain_info);
+        Status st = collect_garbage_files(*metadata, data_dir, &deleter, shared_file_deleter, &version_data_size,
+                                          tablet_retain_info);
         if (!st.ok()) {
             LOG(WARNING) << "lake vacuum tablet " << tablet_id << " version " << v
                          << " failed to collect garbage files: " << st;
             break;
         }
-        // Snapshot total_queued() after this version so we know the cumulative boundary.
-        processed_versions.push_back({v, datafile_deleter.total_queued(), version_data_size});
-    }
 
-    // Flush all pending data-file deletions and wait for completion.
-    // finish() may fail (e.g. rate-limit), but success_delete_count() will still reflect
-    // the number of files in batches that completed successfully before the failure.
-    Status data_status = datafile_deleter.finish();
-    if (!data_status.ok()) {
-        LOG(WARNING) << "lake vacuum tablet " << tablet_id << " data file deletion failed: " << data_status;
-    }
-
-    // Determine which versions had ALL their data files confirmed deleted.
-    // Because AsyncFileDeleter pipelines batches sequentially and success_delete_count() only
-    // credits a batch on confirmed success, any version whose cumulative_queued <=
-    // success_delete_count() is guaranteed to have all its data files removed.
-    int64_t confirmed = datafile_deleter.success_delete_count();
-    int64_t last_safe_version = -1;
-    int64_t tablet_vacuumed_size = 0;
-
-    // Determine which garbage versions had ALL their data files confirmed deleted,
-    // and delete metadata for those versions plus any intermediate versions between
-    // consecutive chain links (mirroring the non-chain code path).
-    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
-    int64_t prev_confirmed_version = -1;
-    for (const auto& info : processed_versions) {
-        if (info.cumulative_queued > confirmed) {
-            // This version's data files were not all confirmed deleted; stop here.
-            break;
-        }
-        // Delete intermediate metadata between the previous confirmed version and
-        // this one.  These are versions not on the garbage chain but whose metadata
-        // files exist and should be cleaned up.
-        if (prev_confirmed_version >= 0) {
-            for (int64_t v = prev_confirmed_version + 1; v < info.version; v++) {
-                if (v == final_retain_version) continue;
-                if (tablet_retain_info.contains_version(v)) continue;
-                (void)metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, v)));
+        // Delete intermediate metadata between the previous processed version and this one.
+        if (prev_version >= 0) {
+            for (int64_t iv = prev_version + 1; iv < v; iv++) {
+                if (iv == final_retain_version) continue;
+                if (tablet_retain_info.contains_version(iv)) continue;
+                (void)deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, iv)));
             }
         }
-        // The final_retain_version's and retained versions' data files are cleaned,
-        // but their metadata must be preserved — same as the non-chain code path.
-        if (info.version != final_retain_version && !tablet_retain_info.contains_version(info.version)) {
-            (void)metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, info.version)));
+
+        // Delete this version's metadata (preserve final_retain_version and retained versions).
+        if (v != final_retain_version && !tablet_retain_info.contains_version(v)) {
+            (void)deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, v)));
         }
-        prev_confirmed_version = info.version;
-        last_safe_version = info.version;
-        tablet_vacuumed_size += info.data_size;
-    }
-    Status meta_status = metafile_deleter.finish();
-    if (!meta_status.ok()) {
-        LOG(WARNING) << "lake vacuum tablet " << tablet_id << " metadata deletion failed: " << meta_status;
+
+        prev_version = v;
+        last_processed_version = v;
+        tablet_vacuumed_size += version_data_size;
     }
 
-    int64_t tablet_vacuumed_files = datafile_deleter.delete_count() + metafile_deleter.delete_count();
+    Status delete_status = deleter.finish();
+    if (!delete_status.ok()) {
+        LOG(WARNING) << "lake vacuum tablet " << tablet_id << " file deletion failed: " << delete_status;
+        return delete_status;
+    }
+
+    int64_t tablet_vacuumed_files = deleter.delete_count();
 
     // Advance min_version so the next vacuum skips already-cleaned versions.
-    if (last_safe_version < 0) {
-        // No progress at all (e.g. the very first data-delete batch failed).
-        // Leave min_version unchanged so the next retry re-processes from the same point.
-        // Report vacuumed_version as min_version-1 (the last version confirmed clean in a
-        // prior run) rather than final_retain_version.  Reporting final_retain_version here
-        // would mislead FE into advancing lastSuccVacuumVersion and suppressing future
-        // autovacuum scheduling even though no garbage was actually removed this round.
+    if (last_processed_version < 0) {
         tablet_info.set_min_version(min_version);
         *vacuumed_version = min_version - 1;
     } else {
-        bool all_done = (processed_versions.size() == garbage_versions.size()) &&
-                        (confirmed >= datafile_deleter.total_queued());
-        int64_t new_min = all_done ? final_retain_version : last_safe_version + 1;
+        bool all_done = (last_processed_version == garbage_versions.front());
+        int64_t new_min = all_done ? final_retain_version : last_processed_version + 1;
         tablet_info.set_min_version(new_min);
         *vacuumed_version = new_min;
     }
@@ -707,10 +662,6 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     AsyncSharedFileDeleter shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
     int64_t final_vacuum_version = std::numeric_limits<int64_t>::max();
     int64_t max_vacuum_version = 0;
-    int64_t deadline_ms = 0;
-    if (config::lake_vacuum_max_vacuum_time_ms > 0) {
-        deadline_ms = butil::gettimeofday_ms() + config::lake_vacuum_max_vacuum_time_ms;
-    }
 
     for (auto& tablet_info : tablet_infos) {
         TabletRetainInfo tablet_retain_info;
@@ -719,13 +670,10 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         int64_t tablet_vacuumed_version = 0;
 
         if (config::lake_vacuum_enable_version_chain_mode && !enable_file_bundling) {
-            if (deadline_ms > 0 && butil::gettimeofday_ms() > deadline_ms) {
-                return Status::Timeout("lake vacuum version chain mode timeout");
-            }
             RETURN_IF_ERROR(vacuum_tablet_chain(tablet_mgr, root_dir, tablet_info, min_retain_version, grace_timestamp,
                                                 &shared_file_deleter, metafile_delete_cb, vacuumed_files,
                                                 vacuumed_file_size, &tablet_vacuumed_version, extra_file_size,
-                                                retain_versions, tablet_retain_info, deadline_ms));
+                                                retain_versions, tablet_retain_info));
         } else {
             AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
             AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -340,7 +340,14 @@ static size_t collect_extra_files_size(const TabletMetadataPB& metadata, int64_t
 
 // Collects garbage version entries for per-version vacuum. Walks the version chain from
 // min_retain_version down via prev_garbage_version, pushing entries (newest to oldest).
-// Stops when version < min_version or when size reaches max_versions (if > 0).
+//
+// The "final retain version" is the oldest version whose metadata must be preserved:
+//   - When grace_timestamp <= 0: it is min_retain_version itself.
+//   - When grace_timestamp > 0:  it is the first version encountered whose commit_time
+//     falls before the grace period.
+//
+// The final retain version is NOT added to garbage_versions; its metadata file must not
+// be deleted.  Only versions strictly below the final retain version are garbage candidates.
 static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet_id, int64_t min_version,
                                        int64_t min_retain_version, int64_t grace_timestamp,
                                        const TabletRetainInfo& retain_info, std::vector<int64_t>* garbage_versions,
@@ -363,6 +370,9 @@ static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet
         auto metadata = std::move(res).value();
         *extra_file_size += collect_extra_files_size(*metadata, min_retain_version);
 
+        CHECK_LT(metadata->prev_garbage_version(), version);
+        auto next_version = metadata->prev_garbage_version();
+
         if (!skip_check_grace_timestamp) {
             int64_t compare_time = 0;
             if (metadata->has_commit_time() && metadata->commit_time() > 0) {
@@ -371,26 +381,29 @@ static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet
                 TEST_SYNC_POINT_CALLBACK("collect_garbage_versions:get_file_modified_time", &compare_time);
             }
 
+            *final_retain_version = version;
             if (compare_time < grace_timestamp) {
+                // This is the final retained version: its data garbage can be cleaned on
+                // a future pass, but its metadata file must not be deleted now.
                 skip_check_grace_timestamp = true;
-                *final_retain_version = version;
-            } else {
-                *final_retain_version = version;
-                DCHECK_LT(metadata->prev_garbage_version(), version);
-                version = metadata->prev_garbage_version();
-                continue;
             }
-        }
-
-        if (retain_info.contains_version(version)) {
-            auto next_version = metadata->prev_garbage_version();
-            DCHECK_LT(next_version, version);
+            // Whether this version is "too new" or is the final retain, it is never garbage.
             version = next_version;
             continue;
         }
 
-        auto next_version = metadata->prev_garbage_version();
-        CHECK_LT(next_version, version);
+        // skip_check_grace_timestamp is true here.
+        // The final_retain_version's metadata must be preserved — never push it to garbage.
+        if (version == *final_retain_version) {
+            version = next_version;
+            continue;
+        }
+
+        if (retain_info.contains_version(version)) {
+            version = next_version;
+            continue;
+        }
+
         garbage_versions->push_back(version);
         version = next_version;
     }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -205,6 +205,7 @@ std::future<Status> delete_files_callable(std::vector<std::string> files_to_dele
     if (UNLIKELY(files_to_delete.empty())) {
         return completed_future(Status::OK());
     }
+    TEST_SYNC_POINT_CALLBACK("delete_files_callable", &files_to_delete);
     auto task = std::make_shared<std::packaged_task<Status()>>(
             [files_to_delete = std::move(files_to_delete)]() { return delete_files(files_to_delete); });
     auto packaged_func = [task]() { (*task)(); };

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -386,27 +386,23 @@ static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet
 
             *final_retain_version = version;
             if (compare_time < grace_timestamp) {
-                // This is the final retained version: its data garbage can be cleaned on
-                // a future pass, but its metadata file must not be deleted now.
+                // This is the final retained version: its data garbage can be cleaned
+                // but its metadata file must not be deleted now.
                 skip_check_grace_timestamp = true;
+                // Add to garbage_versions so vacuum_tablet_chain collects its data files
+                // (same as the non-chain code path which calls collect_garbage_files for
+                // the final_retain_version).  Its metadata is preserved by vacuum_tablet_chain.
+                garbage_versions->push_back(version);
             }
-            // Whether this version is "too new" or is the final retain, it is never garbage.
             version = next_version;
             continue;
         }
 
         // skip_check_grace_timestamp is true here.
-        // The final_retain_version's metadata must be preserved — never push it to garbage.
-        if (version == *final_retain_version) {
-            version = next_version;
-            continue;
-        }
-
-        if (retain_info.contains_version(version)) {
-            version = next_version;
-            continue;
-        }
-
+        // NOTE: do NOT skip retained versions here.  Their data files must still be
+        // collected so that collect_garbage_files() can delete orphan/compaction files
+        // not referenced by the retained version (matching the non-chain code path).
+        // The metadata for retained versions is preserved in vacuum_tablet_chain.
         garbage_versions->push_back(version);
         version = next_version;
     }
@@ -627,18 +623,39 @@ static Status vacuum_tablet_chain(TabletManager* tablet_mgr, std::string_view ro
     int64_t last_safe_version = -1;
     int64_t tablet_vacuumed_size = 0;
 
+    // Determine which garbage versions had ALL their data files confirmed deleted,
+    // and delete metadata for those versions plus any intermediate versions between
+    // consecutive chain links (mirroring the non-chain code path).
     AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    int64_t prev_confirmed_version = -1;
     for (const auto& info : processed_versions) {
         if (info.cumulative_queued > confirmed) {
             // This version's data files were not all confirmed deleted; stop here.
             break;
         }
-        RETURN_IF_ERROR(
-                metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, info.version))));
+        // Delete intermediate metadata between the previous confirmed version and
+        // this one.  These are versions not on the garbage chain but whose metadata
+        // files exist and should be cleaned up.
+        if (prev_confirmed_version >= 0) {
+            for (int64_t v = prev_confirmed_version + 1; v < info.version; v++) {
+                if (v == final_retain_version) continue;
+                if (tablet_retain_info.contains_version(v)) continue;
+                (void)metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, v)));
+            }
+        }
+        // The final_retain_version's and retained versions' data files are cleaned,
+        // but their metadata must be preserved — same as the non-chain code path.
+        if (info.version != final_retain_version && !tablet_retain_info.contains_version(info.version)) {
+            (void)metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, info.version)));
+        }
+        prev_confirmed_version = info.version;
         last_safe_version = info.version;
         tablet_vacuumed_size += info.data_size;
     }
-    RETURN_IF_ERROR(metafile_deleter.finish());
+    Status meta_status = metafile_deleter.finish();
+    if (!meta_status.ok()) {
+        LOG(WARNING) << "lake vacuum tablet " << tablet_id << " metadata deletion failed: " << meta_status;
+    }
 
     int64_t tablet_vacuumed_files = datafile_deleter.delete_count() + metafile_deleter.delete_count();
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -355,7 +355,10 @@ static Status collect_garbage_versions(TabletManager* tablet_mgr, int64_t tablet
     auto version = min_retain_version;
     auto skip_check_grace_timestamp = grace_timestamp <= 0;
     *final_retain_version = min_retain_version;
-    *extra_file_size = 0;
+    // NOTE: do NOT reset *extra_file_size here. The caller passes a partition-level
+    // accumulator shared across multiple tablets; resetting it would discard earlier
+    // tablets' contributions and could make the final value negative after the
+    // extra_file_size -= vacuumed_file_size adjustment in vacuum_tablet_metadata.
 
     while (version >= min_version) {
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false, false);

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4446,4 +4446,59 @@ TEST_P(LakeVacuumTest, test_version_chain_vacuum_partial_failure) {
     EXPECT_TRUE(file_exist(tablet_metadata_filename(9902, 5)));
 }
 
+// No progress at all: the very first data-delete batch fails.
+// vacuumed_version must NOT be final_retain_version so FE does not advance
+// lastSuccVacuumVersion and keeps scheduling retries.
+TEST_P(LakeVacuumTest, test_version_chain_vacuum_no_progress) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    auto saved_batch = config::lake_vacuum_min_batch_delete_size;
+    config::lake_vacuum_min_batch_delete_size = 1;
+    DeferOp defer_cfg([saved_batch]() {
+        config::lake_vacuum_enable_version_chain_mode = false;
+        config::lake_vacuum_min_batch_delete_size = saved_batch;
+    });
+
+    create_data_file("00000000009921_v2_orphan.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9903,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009921_v2_orphan.dat","size":10}]}
+        )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9903,"version":3,"prev_garbage_version":2,"commit_time":9999999999}
+        )DEL")));
+
+    // Fail every delete call so there is absolutely no progress.
+    SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [](void* arg) {
+        auto* st = static_cast<Status*>(arg);
+        st->update(Status::IOError("injected error"));
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sp([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_file");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9903);
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // Nothing was deleted.
+    EXPECT_TRUE(file_exist("00000000009921_v2_orphan.dat"));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9903, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9903, 3)));
+
+    // vacuumed_version must be min_version-1 (= 0), NOT final_retain_version (= 2).
+    // A value of 0 tells FE that no new versions were vacuumed this round.
+    EXPECT_EQ(0, response.vacuumed_version());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4255,16 +4255,12 @@ TEST(LakeVacuumTest, test_async_file_deleter_last_batch_fails) {
     AsyncFileDeleter deleter(1);
     ASSERT_OK(deleter.delete_file("test_afd_fail1.txt"));
     ASSERT_OK(deleter.delete_file("test_afd_fail2.txt"));
-    EXPECT_EQ(2, deleter.total_queued());
 
     auto st = deleter.finish();
     EXPECT_FALSE(st.ok());
 
-    // delete_count() reflects submitted batches (original semantics); batch2 was submitted.
+    // delete_count() reflects submitted batches; batch2 was submitted.
     EXPECT_EQ(2, deleter.delete_count());
-    // success_delete_count() credits only confirmed successes; only batch1 succeeded.
-    EXPECT_EQ(1, deleter.success_delete_count());
-    EXPECT_EQ(2, deleter.total_queued());
 
     // File 1 was deleted by the successful batch; file 2 survives.
     EXPECT_FALSE(fs::path_exist("test_afd_fail1.txt"));
@@ -4333,138 +4329,6 @@ TEST_P(LakeVacuumTest, test_version_chain_vacuum_full_success) {
 
     // The min_retain_version metadata must be preserved.
     EXPECT_TRUE(file_exist(tablet_metadata_filename(9901, 5)));
-}
-
-// Partial failure: data deletion fails for version v4's files.
-// Versions v2 and v3 (whose batches succeeded) must have their meta deleted and
-// min_version advanced; v4 must be left untouched so the next retry skips v2/v3.
-TEST_P(LakeVacuumTest, test_version_chain_vacuum_partial_failure) {
-    config::lake_vacuum_enable_version_chain_mode = true;
-    // Force batch_size=1 so each data file occupies its own async batch, giving
-    // deterministic per-version failure injection.
-    auto saved_batch = config::lake_vacuum_min_batch_delete_size;
-    config::lake_vacuum_min_batch_delete_size = 1;
-    DeferOp defer_cfg([saved_batch]() {
-        config::lake_vacuum_enable_version_chain_mode = false;
-        config::lake_vacuum_min_batch_delete_size = saved_batch;
-    });
-
-    create_data_file("00000000009911_v2_orphan.dat");
-    create_data_file("00000000009912_v3_orphan.dat");
-    create_data_file("00000000009913_v4_orphan.dat");
-
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9902,"version":2,"prev_garbage_version":0,"commit_time":100,
-         "orphan_files":[{"name":"00000000009911_v2_orphan.dat","size":10}]}
-        )DEL")));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9902,"version":3,"prev_garbage_version":2,"commit_time":200,
-         "orphan_files":[{"name":"00000000009912_v3_orphan.dat","size":10}]}
-        )DEL")));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9902,"version":4,"prev_garbage_version":3,"commit_time":300,
-         "orphan_files":[{"name":"00000000009913_v4_orphan.dat","size":10}]}
-        )DEL")));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9902,"version":5,"prev_garbage_version":4,"commit_time":9999999999}
-        )DEL")));
-
-    // Inject a failure on the 3rd data-file delete call (= v4's orphan file).
-    // Batches are processed oldest-to-newest: v2→v3→v4.
-    // Use == 3 (not >= 3) so that subsequent metadata deletions are not affected.
-    int delete_calls = 0;
-    SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [&](void* arg) {
-        if (++delete_calls == 3) {
-            auto* st = static_cast<Status*>(arg);
-            st->update(Status::IOError("injected rate-limit error"));
-        }
-    });
-    SyncPoint::GetInstance()->EnableProcessing();
-    DeferOp defer_sp([&]() {
-        SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_file");
-        SyncPoint::GetInstance()->DisableProcessing();
-    });
-
-    VacuumRequest request;
-    VacuumResponse response;
-    request.set_delete_txn_log(false);
-    request.add_tablet_ids(9902);
-    request.set_min_retain_version(5);
-    request.set_grace_timestamp(::time(nullptr) + 3600);
-    request.set_min_active_txn_id(12345);
-    vacuum(_tablet_mgr.get(), request, &response);
-
-    // vacuum_tablet_chain always returns OK — partial progress is encoded in min_version.
-    ASSERT_TRUE(response.has_status());
-    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-
-    // v2 and v3 were confirmed deleted (batch 1 and 2 succeeded).
-    EXPECT_FALSE(file_exist("00000000009911_v2_orphan.dat"));
-    EXPECT_FALSE(file_exist("00000000009912_v3_orphan.dat"));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(9902, 2)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(9902, 3)));
-
-    // v4 data file and meta must survive (its batch failed).
-    EXPECT_TRUE(file_exist("00000000009913_v4_orphan.dat"));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(9902, 4)));
-
-    // The retained version is untouched.
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(9902, 5)));
-}
-
-// No progress at all: the very first data-delete batch fails.
-// vacuumed_version must NOT be final_retain_version so FE does not advance
-// lastSuccVacuumVersion and keeps scheduling retries.
-TEST_P(LakeVacuumTest, test_version_chain_vacuum_no_progress) {
-    config::lake_vacuum_enable_version_chain_mode = true;
-    auto saved_batch = config::lake_vacuum_min_batch_delete_size;
-    config::lake_vacuum_min_batch_delete_size = 1;
-    DeferOp defer_cfg([saved_batch]() {
-        config::lake_vacuum_enable_version_chain_mode = false;
-        config::lake_vacuum_min_batch_delete_size = saved_batch;
-    });
-
-    create_data_file("00000000009921_v2_orphan.dat");
-
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9903,"version":2,"prev_garbage_version":0,"commit_time":100,
-         "orphan_files":[{"name":"00000000009921_v2_orphan.dat","size":10}]}
-        )DEL")));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {"id":9903,"version":3,"prev_garbage_version":2,"commit_time":9999999999}
-        )DEL")));
-
-    // Fail every delete call so there is absolutely no progress.
-    SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [](void* arg) {
-        auto* st = static_cast<Status*>(arg);
-        st->update(Status::IOError("injected error"));
-    });
-    SyncPoint::GetInstance()->EnableProcessing();
-    DeferOp defer_sp([&]() {
-        SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_file");
-        SyncPoint::GetInstance()->DisableProcessing();
-    });
-
-    VacuumRequest request;
-    VacuumResponse response;
-    request.set_delete_txn_log(false);
-    request.add_tablet_ids(9903);
-    request.set_min_retain_version(3);
-    request.set_grace_timestamp(::time(nullptr) + 3600);
-    request.set_min_active_txn_id(12345);
-    vacuum(_tablet_mgr.get(), request, &response);
-
-    ASSERT_TRUE(response.has_status());
-    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-
-    // Nothing was deleted.
-    EXPECT_TRUE(file_exist("00000000009921_v2_orphan.dat"));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(9903, 2)));
-    EXPECT_TRUE(file_exist(tablet_metadata_filename(9903, 3)));
-
-    // vacuumed_version must be min_version-1 (= 0), NOT final_retain_version (= 2).
-    // A value of 0 tells FE that no new versions were vacuumed this round.
-    EXPECT_EQ(0, response.vacuumed_version());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4226,4 +4226,224 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
     }
 }
 
+// ---------------------------------------------------------------------------
+// AsyncFileDeleter: success_delete_count / total_queued unit tests
+// ---------------------------------------------------------------------------
+
+TEST(LakeVacuumTest2, test_async_file_deleter_all_success) {
+    // Create 3 small files that will be deleted successfully.
+    for (const auto& name :
+         {"test_afd_ok_1.txt", "test_afd_ok_2.txt", "test_afd_ok_3.txt"}) {
+        WritableFileOptions opts;
+        opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+        ASSIGN_OR_ABORT(auto f, fs::new_writable_file(opts, name));
+        ASSERT_OK(f->append("x"));
+        ASSERT_OK(f->close());
+    }
+
+    // batch_size=1 so each file gets its own async batch.
+    AsyncFileDeleter deleter(1);
+    ASSERT_OK(deleter.delete_file("test_afd_ok_1.txt"));
+    ASSERT_OK(deleter.delete_file("test_afd_ok_2.txt"));
+    ASSERT_OK(deleter.delete_file("test_afd_ok_3.txt"));
+    EXPECT_EQ(3, deleter.total_queued());
+
+    ASSERT_OK(deleter.finish());
+
+    // All counts must agree when every batch succeeds.
+    EXPECT_EQ(3, deleter.delete_count());
+    EXPECT_EQ(3, deleter.success_delete_count());
+    EXPECT_EQ(3, deleter.total_queued());
+
+    EXPECT_FALSE(fs::path_exist("test_afd_ok_1.txt"));
+    EXPECT_FALSE(fs::path_exist("test_afd_ok_2.txt"));
+    EXPECT_FALSE(fs::path_exist("test_afd_ok_3.txt"));
+}
+
+TEST(LakeVacuumTest2, test_async_file_deleter_last_batch_fails) {
+    // Create 2 files; the second batch will be injected with a failure.
+    for (const auto& name : {"test_afd_fail1.txt", "test_afd_fail2.txt"}) {
+        WritableFileOptions opts;
+        opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+        ASSIGN_OR_ABORT(auto f, fs::new_writable_file(opts, name));
+        ASSERT_OK(f->append("x"));
+        ASSERT_OK(f->close());
+    }
+
+    int delete_calls = 0;
+    SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [&](void* arg) {
+        if (++delete_calls >= 2) {
+            auto* st = static_cast<Status*>(arg);
+            st->update(Status::IOError("injected rate-limit error"));
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sp([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_file");
+        SyncPoint::GetInstance()->DisableProcessing();
+        (void)fs::delete_file("test_afd_fail1.txt");
+        (void)fs::delete_file("test_afd_fail2.txt");
+    });
+
+    // batch_size=1: file1 → batch1 (succeeds), file2 → batch2 (fails).
+    AsyncFileDeleter deleter(1);
+    ASSERT_OK(deleter.delete_file("test_afd_fail1.txt"));
+    ASSERT_OK(deleter.delete_file("test_afd_fail2.txt"));
+    EXPECT_EQ(2, deleter.total_queued());
+
+    auto st = deleter.finish();
+    EXPECT_FALSE(st.ok());
+
+    // delete_count() reflects submitted batches (original semantics); batch2 was submitted.
+    EXPECT_EQ(2, deleter.delete_count());
+    // success_delete_count() credits only confirmed successes; only batch1 succeeded.
+    EXPECT_EQ(1, deleter.success_delete_count());
+    EXPECT_EQ(2, deleter.total_queued());
+
+    // File 1 was deleted by the successful batch; file 2 survives.
+    EXPECT_FALSE(fs::path_exist("test_afd_fail1.txt"));
+    EXPECT_TRUE(fs::path_exist("test_afd_fail2.txt"));
+}
+
+// ---------------------------------------------------------------------------
+// vacuum_tablet_chain integration tests (lake_vacuum_enable_version_chain_mode)
+// ---------------------------------------------------------------------------
+
+// Full success: all garbage versions (v2, v3, v4) have their data and meta files
+// deleted; min_retain_version (v5) metadata is preserved.
+TEST_P(LakeVacuumTest, test_version_chain_vacuum_full_success) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    // Orphan files – one per garbage version.
+    create_data_file("00000000009901_v2_orphan.dat");
+    create_data_file("00000000009902_v3_orphan.dat");
+    create_data_file("00000000009903_v4_orphan.dat");
+
+    // v2: orphan file, commit_time old enough to be garbage.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9901,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009901_v2_orphan.dat","size":10}]}
+        )DEL")));
+    // v3: orphan file, chains back to v2.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9901,"version":3,"prev_garbage_version":2,"commit_time":200,
+         "orphan_files":[{"name":"00000000009902_v3_orphan.dat","size":10}]}
+        )DEL")));
+    // v4: orphan file, chains back to v3.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9901,"version":4,"prev_garbage_version":3,"commit_time":300,
+         "orphan_files":[{"name":"00000000009903_v4_orphan.dat","size":10}]}
+        )DEL")));
+    // v5: the retained version (commit_time in the future relative to grace_timestamp).
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9901,"version":5,"prev_garbage_version":4,"commit_time":9999999999}
+        )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9901);
+    request.set_min_retain_version(5);
+    // grace_timestamp < commit_time of v5 but > commit_time of v4, so v5 is "too new"
+    // and v4 becomes the final_retain_version trigger — with the fix, v4's meta is kept
+    // in that round.  Using a large grace_timestamp here makes v5 the first "too new"
+    // version (since its commit_time=9999999999 >> grace_timestamp=now+3600).
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // All three orphan data files must be gone.
+    EXPECT_FALSE(file_exist("00000000009901_v2_orphan.dat"));
+    EXPECT_FALSE(file_exist("00000000009902_v3_orphan.dat"));
+    EXPECT_FALSE(file_exist("00000000009903_v4_orphan.dat"));
+
+    // Garbage version metadata files must be gone.
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 2)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 3)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 4)));
+
+    // The retained version metadata must be preserved.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9901, 5)));
+}
+
+// Partial failure: data deletion fails for version v4's files.
+// Versions v2 and v3 (whose batches succeeded) must have their meta deleted and
+// min_version advanced; v4 must be left untouched so the next retry skips v2/v3.
+TEST_P(LakeVacuumTest, test_version_chain_vacuum_partial_failure) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    // Force batch_size=1 so each data file occupies its own async batch, giving
+    // deterministic per-version failure injection.
+    auto saved_batch = config::lake_vacuum_min_batch_delete_size;
+    config::lake_vacuum_min_batch_delete_size = 1;
+    DeferOp defer_cfg([saved_batch]() {
+        config::lake_vacuum_enable_version_chain_mode = false;
+        config::lake_vacuum_min_batch_delete_size = saved_batch;
+    });
+
+    create_data_file("00000000009911_v2_orphan.dat");
+    create_data_file("00000000009912_v3_orphan.dat");
+    create_data_file("00000000009913_v4_orphan.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9902,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009911_v2_orphan.dat","size":10}]}
+        )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9902,"version":3,"prev_garbage_version":2,"commit_time":200,
+         "orphan_files":[{"name":"00000000009912_v3_orphan.dat","size":10}]}
+        )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9902,"version":4,"prev_garbage_version":3,"commit_time":300,
+         "orphan_files":[{"name":"00000000009913_v4_orphan.dat","size":10}]}
+        )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9902,"version":5,"prev_garbage_version":4,"commit_time":9999999999}
+        )DEL")));
+
+    // Inject a failure on the 3rd data-file delete call (= v4's orphan file).
+    // Batches are processed oldest-to-newest: v2→v3→v4.
+    int delete_calls = 0;
+    SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [&](void* arg) {
+        if (++delete_calls >= 3) {
+            auto* st = static_cast<Status*>(arg);
+            st->update(Status::IOError("injected rate-limit error"));
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sp([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_file");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9902);
+    request.set_min_retain_version(5);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    // vacuum_tablet_chain always returns OK — partial progress is encoded in min_version.
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // v2 and v3 were confirmed deleted (batch 1 and 2 succeeded).
+    EXPECT_FALSE(file_exist("00000000009911_v2_orphan.dat"));
+    EXPECT_FALSE(file_exist("00000000009912_v3_orphan.dat"));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9902, 2)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9902, 3)));
+
+    // v4 data file and meta must survive (its batch failed).
+    EXPECT_TRUE(file_exist("00000000009913_v4_orphan.dat"));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9902, 4)));
+
+    // The retained version is untouched.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9902, 5)));
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4232,8 +4232,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
 
 TEST(LakeVacuumTest2, test_async_file_deleter_all_success) {
     // Create 3 small files that will be deleted successfully.
-    for (const auto& name :
-         {"test_afd_ok_1.txt", "test_afd_ok_2.txt", "test_afd_ok_3.txt"}) {
+    for (const auto& name : {"test_afd_ok_1.txt", "test_afd_ok_2.txt", "test_afd_ok_3.txt"}) {
         WritableFileOptions opts;
         opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
         ASSIGN_OR_ABORT(auto f, fs::new_writable_file(opts, name));

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4226,40 +4226,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
     }
 }
 
-// ---------------------------------------------------------------------------
-// AsyncFileDeleter: success_delete_count / total_queued unit tests
-// ---------------------------------------------------------------------------
-
-TEST(LakeVacuumTest2, test_async_file_deleter_all_success) {
-    // Create 3 small files that will be deleted successfully.
-    for (const auto& name : {"test_afd_ok_1.txt", "test_afd_ok_2.txt", "test_afd_ok_3.txt"}) {
-        WritableFileOptions opts;
-        opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
-        ASSIGN_OR_ABORT(auto f, fs::new_writable_file(opts, name));
-        ASSERT_OK(f->append("x"));
-        ASSERT_OK(f->close());
-    }
-
-    // batch_size=1 so each file gets its own async batch.
-    AsyncFileDeleter deleter(1);
-    ASSERT_OK(deleter.delete_file("test_afd_ok_1.txt"));
-    ASSERT_OK(deleter.delete_file("test_afd_ok_2.txt"));
-    ASSERT_OK(deleter.delete_file("test_afd_ok_3.txt"));
-    EXPECT_EQ(3, deleter.total_queued());
-
-    ASSERT_OK(deleter.finish());
-
-    // All counts must agree when every batch succeeds.
-    EXPECT_EQ(3, deleter.delete_count());
-    EXPECT_EQ(3, deleter.success_delete_count());
-    EXPECT_EQ(3, deleter.total_queued());
-
-    EXPECT_FALSE(fs::path_exist("test_afd_ok_1.txt"));
-    EXPECT_FALSE(fs::path_exist("test_afd_ok_2.txt"));
-    EXPECT_FALSE(fs::path_exist("test_afd_ok_3.txt"));
-}
-
-TEST(LakeVacuumTest2, test_async_file_deleter_last_batch_fails) {
+TEST(LakeVacuumTest, test_async_file_deleter_last_batch_fails) {
     // Create 2 files; the second batch will be injected with a failure.
     for (const auto& name : {"test_afd_fail1.txt", "test_afd_fail2.txt"}) {
         WritableFileOptions opts;
@@ -4303,10 +4270,6 @@ TEST(LakeVacuumTest2, test_async_file_deleter_last_batch_fails) {
     EXPECT_FALSE(fs::path_exist("test_afd_fail1.txt"));
     EXPECT_TRUE(fs::path_exist("test_afd_fail2.txt"));
 }
-
-// ---------------------------------------------------------------------------
-// vacuum_tablet_chain integration tests (lake_vacuum_enable_version_chain_mode)
-// ---------------------------------------------------------------------------
 
 // Full success: all garbage versions (v2, v3, v4) have their data and meta files
 // deleted; min_retain_version (v5) metadata is preserved.

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4331,4 +4331,259 @@ TEST_P(LakeVacuumTest, test_version_chain_vacuum_full_success) {
     EXPECT_TRUE(file_exist(tablet_metadata_filename(9901, 5)));
 }
 
+// Verify that vacuum_tablet_chain deletes data files before metadata files.
+// Uses delete_files_callable sync point to capture the deletion order and assert
+// that for each version, dat files appear before the corresponding meta file.
+TEST_P(LakeVacuumTest, test_version_chain_dat_before_meta_ordering) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    create_data_file("00000000009801_v2_orphan.dat");
+    create_data_file("00000000009802_v3_orphan.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9801,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009801_v2_orphan.dat","size":10}]}
+    )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9801,"version":3,"prev_garbage_version":2,"commit_time":200,
+         "orphan_files":[{"name":"00000000009802_v3_orphan.dat","size":10}]}
+    )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9801,"version":4,"prev_garbage_version":3,"commit_time":9999999999}
+    )DEL")));
+
+    // Capture deletion order via sync point.
+    std::vector<std::string> deletion_order;
+    std::mutex mu;
+    SyncPoint::GetInstance()->SetCallBack("delete_files_callable", [&](void* arg) {
+        auto* files = static_cast<std::vector<std::string>*>(arg);
+        std::lock_guard<std::mutex> lock(mu);
+        for (const auto& f : *files) {
+            deletion_order.push_back(f);
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sp([]() {
+        SyncPoint::GetInstance()->ClearCallBack("delete_files_callable");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9801);
+    request.set_min_retain_version(4);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    EXPECT_FALSE(file_exist("00000000009801_v2_orphan.dat"));
+    EXPECT_FALSE(file_exist("00000000009802_v3_orphan.dat"));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9801, 2)));
+    // v3 is the final_retain_version, its meta is preserved.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9801, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9801, 4)));
+
+    // Verify ordering: dat file must appear before its meta file.
+    auto find_index = [&](const std::string& suffix) -> int {
+        for (int i = 0; i < static_cast<int>(deletion_order.size()); i++) {
+            if (deletion_order[i].find(suffix) != std::string::npos) return i;
+        }
+        return -1;
+    };
+
+    auto dat_v2 = find_index("00000000009801_v2_orphan.dat");
+    auto meta_v2 = find_index(tablet_metadata_filename(9801, 2));
+    ASSERT_GE(dat_v2, 0);
+    ASSERT_GE(meta_v2, 0);
+    EXPECT_LT(dat_v2, meta_v2) << "v2: data file (idx " << dat_v2 << ") must be deleted before meta file (idx "
+                               << meta_v2 << ")";
+}
+
+// Verify compaction_inputs (segments) are cleaned by vacuum_tablet_chain.
+TEST_P(LakeVacuumTest, test_version_chain_compaction_inputs) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    create_data_file("00000000009701_seg0.dat");
+    create_data_file("00000000009701_seg1.dat");
+
+    // v2: compaction produced two input segments that became garbage.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9701,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "compaction_inputs":[{"segments":["00000000009701_seg0.dat","00000000009701_seg1.dat"],"data_size":100}]}
+    )DEL")));
+    // v3: retained version.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9701,"version":3,"prev_garbage_version":2,"commit_time":9999999999}
+    )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9701);
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // Compaction input segments must be deleted.
+    EXPECT_FALSE(file_exist("00000000009701_seg0.dat"));
+    EXPECT_FALSE(file_exist("00000000009701_seg1.dat"));
+    // v2 is final_retain_version (first version with commit_time < grace_timestamp),
+    // so its data is cleaned but its metadata is preserved.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9701, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9701, 3)));
+}
+
+// Verify intermediate version metadata is cleaned when the chain has gaps.
+// Chain: v5 -> v3(prev=0), so v4 is an intermediate version with no chain pointer.
+// Its metadata should be deleted as well.
+TEST_P(LakeVacuumTest, test_version_chain_intermediate_meta_cleanup) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    create_data_file("00000000009601_v3_orphan.dat");
+
+    // v3: has garbage, chains to 0.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9601,"version":3,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009601_v3_orphan.dat","size":10}]}
+    )DEL")));
+    // v4: intermediate version — exists as metadata but NOT in garbage chain.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9601,"version":4,"prev_garbage_version":3,"commit_time":150}
+    )DEL")));
+    // v5: has garbage, chains back to v3 (skips v4).
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9601,"version":5,"prev_garbage_version":3,"commit_time":200}
+    )DEL")));
+    // v6: retained version.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9601,"version":6,"prev_garbage_version":5,"commit_time":9999999999}
+    )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9601);
+    request.set_min_retain_version(6);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // v3 data file cleaned.
+    EXPECT_FALSE(file_exist("00000000009601_v3_orphan.dat"));
+    // v3 metadata cleaned.
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9601, 3)));
+    // v4 intermediate metadata also cleaned.
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(9601, 4)));
+    // v5 is the final_retain_version, preserved.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9601, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9601, 6)));
+}
+
+// All versions have commit_time > grace_timestamp → nothing should be deleted.
+TEST_P(LakeVacuumTest, test_version_chain_all_too_new) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    create_data_file("00000000009501_v2_orphan.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9501,"version":2,"prev_garbage_version":0,"commit_time":9999999999,
+         "orphan_files":[{"name":"00000000009501_v2_orphan.dat","size":10}]}
+    )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9501,"version":3,"prev_garbage_version":2,"commit_time":9999999999}
+    )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    request.add_tablet_ids(9501);
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // Nothing should be deleted.
+    EXPECT_TRUE(file_exist("00000000009501_v2_orphan.dat"));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9501, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9501, 3)));
+}
+
+// Verify min_version advances correctly after vacuum, so a second vacuum
+// skips already-cleaned versions.
+TEST_P(LakeVacuumTest, test_version_chain_min_version_advance) {
+    config::lake_vacuum_enable_version_chain_mode = true;
+    DeferOp defer_cfg([]() { config::lake_vacuum_enable_version_chain_mode = false; });
+
+    create_data_file("00000000009401_v2_orphan.dat");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9401,"version":2,"prev_garbage_version":0,"commit_time":100,
+         "orphan_files":[{"name":"00000000009401_v2_orphan.dat","size":10}]}
+    )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9401,"version":3,"prev_garbage_version":2,"commit_time":200}
+    )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {"id":9401,"version":4,"prev_garbage_version":3,"commit_time":9999999999}
+    )DEL")));
+
+    auto grace_ts = ::time(nullptr) + 3600;
+
+    // First vacuum.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        request.add_tablet_ids(9401);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(grace_ts);
+        request.set_min_active_txn_id(12345);
+        vacuum(_tablet_mgr.get(), request, &response);
+
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_FALSE(file_exist("00000000009401_v2_orphan.dat"));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(9401, 2)));
+        // v3 is final_retain_version (commit_time=200 < grace_ts), metadata preserved.
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(9401, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(9401, 4)));
+    }
+
+    // Second vacuum: should be a no-op since min_version has advanced past garbage.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        request.add_tablet_ids(9401);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(grace_ts);
+        request.set_min_active_txn_id(12345);
+        vacuum(_tablet_mgr.get(), request, &response);
+
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        // No files should be deleted in the second run.
+        EXPECT_EQ(0, response.vacuumed_files());
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4326,9 +4326,12 @@ TEST_P(LakeVacuumTest, test_version_chain_vacuum_full_success) {
     // Garbage version metadata files must be gone.
     EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 2)));
     EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 3)));
-    EXPECT_FALSE(file_exist(tablet_metadata_filename(9901, 4)));
 
-    // The retained version metadata must be preserved.
+    // v4 is the final_retain_version (first version with commit_time < grace_timestamp):
+    // its orphan data files are cleaned but its metadata is preserved.
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(9901, 4)));
+
+    // The min_retain_version metadata must be preserved.
     EXPECT_TRUE(file_exist(tablet_metadata_filename(9901, 5)));
 }
 
@@ -4368,9 +4371,10 @@ TEST_P(LakeVacuumTest, test_version_chain_vacuum_partial_failure) {
 
     // Inject a failure on the 3rd data-file delete call (= v4's orphan file).
     // Batches are processed oldest-to-newest: v2→v3→v4.
+    // Use == 3 (not >= 3) so that subsequent metadata deletions are not affected.
     int delete_calls = 0;
     SyncPoint::GetInstance()->SetCallBack("PosixFileSystem::delete_file", [&](void* arg) {
-        if (++delete_calls >= 3) {
+        if (++delete_calls == 3) {
             auto* st = static_cast<Status*>(arg);
             st->update(Status::IOError("injected rate-limit error"));
         }


### PR DESCRIPTION
## Why I'm doing:
Track per-version cumulative data-file counts so that when a batch delete fails mid-way, we can determine exactly which versions had all their data files confirmed deleted and safely delete only those versions' metadata files, advancing min_version accordingly.


## What I'm doing:
Recycle garbage files by version. For each tablet version, submit a task to delete the meta file immediately after deleting the dat files. Do not delete all dat files for the tablet first and then delete all meta files in bulk.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
