### PR TITLE
[Enhancement] Support iceberg global shuffle based on transform partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -22,6 +22,8 @@ import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -34,12 +36,14 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.ConnectorSinkSortScope;
+import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -75,6 +79,7 @@ import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
@@ -98,6 +103,7 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.base.RoundRobinDistributionSpec;
 import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -121,6 +127,7 @@ import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
@@ -582,8 +589,11 @@ public class InsertPlanner {
     private ExecPlan buildExecPlan(InsertStmt insertStmt, ConnectContext session, List<ColumnRefOperator> outputColumns,
                                    LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
                                    QueryRelation queryRelation, Table targetTable) {
+        PreOptimizePlanContext preOptimizePlanContext = preparePreOptimizePlanContext(
+                insertStmt, session.getSessionVariable(), targetTable, outputColumns, columnRefFactory, logicalPlan);
+
         PhysicalPropertySet requiredPropertySet = createPhysicalPropertySet(insertStmt, outputColumns,
-                session.getSessionVariable());
+                session.getSessionVariable(), preOptimizePlanContext.partitionColumnIDs);
         OptExpression optimizedPlan;
 
         int sourceTablesCount = collectSourceTablesCount(session, insertStmt);
@@ -593,9 +603,9 @@ public class InsertPlanner {
             optimizerContext.setSourceTablesCount(sourceTablesCount);
             Optimizer optimizer = OptimizerFactory.create(optimizerContext);
             optimizedPlan = optimizer.optimize(
-                    logicalPlan.getRoot(),
+                    preOptimizePlanContext.root,
                     requiredPropertySet,
-                    new ColumnRefSet(logicalPlan.getOutputColumn()));
+                    preOptimizePlanContext.requiredColumns);
         }
 
         //8. Build fragment exec plan
@@ -608,6 +618,49 @@ public class InsertPlanner {
                     queryRelation.getColumnOutputNames(), TResultSinkType.MYSQL_PROTOCAL, hasOutputFragment);
         }
         return execPlan;
+    }
+
+    private PreOptimizePlanContext preparePreOptimizePlanContext(InsertStmt insertStmt,
+                                                                 SessionVariable sessionVariable,
+                                                                 Table targetTable,
+                                                                 List<ColumnRefOperator> outputColumns,
+                                                                 ColumnRefFactory columnRefFactory,
+                                                                 LogicalPlan logicalPlan) {
+        OptExpression root = logicalPlan.getRoot();
+        ColumnRefSet requiredColumns = new ColumnRefSet(logicalPlan.getOutputColumn());
+        if (!(targetTable instanceof IcebergTable icebergTable) ||
+                !shouldPlanIcebergShuffle(insertStmt, icebergTable, sessionVariable)) {
+            return new PreOptimizePlanContext(root, requiredColumns, null);
+        }
+
+        Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>> result =
+                buildIcebergPartitionShuffleColumns(icebergTable, outputColumns, columnRefFactory);
+        Map<ColumnRefOperator, ScalarOperator> transformProjection = result.second;
+        if (transformProjection.isEmpty()) {
+            return new PreOptimizePlanContext(root, requiredColumns, result.first);
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        for (ColumnRefOperator col : outputColumns) {
+            projectionMap.put(col, col);
+        }
+        projectionMap.putAll(transformProjection);
+        for (ColumnRefOperator transformCol : transformProjection.keySet()) {
+            requiredColumns.union(transformCol.getId());
+        }
+        root = OptExpression.create(new LogicalProjectOperator(projectionMap), root);
+        return new PreOptimizePlanContext(root, requiredColumns, result.first);
+    }
+
+    private boolean shouldPlanIcebergShuffle(InsertStmt insertStmt, IcebergTable icebergTable,
+                                             SessionVariable sessionVariable) {
+        ConnectorSinkShuffleMode shuffleMode = sessionVariable.getConnectorSinkShuffleMode();
+        if (shuffleMode == ConnectorSinkShuffleMode.NEVER || icebergTable.getPartitionColumns().isEmpty()) {
+            return false;
+        }
+        return shuffleMode == ConnectorSinkShuffleMode.FORCE ||
+                (shuffleMode == ConnectorSinkShuffleMode.AUTO &&
+                        shouldEnableAdaptiveGlobalShuffle(insertStmt, icebergTable, sessionVariable));
     }
 
     private void castLiteralToTargetColumnsType(InsertStmt insertStatement) {
@@ -912,6 +965,169 @@ public class InsertPlanner {
     }
 
     /**
+     * Build partition shuffle columns for Iceberg tables with partition transforms.
+     * For identity transforms, uses the source column ref directly.
+     * For non-identity transforms (year, month, day, hour, bucket, truncate), creates
+     * CallOperator expressions so shuffle happens on transformed values.
+     *
+     * @return Pair of (partition column IDs for hash distribution, projection map for transform expressions)
+     */
+    private Pair<List<Integer>, Map<ColumnRefOperator, ScalarOperator>> buildIcebergPartitionShuffleColumns(
+            IcebergTable icebergTable, List<ColumnRefOperator> outputColumns, ColumnRefFactory columnRefFactory) {
+        List<Integer> partitionColumnIDs = new ArrayList<>();
+        Map<ColumnRefOperator, ScalarOperator> transformProjection = new HashMap<>();
+
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        PartitionSpec spec = nativeTable.spec();
+
+        // For unpartitioned tables or identity-only partitions, fall back to source column indexes
+        if (spec.isUnpartitioned()) {
+            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
+                    .filter(x -> x >= 0 && x < outputColumns.size())
+                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+            return Pair.create(fallbackIDs, transformProjection);
+        }
+
+        boolean allIdentity = spec.fields().stream().allMatch(f -> f.transform().isIdentity());
+        if (allIdentity) {
+            List<Integer> fallbackIDs = icebergTable.partitionColumnIndexes().stream()
+                    .filter(x -> x >= 0 && x < outputColumns.size())
+                    .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+            return Pair.create(fallbackIDs, transformProjection);
+        }
+
+        org.apache.iceberg.Schema icebergSchema = nativeTable.schema();
+        List<Column> fullSchema = icebergTable.getFullSchema();
+
+        for (PartitionField field : spec.fields()) {
+            String sourceColumnName = icebergSchema.findColumnName(field.sourceId());
+            int sourceColumnIndex = -1;
+            for (int i = 0; i < fullSchema.size(); i++) {
+                if (fullSchema.get(i).getName().equalsIgnoreCase(sourceColumnName)) {
+                    sourceColumnIndex = i;
+                    break;
+                }
+            }
+            if (sourceColumnIndex < 0 || sourceColumnIndex >= outputColumns.size()) {
+                continue;
+            }
+
+            ColumnRefOperator sourceRef = outputColumns.get(sourceColumnIndex);
+            IcebergPartitionTransform transform =
+                    IcebergPartitionTransform.fromString(field.transform().toString());
+
+            switch (transform) {
+                case IDENTITY:
+                    partitionColumnIDs.add(sourceRef.getId());
+                    break;
+                case YEAR:
+                case MONTH:
+                case DAY:
+                case HOUR: {
+                    String funcName = FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX +
+                            transform.name().toLowerCase();
+                    Type[] argTypes = new Type[] {sourceRef.getType()};
+                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        // Fallback to source column if function not found
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    Type returnType = fn.getReturnType();
+                    CallOperator callOp = new CallOperator(funcName, returnType, Lists.newArrayList(sourceRef), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(
+                            funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case BUCKET: {
+                    int numBuckets = extractTransformParam(field.transform().toString());
+                    if (numBuckets <= 0) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    String funcName = FunctionSet.ICEBERG_TRANSFORM_BUCKET;
+                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
+                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    Type returnType = fn.getReturnType();
+                    CallOperator callOp = new CallOperator(funcName, returnType,
+                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(numBuckets)), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(
+                            funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case TRUNCATE: {
+                    int width = extractTransformParam(field.transform().toString());
+                    if (width <= 0) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    String funcName = FunctionSet.ICEBERG_TRANSFORM_TRUNCATE;
+                    Type[] argTypes = new Type[] {sourceRef.getType(), com.starrocks.type.IntegerType.INT};
+                    Function fn = ExprUtils.getBuiltinFunction(funcName, argTypes,
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    if (fn == null) {
+                        partitionColumnIDs.add(sourceRef.getId());
+                        break;
+                    }
+                    // For truncate, the return type matches the source column type (mirrors FunctionAnalyzer).
+                    // fn.getReturnType() returns a generic DECIMAL type for decimal columns (wildcard
+                    // precision/scale), which would produce incorrect shuffle hash keys.
+                    Type returnType = sourceRef.getType();
+                    CallOperator callOp = new CallOperator(funcName, returnType,
+                            Lists.newArrayList(sourceRef, ConstantOperator.createInt(width)), fn);
+                    ColumnRefOperator transformRef = columnRefFactory.create(
+                            funcName, returnType, true);
+                    transformProjection.put(transformRef, callOp);
+                    partitionColumnIDs.add(transformRef.getId());
+                    break;
+                }
+                case UNKNOWN:
+                default:
+                    // Skip void/unknown transforms
+                    break;
+            }
+        }
+
+        return Pair.create(partitionColumnIDs, transformProjection);
+    }
+
+    private static int extractTransformParam(String transform) {
+        int l = transform.indexOf('[');
+        int r = transform.indexOf(']');
+        if (l >= 0 && r > l) {
+            try {
+                return Integer.parseInt(transform.substring(l + 1, r));
+            } catch (NumberFormatException ignore) {
+                // fall through
+            }
+        }
+        return 0;
+    }
+
+    private static final class PreOptimizePlanContext {
+        private final OptExpression root;
+        private final ColumnRefSet requiredColumns;
+        private final List<Integer> partitionColumnIDs;
+
+        private PreOptimizePlanContext(OptExpression root, ColumnRefSet requiredColumns,
+                                       List<Integer> partitionColumnIDs) {
+            this.root = root;
+            this.requiredColumns = requiredColumns;
+            this.partitionColumnIDs = partitionColumnIDs;
+        }
+    }
+
+    /**
      * OlapTableSink may be executed in multiply fragment instances of different machines
      * For non-duplicate key types, we must guarantee that the orders of the same key are
      * exactly the same. In order to achieve this goal, we can perform shuffle before TableSink
@@ -919,7 +1135,8 @@ public class InsertPlanner {
      */
     private PhysicalPropertySet createPhysicalPropertySet(InsertStmt insertStmt,
                                                           List<ColumnRefOperator> outputColumns,
-                                                          SessionVariable session) {
+                                                          SessionVariable session,
+                                                          List<Integer> preComputedPartitionColumnIDs) {
         QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
         if ((queryRelation instanceof SelectRelation && queryRelation.hasLimit())) {
             DistributionProperty distributionProperty = DistributionProperty
@@ -933,20 +1150,12 @@ public class InsertPlanner {
 
             // Create distribution property if global shuffle is enabled
             DistributionProperty distributionProperty = EmptyDistributionProperty.INSTANCE;
-            ConnectorSinkShuffleMode shuffleMode = session.getConnectorSinkShuffleMode();
 
-            // For shuffle mode except NEVER, only apply shuffle to partitioned tables
-            if (shuffleMode != ConnectorSinkShuffleMode.NEVER && !icebergTable.getPartitionColumns().isEmpty()) {
-
-                // For FORCE mode - always enable global shuffle, we also handle the old session variable
-                // `enable_iceberg_sink_global_shuffle` for compatibility.
-                // For AUTO mode - use adaptive logic based on partition count and backend count
-                if (shuffleMode == ConnectorSinkShuffleMode.FORCE || (shuffleMode == ConnectorSinkShuffleMode.AUTO &&
-                        shouldEnableAdaptiveGlobalShuffle(insertStmt, icebergTable, session))) {
-                    List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
-                            .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                    distributionProperty = createDistributionPropertyFromPartitions(partitionColumnIDs);
-                }
+            if (preComputedPartitionColumnIDs != null && !preComputedPartitionColumnIDs.isEmpty()) {
+                // Use pre-computed partition column IDs (which may include transform expressions).
+                // If preComputedPartitionColumnIDs is null, shouldPlanIcebergShuffle already decided
+                // not to shuffle, so we skip redundant re-evaluation.
+                distributionProperty = createDistributionPropertyFromPartitions(preComputedPartitionColumnIDs);
             }
 
             // Check if we should use host-level sorting for connector sink

--- a/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
@@ -161,9 +161,9 @@ public class InsertPlannerTest {
 
         // Use reflection to call the private method
         Method method = InsertPlanner.class.getDeclaredMethod(
-                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class, List.class);
         method.setAccessible(true);
-        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session, null);
 
         // FILE mode should not create SortProperty
         // PhysicalPropertySet should be empty (no distribution, no sort)
@@ -196,9 +196,9 @@ public class InsertPlannerTest {
 
         // Use reflection to call the private method
         Method method = InsertPlanner.class.getDeclaredMethod(
-                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class, List.class);
         method.setAccessible(true);
-        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session, null);
 
         // HOST mode with no sort order should not create SortProperty
         assert result != null;
@@ -254,9 +254,9 @@ public class InsertPlannerTest {
 
         // Use reflection to call the private method
         Method method = InsertPlanner.class.getDeclaredMethod(
-                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class, List.class);
         method.setAccessible(true);
-        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session, null);
 
         // Verify the result - HOST mode with sort order should create SortProperty
         assert result != null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -40,15 +40,19 @@ import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -66,6 +71,15 @@ public class InsertPlanTest extends PlanTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        starRocksAssert.withTable("CREATE TABLE iceberg_shuffle_src (\n" +
+                "  id INT,\n" +
+                "  dt DATE,\n" +
+                "  ts DATETIME,\n" +
+                "  data VARCHAR(20)\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES ('replication_num' = '1');");
     }
 
     @Test
@@ -929,99 +943,16 @@ public class InsertPlanTest extends PlanTestBase {
 
     @Test
     public void testInsertIcebergWithGlobalShuffle() throws Exception {
-        String createIcebergCatalogStmt = "create external catalog iceberg_catalog_shuffle properties (\"type\"=\"iceberg\", " +
-                "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
-        starRocksAssert.withCatalog(createIcebergCatalogStmt);
-        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
-
-        Table nativeTable = new BaseTable(null, null);
-
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "k1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec identitySpec = PartitionSpec.builderFor(icebergSchema).identity("k1").build();
         Column k1 = new Column("k1", IntegerType.INT);
         Column k2 = new Column("k2", IntegerType.INT);
-        IcebergTable.Builder builder = IcebergTable.builder();
-        builder.setCatalogName("iceberg_catalog_shuffle");
-        builder.setCatalogDBName("iceberg_db");
-        builder.setCatalogTableName("iceberg_table");
-        builder.setSrTableName("iceberg_table");
-        builder.setFullSchema(Lists.newArrayList(k1, k2));
-        builder.setNativeTable(nativeTable);
-        IcebergTable icebergTable = builder.build();
-
-        new Expectations(icebergTable) {
-            {
-                icebergTable.getUUID();
-                result = 12345566;
-                minTimes = 0;
-
-                icebergTable.isUnPartitioned();
-                result = false;
-                minTimes = 0;
-
-                icebergTable.getPartitionColumns();
-                result = Arrays.asList(k1);
-
-                icebergTable.partitionColumnIndexes();
-                result = Arrays.asList(0);
-            }
-        };
-
-        new Expectations(nativeTable) {
-            {
-                nativeTable.sortOrder();
-                result = SortOrder.unsorted();
-                minTimes = 0;
-
-                nativeTable.location();
-                result = "hdfs://fake_location";
-                minTimes = 0;
-
-                nativeTable.properties();
-                result = new HashMap<String, String>();
-                minTimes = 0;
-
-                nativeTable.io();
-                result = new HadoopFileIO();
-                minTimes = 0;
-
-                nativeTable.spec();
-                result = PartitionSpec.unpartitioned();
-            }
-        };
-
-        new Expectations(metadata) {
-            {
-                metadata.getDb((ConnectContext) any, "iceberg_catalog_shuffle", "iceberg_db");
-                result = new Database(12345566, "iceberg_db");
-                minTimes = 0;
-
-                metadata.getTable((ConnectContext) any, "iceberg_catalog_shuffle", "iceberg_db", "iceberg_table");
-                result = icebergTable;
-                minTimes = 0;
-            }
-        };
-
-        new MockUp<SessionVariable>() {
-            @Mock
-            public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
-                return ConnectorSinkShuffleMode.FORCE;
-            }
-        };
-
-        new MockUp<MetaUtils>() {
-            @Mock
-            public Database getDatabase(String catalogName, String tableName) {
-                return new Database(12345566, "iceberg_db");
-            }
-
-            @Mock
-            public com.starrocks.catalog.Table getSessionAwareTable(
-                    ConnectContext context, Database database, TableName tableName) {
-                return icebergTable;
-            }
-        };
-
-        String actualRes = getInsertExecPlan(
-                "explain insert into iceberg_catalog_shuffle.iceberg_db.iceberg_table select 1, 2 from t0");
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_shuffle", "iceberg_table", 12345566, icebergSchema, identitySpec,
+                Lists.newArrayList(k1, k2), Lists.newArrayList(k1), Arrays.asList(0), "select 1, 2 from t0");
         String expected = "PLAN FRAGMENT 0\n" +
                 " OUTPUT EXPRS:6: k1 | 7: k2\n" +
                 "  PARTITION: HASH_PARTITIONED: 6: k1\n" +
@@ -1055,6 +986,218 @@ public class InsertPlanTest extends PlanTestBase {
                 "     cardinality=1\n" +
                 "     avgRowSize=9.0\n";
         Assertions.assertEquals(expected, actualRes);
+        Assertions.assertFalse(actualRes.contains(FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX),
+                "Identity partition should shuffle on source column, but got:\n" + actualRes);
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "k1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec bucketSpec = PartitionSpec.builderFor(icebergSchema).bucket("k1", 10).build();
+        Column k1 = new Column("k1", IntegerType.INT);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform", "iceberg_transform_table", 12345567, icebergSchema, bucketSpec,
+                Lists.newArrayList(k1, k2), Lists.newArrayList(k1), Arrays.asList(0), "select v1, v2 from t0");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_bucket");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleYearTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.DateType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec yearSpec = PartitionSpec.builderFor(icebergSchema).year("ts").build();
+        Column ts = new Column("ts", DateType.DATE);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_year", "iceberg_year_table", 12345568, icebergSchema, yearSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select dt, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_year");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleMonthTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.DateType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec monthSpec = PartitionSpec.builderFor(icebergSchema).month("ts").build();
+        Column ts = new Column("ts", DateType.DATE);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_month", "iceberg_month_table", 12345569, icebergSchema, monthSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select dt, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_month");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleDayTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.DateType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec daySpec = PartitionSpec.builderFor(icebergSchema).day("ts").build();
+        Column ts = new Column("ts", DateType.DATE);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_day", "iceberg_day_table", 12345570, icebergSchema, daySpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select dt, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_day");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleHourTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "ts", Types.TimestampType.withoutZone()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec hourSpec = PartitionSpec.builderFor(icebergSchema).hour("ts").build();
+        Column ts = new Column("ts", DateType.DATETIME);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_hour", "iceberg_hour_table", 12345571, icebergSchema, hourSpec,
+                Lists.newArrayList(ts, k2), Lists.newArrayList(ts), Arrays.asList(0),
+                "select ts, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_hour");
+    }
+
+    @Test
+    public void testInsertIcebergWithGlobalShuffleTruncateTransformPartition() throws Exception {
+        Schema icebergSchema = new Schema(
+                Types.NestedField.required(1, "data", Types.StringType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        PartitionSpec truncateSpec = PartitionSpec.builderFor(icebergSchema).truncate("data", 5).build();
+        Column data = new Column("data", StringType.STRING);
+        Column k2 = new Column("k2", IntegerType.INT);
+        String actualRes = getIcebergInsertExecPlanWithGlobalShuffle(
+                "iceberg_catalog_transform_truncate", "iceberg_truncate_table", 12345572, icebergSchema, truncateSpec,
+                Lists.newArrayList(data, k2), Lists.newArrayList(data), Arrays.asList(0),
+                "select data, id from iceberg_shuffle_src");
+        assertHashPartitionedByExpression(actualRes, "__iceberg_transform_truncate");
+    }
+
+    private String getIcebergInsertExecPlanWithGlobalShuffle(String catalogName, String tableName, long tableId,
+                                                             Schema icebergSchema, PartitionSpec partitionSpec,
+                                                             List<Column> fullSchema, List<Column> partitionColumns,
+                                                             List<Integer> partitionColumnIndexes, String selectSql)
+            throws Exception {
+        String createIcebergCatalogStmt = String.format(
+                "create external catalog %s properties (\"type\"=\"iceberg\", " +
+                        "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")",
+                catalogName);
+        starRocksAssert.withCatalog(createIcebergCatalogStmt);
+        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
+
+        Table nativeTable = new BaseTable(null, null);
+        IcebergTable.Builder builder = IcebergTable.builder();
+        builder.setCatalogName(catalogName);
+        builder.setCatalogDBName("iceberg_db");
+        builder.setCatalogTableName(tableName);
+        builder.setSrTableName(tableName);
+        builder.setFullSchema(fullSchema);
+        builder.setNativeTable(nativeTable);
+        IcebergTable icebergTable = builder.build();
+
+        new Expectations(icebergTable) {
+            {
+                icebergTable.getUUID();
+                result = tableId;
+                minTimes = 0;
+
+                icebergTable.isUnPartitioned();
+                result = false;
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = partitionColumns;
+                minTimes = 0;
+
+                icebergTable.partitionColumnIndexes();
+                result = partitionColumnIndexes;
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(nativeTable) {
+            {
+                nativeTable.sortOrder();
+                result = SortOrder.unsorted();
+                minTimes = 0;
+
+                nativeTable.location();
+                result = "hdfs://fake_location";
+                minTimes = 0;
+
+                nativeTable.properties();
+                result = new HashMap<String, String>();
+                minTimes = 0;
+
+                nativeTable.io();
+                result = new HadoopFileIO();
+                minTimes = 0;
+
+                nativeTable.spec();
+                result = partitionSpec;
+                minTimes = 0;
+
+                nativeTable.schema();
+                result = icebergSchema;
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, catalogName, "iceberg_db");
+                result = new Database(tableId, "iceberg_db");
+                minTimes = 0;
+
+                metadata.getTable((ConnectContext) any, catalogName, "iceberg_db", tableName);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<SessionVariable>() {
+            @Mock
+            public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+                return ConnectorSinkShuffleMode.FORCE;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Database getDatabase(String currentCatalogName, String dbName) {
+                return new Database(tableId, "iceberg_db");
+            }
+
+            @Mock
+            public com.starrocks.catalog.Table getSessionAwareTable(
+                    ConnectContext context, Database database, TableName currentTableName) {
+                return icebergTable;
+            }
+        };
+
+        return getInsertExecPlan(String.format(
+                "explain insert into %s.iceberg_db.%s %s", catalogName, tableName, selectSql));
+    }
+
+    private void assertHashPartitionedByExpression(String actualRes, String expectedExpr) {
+        Assertions.assertTrue(actualRes.contains(expectedExpr),
+                "Expected shuffle expression " + expectedExpr + " but got:\n" + actualRes);
+        Pattern distributionPattern = Pattern.compile(
+                "HASH_PARTITIONED:[^\\n]*" + Pattern.quote(expectedExpr));
+        Assertions.assertTrue(distributionPattern.matcher(actualRes).find(),
+                "Expected HASH_PARTITIONED on " + expectedExpr + " but got:\n" + actualRes);
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_global_shuffle_transform
+++ b/test/sql/test_iceberg/R/test_iceberg_global_shuffle_transform
@@ -1,0 +1,240 @@
+-- name: test_iceberg_global_shuffle_transform
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog iceberg_shuffle_${uuid0} PROPERTIES (
+    "type" = "iceberg", 
+    "iceberg.catalog.type" = "hadoop", 
+    "iceberg.catalog.warehouse" = "oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0};
+-- result:
+-- !result
+set connector_sink_shuffle_mode = 'force';
+-- result:
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition (
+    id int,
+    name string
+) partition by bucket(id, 3);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+-- result:
+1	a
+2	b
+3	c
+4	d
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition (
+    event_date date,
+    name string
+) partition by year(event_date);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2024-02-20', 'b'), 
+    (date '2023-06-10', 'c');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition order by event_date;
+-- result:
+2023-01-15	a
+2023-06-10	c
+2024-02-20	b
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition (
+    event_date date,
+    name string
+) partition by month(event_date);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2023-02-20', 'b'), 
+    (date '2023-01-25', 'c');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition order by event_date;
+-- result:
+2023-01-15	a
+2023-01-25	c
+2023-02-20	b
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition (
+    event_date date,
+    name string
+) partition by day(event_date);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2023-01-16', 'b'), 
+    (date '2023-01-15', 'c');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition order by event_date;
+-- result:
+2023-01-15	a
+2023-01-15	c
+2023-01-16	b
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition (
+    event_ts datetime,
+    name string
+) partition by hour(event_ts);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition values 
+    (datetime '2023-01-15 10:30:00', 'a'), 
+    (datetime '2023-01-15 11:45:00', 'b'), 
+    (datetime '2023-01-15 10:00:00', 'c');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition order by event_ts;
+-- result:
+2023-01-15 10:00:00	c
+2023-01-15 10:30:00	a
+2023-01-15 11:45:00	b
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition (
+    name string,
+    value int
+) partition by truncate(name, 3);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition values 
+    ('apple', 1), 
+    ('application', 2), 
+    ('banana', 3);
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition order by name;
+-- result:
+apple	1
+application	2
+banana	3
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition (
+    id int,
+    event_date date,
+    name string
+) partition by bucket(id, 2), month(event_date);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition values 
+    (1, date '2023-01-15', 'a'), 
+    (2, date '2023-01-20', 'b'), 
+    (1, date '2023-02-10', 'c');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition order by id, event_date;
+-- result:
+1	2023-01-15	a
+1	2023-02-10	c
+2	2023-01-20	b
+-- !result
+set connector_sink_shuffle_mode = 'auto';
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (5, 'e'), (6, 'f');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+-- result:
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+-- !result
+set connector_sink_shuffle_mode = 'never';
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (7, 'g'), (8, 'h');
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+-- result:
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+7	g
+8	h
+-- !result
+set connector_sink_shuffle_mode = 'force';
+-- result:
+-- !result
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table (
+    id int,
+    event_date date,
+    name string
+) partition by bucket(id, 2);
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table values 
+    (10, date '2024-01-01', 'src_a'),
+    (20, date '2024-01-02', 'src_b'),
+    (10, date '2024-01-03', 'src_c');
+-- result:
+-- !result
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition 
+select id, name from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table order by id;
+-- result:
+-- !result
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition where id >= 10 order by id;
+-- result:
+10	src_a
+10	src_c
+20	src_b
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition force;
+-- result:
+-- !result
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition force;
+-- result:
+-- !result
+drop database iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_shuffle_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_global_shuffle_transform
+++ b/test/sql/test_iceberg/T/test_iceberg_global_shuffle_transform
@@ -1,0 +1,153 @@
+-- name: test_iceberg_global_shuffle_transform
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog iceberg_shuffle_${uuid0} PROPERTIES (
+    "type" = "iceberg", 
+    "iceberg.catalog.type" = "hadoop", 
+    "iceberg.catalog.warehouse" = "oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0};
+
+set connector_sink_shuffle_mode = 'force';
+
+-- test bucket partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition (
+    id int,
+    name string
+) partition by bucket(id, 3);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+
+-- test year partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition (
+    event_date date,
+    name string
+) partition by year(event_date);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2024-02-20', 'b'), 
+    (date '2023-06-10', 'c');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition order by event_date;
+
+-- test month partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition (
+    event_date date,
+    name string
+) partition by month(event_date);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2023-02-20', 'b'), 
+    (date '2023-01-25', 'c');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition order by event_date;
+
+-- test day partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition (
+    event_date date,
+    name string
+) partition by day(event_date);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition values 
+    (date '2023-01-15', 'a'), 
+    (date '2023-01-16', 'b'), 
+    (date '2023-01-15', 'c');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition order by event_date;
+
+-- test hour partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition (
+    event_ts datetime,
+    name string
+) partition by hour(event_ts);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition values 
+    (datetime '2023-01-15 10:30:00', 'a'), 
+    (datetime '2023-01-15 11:45:00', 'b'), 
+    (datetime '2023-01-15 10:00:00', 'c');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition order by event_ts;
+
+-- test truncate partition with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition (
+    name string,
+    value int
+) partition by truncate(name, 3);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition values 
+    ('apple', 1), 
+    ('application', 2), 
+    ('banana', 3);
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition order by name;
+
+-- test multiple transform partitions with global shuffle
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition (
+    id int,
+    event_date date,
+    name string
+) partition by bucket(id, 2), month(event_date);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition values 
+    (1, date '2023-01-15', 'a'), 
+    (2, date '2023-01-20', 'b'), 
+    (1, date '2023-02-10', 'c');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition order by id, event_date;
+
+-- test with connector_sink_shuffle_mode = auto
+set connector_sink_shuffle_mode = 'auto';
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (5, 'e'), (6, 'f');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+
+-- test with connector_sink_shuffle_mode = never (no shuffle)
+set connector_sink_shuffle_mode = 'never';
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition values (7, 'g'), (8, 'h');
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition order by id;
+
+-- test insert from source table with transform partition
+set connector_sink_shuffle_mode = 'force';
+
+create table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table (
+    id int,
+    event_date date,
+    name string
+) partition by bucket(id, 2);
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table values 
+    (10, date '2024-01-01', 'src_a'),
+    (20, date '2024-01-02', 'src_b'),
+    (10, date '2024-01-03', 'src_c');
+
+insert into iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition 
+select id, name from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table order by id;
+
+select * from iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition where id >= 10 order by id;
+
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.source_table force;
+
+-- cleanup
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.bucket_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.year_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.month_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.day_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.hour_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.truncate_partition force;
+drop table iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0}.multi_transform_partition force;
+drop database iceberg_shuffle_${uuid0}.iceberg_shuffle_db_${uuid0};
+drop catalog iceberg_shuffle_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_global_shuffle_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## What I'm doing:
This pull request refactors and enhances the planning logic for INSERT operations into Iceberg tables, specifically improving how partition shuffle columns are handled when partition transforms are present. The changes introduce a new mechanism to precompute partition shuffle columns—including transformed expressions—for more accurate and efficient data distribution during inserts. Additionally, the code is reorganized to cleanly separate pre-optimization context preparation and to ensure partition shuffle logic is consistently applied. Test cases are updated to reflect the new method signatures.

Enhancements for Iceberg partition shuffle planning:

* Added `buildIcebergPartitionShuffleColumns` method to compute partition shuffle columns, supporting both identity and non-identity transforms (year, month, day, hour, bucket, truncate) using `CallOperator` expressions for non-identity transforms.
* Refactored the planning flow by introducing `PreOptimizePlanContext`, which encapsulates the optimized plan root, required columns, and precomputed partition column IDs, ensuring partition shuffle logic is applied before physical property set creation.

Distribution property computation improvements:

* Modified `createPhysicalPropertySet` to accept precomputed partition column IDs and use them for distribution property creation, ensuring transformed partition columns are considered for shuffle.

Test updates:

* Updated test cases in `InsertPlannerTest.java` to use the new method signature for `createPhysicalPropertySet`, passing the partition column IDs as an additional argument.
Dependency and import updates:

* Added necessary imports for new classes and utilities used in partition transform computation and expression handling. 


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
