### PR TITLE
[BugFix] Partition predicates are pruned unexpectedly because of mismatch types boundary comparison

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -120,6 +120,17 @@ public class ColumnFilterConverter {
                         return true;
                     }
                 }
+            } else if (FunctionSet.STR2DATE.equalsIgnoreCase(functionName)
+                    || FunctionSet.STR_TO_DATE.equalsIgnoreCase(functionName)) {
+                // str2date/str_to_date(partition_col, format) -> str2date/str_to_date(constant, format)
+                // so that the partition expression can be evaluated to a date literal.
+                Expr firstExpr = node.getChild(0);
+                if (firstExpr instanceof SlotRef slotRef) {
+                    if (columnRef.getName().equals(slotRef.getColumnName())) {
+                        node.setChild(0, new StringLiteral(constant.getVarchar()));
+                        return true;
+                    }
+                }
             } else if (FunctionSet.FROM_UNIXTIME.equalsIgnoreCase(functionName) ||
                     FunctionSet.FROM_UNIXTIME_MS.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
@@ -185,6 +196,21 @@ public class ColumnFilterConverter {
         predicate.accept(COLUMN_FILTER_VISITOR, result);
     }
 
+    public static Optional<List<Expr>> getPartitionExprs(Table table) {
+        if (!(table instanceof OlapTable)) {
+            return Optional.empty();
+        }
+        PartitionInfo partitionInfo = ((OlapTable) table).getPartitionInfo();
+        if (partitionInfo instanceof ExpressionRangePartitionInfoV2) {
+            return Optional.ofNullable(
+                    ((ExpressionRangePartitionInfoV2) partitionInfo).getPartitionExprs(table.getIdToColumn()));
+        } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+            return Optional.ofNullable(
+                    ((ExpressionRangePartitionInfo) partitionInfo).getPartitionExprs(table.getIdToColumn()));
+        } else {
+            return Optional.empty();
+        }
+    }
     public static void convertColumnFilter(ScalarOperator predicate, Map<String, PartitionColumnFilter> result,
                                            Table table) {
         // convert bool_col predicate to bool_col = true
@@ -196,11 +222,9 @@ public class ColumnFilterConverter {
             return;
         }
 
-        if (table != null && table.isExprPartitionTable()) {
-            OlapTable olapTable = (OlapTable) table;
-            predicate = convertPredicate(predicate,
-                    (ExpressionRangePartitionInfoV2) olapTable.getPartitionInfo(),
-                    table.getIdToColumn());
+        Optional<List<Expr>> optPartitionExprs = getPartitionExprs(table);
+        if (optPartitionExprs.isPresent()) {
+            predicate = convertPredicate(predicate, optPartitionExprs.get());
         }
 
         if (!checkColumnRefCanPartition(predicate.getChild(0), table)) {
@@ -319,16 +343,23 @@ public class ColumnFilterConverter {
         }
     }
 
-    // Replace the predicate of the query with the predicate of the partition expression and evaluate.
-    // If the condition is not met, there will be no change to the predicate.
     public static ScalarOperator convertPredicate(ScalarOperator predicate,
                                                   ExpressionRangePartitionInfoV2 exprRangePartitionInfo,
                                                   Map<ColumnId, Column> idToColumn) {
-        // Currently only one partition column is supported
         if (exprRangePartitionInfo.getPartitionExprsSize() != 1) {
             return predicate;
         }
         Expr firstPartitionExpr = exprRangePartitionInfo.getPartitionExprs(idToColumn).get(0);
+        return convertPredicate(predicate, List.of(firstPartitionExpr));
+    }
+    // Replace the predicate of the query with the predicate of the partition expression and evaluate.
+    // If the condition is not met, there will be no change to the predicate.
+    public static ScalarOperator convertPredicate(ScalarOperator predicate, List<Expr> partitionExprs) {
+        if (partitionExprs.size() != 1) {
+            return predicate;
+        }
+        // Currently only one partition column is supported
+        Expr firstPartitionExpr = partitionExprs.get(0);
         Expr predicateExpr = firstPartitionExpr.clone();
 
         // only support binary predicate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
+import com.starrocks.sql.ast.expression.MaxLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -248,20 +249,26 @@ public class OptOlapPartitionPruner {
             if (null != lowerBound) {
                 lowerBind = false;
                 PartitionKey min = new PartitionKey();
-                min.pushColumn(pcf.getLowerBound(), column.getPrimitiveType());
-                int cmp = minRange.compareTo(min);
-                if (cmp > 0 || (0 == cmp && pcf.lowerBoundInclusive)) {
-                    lowerBind = true;
+                if (lowerBound instanceof MaxLiteral || minRange.getKeys().get(0) instanceof MaxLiteral ||
+                        lowerBound.getType().matchesType(minRange.getKeys().get(0).getType())) {
+                    min.pushColumn(lowerBound, lowerBound.getType().getPrimitiveType());
+                    int cmp = minRange.compareTo(min);
+                    if (cmp > 0 || (0 == cmp && pcf.lowerBoundInclusive)) {
+                        lowerBind = true;
+                    }
                 }
             }
 
             if (null != upperBound) {
                 upperBind = false;
                 PartitionKey max = new PartitionKey();
-                max.pushColumn(upperBound, column.getPrimitiveType());
-                int cmp = maxRange.compareTo(max);
-                if (cmp < 0 || (0 == cmp && pcf.upperBoundInclusive)) {
-                    upperBind = true;
+                if (upperBound instanceof MaxLiteral || maxRange.getKeys().get(0) instanceof MaxLiteral ||
+                        upperBound.getType().matchesType(maxRange.getKeys().get(0).getType())) {
+                    max.pushColumn(upperBound, upperBound.getType().getPrimitiveType());
+                    int cmp = maxRange.compareTo(max);
+                    if (cmp < 0 || (0 == cmp && pcf.upperBoundInclusive)) {
+                        upperBind = true;
+                    }
                 }
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -256,7 +256,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
                         " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                         " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                        " where t1.d < '20230802';";
+                        " where t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv1\n" +
@@ -323,7 +323,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
                         " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                         " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                        " where t1.d < '20230802';";
+                        " where t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
@@ -395,7 +395,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
                         " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                         " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                        " where t1.d < '20230802';";
+                        " where t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv1\n" +
@@ -462,7 +462,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
                         " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
                         " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                         " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
-                        " where t1.d < '20230802';";
+                        " where t1.d < '2023-08-02';";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
@@ -82,7 +82,6 @@ public class MvRefreshAndRewriteJDBCTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv1\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 16: d = '20230801'\n" +
                         "     partitions=1/4");
         }
 
@@ -96,7 +95,6 @@ public class MvRefreshAndRewriteJDBCTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv1\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 16: d >= '20230801'\n" +
                         "     partitions=3/4\n" +
                         "     rollup: test_mv1");
         }
@@ -195,7 +193,6 @@ public class MvRefreshAndRewriteJDBCTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv3\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 16: d = '20230801'\n" +
                         "     partitions=1/4");
         }
 
@@ -209,7 +206,6 @@ public class MvRefreshAndRewriteJDBCTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                         "     TABLE: test_mv3\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 16: d >= '20230801'\n" +
                         "     partitions=3/4\n" +
                         "     rollup: test_mv3");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExprRangePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExprRangePartitionPruneTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ExprRangePartitionPruneTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+
+        starRocksAssert.withTable("CREATE TABLE `test32` (\n" +
+                "  `busness_date` varchar(8) NULL COMMENT \"\",\n" +
+                "  `id` int(11) NULL COMMENT \"\",\n" +
+                "  `name` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`busness_date`)\n" +
+                "PARTITION BY RANGE(str2date(busness_date, '%Y%m%d'))\n" +
+                "(PARTITION p2025 VALUES [(\"0000-01-01\"), (\"2026-01-01\")),\n" +
+                "PARTITION p2026 VALUES [(\"2026-01-01\"), (\"2027-01-01\")))\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")");
+
+    }
+
+    @Test
+    public void testExprRangePartitionUpperBoundReserved1() throws Exception {
+        String sql = "select * from test32 "
+                + "where str2date(busness_date, '%Y%m%d')>= '2026-01-01' "
+                + "and str2date(busness_date, '%Y%m%d')<= '2026-03-01'";
+        String plan = getFragmentPlan(sql);
+
+        assertCContains(plan, "PREDICATES: str2date(1: busness_date, '%Y%m%d') >= '2026-01-01', " +
+                "str2date(1: busness_date, '%Y%m%d') <= '2026-03-01'");
+
+        assertCContains(plan, "partitions=2/2");
+    }
+
+    @Test
+    public void testExprRangePartitionUpperBoundReserved2() throws Exception {
+        String sql = "select * from test32 "
+                + "where busness_date >= '20260101' "
+                + "and busness_date <= '20260301'";
+        String plan = getFragmentPlan(sql);
+
+        assertCContains(plan, "1: busness_date <= '20260301");
+        assertCContains(plan, "partitions=1/2");
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:
After partition predicates applied to expr range-partitions, if the partition predicate covers the reserved partitions fully, this predicate would be pruned. but when partition expr is  str2date(column, ...). the boundaries  comparision between partition predicates and reserved partitions are using mismatch types, in such case, the comparison's result is wrong, so the partition predicate are droped mistakenly.

## What I'm doing:

Types of boundaries of both partition predicates and reserved partitions should check to ensure match before pruning.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
