### PR TITLE
[BugFix] Fix join spill process crash when set_callback_function

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -105,10 +105,12 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
         return spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
+    _join_builder->ref();
     auto set_call_back_function = [this](RuntimeState* state) {
         auto& spiller = _join_builder->spiller();
         return spiller->set_flush_all_call_back(
-                [this]() {
+                [this, state]() {
+                    auto defer = DeferOp([&]() { _join_builder->unref(state); });
                     _is_finished = true;
                     _join_builder->enter_probe_phase();
                     FAIL_POINT_TRIGGER_EXECUTE(spill_flush_set_invalid_status, {


### PR DESCRIPTION
## Why I'm doing:

introduced in #66669

```
4.0.6-ee RELEASE (build 9c3878a distro ubuntu arch aarch64)
query_id:019cd143-4917-747d-94d9-b84fdac5b8f2, fragment_instance:019cd143-4917-747d-94d9-b84fdac5ba98, plan_node_id:-1
*** Aborted at 1773037452 (unix time) try "date -d @1773037452" if you are using GNU date ***
PC: @          0xc196cb0 std::_Function_handler<starrocks::StatusOr<std::shared_ptr<starrocks::Chunk> > (), starrocks::SpillProcessTasksBuilder::finally<starrocks::pipeline::SpillableHashJoinBuildOperator::set_fin
ishing(starrocks::RuntimeState*)::{lambda(starrocks::RuntimeState*)#
*** SIGSEGV (@0x8) received by PID 29067 (TID 0xf4bb7c3afa00) LWP(30271) from PID 8; stack trace: ***
    @     0xf4bc96b653dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @         0x10c54b58 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xf4bc97bafa84 PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0]
    @     0xf4bc97bb043c JVM_handle_linux_signal
    @     0xf4bc982148f8 ([vdso]+0x8f7)
    @          0xc196cb0 std::_Function_handler<starrocks::StatusOr<std::shared_ptr<starrocks::Chunk> > (), starrocks::SpillProcessTasksBuilder::finally<starrocks::pipeline::SpillableHashJoinBuildOperator::set_fin
ishing(starrocks::RuntimeState*)::{lambda(starrocks::RuntimeState*)#
    @          0xc0b4834 starrocks::SpillProcessChannel::close()
    @          0xc0b25cc starrocks::pipeline::SpillProcessOperator::close(starrocks::RuntimeState*)
    @          0xad4e8cc starrocks::pipeline::PipelineDriver::_mark_operator_closed(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0xad4ec14 starrocks::pipeline::PipelineDriver::_close_operators(starrocks::RuntimeState*)
    @          0xad4ef84 starrocks::pipeline::PipelineDriver::finalize(starrocks::RuntimeState*, starrocks::pipeline::DriverState)
    @          0xbda0bec starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xd88c304 starrocks::ThreadPool::dispatch_thread()
    @          0xd882fa8 starrocks::Thread::supervise_thread(void*)
    @     0xf4bc96b60398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xf4bc96bc9e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
