### PR TITLE
[Enhancement] Expanding constant tracking in UnionDictManager (#69893)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -490,6 +490,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         context.parent = parent;
         DecodeInfo info = optExpression.getOp().accept(this, optExpression, context);
         if (info.isEmpty()) {
+            collectProjection(optExpression.getOp(), info);
             return info;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -162,6 +163,9 @@ public class UnionDictionaryManager {
             if (constantColumns.containsKey(c.getId())) {
                 constantColumns.put(key.getId(), constantColumns.get(c.getId()));
             }
+        } else if (value instanceof CastOperator && (value.getType().isStringType() || value.getType().isNull())
+                && (value.getChild(0).getType().isStringType() || value.getChild(0).getType().isNull())) {
+            recordIfConstant(key, value.getChild(0));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -19,10 +19,13 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.type.NullType;
+import com.starrocks.type.StringType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -279,5 +282,36 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(2, constantEncodingMap.size());
         Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
         Assertions.assertEquals(Map.of(col7, ConstantOperator.createInt(2)), constantEncodingMap.get(1));
+    }
+
+    @Test
+    void testConstantCasts() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, StringType.STRING, "col1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, StringType.STRING, "col2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, StringType.STRING, "col3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, StringType.STRING, "col4", true);
+        ColumnRefOperator col5 = new ColumnRefOperator(3, StringType.STRING, "col3", true);
+        ColumnRefOperator col6 = new ColumnRefOperator(4, StringType.STRING, "col4", true);
+        ColumnRefOperator col7 = new ColumnRefOperator(7, StringType.STRING, "col4", true);
+        ColumnRefOperator col8 = new ColumnRefOperator(8, StringType.STRING, "col4", true);
+
+        UnionDictionaryManager dictManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), Map.of(), Set.of());
+        dictManager.recordIfConstant(col1, ConstantOperator.createNull(NullType.NULL));
+        dictManager.recordIfConstant(col2, ConstantOperator.createVarchar("abc"));
+        dictManager.recordIfConstant(col3, new CastOperator(StringType.STRING, col1));
+        dictManager.recordIfConstant(col4, new CastOperator(StringType.STRING, col2));
+        dictManager.recordIfConstant(col5, new CastOperator(StringType.STRING, ConstantOperator.createNull(NullType.NULL)));
+        dictManager.recordIfConstant(col6, new CastOperator(StringType.STRING, ConstantOperator.createVarchar("abc")));
+        dictManager.recordIfConstant(col8, new CastOperator(StringType.STRING, col7));
+
+        Assertions.assertTrue(dictManager.isSupportedConstant(col1));
+        Assertions.assertTrue(dictManager.isSupportedConstant(col2));
+        Assertions.assertTrue(dictManager.isSupportedConstant(col3));
+        Assertions.assertTrue(dictManager.isSupportedConstant(col4));
+        Assertions.assertTrue(dictManager.isSupportedConstant(col5));
+        Assertions.assertTrue(dictManager.isSupportedConstant(col6));
+        Assertions.assertFalse(dictManager.isSupportedConstant(col7));
+        Assertions.assertFalse(dictManager.isSupportedConstant(col8));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2685,4 +2685,26 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |    |  35 <-> 2\n" +
                 "  |    |  36 <-> NULL", plan);
     }
+
+    @Test
+    public void testUnionWithAllConstants() throws Exception {
+        String sql = """
+                  SELECT
+                      C_USER a, C_USER as b, C_USER as c
+                    FROM
+                      low_card_t1
+                  UNION ALL
+                  SELECT
+                    NULL, 'zzz', NULL
+                  FROM
+                      supplier
+                  """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [30, INT, true] | [31, INT, true] | [33, INT, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [29: c_user, INT, true] | [32: cast, INT, true] | [29: c_user, INT, true]\n" +
+                "  |      [35: expr, INT, true] | [34: expr, INT, false] | [36: expr, INT, true]", plan);
+    }
 }


### PR DESCRIPTION
(cherry picked from commit 98f75c010834ee803244ec7ad261e5d31d09b45a)

## Why I'm doing:
Currently constant tracking in UnionDictManager doesn't record constant columns in the following scenarios:

Constants which are generated in projections with no dictified input columns.
Casts on other constants.

## What I'm doing:
Adding support for cases above.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

