### PR TITLE
[UT] Fix UT in json_functions_test

### DIFF
--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -176,7 +176,7 @@ TEST_F(JsonFunctionsTest, get_json_string_scalar) {
                                         R"({"k11":       "v11"})",
                                         R"({"k11":       "v11"})"};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             strings->append(values[j]);
             strings2->append(strs[j]);
         }
@@ -193,8 +193,8 @@ TEST_F(JsonFunctionsTest, get_json_string_scalar) {
 
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
-            ASSERT_EQ(length_strings[j], v->get_data()[j].to_string());
+        for (int j = 0; j < std::size(values); ++j) {
+            ASSERT_EQ(length_strings[j], v->get_slice(j).to_string());
         }
 
         ASSERT_TRUE(JsonFunctions::native_json_path_close(
@@ -393,7 +393,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         std::string strs[] = {"$.k1", "$.k1", "$.k1"};
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             strings->append(values[j]);
             strings2->append(strs[j]);
         }
@@ -410,7 +410,7 @@ TEST_F(JsonFunctionsTest, get_json_emptyTest) {
 
         auto v = ColumnHelper::as_column<NullableColumn>(result);
 
-        for (int j = 0; j < sizeof(values) / sizeof(values[0]); ++j) {
+        for (int j = 0; j < std::size(values); ++j) {
             ASSERT_TRUE(v->is_null(j));
         }
 


### PR DESCRIPTION
## Why I'm doing:
Fix UT in json_functions_test because of the https://github.com/StarRocks/starrocks/pull/69848 remove get_data.
But in the patch https://github.com/StarRocks/starrocks/pull/68815 used get_data
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
