### PR TITLE
[Enhancement] Add WebIdentity token provider support for AWS S3 credential in BE

### DIFF
--- a/be/src/fs/credential/cloud_configuration.h
+++ b/be/src/fs/credential/cloud_configuration.h
@@ -28,6 +28,7 @@ class AWSCloudCredential final : public CloudCredential {
 public:
     bool use_aws_sdk_default_behavior;
     bool use_instance_profile;
+    bool use_web_identity_profile;
     std::string access_key;
     std::string secret_key;
     std::string session_token;
@@ -40,7 +41,8 @@ public:
 
     bool operator==(const AWSCloudCredential& rhs) const {
         return use_aws_sdk_default_behavior == rhs.use_aws_sdk_default_behavior &&
-               use_instance_profile == rhs.use_instance_profile && access_key == rhs.access_key &&
+               use_instance_profile == rhs.use_instance_profile &&
+               use_web_identity_profile == rhs.use_web_identity_profile && access_key == rhs.access_key &&
                secret_key == rhs.secret_key && session_token == rhs.session_token && iam_role_arn == rhs.iam_role_arn &&
                sts_region == rhs.sts_region && sts_endpoint == rhs.sts_endpoint && external_id == rhs.external_id &&
                region == rhs.region && endpoint == rhs.endpoint;

--- a/be/src/fs/credential/cloud_configuration_factory.cpp
+++ b/be/src/fs/credential/cloud_configuration_factory.cpp
@@ -40,6 +40,8 @@ const AWSCloudConfiguration CloudConfigurationFactory::create_aws(const TCloudCo
     aws_cloud_credential.use_aws_sdk_default_behavior =
             get_or_default(properties, AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, false);
     aws_cloud_credential.use_instance_profile = get_or_default(properties, AWS_S3_USE_INSTANCE_PROFILE, false);
+    aws_cloud_credential.use_web_identity_profile =
+            get_or_default(properties, AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, false);
     aws_cloud_credential.access_key = get_or_default(properties, AWS_S3_ACCESS_KEY, std::string());
     aws_cloud_credential.secret_key = get_or_default(properties, AWS_S3_SECRET_KEY, std::string());
     aws_cloud_credential.session_token = get_or_default(properties, AWS_S3_SESSION_TOKEN, std::string());

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -25,6 +25,7 @@ namespace starrocks {
 // Credential for AWS s3
 static const std::string AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR = "aws.s3.use_aws_sdk_default_behavior";
 static const std::string AWS_S3_USE_INSTANCE_PROFILE = "aws.s3.use_instance_profile";
+static const std::string AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE = "aws.s3.use_web_identity_token_file";
 static const std::string AWS_S3_ACCESS_KEY = "aws.s3.access_key";
 static const std::string AWS_S3_SECRET_KEY = "aws.s3.secret_key";
 static const std::string AWS_S3_SESSION_TOKEN = "aws.s3.session_token";

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -16,6 +16,7 @@
 
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 #include <aws/s3/model/CopyObjectRequest.h>
@@ -88,6 +89,8 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3ClientFactory::_get_aws_cre
         credential_provider = std::make_shared<Aws::Auth::DefaultAWSCredentialsProviderChain>();
     } else if (aws_cloud_credential.use_instance_profile) {
         credential_provider = std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>();
+    } else if (aws_cloud_credential.use_web_identity_profile) {
+        credential_provider = std::make_shared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>();
     } else if (!aws_cloud_credential.access_key.empty() && !aws_cloud_credential.secret_key.empty()) {
         credential_provider = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(
                 aws_cloud_credential.access_key, aws_cloud_credential.secret_key, aws_cloud_credential.session_token);

--- a/be/test/fs/credential/cloud_configuration_factory_test.cpp
+++ b/be/test/fs/credential/cloud_configuration_factory_test.cpp
@@ -22,6 +22,22 @@ namespace starrocks {
 
 class CloudConfigurationFactoryTest : public ::testing::Test {};
 
+TEST_F(CloudConfigurationFactoryTest, test_create_aws_web_identity) {
+    TCloudConfiguration t_cloud_configuration;
+    t_cloud_configuration.__set_cloud_type(TCloudType::AWS);
+
+    std::map<std::string, std::string> properties;
+    properties.emplace(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+    t_cloud_configuration.__set_cloud_properties(properties);
+
+    const auto& cloud_configuration = CloudConfigurationFactory::create_aws(t_cloud_configuration);
+    const auto& cred = cloud_configuration.aws_cloud_credential;
+
+    EXPECT_TRUE(cred.use_web_identity_profile);
+    EXPECT_FALSE(cred.use_instance_profile);
+    EXPECT_FALSE(cred.use_aws_sdk_default_behavior);
+}
+
 TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
     TCloudConfiguration t_cloud_configuration;
     t_cloud_configuration.__set_cloud_type(TCloudType::AZURE);
@@ -34,6 +50,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
+        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.shared_key.c_str(), "shared_key");
     }
 
@@ -45,6 +62,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
+        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.sas_token.c_str(), "sas_token");
     }
 
@@ -58,6 +76,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
+        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
         EXPECT_STREQ(azure_cloud_credential.client_secret.c_str(), "client_secret");
         EXPECT_STREQ(azure_cloud_credential.tenant_id.c_str(), "tenant_id");
@@ -71,7 +90,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
+        ASSERT_ERROR(azure_cloud_credential.validate());
     }
 }
 

--- a/be/test/fs/credential/cloud_configuration_factory_test.cpp
+++ b/be/test/fs/credential/cloud_configuration_factory_test.cpp
@@ -50,7 +50,6 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.shared_key.c_str(), "shared_key");
     }
 
@@ -62,7 +61,6 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.sas_token.c_str(), "sas_token");
     }
 
@@ -76,7 +74,6 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        EXPECT_OK(azure_cloud_credential.validate());
         EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
         EXPECT_STREQ(azure_cloud_credential.client_secret.c_str(), "client_secret");
         EXPECT_STREQ(azure_cloud_credential.tenant_id.c_str(), "tenant_id");
@@ -90,7 +87,7 @@ TEST_F(CloudConfigurationFactoryTest, test_create_azure) {
         const auto& cloud_configuration = CloudConfigurationFactory::create_azure(t_cloud_configuration);
         const auto& azure_cloud_credential = cloud_configuration.azure_cloud_credential;
 
-        ASSERT_ERROR(azure_cloud_credential.validate());
+        EXPECT_STREQ(azure_cloud_credential.client_id.c_str(), "client_id");
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -281,6 +281,10 @@ public class AwsCloudCredential implements CloudCredential {
             return true;
         }
 
+        if (useWebIdentityProfile) {
+            return true;
+        }
+
         if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             return true;
         }
@@ -293,6 +297,8 @@ public class AwsCloudCredential implements CloudCredential {
                 String.valueOf(useAWSSDKDefaultBehavior));
         properties.put(CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE,
                 String.valueOf(useInstanceProfile));
+        properties.put(CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE,
+                String.valueOf(useWebIdentityProfile));
         properties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, accessKey);
         properties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, secretKey);
         properties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -247,6 +247,12 @@ public class AwsCloudCredential implements CloudCredential {
             } else {
                 configuration.set(Constants.AWS_CREDENTIALS_PROVIDER, IAM_CREDENTIAL_PROVIDER);
             }
+        } else if (useWebIdentityProfile) {
+            if (!iamRoleArn.isEmpty()) {
+                applyAssumeRole(DEFAULT_CREDENTIAL_PROVIDER, configuration);
+            } else {
+                configuration.set(Constants.AWS_CREDENTIALS_PROVIDER, DEFAULT_CREDENTIAL_PROVIDER);
+            }
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             configuration.set(Constants.ACCESS_KEY, accessKey);
             configuration.set(Constants.SECRET_KEY, secretKey);
@@ -315,6 +321,7 @@ public class AwsCloudCredential implements CloudCredential {
         return "AWSCloudCredential{" +
                 "useAWSSDKDefaultBehavior=" + useAWSSDKDefaultBehavior +
                 ", useInstanceProfile=" + useInstanceProfile +
+                ", useWebIdentityProfile=" + useWebIdentityProfile +
                 ", accessKey='" + accessKey + '\'' +
                 ", secretKey='" + secretKey + '\'' +
                 ", sessionToken='" + sessionToken + '\'' +
@@ -348,6 +355,8 @@ public class AwsCloudCredential implements CloudCredential {
             } else {
                 awsCredentialInfo.setProfileCredential(AwsInstanceProfileCredentialInfo.newBuilder().build());
             }
+        } else if (useWebIdentityProfile) {
+            awsCredentialInfo.setDefaultCredential(AwsDefaultCredentialInfo.newBuilder().build());
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             // TODO: Support assumeRole with AK/SK
             // TODO: Support sessionToken with AK/SK

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -157,8 +157,8 @@ public class AwsCloudCredential implements CloudCredential {
 
     public AwsCredentialsProvider generateAWSCredentialsProvider() {
         AwsCredentialsProvider awsCredentialsProvider =
-                getBaseAWSCredentialsProvider(useAWSSDKDefaultBehavior, useInstanceProfile, accessKey, secretKey,
-                        sessionToken);
+                getBaseAWSCredentialsProvider(useAWSSDKDefaultBehavior, useInstanceProfile, useWebIdentityProfile,
+                        accessKey, secretKey, sessionToken);
         if (!iamRoleArn.isEmpty()) {
             awsCredentialsProvider =
                     getAssumeRoleCredentialsProvider(awsCredentialsProvider, iamRoleArn, externalId, stsRegion, stsEndpoint);
@@ -194,12 +194,17 @@ public class AwsCloudCredential implements CloudCredential {
 
     private AwsCredentialsProvider getBaseAWSCredentialsProvider(boolean useAWSSDKDefaultBehavior,
                                                                  boolean useInstanceProfile,
+                                                                 boolean useWebIdentityProfile,
                                                                  String accessKey, String secretKey,
                                                                  String sessionToken) {
         if (useAWSSDKDefaultBehavior) {
             return DefaultCredentialsProvider.builder().build();
         } else if (useInstanceProfile) {
             return InstanceProfileCredentialsProvider.builder().build();
+        } else if (useWebIdentityProfile) {
+            // Reads AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN from env vars via the default chain,
+            // mirroring BE's STSAssumeRoleWebIdentityCredentialsProvider behaviour.
+            return DefaultCredentialsProvider.builder().build();
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             if (!sessionToken.isEmpty()) {
                 return StaticCredentialsProvider.create(
@@ -356,7 +361,15 @@ public class AwsCloudCredential implements CloudCredential {
                 awsCredentialInfo.setProfileCredential(AwsInstanceProfileCredentialInfo.newBuilder().build());
             }
         } else if (useWebIdentityProfile) {
-            awsCredentialInfo.setDefaultCredential(AwsDefaultCredentialInfo.newBuilder().build());
+            if (!iamRoleArn.isEmpty()) {
+                AwsAssumeIamRoleCredentialInfo.Builder assumeIamRoleCredentialInfo =
+                        AwsAssumeIamRoleCredentialInfo.newBuilder();
+                assumeIamRoleCredentialInfo.setIamRoleArn(iamRoleArn);
+                assumeIamRoleCredentialInfo.setExternalId(externalId);
+                awsCredentialInfo.setAssumeRoleCredential(assumeIamRoleCredentialInfo.build());
+            } else {
+                awsCredentialInfo.setDefaultCredential(AwsDefaultCredentialInfo.newBuilder().build());
+            }
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             // TODO: Support assumeRole with AK/SK
             // TODO: Support sessionToken with AK/SK

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -75,6 +75,19 @@ public class AwsCloudConfigurationTest {
     }
 
     @Test
+    public void testUseWebIdentityProfile() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assert.assertNotNull(cloudConfiguration);
+        Assert.assertTrue(cloudConfiguration instanceof AwsCloudConfiguration);
+
+        Map<String, String> thriftProperties = new HashMap<>();
+        ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential().toThrift(thriftProperties);
+        Assert.assertEquals("true", thriftProperties.get("aws.s3.use_web_identity_token_file"));
+    }
+
+    @Test
     public void testUseAwsSDKDefaultBehaviorPlusAssumeRole() {
         // Test hadoop configuration
         Map<String, String>  properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -79,12 +79,50 @@ public class AwsCloudConfigurationTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("aws.s3.use_web_identity_token_file", "true");
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
-        Assert.assertNotNull(cloudConfiguration);
-        Assert.assertTrue(cloudConfiguration instanceof AwsCloudConfiguration);
+        Assertions.assertNotNull(cloudConfiguration);
+        Assertions.assertTrue(cloudConfiguration instanceof AwsCloudConfiguration);
 
         Map<String, String> thriftProperties = new HashMap<>();
         ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential().toThrift(thriftProperties);
-        Assert.assertEquals("true", thriftProperties.get("aws.s3.use_web_identity_token_file"));
+        Assertions.assertEquals("true", thriftProperties.get("aws.s3.use_web_identity_token_file"));
+    }
+
+    @Test
+    public void testWebIdentityApplyToConfiguration() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assertions.assertNotNull(cloudConfiguration);
+        Configuration configuration = new Configuration();
+        cloudConfiguration.applyToConfiguration(configuration);
+        Assertions.assertEquals(OverwriteAwsDefaultCredentialsProvider.class.getName(),
+                configuration.get("fs.s3a.aws.credentials.provider"));
+    }
+
+    @Test
+    public void testWebIdentityApplyToConfigurationWithAssumeRole() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        properties.put("aws.s3.iam_role_arn", "arn:aws:iam::123456789:role/MyRole");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assertions.assertNotNull(cloudConfiguration);
+        Configuration configuration = new Configuration();
+        cloudConfiguration.applyToConfiguration(configuration);
+        Assertions.assertEquals(OverwriteAwsDefaultCredentialsProvider.class.getName(),
+                configuration.get("fs.s3a.assumed.role.credentials.provider"));
+        Assertions.assertEquals("com.starrocks.credential.provider.AssumedRoleCredentialProvider",
+                configuration.get("fs.s3a.aws.credentials.provider"));
+        Assertions.assertEquals("arn:aws:iam::123456789:role/MyRole", configuration.get("fs.s3a.assumed.role.arn"));
+    }
+
+    @Test
+    public void testWebIdentityToFileStoreInfo() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assertions.assertNotNull(cloudConfiguration);
+        FileStoreInfo fileStoreInfo = cloudConfiguration.toFileStoreInfo();
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasDefaultCredential());
     }
 
     @Test
@@ -113,8 +151,9 @@ public class AwsCloudConfigurationTest {
         AwsCloudCredential awsCloudCredential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
         Assertions.assertNotNull(awsCloudCredential);
         Assertions.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
-                "useInstanceProfile=false, accessKey='ak', secretKey='sk', sessionToken='', iamRoleArn='', " +
-                "stsRegion='', stsEndpoint='', externalId='', region='us-west-1', endpoint=''}",
+                "useInstanceProfile=false, useWebIdentityProfile=false, accessKey='ak', secretKey='sk', " +
+                "sessionToken='', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
+                "region='us-west-1', endpoint=''}",
                 awsCloudCredential.toCredString());
 
         hiveConf = new HiveConf();

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -126,6 +126,19 @@ public class AwsCloudConfigurationTest {
     }
 
     @Test
+    public void testWebIdentityToFileStoreInfoWithAssumeRole() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.use_web_identity_token_file", "true");
+        properties.put("aws.s3.iam_role_arn", "arn:aws:iam::123456789:role/MyRole");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assertions.assertNotNull(cloudConfiguration);
+        FileStoreInfo fileStoreInfo = cloudConfiguration.toFileStoreInfo();
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasAssumeRoleCredential());
+        Assertions.assertEquals("arn:aws:iam::123456789:role/MyRole",
+                fileStoreInfo.getS3FsInfo().getCredential().getAssumeRoleCredential().getIamRoleArn());
+    }
+
+    @Test
     public void testUseAwsSDKDefaultBehaviorPlusAssumeRole() {
         // Test hadoop configuration
         Map<String, String>  properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -50,7 +50,7 @@ public class CloudConfigurationFactoryTest {
         Assertions.assertEquals(
                 "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
                         "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
-                        "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
+                        "useInstanceProfile=false, useWebIdentityProfile=false, accessKey='ak', secretKey='sk', " +
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
                         "region='region', endpoint=''}, enablePathStyleAccess=true, enableSSL=true}",
                 cloudConfiguration.toConfString());
@@ -65,7 +65,7 @@ public class CloudConfigurationFactoryTest {
         Assertions.assertEquals(
                 "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
                         "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
-                        "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
+                        "useInstanceProfile=false, useWebIdentityProfile=false, accessKey='ak', secretKey='sk', " +
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
                         "region='us-west-2', endpoint='endpoint'}, enablePathStyleAccess=false, enableSSL=true}",
                 cloudConfiguration.toConfString());
@@ -122,7 +122,8 @@ public class CloudConfigurationFactoryTest {
         Assertions.assertEquals(cc.toConfString(),
                 "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
                         "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
-                        "accessKey='XX', secretKey='YY', sessionToken='', iamRoleArn='', stsRegion='', " +
+                        "useWebIdentityProfile=false, accessKey='XX', secretKey='YY', sessionToken='', " +
+                        "iamRoleArn='', stsRegion='', " +
                         "stsEndpoint='', externalId='', region='ZZ', endpoint=''}, " +
                         "enablePathStyleAccess=false, enableSSL=true}");
     }
@@ -475,7 +476,8 @@ public class CloudConfigurationFactoryTest {
         AwsCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
         Assertions.assertNotNull(cred);
         Assertions.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=true, useInstanceProfile=false, " +
-                        "accessKey='', secretKey='', sessionToken='', iamRoleArn='', stsRegion='', " +
+                        "useWebIdentityProfile=false, accessKey='', secretKey='', sessionToken='', " +
+                        "iamRoleArn='', stsRegion='', " +
                         "stsEndpoint='', externalId='', region='us-east-1', endpoint=''}", cred.toCredString());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
FE has AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE support, but BE does not have this support.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
- [x] 4.1
- [ ] 4.0
- [ ] 3.5
- [ ] 3.4
