### PR TITLE
[Enhancement] Reduce lake pk tablet stat collection overhead in shared-data mode cluster (backport #69548)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -643,6 +643,19 @@ CONF_mInt32(retry_apply_timeout_second, "7200");
 // Update interval of tablet stat cache.
 CONF_mInt32(tablet_stat_cache_update_interval_second, "300");
 
+// Whether to use accurate row count for lake primary key tablets by reading delete vectors from object storage.
+// When enabled, each rowset's delete vector is fetched from remote storage to deduct deleted rows, which may
+// significantly increase the overhead of get_tablet_stats RPC.
+// When disabled, the approximate num_dels field stored in rowset metadata is used,
+// which avoids remote I/O but may slightly overcount rows that are deleted but not yet compacted.
+CONF_mBool(lake_enable_accurate_pk_row_count, "true");
+
+// Threshold in milliseconds for logging slow tablet stat collection tasks.
+// When a single tablet stat task takes longer than this threshold, a warning log is emitted
+// with diagnostic info (tablet_id, version, rowset count, accurate_mode, elapsed time).
+// Default is 5 minutes (300000 ms).
+CONF_mInt64(lake_tablet_stat_slow_log_ms, "300000");
+
 // Result buffer cancelled time (unit: second).
 CONF_mInt32(result_buffer_cancelled_interval_time, "300");
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -765,6 +765,8 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                         return;
                     }
 
+                    auto task_start_us = butil::gettimeofday_us();
+
                     // Don't fill meta cache to avoid polluting the cache
                     lake::CacheOptions cache_opts{.fill_meta_cache = false, .fill_data_cache = true};
                     auto tablet_metadata = _tablet_mgr->get_tablet_metadata(tablet_id, version, cache_opts);
@@ -774,16 +776,57 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                         return;
                     }
 
+                    // Determine if this is a primary-key tablet.  Only PK tablets maintain delete vectors
+                    // (delvec), so calling get_rowset_num_deletes() for non-PK tablets is wasteful.
+                    const bool is_pk_tablet = (*tablet_metadata)->schema().keys_type() == PRIMARY_KEYS;
+                    const bool accurate_mode = is_pk_tablet && config::lake_enable_accurate_pk_row_count;
+                    const int num_rowsets = (*tablet_metadata)->rowsets_size();
+
                     int64_t num_rows = 0;
                     int64_t data_size = 0;
                     for (const auto& rowset : (*tablet_metadata)->rowsets()) {
-                        size_t num_deletes =
-                                _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset);
-                        num_rows += rowset.num_rows() - num_deletes;
+                        int64_t num_deletes = 0;
+                        if (is_pk_tablet) {
+                            if (accurate_mode) {
+                                // Accurate mode (default): fetch delete vectors from object storage.
+                                // NOTE!! Each segment incurs a remote metadata read - expensive for large tablets.
+                                num_deletes = static_cast<int64_t>(
+                                        _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
+                            } else {
+                                // Approximate mode: prefer the pre-stored num_dels field in rowset
+                                // metadata. This avoids additional I/O while still providing a reasonable estimate.
+                                // Rows deleted but not yet compacted may be slightly overcounted.
+                                if (rowset.has_num_dels()) {
+                                    num_deletes = rowset.num_dels();
+                                } else {
+                                    // Fallback for old metadata without num_dels.
+                                    num_deletes =
+                                            static_cast<int64_t>(_tablet_mgr->update_mgr()->get_rowset_num_deletes(
+                                                    tablet_id, version, rowset));
+                                }
+                            }
+                        }
+                        // For non-PK tablets, num_deletes stays 0: they have no delete vectors.
+                        // Clamp to avoid negative contribution when approximate num_dels overcounts.
+                        int64_t rowset_live_rows = rowset.num_rows() - num_deletes;
+                        if (UNLIKELY(rowset_live_rows < 0)) {
+                            rowset_live_rows = 0;
+                        }
+                        num_rows += rowset_live_rows;
                         data_size += rowset.data_size();
                     }
                     for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {
                         data_size += file.size();
+                    }
+
+                    auto elapsed_ms = (butil::gettimeofday_us() - task_start_us) / 1000;
+                    if (elapsed_ms >= config::lake_tablet_stat_slow_log_ms) {
+                        TEST_SYNC_POINT_CALLBACK("LakeServiceImpl::get_tablet_stats:slow_log", nullptr);
+                        LOG(WARNING) << "Slow tablet stat collection. tablet_id: " << tablet_id
+                                     << ", version: " << version << ", is_pk_tablet: " << is_pk_tablet
+                                     << ", accurate_mode: " << accurate_mode << ", num_rowsets: " << num_rowsets
+                                     << ", num_rows: " << num_rows << ", data_size: " << data_size
+                                     << ", elapsed_ms: " << elapsed_ms;
                     }
 
                     std::lock_guard l(response_mtx);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -19,6 +19,7 @@
 
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "common/config.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/util.h"
 #include "runtime/exec_env.h"
@@ -1606,6 +1607,10 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
+    // Prune the metacache so we can verify that get_tablet_stats() itself does not refill it.
+    // publish_version() above may have cached v3 metadata.
+    _tablet_mgr->metacache()->prune();
+
     { // get the tablet stat again
         TabletStatRequest request;
         TabletStatResponse response;
@@ -1619,9 +1624,12 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
         EXPECT_EQ(expected_data_size, response.tablet_stats(0).data_size());
     }
 
-    // get_tablet_stats() should not fill metadata cache
-    auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
-    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr);
+    // get_tablet_stats() should not fill the metadata cache (fill_cache=false) to avoid polluting
+    // the precious LRU metacache with stat-collection workloads.
+    auto cache_key_v1 = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
+    auto cache_key_v3 = _tablet_mgr->tablet_metadata_location(_tablet_id, 3);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key_v1) == nullptr);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key_v3) == nullptr);
 
     // test timeout
     response.clear_tablet_stats();
@@ -1637,6 +1645,195 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
 
     _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
     ASSERT_EQ(0, response.tablet_stats_size());
+}
+
+// Verify that DUP_KEYS tablet stats are computed correctly without involving
+// get_rowset_num_deletes() (which is only meaningful for PK tablets).
+TEST_F(LakeServiceTest, test_get_tablet_stats_dup_keys_no_delvec) {
+    // Create a DUP_KEYS tablet (the default fixture tablet type)
+    size_t expected_num_rows = 500;
+    size_t expected_data_size = 8192;
+    auto txn_log = generate_write_txn_log(1, expected_num_rows, expected_data_size);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(_tablet_id);
+        req.add_txn_ids(txn_log.txn_id());
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+    // For DUP_KEYS tablets num_dels in rowset metadata is always 0, so num_rows == expected
+    EXPECT_EQ(expected_num_rows, response.tablet_stats(0).num_rows());
+    EXPECT_EQ(expected_data_size, response.tablet_stats(0).data_size());
+}
+
+// Verify that in approximate mode (default), num_dels from rowset metadata is used for PK tablets
+// instead of calling get_rowset_num_deletes() which reads delete vectors from object storage.
+TEST_F(LakeServiceTest, test_get_tablet_stats_pk_approximate_mode) {
+    // Re-create the test tablet as a PRIMARY_KEYS tablet
+    auto pk_metadata = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+    int64_t pk_tablet_id = pk_metadata->id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
+
+    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows)
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    rowset->set_num_rows(100);
+    rowset->set_data_size(4096);
+    rowset->set_num_dels(20); // 20 rows deleted but not yet compacted
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    // Force approximate mode for this case, independent of global default value.
+    bool old_value = config::lake_enable_accurate_pk_row_count;
+    config::lake_enable_accurate_pk_row_count = false;
+    DeferOp restore_config([old_value] { config::lake_enable_accurate_pk_row_count = old_value; });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(pk_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(pk_tablet_id, response.tablet_stats(0).tablet_id());
+    // Approximate mode: num_rows - num_dels = 100 - 20 = 80
+    EXPECT_EQ(80, response.tablet_stats(0).num_rows());
+}
+
+// Verify that in accurate mode, get_rowset_num_deletes() is used for PK tablets
+// to get precise row counts by reading delete vectors from object storage.
+TEST_F(LakeServiceTest, test_get_tablet_stats_pk_accurate_mode) {
+    // Re-create the test tablet as a PRIMARY_KEYS tablet
+    auto pk_metadata = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+    int64_t pk_tablet_id = pk_metadata->id();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
+
+    // Simulate a rowset with num_rows=200 and num_dels=50
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    rowset->set_num_rows(200);
+    rowset->set_data_size(8192);
+    rowset->set_num_dels(50);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
+
+    // Enable accurate mode
+    bool old_value = config::lake_enable_accurate_pk_row_count;
+    config::lake_enable_accurate_pk_row_count = true;
+    DeferOp restore_config([old_value] { config::lake_enable_accurate_pk_row_count = old_value; });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(pk_tablet_id);
+    info->set_version(2);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(pk_tablet_id, response.tablet_stats(0).tablet_id());
+    // In accurate mode, get_rowset_num_deletes() reads actual delete vectors.
+    // Without actual delete vectors written, no deletes should be deducted.
+    EXPECT_EQ(200, response.tablet_stats(0).num_rows());
+    EXPECT_EQ(8192, response.tablet_stats(0).data_size());
+}
+
+// Verify that tablet stat collection logs a slow warning when elapsed time exceeds
+// the configured threshold (lake_tablet_stat_slow_log_ms).
+TEST_F(LakeServiceTest, test_get_tablet_stats_slow_log) {
+    // Set a very low threshold so that even a fast task triggers the slow log
+    int64_t old_threshold = config::lake_tablet_stat_slow_log_ms;
+    config::lake_tablet_stat_slow_log_ms = 0; // 0 ms: any task should be logged as slow
+    DeferOp restore_config([old_threshold] { config::lake_tablet_stat_slow_log_ms = old_threshold; });
+    std::atomic<bool> slow_log_triggered = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeServiceImpl::get_tablet_stats:slow_log",
+                                          [&](void* /*arg*/) { slow_log_triggered.store(true); });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp clear_sync_point([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("LakeServiceImpl::get_tablet_stats:slow_log");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(1);
+
+    _tablet_mgr->metacache()->prune();
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    ASSERT_TRUE(slow_log_triggered.load());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+    EXPECT_EQ(0, response.tablet_stats(0).num_rows());
+    EXPECT_EQ(0, response.tablet_stats(0).data_size());
+}
+
+// Verify that get_tablet_stats() does NOT fill the metadata cache (fill_cache=false) so that
+// stat-collection workloads do not evict hot metadata entries from the precious LRU metacache.
+TEST_F(LakeServiceTest, test_get_tablet_stats_does_not_pollute_metacache) {
+    _tablet_mgr->metacache()->prune();
+
+    TabletStatRequest request;
+    TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(1);
+
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+
+    // Metadata must NOT be in the metacache after a stat request
+    auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
+    ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr)
+            << "get_tablet_stats should not fill the metacache (fill_cache=false)";
 }
 
 TEST_F(LakeServiceTest, test_drop_table_no_thread_pool) {

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1463,6 +1463,23 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The time interval at which Tablet Stat Cache updates.
 - Introduced in: -
 
+##### lake_enable_accurate_pk_row_count
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to use accurate row counts for lake primary-key tablets. When enabled, StarRocks reads each rowset's delete vector from object storage and subtracts deleted rows, producing more accurate stats but potentially increasing `get_tablet_stats` RPC overhead. When disabled, StarRocks uses the approximate `num_dels` value in rowset metadata to avoid remote I/O, which may slightly overcount rows that were deleted but not yet compacted.
+- Introduced in: -
+##### lake_tablet_stat_slow_log_ms
+
+- Default: 300000
+- Type: Int64
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Threshold (in milliseconds) for logging slow tablet-stat collection tasks. If a single tablet stat task exceeds this value, StarRocks emits a warning log with diagnostics such as `tablet_id`, version, rowset count, accurate mode, and elapsed time.
+- Introduced in: -
+
 ##### enable_bitmap_union_disk_format_with_set
 
 - Default: false

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1787,6 +1787,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: JIT コンパイルのための LRU キャッシュサイズ。0 より大きい場合、キャッシュの実際のサイズを表します。0 以下に設定されている場合、システムは `jit_lru_cache_size = min(mem_limit*0.01, 1GB)` の式を使用してキャッシュを適応的に設定します (ノードの `mem_limit` は 16 GB 以上でなければなりません)。
 - 導入バージョン: -
 
+##### lake_enable_accurate_pk_row_count
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: Lake（共有データ）主キーテーブルの tablet 行数統計で正確な行数を使うかどうか。`true` の場合、各 rowset の delete vector をオブジェクトストレージから取得して削除行を差し引くため精度は上がりますが、`get_tablet_stats` RPC のオーバーヘッドが増える可能性があります。`false` の場合は rowset メタデータの近似 `num_dels` を使ってリモート I/O を回避しますが、未 compaction の削除行をわずかに過大計上する可能性があります。
+- 導入バージョン: -
+##### lake_tablet_stat_slow_log_ms
+
+- デフォルト: 300000
+- タイプ: Int64
+- 単位: Milliseconds
+- 可変: はい
+- 説明: Tablet 統計収集タスクの遅延ログしきい値（ミリ秒）。単一タスクの実行時間がこの値を超えると、`tablet_id`、バージョン、rowset 数、正確モード、経過時間などの診断情報を含む警告ログを出力します。
+- 導入バージョン: -
+- 導入バージョン: -
+
 ### 共有データ
 
 ##### starlet_port

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1374,6 +1374,23 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Tablet Stat Cache 的更新间隔。
 - 引入版本：-
 
+##### lake_enable_accurate_pk_row_count
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否为存算分离（Lake）主键表 tablet 使用精确行数统计。开启后会读取每个 rowset 在对象存储中的 delete vector 来扣减删除行，统计更准确，但会显著增加 `get_tablet_stats` RPC 的开销；关闭后使用 rowset 元数据中的近似 `num_dels`，可避免远端 I/O，但对“已删除但尚未 compaction”的行可能略有高估。
+- 引入版本：-
+##### lake_tablet_stat_slow_log_ms
+
+- 默认值：300000
+- 类型：Int64
+- 单位：Milliseconds
+- 是否动态：是
+- 描述：Tablet 统计采集慢日志阈值（毫秒）。单次 tablet 统计任务耗时超过该阈值时，会输出告警日志，附带 `tablet_id`、版本、rowset 数、是否精确模式和耗时等诊断信息。
+- 引入版本：-
+
 ##### enable_bitmap_union_disk_format_with_set
 
 - 默认值：false


### PR DESCRIPTION
## Why I'm doing:
Backport #69548 to branch-3.5.

## What I'm doing:
Cherry-pick the changes from #69548 to reduce lake pk tablet stat collection overhead in shared-data mode cluster.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport PR