### PR TITLE
[Enhancement] Avoid object storage LIST in random bucketing import path

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1680,6 +1680,10 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "true");
 
+// If set to true, fallback to LIST metadata files on lake metadata cache miss to compute base size.
+// If set to false, skip LIST and use approximate tablet size (base_size=0).
+CONF_mBool(allow_list_object_for_random_bucketing_on_cache_miss, "true");
+
 CONF_mInt32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
 CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -713,6 +713,7 @@
         "lake_vacuum_min_batch_delete_size",
         "lake_local_pk_index_unused_threshold_seconds",
         "lake_enable_vertical_compaction_fill_data_cache",
+        "allow_list_object_for_random_bucketing_on_cache_miss",
         "lake_enable_alter_struct",
         "table_schema_service_max_retries",
         "lake_publish_version_slow_log_ms",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -85,6 +85,10 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "true");
 
+// If set to true, fallback to LIST metadata files on lake metadata cache miss to compute base size.
+// If set to false, skip LIST and use approximate tablet size (base_size=0).
+CONF_mBool(allow_list_object_for_random_bucketing_on_cache_miss, "true");
+
 // Experimental feature, this configuration will be removed after testing is complete.
 CONF_mBool(lake_enable_alter_struct, "true");
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1252,7 +1252,18 @@ int64_t TabletManager::add_in_writing_data_size(int64_t tablet_id, int64_t size)
         }
     }
 
-    int64_t base_size = get_tablet_data_size(tablet_id, nullptr).value_or(0);
+    // Immutable check for random bucketing is best-effort.
+    // On cache hit, compute base_size directly from the cached metadata to avoid any remote I/O.
+    // On cache miss, whether to fallback LIST metadata files is controlled by
+    // `allow_list_object_for_random_bucketing_on_cache_miss`.
+    int64_t base_size = 0;
+    if (auto metadata = get_latest_cached_tablet_metadata(tablet_id); metadata != nullptr) {
+        for (const auto& rowset : metadata->rowsets()) {
+            base_size += rowset.data_size();
+        }
+    } else if (config::allow_list_object_for_random_bucketing_on_cache_miss) {
+        base_size = get_tablet_data_size(tablet_id, nullptr).value_or(0);
+    }
 
     std::unique_lock wrlock(_meta_lock);
     const auto& it = _tablet_in_writing_size.find(tablet_id);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1349,6 +1349,96 @@ TEST_F(LakeTabletManagerTest, test_in_writing_data_size) {
     ASSERT_EQ(_tablet_manager->in_writing_data_size(1), 0);
 }
 
+TEST_F(LakeTabletManagerTest, test_in_writing_data_size_with_cached_metadata) {
+    auto tablet_id = next_id();
+
+    // Put a tablet metadata with known data_size into the cache
+    starrocks::TabletMetadata metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+    auto* rowset1 = metadata.add_rowsets();
+    rowset1->set_id(1);
+    rowset1->set_data_size(500);
+    rowset1->set_num_rows(10);
+    auto* rowset2 = metadata.add_rowsets();
+    rowset2->set_id(2);
+    rowset2->set_data_size(300);
+    rowset2->set_num_rows(5);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    // First call to add_in_writing_data_size should pick up the cached
+    // metadata data_size (500 + 300 = 800) as the base, rather than
+    // triggering list_tablet_metadata (object storage LIST).
+    auto result = _tablet_manager->add_in_writing_data_size(tablet_id, 100);
+    EXPECT_EQ(result, 900); // base_size(800) + size(100)
+
+    // Subsequent call should just accumulate
+    result = _tablet_manager->add_in_writing_data_size(tablet_id, 200);
+    EXPECT_EQ(result, 1100); // 900 + 200
+
+    // in_writing_data_size should return the same accumulated value
+    EXPECT_EQ(_tablet_manager->in_writing_data_size(tablet_id), 1100);
+}
+
+TEST_F(LakeTabletManagerTest, test_in_writing_data_size_without_cached_metadata) {
+    auto tablet_id = next_id();
+    // No metadata exists for this tablet_id.
+    auto result = _tablet_manager->add_in_writing_data_size(tablet_id, 100);
+    EXPECT_EQ(result, 100);
+}
+
+TEST_F(LakeTabletManagerTest, test_in_writing_data_size_cache_miss_fallback_list_configurable) {
+    auto make_meta = [&](int64_t tablet_id) {
+        starrocks::TabletMetadata metadata;
+        metadata.set_id(tablet_id);
+        metadata.set_version(2);
+        auto* rowset1 = metadata.add_rowsets();
+        rowset1->set_id(1);
+        rowset1->set_data_size(500);
+        rowset1->set_num_rows(10);
+        auto* rowset2 = metadata.add_rowsets();
+        rowset2->set_id(2);
+        rowset2->set_data_size(300);
+        rowset2->set_num_rows(5);
+        return metadata;
+    };
+
+    auto put_meta_without_latest_cache = [&](const TabletMetadata& metadata) {
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("TabletManager::skip_cache_latest_metadata");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        SyncPoint::GetInstance()->SetCallBack("TabletManager::skip_cache_latest_metadata",
+                                              [](void* arg) { *(bool*)arg = true; });
+        EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+        _tablet_manager->metacache()->prune();
+    };
+
+    bool old = config::allow_list_object_for_random_bucketing_on_cache_miss;
+    DeferOp config_guard([old] { config::allow_list_object_for_random_bucketing_on_cache_miss = old; });
+
+    // cache miss + LIST fallback enabled -> list metadata and recover base_size from meta files.
+    {
+        auto tablet_id = next_id();
+        auto metadata = make_meta(tablet_id);
+        put_meta_without_latest_cache(metadata);
+        config::allow_list_object_for_random_bucketing_on_cache_miss = true;
+        auto result = _tablet_manager->add_in_writing_data_size(tablet_id, 100);
+        EXPECT_EQ(result, 900);
+    }
+
+    // cache miss + LIST fallback disabled -> skip LIST, base_size stays 0.
+    {
+        auto tablet_id = next_id();
+        auto metadata = make_meta(tablet_id);
+        put_meta_without_latest_cache(metadata);
+        config::allow_list_object_for_random_bucketing_on_cache_miss = false;
+        auto result = _tablet_manager->add_in_writing_data_size(tablet_id, 100);
+        EXPECT_EQ(result, 100);
+    }
+}
+
 TEST_F(LakeTabletManagerTest, test_get_output_rorwset_schema) {
     std::shared_ptr<TabletMetadata> tablet_metadata = lake::generate_simple_tablet_metadata(DUP_KEYS);
     for (int i = 0; i < 5; i++) {

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1279,6 +1279,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: Specifies whether to enable parallel memtable finalize when loading data to lake tables (shared-data mode). When enabled, the memtable finalize operation (sort/aggregate) is moved from the write thread to the flush thread, allowing the write thread to continue inserting data into a new memtable while the previous one is being finalized and flushed in parallel. This can significantly improve load throughput by overlapping CPU-intensive finalize operations with I/O-bound flush operations. Note that this optimization is automatically disabled when auto-increment columns need to be filled, as auto-increment ID assignment must happen before the memtable is submitted for flush.
 - Introduced in: -
 
+##### allow_list_object_for_random_bucketing_on_cache_miss
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether to allow object-storage LIST fallback when lake metadata cache misses during random bucketing size checks. `true` means fallback to LIST metadata files to compute base size (historical behavior, more accurate size estimation). `false` means skip LIST and use `base_size = 0`, which reduces LIST object requests but may delay immutable marking due to less accurate size estimation.
+- Introduced in: 4.1.0, 4.0.7, 3.5.15
+
 ##### enable_stream_load_verbose_log
 
 - Default: false

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1029,6 +1029,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: Lake テーブル（ストレージとコンピューティングの分離モード）へのデータロード時に並列 MemTable Finalize を有効にするかどうかを指定します。有効にすると、MemTable の Finalize 操作（ソート/集計）が書き込みスレッドからフラッシュスレッドに移動され、前の MemTable が並列で Finalize およびフラッシュされている間、書き込みスレッドは新しい MemTable へのデータ挿入を継続できます。これにより、CPU 集約型の Finalize 操作と I/O 集約型のフラッシュ操作をオーバーラップさせることで、ロードスループットを大幅に向上させることができます。注意: 自動インクリメント列を埋める必要がある場合、自動インクリメント ID の割り当ては MemTable がフラッシュに送信される前に完了する必要があるため、この最適化は自動的に無効になります。
 - 導入バージョン: -
 
+##### allow_list_object_for_random_bucketing_on_cache_miss
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: random bucketing のサイズ判定で Lake metadata がキャッシュミスした際に、object-storage LIST フォールバックを許可するかを制御します。`true` の場合は metadata ファイル LIST にフォールバックして base size を計算します（従来動作、推定がより正確）。`false` の場合は LIST をスキップして `base_size = 0` を使用し、LIST object リクエストを削減しますが、推定精度低下により immutable 判定がやや遅れる可能性があります。
+- 導入バージョン: 4.1.0, 4.0.7, 3.5.15 
+
 ##### enable_stream_load_verbose_log
 
 - デフォルト: false

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1259,6 +1259,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：是否在存算分离（Lake）表导入数据时启用并行 MemTable Finalize。启用后，MemTable 的 Finalize 操作（排序/聚合）将从写入线程移至 Flush 线程执行，使写入线程可以继续向新的 MemTable 插入数据，同时前一个 MemTable 正在并行进行 Finalize 和 Flush。这可以通过重叠 CPU 密集型的 Finalize 操作与 I/O 密集型的 Flush 操作来显著提高导入吞吐量。注意：当需要填充自增列时，此优化会自动禁用，因为自增 ID 的分配必须在 MemTable 提交 Flush 之前完成。
 - 引入版本：-
 
+##### allow_list_object_for_random_bucketing_on_cache_miss
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：控制 random bucketing 大小检查在 Lake metadata 缓存未命中时是否允许回退到对象存储 LIST。`true` 表示回退到 LIST 元数据文件计算 base size（历史行为、估算更准确）；`false` 表示跳过 LIST，直接使用 `base_size = 0`，可减少 LIST object 请求，但因大小估算精度下降，可能使 immutable 标记稍晚触发。
+- 引入版本：4.1.0, 4.0.7, 3.5.15
+
 ##### enable_stream_load_verbose_log
 
 - 默认值：false


### PR DESCRIPTION
## Why I'm doing:

When importing data into random bucketing tables in shared-data mode, add_in_writing_data_size() was calling get_tablet_data_size(tablet_id, nullptr), which triggers list_tablet_metadata() and thus an expensive object storage LIST operation for every tablet on first access.

## What I'm doing:

Fixes #68783
Replace the LIST-based fallback with a cache lookup via get_latest_cached_tablet_metadata():
* If cached metadata exists → compute the base data size from it
* If no cache hit → use 0 as the base size

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
