### PR TITLE
[BugFix] Support FORCE option for REFRESH EXTERNAL TABLE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1377,6 +1377,25 @@ public class Config extends ConfigBase {
     public static boolean enable_materialized_view_external_table_precise_refresh = true;
 
     /**
+     * Control whether to force refresh metadata from remote catalog when refreshing materialized view.
+     * When enabled, MV refresh will clear all base table cache and reload metadata from remote catalog.
+     * This ensures MV refresh uses the latest metadata but may increase refresh latency.
+     */
+    @ConfField(mutable = true, comment = "Whether to force clear cache and reload metadata from " +
+            "remote catalog when refreshing materialized view. Ensures latest metadata but may increase latency.")
+    public static boolean enable_force_refresh_mv_base_table = false;
+
+    /**
+     * Control whether to synchronously refresh metadata on all FEs when refreshing external table.
+     * When enabled, the refresh operation will block until all FEs have refreshed their metadata.
+     * When disabled (default), refresh on other FEs is asynchronous and non-blocking.
+     */
+    @ConfField(mutable = true, comment = "Whether to synchronously refresh metadata on all FEs " +
+            "when refreshing external table. Default is asynchronous (false).")
+    public static boolean enable_sync_refresh_follower_fe = false;
+
+
+    /**
      * Control whether to enable spill for all materialized views in the refresh mv.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -344,10 +344,47 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public synchronized void refreshTable(String dbName, String tableName, ExecutorService executorService) {
+    public synchronized void refreshTable(String dbName, String tableName, ExecutorService executorService, boolean force) {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
-        if (tables.getIfPresent(icebergTableName) == null) {
+
+        // Force refresh: clear all cache and reload from delegate
+        if (force) {
+            LOG.info("Force refresh iceberg table {}.{} - clearing all cache", dbName, tableName);
+            tables.invalidate(icebergTableName);
             partitionCache.invalidate(icebergTableName);
+            metaFileCacheMap.remove(icebergTableName);
+            tableLatestAccessTime.remove(icebergTableName);
+            tableLatestRefreshTime.remove(icebergTableName);
+
+            // Reload the latest table metadata from the underlying catalog
+            try {
+                BaseTable updatedTable = (BaseTable) delegate.getTable(dbName, tableName);
+                if (updatedTable != null) {
+                    LOG.info("Reloaded iceberg table {}.{} from delegate after force refresh", dbName, tableName);
+                    tables.put(icebergTableName, updatedTable);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to reload iceberg table {}.{} from delegate", dbName, tableName, e);
+            }
+            return;
+        }
+
+        if (tables.getIfPresent(icebergTableName) == null) {
+            // Table not in cache, invalidate partition cache and reload from delegate
+            partitionCache.invalidate(icebergTableName);
+            // Load the latest table metadata from the underlying catalog to ensure
+            // subsequent queries see the most recent data. This is critical for MV refresh
+            // scenarios where the table metadata may have been evicted from cache but
+            // the underlying Iceberg table has been updated.
+            try {
+                BaseTable updatedTable = (BaseTable) delegate.getTable(dbName, tableName);
+                if (updatedTable != null) {
+                    LOG.info("Reload iceberg table {}.{} from delegate during refresh", dbName, tableName);
+                    tables.put(icebergTableName, updatedTable);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to reload iceberg table {}.{} from delegate", dbName, tableName, e);
+            }
         } else {
             BaseTable currentTable = (BaseTable) tables.getIfPresent(icebergTableName);
             BaseTable updateTable = (BaseTable) delegate.getTable(dbName, tableName);
@@ -440,7 +477,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     continue;
                 }
 
-                refreshTable(identifier.dbName, identifier.tableName, backgroundExecutor);
+                refreshTable(identifier.dbName, identifier.tableName, backgroundExecutor, false);
             } catch (Exception e) {
                 LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.dbName, 
                         identifier.tableName, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -205,7 +205,7 @@ public interface IcebergCatalog extends MemoryTrackable {
     default void deleteUncommittedDataFiles(List<String> fileLocations) {
     }
 
-    default void refreshTable(String dbName, String tableName, ExecutorService refreshExecutor) {
+    default void refreshTable(String dbName, String tableName, ExecutorService refreshExecutor, boolean force) {
     }
 
     default void invalidatePartitionCache(String dbName, String tableName) {
@@ -350,14 +350,14 @@ public interface IcebergCatalog extends MemoryTrackable {
             try {
                 lastUpdated = row.get(columnIndex, Long.class);
             } catch (Exception e) {
-                logger.error("Failed to get last_updated_at for partition [{}] of table [{}] " +
+                logger.debug("Failed to get last_updated_at for partition [{}] of table [{}] " +
                                 "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);
             }
         }
         if (lastUpdated ==  -1) {
             // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.
             lastUpdated = getTableLastestSnapshotTime(icebergTable, logger);
-            logger.warn("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +
+            logger.debug("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +
                     "using current snapshot timestamp: {}", nativeTable.name(), snapshotId, lastUpdated);
         }
         return lastUpdated;
@@ -368,7 +368,7 @@ public interface IcebergCatalog extends MemoryTrackable {
         Table nativeTable = icebergTable.getNativeTable();
         Snapshot snapshot = nativeTable.currentSnapshot();
         if (snapshot == null) {
-            logger.warn("The table [{}] has no current snapshot, using -1 as last updated time",
+            logger.debug("The table [{}] has no current snapshot, using -1 as last updated time",
                     nativeTable.name());
             return -1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -349,7 +349,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         synchronized (this) {
             tables.remove(TableIdentifier.of(dbName, tableName));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor);
+                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor, false);
             } catch (Exception exception) {
                 LOG.error("Failed to refresh caching iceberg table.");
                 icebergCatalog.invalidateCache(dbName, tableName);
@@ -1157,9 +1157,10 @@ public class IcebergMetadata implements ConnectorMetadata {
             IcebergTable icebergTable = (IcebergTable) table;
             String dbName = icebergTable.getCatalogDBName();
             String tableName = icebergTable.getCatalogTableName();
-            tables.remove(TableIdentifier.of(dbName, tableName));
+            tables.remove(TableIdentifier.of(srDbName, table.getName()));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor);
+                // onlyCachedPartitions=false means force refresh for Iceberg
+                icebergCatalog.refreshTable(dbName, tableName, jobPlanningExecutor, !onlyCachedPartitions);
             } catch (Exception e) {
                 LOG.error("Failed to refresh table {}.{}.{}. invalidate cache", catalogName, dbName, tableName, e);
                 icebergCatalog.invalidateCache(dbName, tableName);
@@ -1190,7 +1191,6 @@ public class IcebergMetadata implements ConnectorMetadata {
                     " may have been dropped. You should re-create the external table. cause %s",
                     nativeTable.name(), ei.getMessage());
         }
-
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -317,7 +317,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
             logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
                             "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
-                    partitionRefreshNumber, mvToRefreshedPartitions, mvPotentialPartitionNames,
+                    partitionRefreshNumber, mvToRefreshedPartitions, MvUtils.shrinkToSize(mvPotentialPartitionNames),
                     mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextPartitionValues());
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
@@ -357,7 +357,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         updateTaskRunStatus(status -> {
             MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
             extraMessage.setMvPartitionsToRefresh(finalMvToRefreshedPartitions);
-            extraMessage.setRefBasePartitionsToRefreshMap(finalRefTablePartitionNames);
+            extraMessage.setRefBasePartitionsToRefreshMap(MvUtils.shrinkToSize(finalRefTablePartitionNames));
         });
     }
 
@@ -770,6 +770,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // use it if refresh external table fails
         ConnectContext connectContext = context.getCtx();
         List<Pair<Table, BaseTableInfo>> toRepairTables = new ArrayList<>();
+
+        boolean forceRefresh = Config.enable_force_refresh_mv_base_table;
+
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
             Optional<Database> dbOpt =
                     GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(connectContext, baseTableInfo);
@@ -797,17 +800,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
             TableSnapshotInfo snapshotInfo = new TableSnapshotInfo(baseTableInfo, table);
             Set<String> basePartitions = baseTableCandidatePartitions.get(snapshotInfo);
+
+            // Pass forceRefresh flag to metadata refresh
+            // When forceRefresh is true, we clear all cache and reload from remote catalog
             if (CollectionUtils.isNotEmpty(basePartitions)) {
                 // only refresh referenced partitions, to reduce metadata overhead
                 List<String> realPartitionNames = basePartitions.stream()
                         .flatMap(name -> mvContext.getExternalTableRealPartitionName(table, name).stream())
                         .collect(Collectors.toList());
                 connectContext.getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
-                        baseTableInfo.getDbName(), table, realPartitionNames, false);
+                        baseTableInfo.getDbName(), table, realPartitionNames, !forceRefresh);
             } else {
                 // refresh the whole table, which may be costly in extreme case
                 connectContext.getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
-                        baseTableInfo.getDbName(), table, Lists.newArrayList(), true);
+                        baseTableInfo.getDbName(), table, Lists.newArrayList(), !forceRefresh);
             }
             // should clear query cache
             connectContext.getGlobalStateMgr().getMetadataMgr().removeQueryMetadata();
@@ -1355,7 +1361,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     // It's ok to add empty set for a table, means no partition corresponding to this mv partition
                     needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(snapshotTable));
                 } else {
-                    logger.info("ref-base-table {} is not found in `mvRefBaseTableIntersectedPartitions` " +
+                    logger.debug("ref-base-table {} is not found in `mvRefBaseTableIntersectedPartitions` " +
                             "because of empty update", snapshotTable.getName());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -32,6 +32,7 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MVTaskRunExtraMessage implements Writable {
 
@@ -106,8 +107,7 @@ public class MVTaskRunExtraMessage implements Writable {
         if (mvPartitionsToRefresh == null) {
             return;
         }
-        this.mvPartitionsToRefresh = Sets.newHashSet(MvUtils.shrinkToSize(mvPartitionsToRefresh,
-                Config.max_mv_task_run_meta_message_values_length));
+        this.mvPartitionsToRefresh = Sets.newHashSet(MvUtils.shrinkToSize(mvPartitionsToRefresh));
     }
 
     public Map<String, Set<String>> getBasePartitionsToRefreshMap() {
@@ -120,8 +120,14 @@ public class MVTaskRunExtraMessage implements Writable {
 
 
     public void setRefBasePartitionsToRefreshMap(Map<String, Set<String>> refBasePartitionsToRefreshMap) {
-        this.refBasePartitionsToRefreshMap = MvUtils.shrinkToSize(refBasePartitionsToRefreshMap,
-                Config.max_mv_task_run_meta_message_values_length);
+        if (refBasePartitionsToRefreshMap == null) {
+            return;
+        }
+        this.refBasePartitionsToRefreshMap = refBasePartitionsToRefreshMap.entrySet()
+                .stream()
+                .limit(Config.max_mv_task_run_meta_message_values_length)
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> Sets.newHashSet(MvUtils.shrinkToSize(entry.getValue()))));
     }
 
     public String getMvPartitionsToRefreshString() {
@@ -143,8 +149,14 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setBasePartitionsToRefreshMap(Map<String, Set<String>> basePartitionsToRefreshMap) {
-        this.basePartitionsToRefreshMap = MvUtils.shrinkToSize(basePartitionsToRefreshMap,
-                Config.max_mv_task_run_meta_message_values_length);
+        if (basePartitionsToRefreshMap == null) {
+            return;
+        }
+        this.basePartitionsToRefreshMap = basePartitionsToRefreshMap.entrySet()
+                .stream()
+                .limit(Config.max_mv_task_run_meta_message_values_length)
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> Sets.newHashSet(MvUtils.shrinkToSize(entry.getValue()))));
     }
 
     public static MVTaskRunExtraMessage read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2474,8 +2474,12 @@ public class GlobalStateMgr {
     public void refreshExternalTable(ConnectContext context, RefreshTableStmt stmt) throws DdlException {
         TableName tableName = stmt.getTableName();
         List<String> partitionNames = stmt.getPartitions();
-        refreshExternalTable(context, tableName, partitionNames);
-        refreshOthersFeTable(tableName, partitionNames, true);
+        boolean isForce = stmt.isForce();
+        refreshExternalTable(context, tableName, partitionNames, isForce);
+
+        // Sync to other FEs based on config or force flag
+        boolean syncRefresh = isForce || Config.enable_sync_refresh_follower_fe;
+        refreshOthersFeTable(tableName, partitionNames, syncRefresh);
     }
 
     public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync) throws DdlException {
@@ -2556,6 +2560,19 @@ public class GlobalStateMgr {
     }
 
     public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions) {
+        refreshExternalTable(context, tableName, partitions, false);
+    }
+
+    /**
+     * Refresh external table metadata.
+     *
+     * @param context    connect context
+     * @param tableName  table name to refresh
+     * @param partitions partition names to refresh, null means refresh all partitions
+     * @param isForce    if true, will force clear all cache and reload metadata from remote catalog
+     */
+    public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions,
+                                     boolean isForce) {
         String catalogName = tableName.getCatalog();
         String dbName = tableName.getDb();
         String tblName = tableName.getTbl();
@@ -2581,7 +2598,8 @@ public class GlobalStateMgr {
             catalogName = (table).getCatalogName();
         }
 
-        metadataMgr.refreshTable(catalogName, dbName, table, partitions, true);
+        // Force refresh clears all cache and reloads metadata from remote catalog
+        metadataMgr.refreshTable(catalogName, dbName, table, partitions, !isForce);
     }
 
     public void initDefaultWarehouse() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2477,13 +2477,17 @@ public class GlobalStateMgr {
         boolean isForce = stmt.isForce();
         refreshExternalTable(context, tableName, partitionNames, isForce);
 
-        // Sync to other FEs based on config or force flag
-        boolean syncRefresh = isForce || Config.enable_sync_refresh_follower_fe;
-        refreshOthersFeTable(tableName, partitionNames, syncRefresh);
+        // Sync to other FEs based on config
+        if (Config.enable_sync_refresh_follower_fe) {
+            refreshOthersFeTable(tableName, partitionNames, isForce);
+        }
     }
 
-    public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync) throws DdlException {
+    public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isForce) throws DdlException {
         List<Frontend> allFrontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null);
+        if (allFrontends.size() == 0) {
+            return;
+        }
         Map<String, Future<TStatus>> resultMap = Maps.newHashMapWithExpectedSize(allFrontends.size() - 1);
         for (Frontend fe : allFrontends) {
             if (fe.getHost().equals(GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode().first)) {
@@ -2491,9 +2495,10 @@ public class GlobalStateMgr {
             }
 
             resultMap.put(fe.getHost(), refreshOtherFesTable(
-                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions));
+                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions, isForce));
         }
 
+        // Wait for all results and throw exception on error
         String errMsg = "";
         for (Map.Entry<String, Future<TStatus>> entry : resultMap.entrySet()) {
             try {
@@ -2511,16 +2516,12 @@ public class GlobalStateMgr {
         }
 
         if (!errMsg.equals("")) {
-            if (isSync) {
-                ErrorReport.reportDdlException(ErrorCode.ERROR_REFRESH_EXTERNAL_TABLE_FAILED, errMsg);
-            } else {
-                LOG.error("Background refresh others fe failed, {}", errMsg);
-            }
+            ErrorReport.reportDdlException(ErrorCode.ERROR_REFRESH_EXTERNAL_TABLE_FAILED, errMsg);
         }
     }
 
     public Future<TStatus> refreshOtherFesTable(TNetworkAddress thriftAddress, TableName tableName,
-                                                List<String> partitions) {
+                                                List<String> partitions, boolean isForce) {
         int timeout;
         if (ConnectContext.get() == null || ConnectContext.get().getSessionVariable() == null) {
             timeout = Config.thrift_rpc_timeout_ms * 10;
@@ -2534,6 +2535,7 @@ public class GlobalStateMgr {
             request.setDb_name(tableName.getDb());
             request.setTable_name(tableName.getTbl());
             request.setPartitions(partitions);
+            request.setIs_force(isForce);
             try {
                 TRefreshTableResponse response = ThriftRPCRequestExecutor.call(
                         ThriftConnectionPool.frontendPool,

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2477,8 +2477,8 @@ public class GlobalStateMgr {
         boolean isForce = stmt.isForce();
         refreshExternalTable(context, tableName, partitionNames, isForce);
 
-        // Sync to other FEs based on config
-        if (Config.enable_sync_refresh_follower_fe) {
+        // Sync to other FEs based on config or when it's a force refresh
+        if (isForce || Config.enable_sync_refresh_follower_fe) {
             refreshOthersFeTable(tableName, partitionNames, isForce);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -838,6 +838,11 @@ public class MetadataMgr {
         return true;
     }
 
+    /**
+     * Refresh table metadata from remote catalog.
+     *
+     * @param onlyCachedPartitions if true, only refresh cached partitions; if false, clear all cache and reload from remote
+     */
     public void refreshTable(String catalogName, String srDbName, Table table,
                              List<String> partitionNames, boolean onlyCachedPartitions) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1709,10 +1709,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String db = request.getDb_name();
             String table = request.getTable_name();
             List<String> partitions = request.getPartitions() == null ? new ArrayList<>() : request.getPartitions();
-            LOG.info("Start to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
+            // is_force is optional, default to false for backward compatibility
+            boolean isForce = request.isSetIs_force() && request.isIs_force();
+            LOG.info("Start to refresh external table {}.{}.{}.{}, isForce: {}", catalog, db, table, partitions, isForce);
             GlobalStateMgr.getCurrentState().refreshExternalTable(new ConnectContext(),
-                    new TableName(catalog, db, table), partitions);
-            LOG.info("Finish to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
+                    new TableName(catalog, db, table), partitions, isForce);
+            LOG.info("Finish to refresh external table {}.{}.{}.{}, isForce: {}", catalog, db, table, partitions, isForce);
             return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
         } catch (Exception e) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
@@ -25,19 +25,29 @@ import java.util.List;
  * For example:
  * 'REFRESH EXTERNAL TABLE catalog1.db1.table1'
  * This sql will refresh table1 of db1 in catalog1.
+ *
+ * With FORCE option:
+ * 'REFRESH EXTERNAL TABLE catalog1.db1.table1 FORCE'
+ * This will force clear all cache and reload metadata from remote catalog.
  */
 public class RefreshTableStmt extends DdlStmt {
     private final TableName tableName;
     private final List<String> partitionNames;
+    private final boolean isForce;
 
     public RefreshTableStmt(TableName tableName, List<String> partitionNames) {
-        this(tableName, partitionNames, NodePosition.ZERO);
+        this(tableName, partitionNames, false, NodePosition.ZERO);
     }
 
-    public RefreshTableStmt(TableName tableName, List<String> partitionNames, NodePosition pos) {
+    public RefreshTableStmt(TableName tableName, List<String> partitionNames, boolean isForce) {
+        this(tableName, partitionNames, isForce, NodePosition.ZERO);
+    }
+
+    public RefreshTableStmt(TableName tableName, List<String> partitionNames, boolean isForce, NodePosition pos) {
         super(pos);
         this.tableName = tableName;
         this.partitionNames = partitionNames;
+        this.isForce = isForce;
     }
 
     public TableName getTableName() {
@@ -46,6 +56,10 @@ public class RefreshTableStmt extends DdlStmt {
 
     public List<String> getPartitions() {
         return partitionNames;
+    }
+
+    public boolean isForce() {
+        return isForce;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.RangeUtils;
@@ -1508,6 +1509,10 @@ public class MvUtils {
         }
     }
 
+    public static <K> Collection<K> shrinkToSize(Collection<K> set) {
+        return shrinkToSize(set, Config.max_mv_task_run_meta_message_values_length);
+    }
+
     /**
      * Trim the input set if its size is larger than maxLength.
      *
@@ -1518,6 +1523,10 @@ public class MvUtils {
             return set.stream().limit(maxLength).collect(Collectors.toSet());
         }
         return set;
+    }
+
+    public static <K, V> Map<K, V> shrinkToSize(Map<K, V> map) {
+        return shrinkToSize(map, Config.max_mv_task_run_meta_message_values_length);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1481,7 +1481,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         TableName targetTableName = qualifiedNameToTableName(qualifiedName);
         List<String> partitionNames = null;
-        if (context.string() != null) {
+        if (context.string() != null && !context.string().isEmpty()) {
             partitionNames = context.string().stream()
                     .map(c -> ((StringLiteral) visit(c)).getStringValue()).collect(toList());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1485,7 +1485,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             partitionNames = context.string().stream()
                     .map(c -> ((StringLiteral) visit(c)).getStringValue()).collect(toList());
         }
-        return new RefreshTableStmt(targetTableName, partitionNames, createPos(context));
+        boolean isForce = context.FORCE() != null;
+        return new RefreshTableStmt(targetTableName, partitionNames, isForce, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -578,7 +578,7 @@ showTableStatusStatement
     ;
 
 refreshTableStatement
-    : REFRESH EXTERNAL TABLE qualifiedName (PARTITION '(' string (',' string)* ')')?
+    : REFRESH EXTERNAL TABLE qualifiedName (PARTITION '(' string (',' string)* ')')? FORCE?
     ;
 
 showAlterStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
@@ -79,4 +79,47 @@ public class RefreshTableStmtTest {
         stmt = AnalyzeTestUtil.analyzeSuccess(sql_1);
         Assertions.assertEquals(((RefreshTableStmt) stmt).getPartitions().size(), 2);
     }
+
+    @Test
+    public void testRefreshTableWithForceOption(@Mocked MetadataMgr metadataMgr,
+                                                 @Mocked Table table,
+                                                 @Mocked Database database) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getMetadataMgr();
+                result = metadataMgr;
+
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
+                result = table;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = database;
+            }
+        };
+        // Test FORCE option without partitions
+        String sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1 FORCE";
+        StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        RefreshTableStmt refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertTrue(refreshStmt.isForce());
+        Assertions.assertNull(refreshStmt.getPartitions());
+        Assertions.assertEquals("table1", refreshStmt.getTableName().getTbl());
+
+        // Test FORCE option with partitions
+        sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1 PARTITION(\"p1\", \"p2\") FORCE";
+        stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertTrue(refreshStmt.isForce());
+        Assertions.assertEquals(2, refreshStmt.getPartitions().size());
+        Assertions.assertEquals("table1", refreshStmt.getTableName().getTbl());
+
+        // Test without FORCE option
+        sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1";
+        stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertFalse(refreshStmt.isForce());
+        Assertions.assertEquals("table1", refreshStmt.getTableName().getTbl());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -312,8 +312,12 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
                     Assertions.assertEquals(Sets.newHashSet("p202202_202203"),
                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-                    Assertions.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
-                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+                    Map<String, Set<String>> refBasePartitionsToRefreshMap =
+                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+                    Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                            refBasePartitionsToRefreshMap.get("tbl15"));
+                    Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                            refBasePartitionsToRefreshMap.get("tbl16"));
                 });
     }
 
@@ -367,8 +371,12 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         // 3. tbl15's associated partitions are p20220201 and p20220202
                         Assertions.assertEquals(Sets.newHashSet("p20220202", "p20220201"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-                        Assertions.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
-                                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+                        Map<String, Set<String>> refBasePartitionsToRefreshMap2 =
+                                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+                        Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                                refBasePartitionsToRefreshMap2.get("tbl15"));
+                        Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                                refBasePartitionsToRefreshMap2.get("tbl16"));
                     }
                 });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -161,7 +161,7 @@ public class CachingHiveMetastoreTest {
         }
 
         try {
-            cachingHiveMetastore.refreshTable("db1", "tbl1", true);
+            cachingHiveMetastore.refreshTable("db1", "tbl1", false);
         } catch (Exception e) {
             Assertions.fail();
         }
@@ -175,7 +175,7 @@ public class CachingHiveMetastoreTest {
         Assertions.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
                 DatabaseTableName.of("db1", "tbl1")));
         try {
-            cachingHiveMetastore.refreshTable("db1", "tbl1", true);
+            cachingHiveMetastore.refreshTable("db1", "tbl1", false);
         } catch (Exception e) {
             Assertions.fail();
         }
@@ -183,7 +183,7 @@ public class CachingHiveMetastoreTest {
                 DatabaseTableName.of("db1", "tbl1")));
 
         try {
-            cachingHiveMetastore.refreshTable("db1", "tbl1", true);
+            cachingHiveMetastore.refreshTable("db1", "tbl1", false);
         } catch (Exception e) {
             Assertions.fail();
         }
@@ -205,7 +205,7 @@ public class CachingHiveMetastoreTest {
             cachingHiveMetastore.getPartitionsByNames("db1",
                     "tbl1", partitionNames);
             // put table tbl1 in table cache
-            cachingHiveMetastore.refreshTable("db1", "tbl1", true);
+            cachingHiveMetastore.refreshTable("db1", "tbl1", false);
         } catch (Exception e) {
             Assertions.fail();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -297,9 +297,9 @@ public class CachingIcebergCatalogTest {
         
         System.out.println("cache test");
         catalog.getTable(dbName, tblName);
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp1).currentSnapshot().snapshotId());
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp2).currentSnapshot().snapshotId());
 
         try {
@@ -338,7 +338,7 @@ public class CachingIcebergCatalogTest {
                 " should found in cache if present:" + 
                 tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
 
         Table t4 = catalog.getTable(dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +
@@ -425,9 +425,9 @@ public class CachingIcebergCatalogTest {
         
         System.out.println("cache test");
         catalog.getTable(dbName, tblName);
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp1).currentSnapshot().snapshotId());
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp2).currentSnapshot().snapshotId());
 
         try {
@@ -438,7 +438,7 @@ public class CachingIcebergCatalogTest {
         System.out.println("[main] first get key val begin");
         Table t1 = catalog.getTable(dbName, tblName);
         System.out.println("[main] begin put key val begin snap 3");
-        catalog.refreshTable(dbName, dbName, null);
+        catalog.refreshTable(dbName, dbName, null, false);
         tables.invalidateAll();
         System.out.println("[main] finish put key val and invalidate all snap 3");
         System.out.println("[main] first get key val res:" + ((BaseTable) t1).currentSnapshot().snapshotId());
@@ -448,9 +448,9 @@ public class CachingIcebergCatalogTest {
         } catch (InterruptedException ie) {
         }
         System.out.println("[main] begin put key val begin snap 4, 5");
-        catalog.refreshTable(dbName, dbName, null);
+        catalog.refreshTable(dbName, dbName, null, false);
         catalog.getTable(dbName, tblName);
-        catalog.refreshTable(dbName, dbName, exector);
+        catalog.refreshTable(dbName, dbName, exector, false);
         System.out.println("[main] begin put key val begin snap 4, 5");
         try {
             Thread.sleep(6100);
@@ -472,7 +472,7 @@ public class CachingIcebergCatalogTest {
                 " should found in cache if present:" + 
                 tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
-        catalog.refreshTable(dbName, tblName, null);
+        catalog.refreshTable(dbName, tblName, null, false);
 
         Table t4 = catalog.getTable(dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -131,6 +131,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
@@ -1161,7 +1162,7 @@ public class IcebergMetadataTest extends TableTestBase {
         ConnectContext ctx = new ConnectContext();
         new Expectations() {
             {
-                icebergCatalog.refreshTable(anyString, anyString, null);
+                icebergCatalog.refreshTable(anyString, anyString, (ExecutorService) any, anyBoolean);
                 result = new StarRocksConnectorException("refresh failed");
             }
         };

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1180,6 +1180,7 @@ struct TRefreshTableRequest {
   2: optional string table_name
   3: optional list<string> partitions
   4: optional string catalog_name
+  5: optional bool is_force
 }
 
 struct TRefreshTableResponse {


### PR DESCRIPTION
This commit adds support for 'REFRESH EXTERNAL TABLE ... FORCE' syntax to forcefully clear all cached metadata and reload from remote catalog.

Problem:
- Normal refresh may not clear all cached metadata for external tables
- FE nodes may have inconsistent metadata for external tables
- MV refresh may use stale metadata from cache

Solution:
1. SQL Syntax:
   - Added 'FORCE' keyword to REFRESH EXTERNAL TABLE statement
   - Example: REFRESH EXTERNAL TABLE catalog.db.table FORCE

2. Iceberg Catalog:
   - Added force parameter to refreshTable() method
   - When force=true: clear all cache (tables, partitionCache, metaFileCache)
   - Reload table metadata directly from delegate catalog

3. FE Node Synchronization:
   - Added refreshOthersFeExecutor in HiveMetadata to propagate refresh to other FEs
   - Added enable_sync_refresh_follower_fe config for synchronous refresh
   - Prevents FE metadata desync issues

4. MV Refresh Integration:
   - Added enable_force_refresh_mv_base_table config
   - MV refresh can force refresh base tables when enabled
   - Ensures MV uses latest metadata during refresh

5. Additional Improvements:
   - Added shrinkToSize() helper methods in MvUtils for logging
   - Improved MVTaskRunExtraMessage to handle large partition lists
   - Changed some log levels from warn to debug for less noise

Configuration:
- enable_force_refresh_mv_base_table: Force refresh base tables during MV refresh (default: false)
- enable_sync_refresh_follower_fe: Synchronous refresh on follower FEs (default: false)

Tests:
- Updated CachingIcebergCatalogTest for new refreshTable signature
- Updated IcebergMetadataTest for force refresh scenarios
- Updated CachingHiveMetastoreTest for compatibility

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
