### PR TITLE
[BugFix] Fix connector sink mem tracker release on poller threads

### DIFF
--- a/be/src/exec/pipeline/sink/connector_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.cpp
@@ -21,6 +21,7 @@
 #include "formats/utils.h"
 #include "glog/logging.h"
 #include "runtime/exec_env.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks::pipeline {
 
@@ -61,16 +62,23 @@ bool ConnectorSinkOperator::need_input() const {
         return false;
     }
 
-    auto [status, _] = _io_poller->poll();
-    if (status.ok()) {
-        status = _connector_chunk_sink->status();
+    auto* runtime_state = _fragment_context->runtime_state();
+    Status status;
+    bool can_accept_more_input;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(runtime_state->instance_mem_tracker());
+        std::tie(status, std::ignore) = _io_poller->poll();
+        if (status.ok()) {
+            status = _connector_chunk_sink->status();
+        }
+        can_accept_more_input = _sink_mem_mgr->can_accept_more_input(_op_mem_mgr);
     }
     if (!status.ok()) {
         LOG(WARNING) << "cancel fragment: " << status;
         _fragment_context->cancel(status);
     }
 
-    return _sink_mem_mgr->can_accept_more_input(_op_mem_mgr);
+    return can_accept_more_input;
 }
 
 bool ConnectorSinkOperator::is_finished() const {
@@ -78,15 +86,22 @@ bool ConnectorSinkOperator::is_finished() const {
         return false;
     }
 
-    auto [status, finished] = _io_poller->poll();
-    if (status.ok()) {
-        status = _connector_chunk_sink->status();
+    auto* runtime_state = _fragment_context->runtime_state();
+    Status status;
+    bool finished;
+    bool ret;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(runtime_state->instance_mem_tracker());
+        std::tie(status, finished) = _io_poller->poll();
+        if (status.ok()) {
+            status = _connector_chunk_sink->status();
+        }
+        ret = finished && _connector_chunk_sink->is_finished();
     }
     if (!status.ok()) {
         LOG(WARNING) << "cancel fragment: " << status;
         _fragment_context->cancel(status);
     }
-    bool ret = finished && _connector_chunk_sink->is_finished();
     return ret;
 }
 

--- a/be/src/exec/pipeline/sink/connector_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.cpp
@@ -20,8 +20,8 @@
 #include "connector/async_flush_stream_poller.h"
 #include "formats/utils.h"
 #include "glog/logging.h"
-#include "runtime/exec_env.h"
 #include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
 
 namespace starrocks::pipeline {
 

--- a/be/test/exec/sink/connector_sink_operator_test.cpp
+++ b/be/test/exec/sink/connector_sink_operator_test.cpp
@@ -140,8 +140,8 @@ class ConnectorSinkOperatorTest : public ::testing::Test {
 protected:
     void SetUp() override {
         _fragment_context = _pool.add(new FragmentContext);
-        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>(
-                TUniqueId(), TUniqueId(), TQueryOptions(), TQueryGlobals(), ExecEnv::GetInstance()));
+        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>(TUniqueId(), TUniqueId(), TQueryOptions(),
+                                                                            TQueryGlobals(), ExecEnv::GetInstance()));
         _runtime_state = _fragment_context->runtime_state();
         _runtime_state->set_fragment_ctx(_fragment_context);
     }
@@ -152,7 +152,8 @@ protected:
         auto* process_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
         _query_pool_tracker =
                 std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 100, "query_pool_ut", process_tracker);
-        _query_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY, 100, "query_ut", _query_pool_tracker.get());
+        _query_tracker =
+                std::make_shared<MemTracker>(MemTrackerType::QUERY, 100, "query_ut", _query_pool_tracker.get());
         _runtime_state->init_mem_trackers(_query_tracker);
     }
 
@@ -207,10 +208,9 @@ TEST_F(ConnectorSinkOperatorTest, need_input_releases_flush_memory_under_instanc
     ASSERT_OK(op_mem_mgr->init(&writers, &poller, [](const CommitResult&) {}));
 
     auto chunk_sink = std::make_unique<TestConnectorChunkSink>(_runtime_state);
-    auto op = std::make_shared<ConnectorSinkOperator>(nullptr, 0, Operator::s_pseudo_plan_node_id_for_final_sink, 0,
-                                                      std::move(chunk_sink),
-                                                      std::make_unique<connector::AsyncFlushStreamPoller>(),
-                                                      sink_mem_mgr, op_mem_mgr, _fragment_context);
+    auto op = std::make_shared<ConnectorSinkOperator>(
+            nullptr, 0, Operator::s_pseudo_plan_node_id_for_final_sink, 0, std::move(chunk_sink),
+            std::make_unique<connector::AsyncFlushStreamPoller>(), sink_mem_mgr, op_mem_mgr, _fragment_context);
 
     {
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(process_tracker);
@@ -229,8 +229,8 @@ TEST_F(ConnectorSinkOperatorTest, is_finished_releases_polled_stream_under_insta
     auto stream = [&]() {
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
         CurrentThread::mem_consume_without_cache(kTrackedBytes);
-        return std::make_shared<Stream>(
-                std::make_unique<ReleaseOnDestructWritableFile>("stream.out", kTrackedBytes), nullptr, _runtime_state);
+        return std::make_shared<Stream>(std::make_unique<ReleaseOnDestructWritableFile>("stream.out", kTrackedBytes),
+                                        nullptr, _runtime_state);
     }();
     ASSERT_EQ(_query_pool_tracker->consumption(), kTrackedBytes);
     ASSERT_EQ(_query_tracker->consumption(), kTrackedBytes);

--- a/be/test/exec/sink/connector_sink_operator_test.cpp
+++ b/be/test/exec/sink/connector_sink_operator_test.cpp
@@ -23,25 +23,141 @@
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
+#include "connector/async_flush_stream_poller.h"
 #include "connector/connector_chunk_sink.h"
 #include "connector/hive_chunk_sink.h"
+#include "connector/sink_memory_manager.h"
 #include "formats/utils.h"
+#include "io/async_flush_output_stream.h"
+#include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
 
 namespace starrocks::pipeline {
 namespace {
 
 using CommitResult = formats::FileWriter::CommitResult;
+using Stream = io::AsyncFlushOutputStream;
+
+class NoopWritableFile : public WritableFile {
+public:
+    explicit NoopWritableFile(std::string filename) : _filename(std::move(filename)) {}
+
+    Status append(const Slice& data) override {
+        _size += data.size;
+        return Status::OK();
+    }
+
+    Status appendv(const Slice* data, size_t cnt) override {
+        for (size_t i = 0; i < cnt; ++i) {
+            _size += data[i].size;
+        }
+        return Status::OK();
+    }
+
+    Status pre_allocate(uint64_t size) override { return Status::OK(); }
+    Status close() override { return Status::OK(); }
+    Status flush(FlushMode mode) override { return Status::OK(); }
+    Status sync() override { return Status::OK(); }
+    uint64_t size() const override { return _size; }
+    const std::string& filename() const override { return _filename; }
+
+private:
+    std::string _filename;
+    uint64_t _size = 0;
+};
+
+class ReleaseOnDestructWritableFile final : public NoopWritableFile {
+public:
+    ReleaseOnDestructWritableFile(std::string filename, int64_t bytes)
+            : NoopWritableFile(std::move(filename)), _bytes(bytes) {}
+
+    ~ReleaseOnDestructWritableFile() override { CurrentThread::mem_release_without_cache(_bytes); }
+
+private:
+    int64_t _bytes;
+};
+
+class NoopPartitionChunkWriterFactory final : public connector::PartitionChunkWriterFactory {
+public:
+    Status init() override { return Status::OK(); }
+
+    connector::PartitionChunkWriterPtr create(std::string partition,
+                                              std::vector<int8_t> partition_field_null_list) const override {
+        return nullptr;
+    }
+};
+
+class TestConnectorChunkSink final : public connector::ConnectorChunkSink {
+public:
+    explicit TestConnectorChunkSink(RuntimeState* state)
+            : ConnectorChunkSink({}, {}, std::make_unique<NoopPartitionChunkWriterFactory>(), state, false) {}
+
+    void callback_on_commit(const CommitResult& result) override {}
+
+    Status finish() override {
+        _finished = true;
+        return Status::OK();
+    }
+
+    bool is_finished() override { return _finished; }
+
+    void set_finished(bool finished) { _finished = finished; }
+
+private:
+    bool _finished = true;
+};
+
+class TestPartitionChunkWriter final : public connector::PartitionChunkWriter {
+public:
+    TestPartitionChunkWriter(RuntimeState* state, int64_t flushable_bytes)
+            : PartitionChunkWriter("", {}, std::make_shared<connector::PartitionChunkWriterContext>()),
+              _flushable_bytes(flushable_bytes) {
+        _out_stream = std::make_shared<Stream>(std::make_unique<NoopWritableFile>("writer.out"), nullptr, state);
+    }
+
+    Status init() override { return Status::OK(); }
+    Status write(const ChunkPtr& chunk) override { return Status::OK(); }
+
+    Status flush() override {
+        if (_flushable_bytes > 0) {
+            CurrentThread::mem_release_without_cache(_flushable_bytes);
+            _flushable_bytes = 0;
+        }
+        return Status::OK();
+    }
+
+    Status wait_flush() override { return Status::OK(); }
+    Status finish() override { return Status::OK(); }
+    bool is_finished() override { return true; }
+    int64_t get_written_bytes() override { return _flushable_bytes; }
+    int64_t get_flushable_bytes() override { return _flushable_bytes; }
+
+private:
+    int64_t _flushable_bytes;
+};
 
 class ConnectorSinkOperatorTest : public ::testing::Test {
 protected:
     void SetUp() override {
         _fragment_context = _pool.add(new FragmentContext);
-        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>());
+        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>(
+                TUniqueId(), TUniqueId(), TQueryOptions(), TQueryGlobals(), ExecEnv::GetInstance()));
         _runtime_state = _fragment_context->runtime_state();
+        _runtime_state->set_fragment_ctx(_fragment_context);
     }
 
     void TearDown() override {}
 
+    void init_mem_trackers() {
+        auto* process_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
+        _query_pool_tracker =
+                std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 100, "query_pool_ut", process_tracker);
+        _query_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY, 100, "query_ut", _query_pool_tracker.get());
+        _runtime_state->init_mem_trackers(_query_tracker);
+    }
+
+    std::shared_ptr<MemTracker> _query_pool_tracker;
+    std::shared_ptr<MemTracker> _query_tracker;
     ObjectPool _pool;
     FragmentContext* _fragment_context;
     RuntimeState* _runtime_state;
@@ -69,6 +185,81 @@ TEST_F(ConnectorSinkOperatorTest, test_factory) {
         auto op = op_factory->create(1, 0);
         EXPECT_OK(op->prepare(_runtime_state));
     }
+}
+
+TEST_F(ConnectorSinkOperatorTest, need_input_releases_flush_memory_under_instance_tracker) {
+    auto* process_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
+    init_mem_trackers();
+
+    constexpr int64_t kTrackedBytes = 100;
+    connector::AsyncFlushStreamPoller poller;
+    std::vector<connector::PartitionChunkWriterPtr> writers;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
+        CurrentThread::mem_consume_without_cache(kTrackedBytes);
+        writers.emplace_back(std::make_shared<TestPartitionChunkWriter>(_runtime_state, kTrackedBytes));
+    }
+    ASSERT_EQ(_query_pool_tracker->consumption(), kTrackedBytes);
+    ASSERT_EQ(_query_tracker->consumption(), kTrackedBytes);
+
+    auto sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(_query_pool_tracker.get(), _query_tracker.get());
+    auto* op_mem_mgr = sink_mem_mgr->create_child_manager();
+    ASSERT_OK(op_mem_mgr->init(&writers, &poller, [](const CommitResult&) {}));
+
+    auto chunk_sink = std::make_unique<TestConnectorChunkSink>(_runtime_state);
+    auto op = std::make_shared<ConnectorSinkOperator>(nullptr, 0, Operator::s_pseudo_plan_node_id_for_final_sink, 0,
+                                                      std::move(chunk_sink),
+                                                      std::make_unique<connector::AsyncFlushStreamPoller>(),
+                                                      sink_mem_mgr, op_mem_mgr, _fragment_context);
+
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(process_tracker);
+        EXPECT_TRUE(op->need_input());
+    }
+
+    EXPECT_EQ(_query_pool_tracker->consumption(), 0);
+    EXPECT_EQ(_query_tracker->consumption(), 0);
+}
+
+TEST_F(ConnectorSinkOperatorTest, is_finished_releases_polled_stream_under_instance_tracker) {
+    auto* process_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
+    init_mem_trackers();
+
+    constexpr int64_t kTrackedBytes = 64;
+    auto stream = [&]() {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
+        CurrentThread::mem_consume_without_cache(kTrackedBytes);
+        return std::make_shared<Stream>(
+                std::make_unique<ReleaseOnDestructWritableFile>("stream.out", kTrackedBytes), nullptr, _runtime_state);
+    }();
+    ASSERT_EQ(_query_pool_tracker->consumption(), kTrackedBytes);
+    ASSERT_EQ(_query_tracker->consumption(), kTrackedBytes);
+    ASSERT_OK(stream->close());
+
+    auto io_poller = std::make_unique<connector::AsyncFlushStreamPoller>();
+    io_poller->enqueue(stream);
+    stream.reset();
+
+    auto sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(_query_pool_tracker.get(), _query_tracker.get());
+    auto* op_mem_mgr = sink_mem_mgr->create_child_manager();
+    std::vector<connector::PartitionChunkWriterPtr> writers;
+    connector::AsyncFlushStreamPoller empty_poller;
+    ASSERT_OK(op_mem_mgr->init(&writers, &empty_poller, [](const CommitResult&) {}));
+
+    auto chunk_sink = std::make_unique<TestConnectorChunkSink>(_runtime_state);
+    chunk_sink->set_finished(true);
+    auto op = std::make_shared<ConnectorSinkOperator>(nullptr, 0, Operator::s_pseudo_plan_node_id_for_final_sink, 0,
+                                                      std::move(chunk_sink), std::move(io_poller), sink_mem_mgr,
+                                                      op_mem_mgr, _fragment_context);
+    ASSERT_OK(op->set_finishing(_runtime_state));
+
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(process_tracker);
+        EXPECT_TRUE(op->is_finished());
+    }
+
+    EXPECT_EQ(_query_pool_tracker->consumption(), 0);
+    EXPECT_EQ(_query_tracker->consumption(), 0);
 }
 
 } // namespace


### PR DESCRIPTION
## Why I'm doing:
A connector sink query can keep query pool memory accounted after async flush polling or victim flushing is triggered from the blocked-driver poller thread. That causes query pool consumption to keep growing until it exceeds the process tracker and eventually hits the query memory limit incorrectly.

## What I'm doing:
Bind the fragment instance mem tracker while `ConnectorSinkOperator::need_input()` and `ConnectorSinkOperator::is_finished()` execute, so poller-thread cleanup and victim flushing release memory back to the correct query and query-pool tracker chain.

Add regression tests covering both the `need_input()` victim-flush path and the `is_finished()` async-stream cleanup path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
