### PR TITLE
[UT] Fix flaky OptimizeJobV2Test by acquiring taskRunLock during scheduler cleanup

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -27,6 +27,8 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.ThreadUtil;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRunManager;
+import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DDLTestBase;
@@ -173,10 +175,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
         List<OptimizeTask> optimizeTasks = optimizeJob.getOptimizeTasks();
         for (int i = 0; i < optimizeTasks.size(); ++i) {
             OptimizeTask optimizeTask = optimizeTasks.get(i);
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                        .getTaskRunScheduler().removeRunningTask(optimizeTask.getId());
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                        .getTaskRunScheduler().removePendingTask(optimizeTask);
+            removeTaskFromScheduler(optimizeTask);
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setTaskName(optimizeTask.getName());
             taskRunStatus.setState(Constants.TaskRunState.SUCCESS);
@@ -210,10 +209,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
 
         // Mark all tasks SQL SUCCESS and add history
         for (OptimizeTask t : job.getOptimizeTasks()) {
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                .getTaskRunScheduler().removeRunningTask(t.getId());
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                .getTaskRunScheduler().removePendingTask(t);
+            removeTaskFromScheduler(t);
             TaskRunStatus s = new TaskRunStatus();
             s.setTaskName(t.getName());
             s.setDbName(db.getFullName());
@@ -254,10 +250,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
         Assertions.assertEquals(JobState.RUNNING, job.getJobState());
 
         for (OptimizeTask t : job.getOptimizeTasks()) {
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                .getTaskRunScheduler().removeRunningTask(t.getId());
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                .getTaskRunScheduler().removePendingTask(t);
+            removeTaskFromScheduler(t);
             TaskRunStatus s = new TaskRunStatus();
             s.setTaskName(t.getName());
             s.setDbName(db.getFullName());
@@ -642,10 +635,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
         List<OptimizeTask> optimizeTasks = optimizeJob.getOptimizeTasks();
         for (OptimizeTask t : optimizeTasks) {
             t.setOptimizeTaskState(Constants.TaskRunState.PENDING);
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                    .getTaskRunScheduler().removeRunningTask(t.getId());
-            GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                    .getTaskRunScheduler().removePendingTask(t);
+            removeTaskFromScheduler(t);
         }
 
         // Trigger path: executeTask for PENDING tasks should set state to RUNNING or FAILED
@@ -692,6 +682,19 @@ public class OptimizeJobV2Test extends DDLTestBase {
         Assertions.assertEquals(Constants.TaskRunState.FAILED, fakeTask.getOptimizeTaskState());
         // Job should remain RUNNING because other tasks are not finished
         Assertions.assertEquals(JobState.RUNNING, optimizeJob.getJobState());
+    }
+
+    private void removeTaskFromScheduler(OptimizeTask task) {
+        TaskRunManager trm = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
+        TaskRunScheduler trs = trm.getTaskRunScheduler();
+        if (trm.tryTaskRunLock()) {
+            try {
+                trs.removePendingTask(task);
+                trs.removeRunningTask(task.getId());
+            } finally {
+                trm.taskRunUnlock();
+            }
+        }
     }
 
     private OptimizeJobV2 spyPreviousTxnFinished(OptimizeJobV2 job) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
