### PR TITLE
[Refactor] fix clang-tidy modernize-use-equals-delete warnings

### DIFF
--- a/be/src/base/concurrency/core_local.h
+++ b/be/src/base/concurrency/core_local.h
@@ -56,12 +56,10 @@ class CoreDataAllocatorFactory {
 public:
     CoreDataAllocatorFactory() = default;
     ~CoreDataAllocatorFactory();
-    CoreDataAllocator* get_allocator(size_t cpu_id, size_t data_bytes);
-    static CoreDataAllocatorFactory* instance();
-
-private:
     CoreDataAllocatorFactory(const CoreDataAllocatorFactory&) = delete;
     const CoreDataAllocatorFactory& operator=(const CoreDataAllocatorFactory&) = delete;
+    CoreDataAllocator* get_allocator(size_t cpu_id, size_t data_bytes);
+    static CoreDataAllocatorFactory* instance();
 
 private:
     std::mutex _lock;
@@ -84,6 +82,8 @@ public:
     }
 
     ~CoreLocalValueController() = default;
+    CoreLocalValueController(const CoreLocalValueController&) = delete;
+    const CoreLocalValueController& operator=(const CoreLocalValueController&) = delete;
 
     int get_id() {
         std::lock_guard<std::mutex> l(_lock);
@@ -107,10 +107,6 @@ public:
         static CoreLocalValueController<T> _s_instance;
         return &_s_instance;
     }
-
-private:
-    CoreLocalValueController(const CoreLocalValueController&) = delete;
-    const CoreLocalValueController& operator=(const CoreLocalValueController&) = delete;
 
 private:
     std::mutex _lock;

--- a/be/src/base/concurrency/countdown_latch.h
+++ b/be/src/base/concurrency/countdown_latch.h
@@ -52,6 +52,8 @@ class GenericCountDownLatch {
 public:
     // Initialize the latch with the given initial count.
     explicit GenericCountDownLatch(int count) : count_(count) {}
+    GenericCountDownLatch(const GenericCountDownLatch&) = delete;
+    const GenericCountDownLatch& operator=(const GenericCountDownLatch&) = delete;
 
     // REQUIRES: amount >= 0.
     // Decrement the count of this latch by 'amount'.
@@ -122,8 +124,6 @@ private:
     mutable Cond cond_;
 
     int64_t count_;
-    GenericCountDownLatch(const GenericCountDownLatch&) = delete;
-    const GenericCountDownLatch& operator=(const GenericCountDownLatch&) = delete;
 };
 
 using CountDownLatch = GenericCountDownLatch<std::mutex, std::condition_variable>;
@@ -134,11 +134,10 @@ class CountDownOnScopeExit {
 public:
     explicit CountDownOnScopeExit(T* latch) : latch_(latch) {}
     ~CountDownOnScopeExit() { latch_->count_down(); }
-
-private:
     CountDownOnScopeExit(const CountDownOnScopeExit&) = delete;
     const CountDownOnScopeExit& operator=(const CountDownOnScopeExit&) = delete;
 
+private:
     T* latch_;
 };
 

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -115,6 +115,8 @@ enum class CachePriority { NORMAL = 0, DURABLE = 1 };
 class Cache {
 public:
     Cache() = default;
+    Cache(const Cache&) = delete;
+    const Cache& operator=(const Cache&) = delete;
 
     // Destroys all existing entries by calling the "deleter"
     // function that was passed to the constructor.
@@ -189,10 +191,6 @@ public:
 
     //  Decrease or increase cache capacity.
     virtual bool adjust_capacity(int64_t delta, size_t min_capacity = 0) = 0;
-
-private:
-    Cache(const Cache&) = delete;
-    const Cache& operator=(const Cache&) = delete;
 };
 
 // An entry is a variable length heap-allocated structure.  Entries

--- a/be/src/base/debug/leakcheck_disabler.h
+++ b/be/src/base/debug/leakcheck_disabler.h
@@ -26,14 +26,13 @@ namespace starrocks::debug {
 class ScopedLeakCheckDisabler {
 public:
     ScopedLeakCheckDisabler() = default;
+    ScopedLeakCheckDisabler(const ScopedLeakCheckDisabler&) = delete;
+    const ScopedLeakCheckDisabler& operator=(const ScopedLeakCheckDisabler&) = delete;
 
 private:
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER)
     ScopedLSANDisabler lsan_disabler;
 #endif
-
-    ScopedLeakCheckDisabler(const ScopedLeakCheckDisabler&) = delete;
-    const ScopedLeakCheckDisabler& operator=(const ScopedLeakCheckDisabler&) = delete;
 };
 
 } // namespace starrocks::debug

--- a/be/src/base/debug/trace.h
+++ b/be/src/base/debug/trace.h
@@ -127,6 +127,8 @@ struct TraceEntry;
 class Trace : public RefCountedThreadSafe<Trace> {
 public:
     Trace() = default;
+    Trace(const Trace&) = delete;
+    const Trace& operator=(const Trace&) = delete;
 
     // Logs a message into the trace buffer.
     //
@@ -223,9 +225,6 @@ private:
     TraceMetrics metrics_;
 
     uint32_t trace_level_ = 0;
-
-    Trace(const Trace&) = delete;
-    const Trace& operator=(const Trace&) = delete;
 };
 
 // Adopt a Trace object into the current thread for the duration
@@ -249,13 +248,12 @@ public:
         Trace::threadlocal_trace_ = old_trace_;
         DFAKE_SCOPED_LOCK_THREAD_LOCKED(ctor_dtor_);
     }
+    ScopedAdoptTrace(const ScopedAdoptTrace&) = delete;
+    const ScopedAdoptTrace& operator=(const ScopedAdoptTrace&) = delete;
 
 private:
     DFAKE_MUTEX(ctor_dtor_);
     Trace* old_trace_;
-
-    ScopedAdoptTrace(const ScopedAdoptTrace&) = delete;
-    const ScopedAdoptTrace& operator=(const ScopedAdoptTrace&) = delete;
 };
 
 // Implementation for TRACE_COUNTER_SCOPE_LATENCY_US(...) macro above.
@@ -264,12 +262,12 @@ public:
     explicit ScopedTraceLatencyCounter(const char* counter) : counter_(counter), start_time_(GetCurrentTimeMicros()) {}
 
     ~ScopedTraceLatencyCounter() { TRACE_COUNTER_INCREMENT(counter_, GetCurrentTimeMicros() - start_time_); }
+    ScopedTraceLatencyCounter(const ScopedTraceLatencyCounter&) = delete;
+    const ScopedTraceLatencyCounter& operator=(const ScopedTraceLatencyCounter&) = delete;
 
 private:
     const char* const counter_;
     MicrosecondsInt64 start_time_;
-    ScopedTraceLatencyCounter(const ScopedTraceLatencyCounter&) = delete;
-    const ScopedTraceLatencyCounter& operator=(const ScopedTraceLatencyCounter&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/base/debug/trace_metrics.h
+++ b/be/src/base/debug/trace_metrics.h
@@ -56,6 +56,8 @@ class TraceMetrics {
 public:
     TraceMetrics() = default;
     ~TraceMetrics() = default;
+    TraceMetrics(const TraceMetrics&) = delete;
+    const TraceMetrics& operator=(const TraceMetrics&) = delete;
 
     // Internalize the given string by duplicating it into a process-wide
     // pool. If this string has already been interned, returns a pointer
@@ -84,9 +86,6 @@ public:
 private:
     mutable SpinLock lock_;
     std::map<const char*, int64_t> counters_;
-
-    TraceMetrics(const TraceMetrics&) = delete;
-    const TraceMetrics& operator=(const TraceMetrics&) = delete;
 };
 
 inline void TraceMetrics::Increment(const char* name, int64_t amount) {

--- a/be/src/base/utility/factory_method.h
+++ b/be/src/base/utility/factory_method.h
@@ -20,6 +20,9 @@ namespace starrocks {
 template <typename Base, typename Derived>
 class FactoryMethod : public Base {
 public:
+    using Self = FactoryMethod<Base, Derived>;
+    Self& operator=(const Self&) = delete;
+
     template <typename... Args>
     FactoryMethod(Args&&... args) : Base(std::forward<Args>(args)...) {}
 
@@ -28,9 +31,5 @@ public:
     static DerivedPtr create(Args&&... args) {
         return std::make_shared<Derived>(std::forward<Args>(args)...);
     }
-
-private:
-    using Self = FactoryMethod<Base, Derived>;
-    Self& operator=(const Self&) = delete;
 };
 } // namespace starrocks

--- a/be/src/common/system/backend_options.h
+++ b/be/src/common/system/backend_options.h
@@ -30,6 +30,9 @@ class CIDR;
 
 class BackendOptions {
 public:
+    BackendOptions(const BackendOptions&) = delete;
+    const BackendOptions& operator=(const BackendOptions&) = delete;
+
     static bool init(bool is_cn);
     static std::string get_localhost();
     static std::string get_local_ip();
@@ -53,9 +56,6 @@ private:
     static TBackend _backend;
     static bool _bind_ipv6;
     static bool _is_cn;
-
-    BackendOptions(const BackendOptions&) = delete;
-    const BackendOptions& operator=(const BackendOptions&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/common/thread/thread.h
+++ b/be/src/common/thread/thread.h
@@ -273,6 +273,8 @@ private:
 class ThreadJoiner {
 public:
     explicit ThreadJoiner(Thread* thread);
+    ThreadJoiner(const ThreadJoiner&) = delete;
+    const ThreadJoiner& operator=(const ThreadJoiner&) = delete;
 
     // Start emitting warnings after this many milliseconds.
     //
@@ -308,9 +310,6 @@ private:
     int _warn_after_ms;
     int _warn_every_ms;
     int _give_up_after_ms;
-
-    ThreadJoiner(const ThreadJoiner&) = delete;
-    const ThreadJoiner& operator=(const ThreadJoiner&) = delete;
 };
 
 } //namespace starrocks

--- a/be/src/common/thread/threadpool.h
+++ b/be/src/common/thread/threadpool.h
@@ -144,6 +144,8 @@ protected:
 class ThreadPoolBuilder {
 public:
     explicit ThreadPoolBuilder(std::string name);
+    ThreadPoolBuilder(const ThreadPoolBuilder&) = delete;
+    const ThreadPoolBuilder& operator=(const ThreadPoolBuilder&) = delete;
 
     // Note: We violate the style guide by returning mutable references here
     // in order to provide traditional Builder pattern conveniences.
@@ -166,9 +168,6 @@ private:
     MonoDelta _idle_timeout;
     CpuUtil::CpuIds _cpuids;
     std::vector<CpuUtil::CpuIds> _borrowed_cpuids;
-
-    ThreadPoolBuilder(const ThreadPoolBuilder&) = delete;
-    const ThreadPoolBuilder& operator=(const ThreadPoolBuilder&) = delete;
 };
 
 // Thread pool with a variable number of threads.
@@ -208,6 +207,9 @@ private:
 //    thread_pool->SubmitFunc(std::bind(&Func, 10));
 class ThreadPool {
 public:
+    ThreadPool(const ThreadPool&) = delete;
+    const ThreadPool& operator=(const ThreadPool&) = delete;
+
     enum Priority {
         LOW_PRIORITY = 0,
         HIGH_PRIORITY,
@@ -435,9 +437,6 @@ private:
 
     // Total time in nanoseconds to execute tasks.
     CoreLocalCounter<int64_t> _total_execute_time_ns{MetricUnit::NOUNIT};
-
-    ThreadPool(const ThreadPool&) = delete;
-    const ThreadPool& operator=(const ThreadPool&) = delete;
 };
 
 // Entry point for token-based task submission and blocking for a particular
@@ -447,6 +446,9 @@ private:
 // ThreadPool's lock.
 class ThreadPoolToken {
 public:
+    ThreadPoolToken(const ThreadPoolToken&) = delete;
+    const ThreadPoolToken& operator=(const ThreadPoolToken&) = delete;
+
     // Destroys the token.
     //
     // May be called on a token with outstanding tasks, as Shutdown() will be
@@ -545,9 +547,6 @@ private:
     // Number of worker threads currently executing tasks belonging to this
     // token.
     int _active_threads;
-
-    ThreadPoolToken(const ThreadPoolToken&) = delete;
-    const ThreadPoolToken& operator=(const ThreadPoolToken&) = delete;
 };
 
 // A class use to limit the number of tasks submitted to the thread pool.

--- a/be/src/fs/hdfs/hdfs_fs_cache.h
+++ b/be/src/fs/hdfs/hdfs_fs_cache.h
@@ -45,6 +45,8 @@ public:
 class HdfsFsCache {
 public:
     ~HdfsFsCache() = default;
+    HdfsFsCache(const HdfsFsCache&) = delete;
+    const HdfsFsCache& operator=(const HdfsFsCache&) = delete;
     static HdfsFsCache* instance() {
         static HdfsFsCache s_instance;
         return &s_instance;
@@ -61,8 +63,6 @@ private:
     Random _rand{(uint32_t)time(nullptr)};
 
     HdfsFsCache() = default;
-    HdfsFsCache(const HdfsFsCache&) = delete;
-    const HdfsFsCache& operator=(const HdfsFsCache&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -93,6 +93,7 @@ class RuntimeState {
 public:
     // for ut only
     RuntimeState();
+    RuntimeState(const RuntimeState&) = delete;
     // for ut only
     RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                  const TQueryGlobals& query_globals, ExecEnv* exec_env);
@@ -658,9 +659,6 @@ private:
 
     std::mutex _sink_commit_infos_lock;
     std::vector<TSinkCommitInfo> _sink_commit_infos;
-
-    // prohibit copies
-    RuntimeState(const RuntimeState&) = delete;
 
     RuntimeFilterPort* _runtime_filter_port = nullptr;
 

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -36,6 +36,10 @@ class StorageEngine;
 class CompactionManager {
 public:
     CompactionManager();
+    CompactionManager(const CompactionManager& compaction_manager) = delete;
+    CompactionManager(CompactionManager&& compaction_manager) = delete;
+    CompactionManager& operator=(const CompactionManager& compaction_manager) = delete;
+    CompactionManager& operator=(CompactionManager&& compaction_manager) = delete;
 
     ~CompactionManager() = default;
 
@@ -131,11 +135,6 @@ public:
     void disable_table_compaction(int64_t table_id, int64_t deadline);
 
 private:
-    CompactionManager(const CompactionManager& compaction_manager) = delete;
-    CompactionManager(CompactionManager&& compaction_manager) = delete;
-    CompactionManager& operator=(const CompactionManager& compaction_manager) = delete;
-    CompactionManager& operator=(CompactionManager&& compaction_manager) = delete;
-
     void _dispatch_worker();
     bool _check_precondition(const CompactionCandidate& candidate);
     bool _check_compaction_disabled(const CompactionCandidate& candidate);

--- a/be/src/storage/rowset/bitmap_index_writer.h
+++ b/be/src/storage/rowset/bitmap_index_writer.h
@@ -54,6 +54,8 @@ public:
 
     BitmapIndexWriter() = default;
     virtual ~BitmapIndexWriter() = default;
+    BitmapIndexWriter(const BitmapIndexWriter&) = delete;
+    const BitmapIndexWriter& operator=(const BitmapIndexWriter&) = delete;
 
     virtual void add_value_with_current_rowid(const void* vptr) = 0;
 
@@ -72,10 +74,6 @@ public:
 
 protected:
     CompressionTypePB _dictionary_compression = LZ4;
-
-private:
-    BitmapIndexWriter(const BitmapIndexWriter&) = delete;
-    const BitmapIndexWriter& operator=(const BitmapIndexWriter&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/bloom_filter_index_writer.h
+++ b/be/src/storage/rowset/bloom_filter_index_writer.h
@@ -56,6 +56,8 @@ public:
 
     BloomFilterIndexWriter() = default;
     virtual ~BloomFilterIndexWriter() = default;
+    BloomFilterIndexWriter(const BloomFilterIndexWriter&) = delete;
+    const BloomFilterIndexWriter& operator=(const BloomFilterIndexWriter&) = delete;
 
     virtual void add_values(const void* values, size_t count) = 0;
 
@@ -66,10 +68,6 @@ public:
     virtual Status finish(WritableFile* wfile, ColumnIndexMetaPB* index_meta) = 0;
 
     virtual uint64_t size() = 0;
-
-private:
-    BloomFilterIndexWriter(const BloomFilterIndexWriter&) = delete;
-    const BloomFilterIndexWriter& operator=(const BloomFilterIndexWriter&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/indexed_column_writer.h
+++ b/be/src/storage/rowset/indexed_column_writer.h
@@ -86,6 +86,8 @@ struct IndexedColumnWriterOptions {
 class IndexedColumnWriter {
 public:
     explicit IndexedColumnWriter(const IndexedColumnWriterOptions& options, TypeInfoPtr typeinfo, WritableFile* wfile);
+    IndexedColumnWriter(const IndexedColumnWriter&) = delete;
+    const IndexedColumnWriter& operator=(const IndexedColumnWriter&) = delete;
 
     ~IndexedColumnWriter();
 
@@ -124,9 +126,6 @@ private:
     // encoder for value index's key
     const KeyCoder* _validx_key_coder;
     const BlockCompressionCodec* _compress_codec;
-
-    IndexedColumnWriter(const IndexedColumnWriter&) = delete;
-    const IndexedColumnWriter& operator=(const IndexedColumnWriter&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/page_builder.h
+++ b/be/src/storage/rowset/page_builder.h
@@ -55,6 +55,8 @@ namespace starrocks {
 class PageBuilder {
 public:
     PageBuilder() = default;
+    PageBuilder(const PageBuilder&) = delete;
+    const PageBuilder& operator=(const PageBuilder&) = delete;
 
     virtual ~PageBuilder() = default;
 
@@ -112,10 +114,6 @@ public:
     // only `BinaryDictPageBuilder` needed to overload this method.
     // this information is used for doing low-cardinality string column read optimization.
     virtual bool all_dict_encoded() const { return false; }
-
-private:
-    PageBuilder(const PageBuilder&) = delete;
-    const PageBuilder& operator=(const PageBuilder&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/unique_rowset_id_generator.h
+++ b/be/src/storage/rowset/unique_rowset_id_generator.h
@@ -46,6 +46,8 @@ class UniqueRowsetIdGenerator : public RowsetIdGenerator {
 public:
     UniqueRowsetIdGenerator(const UniqueId& backend_uid);
     ~UniqueRowsetIdGenerator() override = default;
+    UniqueRowsetIdGenerator(const UniqueRowsetIdGenerator&) = delete;
+    const UniqueRowsetIdGenerator& operator=(const UniqueRowsetIdGenerator&) = delete;
 
     RowsetId next_id() override;
 
@@ -59,9 +61,6 @@ private:
     const int64_t _version = 2; // modify it when create new version id generator
     std::atomic<int64_t> _inc_id;
     std::unordered_set<int64_t> _valid_rowset_id_hi;
-
-    UniqueRowsetIdGenerator(const UniqueRowsetIdGenerator&) = delete;
-    const UniqueRowsetIdGenerator& operator=(const UniqueRowsetIdGenerator&) = delete;
 }; // UniqueRowsetIdGenerator
 
 } // namespace starrocks

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -100,6 +100,8 @@ class RowsetUpdateState {
 public:
     RowsetUpdateState();
     ~RowsetUpdateState();
+    RowsetUpdateState(const RowsetUpdateState&) = delete;
+    const RowsetUpdateState& operator=(const RowsetUpdateState&) = delete;
 
     Status load(Tablet* tablet, Rowset* rowset);
 
@@ -189,9 +191,6 @@ private:
 
     std::vector<AutoIncrementPartialUpdateState> _auto_increment_partial_update_states;
     std::map<string, string> _column_to_expr_value;
-
-    RowsetUpdateState(const RowsetUpdateState&) = delete;
-    const RowsetUpdateState& operator=(const RowsetUpdateState&) = delete;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -97,6 +97,9 @@ enum TabletDropFlag {
 // please uniformly name the method in "xxx_unlocked()" mode
 class TabletManager {
 public:
+    TabletManager(const TabletManager&) = delete;
+    const TabletManager& operator=(const TabletManager&) = delete;
+
     explicit TabletManager(int64_t tablet_map_lock_shard_size);
     ~TabletManager() = default;
 
@@ -234,9 +237,6 @@ private:
         SpinLock _latches[kNumShard];
         std::unordered_set<int64_t> _locks[kNumShard];
     };
-
-    TabletManager(const TabletManager&) = delete;
-    const TabletManager& operator=(const TabletManager&) = delete;
 
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -91,6 +91,9 @@ struct TabletTxnInfo {
 // txn manager is used to manage mapping between tablet and txns
 class TxnManager {
 public:
+    TxnManager(const TxnManager&) = delete;
+    const TxnManager& operator=(const TxnManager&) = delete;
+
     TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, uint32_t store_num);
 
     ~TxnManager() = default;
@@ -213,9 +216,6 @@ private:
 
     // Dynamic thread pool used to concurrently flush WAL to disk
     std::unique_ptr<ThreadPool> _flush_thread_pool;
-
-    TxnManager(const TxnManager&) = delete;
-    const TxnManager& operator=(const TxnManager&) = delete;
 }; // TxnManager
 
 inline std::shared_mutex& TxnManager::_get_txn_map_lock(TTransactionId transactionId) {

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -68,6 +68,9 @@ private:
 // async apply thread pool.
 class UpdateManager {
 public:
+    UpdateManager(const UpdateManager&) = delete;
+    const UpdateManager& operator=(const UpdateManager&) = delete;
+
     UpdateManager(MemTracker* mem_tracker);
     ~UpdateManager();
 
@@ -191,9 +194,6 @@ private:
     std::unique_ptr<PersistentIndexLoadExecutor> _pindex_load_executor;
 
     bool _keep_pindex_bf = true;
-
-    UpdateManager(const UpdateManager&) = delete;
-    const UpdateManager& operator=(const UpdateManager&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -95,6 +95,9 @@ private:
 
 class HttpBrpcStubCache {
 public:
+    HttpBrpcStubCache(const HttpBrpcStubCache&) = delete;
+    HttpBrpcStubCache& operator=(const HttpBrpcStubCache&) = delete;
+
     static HttpBrpcStubCache* getInstance();
     StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr);
     void cleanup_expired(const butil::EndPoint& endpoint);
@@ -102,8 +105,6 @@ public:
 
 private:
     HttpBrpcStubCache();
-    HttpBrpcStubCache(const HttpBrpcStubCache&) = delete;
-    HttpBrpcStubCache& operator=(const HttpBrpcStubCache&) = delete;
     ~HttpBrpcStubCache();
 
     SpinLock _lock;
@@ -116,6 +117,9 @@ private:
 #ifndef __APPLE__
 class LakeServiceBrpcStubCache {
 public:
+    LakeServiceBrpcStubCache(const LakeServiceBrpcStubCache&) = delete;
+    LakeServiceBrpcStubCache& operator=(const LakeServiceBrpcStubCache&) = delete;
+
     static LakeServiceBrpcStubCache* getInstance();
     StatusOr<std::shared_ptr<starrocks::LakeService_RecoverableStub>> get_stub(const std::string& host, int port);
     void cleanup_expired(const butil::EndPoint& endpoint);
@@ -123,8 +127,6 @@ public:
 
 private:
     LakeServiceBrpcStubCache();
-    LakeServiceBrpcStubCache(const LakeServiceBrpcStubCache&) = delete;
-    LakeServiceBrpcStubCache& operator=(const LakeServiceBrpcStubCache&) = delete;
     ~LakeServiceBrpcStubCache();
 
     SpinLock _lock;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
