### PR TITLE
[BugFix] update jdbc fwd config

### DIFF
--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -121,6 +121,17 @@ CONF_Int16(jdbc_minimum_idle_connections, "1");
 // The minimum allowed value is 10000(10 seconds).
 CONF_Int32(jdbc_connection_idle_timeout_ms, "600000");
 
+// Maximum lifetime of a connection in the JDBC connection pool (ms).
+// Minimum allowed value is 30000 (30 seconds). Default: 300000 (5 minutes).
+CONF_Int64(jdbc_connection_max_lifetime_ms, "300000");
+
+// Keepalive interval for idle JDBC connections (ms).
+// Idle connections are tested at this interval to detect stale connections proactively.
+// Set to 0 to disable keepalive probing.
+// When enabled, must be >= 30000 and < jdbc_connection_max_lifetime_ms.
+// Invalid enabled values are silently disabled (reset to 0). Default: 30000 (30 seconds).
+CONF_Int64(jdbc_connection_keepalive_time_ms, "30000");
+
 // when spill occurs, whether enable skip synchronous flush
 CONF_mBool(experimental_spill_skip_sync, "true");
 


### PR DESCRIPTION
## Why I'm doing:

fix ci
```
/root/starrocks/be/src/exec/jdbc_scanner.cpp: In member function ‘starrocks::Status starrocks::JDBCScanner::_init_jdbc_scan_context(starrocks::RuntimeState*)’:
/root/starrocks/be/src/exec/jdbc_scanner.cpp:150:39: error: ‘jdbc_connection_max_lifetime_ms’ is not a member of ‘starrocks::config’; did you mean ‘jdbc_connection_idle_timeout_ms’?
  150 |     int64_t max_lifetime_ms = config::jdbc_connection_max_lifetime_ms;
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                       jdbc_connection_idle_timeout_ms
/root/starrocks/be/src/exec/jdbc_scanner.cpp:158:41: error: ‘jdbc_connection_keepalive_time_ms’ is not a member of ‘starrocks::config’; did you mean ‘jdbc_connection_idle_timeout_ms’?
  158 |     int64_t keepalive_time_ms = config::jdbc_connection_keepalive_time_ms;
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                         jdbc_connection_idle_timeout_ms
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
