### PR TITLE
[BugFix] Fix MV rewrite ignoring dropped partitions in base table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -327,9 +327,15 @@ public abstract class MVTimelinessArbiter {
             }
         }
         Map<String, PCell> adds = diff.getAdds();
+        Map<String, PCell> deletes = diff.getDeletes();
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.LOOSE);
         if (!CollectionUtils.sizeIsEmpty(adds)) {
             adds.keySet().stream().forEach(mvPartitionName ->
+                    mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
+        }
+        // Add deleted partitions to refresh list to ensure they are excluded from transparent rewrite
+        if (!CollectionUtils.sizeIsEmpty(deletes)) {
+            deletes.keySet().stream().forEach(mvPartitionName ->
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
@@ -393,10 +399,16 @@ public abstract class MVTimelinessArbiter {
             }
         }
         Map<String, PCell> adds = diff.getAdds();
+        Map<String, PCell> deletes = diff.getDeletes();
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.FORCE_MV);
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         if (!CollectionUtils.sizeIsEmpty(adds)) {
             adds.keySet().stream().forEach(mvPartitionName ->
+                    mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
+        }
+        // Add deleted partitions to refresh list to ensure they are excluded from transparent rewrite
+        if (!CollectionUtils.sizeIsEmpty(deletes)) {
+            deletes.keySet().stream().forEach(mvPartitionName ->
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
         }
         return mvUpdateInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -24,12 +24,16 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
@@ -39,6 +43,57 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
 
     public MVTimelinessNonPartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
         super(mv, queryRewriteParams);
+    }
+
+    /**
+     * Check if any partitions have been deleted from the base table.
+     * For non-partitioned MVs with external tables, if partitions that were previously
+     * refreshed no longer exist in the base table, the MV needs a full refresh.
+     *
+     * @param baseTableInfo the base table info
+     * @param table the base table
+     * @return true if partitions have been deleted from the base table
+     */
+    private boolean hasDeletedPartitions(BaseTableInfo baseTableInfo, Table table) {
+        // Only check for external tables (Iceberg, Hive, etc.)
+        if (table.isNativeTableOrMaterializedView()) {
+            return false;
+        }
+
+        try {
+            // Get current partitions from the base table
+            ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(mv, table);
+            Map<String, com.starrocks.connector.PartitionInfo> latestPartitionInfo =
+                    traits.getPartitionNameWithPartitionInfo();
+
+            // Get the partitions that were previously refreshed
+            Map<String, MaterializedView.BasePartitionInfo> versionMap =
+                    mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableRefreshInfo(baseTableInfo);
+
+            if (MapUtils.isEmpty(versionMap)) {
+                return false;
+            }
+
+            // Check if any previously refreshed partitions no longer exist
+            Set<String> currentPartitions = latestPartitionInfo.keySet();
+            for (String refreshedPartition : versionMap.keySet()) {
+                if (!currentPartitions.contains(refreshedPartition)) {
+                    logMVPrepare(mv, String.format(
+                            "Base table partition %s has been deleted, need refresh totally.", refreshedPartition));
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // If we can't determine partition info (e.g., connector doesn't support partition metadata APIs),
+            // skip the deleted partition check rather than forcing a refresh. This avoids regressing MV rewrite
+            // for connectors that don't implement full partition metadata support.
+            LOG.debug("Cannot check for deleted partitions for table {}.{}.{}, skipping check: {}",
+                    baseTableInfo.getCatalogName(), baseTableInfo.getDbName(), baseTableInfo.getTableName(),
+                    e.getMessage());
+            return false;
+        }
+
+        return false;
     }
 
     /**
@@ -73,6 +128,12 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
             if (mvBaseTableUpdateInfo != null &&
                     CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {
                 logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
+
+            // Check if any partitions have been deleted from external tables
+            if (hasDeletedPartitions(tableInfo, table)) {
+                logMVPrepare(mv, "Non-partitioned base table has deleted partitions, need refresh totally.");
                 return MvUpdateInfo.fullRefresh(mv);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -18,6 +18,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -44,6 +45,8 @@ import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCell;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
@@ -64,6 +67,7 @@ import static com.starrocks.sql.optimizer.rule.transformation.partition.Partitio
  */
 public abstract class MVPCTRefreshPartitioner {
     protected  static final int CREATE_PARTITION_BATCH_SIZE = 64;
+    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshPartitioner.class);
 
     protected final MvTaskRunContext mvContext;
     protected final TaskRunContext context;
@@ -273,9 +277,55 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     /**
+     * Check if any partitions have been deleted from the base table for non-partitioned MV.
+     * For non-partitioned MVs with external tables, if partitions that were previously
+     * refreshed no longer exist in the base table, the MV needs a full refresh.
+     */
+    private static boolean hasDeletedPartitions(MaterializedView mv, BaseTableInfo baseTableInfo, Table table) {
+        // Only check for external tables (Iceberg, Hive, etc.)
+        if (table.isNativeTableOrMaterializedView()) {
+            return false;
+        }
+
+        try {
+            // Get current partitions from the base table
+            ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(mv, table);
+            Map<String, com.starrocks.connector.PartitionInfo> latestPartitionInfo =
+                    traits.getPartitionNameWithPartitionInfo();
+
+            // Get the partitions that were previously refreshed
+            Map<String, MaterializedView.BasePartitionInfo> versionMap =
+                    mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableRefreshInfo(baseTableInfo);
+
+            if (MapUtils.isEmpty(versionMap)) {
+                return false;
+            }
+
+            // Check if any previously refreshed partitions no longer exist
+            Set<String> currentPartitions = latestPartitionInfo.keySet();
+            for (String refreshedPartition : versionMap.keySet()) {
+                if (!currentPartitions.contains(refreshedPartition)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // If we can't determine partition info (e.g., connector doesn't support partition metadata APIs),
+            // skip the deleted partition check rather than forcing a refresh. This avoids regressing MV refresh
+            // for connectors that don't implement full partition metadata support.
+            LOG.debug("Cannot check for deleted partitions for table {}.{}.{}, skipping check: {}",
+                    baseTableInfo.getCatalogName(), baseTableInfo.getDbName(), baseTableInfo.getTableName(),
+                    e.getMessage());
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
      * Whether non-partitioned materialized view needs to be refreshed or not, it needs refresh when:
      * - its base table is not supported refresh by partition.
      * - its base table has updated.
+     * - its base table has deleted partitions.
      */
     public static boolean isNonPartitionedMVNeedToRefresh(Map<Long, TableSnapshotInfo> snapshotBaseTables,
                                                           MaterializedView mv) {
@@ -286,6 +336,10 @@ public abstract class MVPCTRefreshPartitioner {
             }
             if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable,
                     MVTimelinessArbiter.QueryRewriteParams.ofRefresh())) {
+                return true;
+            }
+            // Check if any partitions have been deleted from external tables
+            if (hasDeletedPartitions(mv, snapshotInfo.getBaseTableInfo(), snapshotTable)) {
                 return true;
             }
         }

--- a/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,114 @@
+-- name: test_non_partitioned_mv_with_dropped_partitions
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set enable_materialized_view_transparent_union_rewrite = true;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW non_partitioned_mv 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+-- result:
+-- !result
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+True
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+False
+-- !result
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+-- result:
+-- !result
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+True
+-- !result
+DROP MATERIALIZED VIEW non_partitioned_mv;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+DROP CATALOG mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,140 @@
+-- name: test_partitioned_mv_with_dropped_partitions
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set enable_materialized_view_transparent_union_rewrite = true;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW partitioned_mv_loose 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "LOOSE"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+-- result:
+-- !result
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+True
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-18' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+True
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+-- result:
+-- !result
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+CREATE MATERIALIZED VIEW partitioned_mv_force 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "FORCE_MV"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_force WITH SYNC MODE;
+-- result:
+-- !result
+SELECT * FROM partitioned_mv_force ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+DROP MATERIALIZED VIEW partitioned_mv_loose;
+-- result:
+-- !result
+DROP MATERIALIZED VIEW partitioned_mv_force;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+DROP CATALOG mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,85 @@
+-- name: test_non_partitioned_mv_with_dropped_partitions
+-- description: Test non-partitioned MV with Iceberg base table when partitions are dropped.
+-- This tests the fix for the bug where MV rewrite would return stale data when
+-- partitions were dropped from the base Iceberg table.
+
+-- create iceberg catalog
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+set enable_materialized_view_transparent_union_rewrite = true;
+
+-- create iceberg table with partitions
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+
+-- Insert data into multiple partitions
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+
+-- Switch to default catalog and create MV
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create a non-partitioned MV that references a partitioned iceberg table
+CREATE MATERIALIZED VIEW non_partitioned_mv 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+-- Refresh MV to load all data
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+
+-- Verify MV contains all data
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+
+-- Verify MV is used for query rewrite
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Drop a partition from the base iceberg table
+set catalog mv_iceberg_${uuid0};
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+
+-- Switch back to default catalog
+set catalog default_catalog;
+use db_${uuid0};
+
+-- Query should not hit MV since it's stale (partition was dropped)
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Refresh MV to sync with base table
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+
+-- After refresh, MV should contain updated data (without the dropped partition)
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+
+-- MV should be used for query rewrite again
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Clean up
+DROP MATERIALIZED VIEW non_partitioned_mv;
+DROP DATABASE db_${uuid0};
+set catalog mv_iceberg_${uuid0};
+DROP DATABASE mv_iceberg_db_${uuid0};
+DROP CATALOG mv_iceberg_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,104 @@
+-- name: test_partitioned_mv_with_dropped_partitions
+-- description: Test partitioned MV with Iceberg base table when partitions are dropped.
+-- This tests the fix for the bug where MV rewrite would return stale data when
+-- partitions were dropped from the base Iceberg table in LOOSE and FORCE_MV modes.
+
+-- create iceberg catalog
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+set enable_materialized_view_transparent_union_rewrite = true;
+
+-- create iceberg table with partitions
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+
+-- Insert data into multiple partitions
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+
+-- Switch to default catalog and create partitioned MV with LOOSE mode
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create a partitioned MV with LOOSE consistency mode
+CREATE MATERIALIZED VIEW partitioned_mv_loose 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "LOOSE"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+
+-- Verify MV contains all data
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Drop a partition from the base iceberg table
+set catalog mv_iceberg_${uuid0};
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+
+-- Switch back to default catalog
+set catalog default_catalog;
+use db_${uuid0};
+
+-- Query with dropped partition should not hit MV in LOOSE mode
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Query with existing partition should still hit MV
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-18' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Refresh MV to sync with base table
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+
+-- After refresh, query should work correctly
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+
+-- Create a partitioned MV with FORCE_MV consistency mode
+CREATE MATERIALIZED VIEW partitioned_mv_force 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "FORCE_MV"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_force WITH SYNC MODE;
+
+-- Verify MV contains data
+SELECT * FROM partitioned_mv_force ORDER BY dt;
+
+-- Clean up
+DROP MATERIALIZED VIEW partitioned_mv_loose;
+DROP MATERIALIZED VIEW partitioned_mv_force;
+DROP DATABASE db_${uuid0};
+set catalog mv_iceberg_${uuid0};
+DROP DATABASE mv_iceberg_db_${uuid0};
+DROP CATALOG mv_iceberg_${uuid0};


### PR DESCRIPTION
This commit fixes a critical bug where Materialized View (MV) transparent rewrite would return stale data when partitions were dropped from the base Iceberg table.

Problem:
- When partitions are deleted from the base table, MV rewrite still used stale data
- For partitioned MVs: LOOSE and FORCE_MV modes didn't handle deleted partitions
- For non-partitioned MVs: No detection of deleted partitions at all

Solution:
1. For partitioned MVs (MVTimelinessArbiter):
   - Added handling for diff.getDeletes() in LOOSE mode
   - Added handling for diff.getDeletes() in FORCE_MV mode
   - Deleted partitions are now added to refresh list to exclude them from rewrite

2. For non-partitioned MVs (MVTimelinessNonPartitionArbiter):
   - Added hasDeletedPartitions() method to detect deleted partitions
   - Compares current partitions with previously refreshed partitions
   - Returns fullRefresh if any previously refreshed partition no longer exists

Impact:
- MV transparent rewrite will now correctly detect deleted partitions
- Queries will not use stale MV data when base table partitions are dropped
- Ensures data consistency between base tables and MVs

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
