### PR TITLE
[BugFix] Fix Broker Load GCS auth failure after gcs-connector upgrade to 3.0.13

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
@@ -63,13 +63,23 @@ public class GCPCloudCredential implements CloudCredential {
         return endpoint;
     }
 
+    private boolean hasServiceAccountCredentials() {
+        return !serviceAccountEmail.isEmpty() && !serviceAccountPrivateKeyId.isEmpty()
+                && !serviceAccountPrivateKey.isEmpty();
+    }
+
+    private boolean hasAccessToken() {
+        return accessToken != null && !accessToken.isEmpty();
+    }
+
     private void tryGenerateHadoopConfiguration(Map<String, String> hadoopConfiguration) {
         if (!endpoint.isEmpty()) {
             hadoopConfiguration.put("fs.gs.endpoint", endpoint);
         }
         if (useComputeEngineServiceAccount) {
             hadoopConfiguration.put("fs.gs.auth.type", "COMPUTE_ENGINE");
-        } else {
+        } else if (hasServiceAccountCredentials()) {
+            hadoopConfiguration.put("fs.gs.auth.type", "SERVICE_ACCOUNT_JSON_KEYFILE");
             hadoopConfiguration.put("fs.gs.auth.service.account.email", serviceAccountEmail);
             hadoopConfiguration.put("fs.gs.auth.service.account.private.key.id", serviceAccountPrivateKeyId);
             hadoopConfiguration.put("fs.gs.auth.service.account.private.key", serviceAccountPrivateKey);
@@ -77,7 +87,7 @@ public class GCPCloudCredential implements CloudCredential {
         if (!impersonationServiceAccount.isEmpty()) {
             hadoopConfiguration.put("fs.gs.auth.impersonation.service.account", impersonationServiceAccount);
         }
-        if (accessToken != null && !accessToken.isEmpty()) {
+        if (hasAccessToken()) {
             hadoopConfiguration.put("fs.gs.auth.access.token.provider.impl",
                     ACCESS_TOKEN_PROVIDER_IMPL);
             hadoopConfiguration.put(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY, accessToken);
@@ -97,11 +107,10 @@ public class GCPCloudCredential implements CloudCredential {
         if (useComputeEngineServiceAccount) {
             return true;
         }
-        if (!serviceAccountEmail.isEmpty() && !serviceAccountPrivateKeyId.isEmpty()
-                && !serviceAccountPrivateKey.isEmpty()) {
+        if (hasServiceAccountCredentials()) {
             return true;
         }
-        if (accessToken != null && !accessToken.isEmpty()) {
+        if (hasAccessToken()) {
             return true;
         }
         return false;
@@ -134,7 +143,7 @@ public class GCPCloudCredential implements CloudCredential {
         gsFileStoreInfo.setEndpoint(endpoint);
 
         gsFileStoreInfo.setUseComputeEngineServiceAccount(useComputeEngineServiceAccount);
-        if (!useComputeEngineServiceAccount) {
+        if (hasServiceAccountCredentials()) {
             gsFileStoreInfo.setServiceAccountEmail(serviceAccountEmail);
             gsFileStoreInfo.setServiceAccountPrivateKeyId(serviceAccountPrivateKeyId);
             gsFileStoreInfo.setServiceAccountPrivateKey(serviceAccountPrivateKey);

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -386,6 +386,10 @@ public class CloudConfigurationFactoryTest {
                         "cred=GCPCloudCredential{endpoint='http://xx', useComputeEngineServiceAccount=false, " +
                         "serviceAccountEmail='XX', serviceAccountPrivateKeyId='XX', serviceAccountPrivateKey='XX', " +
                         "impersonationServiceAccount='XX', accessToken='', accessTokenExpiresAt=''}}");
+        Assertions.assertEquals("SERVICE_ACCOUNT_JSON_KEYFILE", conf.get("fs.gs.auth.type"));
+        Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.email"));
+        Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.private.key.id"));
+        Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.private.key"));
     }
 
     @Test
@@ -402,6 +406,10 @@ public class CloudConfigurationFactoryTest {
                         "serviceAccountPrivateKey='', impersonationServiceAccount='', accessToken='access_token', " +
                         "accessTokenExpiresAt='9223372036854775807'}}",
                 cloudConfiguration.toConfString());
+        Configuration conf = new Configuration();
+        cloudConfiguration.applyToConfiguration(conf);
+        Assertions.assertNull(conf.get("fs.gs.auth.type"));
+        Assertions.assertEquals("access_token", conf.get("fs.gs.temporary.access.token"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.credential.gcp;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GCPCloudCredentialTest {
+
+    @Test
+    public void testServiceAccountCredentials() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", false,
+                "test@project.iam.gserviceaccount.com",
+                "key-id-123",
+                "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+                "", null, null);
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        assertEquals("SERVICE_ACCOUNT_JSON_KEYFILE", conf.get("fs.gs.auth.type"));
+        assertEquals("test@project.iam.gserviceaccount.com",
+                conf.get("fs.gs.auth.service.account.email"));
+        assertEquals("key-id-123",
+                conf.get("fs.gs.auth.service.account.private.key.id"));
+        assertEquals("-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+                conf.get("fs.gs.auth.service.account.private.key"));
+        assertTrue(credential.validate());
+    }
+
+    @Test
+    public void testEmptyServiceAccountCredentials() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", false,
+                "", "", "",
+                "",
+                "ya29.access-token", "2026-12-31T00:00:00Z");
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        assertNull(conf.get("fs.gs.auth.type"));
+        assertNull(conf.get("fs.gs.auth.service.account.email"));
+        assertEquals("ya29.access-token",
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
+        assertTrue(credential.validate());
+    }
+
+    @Test
+    public void testComputeEngineServiceAccount() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", true,
+                "", "", "",
+                "", null, null);
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        assertEquals("COMPUTE_ENGINE", conf.get("fs.gs.auth.type"));
+        assertNull(conf.get("fs.gs.auth.service.account.email"));
+        assertTrue(credential.validate());
+    }
+}


### PR DESCRIPTION
  ## Why I'm doing:

  After `gcs-connector` was upgraded from `hadoop3-2.2.26` to `3.0.13` in commit e93b3e3cb3 (#65127), Broker Load with explicit GCS service account credentials fails with:

  type:ETL_RUN_FAIL; msg:Fail to get file status: Concurrent glob execution failed:
  java.io.IOException: Error accessing gs://...

  Root cause from FE log:
  java.io.IOException: ComputeEngineCredentials cannot find the metadata server.
  This is likely because code is not running on Google Compute Engine.
  Caused by: java.net.UnknownHostException: metadata.google.internal

  `gcs-connector 3.x` requires `fs.gs.auth.type` to be explicitly set. Without it, the connector falls back to Application Default Credentials → Compute Engine metadata server → fails in non-GCE environments. The previous `gcs-connector 2.x` automatically recognized
  service account properties without `fs.gs.auth.type`.

  ## What I'm doing:

  Set `fs.gs.auth.type=SERVICE_ACCOUNT_JSON_KEYFILE` in `GCPCloudCredential.tryGenerateHadoopConfiguration()` when service account credentials are provided.

  Fixes #70011

  ## What type of PR is this:
  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  ## Does this PR entail a change in behavior?
  - [x] Yes, this PR will result in a change in behavior.
  - [ ] No, this PR will not result in a change in behavior.

  ## If yes, please specify the type of change:
  - [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [x] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:
  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This PR needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
  - [ ] This is a backport PR

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the PR will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [ ] 3.5
    - [ ] 3.4
