### PR TITLE
[Enhancement] Optimize update compaction tablet selection with cached top-N candidates

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -388,6 +388,9 @@ CONF_mInt64(max_compaction_candidate_num, "40960");
 CONF_mBool(enable_lazy_delta_column_compaction, "true");
 
 CONF_mInt32(update_compaction_check_interval_seconds, "10");
+// Number of cached update compaction candidates per thread per DataDir (disk).
+// Actual topn per DataDir (disk) = this value * update_compaction_num_threads_per_disk.
+CONF_mInt32(update_compaction_candidates_per_thread, "32");
 CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_mInt32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
 // using this config to adjust chunk size used in compaction for row store

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -194,6 +194,10 @@ Status StorageEngine::start_bg_threads() {
         Thread::set_thread_name(_compaction_checker_thread, "compact_check");
     }
 
+    // Start a single thread to scan and cache update compaction candidates for all DataDirs
+    _update_compaction_scan_thread = std::thread([this] { _update_compaction_scan_thread_callback(nullptr); });
+    Thread::set_thread_name(_update_compaction_scan_thread, "upd_cmp_scan");
+
     int32_t update_compaction_num_threads_per_disk =
             config::update_compaction_num_threads_per_disk >= 0 ? config::update_compaction_num_threads_per_disk : 1;
     int32_t update_compaction_num_threads = update_compaction_num_threads_per_disk * data_dir_num;
@@ -366,6 +370,32 @@ void* StorageEngine::_local_pk_index_shared_data_gc_evict_thread_callback(void* 
     return nullptr;
 }
 #endif
+
+int32_t StorageEngine::compute_update_compaction_topn() {
+    constexpr int MAX_TOPN = 8192;
+    int32_t per_thread = config::update_compaction_candidates_per_thread;
+    if (per_thread <= 0) per_thread = 3;
+    int32_t threads_per_disk = config::update_compaction_num_threads_per_disk;
+    if (threads_per_disk <= 0) threads_per_disk = 1;
+    return static_cast<int32_t>(std::min<int64_t>(static_cast<int64_t>(per_thread) * threads_per_disk, MAX_TOPN));
+}
+
+void* StorageEngine::_update_compaction_scan_thread_callback(void* arg) {
+    while (!_bg_worker_stopped.load(std::memory_order_consume)) {
+        int32_t interval = config::update_compaction_check_interval_seconds;
+        if (interval <= 0) {
+            interval = 1;
+        }
+
+        if (config::update_compaction_num_threads_per_disk > 0) {
+            int32_t topn = compute_update_compaction_topn();
+            _tablet_manager->build_update_compaction_candidates(topn);
+        }
+
+        SLEEP_IN_BG_WORKER(interval);
+    }
+    return nullptr;
+}
 
 void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data_dir) {
 #ifdef GOOGLE_PROFILER

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -641,6 +641,7 @@ void StorageEngine::stop() {
 
     JOIN_THREADS(_base_compaction_threads)
     JOIN_THREADS(_cumulative_compaction_threads)
+    JOIN_THREAD(_update_compaction_scan_thread)
     JOIN_THREADS(_update_compaction_threads)
 
     JOIN_THREAD(_repair_compaction_thread)

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -320,6 +320,9 @@ public:
 
     bool enable_light_pk_compaction_publish();
 
+    // Compute the top-N candidate count for update compaction, with overflow-safe clamping.
+    static int32_t compute_update_compaction_topn();
+
 protected:
     static StorageEngine* _s_instance;
 
@@ -408,6 +411,8 @@ private:
 
     void* _schedule_apply_thread_callback(void* arg);
 
+    void* _update_compaction_scan_thread_callback(void* arg);
+
     void _start_clean_fd_cache();
     Status _perform_cumulative_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
     Status _perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
@@ -455,6 +460,8 @@ private:
     std::thread _pk_index_major_compaction_thread;
     // thread to generate pk dump
     std::thread _pk_dump_thread;
+    // thread to scan and cache update compaction candidates
+    std::thread _update_compaction_scan_thread;
     // thread to gc/evict local pk index in sharded_data
     std::thread _local_pk_index_shared_data_gc_evict_thread;
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -841,42 +841,84 @@ std::vector<TabletAndScore> TabletManager::pick_tablets_to_do_pk_index_major_com
     return pick_tablets;
 }
 
-TabletSharedPtr TabletManager::find_best_tablet_to_do_update_compaction(DataDir* data_dir) {
-    int64_t highest_score = 0;
-    TabletSharedPtr best_tablet;
+void TabletManager::build_update_compaction_candidates(int32_t topn_per_dir) {
+    if (topn_per_dir <= 0) {
+        std::lock_guard lg(_update_compaction_candidates_mutex);
+        _update_compaction_candidates.clear();
+        return;
+    }
+
+    // Temporary map: path_hash -> min-heap of {score, tablet_id}
+    std::unordered_map<size_t, std::vector<std::pair<int64_t, int64_t>>> tmp;
+
     for (const auto& tablets_shard : _tablets_shards) {
-        std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard, PRIMARY_KEYS);
-        for (const auto& tablet_ptr : all_tablets_by_shard) {
-            // A not-ready tablet maybe a newly created tablet under schema-change, skip it
-            if (tablet_ptr->tablet_state() == TABLET_NOTREADY) {
-                continue;
-            }
+        auto tablets = _get_all_tablets_from_shard(tablets_shard, PRIMARY_KEYS);
+        for (const auto& tablet : tablets) {
+            if (tablet->tablet_state() == TABLET_NOTREADY) continue;
+            if (!tablet->is_used() || !tablet->init_succeeded()) continue;
+            int64_t score = tablet->updates()->get_compaction_score();
+            if (score <= 0) continue;
 
-            if (tablet_ptr->data_dir()->path_hash() != data_dir->path_hash() || !tablet_ptr->is_used() ||
-                !tablet_ptr->init_succeeded()) {
-                continue;
-            }
-
-            int64_t table_score = tablet_ptr->updates()->get_compaction_score();
-            // tablet_score maybe negative, which means it's not worthy to do compaction
-            if (table_score <= 0) {
-                continue;
-            }
-
-            if (table_score > highest_score) {
-                highest_score = table_score;
-                best_tablet = tablet_ptr;
+            size_t ph = tablet->data_dir()->path_hash();
+            auto& heap = tmp[ph];
+            if (static_cast<int32_t>(heap.size()) < topn_per_dir) {
+                heap.emplace_back(score, tablet->tablet_id());
+                std::push_heap(heap.begin(), heap.end(), std::greater<std::pair<int64_t, int64_t>>());
+            } else if (score > heap.front().first) {
+                std::pop_heap(heap.begin(), heap.end(), std::greater<std::pair<int64_t, int64_t>>());
+                heap.back() = {score, tablet->tablet_id()};
+                std::push_heap(heap.begin(), heap.end(), std::greater<std::pair<int64_t, int64_t>>());
             }
         }
     }
 
-    if (best_tablet != nullptr) {
+    // Sort each list by score ascend for easy consumption from back and track max score
+    int64_t max_score = 0;
+    for (auto& [ph, vec] : tmp) {
+        std::sort(vec.begin(), vec.end(), std::less<std::pair<int64_t, int64_t>>());
+        if (!vec.empty() && vec.back().first > max_score) {
+            max_score = vec.back().first;
+        }
+    }
+    StarRocksMetrics::instance()->tablet_update_max_compaction_score.set_value(max_score);
+
+    std::lock_guard lg(_update_compaction_candidates_mutex);
+    _update_compaction_candidates = std::move(tmp);
+}
+
+TabletSharedPtr TabletManager::find_best_tablet_to_do_update_compaction(DataDir* data_dir) {
+    size_t ph = data_dir->path_hash();
+
+    // Pop one candidate at a time so other threads can access remaining candidates
+    while (true) {
+        std::pair<int64_t, int64_t> candidate;
+        {
+            std::lock_guard lg(_update_compaction_candidates_mutex);
+            auto it = _update_compaction_candidates.find(ph);
+            if (it == _update_compaction_candidates.end() || it->second.empty()) {
+                return nullptr;
+            }
+            candidate = it->second.back();
+            it->second.pop_back();
+            if (it->second.empty()) {
+                _update_compaction_candidates.erase(it);
+            }
+        }
+
+        auto [cached_score, tablet_id] = candidate;
+        auto tablet_ptr = get_tablet(tablet_id);
+        if (tablet_ptr == nullptr) continue;
+        if (tablet_ptr->tablet_state() == TABLET_NOTREADY) continue;
+        if (!tablet_ptr->is_used() || !tablet_ptr->init_succeeded()) continue;
+
+        int64_t score = tablet_ptr->updates()->get_compaction_score();
+        if (score <= 0) continue;
+
         VLOG(2) << "Found the best tablet to compact. "
                 << "compaction_type=update"
-                << " tablet_id=" << best_tablet->tablet_id() << " highest_score=" << highest_score;
-        StarRocksMetrics::instance()->tablet_update_max_compaction_score.set_value(highest_score);
+                << " tablet_id=" << tablet_ptr->tablet_id() << " compaction_score=" << score;
+        return tablet_ptr;
     }
-    return best_tablet;
 }
 
 Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id, TSchemaHash schema_hash,

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -118,6 +118,9 @@ public:
 
     TabletSharedPtr find_best_tablet_to_do_update_compaction(DataDir* data_dir);
 
+    // Single scan: populates cached top-N update compaction candidates for all DataDirs
+    void build_update_compaction_candidates(int32_t topn_per_dir);
+
     // TODO: pass |include_deleted| as an enum instead of boolean to avoid unexpected implicit cast.
     TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false, std::string* err = nullptr);
 
@@ -309,6 +312,10 @@ private:
     // context for compaction checker
     size_t _cur_shard = 0;
     std::unordered_set<int64_t> _shard_visited_tablet_ids;
+
+    // Cached top-N update compaction candidates per DataDir (path_hash -> sorted vector of {score, tablet_id})
+    mutable std::mutex _update_compaction_candidates_mutex;
+    std::unordered_map<size_t, std::vector<std::pair<int64_t, int64_t>>> _update_compaction_candidates;
 };
 
 inline bool TabletManager::LockTable::is_locked(int64_t tablet_id) {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -302,16 +302,13 @@ static void commit_rowsets(const TabletSharedPtr& tablet, std::vector<RowsetShar
 
 static void compact(const TabletSharedPtr& tablet, int64_t& version, int64_t expected_num_rowsets,
                     MemTracker* compaction_mem_tracker) {
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(tablet->data_dir());
-    ASSERT_EQ(best_tablet->tablet_id(), tablet->tablet_id());
-    ASSERT_TRUE(best_tablet->updates()->get_compaction_score() > 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(compaction_mem_tracker).ok());
+    ASSERT_TRUE(tablet->updates()->get_compaction_score() > 0);
+    ASSERT_TRUE(tablet->updates()->compaction(compaction_mem_tracker).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), expected_num_rowsets);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), version + 1);
+    ASSERT_EQ(tablet->updates()->num_rowsets(), expected_num_rowsets);
+    ASSERT_EQ(tablet->updates()->version_history_count(), version + 1);
     // the time interval is not enough after last compaction
-    ASSERT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+    ASSERT_EQ(tablet->updates()->get_compaction_score(), -1);
 }
 
 static Status full_clone(const TabletSharedPtr& sourcetablet, int64_t clone_version,

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1287,9 +1287,6 @@ void TabletUpdatesTest::test_compaction_score_not_enough(bool enable_persistent_
     }
     ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet, nullptr);
     // the compaction score is not enough due to the enough rows and lacking deletion.
     EXPECT_LT(_tablet->updates()->get_compaction_score(), 0);
 }
@@ -1318,9 +1315,6 @@ void TabletUpdatesTest::test_compaction_score_enough_duplicate(bool enable_persi
     // but currently underlying implementation still support this, so we test this case anyway
     ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys, &deletes)).ok());
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_NE(best_tablet, nullptr);
     // the compaction score is enough due to the enough deletion.
     EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
 }
@@ -1347,9 +1341,6 @@ void TabletUpdatesTest::test_compaction_score_enough_normal(bool enable_persiste
     deletes.append_numbers(keys.data(), sizeof(int64_t) * 86);
     ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, {}, &deletes)).ok());
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_NE(best_tablet, nullptr);
     // the compaction score is enough due to the enough deletion.
     EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
 }
@@ -1381,24 +1372,21 @@ void TabletUpdatesTest::test_horizontal_compaction(bool enable_persistent_index,
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
     ASSERT_EQ(N, read_tablet(_tablet, 4));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
+    EXPECT_EQ(100, read_tablet_and_compare(_tablet, 4, keys));
     if (!random_compaction) {
-        ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-        ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+        ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+        ASSERT_EQ(_tablet->updates()->version_history_count(), 5);
         // the time interval is not enough after last compaction
-        EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+        EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
     }
-    EXPECT_TRUE(best_tablet->verify().ok());
+    EXPECT_TRUE(_tablet->verify().ok());
 
     if (show_status) {
         std::string json_result;
-        best_tablet->updates()->get_compaction_status(&json_result);
+        _tablet->updates()->get_compaction_status(&json_result);
         EXPECT_TRUE(json_result.find("\"last_version\": \"4_1\"") != std::string::npos);
     }
 }
@@ -1426,26 +1414,22 @@ void TabletUpdatesTest::test_horizontal_compaction_with_rows_mapper(bool enable_
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
     ASSERT_EQ(N, read_tablet(_tablet, 4));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
     // stop apply
-    best_tablet->updates()->stop_apply(true);
-    std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
+    _tablet->updates()->stop_apply(true);
+    std::thread th([&]() { ASSERT_FALSE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
     RowsetSharedPtr output_rs;
     size_t retry_cnt = 0;
     while (output_rs == nullptr && retry_cnt <= 10) {
         // check rows mapper file
         std::this_thread::sleep_for(std::chrono::seconds(1));
         // read from file
-        output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+        output_rs = _tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
         retry_cnt++;
     }
     ASSERT_TRUE(output_rs != nullptr);
     RowsMapperIterator iterator;
-    ASSERT_OK(
-            iterator.open(FileInfo{.path = local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())}));
+    ASSERT_OK(iterator.open(FileInfo{.path = local_rows_mapper_filename(_tablet.get(), output_rs->rowset_id_str())}));
     for (uint32_t i = 0; i < 100; i += 20) {
         std::vector<uint64_t> rows_mapper;
         ASSERT_OK(iterator.next_values(20, &rows_mapper));
@@ -1460,17 +1444,17 @@ void TabletUpdatesTest::test_horizontal_compaction_with_rows_mapper(bool enable_
     std::vector<uint64_t> rows_mapper;
     ASSERT_TRUE(iterator.next_values(1, &rows_mapper).is_end_of_file());
     // restart apply
-    best_tablet->updates()->stop_apply(false);
-    best_tablet->updates()->check_for_apply();
+    _tablet->updates()->stop_apply(false);
+    _tablet->updates()->check_for_apply();
 
     // check final result
     th.join();
-    EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+    EXPECT_EQ(100, read_tablet_and_compare(_tablet, 4, keys));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), 5);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
-    EXPECT_TRUE(best_tablet->verify().ok());
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_TRUE(_tablet->verify().ok());
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction) {
@@ -1532,17 +1516,14 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
     ASSERT_EQ(N * loop, read_tablet(_tablet, loop + 1));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(N * loop, read_tablet_and_compare(best_tablet, loop + 1, sorted_keys));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
+    EXPECT_EQ(N * loop, read_tablet_and_compare(_tablet, loop + 1, sorted_keys));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
 
     auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
     auto sk_chunk = ChunkHelper::new_chunk(schema, loop);
@@ -1581,17 +1562,14 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key_error_encode_case)
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_EQ(_tablet->updates()->version_history_count(), 3);
     ASSERT_EQ(10, read_tablet(_tablet, 3));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(10, read_tablet_and_compare_sort_key_error_encode_case(best_tablet, 3, {4, 3, 2, 1, 0, 9, 8, 7, 6, 5}));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 4);
+    EXPECT_EQ(10, read_tablet_and_compare_sort_key_error_encode_case(_tablet, 3, {4, 3, 2, 1, 0, 9, 8, 7, 6, 5}));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_nullable_sort_key) {
@@ -1620,20 +1598,20 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_nullable_sort_key) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         ASSERT_EQ(_tablet->updates()->version_history_count(), 3);
         ASSERT_EQ(12, read_tablet(_tablet, 3));
-        const auto& best_tablet = StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(
-                _tablet->data_dir());
-        EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-        EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-        ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+        EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+        ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        EXPECT_EQ(12, read_tablet_and_compare_nullable_sort_key(best_tablet, 3,
+        EXPECT_EQ(12, read_tablet_and_compare_nullable_sort_key(_tablet, 3,
                                                                 {{1, 5, 2, 6, 3, 7, 4, 8, 9, 10, 11, 12},
                                                                  {8, 12, 7, 11, 6, 10, 5, 9, 8, 7, 6, 5},
                                                                  {-1, -1, -1, -1, -1, -1, -1, -1, 9, 10, 11, 12}}));
-        ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-        ASSERT_EQ(best_tablet->updates()->version_history_count(), 4);
+        ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+        ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
         // the time interval is not enough after last compaction
-        EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+        EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
+        // Drop the tablet before the next block reassigns _tablet
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+        _tablet.reset();
     }
 
     {
@@ -1662,22 +1640,19 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_nullable_sort_key) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         ASSERT_EQ(_tablet->updates()->version_history_count(), 3);
         ASSERT_EQ(12, read_tablet(_tablet, 3));
-        const auto& best_tablet = StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(
-                _tablet->data_dir());
-        EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-        EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-        ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+        EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+        ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        EXPECT_EQ(12, read_tablet_and_compare_nullable_sort_key(best_tablet, 3,
+        EXPECT_EQ(12, read_tablet_and_compare_nullable_sort_key(_tablet, 3,
                                                                 {
                                                                         {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
                                                                         {-1, -1, -1, -1, -1, -1, -1, -1, 9, 10, 11, 12},
                                                                         {8, 7, 6, 5, 12, 11, 10, 9, 8, 7, 6, 5},
                                                                 }));
-        ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-        ASSERT_EQ(best_tablet->updates()->version_history_count(), 4);
+        ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+        ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
         // the time interval is not enough after last compaction
-        EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+        EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
     }
 }
 
@@ -1702,17 +1677,14 @@ void TabletUpdatesTest::test_vertical_compaction(bool enable_persistent_index) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
     ASSERT_EQ(N, read_tablet(_tablet, 4));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+    EXPECT_EQ(100, read_tablet_and_compare(_tablet, 4, keys));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), 5);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
 
     {
         _tablet2 = create_tablet(rand(), rand());
@@ -1766,26 +1738,22 @@ void TabletUpdatesTest::test_vertical_compaction_with_rows_mapper(bool enable_pe
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
     ASSERT_EQ(N, read_tablet(_tablet, 4));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
     // stop apply
-    best_tablet->updates()->stop_apply(true);
-    std::thread th([&]() { ASSERT_FALSE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
+    _tablet->updates()->stop_apply(true);
+    std::thread th([&]() { ASSERT_FALSE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok()); });
     RowsetSharedPtr output_rs;
     size_t retry_cnt = 0;
     while (output_rs == nullptr && retry_cnt <= 10) {
         // check rows mapper file
         std::this_thread::sleep_for(std::chrono::seconds(1));
         // read from file
-        output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
+        output_rs = _tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
         retry_cnt++;
     }
     ASSERT_TRUE(output_rs != nullptr);
     RowsMapperIterator iterator;
-    ASSERT_OK(
-            iterator.open(FileInfo{.path = local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())}));
+    ASSERT_OK(iterator.open(FileInfo{.path = local_rows_mapper_filename(_tablet.get(), output_rs->rowset_id_str())}));
     for (uint32_t i = 0; i < 100; i += 20) {
         std::vector<uint64_t> rows_mapper;
         ASSERT_OK(iterator.next_values(20, &rows_mapper));
@@ -1800,17 +1768,17 @@ void TabletUpdatesTest::test_vertical_compaction_with_rows_mapper(bool enable_pe
     std::vector<uint64_t> rows_mapper;
     ASSERT_TRUE(iterator.next_values(1, &rows_mapper).is_end_of_file());
     // restart apply
-    best_tablet->updates()->stop_apply(false);
-    best_tablet->updates()->check_for_apply();
+    _tablet->updates()->stop_apply(false);
+    _tablet->updates()->check_for_apply();
 
     // check final result
     th.join();
-    EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+    EXPECT_EQ(100, read_tablet_and_compare(_tablet, 4, keys));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), 5);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
-    EXPECT_TRUE(best_tablet->verify().ok());
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_TRUE(_tablet->verify().ok());
 }
 
 TEST_F(TabletUpdatesTest, vertical_compaction) {
@@ -1867,17 +1835,14 @@ TEST_F(TabletUpdatesTest, vertical_compaction_with_sort_key) {
     }
 
     ASSERT_EQ(N * loop, read_tablet(_tablet, loop + 1));
-    const auto& best_tablet =
-            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
-    EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
-    EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
-    ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
+    EXPECT_GT(_tablet->updates()->get_compaction_score(), 0);
+    ASSERT_TRUE(_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(N * loop, read_tablet_and_compare(best_tablet, loop + 1, sorted_keys));
-    ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
+    EXPECT_EQ(N * loop, read_tablet_and_compare(_tablet, loop + 1, sorted_keys));
+    ASSERT_EQ(_tablet->updates()->num_rowsets(), 1);
+    ASSERT_EQ(_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
-    EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+    EXPECT_EQ(_tablet->updates()->get_compaction_score(), -1);
 
     auto schema = ChunkHelper::convert_schema(_tablet->thread_safe_get_tablet_schema());
     auto sk_chunk = ChunkHelper::new_chunk(schema, loop);
@@ -4429,6 +4394,165 @@ TEST_F(TabletUpdatesTest, test_make_snapshot_on_tablet_meta_keep_rowsets) {
 
     ASSERT_TRUE(has_meta_file);
     ASSERT_TRUE(still_has_rowset_files);
+}
+
+// NOLINTNEXTLINE
+void TabletUpdatesTest::test_build_and_consume_compaction_candidates() {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 100; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_GT(_tablet->updates()->get_compaction_score(), 0);
+
+    // Build candidates and verify the tablet is among them
+    StorageEngine::instance()->tablet_manager()->build_update_compaction_candidates(100);
+    bool found = false;
+    int consumed = 0;
+    while (true) {
+        auto candidate = StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(
+                _tablet->data_dir());
+        if (candidate == nullptr) break;
+        consumed++;
+        if (candidate->tablet_id() == _tablet->tablet_id()) {
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found) << "Expected tablet " << _tablet->tablet_id() << " to be among compaction candidates";
+    EXPECT_GE(consumed, 1);
+
+    // All candidates consumed — next call should return nullptr (cache exhausted)
+    const auto& after_exhausted =
+            StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
+    EXPECT_EQ(after_exhausted, nullptr);
+}
+
+TEST_F(TabletUpdatesTest, build_and_consume_compaction_candidates) {
+    test_build_and_consume_compaction_candidates();
+}
+
+// NOLINTNEXTLINE
+void TabletUpdatesTest::test_build_compaction_candidates_topn_limit() {
+    srand(GetCurrentTimeMicros());
+    // Create 5 tablets with positive compaction scores
+    std::vector<TabletSharedPtr> tablets;
+    for (int t = 0; t < 5; t++) {
+        auto tablet = create_tablet(rand(), rand());
+        std::vector<int64_t> keys;
+        for (int i = 0; i < 100; i++) {
+            keys.emplace_back(i);
+        }
+        ASSERT_TRUE(tablet->rowset_commit(2, create_rowset(tablet, keys)).ok());
+        ASSERT_TRUE(tablet->rowset_commit(3, create_rowset(tablet, keys)).ok());
+        ASSERT_TRUE(tablet->rowset_commit(4, create_rowset(tablet, keys)).ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ASSERT_GT(tablet->updates()->get_compaction_score(), 0);
+        tablets.push_back(tablet);
+    }
+    _tablet = tablets[0];
+    auto data_dir = _tablet->data_dir();
+
+    // Build with topn=3
+    StorageEngine::instance()->tablet_manager()->build_update_compaction_candidates(3);
+
+    // Should get at most 3 candidates (topn limit), and at least 3 if there are enough tablets
+    int count = 0;
+    while (true) {
+        auto best = StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(data_dir);
+        if (best == nullptr) break;
+        count++;
+    }
+    EXPECT_EQ(count, 3);
+
+    // Clean up extra tablets (TearDown drops _tablet)
+    for (size_t i = 1; i < tablets.size(); i++) {
+        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(tablets[i]->tablet_id());
+    }
+}
+
+TEST_F(TabletUpdatesTest, build_compaction_candidates_topn_limit) {
+    test_build_compaction_candidates_topn_limit();
+}
+
+// NOLINTNEXTLINE
+void TabletUpdatesTest::test_build_compaction_candidates_stale_tablet() {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 100; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_GT(_tablet->updates()->get_compaction_score(), 0);
+
+    // Build candidates then drop the tablet
+    StorageEngine::instance()->tablet_manager()->build_update_compaction_candidates(100);
+    auto data_dir = _tablet->data_dir();
+    auto tablet_id = _tablet->tablet_id();
+    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(tablet_id);
+
+    // find_best should skip the stale (dropped) tablet — verify it never returns the dropped tablet
+    while (true) {
+        auto best = StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(data_dir);
+        if (best == nullptr) break;
+        EXPECT_NE(best->tablet_id(), tablet_id) << "Dropped tablet should not be returned as candidate";
+    }
+
+    // Recreate a tablet so TearDown doesn't fail
+    _tablet = create_tablet(rand(), rand());
+}
+
+TEST_F(TabletUpdatesTest, build_compaction_candidates_stale_tablet) {
+    test_build_compaction_candidates_stale_tablet();
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletUpdatesTest, compute_update_compaction_topn) {
+    // Save original config values
+    auto orig_per_thread = config::update_compaction_candidates_per_thread;
+    auto orig_threads_per_disk = config::update_compaction_num_threads_per_disk;
+    DeferOp restore_config([&] {
+        config::update_compaction_candidates_per_thread = orig_per_thread;
+        config::update_compaction_num_threads_per_disk = orig_threads_per_disk;
+    });
+
+    // Default configs (per_thread=3, threads_per_disk=1) → 3
+    config::update_compaction_candidates_per_thread = 3;
+    config::update_compaction_num_threads_per_disk = 1;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 3);
+
+    // Normal (per_thread=5, threads_per_disk=4) → 20
+    config::update_compaction_candidates_per_thread = 5;
+    config::update_compaction_num_threads_per_disk = 4;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 20);
+
+    // Negative per_thread → falls back to 3, threads_per_disk=1 → 3
+    config::update_compaction_candidates_per_thread = -1;
+    config::update_compaction_num_threads_per_disk = 1;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 3);
+
+    // Zero threads_per_disk → falls back to 1, per_thread=3 → 3
+    config::update_compaction_candidates_per_thread = 3;
+    config::update_compaction_num_threads_per_disk = 0;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 3);
+
+    // Overflow (INT32_MAX * INT32_MAX) → clamped to 8192
+    config::update_compaction_candidates_per_thread = INT32_MAX;
+    config::update_compaction_num_threads_per_disk = INT32_MAX;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 8192);
+
+    // Large but valid (100 * 100) → clamped to 8192
+    config::update_compaction_candidates_per_thread = 100;
+    config::update_compaction_num_threads_per_disk = 100;
+    EXPECT_EQ(StorageEngine::compute_update_compaction_topn(), 8192);
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -857,6 +857,9 @@ public:
     void update_and_recover(bool enable_persistent_index);
     void test_recover_rowset_sorter();
     void test_get_column_values_with_invalid_rssid(bool enable_persistent_index);
+    void test_build_and_consume_compaction_candidates();
+    void test_build_compaction_candidates_topn_limit();
+    void test_build_compaction_candidates_stale_tablet();
 
 protected:
     TabletSharedPtr _tablet;

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2883,6 +2883,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The expiration time of Update Cache.
 - Introduced in: -
 
+##### update_compaction_candidates_per_thread
+
+- Default: 32
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The number of cached update compaction candidates per thread per DataDir for Primary Key table update compaction. The actual top-N candidates cached per DataDir equals this value multiplied by `update_compaction_num_threads_per_disk`. A single background scan selects the top-N tablets by compaction score for each DataDir. Per-DataDir compaction threads then consume from this cached list, avoiding redundant full tablet scans.
+- Introduced in: v4.1.0, v4.0.9
+
 ##### update_compaction_check_interval_seconds
 
 - Default: 10

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -2363,6 +2363,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: Update Cache の有効期限。
 - 導入バージョン: -
 
+##### update_compaction_candidates_per_thread
+
+- デフォルト: 32
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: 各 DataDir のスレッドごとにキャッシュする主キーテーブルの更新コンパクション候補タブレット数。各 DataDir で実際にキャッシュされる上位 N 個の候補数 = この値 × `update_compaction_num_threads_per_disk`。バックグラウンドスキャンスレッドがすべてのタブレットを一括スキャンし、各 DataDir ごとにコンパクションスコアが最も高い上位 N 個のタブレットをキャッシュします。各 DataDir のコンパクションスレッドはキャッシュリストから取得するため、冗長なフルスキャンを回避できます。
+- 導入バージョン: v4.1.0, v4.0.9
+
 ##### update_compaction_check_interval_seconds
 
 - デフォルト: 10

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -2845,6 +2845,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Update Cache 的过期时间。
 - 引入版本：-
 
+##### update_compaction_candidates_per_thread
+
+- 默认值：32
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：每个 DataDir 中每个线程缓存的主键表更新 Compaction 候选 Tablet 数量。每个 DataDir 实际缓存的 top-N 候选数 = 该值 × `update_compaction_num_threads_per_disk`。后台扫描线程会统一扫描所有 Tablet，为每个 DataDir 选取得分最高的 top-N 个 Tablet 缓存。各 DataDir 的 Compaction 线程从缓存列表中取用，避免重复全量扫描。
+- 引入版本：v4.1.0, v4.0.9
+
 ##### update_compaction_check_interval_seconds
 
 - 默认值：10


### PR DESCRIPTION
Replace per-DataDir independent O(N) tablet scans with a single shared scan that caches top-N candidates per DataDir. A dedicated background thread periodically scans all PK tablets once and populates a per-DataDir sorted candidate list. Compaction threads then pop from their cached list in O(1) instead of each doing a full scan, reducing total tablet visits from M*N to N per scan interval (M = number of DataDirs, N = tablet count).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4