### PR TITLE
[Enhancement] Asynchronously close HDFS file systems to prevent blocking management thread

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -219,7 +219,7 @@ public class ThreadPoolManager {
     /**
      * A handler for rejected task that discards and log it, used for cached thread pool
      */
-    public static class LogDiscardPolicy implements RejectedExecutionHandler {
+    static class LogDiscardPolicy implements RejectedExecutionHandler {
 
         private static final Logger LOG = LogManager.getLogger(LogDiscardPolicy.class);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -219,7 +219,7 @@ public class ThreadPoolManager {
     /**
      * A handler for rejected task that discards and log it, used for cached thread pool
      */
-    static class LogDiscardPolicy implements RejectedExecutionHandler {
+    public static class LogDiscardPolicy implements RejectedExecutionHandler {
 
         private static final Logger LOG = LogManager.getLogger(LogDiscardPolicy.class);
 

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -60,10 +61,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 class ConfigurationWrap extends Configuration {
     private static final Logger LOG = LogManager.getLogger(ConfigurationWrap.class);
@@ -355,6 +362,21 @@ public class HdfsFsManager {
     protected static final String FS_TOS_REGION = "fs.tos.region";
 
     private final ScheduledExecutorService handleManagementPool = Executors.newScheduledThreadPool(1);
+
+    private long fileSystemCloseTimeoutSecs = 60L;
+
+    private final ExecutorService fileSystemClosePool = createFileSystemClosePool();
+
+    private static ThreadPoolExecutor createFileSystemClosePool() {
+        String name = "hdfs-fs-close";
+        ThreadPoolExecutor pool = ThreadPoolManager.newDaemonThreadPool(
+                5, 5, 60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(1024),
+                new ThreadPoolManager.LogDiscardPolicy(name),
+                name, true);
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
+    }
 
     private int readBufferSize = 128 << 10; // 128k
     private int writeBufferSize = 128 << 10; // 128k
@@ -1624,19 +1646,49 @@ public class HdfsFsManager {
         @Override
         public void run() {
             try {
+                int expireSeconds = Config.hdfs_file_system_expire_seconds;
+
+                List<HdfsFs> expiredFsList = new ArrayList<>();
                 for (HdfsFs fileSystem : cachedFileSystem.values()) {
-                    if (fileSystem.isExpired(Config.hdfs_file_system_expire_seconds)) {
-                        LOG.info("file system " + fileSystem + " is expired, close and remove it");
+                    if (fileSystem.isExpired(expireSeconds)) {
+                        expiredFsList.add(fileSystem);
+                    }
+                }
+
+                for (HdfsFs fileSystem : expiredFsList) {
+                    CompletableFuture<Void> cf = new CompletableFuture<>();
+                    Future<?> closeTask = fileSystemClosePool.submit(() -> {
                         fileSystem.getLock().lock();
                         try {
+                            // check expired again
+                            if (!fileSystem.isExpired(expireSeconds)) {
+                                cf.complete(null);
+                                return;
+                            }
+                            if (!cachedFileSystem.containsKey(fileSystem.getIdentity())) {
+                                cf.complete(null);
+                                return;
+                            }
+
+                            LOG.info("file system {} is expired, close and remove it", fileSystem);
                             fileSystem.closeFileSystem();
+                            cachedFileSystem.remove(fileSystem.getIdentity());
+                            cf.complete(null);
                         } catch (Throwable t) {
                             LOG.error("errors while close file system", t);
-                        } finally {
                             cachedFileSystem.remove(fileSystem.getIdentity());
+                            cf.completeExceptionally(t);
+                        } finally {
                             fileSystem.getLock().unlock();
                         }
-                    }
+                    });
+
+                    cf.orTimeout(fileSystemCloseTimeoutSecs, TimeUnit.SECONDS).whenComplete((res, ex) -> {
+                        if (ex instanceof TimeoutException) {
+                            LOG.warn("Closing file system timed out for {}, interrupting...", fileSystem);
+                            closeTask.cancel(true);
+                        }
+                    });
                 }
             } finally {
                 HdfsFsManager.this.handleManagementPool.schedule(this, 60, TimeUnit.SECONDS);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1682,6 +1682,10 @@ public class HdfsFsManager {
                                 cf.completeExceptionally(t);
                             } finally {
                                 fileSystem.getLock().unlock();
+                                // Clear interrupt status so it does not leak into the next task
+                                // executed by this thread if cancel(true) set it and closeFileSystem()
+                                // did not consume it.
+                                Thread.interrupted();
                             }
                         });
                     } catch (RejectedExecutionException e) {
@@ -1691,8 +1695,13 @@ public class HdfsFsManager {
 
                     cf.orTimeout(fileSystemCloseTimeoutSecs, TimeUnit.SECONDS).whenComplete((res, ex) -> {
                         if (ex instanceof TimeoutException) {
-                            LOG.warn("Closing file system timed out for {}, interrupting...", fileSystem);
+                            LOG.warn("Closing file system timed out for {}, interrupting and evicting from cache",
+                                    fileSystem);
                             closeTask.cancel(true);
+                            // Evict from cache regardless of whether cancel() stops the task,
+                            // so the checker does not keep submitting new close tasks for an
+                            // unresponsive FileSystem.close() that ignores interrupts.
+                            cachedFileSystem.remove(fileSystem.getIdentity(), fileSystem);
                         }
                     });
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -67,6 +67,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -368,12 +369,11 @@ public class HdfsFsManager {
     private final ExecutorService fileSystemClosePool = createFileSystemClosePool();
 
     private static ThreadPoolExecutor createFileSystemClosePool() {
-        String name = "hdfs-fs-close";
         ThreadPoolExecutor pool = ThreadPoolManager.newDaemonThreadPool(
                 5, 5, 60L, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(1024),
-                new ThreadPoolManager.LogDiscardPolicy(name),
-                name, true);
+                new ThreadPoolExecutor.AbortPolicy(),
+                "hdfs-fs-close", true);
         pool.allowCoreThreadTimeOut(true);
         return pool;
     }
@@ -1657,31 +1657,37 @@ public class HdfsFsManager {
 
                 for (HdfsFs fileSystem : expiredFsList) {
                     CompletableFuture<Void> cf = new CompletableFuture<>();
-                    Future<?> closeTask = fileSystemClosePool.submit(() -> {
-                        fileSystem.getLock().lock();
-                        try {
-                            // check expired again
-                            if (!fileSystem.isExpired(expireSeconds)) {
-                                cf.complete(null);
-                                return;
-                            }
-                            if (!cachedFileSystem.containsKey(fileSystem.getIdentity())) {
-                                cf.complete(null);
-                                return;
-                            }
+                    Future<?> closeTask;
+                    try {
+                        closeTask = fileSystemClosePool.submit(() -> {
+                            fileSystem.getLock().lock();
+                            try {
+                                // check expired again, and verify this is still the same instance in cache
+                                if (!fileSystem.isExpired(expireSeconds)) {
+                                    cf.complete(null);
+                                    return;
+                                }
+                                if (cachedFileSystem.get(fileSystem.getIdentity()) != fileSystem) {
+                                    cf.complete(null);
+                                    return;
+                                }
 
-                            LOG.info("file system {} is expired, close and remove it", fileSystem);
-                            fileSystem.closeFileSystem();
-                            cachedFileSystem.remove(fileSystem.getIdentity());
-                            cf.complete(null);
-                        } catch (Throwable t) {
-                            LOG.error("errors while close file system", t);
-                            cachedFileSystem.remove(fileSystem.getIdentity());
-                            cf.completeExceptionally(t);
-                        } finally {
-                            fileSystem.getLock().unlock();
-                        }
-                    });
+                                LOG.info("file system {} is expired, close and remove it", fileSystem);
+                                fileSystem.closeFileSystem();
+                                cachedFileSystem.remove(fileSystem.getIdentity(), fileSystem);
+                                cf.complete(null);
+                            } catch (Throwable t) {
+                                LOG.error("errors while close file system", t);
+                                cachedFileSystem.remove(fileSystem.getIdentity(), fileSystem);
+                                cf.completeExceptionally(t);
+                            } finally {
+                                fileSystem.getLock().unlock();
+                            }
+                        });
+                    } catch (RejectedExecutionException e) {
+                        LOG.warn("Close pool is saturated, will retry closing file system {} on next run", fileSystem);
+                        continue;
+                    }
 
                     cf.orTimeout(fileSystemCloseTimeoutSecs, TimeUnit.SECONDS).whenComplete((res, ex) -> {
                         if (ex instanceof TimeoutException) {
@@ -1691,7 +1697,9 @@ public class HdfsFsManager {
                     });
                 }
             } finally {
-                HdfsFsManager.this.handleManagementPool.schedule(this, 60, TimeUnit.SECONDS);
+                if (!HdfsFsManager.this.handleManagementPool.isShutdown()) {
+                    HdfsFsManager.this.handleManagementPool.schedule(this, 60, TimeUnit.SECONDS);
+                }
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
@@ -20,8 +20,10 @@ package com.starrocks.fs;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.fs.hdfs.HdfsFs;
+import com.starrocks.fs.hdfs.HdfsFsIdentity;
 import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
@@ -36,6 +38,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -275,4 +280,149 @@ public class HdfsFsManagerTest {
             fs4.getDFSFileSystem().close();
         }
     }
+
+    @Test
+    public void testFileSystemExpirationChecker() throws Exception {
+        HdfsFsManager hdfsFsManager = new HdfsFsManager();
+        ReentrantLock lock = new ReentrantLock();
+        CountDownLatch closeLatch = new CountDownLatch(1);
+
+        // Mock an expired HdfsFs
+        HdfsFs expiredFs = Mockito.mock(HdfsFs.class);
+        Mockito.when(expiredFs.isExpired(Mockito.anyLong())).thenReturn(true);
+        HdfsFsIdentity expiredIdentity = new HdfsFsIdentity("hdfs://expired", "user");
+        Mockito.when(expiredFs.getIdentity()).thenReturn(expiredIdentity);
+        Mockito.when(expiredFs.getLock()).thenReturn(lock);
+        Mockito.doAnswer(inv -> {
+            closeLatch.countDown();
+            return null;
+        }).when(expiredFs).closeFileSystem();
+
+        // Mock a non-expired HdfsFs
+        HdfsFs normalFs = Mockito.mock(HdfsFs.class);
+        Mockito.when(normalFs.isExpired(Mockito.anyLong())).thenReturn(false);
+        HdfsFsIdentity normalIdentity = new HdfsFsIdentity("hdfs://normal", "user");
+        Mockito.when(normalFs.getIdentity()).thenReturn(normalIdentity);
+        Mockito.when(normalFs.getLock()).thenReturn(lock);
+
+        // Add them to cachedFileSystem
+        Map<HdfsFsIdentity, HdfsFs> cache = Deencapsulation.getField(hdfsFsManager, "cachedFileSystem");
+        cache.put(expiredIdentity, expiredFs);
+        cache.put(normalIdentity, normalFs);
+
+        // Run the checker
+        Class<?> checkerClass = Class.forName("com.starrocks.fs.hdfs.HdfsFsManager$FileSystemExpirationChecker");
+        Runnable checker = (Runnable) Deencapsulation.newInstance(checkerClass, hdfsFsManager);
+
+        checker.run();
+
+        // Wait for closeFileSystem(), then poll until the subsequent cache.remove() also completes
+        Assertions.assertTrue(closeLatch.await(5, TimeUnit.SECONDS), "closeFileSystem was not called in time");
+        long deadline = System.currentTimeMillis() + 2000;
+        while (cache.containsKey(expiredIdentity) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+
+        // Verify expired fs is removed and closed
+        Assertions.assertFalse(cache.containsKey(expiredIdentity));
+        Mockito.verify(expiredFs, Mockito.times(1)).closeFileSystem();
+
+        // Verify normal fs is still there and not closed
+        Assertions.assertTrue(cache.containsKey(normalIdentity));
+        Mockito.verify(normalFs, Mockito.never()).closeFileSystem();
+    }
+
+    @Test
+    public void testFileSystemExpirationCheckerBranches() throws Exception {
+        HdfsFsManager hdfsFsManager = new HdfsFsManager();
+        Deencapsulation.setField(hdfsFsManager, "fileSystemCloseTimeoutSecs", 1L);
+
+        Map<HdfsFsIdentity, HdfsFs> cache = Deencapsulation.getField(hdfsFsManager, "cachedFileSystem");
+
+        // Case 1: isExpired becomes false during double check
+        HdfsFs fs1 = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs1.isExpired(Mockito.anyLong())).thenReturn(true).thenReturn(false);
+        HdfsFsIdentity id1 = new HdfsFsIdentity("hdfs://fs1", "user");
+        Mockito.when(fs1.getIdentity()).thenReturn(id1);
+        Mockito.when(fs1.getLock()).thenReturn(new ReentrantLock());
+        cache.put(id1, fs1);
+
+        // Case 2: no longer in cache
+        HdfsFs fs2 = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs2.isExpired(Mockito.anyLong())).thenReturn(true);
+        HdfsFsIdentity id2 = new HdfsFsIdentity("hdfs://fs2", "user");
+        Mockito.when(fs2.getIdentity()).thenReturn(id2);
+        Mockito.when(fs2.getLock()).thenReturn(new ReentrantLock() {
+            @Override
+            public void lock() {
+                super.lock();
+                cache.remove(id2);
+            }
+        });
+        cache.put(id2, fs2);
+
+        // Case 3: exception thrown during close
+        CountDownLatch fs3Latch = new CountDownLatch(1);
+        HdfsFs fs3 = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs3.isExpired(Mockito.anyLong())).thenReturn(true);
+        HdfsFsIdentity id3 = new HdfsFsIdentity("hdfs://fs3", "user");
+        Mockito.when(fs3.getIdentity()).thenReturn(id3);
+        Mockito.when(fs3.getLock()).thenReturn(new ReentrantLock());
+        Mockito.doAnswer(inv -> {
+            fs3Latch.countDown();
+            throw new RuntimeException("Test Exception");
+        }).when(fs3).closeFileSystem();
+        cache.put(id3, fs3);
+
+        // Case 4: timeout — blocks until interrupted, then signals via latch
+        CountDownLatch fs4InterruptedLatch = new CountDownLatch(1);
+        HdfsFs fs4 = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs4.isExpired(Mockito.anyLong())).thenReturn(true);
+        HdfsFsIdentity id4 = new HdfsFsIdentity("hdfs://fs4", "user");
+        Mockito.when(fs4.getIdentity()).thenReturn(id4);
+        Mockito.when(fs4.getLock()).thenReturn(new ReentrantLock());
+        Mockito.doAnswer(invocation -> {
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException e) {
+                fs4InterruptedLatch.countDown();
+                throw new RuntimeException(e);
+            }
+            return null;
+        }).when(fs4).closeFileSystem();
+        cache.put(id4, fs4);
+
+        // Run the checker
+        Class<?> checkerClass = Class.forName("com.starrocks.fs.hdfs.HdfsFsManager$FileSystemExpirationChecker");
+        Runnable checker = (Runnable) Deencapsulation.newInstance(checkerClass, hdfsFsManager);
+
+        checker.run();
+
+        // Wait for case 3 (exception) and case 4 (timeout interrupt) to complete
+        Assertions.assertTrue(fs3Latch.await(5, TimeUnit.SECONDS), "fs3 closeFileSystem was not called in time");
+        Assertions.assertTrue(fs4InterruptedLatch.await(5, TimeUnit.SECONDS), "fs4 was not interrupted in time");
+
+        // Allow a short window for whenComplete callbacks to update the cache
+        long deadline = System.currentTimeMillis() + 2000;
+        while (cache.containsKey(id4) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+
+        // Verify case 1
+        Mockito.verify(fs1, Mockito.never()).closeFileSystem();
+        Assertions.assertTrue(cache.containsKey(id1));
+
+        // Verify case 2
+        Mockito.verify(fs2, Mockito.never()).closeFileSystem();
+        Assertions.assertFalse(cache.containsKey(id2));
+
+        // Verify case 3
+        Mockito.verify(fs3, Mockito.times(1)).closeFileSystem();
+        Assertions.assertFalse(cache.containsKey(id3));
+
+        // Verify case 4
+        Mockito.verify(fs4, Mockito.times(1)).closeFileSystem();
+        Assertions.assertFalse(cache.containsKey(id4));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
@@ -39,6 +39,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -284,6 +287,10 @@ public class HdfsFsManagerTest {
     @Test
     public void testFileSystemExpirationChecker() throws Exception {
         HdfsFsManager hdfsFsManager = new HdfsFsManager();
+        // Shut down the auto-scheduled background checker so it cannot race with our manual run
+        ScheduledExecutorService mgmtPool = Deencapsulation.getField(hdfsFsManager, "handleManagementPool");
+        mgmtPool.shutdownNow();
+
         ReentrantLock lock = new ReentrantLock();
         CountDownLatch closeLatch = new CountDownLatch(1);
 
@@ -316,15 +323,15 @@ public class HdfsFsManagerTest {
 
         checker.run();
 
-        // Wait for closeFileSystem(), then poll until the subsequent cache.remove() also completes
+        // closeFileSystem() and cache.remove() run sequentially in the same worker thread;
+        // once the latch fires, spin-wait briefly for the remove() that immediately follows.
         Assertions.assertTrue(closeLatch.await(5, TimeUnit.SECONDS), "closeFileSystem was not called in time");
-        long deadline = System.currentTimeMillis() + 2000;
+        long deadline = System.currentTimeMillis() + 5000;
         while (cache.containsKey(expiredIdentity) && System.currentTimeMillis() < deadline) {
             Thread.sleep(10);
         }
-
         // Verify expired fs is removed and closed
-        Assertions.assertFalse(cache.containsKey(expiredIdentity));
+        Assertions.assertFalse(cache.containsKey(expiredIdentity), "cache.remove() did not complete in time");
         Mockito.verify(expiredFs, Mockito.times(1)).closeFileSystem();
 
         // Verify normal fs is still there and not closed
@@ -335,6 +342,9 @@ public class HdfsFsManagerTest {
     @Test
     public void testFileSystemExpirationCheckerBranches() throws Exception {
         HdfsFsManager hdfsFsManager = new HdfsFsManager();
+        // Shut down the auto-scheduled background checker so it cannot race with our manual run
+        ScheduledExecutorService mgmtPool = Deencapsulation.getField(hdfsFsManager, "handleManagementPool");
+        mgmtPool.shutdownNow();
         Deencapsulation.setField(hdfsFsManager, "fileSystemCloseTimeoutSecs", 1L);
 
         Map<HdfsFsIdentity, HdfsFs> cache = Deencapsulation.getField(hdfsFsManager, "cachedFileSystem");
@@ -423,6 +433,35 @@ public class HdfsFsManagerTest {
         // Verify case 4
         Mockito.verify(fs4, Mockito.times(1)).closeFileSystem();
         Assertions.assertFalse(cache.containsKey(id4));
+    }
+
+    @Test
+    public void testClosePoolRejection() throws Exception {
+        HdfsFsManager hdfsFsManager = new HdfsFsManager();
+        ScheduledExecutorService mgmtPool = Deencapsulation.getField(hdfsFsManager, "handleManagementPool");
+        mgmtPool.shutdownNow();
+
+        // Replace fileSystemClosePool with a terminated executor to simulate pool saturation
+        ExecutorService saturatedPool = Executors.newSingleThreadExecutor();
+        saturatedPool.shutdown();
+        Deencapsulation.setField(hdfsFsManager, "fileSystemClosePool", saturatedPool);
+
+        Map<HdfsFsIdentity, HdfsFs> cache = Deencapsulation.getField(hdfsFsManager, "cachedFileSystem");
+
+        HdfsFs fs = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs.isExpired(Mockito.anyLong())).thenReturn(true);
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://rejected", "user");
+        Mockito.when(fs.getIdentity()).thenReturn(id);
+        cache.put(id, fs);
+
+        Class<?> checkerClass = Class.forName("com.starrocks.fs.hdfs.HdfsFsManager$FileSystemExpirationChecker");
+        Runnable checker = (Runnable) Deencapsulation.newInstance(checkerClass, hdfsFsManager);
+
+        checker.run();
+
+        // fs should remain in cache — rejected tasks are retried on the next checker run
+        Assertions.assertTrue(cache.containsKey(id));
+        Mockito.verify(fs, Mockito.never()).closeFileSystem();
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, `FileSystemExpirationChecker` cleans up expired HDFS file systems synchronously within the FE `handleManagementPool`. If the network is unstable or the remote HDFS/Object Storage is unresponsive, `HdfsFs.closeFileSystem()` can hang for a long time. This effectively blocks the management thread, delaying or preventing other critical scheduled tasks in the FE node from executing. 

## What I'm doing:
1. **Asynchronous execution**: Introduced a bounded, dedicated daemon thread pool (`fileSystemClosePool`) using `ThreadPoolManager` to handle file system close operations asynchronously.
2. **Non-blocking timeout mechanism**: Utilized Java 11 `CompletableFuture.orTimeout()` to enforce a 60-second timeout on the close operations. This ensures the management thread is completely unblocked.
3. **Safe interruption**: If a close operation times out, it safely triggers `closeTask.cancel(true)` to send an interrupt signal to the hanging I/O thread, preventing thread and memory leaks.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
