### PR TITLE
[Enhancement] support dummy select _CACHE_STATS_ in shared-data cluster

### DIFF
--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -22,6 +22,7 @@ ADD_BE_LIB(Connector
         lake_connector.cpp
         mysql_connector.cpp
         benchmark_connector.cpp
+        cache_stats_connector.cpp
         file_connector.cpp
         binlog_connector.cpp
         iceberg_connector.cpp

--- a/be/src/connector/cache_stats_connector.cpp
+++ b/be/src/connector/cache_stats_connector.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/cache_stats_connector.h"
+
+#include "connector/connector.h"
+#include "exec/cache_stats_scanner.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::connector {
+
+DataSourceProviderPtr CacheStatsConnector::create_data_source_provider(ConnectorScanNode* scan_node,
+                                                                       const TPlanNode& plan_node) const {
+    (void)scan_node;
+    return std::make_unique<CacheStatsDataSourceProvider>(plan_node);
+}
+
+CacheStatsDataSourceProvider::CacheStatsDataSourceProvider(const TPlanNode& plan_node)
+        : _cache_stats_scan_node(plan_node.cache_stats_scan_node) {}
+
+DataSourcePtr CacheStatsDataSourceProvider::create_data_source(const TScanRange& scan_range) {
+    return std::make_unique<CacheStatsDataSource>(this, scan_range);
+}
+
+const TupleDescriptor* CacheStatsDataSourceProvider::tuple_descriptor(RuntimeState* state) const {
+    return state->desc_tbl().get_tuple_descriptor(_cache_stats_scan_node.tuple_id);
+}
+
+CacheStatsDataSource::CacheStatsDataSource(const CacheStatsDataSourceProvider* provider, const TScanRange& scan_range)
+        : _provider(provider), _scan_range(scan_range.internal_scan_range) {}
+
+std::string CacheStatsDataSource::name() const {
+    return "CacheStatsDataSource";
+}
+
+Status CacheStatsDataSource::open(RuntimeState* state) {
+    _tuple_desc = state->desc_tbl().get_tuple_descriptor(_provider->_cache_stats_scan_node.tuple_id);
+    if (_tuple_desc == nullptr) {
+        return Status::InternalError("Failed to get tuple descriptor for cache stats scan");
+    }
+
+    _scanner = std::make_unique<starrocks::CacheStatsScanner>(_tuple_desc);
+    RETURN_IF_ERROR(_scanner->init(state, _scan_range));
+    RETURN_IF_ERROR(_scanner->open(state));
+    return Status::OK();
+}
+
+void CacheStatsDataSource::close(RuntimeState* state) {
+    if (_scanner != nullptr) {
+        _scanner->close(state);
+    }
+}
+
+Status CacheStatsDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
+    bool eos = false;
+    do {
+        RETURN_IF_ERROR(_scanner->get_chunk(state, chunk, &eos));
+    } while (!eos && (*chunk)->num_rows() == 0);
+    if (eos) {
+        return Status::EndOfFile("");
+    }
+    _rows_read += (*chunk)->num_rows();
+    _bytes_read += (*chunk)->bytes_usage();
+    return Status::OK();
+}
+
+int64_t CacheStatsDataSource::raw_rows_read() const {
+    return _rows_read;
+}
+
+int64_t CacheStatsDataSource::num_rows_read() const {
+    return _rows_read;
+}
+
+int64_t CacheStatsDataSource::num_bytes_read() const {
+    return _bytes_read;
+}
+
+int64_t CacheStatsDataSource::cpu_time_spent() const {
+    return 0;
+}
+
+} // namespace starrocks::connector

--- a/be/src/connector/cache_stats_connector.h
+++ b/be/src/connector/cache_stats_connector.h
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "connector/connector.h"
+
+namespace starrocks {
+class CacheStatsScanner;
+} // namespace starrocks
+
+namespace starrocks::connector {
+
+class CacheStatsConnector final : public Connector {
+public:
+    ~CacheStatsConnector() override = default;
+
+    DataSourceProviderPtr create_data_source_provider(ConnectorScanNode* scan_node,
+                                                      const TPlanNode& plan_node) const override;
+
+    ConnectorType connector_type() const override { return ConnectorType::CACHE_STATS; }
+};
+
+class CacheStatsDataSource;
+class CacheStatsDataSourceProvider final : public DataSourceProvider {
+public:
+    ~CacheStatsDataSourceProvider() override = default;
+    friend class CacheStatsDataSource;
+    explicit CacheStatsDataSourceProvider(const TPlanNode& plan_node);
+
+    DataSourcePtr create_data_source(const TScanRange& scan_range) override;
+
+    bool insert_local_exchange_operator() const override { return false; }
+    bool accept_empty_scan_ranges() const override { return false; }
+
+    const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
+
+private:
+    const TCacheStatsScanNode _cache_stats_scan_node;
+};
+
+class CacheStatsDataSource final : public DataSource {
+public:
+    ~CacheStatsDataSource() override = default;
+
+    CacheStatsDataSource(const CacheStatsDataSourceProvider* provider, const TScanRange& scan_range);
+    std::string name() const override;
+    Status open(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+    Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
+
+    int64_t raw_rows_read() const override;
+    int64_t num_rows_read() const override;
+    int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
+
+private:
+    const CacheStatsDataSourceProvider* _provider;
+    TInternalScanRange _scan_range;
+    std::unique_ptr<starrocks::CacheStatsScanner> _scanner;
+    int64_t _rows_read = 0;
+    int64_t _bytes_read = 0;
+};
+
+} // namespace starrocks::connector

--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -22,6 +22,7 @@
 #include "connector/iceberg_connector.h"
 #endif
 #include "connector/benchmark_connector.h"
+#include "connector/cache_stats_connector.h"
 #include "connector/jdbc_connector.h"
 #include "connector/lake_connector.h"
 #include "connector/mysql_connector.h"
@@ -54,6 +55,7 @@ const std::string Connector::LAKE = "lake";
 const std::string Connector::BINLOG = "binlog";
 const std::string Connector::ICEBERG = "iceberg";
 const std::string Connector::BENCHMARK = "benchmark";
+const std::string Connector::CACHE_STATS = "cache_stats";
 
 class ConnectorManagerInit {
 public:
@@ -64,6 +66,7 @@ public:
         cm->put(Connector::JDBC, std::make_unique<JDBCConnector>());
         cm->put(Connector::MYSQL, std::make_unique<MySQLConnector>());
         cm->put(Connector::BENCHMARK, std::make_unique<BenchmarkConnector>());
+        cm->put(Connector::CACHE_STATS, std::make_unique<CacheStatsConnector>());
         cm->put(Connector::FILE, std::make_unique<FileConnector>());
         cm->put(Connector::LAKE, std::make_unique<LakeConnector>());
         cm->put(Connector::BINLOG, std::make_unique<BinlogConnector>());

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -200,6 +200,7 @@ enum ConnectorType {
     BINLOG = 6,
     ICEBERG = 7,
     BENCHMARK = 8,
+    CACHE_STATS = 9,
 };
 
 class Connector {
@@ -214,6 +215,7 @@ public:
     static const std::string BINLOG;
     static const std::string ICEBERG;
     static const std::string BENCHMARK;
+    static const std::string CACHE_STATS;
 
     virtual ~Connector() = default;
     // First version we use TPlanNode to construct data source provider.

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -46,6 +46,7 @@ set(EXEC_FILES
     multi_olap_table_sink.cpp
     mysql_scanner.cpp
     benchmark_scanner.cpp
+    cache_stats_scanner.cpp
     es/es_predicate.cpp
     es/es_scan_reader.cpp
     es/es_scroll_query.cpp

--- a/be/src/exec/cache_stats_scanner.cpp
+++ b/be/src/exec/cache_stats_scanner.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/cache_stats_scanner.h"
+
+#include "base/string/string_parser.hpp"
+
+namespace starrocks {
+
+CacheStatsScanner::CacheStatsScanner(const TupleDescriptor* tuple_desc) {
+    (void)tuple_desc;
+}
+
+Status CacheStatsScanner::init(RuntimeState* state, const TInternalScanRange& scan_range) {
+    (void)state;
+    _tablet_id = scan_range.tablet_id;
+    if (!scan_range.version.empty()) {
+        StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
+        _version = StringParser::string_to_int<int64_t>(scan_range.version.data(),
+                                                        static_cast<int>(scan_range.version.size()), &result);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InvalidArgument("Invalid cache stats scan range version: " + scan_range.version);
+        }
+    }
+    return Status::OK();
+}
+
+Status CacheStatsScanner::open(RuntimeState* state) {
+    (void)state;
+    return Status::OK();
+}
+
+void CacheStatsScanner::close(RuntimeState* state) {
+    (void)state;
+}
+
+Status CacheStatsScanner::get_chunk(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
+    (void)state;
+    (void)chunk;
+    *eos = false;
+    return Status::NotSupported("_CACHE_STATS_ is not implemented in BE");
+}
+
+} // namespace starrocks

--- a/be/src/exec/cache_stats_scanner.h
+++ b/be/src/exec/cache_stats_scanner.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "common/status.h"
+#include "gen_cpp/InternalService_types.h"
+
+namespace starrocks {
+
+class Chunk;
+class RuntimeState;
+class TupleDescriptor;
+using ChunkPtr = std::shared_ptr<Chunk>;
+
+class CacheStatsScanner {
+public:
+    explicit CacheStatsScanner(const TupleDescriptor* tuple_desc);
+    ~CacheStatsScanner() = default;
+
+    Status init(RuntimeState* state, const TInternalScanRange& scan_range);
+    Status open(RuntimeState* state);
+    void close(RuntimeState* state);
+    Status get_chunk(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+
+private:
+    int64_t _tablet_id = 0;
+    int64_t _version = 0;
+};
+
+} // namespace starrocks

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -342,6 +342,14 @@ Status ExecFactory::create_vectorized_node(RuntimeState* state, ObjectPool* pool
         *node = pool->add(new LookUpNode(pool, tnode, descs));
         return Status::OK();
     }
+    case TPlanNodeType::LAKE_CACHE_STATS_SCAN_NODE: {
+        TPlanNode new_node = tnode;
+        TConnectorScanNode connector_scan_node;
+        connector_scan_node.connector_name = connector::Connector::CACHE_STATS;
+        new_node.connector_scan_node = connector_scan_node;
+        *node = pool->add(new ConnectorScanNode(pool, new_node, descs));
+        return Status::OK();
+    }
     default:
         return Status::InternalError(strings::Substitute("Vectorized engine not support node: $0", tnode.node_type));
     }

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -373,6 +373,7 @@ void ExecNode::collect_scan_nodes(vector<ExecNode*>* nodes) {
     collect_nodes(TPlanNodeType::MYSQL_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::BENCHMARK_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::LAKE_SCAN_NODE, nodes);
+    collect_nodes(TPlanNodeType::LAKE_CACHE_STATS_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::SCHEMA_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::STREAM_SCAN_NODE, nodes);
 }

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -255,8 +255,7 @@ public:
     }
 
     // Get file cache stats, return <cached_bytes, total_bytes>.
-    virtual StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
-                                                                int64_t size) {
+    virtual StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset, int64_t size) {
         return Status::NotSupported("FileSystem::get_cache_stats");
     }
 

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -14,6 +14,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "base/string/slice.h"
 #include "common/statusor.h"
@@ -251,6 +252,12 @@ public:
     // On success, Status::OK is returned. If there is no cache, Status::NotFound is returned.
     virtual Status drop_local_cache(const std::string& path, int64_t offset = 0, int64_t size = -1) {
         return Status::NotFound(path);
+    }
+
+    // Get file cache stats, return <cached_bytes, total_bytes>.
+    virtual StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
+                                                                int64_t size) {
+        return Status::NotSupported("FileSystem::get_cache_stats");
     }
 
     // Batch delete the given files.

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -678,6 +678,17 @@ public:
             return Status::IOError(fmt::format("fail to get space info of path {}: {}", path, e.what()));
         }
     }
+
+    // Directly return size as both cached and total for local file system.
+    StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
+                                                        int64_t size) override {
+        (void)offset;
+        if (size < 0) {
+            ASSIGN_OR_RETURN(auto file_size, get_file_size(path));
+            return std::make_pair(static_cast<size_t>(file_size), static_cast<size_t>(file_size));
+        }
+        return std::make_pair(static_cast<size_t>(size), static_cast<size_t>(size));
+    }
 };
 
 // Default Posix FileSystem

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -595,6 +595,20 @@ public:
         return to_status((*fs_st)->drop_cache(pair.first, offset, size));
     }
 
+    StatusOr<std::pair<size_t, size_t>> get_cache_stats(const std::string& path, int64_t offset,
+                                                        int64_t size) override {
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
+        auto fs_st = get_shard_filesystem(pair.second);
+        if (!fs_st.ok()) {
+            return to_status(fs_st.status());
+        }
+        auto cache_stats_or = (*fs_st)->get_cache_stats(pair.first, offset, size);
+        if (!cache_stats_or.ok()) {
+            return to_status(cache_stats_or.status());
+        }
+        return std::make_pair((*cache_stats_or).cached_bytes, (*cache_stats_or).total_bytes);
+    }
+
     Status delete_files(std::span<const std::string> paths) override {
         using FsPtr = std::shared_ptr<staros::starlet::fslib::FileSystem>;
         using PathList = std::vector<std::string>;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -103,6 +103,7 @@ set(EXEC_FILES
         ./exec/hdfs_scan_node_test.cpp
         ./exec/join_hash_map_test.cpp
         ./exec/json_parser_test.cpp
+        ./exec/cache_stats_scanner_test.cpp
         ./exec/lake_meta_scanner_test.cpp
         ./exec/multi_olap_table_sink_test.cpp
         ./exec/parquet_schema_builder_test.cpp

--- a/be/test/exec/cache_stats_scanner_test.cpp
+++ b/be/test/exec/cache_stats_scanner_test.cpp
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BE_TEST
+#define BE_TEST
+#endif
+
+#include "exec/cache_stats_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "common/config_exec_fwd.h"
+#include "common/status.h"
+#include "connector/cache_stats_connector.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+
+namespace starrocks {
+
+class CacheStatsScannerTest : public ::testing::Test {
+public:
+    CacheStatsScannerTest() : _tablet_id(next_id()) {
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
+        _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
+
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName))
+                      .ok());
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName))
+                      .ok());
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName))
+                      .ok());
+
+        TUniqueId query_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        TUniqueId fragment_id;
+        _state = _pool.add(
+                new RuntimeState(query_id, fragment_id, query_options, query_globals, ExecEnv::GetInstance()));
+        _state->init_mem_trackers(query_id);
+    }
+
+    ~CacheStatsScannerTest() override {
+        (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kRootLocation);
+    }
+
+protected:
+    void build_desc_tbl(bool with_unknown_slot = false) {
+        TDescriptorTableBuilder table_desc_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+
+        auto slot0 = TSlotDescriptorBuilder()
+                             .type(LogicalType::TYPE_BIGINT)
+                             .column_name("tablet_id")
+                             .column_pos(0)
+                             .nullable(false)
+                             .build();
+        auto slot1 = TSlotDescriptorBuilder()
+                             .type(LogicalType::TYPE_BIGINT)
+                             .column_name("cached_bytes")
+                             .column_pos(1)
+                             .nullable(false)
+                             .build();
+        auto slot2 = TSlotDescriptorBuilder()
+                             .type(LogicalType::TYPE_BIGINT)
+                             .column_name("total_bytes")
+                             .column_pos(2)
+                             .nullable(false)
+                             .build();
+
+        tuple_desc_builder.add_slot(slot0);
+        tuple_desc_builder.add_slot(slot1);
+        tuple_desc_builder.add_slot(slot2);
+        if (with_unknown_slot) {
+            auto slot3 = TSlotDescriptorBuilder()
+                                 .type(LogicalType::TYPE_BIGINT)
+                                 .column_name("unknown_col")
+                                 .column_pos(3)
+                                 .nullable(true)
+                                 .build();
+            tuple_desc_builder.add_slot(slot3);
+        }
+        tuple_desc_builder.build(&table_desc_builder);
+
+        CHECK(DescriptorTbl::create(_state, &_pool, table_desc_builder.desc_tbl(), &_desc_tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        _state->set_desc_tbl(_desc_tbl);
+    }
+
+    const TupleDescriptor* tuple_desc() { return _desc_tbl->get_tuple_descriptor(0); }
+
+    constexpr static const char* const kRootLocation = "./CacheStatsScannerTest";
+    lake::TabletManager* _tablet_mgr;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
+    int64_t _tablet_id;
+
+    ObjectPool _pool;
+    RuntimeState* _state = nullptr;
+    DescriptorTbl* _desc_tbl = nullptr;
+};
+
+TEST_F(CacheStatsScannerTest, test_init_invalid_version) {
+    build_desc_tbl();
+    CacheStatsScanner scanner(tuple_desc());
+
+    TInternalScanRange scan_range;
+    scan_range.tablet_id = _tablet_id;
+    scan_range.version = "abc";
+
+    auto st = scanner.init(nullptr, scan_range);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("Invalid") != std::string::npos) << st.message();
+}
+
+TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported) {
+    build_desc_tbl();
+    CacheStatsScanner scanner(tuple_desc());
+
+    TInternalScanRange scan_range;
+    scan_range.tablet_id = _tablet_id;
+    scan_range.version = "99";
+
+    ASSERT_TRUE(scanner.init(nullptr, scan_range).ok());
+    ASSERT_TRUE(scanner.open(nullptr).ok());
+
+    ChunkPtr chunk;
+    bool eos = false;
+    auto st = scanner.get_chunk(nullptr, &chunk, &eos);
+    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(chunk, nullptr);
+}
+
+TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported_with_unknown_slot) {
+    build_desc_tbl(true);
+    CacheStatsScanner scanner(tuple_desc());
+
+    TInternalScanRange scan_range;
+    scan_range.tablet_id = _tablet_id;
+    scan_range.version = "2";
+
+    ASSERT_TRUE(scanner.init(nullptr, scan_range).ok());
+    ASSERT_TRUE(scanner.open(nullptr).ok());
+
+    ChunkPtr chunk;
+    bool eos = false;
+    auto st = scanner.get_chunk(nullptr, &chunk, &eos);
+    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(chunk, nullptr);
+
+    scanner.close(nullptr);
+}
+
+TEST_F(CacheStatsScannerTest, test_connector_data_source) {
+    const int64_t version = 4;
+    build_desc_tbl();
+
+    connector::CacheStatsConnector connector;
+    ASSERT_EQ(connector.connector_type(), connector::ConnectorType::CACHE_STATS);
+
+    TCacheStatsScanNode scan_node;
+    scan_node.__set_tuple_id(0);
+
+    TPlanNode plan_node;
+    plan_node.__set_cache_stats_scan_node(scan_node);
+
+    auto provider = connector.create_data_source_provider(nullptr, plan_node);
+    ASSERT_NE(provider, nullptr);
+    ASSERT_FALSE(provider->insert_local_exchange_operator());
+    ASSERT_FALSE(provider->accept_empty_scan_ranges());
+    ASSERT_EQ(provider->tuple_descriptor(_state), _state->desc_tbl().get_tuple_descriptor(0));
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = _tablet_id;
+    internal_scan_range.version = std::to_string(version);
+
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    auto data_source = provider->create_data_source(scan_range);
+    ASSERT_NE(data_source, nullptr);
+    ASSERT_EQ(data_source->name(), "CacheStatsDataSource");
+    ASSERT_TRUE(data_source->open(_state).ok());
+
+    ChunkPtr chunk;
+    auto st = data_source->get_next(_state, &chunk);
+    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    ASSERT_EQ(chunk, nullptr);
+    ASSERT_EQ(data_source->raw_rows_read(), 0);
+    ASSERT_EQ(data_source->num_rows_read(), 0);
+    ASSERT_EQ(data_source->num_bytes_read(), 0);
+    ASSERT_EQ(data_source->cpu_time_spent(), 0);
+
+    data_source->close(_state);
+}
+
+} // namespace starrocks

--- a/be/test/exec/exec_factory_test.cpp
+++ b/be/test/exec/exec_factory_test.cpp
@@ -177,6 +177,11 @@ TEST_F(ExecFactoryTest, test_create_tree_invalid_tuple_id) {
     ASSERT_NE(st.message().find("Tuple ids are not in descs"), std::string::npos);
 }
 
+TEST_F(ExecFactoryTest, test_lake_cache_stats_scan_node) {
+    TPlanNode tnode = make_base_plan_node(TPlanNodeType::LAKE_CACHE_STATS_SCAN_NODE);
+    assert_node_instance<ConnectorScanNode>(tnode);
+}
+
 TEST_F(ExecFactoryTest, test_create_tree_malformed_or_partial_tree) {
     {
         TPlan malformed_plan;

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -446,4 +446,25 @@ TEST_F(PosixFileSystemTest, test_delete_files) {
     EXPECT_OK(fs->delete_dir_recursive(path2));
 }
 
+TEST_F(PosixFileSystemTest, get_cache_stats) {
+    auto fs = FileSystem::Default();
+    std::string fname = "./ut_dir/fs_posix/cache_stats_test";
+    ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(fname));
+    ASSERT_OK(wf->append("hello world!"));
+    ASSERT_OK(wf->close());
+
+    // size < 0: uses get_file_size
+    {
+        ASSIGN_OR_ABORT(auto stats, fs->get_cache_stats(fname, 0, -1));
+        ASSERT_EQ(stats.first, 12);
+        ASSERT_EQ(stats.second, 12);
+    }
+    // size >= 0: returns size directly
+    {
+        ASSIGN_OR_ABORT(auto stats, fs->get_cache_stats(fname, 0, 100));
+        ASSERT_EQ(stats.first, 100);
+        ASSERT_EQ(stats.second, 100);
+    }
+}
+
 } // namespace starrocks

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -459,6 +459,24 @@ TEST_P(StarletFileSystemTest, test_drop_cache) {
     config::lake_clear_corrupted_cache_data = old;
 }
 
+TEST_P(StarletFileSystemTest, test_get_cache_stats) {
+    auto uri = StarletPath("cache_stats.dat");
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(uri));
+    ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(uri));
+    ASSERT_OK(wf->append("hello"));
+    ASSERT_OK(wf->append(" world!"));
+    ASSERT_OK(wf->close());
+
+    auto result = fs->get_cache_stats(uri, 0, 12);
+    // get_cache_stats may or may not be supported depending on the underlying fslib,
+    // but the code path in fs_starlet.cpp is exercised either way.
+    if (result.ok()) {
+        EXPECT_EQ(result.value().second, 12);
+    }
+
+    ASSERT_OK(fs->delete_file(uri));
+}
+
 INSTANTIATE_TEST_CASE_P(StarletFileSystem, StarletFileSystemTest,
                         ::testing::Values(std::string("s3"), std::string("cachefs")));
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CacheStatsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CacheStatsScanNode.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TCacheStatsScanNode;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TInternalScanRange;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeType;
+import com.starrocks.thrift.TScanRange;
+import com.starrocks.thrift.TScanRangeLocation;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
+
+public class CacheStatsScanNode extends ScanNode {
+    private static final Logger LOG = LogManager.getLogger(CacheStatsScanNode.class);
+
+    private final OlapTable olapTable;
+    private final Map<Integer, String> columnIdToNames;
+    private final List<String> selectPartitionNames;
+    private final Set<Long> selectedTabletIds;
+    private final List<TScanRangeLocations> result = Lists.newArrayList();
+
+    public CacheStatsScanNode(PlanNodeId id, TupleDescriptor desc, OlapTable olapTable,
+                              Map<Integer, String> columnIdToNames, List<String> selectPartitionNames,
+                              List<Long> selectedTabletIds) {
+        super(id, desc, "CacheStatsScan");
+        this.olapTable = olapTable;
+        this.columnIdToNames = columnIdToNames;
+        this.selectPartitionNames = selectPartitionNames;
+        this.selectedTabletIds = new HashSet<>(selectedTabletIds);
+    }
+
+    public void computeRangeLocations(ComputeResource computeResource) {
+        Collection<PhysicalPartition> partitions;
+        if (selectPartitionNames.isEmpty()) {
+            partitions = olapTable.getPhysicalPartitions();
+        } else {
+            partitions = selectPartitionNames.stream().map(name -> {
+                Partition partition = olapTable.getPartition(name, false);
+                if (partition == null) {
+                    throw new StarRocksPlannerException(
+                            "Partition '" + name + "' not found in table: " + olapTable.getName(), INTERNAL_ERROR);
+                }
+                return partition;
+            }).map(Partition::getSubPartitions).flatMap(Collection::stream).collect(Collectors.toList());
+        }
+
+        for (PhysicalPartition partition : partitions) {
+            MaterializedIndex index = partition.getLatestBaseIndex();
+            List<Tablet> tablets = index.getTablets();
+            long visibleVersion = partition.getVisibleVersion();
+
+            for (Tablet tablet : tablets) {
+                long tabletId = tablet.getId();
+                if (!selectedTabletIds.isEmpty() && !selectedTabletIds.contains(tabletId)) {
+                    continue;
+                }
+                TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
+
+                TInternalScanRange internalRange = new TInternalScanRange();
+                internalRange.setDb_name("");
+                internalRange.setPartition_id(partition.getId());
+                internalRange.setTablet_id(tabletId);
+                internalRange.setVersion(String.valueOf(visibleVersion));
+                internalRange.setVersion_hash("0"); // not used
+                internalRange.setSchema_hash(String.valueOf(-1)); // not used
+
+                List<Replica> allQueryableReplicas = Lists.newArrayList();
+                tablet.getQueryableReplicas(allQueryableReplicas, Collections.emptyList(),
+                        visibleVersion, -1 /* localBeId */, -1 /* schemaHash */, computeResource, null);
+                if (allQueryableReplicas.isEmpty()) {
+                    LOG.error("no queryable replica found in tablet {}. visible version {}",
+                            tabletId, visibleVersion);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("tablet: {}, shard: {}, backends: {}", tabletId,
+                                ((LakeTablet) tablet).getShardId(),
+                                tablet.getBackendIds());
+                    }
+                    throw new StarRocksPlannerException("Failed to get scan range, no queryable replica found " +
+                            "in tablet: " + tabletId, INTERNAL_ERROR);
+                }
+                Collections.shuffle(allQueryableReplicas);
+
+                boolean tabletIsNull = true;
+                for (Replica replica : allQueryableReplicas) {
+                    ComputeNode node =
+                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                                    .getBackendOrComputeNode(replica.getBackendId());
+                    if (node == null) {
+                        LOG.debug("replica {} not exists", replica.getBackendId());
+                        continue;
+                    }
+                    String ip = node.getHost();
+                    int port = node.getBePort();
+                    TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress(ip, port));
+                    scanRangeLocation.setBackend_id(replica.getBackendId());
+                    scanRangeLocations.addToLocations(scanRangeLocation);
+                    internalRange.addToHosts(new TNetworkAddress(ip, port));
+                    tabletIsNull = false;
+                }
+                if (tabletIsNull) {
+                    throw new StarRocksPlannerException(tabletId + " have no alive replicas", INTERNAL_ERROR);
+                }
+                TScanRange scanRange = new TScanRange();
+                scanRange.setInternal_scan_range(internalRange);
+                scanRangeLocations.setScan_range(scanRange);
+
+                result.add(scanRangeLocations);
+            }
+        }
+    }
+
+    @Override
+    public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
+        return result;
+    }
+
+    @Override
+    protected void toThrift(TPlanNode msg) {
+        msg.node_type = TPlanNodeType.LAKE_CACHE_STATS_SCAN_NODE;
+
+        TCacheStatsScanNode scanNode = new TCacheStatsScanNode();
+        scanNode.setTuple_id(desc.getId().asInt());
+        scanNode.setId_to_names(columnIdToNames);
+        scanNode.setTable_id(olapTable.getId());
+        scanNode.setTable_name(olapTable.getName());
+
+        msg.cache_stats_scan_node = scanNode;
+    }
+
+    @Override
+    protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
+        StringBuilder output = new StringBuilder();
+        output.append(prefix).append("Table: ").append(olapTable.getName()).append("\n");
+        output.append(prefix).append("CacheStats Query\n");
+        return output.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -128,6 +128,9 @@ import static com.starrocks.thrift.PlanNodesConstants.BINLOG_OP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_SEQ_ID_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_TIMESTAMP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_VERSION_COLUMN_NAME;
+import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_CACHED_BYTES_COLUMN_NAME;
+import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TABLET_ID_COLUMN_NAME;
+import static com.starrocks.thrift.PlanNodesConstants.CACHE_STATS_TOTAL_BYTES_COLUMN_NAME;
 
 public class QueryAnalyzer {
     private final ConnectContext session;
@@ -805,11 +808,22 @@ public class QueryAnalyzer {
                     columns.put(field, column);
                     fields.add(field);
                 }
-                
                 // Add virtual columns for sync MV queries as well
                 for (Column column : getVirtualColumns(table)) {
                     SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
                     Field field = new Field(column.getName(), column.getType(), tableName, slot, false,
+                            column.isAllowNull());
+                    columns.put(field, column);
+                    fields.add(field);
+                }
+            } else if (node.isCacheStatsQuery()) {
+                if (!table.isCloudNativeTableOrMaterializedView()) {
+                    throw new SemanticException("_CACHE_STATS_ hint is only supported for Lake Table");
+                }
+
+                for (Column column : getCacheStatsColumns()) {
+                    SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
+                    Field field = new Field(column.getName(), column.getType(), tableName, slot, true,
                             column.isAllowNull());
                     columns.put(field, column);
                     fields.add(field);
@@ -919,6 +933,14 @@ public class QueryAnalyzer {
                 OlapTable olapTable = (OlapTable) table;
                 columns.addAll(olapTable.getVirtualColumns());
             }
+            return columns;
+        }
+
+        private List<Column> getCacheStatsColumns() {
+            List<Column> columns = new ArrayList<>();
+            columns.add(new Column(CACHE_STATS_TABLET_ID_COLUMN_NAME, IntegerType.BIGINT));
+            columns.add(new Column(CACHE_STATS_CACHED_BYTES_COLUMN_NAME, IntegerType.BIGINT));
+            columns.add(new Column(CACHE_STATS_TOTAL_BYTES_COLUMN_NAME, IntegerType.BIGINT));
             return columns;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -38,6 +38,7 @@ public class TableRelation extends Relation {
         _BINLOG_,
         _SYNC_MV_,
         _USE_PK_INDEX_,
+        _CACHE_STATS_,
     }
 
     private final TableName name;
@@ -197,6 +198,10 @@ public class TableRelation extends Relation {
 
     public boolean isUsePkIndex() {
         return tableHints.contains(TableHint._USE_PK_INDEX_);
+    }
+
+    public boolean isCacheStatsQuery() {
+        return tableHints.contains(TableHint._CACHE_STATS_);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperato
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalFetchOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalFilterOperator;
@@ -425,6 +426,19 @@ public class LogicalPlanPrinter {
         public OperatorStr visitPhysicalMysqlScan(OptExpression optExpression, Integer step) {
             PhysicalMysqlScanOperator scan = (PhysicalMysqlScanOperator) optExpression.getOp();
             StringBuilder sb = new StringBuilder("SCAN (");
+            sb.append("columns").append(scan.getUsedColumns());
+            sb.append(" predicate[").append(scan.getPredicate()).append("]");
+            sb.append(")");
+            if (scan.getLimit() >= 0) {
+                sb.append(" Limit ").append(scan.getLimit());
+            }
+            return new OperatorStr(sb.toString(), step, Collections.emptyList());
+        }
+
+        @Override
+        public OperatorStr visitPhysicalCacheStatsScan(OptExpression optExpression, Integer step) {
+            PhysicalCacheStatsScanOperator scan = (PhysicalCacheStatsScanOperator) optExpression.getOp();
+            StringBuilder sb = new StringBuilder("CACHE STATS SCAN (");
             sb.append("columns").append(scan.getUsedColumns());
             sb.append(" predicate[").append(scan.getPredicate()).append("]");
             sb.append(")");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpressionVisitor.java
@@ -190,6 +190,10 @@ public abstract class OptExpressionVisitor<R, C> {
         return visitPhysicalScan(optExpression, context);
     }
 
+    public R visitPhysicalCacheStatsScan(OptExpression optExpression, C context) {
+        return visitPhysicalScan(optExpression, context);
+    }
+
     public R visitPhysicalProject(OptExpression optExpression, C context) {
         return visit(optExpression, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
@@ -64,6 +64,7 @@ public enum OperatorType {
     LOGICAL_CTE_CONSUME,
     LOGICAL_SPJG_PIECES,
     LOGICAL_BENCHMARK_SCAN,
+    LOGICAL_CACHE_STATS_SCAN,
 
     /**
      * Physical operator
@@ -93,6 +94,7 @@ public enum OperatorType {
     PHYSICAL_ES_SCAN,
     PHYSICAL_JDBC_SCAN,
     PHYSICAL_BENCHMARK_SCAN,
+    PHYSICAL_CACHE_STATS_SCAN,
 
     PHYSICAL_PROJECT,
     PHYSICAL_SORT,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorVisitor.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalBenchmarkScanOperator
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -59,6 +60,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalBenchmarkScanOperat
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalEsScanOperator;
@@ -458,6 +460,14 @@ public abstract class OperatorVisitor<R, C> {
     }
 
     public R visitPhysicalLookUp(PhysicalLookUpOperator node, C context) {
+        return visitOperator(node, context);
+    }
+
+    public R visitLogicalCacheStatsScan(LogicalCacheStatsScanOperator node, C context) {
+        return visitLogicalTableScan(node, context);
+    }
+
+    public R visitPhysicalCacheStatsScan(PhysicalCacheStatsScanOperator node, C context) {
         return visitOperator(node, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCacheStatsScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCacheStatsScanOperator.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.logical;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class LogicalCacheStatsScanOperator extends LogicalScanOperator {
+
+    private Map<Integer, String> aggColumnIdToNames = ImmutableMap.of();
+    private List<String> selectPartitionNames = Collections.emptyList();
+    private List<Long> selectedTabletIds = ImmutableList.of();
+
+    private LogicalCacheStatsScanOperator() {
+        super(OperatorType.LOGICAL_CACHE_STATS_SCAN);
+    }
+
+    public Map<Integer, String> getAggColumnIdToNames() {
+        return aggColumnIdToNames;
+    }
+
+    public List<String> getSelectPartitionNames() {
+        return selectPartitionNames;
+    }
+
+    public List<Long> getSelectedTabletIds() {
+        return selectedTabletIds;
+    }
+
+    @Override
+    public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalCacheStatsScan(this, context);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder
+            extends LogicalScanOperator.Builder<LogicalCacheStatsScanOperator, Builder> {
+
+        @Override
+        protected LogicalCacheStatsScanOperator newInstance() {
+            return new LogicalCacheStatsScanOperator();
+        }
+
+        @Override
+        public Builder withOperator(LogicalCacheStatsScanOperator operator) {
+            super.withOperator(operator);
+            builder.aggColumnIdToNames = ImmutableMap.copyOf(operator.aggColumnIdToNames);
+            builder.selectPartitionNames = operator.selectPartitionNames;
+            builder.selectedTabletIds = ImmutableList.copyOf(operator.selectedTabletIds);
+            return this;
+        }
+
+        public Builder setAggColumnIdToNames(Map<Integer, String> aggColumnIdToNames) {
+            builder.aggColumnIdToNames = aggColumnIdToNames;
+            return this;
+        }
+
+        public Builder setSelectPartitionNames(List<String> selectPartitionNames) {
+            builder.selectPartitionNames = selectPartitionNames;
+            return this;
+        }
+
+        public Builder setSelectedTabletIds(List<Long> selectedTabletIds) {
+            builder.selectedTabletIds = selectedTabletIds == null ?
+                    ImmutableList.of() : ImmutableList.copyOf(selectedTabletIds);
+            return this;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCacheStatsScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCacheStatsScanOperator.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.physical;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCacheStatsScanOperator;
+
+import java.util.List;
+import java.util.Map;
+
+public class PhysicalCacheStatsScanOperator extends PhysicalScanOperator {
+
+    private Map<Integer, String> aggColumnIdToNames;
+    private List<String> selectPartitionNames;
+    private List<Long> selectedTabletIds;
+
+    public PhysicalCacheStatsScanOperator() {
+        super(OperatorType.PHYSICAL_CACHE_STATS_SCAN);
+        this.aggColumnIdToNames = ImmutableMap.of();
+        this.selectPartitionNames = ImmutableList.of();
+        this.selectedTabletIds = ImmutableList.of();
+    }
+
+    public PhysicalCacheStatsScanOperator(LogicalCacheStatsScanOperator scanOperator) {
+        super(OperatorType.PHYSICAL_CACHE_STATS_SCAN, scanOperator);
+        this.aggColumnIdToNames = scanOperator.getAggColumnIdToNames();
+        this.selectPartitionNames = scanOperator.getSelectPartitionNames();
+        this.selectedTabletIds = scanOperator.getSelectedTabletIds();
+    }
+
+    public Map<Integer, String> getAggColumnIdToNames() {
+        return aggColumnIdToNames;
+    }
+
+    public List<String> getSelectPartitionNames() {
+        return selectPartitionNames;
+    }
+
+    public List<Long> getSelectedTabletIds() {
+        return selectedTabletIds;
+    }
+
+    @Override
+    public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
+        return visitor.visitPhysicalCacheStatsScan(this, context);
+    }
+
+    @Override
+    public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
+        return visitor.visitPhysicalCacheStatsScan(optExpression, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.optimizer.rule.implementation.CTEAnchorToNoCTEImplement
 import com.starrocks.sql.optimizer.rule.implementation.CTEConsumeInlineImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.CTEConsumerReuseImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.CTEProduceImplementationRule;
+import com.starrocks.sql.optimizer.rule.implementation.CacheStatsScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.DeltaLakeScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.EsScanImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.ExceptImplementationRule;
@@ -199,6 +200,7 @@ public class RuleSet {
             new MysqlScanImplementationRule(),
             new EsScanImplementationRule(),
             new MetaScanImplementationRule(),
+            new CacheStatsScanImplementationRule(),
             new JDBCScanImplementationRule(),
             new BenchmarkScanImplementationRule(),
             new TableFunctionTableScanImplementationRule(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -283,6 +283,7 @@ public enum RuleType {
     IMP_STREAM_AGG,
     IMP_STREAM_JOIN,
     IMP_BINLOG_SCAN,
+    IMP_CACHE_STATS_LSCAN_TO_PSCAN,
 
     // The following are combination rules:
     GROUP_RULES,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CacheStatsScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CacheStatsScanImplementationRule.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.implementation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCacheStatsScanOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCacheStatsScanOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.List;
+
+public class CacheStatsScanImplementationRule extends ImplementationRule {
+
+    public CacheStatsScanImplementationRule() {
+        super(RuleType.IMP_CACHE_STATS_LSCAN_TO_PSCAN,
+                Pattern.create(OperatorType.LOGICAL_CACHE_STATS_SCAN));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalCacheStatsScanOperator logical = (LogicalCacheStatsScanOperator) input.getOp();
+        PhysicalCacheStatsScanOperator physical = new PhysicalCacheStatsScanOperator(logical);
+        OptExpression result = new OptExpression(physical);
+        return Lists.newArrayList(result);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -73,6 +73,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalBenchmarkScanOperator
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -907,6 +908,17 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 node.getColRefToColumnMetaMap(), optimizerContext);
         builder.setOutputRowCount(node.getAggColumnIdToColumns().size());
 
+        context.setStatistics(builder.build());
+        return visitOperator(node, context);
+    }
+
+    @Override
+    public Void visitLogicalCacheStatsScan(LogicalCacheStatsScanOperator node, ExpressionContext context) {
+        Statistics.Builder builder = Statistics.builder();
+        for (ColumnRefOperator columnRefOperator : node.getColRefToColumnMetaMap().keySet()) {
+            builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
+        }
+        builder.setOutputRowCount(1);
         context.setStatistics(builder.build());
         return visitOperator(node, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -106,6 +106,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalBenchmarkScanOperator
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -562,9 +563,9 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
             List<Column> distributedColumns = MetaUtils.getColumnsByColumnIds(olapTable,
                     hashDistributionInfo.getDistributionColumns());
 
-            // NOTE: sync mv output columns may not contain the distribution columns,
+            // NOTE: sync mv & cache stats output columns may not contain the distribution columns,
             // set it as random distribution.
-            if (node.isSyncMVQuery() &&
+            if ((node.isSyncMVQuery() || node.isCacheStatsQuery()) &&
                     distributedColumns.stream().anyMatch(x -> !columnMetaToColRefMap.containsKey(x))) {
                 return DistributionSpec.createAnyDistributionSpec();
             }
@@ -649,6 +650,17 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                                 node.getPartitionNames().getPartitionNames())
                         .setSelectedIndexId(((OlapTable) node.getTable()).getBaseIndexMetaId())
                         .setHintsTabletIds(node.getTabletIds())
+                        .build();
+            } else if (node.isCacheStatsQuery()) {
+                if (!node.getTable().isCloudNativeTableOrMaterializedView()) {
+                    throw new SemanticException("_CACHE_STATS_ hint is only supported for Lake Table");
+                }
+                scanOperator = LogicalCacheStatsScanOperator.builder()
+                        .setTable(node.getTable())
+                        .setColRefToColumnMetaMap(colRefToColumnMetaMapBuilder.build())
+                        .setSelectPartitionNames(node.getPartitionNames() == null ? Collections.emptyList() :
+                                node.getPartitionNames().getPartitionNames())
+                        .setSelectedTabletIds(node.getTabletIds())
                         .build();
             } else if (!isMVPlanner) {
                 scanOperator = LogicalOlapScanOperator.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -59,6 +59,7 @@ import com.starrocks.planner.AnalyticEvalNode;
 import com.starrocks.planner.AssertNumRowsNode;
 import com.starrocks.planner.BenchmarkScanNode;
 import com.starrocks.planner.BinlogScanNode;
+import com.starrocks.planner.CacheStatsScanNode;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.DecodeNode;
@@ -167,6 +168,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperato
 import com.starrocks.sql.optimizer.operator.physical.PhysicalBenchmarkScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCacheStatsScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalConcatenateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDecodeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDeltaLakeScanOperator;
@@ -4334,6 +4336,55 @@ public class PlanFragmentBuilder {
             splitConsumeFragment.addChild(splitProduceFragment);
             context.getFragments().add(splitConsumeFragment);
             return splitConsumeFragment;
+        }
+
+        @Override
+        public PlanFragment visitPhysicalCacheStatsScan(OptExpression optExpression, ExecPlan context) {
+            PhysicalCacheStatsScanOperator scan = (PhysicalCacheStatsScanOperator) optExpression.getOp();
+
+            OlapTable olapTable = (OlapTable) scan.getTable();
+            context.getDescTbl().addReferencedTable(olapTable);
+
+            TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
+            tupleDescriptor.setTable(olapTable);
+
+            Map<Integer, String> columnIdToNames = Maps.newHashMap();
+            for (Map.Entry<ColumnRefOperator, Column> entry : scan.getColRefToColumnMetaMap().entrySet()) {
+                SlotDescriptor slotDescriptor = context.getDescTbl()
+                        .addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
+                slotDescriptor.setColumn(entry.getValue());
+                slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
+                slotDescriptor.setIsMaterialized(true);
+                slotDescriptor.setType(entry.getKey().getType());
+                context.getColRefToExpr().put(entry.getKey(),
+                        new SlotRef(entry.getKey().getName(), slotDescriptor));
+
+                columnIdToNames.put(entry.getKey().getId(), entry.getValue().getName());
+            }
+            tupleDescriptor.computeMemLayout();
+
+            CacheStatsScanNode scanNode = new CacheStatsScanNode(
+                    context.getNextNodeId(),
+                    tupleDescriptor,
+                    olapTable,
+                    columnIdToNames,
+                    scan.getSelectPartitionNames(),
+                    scan.getSelectedTabletIds());
+
+            ComputeResource computeResource = ConnectContext.get() != null ?
+                    ConnectContext.get().getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
+            scanNode.computeRangeLocations(computeResource);
+            // scanNode.computeStatistics(optExpression.getStatistics());
+            currentExecGroup.add(scanNode, true);
+
+            context.getScanNodes().add(scanNode);
+
+            PlanFragment fragment = new PlanFragment(
+                    context.getNextFragmentId(),
+                    scanNode,
+                    DataPartition.RANDOM);
+            context.getFragments().add(fragment);
+            return fragment;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
@@ -75,7 +75,7 @@ public class ProfilingExecPlanTest {
                         "STREAM_LOAD_SCAN", "ANALYTIC_EVAL", "ICEBERG_SCAN", "AGGREGATION", "FILE_SCAN", "EXCHANGE",
                         "META_SCAN", "OLAP_SCAN", "ODPS_SCAN", "ICEBERG_METADATA_SCAN", "KUDU_SCAN",
                         "CAPTURE_VERSION", "ICEBERG_EQUALITY_DELETE_SCAN", "RAW_VALUES", "FETCH", "LOOK_UP",
-                        "BENCHMARK_SCAN", "ICEBERG_METADATA_DELETE");
+                        "BENCHMARK_SCAN", "ICEBERG_METADATA_DELETE", "CACHE_STATS_SCAN");
 
         Method method = ProfilingExecPlan.class.getDeclaredMethod("normalizeNodeName", Class.class);
         method.setAccessible(true);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/CacheStatsScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/CacheStatsScanTest.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class CacheStatsScanTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test_cache_stats").useDatabase("test_cache_stats");
+
+        starRocksAssert.withTable("CREATE TABLE lake_t0 (\n" +
+                "  k1 bigint,\n" +
+                "  k2 bigint,\n" +
+                "  k3 bigint\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3");
+
+        starRocksAssert.withTable("CREATE TABLE lake_part_t0 (\n" +
+                "  k1 date,\n" +
+                "  k2 bigint,\n" +
+                "  k3 bigint\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1) (\n" +
+                "  PARTITION p1 VALUES [('2024-01-01'), ('2024-02-01')),\n" +
+                "  PARTITION p2 VALUES [('2024-02-01'), ('2024-03-01'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3");
+    }
+
+    private String getFragmentPlan(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second
+                .getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private ExecPlan getExecPlan(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+    }
+
+    @Test
+    public void testCacheStatsScanPlan() throws Exception {
+        String sql = "SELECT * FROM lake_t0 [_CACHE_STATS_]";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+        Assertions.assertTrue(plan.contains("Table: lake_t0"), plan);
+        Assertions.assertTrue(plan.contains("CacheStats Query"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanSelectColumns() throws Exception {
+        String sql = "SELECT tablet_id, cached_bytes FROM lake_t0 [_CACHE_STATS_]";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanWithPartition() throws Exception {
+        String sql = "SELECT * FROM lake_part_t0 PARTITION(p1) [_CACHE_STATS_]";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+        Assertions.assertTrue(plan.contains("Table: lake_part_t0"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanWithFilter() throws Exception {
+        String sql = "SELECT * FROM lake_t0 [_CACHE_STATS_] WHERE tablet_id > 0";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanWithAggregation() throws Exception {
+        String sql = "SELECT sum(cached_bytes), sum(total_bytes) FROM lake_t0 [_CACHE_STATS_]";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+        Assertions.assertTrue(plan.contains("AGGREGATE"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanExecPlanHasScanNode() throws Exception {
+        String sql = "SELECT * FROM lake_t0 [_CACHE_STATS_]";
+        ExecPlan execPlan = getExecPlan(sql);
+        boolean hasCacheStatsScanNode = execPlan.getScanNodes().stream()
+                .anyMatch(n -> n instanceof CacheStatsScanNode);
+        Assertions.assertTrue(hasCacheStatsScanNode);
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -89,6 +89,7 @@ enum TPlanNodeType {
   FETCH_NODE,
   LOOKUP_NODE,
   BENCHMARK_SCAN_NODE,
+  LAKE_CACHE_STATS_SCAN_NODE
 }
 
 // phases of an execution node
@@ -1350,8 +1351,19 @@ const string TABLET_ID_COLUMN_NAME = "_tablet_id_";
 const string SEGMENT_ID_COLUMN_NAME = "_segment_id_";
 const string ROW_ID_COLUMN_NAME = "_row_id_";
 
+const string CACHE_STATS_TABLET_ID_COLUMN_NAME = "tablet_id";
+const string CACHE_STATS_CACHED_BYTES_COLUMN_NAME = "cached_bytes";
+const string CACHE_STATS_TOTAL_BYTES_COLUMN_NAME = "total_bytes";
+
 struct TBinlogScanNode {
   1: optional Types.TTupleId tuple_id
+}
+
+struct TCacheStatsScanNode {
+    1: optional Types.TTupleId tuple_id
+    2: optional map<i32, string> id_to_names
+    3: optional i64 table_id
+    4: optional string table_name
 }
 
 // Union of all stream source nodes, distinguished by type
@@ -1500,6 +1512,8 @@ struct TPlanNode {
   83: optional TLookUpNode look_up_node;
   // Scan node for benchmark
   84: optional TBenchmarkScanNode benchmark_scan_node;
+
+  85: optional TCacheStatsScanNode cache_stats_scan_node;
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

a dummy implementation of `select * from table [_CACHE_STATS_]`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
