### PR TITLE
[BugFix] IGNORE NULLS silently dropped from VIEW definition when window function argument is an expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -1234,13 +1234,15 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
             }
             sb.append(")");
         } else if (IGNORE_NULL_WINDOW_FUNCTION.contains(functionName)) {
-            List<String> p = node.getChildren().stream().map(child -> {
-                String str = visit(child);
-                if (child instanceof SlotRef && node.getIgnoreNulls()) {
+            List<Expr> children = node.getChildren();
+            List<String> p = new ArrayList<>();
+            for (int i = 0; i < children.size(); i++) {
+                String str = visit(children.get(i));
+                if (i == 0 && node.getIgnoreNulls()) {
                     str += " ignore nulls";
                 }
-                return str;
-            }).collect(Collectors.toList());
+                p.add(str);
+            }
             sb.append(Joiner.on(", ").join(p)).append(")");
         } else {
             List<String> p = node.getChildren().stream().map(this::visit).collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
@@ -147,6 +147,29 @@ public class CreateViewTest extends StarRocksTestBase  {
     }
 
     @Test
+    public void testCreateViewWithWindowFunctionIgnoreNullsWithExpression() throws Exception {
+        starRocksAssert.withTable("create table sample_data2 (\n" +
+                        "    timestamp DATETIME not null,\n" +
+                        "    username string,\n" +
+                        "    price int null\n" +
+                        ")PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\");")
+                .withView("create view test_ignore_nulls_expr as select\n" +
+                        "    timestamp,\n" +
+                        "    username,\n" +
+                        "    last_value(if(price > 0, price, null) ignore nulls) over (partition by username) as price\n" +
+                        ", lead(if(price > 0, price, null) ignore nulls, 1, 0) over (partition by username) as leadValue\n" +
+                        "from sample_data2;");
+
+        Table view = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore()
+                .getDb("test").getTable("test_ignore_nulls_expr");
+        Assertions.assertTrue(view instanceof View);
+        String str = ((View) view).getInlineViewDef();
+        Assertions.assertTrue(str.contains("ignore nulls"),
+                "Expected 'ignore nulls' in view def but got: " + str);
+    }
+
+    @Test
     public void createViewWithComment() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test_table1 (\n" +
                 "  `event_day` date NULL COMMENT \"\" ,\n" +


### PR DESCRIPTION
## Why I'm doing:

When creating a VIEW containing a window function with IGNORE NULLS, the clause is silently dropped from the stored definition if the function argument is any expression other than a direct column reference. The CREATE VIEW succeeds without error, but SHOW CREATE VIEW reveals IGNORE NULLS is missing, meaning queries against the view do not apply the intended null-skipping semantics.

## What I'm doing:

The original fix in PR #37925 added handling in `AST2StringVisitor.visitFunctionCall`, but used `child instanceof SlotRef` as a guard, making it only work for direct column references.

I replaced the `child instanceof SlotRef` check with an index-based check: append `ignore nulls` after the **first argument** (index 0) whenever `node.getIgnoreNulls()` is true. The `IGNORE NULLS` clause always applies to the value argument (the first one) in SQL syntax for these functions.

Fixes #69879

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
