### PR TITLE
[BugFix] Starrocks connect S3 with vip always connect the same S3 backend IP

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1177,9 +1177,9 @@ CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 
 // use poco client to replace default curl client
 CONF_Bool(enable_poco_client_for_aws_sdk, "true");
-// When true, resolve S3 endpoint hostname to IP before creating/reusing HTTP sessions.
-// Use with a VIP or DNS name that resolves to multiple backend IPs so that connections
-// are spread across nodes (each IP gets its own session pool) instead of sticking to one.
+// When true, resolve S3 endpoint hostname to IP before creating/reusing HTTP sessions (HTTP only;
+// HTTPS always uses hostname for TLS SNI and certificate verification). Use with a VIP or DNS
+// name that resolves to multiple backend IPs so that connections are spread across nodes.
 CONF_mBool(object_storage_resolve_host_to_ip, "false");
 
 // default: 16MB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1177,6 +1177,10 @@ CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 
 // use poco client to replace default curl client
 CONF_Bool(enable_poco_client_for_aws_sdk, "true");
+// When true, resolve S3 endpoint hostname to IP before creating/reusing HTTP sessions.
+// Use with a VIP or DNS name that resolves to multiple backend IPs so that connections
+// are spread across nodes (each IP gets its own session pool) instead of sticking to one.
+CONF_mBool(object_storage_resolve_host_to_ip, "false");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -503,7 +503,8 @@
         "aws_sdk_logging_trace_enabled",
         "aws_sdk_logging_trace_level",
         "aws_sdk_enable_compliant_rfc3986_encoding",
-        "enable_poco_client_for_aws_sdk"
+        "enable_poco_client_for_aws_sdk",
+        "object_storage_resolve_host_to_ip"
       ]
     },
     {

--- a/be/src/common/config_object_storage_fwd.h
+++ b/be/src/common/config_object_storage_fwd.h
@@ -91,6 +91,11 @@ CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 // use poco client to replace default curl client
 CONF_Bool(enable_poco_client_for_aws_sdk, "true");
 
+// When true, resolve S3 endpoint hostname to IP before creating/reusing HTTP sessions.
+// Use with a VIP or DNS name that resolves to multiple backend IPs so that connections
+// are spread across nodes (each IP gets its own session pool) instead of sticking to one.
+CONF_mBool(object_storage_resolve_host_to_ip, "false");
+
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");
 

--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -59,4 +59,4 @@ ADD_BE_LIB(FileSystem
     ${EXEC_FILES}
 )
 
-target_link_libraries(FileSystem PUBLIC FSCore)
+target_link_libraries(FileSystem PUBLIC FSCore Base)

--- a/be/src/fs/CMakeLists.txt
+++ b/be/src/fs/CMakeLists.txt
@@ -59,4 +59,4 @@ ADD_BE_LIB(FileSystem
     ${EXEC_FILES}
 )
 
-target_link_libraries(FileSystem PUBLIC FSCore Base)
+target_link_libraries(FileSystem PUBLIC FSCore)

--- a/be/src/fs/s3/poco_common.cpp
+++ b/be/src/fs/s3/poco_common.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "base/network/network_util.h"
 #include "runtime/current_thread.h"
 
 namespace starrocks::poco {
@@ -101,11 +102,23 @@ HTTPSessionPools& HTTPSessionPools::instance() {
     return instance;
 }
 
+// When resolve_host is true, use resolved IP as the session pool key and connection target.
+// This avoids binding all S3 traffic to a single node when using a VIP (virtual IP) that
+// resolves to one of several backend IPs: with hostname as key, the first TCP connection
+// is reused and traffic stays on one node; with resolved IP as key, different backend
+// IPs get different pools and connections are spread across nodes (e.g. DNS round-robin).
 PooledHTTPSessionPtr HTTPSessionPools::getSession(const Poco::URI& uri, const ConnectionTimeouts& timeouts,
                                                   bool resolve_host) {
-    const std::string& host = uri.getHost();
+    std::string host = uri.getHost();
     uint16_t port = uri.getPort();
     bool is_https = isHTTPS(uri);
+
+    if (resolve_host && !host.empty() && !starrocks::is_valid_ip(host)) {
+        std::string resolved_ip;
+        if (starrocks::hostname_to_ip(host, resolved_ip).ok()) {
+            host = std::move(resolved_ip);
+        }
+    }
 
     const Key key = {.host = host, .port = port, .is_https = is_https};
 

--- a/be/src/fs/s3/poco_common.cpp
+++ b/be/src/fs/s3/poco_common.cpp
@@ -14,16 +14,18 @@
 
 #include "fs/s3/poco_common.h"
 
-#include <Poco/Exception.h>
-#include <fmt/format.h>
-
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <unordered_map>
 
+#include <Poco/Exception.h>
+#include <fmt/format.h>
+
 #include "base/network/network_util.h"
+#include "common/logging.h"
 #include "runtime/current_thread.h"
 
 namespace starrocks::poco {
@@ -102,22 +104,56 @@ HTTPSessionPools& HTTPSessionPools::instance() {
     return instance;
 }
 
+// Resolve hostname to IP with TTL cache to avoid blocking DNS on every getSession() and to limit
+// _endpoint_pools growth when DNS results change. Caller must not hold _mutex.
+std::string HTTPSessionPools::resolveHostWithCache(const std::string& host) {
+    auto now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard lock(_mutex);
+        auto it = _resolve_cache.find(host);
+        if (it != _resolve_cache.end() && it->second.expiry > now) {
+            return it->second.resolved_ip;
+        }
+    }
+    std::string resolved_ip;
+    if (!starrocks::hostname_to_ip(host, resolved_ip).ok()) {
+        VLOG(2) << "Failed to resolve S3 endpoint host to IP, using hostname as pool key: " << host;
+        return host;
+    }
+    {
+        std::lock_guard lock(_mutex);
+        _resolve_cache[host] = {
+                resolved_ip,
+                now + std::chrono::seconds(RESOLVE_CACHE_TTL_SEC),
+        };
+    }
+    return resolved_ip;
+}
+
+// When endpoint pool count exceeds cap, evict oldest pools so we don't grow without bound
+// (e.g. when resolve_host is on and DNS returns changing IPs). Caller must hold _mutex.
+void HTTPSessionPools::evictExcessPoolsLocked() {
+    while (_endpoint_pools.size() >= MAX_ENDPOINT_POOLS && !_pool_order.empty()) {
+        const Key& old_key = _pool_order.front();
+        _endpoint_pools.erase(old_key);
+        _pool_order.pop_front();
+    }
+}
+
 // When resolve_host is true, use resolved IP as the session pool key and connection target.
-// This avoids binding all S3 traffic to a single node when using a VIP (virtual IP) that
-// resolves to one of several backend IPs: with hostname as key, the first TCP connection
-// is reused and traffic stays on one node; with resolved IP as key, different backend
-// IPs get different pools and connections are spread across nodes (e.g. DNS round-robin).
+// Resolved IP is cached with TTL to avoid blocking DNS on every request; pool count is capped
+// with eviction to prevent unbounded growth when DNS results change.
+// Host-to-IP resolving is applied only for HTTP. For HTTPS we keep the hostname so that TLS
+// SNI and certificate hostname verification use the hostname (certs are issued for hostnames,
+// not backend IPs); resolving HTTPS to an IP would break verification.
 PooledHTTPSessionPtr HTTPSessionPools::getSession(const Poco::URI& uri, const ConnectionTimeouts& timeouts,
                                                   bool resolve_host) {
     std::string host = uri.getHost();
     uint16_t port = uri.getPort();
     bool is_https = isHTTPS(uri);
 
-    if (resolve_host && !host.empty() && !starrocks::is_valid_ip(host)) {
-        std::string resolved_ip;
-        if (starrocks::hostname_to_ip(host, resolved_ip).ok()) {
-            host = std::move(resolved_ip);
-        }
+    if (resolve_host && !is_https && !host.empty() && !starrocks::is_valid_ip(host)) {
+        host = resolveHostWithCache(host);
     }
 
     const Key key = {.host = host, .port = port, .is_https = is_https};
@@ -125,10 +161,12 @@ PooledHTTPSessionPtr HTTPSessionPools::getSession(const Poco::URI& uri, const Co
     EndpointPoolPtr pool = nullptr;
     {
         std::lock_guard lock(_mutex);
+        evictExcessPoolsLocked();
         auto item = _endpoint_pools.find(key);
         if (item == _endpoint_pools.end()) {
             std::tie(item, std::ignore) =
                     _endpoint_pools.emplace(key, std::make_shared<EndpointHTTPSessionPool>(host, port, is_https));
+            _pool_order.push_back(key);
         }
         pool = item->second;
     }
@@ -142,6 +180,8 @@ PooledHTTPSessionPtr HTTPSessionPools::getSession(const Poco::URI& uri, const Co
 void HTTPSessionPools::shutdown() {
     std::lock_guard lock(_mutex);
     _endpoint_pools.clear();
+    _pool_order.clear();
+    _resolve_cache.clear();
 }
 
 PooledHTTPSessionPtr makeHTTPSession(const Poco::URI& uri, const ConnectionTimeouts& timeouts, bool resolve_host) {

--- a/be/src/fs/s3/poco_common.cpp
+++ b/be/src/fs/s3/poco_common.cpp
@@ -14,15 +14,15 @@
 
 #include "fs/s3/poco_common.h"
 
+#include <Poco/Exception.h>
+#include <fmt/format.h>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <unordered_map>
-
-#include <Poco/Exception.h>
-#include <fmt/format.h>
 
 #include "base/network/network_util.h"
 #include "common/logging.h"

--- a/be/src/fs/s3/poco_common.h
+++ b/be/src/fs/s3/poco_common.h
@@ -127,7 +127,7 @@ private:
 
     std::mutex _mutex;
     std::unordered_map<Key, EndpointPoolPtr, Hasher> _endpoint_pools;
-    std::list<Key> _pool_order;  // insertion order for eviction when over cap
+    std::list<Key> _pool_order; // insertion order for eviction when over cap
     std::unordered_map<std::string, ResolveCacheEntry> _resolve_cache;
 };
 

--- a/be/src/fs/s3/poco_common.h
+++ b/be/src/fs/s3/poco_common.h
@@ -21,7 +21,10 @@
 #include <Poco/URI.h>
 #include <aws/core/http/HttpRequest.h>
 
+#include <chrono>
+#include <list>
 #include <memory>
+#include <unordered_map>
 
 #include "fs/s3/pool_base.h"
 #include "runtime/exec_env.h"
@@ -98,6 +101,19 @@ private:
         }
     };
 
+    // TTL cache for hostname -> resolved IP when resolve_host is enabled, to avoid blocking DNS on every request
+    // and to limit _endpoint_pools growth when DNS results change over time.
+    struct ResolveCacheEntry {
+        std::string resolved_ip;
+        std::chrono::steady_clock::time_point expiry;
+    };
+
+    static constexpr int RESOLVE_CACHE_TTL_SEC = 60;
+    static constexpr size_t MAX_ENDPOINT_POOLS = 2048;
+
+    std::string resolveHostWithCache(const std::string& host);
+    void evictExcessPoolsLocked();
+
 public:
     using EndpointPoolPtr = std::shared_ptr<EndpointHTTPSessionPool>;
     static HTTPSessionPools& instance();
@@ -111,6 +127,8 @@ private:
 
     std::mutex _mutex;
     std::unordered_map<Key, EndpointPoolPtr, Hasher> _endpoint_pools;
+    std::list<Key> _pool_order;  // insertion order for eviction when over cap
+    std::unordered_map<std::string, ResolveCacheEntry> _resolve_cache;
 };
 
 } // namespace starrocks::poco

--- a/be/src/fs/s3/poco_http_client.cpp
+++ b/be/src/fs/s3/poco_http_client.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "base/utility/defer_op.h"
+#include "common/config_object_storage_fwd.h"
 #include "common/logging.h"
 #include "fs/s3/poco_common.h"
 #include "io/s3_zero_copy_iostream.h"
@@ -62,7 +63,7 @@ void PocoHttpClient::MakeRequestInternal(Aws::Http::HttpRequest& request,
             Poco::URI poco_uri(uri);
 
             // URI may changed, because of redirection
-            auto session = makeHTTPSession(poco_uri, timeouts, false);
+            auto session = makeHTTPSession(poco_uri, timeouts, config::object_storage_resolve_host_to_ip);
             DeferOp deal_error([&]() {
                 if (session->networkException() != nullptr) {
                     session.set_not_in_good_condition();

--- a/be/test/fs/poco_http_client_test.cpp
+++ b/be/test/fs/poco_http_client_test.cpp
@@ -212,8 +212,11 @@ TEST_F(S3PocoHttpClientTest, TestNotFoundKey) {
 // --- resolve_host behavior: avoid sticking to a single S3 node when using VIP ---
 // When resolve_host=false, session pool key is the endpoint hostname (e.g. VIP), so
 // all connections reuse the same pool and traffic goes to one node. When resolve_host=true,
-// we resolve hostname to IP and use IP as pool key, so multiple backend IPs get separate
-// pools and traffic is spread (e.g. DNS round-robin).
+// we resolve hostname to IP and use IP as pool key (HTTP only), so multiple backend IPs
+// get separate pools and traffic is spread. For HTTPS we never resolve so TLS SNI and
+// certificate hostname verification keep using the hostname. Resolve failure fallback
+// (use hostname as pool key + VLOG) is in resolveHostWithCache() and not unit-tested
+// here (would require mocking DNS).
 
 TEST_F(S3PocoHttpClientTest, ResolveHostFalse_KeepsOriginalHost) {
     Poco::URI uri("http://my.vip.host:80");
@@ -241,6 +244,16 @@ TEST_F(S3PocoHttpClientTest, ResolveHostTrue_WhenHostIsLocalhost_ResolvesToIP) {
     // Session pool key and connection target must be the resolved IP, not "localhost".
     EXPECT_TRUE(starrocks::is_valid_ip(session->getHost())) << "expected resolved IP, got: " << session->getHost();
     EXPECT_EQ(session->getPort(), 80);
+}
+
+// HTTPS never resolves host to IP so that TLS SNI and certificate verification use the hostname.
+TEST_F(S3PocoHttpClientTest, ResolveHostTrue_WhenHTTPS_KeepsHostname) {
+    Poco::URI uri("https://my.vip.host:443");
+    ConnectionTimeouts timeouts(Poco::Timespan(5000000), Poco::Timespan(5000000), Poco::Timespan(5000000));
+    auto session = makeHTTPSession(uri, timeouts, true);
+    ASSERT_NE(session.operator->(), nullptr);
+    EXPECT_EQ(session->getHost(), "my.vip.host");
+    EXPECT_EQ(session->getPort(), 443);
 }
 
 } // namespace starrocks::poco

--- a/be/test/fs/poco_http_client_test.cpp
+++ b/be/test/fs/poco_http_client_test.cpp
@@ -24,10 +24,12 @@
 
 #include <memory>
 
+#include "base/network/network_util.h"
 #include "base/testutil/assert.h"
 #include "common/config_object_storage_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_s3.h"
+#include "fs/s3/poco_common.h"
 #include "fs/s3/poco_http_client_factory.h"
 #include "io/s3_input_stream.h"
 
@@ -205,6 +207,40 @@ TEST_F(S3PocoHttpClientTest, TestNotFoundKey) {
     EXPECT_TRUE(r.status().message().find("SdkResponseCode=404") != std::string::npos);
     // ErrorCode 16 means RESOURCE_NOT_FOUND
     EXPECT_TRUE(r.status().message().find("SdkErrorType=16") != std::string::npos);
+}
+
+// --- resolve_host behavior: avoid sticking to a single S3 node when using VIP ---
+// When resolve_host=false, session pool key is the endpoint hostname (e.g. VIP), so
+// all connections reuse the same pool and traffic goes to one node. When resolve_host=true,
+// we resolve hostname to IP and use IP as pool key, so multiple backend IPs get separate
+// pools and traffic is spread (e.g. DNS round-robin).
+
+TEST_F(S3PocoHttpClientTest, ResolveHostFalse_KeepsOriginalHost) {
+    Poco::URI uri("http://my.vip.host:80");
+    ConnectionTimeouts timeouts(Poco::Timespan(5000000), Poco::Timespan(5000000), Poco::Timespan(5000000));
+    auto session = makeHTTPSession(uri, timeouts, false);
+    ASSERT_NE(session.operator->(), nullptr);
+    EXPECT_EQ(session->getHost(), "my.vip.host");
+    EXPECT_EQ(session->getPort(), 80);
+}
+
+TEST_F(S3PocoHttpClientTest, ResolveHostTrue_WhenHostIsIP_KeepsIP) {
+    Poco::URI uri("http://127.0.0.1:80");
+    ConnectionTimeouts timeouts(Poco::Timespan(5000000), Poco::Timespan(5000000), Poco::Timespan(5000000));
+    auto session = makeHTTPSession(uri, timeouts, true);
+    ASSERT_NE(session.operator->(), nullptr);
+    EXPECT_EQ(session->getHost(), "127.0.0.1");
+    EXPECT_EQ(session->getPort(), 80);
+}
+
+TEST_F(S3PocoHttpClientTest, ResolveHostTrue_WhenHostIsLocalhost_ResolvesToIP) {
+    Poco::URI uri("http://localhost:80");
+    ConnectionTimeouts timeouts(Poco::Timespan(5000000), Poco::Timespan(5000000), Poco::Timespan(5000000));
+    auto session = makeHTTPSession(uri, timeouts, true);
+    ASSERT_NE(session.operator->(), nullptr);
+    // Session pool key and connection target must be the resolved IP, not "localhost".
+    EXPECT_TRUE(starrocks::is_valid_ip(session->getHost())) << "expected resolved IP, got: " << session->getHost();
+    EXPECT_EQ(session->getPort(), 80);
 }
 
 } // namespace starrocks::poco

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -998,6 +998,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: Timeout duration to establish HTTP connections with object storage. `-1` indicates to use the default timeout duration of the SDK configurations.
 - Introduced in: v3.0.9
 
+##### object_storage_resolve_host_to_ip
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When true, the BE resolves the S3 endpoint hostname to an IP address before creating or reusing HTTP sessions. Use this when the endpoint is a VIP or DNS name that resolves to multiple backend IPs, so that connections are spread across nodes (each IP gets its own session pool) instead of sticking to a single node. When false, the session pool key is the hostname, so all traffic may reuse the same connection(s) to one backend.
+- Introduced in: -
+
 ##### parquet_late_materialization_enable
 
 - Default: true

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1004,7 +1004,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When true, the BE resolves the S3 endpoint hostname to an IP address before creating or reusing HTTP sessions. Use this when the endpoint is a VIP or DNS name that resolves to multiple backend IPs, so that connections are spread across nodes (each IP gets its own session pool) instead of sticking to a single node. When false, the session pool key is the hostname, so all traffic may reuse the same connection(s) to one backend.
+- Description: When true, the BE resolves the S3 endpoint hostname to an IP address before creating or reusing HTTP sessions. This applies to **HTTP only**; HTTPS always uses the hostname so that TLS SNI and certificate verification work (certificates are issued for hostnames, not backend IPs). Use this when the endpoint is a VIP or DNS name that resolves to multiple backend IPs, so that HTTP connections are spread across nodes (each IP gets its own session pool) instead of sticking to a single node. When false, the session pool key is the hostname.
 - Introduced in: -
 
 ##### parquet_late_materialization_enable


### PR DESCRIPTION
## Why I'm doing:

When starrocks connect  S3 by the VIP connection , starrocks will always connect  permanent S3 backend IPs, it will give S3 cluster pressure, when we connect S3 with DNS, it behaviors normal ,  starrocks connects with multiple backend S3 IPs, we can make vip and dns connection behavior the same 

## What I'm doing:
fix code 

Fixes #issue
#70024
## What type of PR is this:

- [x] BugFix

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.

If yes, please specify the type of change:

- [x] Parameter changes: default values, similar parameters but with different default values

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
- [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
