### PR TITLE
[BugFix] Delete shard group meta when erasing lake table from recycle bin

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -176,7 +176,10 @@ public class LakeTableHelper {
         for (Partition partition : table.getAllPartitions()) {
             for (PhysicalPartition subPartition : partition.getSubPartitions()) {
                 for (MaterializedIndex index : subPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                    shardGroupIds.add(index.getShardGroupId());
+                    long shardGroupId = index.getShardGroupId();
+                    if (shardGroupId != PhysicalPartition.INVALID_SHARD_GROUP_ID) {
+                        shardGroupIds.add(shardGroupId);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -75,6 +75,8 @@ public class LakeTableHelper {
         boolean succ = cleaner.cleanTable();
         if (succ) {
             table.removeTabletsFromInvertedIndex();
+            // Best-effort deletion: StarMgrMetaSyncer will clean up any remaining orphaned shard groups.
+            deleteShardGroupMeta(table);
         }
         return succ;
     }
@@ -162,6 +164,26 @@ public class LakeTableHelper {
             }
         }
         return ret;
+    }
+
+    /**
+     * Best-effort deletion of all shard group meta (shards meta included) of a table from StarManager.
+     * If some shard groups fail to be deleted, StarMgrMetaSyncer will eventually clean them up.
+     */
+    static void deleteShardGroupMeta(OlapTable table) {
+        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+        Set<Long> shardGroupIds = new HashSet<>();
+        for (Partition partition : table.getAllPartitions()) {
+            for (PhysicalPartition subPartition : partition.getSubPartitions()) {
+                for (MaterializedIndex index : subPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    shardGroupIds.add(index.getShardGroupId());
+                }
+            }
+        }
+        if (!shardGroupIds.isEmpty()) {
+            starOSAgent.deleteShardGroup(new ArrayList<>(shardGroupIds));
+            LOG.debug("Deleted shard groups of table {}, group ids: {}", table.getId(), shardGroupIds);
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -153,6 +153,64 @@ public class LakeTableHelperTest {
     }
 
     @Test
+    public void testDeleteShardGroupMetaForTable(@Mocked StarOSAgent starOSAgent) {
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        long tableId = 2001L;
+        long partitionId1 = 2000L;
+        long physicalPartitionId1 = 2002L;
+        long partitionId2 = 2003L;
+        long physicalPartitionId2 = 2004L;
+        long groupId1 = 6100L;
+        long groupId2 = 6200L;
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList());
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+
+        // Create table with two partitions, each with a different shard group
+        Partition partition1 =
+                new Partition(partitionId1, physicalPartitionId1, "p1", new MaterializedIndex(), distributionInfo);
+        partition1.getSubPartitions().forEach(sp -> {
+            sp.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).get(0).setShardGroupId(groupId1);
+        });
+
+        Partition partition2 =
+                new Partition(partitionId2, physicalPartitionId2, "p2", new MaterializedIndex(), distributionInfo);
+        partition2.getSubPartitions().forEach(sp -> {
+            sp.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).get(0).setShardGroupId(groupId2);
+        });
+
+        List<Column> columns = Lists.newArrayList(
+                new Column("k1", Type.INT, true, AggregateType.NONE, false, null, null));
+        LakeTable table = new LakeTable(tableId, "test_table", columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        table.addPartition(partition1);
+        table.addPartition(partition2);
+
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        shardGroupInfos.add(ShardGroupInfo.newBuilder().setGroupId(groupId1).build());
+        shardGroupInfos.add(ShardGroupInfo.newBuilder().setGroupId(groupId2).build());
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) {
+                for (long groupId : groupIds) {
+                    shardGroupInfos.removeIf(item -> item.getGroupId() == groupId);
+                }
+            }
+        };
+
+        LakeTableHelper.deleteShardGroupMeta(table);
+        Assertions.assertEquals(0, shardGroupInfos.size());
+    }
+
+    @Test
     public void testRestoreColumnUniqueIdIfNeeded() throws Exception {
         String sql = "create table test_lake_table_helper.test_tb (k1 int, k2 int, k3 varchar)";
         LakeTable table = createTable(sql);


### PR DESCRIPTION
deleteTableFromRecycleBin cleans up remote storage directories but never deletes shard group metadata from StarManager, leaving orphaned shard groups that are only eventually cleaned up by StarMgrMetaSyncer. Add a deleteShardGroupMeta(OlapTable) overload that collects all shard group IDs across all partitions and indices, and call it after cleanTable succeeds. This is best-effort; StarMgrMetaSyncer will handle any remaining failures.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

