### PR TITLE
[Refactor] Fix modernize-use-equals-default warnings in BE

### DIFF
--- a/be/src/base/concurrency/blocking_queue.hpp
+++ b/be/src/base/concurrency/blocking_queue.hpp
@@ -236,7 +236,7 @@ template <typename T, typename Container = std::deque<T>, typename Lock = std::m
           typename CV = std::condition_variable>
 class UnboundedBlockingQueue {
 public:
-    UnboundedBlockingQueue() {}
+    UnboundedBlockingQueue() = default;
     ~UnboundedBlockingQueue() { shutdown(); }
 
     // Return false iff empty *AND* has been shutdown.

--- a/be/src/base/concurrency/concurrent_limiter.h
+++ b/be/src/base/concurrency/concurrent_limiter.h
@@ -44,7 +44,7 @@ private:
 
 class ConcurrentLimiterGuard {
 public:
-    explicit ConcurrentLimiterGuard() {}
+    explicit ConcurrentLimiterGuard() = default;
 
     bool set_limiter(ConcurrentLimiter* limiter) {
         if (limiter->inc()) {

--- a/be/src/base/concurrency/moodycamel/concurrentqueue.h
+++ b/be/src/base/concurrency/moodycamel/concurrentqueue.h
@@ -1688,7 +1688,7 @@ private:
 		{
 		}
 		
-		virtual ~ProducerBase() { }
+		virtual ~ProducerBase() = default;
 		
 		template<typename U>
 		inline bool dequeue(U& element)

--- a/be/src/base/stats/ndv_estimator.h
+++ b/be/src/base/stats/ndv_estimator.h
@@ -21,7 +21,7 @@ namespace starrocks {
 
 class NDVEstimator {
 public:
-    virtual ~NDVEstimator(){};
+    virtual ~NDVEstimator() = default;
 
     virtual int64_t estimate(int64_t sample_row, int64_t sample_distinct, int64_t count_once, double sample_ratio) = 0;
 };

--- a/be/src/base/uid_util.h
+++ b/be/src/base/uid_util.h
@@ -74,7 +74,7 @@ struct UniqueId {
     int64_t hi = 0;
     int64_t lo = 0;
 
-    UniqueId() {}
+    UniqueId() = default;
     UniqueId(int64_t hi_, int64_t lo_) : hi(hi_), lo(lo_) {}
     UniqueId(const TUniqueId& tuid) : hi(tuid.hi), lo(tuid.lo) {}
     UniqueId(const PUniqueId& puid) : hi(puid.hi()), lo(puid.lo()) {}

--- a/be/src/cache/disk_space_monitor.h
+++ b/be/src/cache/disk_space_monitor.h
@@ -41,7 +41,7 @@ public:
 
         virtual dev_t device_id(const std::string& path);
 
-        virtual ~FileSystemWrapper() {}
+        virtual ~FileSystemWrapper() = default;
     };
 
     struct DiskStats {

--- a/be/src/column/container_resource.h
+++ b/be/src/column/container_resource.h
@@ -29,8 +29,7 @@ public:
     ContainerResource(const std::shared_ptr<T>& handle, const void* data, size_t length)
             : _owner(std::static_pointer_cast<void>(handle)), _data(data), _length(length) {}
 
-    ContainerResource(const ContainerResource& other)
-            : _owner(other._owner), _data(other._data), _length(other._length) {}
+    ContainerResource(const ContainerResource& other) = default;
 
     ContainerResource& operator=(const ContainerResource& other) {
         if (this != &other) {

--- a/be/src/connector/connector_sink_executor.h
+++ b/be/src/connector/connector_sink_executor.h
@@ -35,7 +35,7 @@ class SpillPartitionChunkWriter;
 class ConnectorSinkExecutor {
 public:
     ConnectorSinkExecutor(std::string executor_name) : _executor_name(std::move(executor_name)) {}
-    virtual ~ConnectorSinkExecutor() {}
+    virtual ~ConnectorSinkExecutor() = default;
 
     virtual Status init() = 0;
 

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -307,8 +307,7 @@ public:
 
 private:
     // Invoked only by clone.
-    CastToVariantExpr(const CastToVariantExpr& rhs)
-            : Expr(rhs), _from_type(rhs._from_type), _allow_throw_exception(rhs._allow_throw_exception) {}
+    CastToVariantExpr(const CastToVariantExpr& rhs) = default;
 
     TypeDescriptor _from_type;
     bool _allow_throw_exception;
@@ -384,7 +383,7 @@ class MustNullExpr final : public Expr {
 public:
     MustNullExpr(const TExprNode& node) : Expr(node) {}
 
-    MustNullExpr(const MustNullExpr& rhs) : Expr(rhs) {}
+    MustNullExpr(const MustNullExpr& rhs) = default;
 
     ~MustNullExpr() override = default;
 

--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -434,8 +434,7 @@ public:
     VectorizedInConstPredicateGeneric(const TExprNode& node)
             : Predicate(node), _is_not_in(node.in_predicate.is_not_in) {}
 
-    VectorizedInConstPredicateGeneric(const VectorizedInConstPredicateGeneric& other)
-            : Predicate(other), _is_not_in(other._is_not_in), _const_input(other._const_input) {}
+    VectorizedInConstPredicateGeneric(const VectorizedInConstPredicateGeneric& other) = default;
 
     ~VectorizedInConstPredicateGeneric() override = default;
 

--- a/be/src/exprs/match_expr.h
+++ b/be/src/exprs/match_expr.h
@@ -23,7 +23,7 @@ namespace starrocks {
 class MatchExpr final : public Expr {
 public:
     MatchExpr(const TExprNode& node) : Expr(node) {}
-    ~MatchExpr() override {}
+    ~MatchExpr() override = default;
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MatchExpr(*this)); }
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;

--- a/be/src/http/action/jit_cache_action.h
+++ b/be/src/http/action/jit_cache_action.h
@@ -30,7 +30,7 @@ namespace starrocks {
 
 class JITCacheAction : public HttpHandler {
 public:
-    explicit JITCacheAction() {}
+    explicit JITCacheAction() = default;
     ~JITCacheAction() override = default;
 
     void handle(HttpRequest* req) override;

--- a/be/src/runtime/memory/counting_allocator.h
+++ b/be/src/runtime/memory/counting_allocator.h
@@ -109,7 +109,7 @@ public:
     };
     STLCountingAllocator() = default;
     explicit STLCountingAllocator(int64_t* counter) : _counter(counter) {}
-    explicit STLCountingAllocator(const STLCountingAllocator& rhs) : _counter(rhs._counter) {}
+    explicit STLCountingAllocator(const STLCountingAllocator& rhs) = default;
     template <class U>
     STLCountingAllocator(const STLCountingAllocator<U>& other) : _counter(other._counter) {}
 
@@ -152,10 +152,7 @@ public:
 #endif
     }
 
-    STLCountingAllocator& operator=(const STLCountingAllocator& rhs) {
-        _counter = rhs._counter;
-        return *this;
-    }
+    STLCountingAllocator& operator=(const STLCountingAllocator& rhs) = default;
 
     template <class U>
     STLCountingAllocator& operator=(const STLCountingAllocator<U>& rhs) {

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -142,7 +142,7 @@ private:
 class StreamLoadPipeReader {
 public:
     StreamLoadPipeReader(std::shared_ptr<StreamLoadPipe> pipe) : _pipe(std::move(pipe)) {}
-    virtual ~StreamLoadPipeReader() {}
+    virtual ~StreamLoadPipeReader() = default;
     virtual StatusOr<ByteBufferPtr> read() { return _pipe->read(); }
 
 private:

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -42,12 +42,7 @@ struct CompactionCandidate {
         score = other.score;
     }
 
-    CompactionCandidate& operator=(const CompactionCandidate& rhs) {
-        tablet = rhs.tablet;
-        type = rhs.type;
-        score = rhs.score;
-        return *this;
-    }
+    CompactionCandidate& operator=(const CompactionCandidate& rhs) = default;
 
     CompactionCandidate(CompactionCandidate&& other) {
         tablet = std::move(other.tablet);

--- a/be/src/storage/index/inverted/builtin/builtin_plugin.h
+++ b/be/src/storage/index/inverted/builtin/builtin_plugin.h
@@ -35,7 +35,7 @@ public:
                                         LogicalType field_type, std::unique_ptr<InvertedReader>* res) override;
 
 private:
-    BuiltinPlugin() {}
+    BuiltinPlugin() = default;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/inverted/clucene/clucene_plugin.h
+++ b/be/src/storage/index/inverted/clucene/clucene_plugin.h
@@ -47,7 +47,7 @@ public:
                                         LogicalType field_type, std::unique_ptr<InvertedReader>* res) override;
 
 private:
-    CLucenePlugin() {}
+    CLucenePlugin() = default;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -31,7 +31,7 @@ namespace starrocks {
 class TenANNReader final : public VectorIndexReader {
 public:
     TenANNReader() = default;
-    ~TenANNReader() override{};
+    ~TenANNReader() override = default;
 
     Status init_searcher(const tenann::IndexMeta& meta, const std::string& index_path) override;
 

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -50,7 +50,7 @@ public:
               _lcrm_file(std::move(lcrm_file)),
               _segment_id_to_add_dels(segment_id_to_add_dels),
               _delvecs(delvecs) {}
-    ~LakePrimaryKeyCompactionConflictResolver() override {}
+    ~LakePrimaryKeyCompactionConflictResolver() override = default;
 
     StatusOr<FileInfo> filename() const override;
     Schema generate_pkey_schema() override;

--- a/be/src/storage/lake/lake_primary_key_recover.h
+++ b/be/src/storage/lake/lake_primary_key_recover.h
@@ -38,7 +38,7 @@ class LakePrimaryKeyRecover : public PrimaryKeyRecover {
 public:
     explicit LakePrimaryKeyRecover(MetaFileBuilder* builder, Tablet* tablet, MutableTabletMetadataPtr metadata)
             : _builder(builder), _tablet(tablet), _metadata(std::move(metadata)) {}
-    ~LakePrimaryKeyRecover() {}
+    ~LakePrimaryKeyRecover() = default;
 
     // clean old state, include pk index and delvec
     Status pre_cleanup() override;

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -30,7 +30,7 @@ class UpdateManager;
 
 class CompactionState {
 public:
-    CompactionState() {}
+    CompactionState() = default;
     ~CompactionState();
 
     CompactionState(const CompactionState&) = delete;

--- a/be/src/storage/load_spill_block_manager.h
+++ b/be/src/storage/load_spill_block_manager.h
@@ -27,8 +27,8 @@ class ThreadPoolToken;
 
 class LoadSpillBlockMergeExecutor {
 public:
-    LoadSpillBlockMergeExecutor() {}
-    ~LoadSpillBlockMergeExecutor() {}
+    LoadSpillBlockMergeExecutor() = default;
+    ~LoadSpillBlockMergeExecutor() = default;
     Status init();
 
     ThreadPool* get_thread_pool() { return _merge_pool.get(); }

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -35,7 +35,7 @@ public:
               _new_version(new_version),
               _total_deletes(total_deletes),
               _delvecs(delvecs) {}
-    ~LocalPrimaryKeyCompactionConflictResolver() override {}
+    ~LocalPrimaryKeyCompactionConflictResolver() override = default;
 
     StatusOr<FileInfo> filename() const override;
     Schema generate_pkey_schema() override;

--- a/be/src/storage/local_primary_key_recover.h
+++ b/be/src/storage/local_primary_key_recover.h
@@ -21,7 +21,7 @@ namespace starrocks {
 class LocalPrimaryKeyRecover : public PrimaryKeyRecover {
 public:
     LocalPrimaryKeyRecover(Tablet* tablet, UpdateManager* update_mgr) : _tablet(tablet), _update_mgr(update_mgr) {}
-    ~LocalPrimaryKeyRecover() {}
+    ~LocalPrimaryKeyRecover() = default;
 
     Status pre_cleanup() override;
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -434,9 +434,9 @@ struct HashOfRowsetId {
 struct TabletSegmentId {
     int64_t tablet_id = INT64_MAX;
     uint32_t segment_id = UINT32_MAX;
-    TabletSegmentId() {}
+    TabletSegmentId() = default;
     TabletSegmentId(int64_t tid, uint32_t sid) : tablet_id(tid), segment_id(sid) {}
-    ~TabletSegmentId() {}
+    ~TabletSegmentId() = default;
     bool operator==(const TabletSegmentId& rhs) const {
         return tablet_id == rhs.tablet_id && segment_id == rhs.segment_id;
     }
@@ -465,7 +465,7 @@ struct TabletSegmentIdRange {
     TabletSegmentId right;
     TabletSegmentIdRange(int64_t left_tid, uint32_t left_sid, int64_t right_tid, uint32_t right_sid)
             : left(left_tid, left_sid), right(right_tid, right_sid) {}
-    ~TabletSegmentIdRange() {}
+    ~TabletSegmentIdRange() = default;
     // make sure left <= right
     bool is_valid() const { return left < right || left == right; }
     std::string to_string() const {

--- a/be/src/storage/persistent_index_compaction_manager.h
+++ b/be/src/storage/persistent_index_compaction_manager.h
@@ -34,7 +34,7 @@ class ThreadPool;
 
 class PersistentIndexCompactionManager {
 public:
-    PersistentIndexCompactionManager() {}
+    PersistentIndexCompactionManager() = default;
     virtual ~PersistentIndexCompactionManager();
     Status init();
     virtual void schedule(const std::function<std::vector<TabletAndScore>()>& pick_algo);

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -21,7 +21,7 @@ namespace starrocks {
 
 class ReplicationTxnManager {
 public:
-    explicit ReplicationTxnManager() {}
+    explicit ReplicationTxnManager() = default;
 
     Status init(const std::vector<starrocks::DataDir*>& data_dirs);
 

--- a/be/src/storage/row_store_encoder_simple.h
+++ b/be/src/storage/row_store_encoder_simple.h
@@ -24,7 +24,7 @@ namespace starrocks {
 
 class RowStoreEncoderSimple : public RowStoreEncoder {
 public:
-    ~RowStoreEncoderSimple() override {}
+    ~RowStoreEncoderSimple() override = default;
 
 public:
     Status encode_chunk_to_full_row_column(const Schema& schema, const Chunk& chunk,

--- a/be/src/storage/rows_mapper.h
+++ b/be/src/storage/rows_mapper.h
@@ -44,7 +44,7 @@ class TabletManager;
 class RowsMapperBuilder {
 public:
     RowsMapperBuilder(std::string filename) : _filename(std::move(filename)) {}
-    ~RowsMapperBuilder() {}
+    ~RowsMapperBuilder() = default;
     // append rssid rowids to file
     Status append(const std::vector<uint64_t>& rssid_rowids);
     Status finalize();
@@ -68,7 +68,7 @@ private:
 // which is critical for large compactions (can save GBs of memory).
 class RowsMapperIterator {
 public:
-    RowsMapperIterator() {}
+    RowsMapperIterator() = default;
     ~RowsMapperIterator();
     // Open file and prepare internal state.
     // IMPORTANT: Now accepts FileInfo instead of string to support both local and remote storage.

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -30,7 +30,7 @@ class MetadataCache {
 public:
     explicit MetadataCache(size_t capacity);
 
-    ~MetadataCache() {}
+    ~MetadataCache() = default;
 
     DISALLOW_COPY_AND_MOVE(MetadataCache);
 

--- a/be/src/storage/sstable/filter_policy.h
+++ b/be/src/storage/sstable/filter_policy.h
@@ -13,7 +13,7 @@ namespace sstable {
 
 class FilterPolicy {
 public:
-    virtual ~FilterPolicy() {}
+    virtual ~FilterPolicy() = default;
 
     // Return the name of this policy.  Note that if the filter encoding
     // changes in an incompatible way, the name returned by this method

--- a/be/src/types/datetime_value.h
+++ b/be/src/types/datetime_value.h
@@ -517,7 +517,7 @@ protected:
 };
 class TeradataFormat {
 public:
-    TeradataFormat() {}
+    TeradataFormat() = default;
     ~TeradataFormat() = default;
 
     bool prepare(std::string_view format);

--- a/be/src/util/compression/compression_context.h
+++ b/be/src/util/compression/compression_context.h
@@ -20,7 +20,7 @@
 namespace starrocks::compression {
 
 struct ZSTDCompressionContext {
-    ZSTDCompressionContext() {}
+    ZSTDCompressionContext() = default;
 
     // ZSTD compression context
     ZSTD_CCtx* ctx{nullptr};
@@ -36,7 +36,7 @@ struct ZSTDCompressionContext {
 };
 
 struct ZSTDDecompressContext {
-    ZSTDDecompressContext() {}
+    ZSTDDecompressContext() = default;
 
     // ZSTD decompression context
     ZSTD_DCtx* ctx{nullptr};
@@ -45,7 +45,7 @@ struct ZSTDDecompressContext {
 };
 
 struct LZ4FCompressContext {
-    LZ4FCompressContext() {}
+    LZ4FCompressContext() = default;
 
     // LZ4F compression context
     LZ4F_compressionContext_t ctx{nullptr};
@@ -61,7 +61,7 @@ struct LZ4FCompressContext {
 };
 
 struct LZ4FDecompressContext {
-    LZ4FDecompressContext() {}
+    LZ4FDecompressContext() = default;
 
     // LZ4F decompression context
     LZ4F_decompressionContext_t ctx{nullptr};
@@ -71,7 +71,7 @@ struct LZ4FDecompressContext {
 };
 
 struct LZ4CompressContext {
-    LZ4CompressContext() {}
+    LZ4CompressContext() = default;
 
     // LZ4 compression context
     LZ4_stream_t* ctx{nullptr};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
