### PR TITLE
[Tool] add dependabot reminder to docs weekly issue

### DIFF
--- a/.github/workflows/weekly-docs-feedback.yml
+++ b/.github/workflows/weekly-docs-feedback.yml
@@ -78,6 +78,17 @@ jobs:
            | jq -r '.searches | to_entries[] | "- [ ] \(.value.search)", "  failures this week: \(.value.count)"' \
            >> feedback.md
 
+      - name: Add Dependabot reminder for docs
+        run: |
+          set -eo pipefail # Ensure the script fails on any command error
+          manual_dependabot_url="https://github.com/${GITHUB_REPOSITORY}/security/dependabot?q=is%3Aopen+sort%3Anewest+docs"
+
+          echo " " >> feedback.md
+          echo "## Dependabot alerts reminder" >> feedback.md
+          echo "- [ ] Check open Dependabot alerts for docs:" >> feedback.md
+          echo "  ${manual_dependabot_url}" >> feedback.md
+          echo " " >> feedback.md
+
       - name: Create issue from file
         if: always()
         id: weekly-feedback-report

--- a/.github/workflows/weekly-docs-feedback.yml
+++ b/.github/workflows/weekly-docs-feedback.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Add Dependabot reminder for docs
         run: |
           set -eo pipefail # Ensure the script fails on any command error
-          manual_dependabot_url="https://github.com/${GITHUB_REPOSITORY}/security/dependabot?q=is%3Aopen+sort%3Anewest+docs"
+          manual_dependabot_url="https://github.com/${GITHUB_REPOSITORY}/security/dependabot?q=is%3Aopen+sort%3Anewest+severity%3Ahigh+docs"
 
           echo " " >> feedback.md
           echo "## Dependabot alerts reminder" >> feedback.md


### PR DESCRIPTION
## Why I'm doing:

Keep dependabot updates current

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
