### PR TITLE
[BugFix] fix shared-data colocate group breakage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -210,7 +210,6 @@ public class ColocateTableIndex implements Writable {
                 "colocate not supported");
         writeLock();
         try {
-            boolean groupAlreadyExist = true;
             GroupId groupId;
             String fullGroupName = dbId + "_" + groupName;
 
@@ -223,7 +222,6 @@ public class ColocateTableIndex implements Writable {
                 } else {
                     // generate a new one
                     groupId = new GroupId(dbId, GlobalStateMgr.getCurrentState().getNextId());
-                    groupAlreadyExist = false;
                 }
                 HashDistributionInfo distributionInfo = (HashDistributionInfo) tbl.getDefaultDistributionInfo();
                 if (!(tbl instanceof ExternalOlapTable)) {
@@ -244,6 +242,8 @@ public class ColocateTableIndex implements Writable {
             if (tbl.isCloudNativeTableOrMaterializedView()) {
                 if (!isReplay) { // leader create or update meta group
                     List<Long> shardGroupIds = tbl.getShardGroupIds();
+                    // check the group existence in lakeGroups
+                    boolean groupAlreadyExist = lakeGroups.stream().anyMatch(gid -> Objects.equals(gid.grpId, groupId.grpId));
                     if (!groupAlreadyExist) {
                         GlobalStateMgr.getCurrentState().getStarOSAgent().createMetaGroup(groupId.grpId, shardGroupIds);
                     } else {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -38,8 +38,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ColocateTableIndexTest {
     private static final Logger LOG = LogManager.getLogger(ColocateTableIndexTest.class);
@@ -311,6 +313,82 @@ public class ColocateTableIndexTest {
 
         colocateTableIndex.removeTable(tableId, null, false /* isReplay */);
         Assertions.assertFalse(colocateTableIndex.isLakeColocateTable(tableId));
+    }
+
+    // Regression test: when addTableToGroup is called with a non-null assignedGroupId
+    // for a brand new group (not in groupName2Id), it should call createMetaGroup,
+    // not updateMetaGroup. The bug was introduced by the refactoring that splits
+    // modifyTableColocate into prepare + apply: prepareModifyTableColocate always
+    // generates assignedGroupId via getNextId(), but addTableToGroup misinterprets
+    // non-null assignedGroupId as "the group already exists" and calls updateMetaGroup
+    // (join) instead of createMetaGroup (create), causing StarOS NOT_EXIST error.
+    @Test
+    public void testLakeTableNewGroupShouldCallCreateMetaGroup(
+            @Mocked LakeTable olapTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        AtomicBoolean createMetaGroupCalled = new AtomicBoolean(false);
+        AtomicBoolean updateMetaGroupCalled = new AtomicBoolean(false);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createMetaGroup(long metaGroupId, List<Long> shardGroupIds) {
+                createMetaGroupCalled.set(true);
+            }
+
+            @Mock
+            public void updateMetaGroup(long metaGroupId, List<Long> shardGroupIds, boolean isJoin) {
+                updateMetaGroupCalled.set(true);
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        long dbId = 100;
+        long tableId = 200;
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return tableId;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new HashDistributionInfo();
+            }
+        };
+
+        new MockUp<LakeTable>() {
+            @Mock
+            public List<Long> getShardGroupIds() {
+                return Arrays.asList(5001L, 5002L, 5003L);
+            }
+        };
+
+        // Simulate the modifyTableColocate (ALTER TABLE SET colocate_with) path on sr11073:
+        // prepareModifyTableColocate generates a new assignedGroupId via getNextId(),
+        // then passes it to addTableToGroup. The group "newGroup" does NOT exist yet.
+        ColocateTableIndex.GroupId assignedGroupId = new ColocateTableIndex.GroupId(dbId, 99999);
+        colocateTableIndex.addTableToGroup(
+                dbId, (OlapTable) olapTable, "newGroup", assignedGroupId, false /* isReplay */);
+
+        // For a brand new group, createMetaGroup should be called, NOT updateMetaGroup
+        Assertions.assertTrue(createMetaGroupCalled.get(),
+                "createMetaGroup should be called for a brand new colocate group");
+        Assertions.assertFalse(updateMetaGroupCalled.get(),
+                "updateMetaGroup should NOT be called for a brand new colocate group, " +
+                "but it was called due to groupAlreadyExist being incorrectly true " +
+                "when assignedGroupId is non-null");
     }
 
     @Test

--- a/test/sql/test_colocate/R/test_lake_alter_colocate
+++ b/test/sql/test_colocate/R/test_lake_alter_colocate
@@ -1,0 +1,40 @@
+-- name: test_lake_alter_colocate @cloud
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    c0 int,
+    c1 varchar(20)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+ALTER TABLE t1 SET ("colocate_with" = "${uuid0}_group1");
+-- result:
+-- !result
+SHOW CREATE TABLE t1;
+-- result:
+[REGEX].*colocate_with. = .[0-9a-f]+_group1.*
+-- !result
+CREATE TABLE t2 (
+    c0 int,
+    c1 varchar(20)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+ALTER TABLE t2 SET ("colocate_with" = "${uuid0}_group1");
+-- result:
+-- !result
+SHOW CREATE TABLE t2;
+-- result:
+[REGEX].*colocate_with. = .[0-9a-f]+_group1.*
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_colocate/T/test_lake_alter_colocate
+++ b/test/sql/test_colocate/T/test_lake_alter_colocate
@@ -1,0 +1,34 @@
+-- name: test_lake_alter_colocate @cloud
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create a lake table WITHOUT colocate_with property
+CREATE TABLE t1 (
+    c0 int,
+    c1 varchar(20)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+-- ALTER TABLE to set colocate_with to a NEW group (this triggers the bug)
+ALTER TABLE t1 SET ("colocate_with" = "${uuid0}_group1");
+
+-- Verify colocate group was set
+SHOW CREATE TABLE t1;
+
+-- Create a second table and join the same colocate group
+CREATE TABLE t2 (
+    c0 int,
+    c1 varchar(20)
+) DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+ALTER TABLE t2 SET ("colocate_with" = "${uuid0}_group1");
+
+-- Verify both tables are in the same colocate group
+SHOW CREATE TABLE t2;
+
+-- Clean up
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

Introduced in #68932

## What I'm doing:

Fix incorrect groupAlreadyExist logic in addTableToGroup that caused ALTER TABLE SET colocate_with to fail on shared-data (lake) tables.

After the refactoring that split modifyTableColocate into prepare + apply, prepareModifyTableColocate always generates an assignedGroupId via getNextId(). The old code derived groupAlreadyExist from whether the group name was already in groupName2Id, but this was evaluated before the group was actually looked up, causing it to always be true when assignedGroupId was non-null. This led to updateMetaGroup (join) being called instead of createMetaGroup (create) for brand new groups, resulting in a StarOS NOT_EXIST error.

Fix by checking group existence directly against lakeGroups at the point of use, which is the actual source of truth for whether a meta group has been created in StarOS.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
