### PR TITLE
[Refactor] Fix inefficient vector operations in BE loops

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -219,6 +219,7 @@ void AggregatorParams::init() {
             bool is_nullable = desc.nodes[0].is_nullable;
             // collect arg_typedescs for aggregate function.
             std::vector<FunctionContext::TypeDesc> arg_typedescs;
+            arg_typedescs.reserve(fn.arg_types.size());
             for (auto& type : fn.arg_types) {
                 arg_typedescs.push_back(TypeDescriptor::from_thrift(type));
             }
@@ -584,6 +585,7 @@ bool Aggregator::_is_agg_result_nullable(const TExpr& desc, const AggFunctionTyp
 Status Aggregator::_create_aggregate_function(starrocks::RuntimeState* state, const TFunction& fn,
                                               bool is_result_nullable, const AggregateFunction** ret) {
     std::vector<TypeDescriptor> arg_types;
+    arg_types.reserve(fn.arg_types.size());
     for (auto& type : fn.arg_types) {
         arg_types.push_back(TypeDescriptor::from_thrift(type));
     }

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -217,6 +217,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
 
             // Collect arg_typedescs for aggregate function.
             std::vector<FunctionContext::TypeDesc> arg_typedescs;
+            arg_typedescs.reserve(fn.arg_types.size());
             for (auto& type : fn.arg_types) {
                 arg_typedescs.push_back(TypeDescriptor::from_thrift(type));
             }

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -188,6 +188,7 @@ Status CacheSelectScanner::_fetch_parquet() {
     RETURN_IF_ERROR(reader->collect_scan_io_ranges(&io_ranges));
 
     std::vector<DiskRange> disk_ranges{};
+    disk_ranges.reserve(io_ranges.size());
     for (const auto& io_range : io_ranges) {
         disk_ranges.emplace_back(io_range.offset, io_range.size);
     }
@@ -255,6 +256,7 @@ Status CacheSelectScanner::_write_disk_ranges(std::shared_ptr<io::SharedBuffered
                                                 config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
 
     std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    io_ranges.reserve(merged_disk_ranges.size());
     for (const DiskRange& disk_range : merged_disk_ranges) {
         io_ranges.emplace_back(disk_range.offset(), disk_range.length());
     }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -386,6 +386,7 @@ Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std
         std::vector<DiskRange> merged_disk_ranges{};
         DiskRangeHelper::merge_adjacent_disk_ranges(stripes, config::io_coalesce_read_max_distance_size,
                                                     config::orc_tiny_stripe_threshold_size, merged_disk_ranges);
+        io_ranges.reserve(merged_disk_ranges.size());
         for (const auto& disk_range : merged_disk_ranges) {
             io_ranges.emplace_back(disk_range.offset(), disk_range.length());
         }

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -198,6 +198,7 @@ static bool get_predicate_value(ObjectPool* obj_pool, const SlotDescriptor& slot
 
 static std::vector<BoxedExprContext> build_expr_context_containers(const std::vector<ExprContext*>& expr_contexts) {
     std::vector<BoxedExprContext> containers;
+    containers.reserve(expr_contexts.size());
     for (auto* expr_ctx : expr_contexts) {
         containers.emplace_back(expr_ctx);
     }
@@ -206,6 +207,7 @@ static std::vector<BoxedExprContext> build_expr_context_containers(const std::ve
 
 static std::vector<BoxedExpr> build_raw_expr_containers(const std::vector<Expr*>& exprs) {
     std::vector<BoxedExpr> containers;
+    containers.reserve(exprs.size());
     for (auto* expr : exprs) {
         containers.emplace_back(expr);
     }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -663,6 +663,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
 
 void ExchangeSinkOperator::_calc_hash_values_and_bucket_ids() {
     std::vector<const Column*> partitions_columns;
+    partitions_columns.reserve(_partitions_columns.size());
     for (size_t i = 0; i < _partitions_columns.size(); i++) {
         partitions_columns.emplace_back(_partitions_columns[i].get());
     }

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -115,6 +115,7 @@ Status SelectOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_conjunct_ctxs, state));
     std::vector<ExprContext*> common_expr_ctxs;
+    common_expr_ctxs.reserve(_common_exprs.size());
     for (const auto& [_, ctx] : _common_exprs) {
         common_expr_ctxs.emplace_back(ctx);
     }

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -106,6 +106,7 @@ Status LocalPartitionTopnContext::prepare_pre_agg(RuntimeState* state) {
 
         // Collect arg_typedescs for aggregate function.
         std::vector<FunctionContext::TypeDesc> arg_typedescs;
+        arg_typedescs.reserve(fn.arg_types.size());
         for (auto& type : fn.arg_types) {
             arg_typedescs.push_back(TypeDescriptor::from_thrift(type));
         }

--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -127,6 +127,7 @@ Status ShortCircuitHybridScanNode::_process_key_chunk() {
     DCHECK(_tablets.size() > 0);
     _tablet_schema = _tablets[0]->tablet_schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(_tablet_schema->num_key_columns());
     for (size_t i = 0; i < _tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/exec/stream/aggregate/agg_group_state.cpp
+++ b/be/src/exec/stream/aggregate/agg_group_state.cpp
@@ -76,6 +76,7 @@ Status AggGroupState::_prepare_mem_state_tables(RuntimeState* state,
     // intermediate agg_state is created when intermediate/detail agg states are not empty.
     if (!intermediate_agg_states.empty()) {
         std::vector<SlotDescriptor*> intermediate_slots;
+        intermediate_slots.reserve(key_size);
         for (int32_t i = 0; i < key_size; i++) {
             intermediate_slots.push_back(_intermediate_tuple_desc->slots()[i]);
         }
@@ -95,6 +96,7 @@ Status AggGroupState::_prepare_mem_state_tables(RuntimeState* state,
             // detail state table schema:
             // group_by_keys + agg_key -> count
             std::vector<SlotDescriptor*> detail_table_slots;
+            detail_table_slots.reserve(key_size);
             for (auto i = 0; i < key_size; i++) {
                 detail_table_slots.push_back(input_slots[i]);
             }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -309,6 +309,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(_init_node_channels(state, index_id_to_tablet_be_map));
 
     std::vector<IndexChannel*> index_channels;
+    index_channels.reserve(_channels.size());
     for (const auto& channel : _channels) {
         index_channels.emplace_back(channel.get());
     }

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1974,6 +1974,7 @@ StatusOr<ColumnPtr> ArrayFunctions::arrays_zip(FunctionContext* ctx, const Colum
 
     // Create result array with struct elements
     std::vector<std::string> field_names;
+    field_names.reserve(num_arrays);
     for (size_t i = 0; i < num_arrays; ++i) {
         field_names.push_back("col" + std::to_string(i + 1));
     }

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -75,6 +75,7 @@ Status ArrowFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context)
     FunctionContext::TypeDesc return_type = _type;
     std::vector<FunctionContext::TypeDesc> args_types;
 
+    args_types.reserve(_children.size());
     for (Expr* child : _children) {
         args_types.push_back(child->type());
     }

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -127,6 +127,7 @@ Status JavaFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context) 
     FunctionContext::TypeDesc return_type = _type;
     std::vector<FunctionContext::TypeDesc> args_types;
 
+    args_types.reserve(_children.size());
     for (Expr* child : _children) {
         args_types.push_back(child->type());
     }

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -104,6 +104,7 @@ Status JavaUDTFFunction::init(const TFunction& fn, TableFunctionState** state) c
     RETURN_IF_ERROR(instance->get_libpath(fn.fid, fn.hdfs_location, fn.checksum, TFunctionBinaryType::SRJAR, &libpath));
     // Now we only support one return types
     std::vector<TypeDescriptor> arg_typedescs;
+    arg_typedescs.reserve(fn.arg_types.size());
     for (auto& type : fn.arg_types) {
         arg_typedescs.push_back(TypeDescriptor::from_thrift(type));
     }

--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -335,6 +335,7 @@ StatusOr<ColumnPtr> UtilityFunctions::get_query_profile(FunctionContext* context
     TGetProfileRequest req;
 
     std::vector<std::string> query_ids;
+    query_ids.reserve(columns[0]->size());
     for (size_t i = 0; i < columns[0]->size(); ++i) {
         query_ids.emplace_back(viewer.value(i));
     }

--- a/be/src/formats/avro/cpp/column_reader.cpp
+++ b/be/src/formats/avro/cpp/column_reader.cpp
@@ -81,6 +81,7 @@ ColumnReaderUniquePtr ColumnReader::get_nullable_column_reader(const std::string
 
     case TYPE_STRUCT: {
         std::vector<ColumnReaderUniquePtr> field_readers;
+        field_readers.reserve(type_desc.children.size());
         for (size_t i = 0; i < type_desc.children.size(); ++i) {
             field_readers.emplace_back(get_nullable_column_reader(type_desc.field_names[i], type_desc.children[i],
                                                                   timezone, invalid_as_null));

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -566,6 +566,7 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
 
 Status GroupReader::_init_read_chunk() {
     std::vector<SlotDescriptor*> read_slots;
+    read_slots.reserve(_param.read_cols.size());
     for (const auto& column : _param.read_cols) {
         read_slots.emplace_back(column.slot_desc);
     }

--- a/be/src/fs/key_cache.cpp
+++ b/be/src/fs/key_cache.cpp
@@ -337,6 +337,7 @@ std::string KeyCache::to_string() const {
     std::stringstream ss;
     std::lock_guard lg(_lock);
     std::vector<EncryptionKey*> ordered;
+    ordered.reserve(_identifier_to_keys.size());
     for (const auto& e : _identifier_to_keys) {
         ordered.push_back(e.second.get());
     }

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -326,6 +326,7 @@ Status CompactionAction::_handle_submit_repairs(HttpRequest* req, std::string* j
         // do all tablets
         for (auto& itr : tablets_with_small_segment_files) {
             vector<uint32_t> rowsetids;
+            rowsetids.reserve(itr.second.size());
             for (const auto& rowset_segments_pair : itr.second) {
                 rowsetids.emplace_back(rowset_segments_pair.first);
             }

--- a/be/src/runtime/agg_state_desc.cpp
+++ b/be/src/runtime/agg_state_desc.cpp
@@ -29,6 +29,7 @@ AggStateDesc AggStateDesc::from_thrift(const TAggStateDesc& desc) {
     auto return_type = TypeDescriptor::from_thrift(desc.ret_type);
     // arg types
     std::vector<TypeDescriptor> arg_types;
+    arg_types.reserve(desc.arg_types.size());
     for (auto& arg_type : desc.arg_types) {
         arg_types.emplace_back(TypeDescriptor::from_thrift(arg_type));
     }

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -127,6 +127,7 @@ Status DataStreamRecvr::create_merger_for_pipeline(RuntimeState* state, const So
 std::vector<merge_path::MergePathChunkProvider> DataStreamRecvr::create_merge_path_chunk_providers() {
     DCHECK(_is_merging);
     std::vector<merge_path::MergePathChunkProvider> chunk_providers;
+    chunk_providers.reserve(_sender_queues.size());
     for (SenderQueue* q : _sender_queues) {
         chunk_providers.emplace_back([q](bool only_check_if_has_data, ChunkPtr* chunk, bool* eos) {
             if (!q->has_chunk()) {

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -327,10 +327,12 @@ RowPositionDescriptor* RowPositionDescriptor::from_thrift(const TRowPositionDesc
     switch (t_desc.row_position_type) {
     case TRowPositionType::ICEBERG_V3_ROW_POSITION: {
         std::vector<SlotId> fetch_ref_slot_ids;
+        fetch_ref_slot_ids.reserve(t_desc.fetch_ref_slots.size());
         for (const auto& slot_id : t_desc.fetch_ref_slots) {
             fetch_ref_slot_ids.emplace_back(slot_id);
         }
         std::vector<SlotId> lookup_ref_slot_ids;
+        lookup_ref_slot_ids.reserve(t_desc.lookup_ref_slots.size());
         for (const auto& slot_id : t_desc.lookup_ref_slots) {
             lookup_ref_slot_ids.emplace_back(slot_id);
         }

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -173,6 +173,7 @@ std::vector<int32_t> IcebergTableDescriptor::partition_source_index_in_schema() 
 
 const std::vector<std::string> IcebergTableDescriptor::full_column_names() {
     std::vector<std::string> full_column_names;
+    full_column_names.reserve(_columns.size());
     for (const auto& column : _columns) {
         full_column_names.emplace_back(column.column_name);
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -286,6 +286,7 @@ Status GlobalEnv::_init_mem_tracker() {
 
 std::vector<std::shared_ptr<MemTracker>> GlobalEnv::mem_trackers() const {
     std::vector<std::shared_ptr<MemTracker>> mem_trackers;
+    mem_trackers.reserve(_mem_tracker_map.size());
     for (auto& item : _mem_tracker_map) {
         mem_trackers.emplace_back(item.second);
     }

--- a/be/src/runtime/sorted_chunks_merger.cpp
+++ b/be/src/runtime/sorted_chunks_merger.cpp
@@ -306,6 +306,7 @@ CascadeChunkMerger::CascadeChunkMerger(RuntimeState* state) : ChunkMerger(state)
 Status CascadeChunkMerger::init(const std::vector<ChunkProvider>& providers,
                                 const std::vector<ExprContext*>* sort_exprs, const SortDescs& sort_desc) {
     std::vector<std::unique_ptr<SimpleChunkSortCursor>> cursors;
+    cursors.reserve(providers.size());
     for (const auto& provider : providers) {
         cursors.push_back(std::make_unique<SimpleChunkSortCursor>(provider, sort_exprs));
     }

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -81,6 +81,7 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     DCHECK(target_table.columns.size() == output_exprs.size());
 
     std::vector<std::string> column_names;
+    column_names.reserve(target_table.columns.size());
     for (const auto& column : target_table.columns) {
         column_names.push_back(column.column_name);
     }
@@ -136,6 +137,7 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
 
     } else {
         std::vector<TExpr> partition_exprs;
+        partition_exprs.reserve(target_table.partition_column_ids.size());
         for (auto id : target_table.partition_column_ids) {
             partition_exprs.push_back(output_exprs[id]);
         }

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -98,6 +98,7 @@ void CompactionUtils::split_column_into_groups(size_t num_columns, const std::ve
                                                std::vector<std::vector<uint32_t>>* column_groups) {
     column_groups->emplace_back(sort_key_idxes);
     std::vector<ColumnId> all_columns;
+    all_columns.reserve(num_columns);
     for (ColumnId i = 0; i < num_columns; ++i) {
         all_columns.push_back(i);
     }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -887,6 +887,7 @@ const char* DeltaWriter::replica_state_name(ReplicaState state) {
 Status DeltaWriter::_fill_auto_increment_id(Chunk& chunk) {
     // 1. get pk column from chunk
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(_tablet_schema->num_key_columns());
     for (size_t i = 0; i < _tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -448,12 +448,6 @@ public:
             // Dictionary cache currently only works with share-nothing PK tables which always use V1.
             std::vector<uint32_t> idxes;
             idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
-            idxes.reserve(schema.fields().size());
             for (uint32_t i = 0; i < schema.fields().size(); i++) {
                 idxes.push_back((uint32_t)i);
             }

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -447,6 +447,13 @@ public:
         case PK_ENCODE: {
             // Dictionary cache currently only works with share-nothing PK tables which always use V1.
             std::vector<uint32_t> idxes;
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
+            idxes.reserve(schema.fields().size());
             for (uint32_t i = 0; i < schema.fields().size(); i++) {
                 idxes.push_back((uint32_t)i);
             }

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -174,6 +174,7 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
                                                -1 /*unused*/, params.tablet_schema);
     }
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(params.tablet_schema->num_key_columns());
     for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -926,6 +926,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
     ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(_tablet_id));
     // 1. get pk column from chunk
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(_write_schema->num_key_columns());
     for (size_t i = 0; i < _write_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -54,6 +54,7 @@ StatusOr<FileInfo> LakePrimaryKeyCompactionConflictResolver::filename() const {
 Schema LakePrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(_metadata->schema());
     std::vector<uint32_t> pk_columns;
+    pk_columns.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back(static_cast<uint32_t>(i));
     }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -981,6 +981,7 @@ void MetaFileBuilder::batch_apply_opwrite(const TxnLogPB_OpWrite& op_write,
     std::vector<std::string> del_encryption_metas;
 
     // Collect del files
+    dels.reserve(op_write.dels_size());
     for (int i = 0; i < op_write.dels_size(); i++) {
         dels.push_back(op_write.dels(i));
     }

--- a/be/src/storage/lake/pk_tablet_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_sst_writer.cpp
@@ -40,6 +40,7 @@ Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
     ASSIGN_OR_RETURN(auto pk_encoding_type, _tablet_schema_ptr->primary_key_encoding_type_or_error());
     if (_pk_column == nullptr) {
         vector<uint32_t> pk_columns;
+        pk_columns.reserve(_tablet_schema_ptr->num_key_columns());
         for (size_t i = 0; i < _tablet_schema_ptr->num_key_columns(); i++) {
             pk_columns.push_back((uint32_t)i);
         }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -318,6 +318,7 @@ Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpda
     CHECK_MEM_LIMIT("RowsetUpdateState::_do_load_upserts");
     TRACE_COUNTER_SCOPE_LATENCY_US("do_load_upserts_us");
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(params.tablet_schema->num_key_columns());
     for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -846,6 +847,7 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
         return Status::OK();
     }
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(params.tablet_schema->num_key_columns());
     for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -245,6 +245,7 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_group_rows
 
         if (should_start_new_group) {
             std::vector<uint32_t> group_ids;
+            group_ids.reserve(current_group.size());
             for (const auto& r : current_group) {
                 group_ids.push_back(r->id());
             }
@@ -269,6 +270,7 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_group_rows
     // Add the last group if not empty
     if (!current_group.empty()) {
         std::vector<uint32_t> group_ids;
+        group_ids.reserve(current_group.size());
         for (const auto& r : current_group) {
             group_ids.push_back(r->id());
         }
@@ -338,6 +340,7 @@ StatusOr<std::vector<RowsetPtr>> TabletParallelCompactionManager::pick_rowsets_f
     // Log metadata details for debugging duplicate compaction issues
     std::vector<uint32_t> first_rowset_ids;
     int count = std::min(10, metadata->rowsets_size());
+    first_rowset_ids.reserve(count);
     for (int i = 0; i < count; i++) {
         first_rowset_ids.push_back(metadata->rowsets(i).id());
     }
@@ -394,6 +397,7 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::split_rowse
 
     if (stats.total_bytes <= max_bytes || max_parallel <= 1 || stats.has_delete_predicate || not_enough_segments) {
         std::vector<uint32_t> group_ids;
+        group_ids.reserve(all_rowsets.size());
         for (const auto& r : all_rowsets) {
             group_ids.push_back(r->id());
         }

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -58,6 +58,7 @@ Status CompactionState::load_segments(Rowset* rowset, UpdateManager* update_mana
 
 Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id) {
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back(static_cast<uint32_t>(i));
     }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -608,6 +608,7 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
 
     auto tschema = std::make_shared<TabletSchema>(metadata->schema());
     std::vector<uint32_t> pk_cids;
+    pk_cids.reserve(tschema->num_key_columns());
     for (size_t i = 0; i < tschema->num_key_columns(); i++) pk_cids.push_back((uint32_t)i);
     Schema pkey_schema = ChunkHelper::convert_schema(tschema, pk_cids);
 
@@ -933,6 +934,7 @@ Status UpdateManager::_process_single_chunk_update_with_condition(
         // STEP 2: Read condition column values from new rows (from SST files)
         std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
         std::vector<uint32_t> rowids;
+        rowids.reserve(pk_column->size());
         for (int j = 0; j < pk_column->size(); ++j) {
             // Build absolute rowids: current.second is the base offset for this chunk
             rowids.push_back(j + current.second);
@@ -1092,6 +1094,7 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
 
         std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
         std::vector<uint32_t> rowids;
+        rowids.reserve(upsert->size());
         for (int j = 0; j < upsert->size(); ++j) {
             rowids.push_back(j);
         }

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -76,6 +76,7 @@ StatusOr<std::unique_ptr<TabletReader>> VersionedTablet::new_reader(
     std::unique_ptr<TabletReader> res;
     if (!base_rowsets.empty()) {
         std::vector<std::shared_ptr<Rowset>> rowsets;
+        rowsets.reserve(base_rowsets.size());
         for (auto& rowset : base_rowsets) {
             rowsets.emplace_back(std::dynamic_pointer_cast<Rowset>(rowset));
         }

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -37,6 +37,7 @@ StatusOr<FileInfo> LocalPrimaryKeyCompactionConflictResolver::filename() const {
 Schema LocalPrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
     const auto& schema = _rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back(static_cast<uint32_t>(i));
     }

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -112,6 +112,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     // convert keys to pk single column format
     const auto& tablet_schema = _tablet->tablet_schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -141,11 +142,13 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     plan_read_by_rssid(rowids, found, rowids_by_rssid, idxes);
 
     vector<std::pair<uint32_t, uint32_t>> value_column_ids_by_order_with_orig_idx;
+    value_column_ids_by_order_with_orig_idx.reserve(value_column_ids.size());
     for (uint32_t i = 0; i < value_column_ids.size(); ++i) {
         value_column_ids_by_order_with_orig_idx.emplace_back(value_column_ids[i], i);
     }
     std::sort(value_column_ids_by_order_with_orig_idx.begin(), value_column_ids_by_order_with_orig_idx.end());
     vector<uint32_t> value_column_ids_by_order;
+    value_column_ids_by_order.reserve(value_column_ids_by_order_with_orig_idx.size());
     for (const auto& p : value_column_ids_by_order_with_orig_idx) {
         value_column_ids_by_order.push_back(p.first);
     }
@@ -209,6 +212,7 @@ Status handle_tablet_multi_get_rpc(const PTabletReaderMultiGetRequest& request, 
     const auto& tablet_schema = tablet->tablet_schema();
     const auto& keys_pb = request.keys();
     vector<ColumnId> key_column_ids;
+    key_column_ids.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         key_column_ids.push_back(i);
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -53,6 +53,7 @@ Schema MemTable::convert_schema(const TabletSchemaCSPtr& tablet_schema,
             ncolumn--;
         }
         vector<ColumnId> column_idxes;
+        column_idxes.reserve(ncolumn);
         for (ColumnId i = 0; i < ncolumn; i++) {
             column_idxes.push_back(i);
         }

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -116,6 +116,7 @@ Status StorageEngine::start_bg_threads() {
 
     // convert store map to vector
     std::vector<DataDir*> data_dirs;
+    data_dirs.reserve(_store_map.size());
     for (auto& tmp_store : _store_map) {
         data_dirs.push_back(tmp_store.second.get());
     }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3215,6 +3215,7 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
     size_t nshard_bf = meta.shard_bf_off_size();
     DCHECK(nshard_bf == 0 || nshard_bf == nshard + 1);
     std::vector<size_t> bf_off;
+    bf_off.reserve(nshard_bf);
     for (size_t i = 0; i < nshard_bf; i++) {
         bf_off.emplace_back(meta.shard_bf_off(i));
     }

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -591,6 +591,7 @@ Status ScalarColumnWriter::write_inverted_index() {
 Status ScalarColumnWriter::_write_data_page(Page* page) {
     PagePointer pp;
     std::vector<Slice> compressed_body;
+    compressed_body.reserve(page->data.size());
     for (auto& data : page->data) {
         compressed_body.push_back(data.slice());
     }

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -1074,6 +1074,7 @@ Status Rowset::verify() {
     vector<ColumnId> key_columns;
     vector<ColumnId> order_columns;
     bool is_pk_ordered = false;
+    key_columns.reserve(_schema->num_key_columns());
     for (int i = 0; i < _schema->num_key_columns(); i++) {
         key_columns.push_back(i);
     }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -112,6 +112,7 @@ Status SegmentWriter::init() {
 
 Status SegmentWriter::init(bool has_key) {
     std::vector<uint32_t> all_column_indexes;
+    all_column_indexes.reserve(_tablet_schema->num_columns());
     for (uint32_t i = 0; i < _tablet_schema->num_columns(); ++i) {
         all_column_indexes.emplace_back(i);
     }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -508,6 +508,7 @@ CreateIndexDecision ZoneMapIndexQualityJudgerImpl<type>::make_decision() const {
     }
 
     std::vector<ZoneMapWrapper<type>> parsed_zonemap;
+    parsed_zonemap.reserve(_page_zone_maps.size());
     for (auto& zonemap : _page_zone_maps) {
         parsed_zonemap.emplace_back(zonemap);
     }

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -98,6 +98,7 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, MemTracker* update
     OlapReaderStatistics stats;
     auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -552,6 +553,7 @@ Status RowsetColumnUpdateState::_update_primary_index(const TabletSchemaCSPtr& t
                                                       PrimaryIndex& index) {
     // 1. build pk column
     vector<uint32_t> pk_column_ids;
+    pk_column_ids.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_column_ids.push_back((uint32_t)i);
     }

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -110,6 +110,7 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
     OlapReaderStatistics stats;
     const auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -166,6 +167,7 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     _tablet_id = tablet->tablet_id();
     const auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -200,6 +202,7 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
 Status RowsetUpdateState::load_deletes(Rowset* rowset, uint32_t idx) {
     const auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
@@ -213,6 +216,7 @@ Status RowsetUpdateState::load_deletes(Rowset* rowset, uint32_t idx) {
 Status RowsetUpdateState::load_upserts(Rowset* rowset, uint32_t upsert_id) {
     const auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }

--- a/be/src/storage/runtime_filter_predicate.cpp
+++ b/be/src/storage/runtime_filter_predicate.cpp
@@ -140,6 +140,7 @@ Status DictColumnRuntimeFilterPredicate::prepare() {
     }
     auto binary_column = BinaryColumn::create();
     std::vector<Slice> data_slice;
+    data_slice.reserve(_dict_words.size());
     for (const auto& word : _dict_words) {
         data_slice.emplace_back(word.data(), word.size());
     }
@@ -353,6 +354,7 @@ Status RuntimeFilterPredicatesRewriter::rewrite(ObjectPool* obj_pool, RuntimeFil
         std::vector<Slice> all_words;
         RETURN_IF_ERROR(column_iterators[column_id]->fetch_all_dict_words(&all_words));
         std::vector<std::string> dict_words;
+        dict_words.reserve(all_words.size());
         for (const auto& word : all_words) {
             dict_words.emplace_back(std::string(word.get_data(), word.get_size()));
         }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1131,6 +1131,7 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
             // new added dcgs info for every segment in rowset.
             DeltaColumnGroupList dcgs;
             std::vector<int> last_dcg_counts;
+            last_dcg_counts.reserve(sc_params.rowsets_to_change[i]->num_segments());
             for (uint32_t j = 0; j < sc_params.rowsets_to_change[i]->num_segments(); j++) {
                 // check the lastest historical_dcgs version if it is equal to schema change version
                 // of the rowset. If it is, we should merge the dcg info.

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -760,9 +760,11 @@ Status SchemaChangeUtils::parse_request_for_sort_key(const TabletSchemaCSPtr& ba
     const auto& new_sort_key_idxes = new_schema->sort_key_idxes();
     std::vector<int32_t> base_sort_key_unique_ids;
     std::vector<int32_t> new_sort_key_unique_ids;
+    base_sort_key_unique_ids.reserve(base_sort_key_idxes.size());
     for (auto idx : base_sort_key_idxes) {
         base_sort_key_unique_ids.emplace_back(base_schema->column(idx).unique_id());
     }
+    new_sort_key_unique_ids.reserve(new_sort_key_idxes.size());
     for (auto idx : new_sort_key_idxes) {
         new_sort_key_unique_ids.emplace_back(new_schema->column(idx).unique_id());
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1410,6 +1410,7 @@ bool StorageEngine::check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id)
 void StorageEngine::increase_update_compaction_thread(const int num_threads_per_disk) {
     // convert store map to vector
     std::vector<DataDir*> data_dirs;
+    data_dirs.reserve(_store_map.size());
     for (auto& tmp_store : _store_map) {
         data_dirs.push_back(tmp_store.second.get());
     }

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -156,6 +156,7 @@ Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value
         multi_get->add(keys, key_index, key_index);
     }
     vector<TabletMultiGet*> multi_gets;
+    multi_gets.reserve(multi_gets_by_tablet.size());
     for (auto& iter : multi_gets_by_tablet) {
         multi_gets.push_back(iter.second.get());
     }

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -208,6 +208,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
     // get pk eq predicates, and convert these predicates to encoded pk column
     const auto& tablet_schema = _tablet_schema;
     vector<ColumnId> pk_column_ids;
+    pk_column_ids.reserve(tablet_schema->num_key_columns());
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_column_ids.emplace_back(i);
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1975,6 +1975,7 @@ Status TabletUpdates::_do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t
 
             std::map<uint32_t, std::vector<uint32_t>> new_rowids_by_rssid;
             std::vector<uint32_t> rowids;
+            rowids.reserve(upserts[upsert_idx]->size());
             for (int j = 0; j < upserts[upsert_idx]->size(); ++j) {
                 rowids.push_back(j);
             }
@@ -4078,6 +4079,7 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, Ch
         // new added dcgs info for every segment in rowset.
         DeltaColumnGroupList dcgs;
         std::vector<int> last_dcg_counts;
+        last_dcg_counts.reserve(new_rowset_info.num_segments);
         for (uint32_t j = 0; j < new_rowset_info.num_segments; j++) {
             // check the lastest historical_dcgs version if it is equal to schema change version
             // of the rowset. If it is, we should merge the dcg info.
@@ -5661,6 +5663,7 @@ void TabletUpdates::to_rowset_meta_pb(const std::vector<RowsetMetaSharedPtr>& ro
 std::vector<std::string> TabletUpdates::get_version_list() const {
     std::lock_guard wl(_lock);
     std::vector<std::string> version_list;
+    version_list.reserve(_edit_version_infos.size());
     for (auto& edit_version_info : _edit_version_infos) {
         version_list.emplace_back(edit_version_info->version.to_string());
     }

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -71,6 +71,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
     CHECK_MEM_LIMIT("CompactionState::_load_segments");
     const auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
+    pk_columns.reserve(schema->num_key_columns());
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back(static_cast<uint32_t>(i));
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix errors reported by clang-tidy performance-inefficient-vector-operation

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
