### PR TITLE
[Enhancement] Improve sql_mode to handle Division by zero and Fail to parse date for str_to_date/str2date

### DIFF
--- a/be/src/exprs/arithmetic_expr.cpp
+++ b/be/src/exprs/arithmetic_expr.cpp
@@ -16,6 +16,9 @@
 
 #include <optional>
 
+#include "column/column_helper.h"
+#include "column/const_column.h"
+#include "column/nullable_column.h"
 #include "column/type_traits.h"
 #include "common/object_pool.h"
 #include "common/status.h"
@@ -26,7 +29,9 @@
 #include "exprs/decimal_cast_expr.h"
 #include "exprs/overflow.h"
 #include "exprs/unary_function.h"
+#include "gutil/casts.h"
 #include "runtime/runtime_state.h"
+#include "types/decimalv2_value.h"
 #include "types/logical_type.h"
 
 #ifdef STARROCKS_JIT_ENABLE
@@ -44,6 +49,39 @@ namespace starrocks {
     virtual ~CLASS_NAME() {}                          \
                                                       \
     virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new CLASS_NAME(*this)); }
+
+// Check if there exists a row where divisor is zero and dividend is not null.
+// When error_for_division_by_zero is set, we report error only for such rows (consistent with FE: NULL/0 -> NULL).
+template <LogicalType Type>
+bool divisor_contains_zero(const ColumnPtr& dividend, const ColumnPtr& divisor) {
+    if (dividend->only_null() || divisor->only_null() || divisor->empty()) {
+        return false;
+    }
+
+    const Column* divisor_data_col = ColumnHelper::get_data_column(divisor.get());
+    const auto* divisor_data = ColumnHelper::template cast_to_raw<Type>(divisor_data_col);
+    const auto* divisor_values = divisor_data->get_data().data();
+
+    const auto num_rows = divisor->size();
+
+    constexpr auto zero = RunTimeCppType<Type>{};
+    for (size_t i = 0; i < num_rows; i++) {
+        // Skip rows where divisor is NULL.
+        if (divisor->is_null(i)) {
+            continue;
+        }
+        // Skip rows where dividend is NULL (NULL / 0 -> NULL, no error).
+        if (dividend->is_null(i)) {
+            continue;
+        }
+        // For const columns, logical row i maps to physical row 0.
+        const size_t data_row = divisor->is_constant() ? 0 : i;
+        if (divisor_values[data_row] == zero) {
+            return true;
+        }
+    }
+    return false;
+}
 
 [[maybe_unused]] static std::optional<LogicalType> eliminate_trivial_cast_for_decimal_mul(const Expr* e) {
     DIAGNOSTIC_PUSH
@@ -218,6 +256,11 @@ public:
 #ifdef STARROCKS_JIT_ENABLE
 
     bool is_compilable(RuntimeState* state) const override {
+        // When error_for_division_by_zero is set, we must use the non-JIT path which checks divisor for zero.
+        // JIT-generated code does not include this check.
+        if (state->error_for_division_by_zero()) {
+            return false;
+        }
         return state->can_jit_expr(CompilableExprType::DIV) && Type != TYPE_LARGEINT && IRHelper::support_jit(Type);
     }
 
@@ -273,6 +316,9 @@ private:
     StatusOr<ColumnPtr> evaluate_internal(ExprContext* context, Chunk* ptr) {
         ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
         ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
+        if (context != nullptr && context->error_for_division_by_zero() && divisor_contains_zero<LType>(l, r)) {
+            return Status::InvalidArgument("Division by zero");
+        }
         if constexpr (lt_is_decimal<LType>) {
             if (context != nullptr && context->error_if_overflow()) {
                 using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<LType, DivOp, OverflowMode::REPORT_ERROR>;
@@ -303,7 +349,9 @@ public:
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
         ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
         ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
-
+        if (context != nullptr && context->error_for_division_by_zero() && divisor_contains_zero<Type>(l, r)) {
+            return Status::InvalidArgument("Division by zero");
+        }
         if constexpr (lt_is_decimal<Type>) {
             if (context != nullptr && context->error_if_overflow()) {
                 using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, OverflowMode::REPORT_ERROR>;
@@ -322,6 +370,11 @@ public:
 #ifdef STARROCKS_JIT_ENABLE
 
     bool is_compilable(RuntimeState* state) const override {
+        // When error_for_division_by_zero is set, we must use the non-JIT path which checks divisor for zero.
+        // JIT-generated code does not include this check.
+        if (state->error_for_division_by_zero()) {
+            return false;
+        }
         return state->can_jit_expr(CompilableExprType::MOD) && Type != TYPE_LARGEINT && IRHelper::support_jit(Type);
     }
 

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -217,4 +217,7 @@ bool ExprContext::error_if_overflow() const {
     return _runtime_state != nullptr && _runtime_state->error_if_overflow();
 }
 
+bool ExprContext::error_for_division_by_zero() const {
+    return _runtime_state != nullptr && _runtime_state->error_for_division_by_zero();
+}
 } // namespace starrocks

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -122,7 +122,7 @@ public:
     bool is_index_only_filter() const;
 
     bool error_if_overflow() const;
-
+    bool error_for_division_by_zero() const;
     void set_build_from_only_in_filter(bool build_from_only_in_filter) {
         _build_from_only_in_filter = build_from_only_in_filter;
     }
@@ -130,7 +130,6 @@ public:
 
 private:
     friend class Expr;
-    friend class OlapScanNode;
     friend class OlapScanNode;
     friend class EsPredicate;
 

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -2359,7 +2359,7 @@ StatusOr<ColumnPtr> TimeFunctions::str_to_date_from_date_format(FunctionContext*
                 result.append(ts);
             } else {
                 const Slice& fmt = fmt_viewer.value(i);
-                str_to_date_internal(&ts, fmt, str, &result);
+                RETURN_IF_ERROR(str_to_date_internal(context, &ts, fmt, str, &result));
             }
         }
     }
@@ -2367,14 +2367,18 @@ StatusOr<ColumnPtr> TimeFunctions::str_to_date_from_date_format(FunctionContext*
 }
 
 // uncommon approach to process string content, based on uncommon string format.
-void TimeFunctions::str_to_date_internal(TimestampValue* ts, const Slice& fmt, const Slice& str,
-                                         ColumnBuilder<TYPE_DATETIME>* result) {
+Status TimeFunctions::str_to_date_internal(FunctionContext* context, TimestampValue* ts, const Slice& fmt,
+                                           const Slice& str, ColumnBuilder<TYPE_DATETIME>* result) {
     bool r = ts->from_uncommon_format_str(fmt.get_data(), fmt.get_size(), str.get_data(), str.get_size());
     if (r) {
         result->append(*ts);
-    } else {
-        result->append_null();
+        return Status::OK();
     }
+    if (context != nullptr && context->allow_throw_exception()) {
+        return Status::InvalidArgument("Fail to parse date");
+    }
+    result->append_null();
+    return Status::OK();
 }
 
 // Try to process string content, based on uncommon string format
@@ -2393,7 +2397,7 @@ StatusOr<ColumnPtr> TimeFunctions::str_to_date_uncommon(FunctionContext* context
             const Slice& str = str_viewer.value(i);
             const Slice& fmt = fmt_viewer.value(i);
             TimestampValue ts;
-            str_to_date_internal(&ts, fmt, str, &result);
+            RETURN_IF_ERROR(str_to_date_internal(context, &ts, fmt, str, &result));
         }
     }
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -885,8 +885,9 @@ private:
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_to_unix_from_datetime_with_format);
 
     // internal approach to process string content, based on any string format.
-    static void str_to_date_internal(TimestampValue* ts, const Slice& fmt, const Slice& str,
-                                     ColumnBuilder<TYPE_DATETIME>* result);
+    // When allow_throw_exception is set and parsing fails, returns Status::InvalidArgument("Fail to parse date").
+    static Status str_to_date_internal(FunctionContext* context, TimestampValue* ts, const Slice& fmt, const Slice& str,
+                                       ColumnBuilder<TYPE_DATETIME>* result);
 
     static std::string convert_format(const Slice& format);
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -390,6 +390,10 @@ public:
         return _query_options.__isset.overflow_mode && _query_options.overflow_mode == TOverflowMode::REPORT_ERROR;
     }
 
+    bool error_for_division_by_zero() const {
+        return _query_options.__isset.error_for_division_by_zero && _query_options.error_for_division_by_zero;
+    }
+
     bool enable_hyperscan_vec() const {
         return _query_options.__isset.enable_hyperscan_vec && _query_options.enable_hyperscan_vec;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -6059,6 +6059,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         if (SqlModeHelper.check(sqlMode, SqlModeHelper.MODE_ERROR_IF_OVERFLOW)) {
             tResult.setOverflow_mode(TOverflowMode.REPORT_ERROR);
         }
+        if (SqlModeHelper.check(sqlMode, SqlModeHelper.MODE_ERROR_FOR_DIVISION_BY_ZERO)) {
+            tResult.setError_for_division_by_zero(true);
+        }
 
         tResult.setEnable_spill(enableSpill);
         if (enableSpill) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -216,6 +216,9 @@ public enum ScalarOperatorEvaluator {
             if (invoker.isMetaFunction) {
                 throw new StarRocksPlannerException(ErrorType.USER_ERROR, ExceptionUtils.getRootCauseMessage(e));
             }
+            if ((e instanceof InvocationTargetException) && e.getCause() instanceof StarRocksPlannerException) {
+                throw (StarRocksPlannerException) e.getCause();
+            }
         }
         return root;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -44,8 +44,11 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.DecimalLiteral;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.DateType;
 import com.starrocks.type.DecimalType;
@@ -527,30 +530,52 @@ public class ScalarOperatorFunctions {
     public static ConstantOperator dateParse(ConstantOperator date, ConstantOperator fmtLiteral) {
         DateTimeFormatter builder = DateUtils.unixDatetimeFormatter(fmtLiteral.getVarchar(), false);
         String dateStr = StringUtils.strip(date.getVarchar(), "\r\n\t ");
-        if (HAS_TIME_PART.matcher(fmtLiteral.getVarchar()).matches()) {
-            LocalDateTime ldt;
-            try {
-                ldt = LocalDateTime.from(builder.withResolverStyle(ResolverStyle.STRICT).parse(dateStr));
-            } catch (DateTimeParseException e) {
-                // If parsing fails, it can be re-parsed from the position of the successful prefix string.
-                // This way datetime string can use incomplete format
-                // eg. str_to_date('2022-10-18 00:00:00','%Y-%m-%d %H:%s');
-                ldt = LocalDateTime.from(builder.withResolverStyle(ResolverStyle.STRICT)
-                        .parse(dateStr.substring(0, e.getErrorIndex())));
+        boolean allowThrowException = ConnectContext.get() != null
+                && SqlModeHelper.check(ConnectContext.get().getSessionVariable().getSqlMode(),
+                SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION);
+        try {
+            if (HAS_TIME_PART.matcher(fmtLiteral.getVarchar()).matches()) {
+                LocalDateTime ldt;
+                try {
+                    ldt = LocalDateTime.from(builder.withResolverStyle(ResolverStyle.STRICT).parse(dateStr));
+                } catch (DateTimeParseException e) {
+                    // If parsing fails, it can be re-parsed from the position of the successful prefix string.
+                    // This way datetime string can use incomplete format
+                    // eg. str_to_date('2022-10-18 00:00:00','%Y-%m-%d %H:%s');
+                    ldt = LocalDateTime.from(builder.withResolverStyle(ResolverStyle.STRICT)
+                            .parse(dateStr.substring(0, e.getErrorIndex())));
+                }
+                return ConstantOperator.createDatetimeOrNull(ldt);
+            } else {
+                LocalDate ld = LocalDate.from(builder.withResolverStyle(ResolverStyle.STRICT).parse(dateStr));
+                return ConstantOperator.createDatetimeOrNull(ld.atTime(0, 0, 0));
             }
-            return ConstantOperator.createDatetimeOrNull(ldt);
-        } else {
-            LocalDate ld = LocalDate.from(builder.withResolverStyle(ResolverStyle.STRICT).parse(dateStr));
-            return ConstantOperator.createDatetimeOrNull(ld.atTime(0, 0, 0));
+        } catch (DateTimeParseException e) {
+            if (allowThrowException) {
+                throw new StarRocksPlannerException("Fail to parse date", ErrorType.USER_ERROR);
+            } else {
+                throw e;
+            }
         }
     }
 
     @ConstantFunction(name = "str2date", argTypes = {VARCHAR, VARCHAR}, returnType = DATE, isMonotonic = true)
     public static ConstantOperator str2Date(ConstantOperator date, ConstantOperator fmtLiteral) {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar(), false);
-        LocalDate ld = LocalDate.from(builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(
-                StringUtils.strip(date.getVarchar(), "\r\n\t ")));
-        return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), DateType.DATE);
+        boolean allowThrowException = ConnectContext.get() != null
+                && SqlModeHelper.check(ConnectContext.get().getSessionVariable().getSqlMode(),
+                SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION);
+        try {
+            LocalDate ld = LocalDate.from(builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(
+                    StringUtils.strip(date.getVarchar(), "\r\n\t ")));
+            return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), DateType.DATE);
+        } catch (DateTimeParseException e) {
+            if (allowThrowException) {
+                throw new StarRocksPlannerException("Fail to parse date", ErrorType.USER_ERROR);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @ConstantFunction(name = "to_date", argTypes = {DATETIME}, returnType = DATE, isMonotonic = true)
@@ -1185,10 +1210,19 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createLargeInt(first.getLargeInt().multiply(second.getLargeInt()));
     }
 
+    private static ConstantOperator handleDivisionByZero(Type type) {
+        if (ConnectContext.get() != null
+                && SqlModeHelper.check(ConnectContext.get().getSessionVariable().getSqlMode(),
+                SqlModeHelper.MODE_ERROR_FOR_DIVISION_BY_ZERO)) {
+            throw new StarRocksPlannerException("Division by zero", ErrorType.USER_ERROR);
+        }
+        return ConstantOperator.createNull(type);
+    }
+
     @ConstantFunction(name = "divide", argTypes = {DOUBLE, DOUBLE}, returnType = DOUBLE)
     public static ConstantOperator divideDouble(ConstantOperator first, ConstantOperator second) {
         if (second.getDouble() == 0.0) {
-            return ConstantOperator.createNull(FloatType.DOUBLE);
+            return handleDivisionByZero(FloatType.DOUBLE);
         }
         return ConstantOperator.createDouble(first.getDouble() / second.getDouble());
     }
@@ -1202,40 +1236,55 @@ public class ScalarOperatorFunctions {
     })
     public static ConstantOperator divideDecimal(ConstantOperator first, ConstantOperator second) {
         if (BigDecimal.ZERO.compareTo(second.getDecimal()) == 0) {
-            return ConstantOperator.createNull(second.getType());
+            return handleDivisionByZero(second.getType());
         }
         return createDecimalConstant(first.getDecimal().divide(second.getDecimal()));
     }
 
     @ConstantFunction(name = "int_divide", argTypes = {TINYINT, TINYINT}, returnType = TINYINT)
     public static ConstantOperator intDivideTinyInt(ConstantOperator first, ConstantOperator second) {
+        if (second.getTinyInt() == 0) {
+            return handleDivisionByZero(IntegerType.TINYINT);
+        }
         return ConstantOperator.createTinyInt((byte) (first.getTinyInt() / second.getTinyInt()));
     }
 
     @ConstantFunction(name = "int_divide", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT)
     public static ConstantOperator intDivideSmallInt(ConstantOperator first, ConstantOperator second) {
+        if (second.getSmallint() == 0) {
+            return handleDivisionByZero(IntegerType.SMALLINT);
+        }
         return ConstantOperator.createSmallInt((short) (first.getSmallint() / second.getSmallint()));
     }
 
     @ConstantFunction(name = "int_divide", argTypes = {INT, INT}, returnType = INT)
     public static ConstantOperator intDivideInt(ConstantOperator first, ConstantOperator second) {
+        if (second.getInt() == 0) {
+            return handleDivisionByZero(IntegerType.INT);
+        }
         return ConstantOperator.createInt(first.getInt() / second.getInt());
     }
 
     @ConstantFunction(name = "int_divide", argTypes = {BIGINT, BIGINT}, returnType = BIGINT)
     public static ConstantOperator intDivideBigint(ConstantOperator first, ConstantOperator second) {
+        if (second.getBigint() == 0) {
+            return handleDivisionByZero(IntegerType.BIGINT);
+        }
         return ConstantOperator.createBigint(first.getBigint() / second.getBigint());
     }
 
     @ConstantFunction(name = "int_divide", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT)
     public static ConstantOperator intDivideLargeInt(ConstantOperator first, ConstantOperator second) {
+        if (second.getLargeInt().equals(BigInteger.ZERO)) {
+            return handleDivisionByZero(IntegerType.LARGEINT);
+        }
         return ConstantOperator.createLargeInt(first.getLargeInt().divide(second.getLargeInt()));
     }
 
     @ConstantFunction(name = "mod", argTypes = {TINYINT, TINYINT}, returnType = TINYINT)
     public static ConstantOperator modTinyInt(ConstantOperator first, ConstantOperator second) {
         if (second.getTinyInt() == 0) {
-            return ConstantOperator.createNull(IntegerType.TINYINT);
+            return handleDivisionByZero(IntegerType.TINYINT);
         }
         return ConstantOperator.createTinyInt((byte) (first.getTinyInt() % second.getTinyInt()));
     }
@@ -1243,7 +1292,7 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "mod", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT)
     public static ConstantOperator modSMALLINT(ConstantOperator first, ConstantOperator second) {
         if (second.getSmallint() == 0) {
-            return ConstantOperator.createNull(IntegerType.SMALLINT);
+            return handleDivisionByZero(IntegerType.SMALLINT);
         }
         return ConstantOperator.createSmallInt((short) (first.getSmallint() % second.getSmallint()));
     }
@@ -1251,7 +1300,7 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "mod", argTypes = {INT, INT}, returnType = INT)
     public static ConstantOperator modInt(ConstantOperator first, ConstantOperator second) {
         if (second.getInt() == 0) {
-            return ConstantOperator.createNull(IntegerType.INT);
+            return handleDivisionByZero(IntegerType.INT);
         }
         return ConstantOperator.createInt(first.getInt() % second.getInt());
     }
@@ -1259,15 +1308,15 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "mod", argTypes = {BIGINT, BIGINT}, returnType = BIGINT)
     public static ConstantOperator modBigInt(ConstantOperator first, ConstantOperator second) {
         if (second.getBigint() == 0) {
-            return ConstantOperator.createNull(IntegerType.BIGINT);
+            return handleDivisionByZero(IntegerType.BIGINT);
         }
         return ConstantOperator.createBigint(first.getBigint() % second.getBigint());
     }
 
     @ConstantFunction(name = "mod", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT)
     public static ConstantOperator modLargeInt(ConstantOperator first, ConstantOperator second) {
-        if (second.getLargeInt().equals(new BigInteger("0"))) {
-            return ConstantOperator.createNull(IntegerType.LARGEINT);
+        if (second.getLargeInt().equals(BigInteger.ZERO)) {
+            return handleDivisionByZero(IntegerType.LARGEINT);
         }
         return ConstantOperator.createLargeInt(first.getLargeInt().remainder(second.getLargeInt()));
     }
@@ -1281,7 +1330,7 @@ public class ScalarOperatorFunctions {
     })
     public static ConstantOperator modDecimal(ConstantOperator first, ConstantOperator second) {
         if (BigDecimal.ZERO.compareTo(second.getDecimal()) == 0) {
-            return ConstantOperator.createNull(first.getType());
+            return handleDivisionByZero(first.getType());
         }
 
         return createDecimalConstant(first.getDecimal().remainder(second.getDecimal()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -583,4 +583,65 @@ public class ConstantExpressionTest extends PlanTestBase {
         }
 
     }
+
+    @Test
+    public void testDivisionByZeroWithSqlMode() throws Exception {
+        long savedSqlMode = connectContext.getSessionVariable().getSqlMode();
+
+        try {
+            connectContext.getSessionVariable().setSqlMode(
+                    connectContext.getSessionVariable().getSqlMode() | SqlModeHelper.MODE_ERROR_FOR_DIVISION_BY_ZERO);
+
+            // Case 1: When ERROR_FOR_DIVISION_BY_ZERO is ON, division by zero (non-null dividend) should throw
+            assertThrows(Exception.class, () -> getFragmentPlan("SELECT 1.0/0.0"));
+            assertThrows(Exception.class, () -> getFragmentPlan("SELECT 1%0"));
+
+            // Case 2: When dividend is NULL, NULL/0 should return NULL (not throw), consistent with FE semantics
+            String planNullDivZero = getFragmentPlan("SELECT NULL/0");
+            assertContains(planNullDivZero, "NULL");
+
+            // When ERROR_FOR_DIVISION_BY_ZERO is OFF, division by zero should return NULL
+            connectContext.getSessionVariable().setSqlMode(
+                    connectContext.getSessionVariable().getSqlMode() & ~SqlModeHelper.MODE_ERROR_FOR_DIVISION_BY_ZERO);
+            String plan = getFragmentPlan("SELECT 1/0");
+            assertContains(plan, "NULL");
+            plan = getFragmentPlan("SELECT 1%0");
+            assertContains(plan, "NULL");
+
+            // When dividend is NULL, always return NULL
+            plan = getFragmentPlan("SELECT NULL/1");
+            assertContains(plan, "NULL");
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(savedSqlMode);
+        }
+    }
+
+    @Test
+    public void testStrToDateWithAllowThrowException() throws Exception {
+        long savedSqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(
+                    connectContext.getSessionVariable().getSqlMode() | SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION);
+
+            // Case 1: When ALLOW_THROW_EXCEPTION is ON, invalid parse should throw
+            assertThrows(Exception.class, () -> getFragmentPlan("SELECT str_to_date('invalid', '%Y-%m-%d')"));
+            assertThrows(Exception.class, () -> getFragmentPlan("SELECT str2date('invalid', '%Y-%m-%d')"));
+
+            // Case 2: When first argument is NULL, should return NULL (not throw), consistent with FE semantics
+            String planNullInput = getFragmentPlan("SELECT str_to_date(NULL, '%Y-%m-%d')");
+            assertContains(planNullInput, "NULL");
+            planNullInput = getFragmentPlan("SELECT str2date(NULL, '%Y-%m-%d')");
+            assertContains(planNullInput, "NULL");
+
+            // When ALLOW_THROW_EXCEPTION is OFF, invalid parse should return NULL
+            connectContext.getSessionVariable().setSqlMode(
+                    connectContext.getSessionVariable().getSqlMode() & ~SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION);
+            String plan = getFragmentPlan("SELECT str_to_date('invalid', '%Y-%m-%d')");
+            assertContains(plan, "NULL");
+            plan = getFragmentPlan("SELECT str2date('invalid', '%Y-%m-%d')");
+            assertContains(plan, "NULL");
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(savedSqlMode);
+        }
+    }
 }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -293,6 +293,7 @@ struct TQueryOptions {
 
   104: optional TOverflowMode overflow_mode = TOverflowMode.OUTPUT_NULL;
   105: optional bool use_column_pool = true; // Deprecated
+  117: optional bool error_for_division_by_zero = false;
   // Deprecated
   106: optional bool enable_agg_spill_preaggregation;
   107: optional i64 global_runtime_filter_build_max_size;

--- a/test/sql/test_sql_mode_errors/R/test_division_by_zero_and_str_to_date
+++ b/test/sql/test_sql_mode_errors/R/test_division_by_zero_and_str_to_date
@@ -1,0 +1,129 @@
+-- name: test_division_by_zero_and_str_to_date
+set sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO';
+-- result:
+-- !result
+select 1/0;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+select 1%0;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+select 1.0/0.0;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+select NULL/0;
+-- result:
+None
+-- !result
+create table t_div (k1 int, k2 int) duplicate key(k1) distributed by hash(k1) buckets 1 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_div values (1, 1), (2, 0), (3, 1);
+-- result:
+-- !result
+select k1/k2 from t_div order by k1;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+select k1%k2 from t_div order by k1;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+drop table if exists t_div;
+-- result:
+-- !result
+create table t_div_src (k1 int, k2 int)properties('replication_num' = '1');
+-- result:
+-- !result
+create table t_div_dst (k1 int, k2 double)properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_div_src values (1, 1), (2, 0), (3, 1);
+-- result:
+-- !result
+insert into t_div_dst select k1, k1/k2 as k2 from t_div_src;
+-- result:
+[REGEX].*Division by zero.*
+-- !result
+drop table if exists t_div_src;
+-- result:
+-- !result
+drop table if exists t_div_dst;
+-- result:
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select 1/0;
+-- result:
+None
+-- !result
+select 1%0;
+-- result:
+None
+-- !result
+set sql_mode = 'ALLOW_THROW_EXCEPTION';
+-- result:
+-- !result
+select str_to_date('invalid', '%Y-%m-%d');
+-- result:
+[REGEX].*Fail to parse date.*
+-- !result
+select str2date('invalid', '%Y-%m-%d');
+-- result:
+[REGEX].*Fail to parse date.*
+-- !result
+select str_to_date(NULL, '%Y-%m-%d');
+-- result:
+None
+-- !result
+create table t_str_date (c1 varchar(100), c2 varchar(100)) properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_str_date values ('valid', '%Y-%m-%d'), ('invalid', '%Y-%m-%d'), ('2024-01-01', '%Y-%m-%d');
+-- result:
+-- !result
+select str_to_date(c1, c2) from t_str_date order by c1;
+-- result:
+[REGEX].*Fail to parse date.*
+-- !result
+select str2date(c1, c2) from t_str_date order by c1;
+-- result:
+[REGEX].*Fail to parse date.*
+-- !result
+drop table if exists t_str_date;
+-- result:
+-- !result
+create table t_str_date_src (c1 varchar(100), c2 varchar(100)) properties('replication_num' = '1');
+-- result:
+-- !result
+create table t_str_date_dst (c1 datetime) duplicate key(c1)  properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_str_date_src values ('valid', '%Y-%m-%d'), ('invalid', '%Y-%m-%d'), ('2024-01-01', '%Y-%m-%d');
+-- result:
+-- !result
+insert into t_str_date_dst select str_to_date(c1, c2) from t_str_date_src;
+-- result:
+[REGEX].*Fail to parse date.*
+-- !result
+drop table if exists t_str_date_src;
+-- result:
+-- !result
+drop table if exists t_str_date_dst;
+-- result:
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select str_to_date('invalid', '%Y-%m-%d');
+-- result:
+None
+-- !result
+select str2date('invalid', '%Y-%m-%d');
+-- result:
+None
+-- !result

--- a/test/sql/test_sql_mode_errors/T/test_division_by_zero_and_str_to_date
+++ b/test/sql/test_sql_mode_errors/T/test_division_by_zero_and_str_to_date
@@ -1,0 +1,45 @@
+-- name: test_division_by_zero_and_str_to_date
+set sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO';
+select 1/0;
+select 1%0;
+select 1.0/0.0;
+select NULL/0;
+
+create table t_div (k1 int, k2 int) duplicate key(k1) distributed by hash(k1) buckets 1 properties('replication_num' = '1');
+insert into t_div values (1, 1), (2, 0), (3, 1);
+select k1/k2 from t_div order by k1;
+select k1%k2 from t_div order by k1;
+drop table if exists t_div;
+
+create table t_div_src (k1 int, k2 int)properties('replication_num' = '1');
+create table t_div_dst (k1 int, k2 double)properties('replication_num' = '1');
+insert into t_div_src values (1, 1), (2, 0), (3, 1);
+insert into t_div_dst select k1, k1/k2 as k2 from t_div_src;
+drop table if exists t_div_src;
+drop table if exists t_div_dst;
+
+set sql_mode = '';
+select 1/0;
+select 1%0;
+
+set sql_mode = 'ALLOW_THROW_EXCEPTION';
+select str_to_date('invalid', '%Y-%m-%d');
+select str2date('invalid', '%Y-%m-%d');
+select str_to_date(NULL, '%Y-%m-%d');
+
+create table t_str_date (c1 varchar(100), c2 varchar(100)) properties('replication_num' = '1');
+insert into t_str_date values ('valid', '%Y-%m-%d'), ('invalid', '%Y-%m-%d'), ('2024-01-01', '%Y-%m-%d');
+select str_to_date(c1, c2) from t_str_date order by c1;
+select str2date(c1, c2) from t_str_date order by c1;
+drop table if exists t_str_date;
+
+create table t_str_date_src (c1 varchar(100), c2 varchar(100)) properties('replication_num' = '1');
+create table t_str_date_dst (c1 datetime) duplicate key(c1)  properties('replication_num' = '1');
+insert into t_str_date_src values ('valid', '%Y-%m-%d'), ('invalid', '%Y-%m-%d'), ('2024-01-01', '%Y-%m-%d');
+insert into t_str_date_dst select str_to_date(c1, c2) from t_str_date_src;
+drop table if exists t_str_date_src;
+drop table if exists t_str_date_dst;
+
+set sql_mode = '';
+select str_to_date('invalid', '%Y-%m-%d');
+select str2date('invalid', '%Y-%m-%d');


### PR DESCRIPTION
## Why I'm doing:

ERROR_FOR_DIVISION_BY_ZERO and ALLOW_THROW_EXCEPTION are expected to raise user-facing errors consistently across FE constant-folding and BE runtime evaluation. Previously, some cases were silently folded to NULL or executed in BE due to constant-folding exception swallowing and JIT paths that didn’t enforce division-by-zero checks. Also, NULL/0 behavior was inconsistent between FE and BE.

## What I'm doing:
NOT_NULL_VALUE/0 report "Division by zero" error if sql_mode ERROR_FOR_DIVISION_BY_ZERO is on, NULL/0 still returns null;
str2date/str_to_date("invalid_date_str",  str_format) report "Fail to parse date" error if sql_mode ALLOW_THROW_EXCEPTION is on, str2date/str_to_date(NULL,  str_format) stills return NULL.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
