### PR TITLE
[BugFix] Fix DCHECK failure in DeltaWriter::close() called from bthread context

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -998,7 +998,11 @@ void LakeTabletsChannel::_update_tablet_profile(const DeltaWriter* writer, Runti
     ADD_AND_SET_TIMER(profile, "FinishPutTxnLogTime", writer_stat.finish_put_txn_log_time_ns.load());
     ADD_AND_SET_TIMER(profile, "FinishPkPreloadTime", writer_stat.finish_pk_preload_time_ns.load());
 
-    const FlushStatistic* flush_stat = writer->get_flush_stats();
+    // Use get_flush_token() to hold a shared_ptr, keeping the FlushToken alive
+    // while we read its stats. This prevents use-after-free when close()
+    // concurrently resets the token.
+    auto flush_token = writer->get_flush_token();
+    const FlushStatistic* flush_stat = flush_token ? &flush_token->get_stats() : nullptr;
     ADD_AND_SET_COUNTER(profile, "MemtableFlushedCount", TUnit::UNIT,
                         DEFAULT_IF_NULL(flush_stat, flush_stat->flush_count.load(), 0));
     ADD_AND_SET_COUNTER(profile, "MemtableFlushingCount", TUnit::UNIT,

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -171,14 +171,9 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
     auto delta_writer = async_writer->_writer.get();
     if (iter.is_queue_stopped()) {
         // We're in the execution queue's pthread thread pool — safe to block.
-        // First drain all merge tasks (which may still be accessing writer state),
-        // then close the writer. This avoids the race where close() destroys state
-        // (_mem_table_sink, _flush_token) while a MergeBlockTask is still running.
-        // This also avoids calling close() from bthread context (which triggers
-        // DCHECK_EQ(0, bthread_self()) in DeltaWriter::close()).
-        if (async_writer->_block_merge_token != nullptr) {
-            async_writer->_block_merge_token->shutdown();
-        }
+        // Merge tasks have already been drained by _block_merge_token->shutdown()
+        // in AsyncDeltaWriterImpl::close() before execution_queue_stop().
+        // close() runs here in pthread context, avoiding DCHECK_EQ(0, bthread_self()).
         delta_writer->close();
         return 0;
     }
@@ -361,22 +356,28 @@ inline void AsyncDeltaWriterImpl::close() {
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
+        // Shutdown merge token first to drain any running/pending merge tasks.
+        // This must happen BEFORE execution_queue_stop() so that merge tasks
+        // (which access writer state like _mem_table_sink, _flush_token) complete
+        // before the stop handler calls delta_writer->close().
+        // Queued FinishTasks that try to submit new merge tasks will get
+        // ServiceUnavailable — that's fine since we're aborting anyway.
+        if (_block_merge_token != nullptr) {
+            _block_merge_token->shutdown();
+        }
+
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.
         int r = bthread::execution_queue_stop(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to stop execution queue";
 
-        // Wait for all running tasks to complete. When the queue is fully drained, the
-        // stop handler (is_queue_stopped() branch in execute()) will run in the execution
-        // queue's pthread thread pool. The stop handler drains merge tasks via
-        // _block_merge_token->shutdown() and then calls delta_writer->close().
-        // This ensures:
-        // 1. close() runs in pthread context (no DCHECK failure).
-        // 2. All merge tasks complete before close() destroys writer state.
+        // Wait for all running tasks to complete. The stop handler runs in the
+        // execution queue's pthread thread pool and calls delta_writer->close(),
+        // which avoids DCHECK_EQ(0, bthread_self()) failure.
         r = bthread::execution_queue_join(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to join execution queue";
 
-        // Safe to destroy token now since the stop handler already shut it down.
+        // Safe to destroy token now since shutdown() already drained it.
         _block_merge_token.reset();
     }
 }

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -170,11 +170,12 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
     auto async_writer = static_cast<AsyncDeltaWriterImpl*>(meta);
     auto delta_writer = async_writer->_writer.get();
     if (iter.is_queue_stopped()) {
-        // Do NOT call delta_writer->close() here. A MergeBlockTask may still be
-        // running in the merge thread pool and accessing writer state (e.g.,
-        // _mem_table_sink, _flush_token). Closing the writer here would destroy
-        // that state and cause use-after-free. The writer will be closed in
+        // Only perform blocking I/O (wait for flush, close tablet writer) here.
+        // Do NOT reset/destroy internal state (_mem_table_sink, _flush_token, etc.)
+        // because a MergeBlockTask may still be running in the merge thread pool
+        // and accessing that state. Resource cleanup is deferred to
         // AsyncDeltaWriterImpl::close() after all tasks have been drained.
+        delta_writer->flush_and_wait();
         return 0;
     }
     int num_tasks = 0;
@@ -378,11 +379,12 @@ inline void AsyncDeltaWriterImpl::close() {
         // Safe to destroy token now since both execution queue and merge tasks are done.
         _block_merge_token.reset();
 
-        // Close the writer AFTER all tasks (execution queue + merge tasks) have completed.
-        // Previously delta_writer->close() was called in the execution queue's stop handler,
-        // which could race with a still-running MergeBlockTask or external profile readers,
-        // destroying _mem_table_sink/_flush_token while they were still being accessed.
-        _writer->close();
+        // Release writer resources (reset _mem_table_sink, _flush_token, etc.) AFTER all
+        // tasks have completed. The blocking I/O (flush wait + tablet writer close) was
+        // already done in the execution queue's stop handler via flush_and_wait().
+        // We only do the non-blocking resource cleanup here, which is safe because all
+        // concurrent accessors (MergeBlockTask, profile readers) have been drained.
+        _writer->release_resources();
     }
 }
 

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -170,12 +170,16 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
     auto async_writer = static_cast<AsyncDeltaWriterImpl*>(meta);
     auto delta_writer = async_writer->_writer.get();
     if (iter.is_queue_stopped()) {
-        // Only perform blocking I/O (wait for flush, close tablet writer) here.
-        // Do NOT reset/destroy internal state (_mem_table_sink, _flush_token, etc.)
-        // because a MergeBlockTask may still be running in the merge thread pool
-        // and accessing that state. Resource cleanup is deferred to
-        // AsyncDeltaWriterImpl::close() after all tasks have been drained.
-        delta_writer->flush_and_wait();
+        // We're in the execution queue's pthread thread pool — safe to block.
+        // First drain all merge tasks (which may still be accessing writer state),
+        // then close the writer. This avoids the race where close() destroys state
+        // (_mem_table_sink, _flush_token) while a MergeBlockTask is still running.
+        // This also avoids calling close() from bthread context (which triggers
+        // DCHECK_EQ(0, bthread_self()) in DeltaWriter::close()).
+        if (async_writer->_block_merge_token != nullptr) {
+            async_writer->_block_merge_token->shutdown();
+        }
+        delta_writer->close();
         return 0;
     }
     int num_tasks = 0;
@@ -357,34 +361,23 @@ inline void AsyncDeltaWriterImpl::close() {
 
         TEST_SYNC_POINT("AsyncDeltaWriterImpl::close:2");
 
-        // Shutdown (but do NOT reset) _block_merge_token to drain any running merge tasks.
-        // This must happen BEFORE execution_queue_stop() to ensure all merge tasks
-        // (which access writer state like _mem_table_sink) complete before the queue
-        // is torn down. The token remains allocated (not null) so if execute() is still
-        // running and calls _block_merge_token->submit(), it gets a ServiceUnavailable
-        // error instead of SIGSEGV.
-        if (_block_merge_token != nullptr) {
-            _block_merge_token->shutdown();
-        }
-
         // After the execution_queue been `stop()`ed all incoming `write()` and `finish()` requests
         // will fail immediately.
         int r = bthread::execution_queue_stop(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to stop execution queue";
 
-        // Wait for all running tasks completed.
+        // Wait for all running tasks to complete. When the queue is fully drained, the
+        // stop handler (is_queue_stopped() branch in execute()) will run in the execution
+        // queue's pthread thread pool. The stop handler drains merge tasks via
+        // _block_merge_token->shutdown() and then calls delta_writer->close().
+        // This ensures:
+        // 1. close() runs in pthread context (no DCHECK failure).
+        // 2. All merge tasks complete before close() destroys writer state.
         r = bthread::execution_queue_join(old_id);
         PLOG_IF(WARNING, r != 0) << "Fail to join execution queue";
 
-        // Safe to destroy token now since both execution queue and merge tasks are done.
+        // Safe to destroy token now since the stop handler already shut it down.
         _block_merge_token.reset();
-
-        // Release writer resources (reset _mem_table_sink, _flush_token, etc.) AFTER all
-        // tasks have completed. The blocking I/O (flush wait + tablet writer close) was
-        // already done in the execution queue's stop handler via flush_and_wait().
-        // We only do the non-blocking resource cleanup here, which is safe because all
-        // concurrent accessors (MergeBlockTask, profile readers) have been drained.
-        _writer->release_resources();
     }
 }
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -144,6 +144,10 @@ public:
 
     void close();
 
+    void flush_and_wait();
+
+    void release_resources();
+
     void cancel(const Status& st);
 
     [[nodiscard]] int64_t partition_id() const { return _partition_id; }
@@ -991,20 +995,21 @@ Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
     return Status::OK();
 }
 
-void DeltaWriterImpl::close() {
+void DeltaWriterImpl::flush_and_wait() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    auto start_time = MonotonicNanos();
-    DeferOp defer([&] { ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time); });
     if (_flush_token != nullptr) {
         auto st = _flush_token->wait();
         LOG_IF(WARNING, !st.ok()) << "flush token error: " << st;
         VLOG(3) << "Tablet_id: " << tablet_id() << ", flush stats: " << _flush_token->get_stats();
     }
-
-    // Destruct variables manually for counting memory usage into |_mem_tracker|
     if (_tablet_writer != nullptr) {
         _tablet_writer->close();
     }
+}
+
+void DeltaWriterImpl::release_resources() {
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    // Destruct variables manually for counting memory usage into |_mem_tracker|
     _tablet_writer.reset();
     _mem_table.reset();
     _mem_table_sink.reset();
@@ -1017,6 +1022,14 @@ void DeltaWriterImpl::close() {
     _tablet_schema.reset();
     _write_schema.reset();
     _merge_condition.clear();
+}
+
+void DeltaWriterImpl::close() {
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    auto start_time = MonotonicNanos();
+    DeferOp defer([&] { ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time); });
+    flush_and_wait();
+    release_resources();
 }
 
 void DeltaWriterImpl::cancel(const Status& st) {
@@ -1103,6 +1116,14 @@ Status DeltaWriter::finish() {
 void DeltaWriter::close() {
     DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::close() in a bthread";
     _impl->close();
+}
+
+void DeltaWriter::flush_and_wait() {
+    _impl->flush_and_wait();
+}
+
+void DeltaWriter::release_resources() {
+    _impl->release_resources();
 }
 
 void DeltaWriter::cancel(const Status& st) {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -997,6 +997,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
 
 void DeltaWriterImpl::flush_and_wait() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    auto start_time = MonotonicNanos();
     if (_flush_token != nullptr) {
         auto st = _flush_token->wait();
         LOG_IF(WARNING, !st.ok()) << "flush token error: " << st;
@@ -1005,6 +1006,7 @@ void DeltaWriterImpl::flush_and_wait() {
     if (_tablet_writer != nullptr) {
         _tablet_writer->close();
     }
+    ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time);
 }
 
 void DeltaWriterImpl::release_resources() {
@@ -1025,9 +1027,6 @@ void DeltaWriterImpl::release_resources() {
 }
 
 void DeltaWriterImpl::close() {
-    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    auto start_time = MonotonicNanos();
-    DeferOp defer([&] { ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time); });
     flush_and_wait();
     release_resources();
 }
@@ -1119,6 +1118,7 @@ void DeltaWriter::close() {
 }
 
 void DeltaWriter::flush_and_wait() {
+    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::flush_and_wait() in a bthread";
     _impl->flush_and_wait();
 }
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -144,10 +144,6 @@ public:
 
     void close();
 
-    void flush_and_wait();
-
-    void release_resources();
-
     void cancel(const Status& st);
 
     [[nodiscard]] int64_t partition_id() const { return _partition_id; }
@@ -200,6 +196,14 @@ public:
         return _flush_token == nullptr ? nullptr : &(_flush_token->get_stats());
     }
 
+    // Thread-safe accessor: returns a shared_ptr copy so the caller keeps the
+    // FlushToken alive while reading its stats, preventing use-after-free when
+    // close() concurrently resets _flush_token.
+    std::shared_ptr<FlushToken> get_flush_token() const {
+        std::shared_lock l(_cancel_lock);
+        return _flush_token;
+    }
+
     bool has_spill_block() const;
 
     const DictColumnsValidMap* global_dict_columns_valid_info() const;
@@ -247,7 +251,7 @@ private:
     std::unique_ptr<TabletWriter> _tablet_writer;
     std::unique_ptr<MemTable> _mem_table;
     std::unique_ptr<MemTableSink> _mem_table_sink;
-    std::unique_ptr<FlushToken> _flush_token;
+    std::shared_ptr<FlushToken> _flush_token;
 
     // The full list of columns defined
     std::shared_ptr<const TabletSchema> _tablet_schema;
@@ -995,40 +999,32 @@ Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
     return Status::OK();
 }
 
-void DeltaWriterImpl::flush_and_wait() {
+void DeltaWriterImpl::close() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     auto start_time = MonotonicNanos();
+    DeferOp defer([&] { ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time); });
     if (_flush_token != nullptr) {
         auto st = _flush_token->wait();
         LOG_IF(WARNING, !st.ok()) << "flush token error: " << st;
         VLOG(3) << "Tablet_id: " << tablet_id() << ", flush stats: " << _flush_token->get_stats();
     }
+
+    // Destruct variables manually for counting memory usage into |_mem_tracker|
     if (_tablet_writer != nullptr) {
         _tablet_writer->close();
     }
-    ADD_COUNTER_RELAXED(_stats.close_time_ns, MonotonicNanos() - start_time);
-}
-
-void DeltaWriterImpl::release_resources() {
-    SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    // Destruct variables manually for counting memory usage into |_mem_tracker|
     _tablet_writer.reset();
     _mem_table.reset();
     _mem_table_sink.reset();
     {
-        // Take exclusive lock before resetting _flush_token to prevent race with cancel(),
-        // which may be accessing _flush_token concurrently.
+        // Take exclusive lock before resetting _flush_token to prevent race with cancel()
+        // and get_flush_token(), which may be accessing _flush_token concurrently.
         std::unique_lock l(_cancel_lock);
         _flush_token.reset();
     }
     _tablet_schema.reset();
     _write_schema.reset();
     _merge_condition.clear();
-}
-
-void DeltaWriterImpl::close() {
-    flush_and_wait();
-    release_resources();
 }
 
 void DeltaWriterImpl::cancel(const Status& st) {
@@ -1080,11 +1076,8 @@ int64_t DeltaWriterImpl::num_rows() const {
 }
 
 int64_t DeltaWriterImpl::queueing_memtable_num() const {
-    if (_flush_token != nullptr) {
-        return _flush_token->get_stats().queueing_memtable_num;
-    } else {
-        return 0;
-    }
+    auto token = get_flush_token();
+    return token ? token->get_stats().queueing_memtable_num.load() : 0;
 }
 
 //// DeltaWriter
@@ -1115,15 +1108,6 @@ Status DeltaWriter::finish() {
 void DeltaWriter::close() {
     DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::close() in a bthread";
     _impl->close();
-}
-
-void DeltaWriter::flush_and_wait() {
-    DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::flush_and_wait() in a bthread";
-    _impl->flush_and_wait();
-}
-
-void DeltaWriter::release_resources() {
-    _impl->release_resources();
 }
 
 void DeltaWriter::cancel(const Status& st) {
@@ -1203,6 +1187,10 @@ const DeltaWriterStat& DeltaWriter::get_writer_stat() const {
 
 const FlushStatistic* DeltaWriter::get_flush_stats() const {
     return _impl->get_flush_stats();
+}
+
+std::shared_ptr<FlushToken> DeltaWriter::get_flush_token() const {
+    return _impl->get_flush_token();
 }
 
 bool DeltaWriter::has_spill_block() const {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -127,16 +127,6 @@ public:
     // NOTE: Do NOT invoke this method in a bthread unless you are sure that `write()` has never been called.
     void close();
 
-    // Wait for all pending flush tasks to complete and close the tablet writer.
-    // Performs blocking I/O but does NOT reset/destroy internal state (_mem_table_sink, _flush_token, etc.).
-    // Safe to call from a pthread (e.g., execution queue stop handler).
-    void flush_and_wait();
-
-    // Release internal resources (reset unique_ptrs). Non-blocking.
-    // Must be called after flush_and_wait() and after all concurrent accessors (e.g., MergeBlockTask,
-    // profile readers) have completed.
-    void release_resources();
-
     // Cancel the delta writer with the given status.
     // This method can be called concurrently and it is thread-safe.
     // After cancellation, subsequent write/flush operations will fail quickly.
@@ -177,6 +167,11 @@ public:
     const DeltaWriterStat& get_writer_stat() const;
 
     const FlushStatistic* get_flush_stats() const;
+
+    // Thread-safe accessor: returns a shared_ptr copy of the FlushToken.
+    // The caller holds the token alive while reading stats, preventing
+    // use-after-free when close() concurrently resets the token.
+    std::shared_ptr<FlushToken> get_flush_token() const;
 
     bool has_spill_block() const;
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -127,6 +127,16 @@ public:
     // NOTE: Do NOT invoke this method in a bthread unless you are sure that `write()` has never been called.
     void close();
 
+    // Wait for all pending flush tasks to complete and close the tablet writer.
+    // Performs blocking I/O but does NOT reset/destroy internal state (_mem_table_sink, _flush_token, etc.).
+    // Safe to call from a pthread (e.g., execution queue stop handler).
+    void flush_and_wait();
+
+    // Release internal resources (reset unique_ptrs). Non-blocking.
+    // Must be called after flush_and_wait() and after all concurrent accessors (e.g., MergeBlockTask,
+    // profile readers) have completed.
+    void release_resources();
+
     // Cancel the delta writer with the given status.
     // This method can be called concurrently and it is thread-safe.
     // After cancellation, subsequent write/flush operations will fail quickly.

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/async_delta_writer.h"
 
+#include <bthread/bthread.h>
 #include <gtest/gtest.h>
 
 #include <random>
@@ -896,6 +897,68 @@ TEST_F(LakeAsyncDeltaWriterTest, test_close_does_not_destroy_writer_during_merge
     // Now close. Before the fix this would SIGSEGV or trigger ASAN heap-use-after-free.
     // After the fix, close() waits for the merge task to complete before destroying writer state.
     delta_writer->close();
+}
+
+// Test that AsyncDeltaWriter::close() can be called from a bthread without
+// triggering DCHECK_EQ(0, bthread_self()) in DeltaWriter::close().
+// Before the fix, AsyncDeltaWriterImpl::close() called _writer->close() directly,
+// which has a DCHECK that forbids calling from bthread context. This caused crashes
+// in Debug builds when close() was called from brpc handlers (which run in bthread).
+// The fix splits close() into flush_and_wait() (runs in pthread stop handler) and
+// release_resources() (runs in AsyncDeltaWriterImpl::close(), safe from bthread).
+TEST_F(LakeAsyncDeltaWriterTest, test_close_from_bthread_no_dcheck_failure) {
+    static const int kChunkSize = 128;
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+
+    // Write some data
+    CountDownLatch write_latch(1);
+    delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& st) {
+        ASSERT_OK(st);
+        write_latch.count_down();
+    });
+    write_latch.wait();
+
+    // Finish
+    CountDownLatch finish_latch(1);
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
+        ASSERT_TRUE(res.ok()) << res.status();
+        finish_latch.count_down();
+    });
+    finish_latch.wait();
+
+    // Close from a bthread — this simulates LakeTabletsChannel::abort() being called
+    // from a brpc handler. Before the fix, this would crash in Debug builds due to
+    // DCHECK_EQ(0, bthread_self()) in DeltaWriter::close().
+    auto raw_ptr = delta_writer.get();
+    bthread_t bt;
+    int ret = bthread_start_background(
+            &bt, nullptr,
+            [](void* arg) -> void* {
+                // Verify we are indeed running in a bthread
+                EXPECT_NE(0, bthread_self());
+                auto* writer = static_cast<AsyncDeltaWriter*>(arg);
+                writer->close();
+                return nullptr;
+            },
+            raw_ptr);
+    ASSERT_EQ(0, ret);
+    bthread_join(bt, nullptr);
 }
 
 // Test that write tasks are rejected after finish task completes

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -901,11 +901,10 @@ TEST_F(LakeAsyncDeltaWriterTest, test_close_does_not_destroy_writer_during_merge
 
 // Test that AsyncDeltaWriter::close() can be called from a bthread without
 // triggering DCHECK_EQ(0, bthread_self()) in DeltaWriter::close().
-// Before the fix, AsyncDeltaWriterImpl::close() called _writer->close() directly,
-// which has a DCHECK that forbids calling from bthread context. This caused crashes
-// in Debug builds when close() was called from brpc handlers (which run in bthread).
-// The fix splits close() into flush_and_wait() (runs in pthread stop handler) and
-// release_resources() (runs in AsyncDeltaWriterImpl::close(), safe from bthread).
+// Before the fix, calling close() from bthread context would crash in Debug builds
+// because DeltaWriter::close() has a DCHECK that forbids calling from bthread.
+// The fix moves _block_merge_token->shutdown() and delta_writer->close() into the
+// execution queue's stop handler, which runs in a pthread thread pool.
 TEST_F(LakeAsyncDeltaWriterTest, test_close_from_bthread_no_dcheck_failure) {
     static const int kChunkSize = 128;
     auto chunk0 = generate_data(kChunkSize);


### PR DESCRIPTION
## Why I'm doing:

PR #69940 fixed a use-after-free race in AsyncDeltaWriter by moving `delta_writer->close()` from the execution queue's stop handler to `AsyncDeltaWriterImpl::close()`. However, `AsyncDeltaWriterImpl::close()` is called from brpc (bthread context), and `DeltaWriter::close()` has `DCHECK_EQ(0, bthread_self())` which crashes in Debug builds.

Additionally, `DeltaWriter::close()` performs blocking I/O (`_flush_token->wait()`, `_tablet_writer->close()`) which should not run in bthread context.

There is also a profile reader race: `get_flush_stats()` returns a raw pointer to `_flush_token->get_stats()`, but `close()` can concurrently reset `_flush_token`, causing use-after-free.

## What I'm doing:

### Fix 1: DCHECK failure (bthread context close)

Move `_block_merge_token->shutdown()` into the execution queue's stop handler (which runs in the pthread thread pool). The stop handler now:
1. Drains all merge tasks via `_block_merge_token->shutdown()`
2. Calls `delta_writer->close()`

This ensures `close()` always runs in pthread context — no DCHECK failure, no bthread blocking concerns, and destructors run in the proper thread context. No need to split `DeltaWriter::close()` into separate methods, preserving the symmetric API design.

### Fix 2: Profile reader race

Changed `_flush_token` from `unique_ptr` to `shared_ptr` and added `get_flush_token()` accessor that returns a `shared_ptr` copy under `_cancel_lock` (shared_mutex). Profile readers in `LakeTabletsChannel::_update_tablet_profile()` hold the shared_ptr to keep the FlushToken alive while reading stats, preventing use-after-free when `close()` concurrently resets the token.

Fixes DCHECK crash: `Check failed: 0 == bthread_self() Should not invoke DeltaWriter::close() in a bthread`

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5