### PR TITLE
[Enhancement] Use background compute resource for tablet reshard publish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -35,9 +35,9 @@ import com.starrocks.lake.Utils;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -187,6 +187,8 @@ public class MergeTabletJob extends TabletReshardJob {
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             boolean useAggregatePublish = olapTable.isFileBundling();
+            ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                    .getBackgroundComputeResource(tableId);
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
@@ -211,7 +213,7 @@ public class MergeTabletJob extends TabletReshardJob {
                         tablets.addAll(index.getTablets());
                     }
                     Future<Map<Long, TabletRange>> future = publishThreadPool.submit(() -> publishVersion(
-                            tablets, commitVersion, useAggregatePublish));
+                            tablets, commitVersion, useAggregatePublish, computeResource));
                     reshardingPhysicalPartition.setPublishFuture(future);
                 } else if (publishResult.publishState() == PublishState.IN_PROGRESS) {
                     // Publish is in progress
@@ -490,7 +492,7 @@ public class MergeTabletJob extends TabletReshardJob {
     }
 
     private Map<Long, TabletRange> publishVersion(List<Tablet> tablets, long commitVersion,
-            boolean useAggregatePublish) {
+            boolean useAggregatePublish, ComputeResource computeResource) {
         try {
             TxnInfoPB txnInfo = new TxnInfoPB();
             txnInfo.txnId = transactionId;
@@ -501,7 +503,7 @@ public class MergeTabletJob extends TabletReshardJob {
 
             Map<Long, TabletRange> tabletRange = new HashMap<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
-                    WarehouseManager.DEFAULT_RESOURCE, null, useAggregatePublish);
+                    computeResource, null, useAggregatePublish);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -35,9 +35,9 @@ import com.starrocks.lake.Utils;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -187,6 +187,8 @@ public class SplitTabletJob extends TabletReshardJob {
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             boolean useAggregatePublish = olapTable.isFileBundling();
+            ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                    .getBackgroundComputeResource(tableId);
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
@@ -211,7 +213,7 @@ public class SplitTabletJob extends TabletReshardJob {
                         tablets.addAll(index.getTablets());
                     }
                     Future<Map<Long, TabletRange>> future = publishThreadPool.submit(() -> publishVersion(
-                            tablets, commitVersion, useAggregatePublish));
+                            tablets, commitVersion, useAggregatePublish, computeResource));
                     reshardingPhysicalPartition.setPublishFuture(future);
                 } else if (publishResult.publishState() == PublishState.IN_PROGRESS) {
                     // Publish is in progress
@@ -505,7 +507,7 @@ public class SplitTabletJob extends TabletReshardJob {
     }
 
     private Map<Long, TabletRange> publishVersion(List<Tablet> tablets, long commitVersion,
-            boolean useAggregatePublish) {
+            boolean useAggregatePublish, ComputeResource computeResource) {
         try {
             TxnInfoPB txnInfo = new TxnInfoPB();
             txnInfo.txnId = transactionId;
@@ -516,7 +518,7 @@ public class SplitTabletJob extends TabletReshardJob {
 
             Map<Long, TabletRange> tabletRange = new HashMap<>();
             Utils.publishVersion(tablets, txnInfo, commitVersion - 1, commitVersion, null, tabletRange,
-                    WarehouseManager.DEFAULT_RESOURCE, null, useAggregatePublish);
+                    computeResource, null, useAggregatePublish);
 
             return tabletRange;
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -54,6 +54,7 @@ import com.starrocks.utframe.MockedBackend.MockLakeService;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -68,6 +69,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class MergeTabletJobTest {
     protected static ConnectContext connectContext;
@@ -437,7 +439,45 @@ public class MergeTabletJobTest {
         };
 
         Assertions.assertThrows(TabletReshardException.class,
-                () -> Deencapsulation.invoke(mergeJob, "publishVersion", List.of(), 2L, false));
+                () -> Deencapsulation.invoke(mergeJob, "publishVersion", List.of(), 2L, false,
+                        WarehouseManager.DEFAULT_RESOURCE));
+    }
+
+    @Test
+    public void testRunRunningUsesBackgroundComputeResource() throws Exception {
+        MergeTabletJob mergeJob = createMergeTabletReshardJob();
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        ComputeResource expectedResource = WarehouseComputeResource.of(10010L);
+        AtomicReference<ComputeResource> actualResource = new AtomicReference<>();
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeResource getBackgroundComputeResource(long tableId) {
+                Assertions.assertEquals(table.getId(), tableId);
+                return expectedResource;
+            }
+        };
+
+        new MockUp<Utils>() {
+            @Mock
+            public void publishVersion(List<Tablet> tablets, TxnInfoPB txnInfo,
+                                       long baseVersion, long newVersion, Map<Long, Double> compactionScores,
+                                       Map<Long, TabletRange> tabletRanges,
+                                       ComputeResource computeResource,
+                                       Map<Long, Long> tabletRowNums,
+                                       boolean useAggregatePublish) {
+                actualResource.set(computeResource);
+            }
+        };
+
+        try {
+            mergeJob.run();
+            Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());
+            Assertions.assertSame(expectedResource, actualResource.get());
+        } finally {
+            mergeJob.replayAbortedJob();
+            physicalPartition.setNextVersion(physicalPartition.getVisibleVersion() + 1);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -26,15 +26,18 @@ import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.Range;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.Utils;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
 import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.proto.TabletRangePB;
+import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.sql.ast.TabletList;
 import com.starrocks.thrift.TStatusCode;
@@ -42,6 +45,8 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.MockedBackend.MockLakeService;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -57,6 +62,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class SplitTabletJobTest {
     protected static ConnectContext connectContext;
@@ -358,6 +364,41 @@ public class SplitTabletJobTest {
         tabletReshardJob.setJobState(TabletReshardJob.JobState.ABORTED);
         tabletReshardJob.replay();
         Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+    }
+
+    @Test
+    public void testRunRunningUsesBackgroundComputeResource() throws Exception {
+        SplitTabletJob splitJob = (SplitTabletJob) createTabletReshardJob();
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        ComputeResource expectedResource = WarehouseComputeResource.of(10086L);
+        AtomicReference<ComputeResource> actualResource = new AtomicReference<>();
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeResource getBackgroundComputeResource(long tableId) {
+                Assertions.assertEquals(table.getId(), tableId);
+                return expectedResource;
+            }
+        };
+
+        new MockUp<Utils>() {
+            @Mock
+            public void publishVersion(List<Tablet> tablets, TxnInfoPB txnInfo,
+                                       long baseVersion, long newVersion, Map<Long, Double> compactionScores,
+                                       Map<Long, TabletRange> tabletRanges, ComputeResource computeResource,
+                                       Map<Long, Long> tabletRowNums, boolean useAggregatePublish) {
+                actualResource.set(computeResource);
+            }
+        };
+
+        try {
+            splitJob.run();
+            Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, splitJob.getJobState());
+            Assertions.assertSame(expectedResource, actualResource.get());
+        } finally {
+            splitJob.replayAbortedJob();
+            physicalPartition.setNextVersion(physicalPartition.getVisibleVersion() + 1);
+        }
     }
 
     private static Tuple createTuple(int value) {


### PR DESCRIPTION
## Why I'm doing:
  In shared-data mode, tablet reshard publish in `SplitTabletJob` and `MergeTabletJob` always uses the default compute resource. This bypasses the background compute resource selection exposed by `WarehouseManager` and makes the reshard publish path inconsistent with the intended background routing entry point.

  ## What I'm doing:
  Resolve the background compute resource with `WarehouseManager.getBackgroundComputeResource(tableId)` in `SplitTabletJob` and `MergeTabletJob`, and pass it into the local publish helper instead of hardcoding `DEFAULT_RESOURCE`.

  Add unit tests for split and merge reshard jobs to verify that the background compute resource is propagated to `Utils.publishVersion`, and update the existing merge publish helper test to match the new method signature.

  This change does not introduce an observable behavior change today because the current background compute resource resolution still falls back to the default resource, but it wires the reshard publish caller to the correct extension point.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
