### PR TITLE
[BugFix] Catch exceptions in MysqlProto to prevent ERROR 2013

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -43,7 +43,6 @@ import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.authentication.UserAuthenticationInfo;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
@@ -187,7 +186,12 @@ public class MysqlProto {
         if (!Strings.isNullOrEmpty(db)) {
             try {
                 context.changeCatalogDb(db);
-            } catch (DdlException e) {
+            } catch (Exception e) {
+                LOG.warn("Set database [{}] failed during negotiate, user={}, reason={}",
+                        db, authPacket.getUser(), e.getMessage(), e);
+                if (!context.getState().isError()) {
+                    context.getState().setError(e.getMessage());
+                }
                 sendResponsePacket(context);
                 return new NegotiateResult(authPacket, NegotiateState.SET_DATABASE_FAILED);
             }
@@ -232,6 +236,8 @@ public class MysqlProto {
         Set<Long> previousRoleIds = context.getCurrentRoleIds();
         String previousQualifiedUser = context.getQualifiedUser();
         String previousResourceGroup = context.getSessionVariable().getResourceGroup();
+        String previousCatalog = context.getCurrentCatalog();
+        String previousDb = context.getDatabase();
         // do authenticate again
 
         try {
@@ -249,16 +255,20 @@ public class MysqlProto {
         }
         // set database
         String db = changeUserPacket.getDb();
-        String originalDb = context.getDatabase();
         if (!Strings.isNullOrEmpty(db)) {
             try {
                 context.changeCatalogDb(db);
-            } catch (DdlException e) {
-                LOG.error("Command `Change user` failed at stage changing db, from [{}] to [{}], err[{}] ",
-                        previousQualifiedUser, changeUserPacket.getUser(), e.getMessage());
+            } catch (Exception e) {
+                LOG.warn("Command `Change user` failed at stage changing db, from [{}] to [{}], err[{}] ",
+                        previousQualifiedUser, changeUserPacket.getUser(), e.getMessage(), e);
+                if (!context.getState().isError()) {
+                    context.getState().setError(e.getMessage());
+                }
                 sendResponsePacket(context);
                 // reconstruct serializer with context capability
                 context.getSerializer().setCapability(context.getCapability());
+                context.setCurrentCatalog(previousCatalog);
+                context.setDatabase(previousDb);
                 // recover from previous user login info
                 context.getSessionVariable().setResourceGroup(previousResourceGroup);
                 context.setCurrentUserIdentity(previousUserIdentity);
@@ -279,15 +289,8 @@ public class MysqlProto {
             context.setCurrentUserIdentity(previousUserIdentity);
             context.setCurrentRoleIds(previousRoleIds);
             context.setQualifiedUser(previousQualifiedUser);
-
-            if (!context.getDatabase().equals(originalDb)) {
-                try {
-                    context.changeCatalogDb(originalDb);
-                } catch (DdlException e) {
-                    LOG.error("recover original database fail", e);
-                    return false;
-                }
-            }
+            context.setCurrentCatalog(previousCatalog);
+            context.setDatabase(previousDb);
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ChangeCatalogDBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ChangeCatalogDBTest.java
@@ -14,12 +14,18 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -129,5 +135,38 @@ public class ChangeCatalogDBTest {
         Assertions.assertThrows(DdlException.class, () -> {
             ctx.changeCatalogDb("hive_catalog.nonexistent_db");
         });
+    }
+
+    @Test
+    void testChangeCatalogDbAccessDeniedThrowsRuntimeException(@Mocked MetadataMgr metadataMgr) {
+        new Expectations() {
+            {
+                metadataMgr.getDb((ConnectContext) any, "default_catalog", "secret_db");
+                result = new Database(201, "secret_db");
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext ctx,
+                                               String catalogName, String db) throws AccessDeniedException {
+                throw new AccessDeniedException();
+            }
+        };
+
+        ctx.setCurrentCatalog("default_catalog");
+        ctx.setThreadLocalInfo();
+
+        ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class, () -> {
+            ctx.changeCatalogDb("secret_db");
+        });
+
+        Assertions.assertEquals(ErrorCode.ERR_ACCESS_DENIED, ex.getErrorCode(),
+                "Expected ERR_ACCESS_DENIED error code on exception");
+
+        Assertions.assertTrue(ctx.getState().isError(),
+                "QueryState should be ERR after access denied");
+        Assertions.assertEquals(ErrorCode.ERR_ACCESS_DENIED, ctx.getState().getErrorCode(),
+                "QueryState should carry ERR_ACCESS_DENIED error code");
     }
 }


### PR DESCRIPTION

  ## Why I'm doing:

  When connecting with a database the user has no privilege on, `changeCatalogDb()` throws `ErrorReportException` (RuntimeException) on access denied. But `MysqlProto.negotiate()` and `changeUser()` only catch `DdlException`, so the exception escapes uncaught — FE closes the
  connection without sending a MySQL ERR packet, and the client sees ERROR 2013.

  ## What I'm doing:

  Widen `catch (DdlException e)` to `catch (Exception e)` at all `changeCatalogDb()` call sites in `MysqlProto.java` (negotiate, changeUser, recover-original-db), with defensive `setError()` to guarantee a MySQL ERR packet is always sent. Add unit test for the access-denied
  path.

  Fixes #[70071](https://github.com/StarRocks/starrocks/issues/70071)

  ## What type of PR is this:

  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [x] Yes, this PR will result in a change in behavior.
  - [ ] No, this PR will not result in a change in behavior.

  If yes, please specify the type of change:

  - [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [x] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5
    - [ ] 3.4
