### PR TITLE
[BugFix] Fix str_to_date losing microsecond precision in BE runtime e…

### DIFF
--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -402,7 +402,7 @@ bool TimestampValue::from_uncommon_format_str(const char* format, int format_len
     bool result = from_uncommon_format_str(format, format_len, value, value_len, &content, nullptr);
     if (result) {
         _timestamp = timestamp::from_datetime(content._year, content._month, content._day, content._hour,
-                                              content._minute, content._second, 0);
+                                              content._minute, content._second, content._microsecond);
     }
     return result;
 }

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1591,6 +1591,37 @@ TEST_F(TimeFunctionsTest, str_to_date_of_datetimeformat) {
     }
 }
 
+TEST_F(TimeFunctionsTest, str_to_date_microsecond) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    const char* fmt = "%Y-%m-%dT%H:%i:%s.%f";
+    const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    // const fmt <=> non-const input (simulates Routine Load / Stream Load column mapping)
+    {
+        auto str_col = ColumnHelper::create_column(varchar_type_desc, true);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt, 1);
+        (void)str_col->append_nulls(1);
+        str_col->append_datum(Slice("2026-02-09T00:15:01.535569"));
+        str_col->append_datum(Slice("2026-02-09T12:30:45.123"));
+        str_col->append_datum(Slice("2026-02-09T12:30:45.000000"));
+
+        Columns columns;
+        columns.emplace_back(str_col);
+        columns.emplace_back(fmt_col);
+
+        ColumnPtr result = TimeFunctions::str_to_date(ctx, columns).value();
+        ASSERT_TRUE(result->is_nullable());
+
+        auto nullable_col = ColumnHelper::as_column<NullableColumn>(result);
+        ASSERT_EQ(4, nullable_col->size());
+        ASSERT_TRUE(nullable_col->is_null(0));
+        ASSERT_EQ(TimestampValue::create(2026, 2, 9, 0, 15, 1, 535569), nullable_col->get(1).get_timestamp());
+        ASSERT_EQ(TimestampValue::create(2026, 2, 9, 12, 30, 45, 123000), nullable_col->get(2).get_timestamp());
+        ASSERT_EQ(TimestampValue::create(2026, 2, 9, 12, 30, 45, 0), nullable_col->get(3).get_timestamp());
+    }
+}
+
 TEST_F(TimeFunctionsTest, date_format) {
     FunctionContext* ctx = FunctionContext::create_test_context();
     auto ptr = std::unique_ptr<FunctionContext>(ctx);

--- a/be/test/types/timestamp_value_test.cpp
+++ b/be/test/types/timestamp_value_test.cpp
@@ -121,4 +121,34 @@ TEST(TimestampValueTest, unixTime) {
     ASSERT_EQ(1078097430000, v.to_unixtime(cctz::utc_time_zone()));
 }
 
+TEST(TimestampValueTest, from_uncommon_format_str_microsecond) {
+    // Test that from_uncommon_format_str preserves microseconds parsed from %f
+    {
+        TimestampValue ts;
+        std::string format = "%Y-%m-%dT%H:%i:%s.%f";
+        std::string value = "2026-02-09T00:15:01.535569";
+        bool result = ts.from_uncommon_format_str(format.c_str(), format.size(), value.c_str(), value.size());
+        ASSERT_TRUE(result);
+        EXPECT_EQ("2026-02-09 00:15:01.535569", ts.to_string());
+    }
+    // Test with fewer than 6 fractional digits
+    {
+        TimestampValue ts;
+        std::string format = "%Y-%m-%d %H:%i:%s.%f";
+        std::string value = "2026-02-09 12:30:45.123";
+        bool result = ts.from_uncommon_format_str(format.c_str(), format.size(), value.c_str(), value.size());
+        ASSERT_TRUE(result);
+        EXPECT_EQ("2026-02-09 12:30:45.123000", ts.to_string());
+    }
+    // Test with zero microseconds
+    {
+        TimestampValue ts;
+        std::string format = "%Y-%m-%d %H:%i:%s.%f";
+        std::string value = "2026-02-09 12:30:45.000000";
+        bool result = ts.from_uncommon_format_str(format.c_str(), format.size(), value.c_str(), value.size());
+        ASSERT_TRUE(result);
+        EXPECT_EQ("2026-02-09 12:30:45", ts.to_string());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`str_to_date` with `%f` silently drops microsecond precision when evaluated at BE runtime (e.g., Routine Load, Stream Load column mappings). The wrapper overload of `TimestampValue::from_uncommon_format_str` hardcodes microseconds to 0 when calling `timestamp::from_datetime`, discarding the value correctly parsed by the inner function into `content._microsecond`.

This only affects BE runtime evaluation paths. FE constant-folded paths (e.g., `INSERT INTO with literal values`) work correctly because they use a different code path.

## What I'm doing:

Pass `content._microsecond` instead of hardcoded 0 to `timestamp::from_datetime` in the wrapper overload of `TimestampValue::from_uncommon_format_str`.
Added regression tests at both layers:
  - `TimestampValueTest.from_uncommon_format_str_microsecond`: unit test for the parsing function directly
  - `TimeFunctionsTest.str_to_date_microsecond`: expression-layer test with const fmt + non-const input, matching the Routine Load/Stream Load column mapping scenario

Fixes #70056

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4