### PR TITLE
[BugFix] Fix MV rewrite ignoring dropped partitions in base table 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -22,12 +22,15 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellUtils;
 import com.starrocks.sql.common.UnsupportedException;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -201,5 +204,57 @@ public class MvRefreshArbiter {
             baseTableUpdateInfo.addToRefreshPartitionNames(updatedPCellSet);
         }
         return baseTableUpdateInfo;
+    }
+
+    /**
+     * Check if any partitions have been deleted from the base table.
+     * For MVs with external tables, if partitions that were previously refreshed no longer exist
+     * in the base table, the MV needs a full refresh.
+     *
+     * @param mv the materialized view
+     * @param baseTableInfo the base table info
+     * @param table the base table
+     * @return true if partitions have been deleted from the base table, false otherwise
+     */
+    public static boolean hasDeletedPartitions(MaterializedView mv, BaseTableInfo baseTableInfo, Table table) {
+        // Only check for external tables (Iceberg, Hive, etc.)
+        if (table.isNativeTableOrMaterializedView()) {
+            return false;
+        }
+
+        try {
+            // Get current partitions from the base table
+            ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(mv, table);
+            Map<String, com.starrocks.connector.PartitionInfo> latestPartitionInfo =
+                    traits.getPartitionNameWithPartitionInfo();
+
+            // Get the partitions that were previously refreshed
+            Map<String, MaterializedView.BasePartitionInfo> versionMap =
+                    mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableRefreshInfo(baseTableInfo);
+
+            if (MapUtils.isEmpty(versionMap)) {
+                return false;
+            }
+
+            // Check if any previously refreshed partitions no longer exist
+            Set<String> currentPartitions = latestPartitionInfo.keySet();
+            for (String refreshedPartition : versionMap.keySet()) {
+                if (!currentPartitions.contains(refreshedPartition)) {
+                    logMVPrepare(mv, String.format(
+                            "Base table partition %s has been deleted, need refresh totally.", refreshedPartition));
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // If we can't determine partition info (e.g., connector doesn't support partition metadata APIs),
+            // skip the deleted partition check rather than forcing a refresh. This avoids regressing MV rewrite
+            // for connectors that don't implement full partition metadata support.
+            LOG.debug("Cannot check for deleted partitions for table {}.{}.{}, skipping check: {}",
+                    baseTableInfo.getCatalogName(), baseTableInfo.getDbName(), baseTableInfo.getTableName(),
+                    e.getMessage());
+            return false;
+        }
+
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -338,8 +338,12 @@ public abstract class MVTimelinessArbiter {
             }
         }
         PCellSortedSet adds = diff.getAdds();
+        PCellSortedSet deletes = diff.getDeletes();
         if (adds != null && !adds.isEmpty()) {
             mvUpdateInfo.getMVToRefreshPCells().addAll(adds);
+        }
+        if (deletes != null && !deletes.isEmpty()) {
+            mvUpdateInfo.getMVToRefreshPCells().addAll(deletes);
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
@@ -403,9 +407,13 @@ public abstract class MVTimelinessArbiter {
             }
         }
         PCellSortedSet adds = diff.getAdds();
+        PCellSortedSet deletes = diff.getDeletes();
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         if (adds != null && !adds.isEmpty()) {
             mvUpdateInfo.getMVToRefreshPCells().addAll(adds);
+        }
+        if (deletes != null && !deletes.isEmpty()) {
+            mvUpdateInfo.getMVToRefreshPCells().addAll(deletes);
         }
         return mvUpdateInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
+import static com.starrocks.catalog.MvRefreshArbiter.hasDeletedPartitions;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 
 public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
@@ -73,6 +74,12 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
                     mvBaseTableUpdateInfo.getToRefreshPCells() != null &&
                     !mvBaseTableUpdateInfo.getToRefreshPCells().isEmpty()) {
                 logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
+                return MvUpdateInfo.fullRefresh(mv);
+            }
+
+            // Check if any partitions have been deleted from external tables
+            if (hasDeletedPartitions(mv, tableInfo, table)) {
+                logMVPrepare(mv, "Non-partitioned base table has deleted partitions, need refresh totally.");
                 return MvUpdateInfo.fullRefresh(mv);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.EnumSet;
@@ -62,6 +63,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
+import static com.starrocks.catalog.MvRefreshArbiter.hasDeletedPartitions;
 import static com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable;
 import static com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector.getExpiredPartitionsByRetentionCondition;
 
@@ -89,6 +91,7 @@ public abstract class MVPCTRefreshPartitioner {
             Table.TableType.HUDI,
             Table.TableType.DELTALAKE
     );
+    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshPartitioner.class);
     private final Logger logger;
 
     protected final MvTaskRunContext mvContext;
@@ -565,6 +568,7 @@ public abstract class MVPCTRefreshPartitioner {
      * Whether non-partitioned materialized view needs to be refreshed or not, it needs refresh when:
      * - its base table is not supported refresh by partition.
      * - its base table has updated.
+     * - its base table has deleted partitions.
      */
     public static boolean isNonPartitionedMVNeedToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
                                                           MaterializedView mv,
@@ -575,6 +579,10 @@ public abstract class MVPCTRefreshPartitioner {
                 return true;
             }
             if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable, queryRewriteParams)) {
+                return true;
+            }
+            // Check if any partitions have been deleted from external tables
+            if (hasDeletedPartitions(mv, snapshotInfo.getBaseTableInfo(), snapshotTable)) {
                 return true;
             }
         }

--- a/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,117 @@
+-- name: test_non_partitioned_mv_with_dropped_partitions
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set enable_materialized_view_transparent_union_rewrite = true;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW non_partitioned_mv 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+-- result:
+019cf9b8-25b6-7412-88b7-943ab8b5d6d6
+-- !result
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+True
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+False
+-- !result
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+-- result:
+019cf9b8-339f-75c0-a059-2e831991bcac
+-- !result
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+-- result:
+True
+-- !result
+DROP MATERIALIZED VIEW non_partitioned_mv;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0};
+-- result:
+E: (1064, 'Database mv_iceberg_db_4099d441c7e64a828de16c8ffa5853f5 not empty')
+-- !result
+DROP CATALOG mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_non_partitioned_mv_with_dropped_partitions
@@ -108,9 +108,11 @@ DROP DATABASE db_${uuid0};
 set catalog mv_iceberg_${uuid0};
 -- result:
 -- !result
-DROP DATABASE mv_iceberg_db_${uuid0};
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
 -- result:
-E: (1064, 'Database mv_iceberg_db_4099d441c7e64a828de16c8ffa5853f5 not empty')
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0} FORCE;
+-- result:
 -- !result
 DROP CATALOG mv_iceberg_${uuid0};
 -- result:

--- a/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,144 @@
+-- name: test_partitioned_mv_with_dropped_partitions
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set enable_materialized_view_transparent_union_rewrite = true;
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW partitioned_mv_loose 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "LOOSE"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+-- result:
+019cf9b7-eabd-79a7-89f8-71c91ba89137
+-- !result
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+True
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-18' GROUP BY dt;", "partitioned_mv_loose")
+-- result:
+True
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+-- result:
+019cf9b8-0195-749c-9f05-3bc5f282ea50
+-- !result
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+CREATE MATERIALIZED VIEW partitioned_mv_force 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "FORCE_MV"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_force WITH SYNC MODE;
+-- result:
+019cf9b8-057c-7a32-80e0-650c97fb46af
+-- !result
+SELECT * FROM partitioned_mv_force ORDER BY dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+-- !result
+DROP MATERIALIZED VIEW partitioned_mv_loose;
+-- result:
+-- !result
+DROP MATERIALIZED VIEW partitioned_mv_force;
+-- result:
+-- !result
+DROP DATABASE db_${uuid0};
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0};
+-- result:
+E: (1064, 'Database mv_iceberg_db_2b745ea3f4a1482e860de3498160799d not empty')
+-- !result
+DROP CATALOG mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/R/test_partitioned_mv_with_dropped_partitions
@@ -135,9 +135,11 @@ DROP DATABASE db_${uuid0};
 set catalog mv_iceberg_${uuid0};
 -- result:
 -- !result
-DROP DATABASE mv_iceberg_db_${uuid0};
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
 -- result:
-E: (1064, 'Database mv_iceberg_db_2b745ea3f4a1482e860de3498160799d not empty')
+-- !result
+DROP DATABASE mv_iceberg_db_${uuid0} FORCE;
+-- result:
 -- !result
 DROP CATALOG mv_iceberg_${uuid0};
 -- result:

--- a/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,85 @@
+-- name: test_non_partitioned_mv_with_dropped_partitions
+-- description: Test non-partitioned MV with Iceberg base table when partitions are dropped.
+-- This tests the fix for the bug where MV rewrite would return stale data when
+-- partitions were dropped from the base Iceberg table.
+
+-- create iceberg catalog
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+set enable_materialized_view_transparent_union_rewrite = true;
+
+-- create iceberg table with partitions
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+
+-- Insert data into multiple partitions
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+
+-- Switch to default catalog and create MV
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create a non-partitioned MV that references a partitioned iceberg table
+CREATE MATERIALIZED VIEW non_partitioned_mv 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+-- Refresh MV to load all data
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+
+-- Verify MV contains all data
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+
+-- Verify MV is used for query rewrite
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Drop a partition from the base iceberg table
+set catalog mv_iceberg_${uuid0};
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+
+-- Switch back to default catalog
+set catalog default_catalog;
+use db_${uuid0};
+
+-- Query should not hit MV since it's stale (partition was dropped)
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Refresh MV to sync with base table
+[UC]REFRESH MATERIALIZED VIEW non_partitioned_mv WITH SYNC MODE;
+
+-- After refresh, MV should contain updated data (without the dropped partition)
+SELECT * FROM non_partitioned_mv ORDER BY dt;
+
+-- MV should be used for query rewrite again
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt;", "non_partitioned_mv")
+
+-- Clean up
+DROP MATERIALIZED VIEW non_partitioned_mv;
+DROP DATABASE db_${uuid0};
+set catalog mv_iceberg_${uuid0};
+DROP DATABASE mv_iceberg_db_${uuid0};
+DROP CATALOG mv_iceberg_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_non_partitioned_mv_with_dropped_partitions
@@ -81,5 +81,6 @@ function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uui
 DROP MATERIALIZED VIEW non_partitioned_mv;
 DROP DATABASE db_${uuid0};
 set catalog mv_iceberg_${uuid0};
-DROP DATABASE mv_iceberg_db_${uuid0};
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+DROP DATABASE mv_iceberg_db_${uuid0} FORCE;
 DROP CATALOG mv_iceberg_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
@@ -1,0 +1,104 @@
+-- name: test_partitioned_mv_with_dropped_partitions
+-- description: Test partitioned MV with Iceberg base table when partitions are dropped.
+-- This tests the fix for the bug where MV rewrite would return stale data when
+-- partitions were dropped from the base Iceberg table in LOOSE and FORCE_MV modes.
+
+-- create iceberg catalog
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+set enable_materialized_view_transparent_union_rewrite = true;
+
+-- create iceberg table with partitions
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 (
+    num int,
+    dt string
+)
+PARTITION BY (dt);
+
+-- Insert data into multiple partitions
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES
+    (1,"2020-06-15"),(2,"2020-06-15"),
+    (2,"2020-06-18"),(3,"2020-06-18"),
+    (3,"2020-06-21"),(4,"2020-06-21");
+
+-- Switch to default catalog and create partitioned MV with LOOSE mode
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create a partitioned MV with LOOSE consistency mode
+CREATE MATERIALIZED VIEW partitioned_mv_loose 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "LOOSE"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+
+-- Verify MV contains all data
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Drop a partition from the base iceberg table
+set catalog mv_iceberg_${uuid0};
+DELETE FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt = '2020-06-15';
+
+-- Switch back to default catalog
+set catalog default_catalog;
+use db_${uuid0};
+
+-- Query with dropped partition should not hit MV in LOOSE mode
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-15' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Query with existing partition should still hit MV
+function: print_hit_materialized_view("SELECT dt, sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 WHERE dt='2020-06-18' GROUP BY dt;", "partitioned_mv_loose")
+
+-- Refresh MV to sync with base table
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_loose WITH SYNC MODE;
+
+-- After refresh, query should work correctly
+SELECT * FROM partitioned_mv_loose ORDER BY dt;
+
+-- Create a partitioned MV with FORCE_MV consistency mode
+CREATE MATERIALIZED VIEW partitioned_mv_force 
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "FORCE_MV"
+)
+AS 
+SELECT dt, sum(num) as total_num 
+FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 
+GROUP BY dt;
+
+[UC]REFRESH MATERIALIZED VIEW partitioned_mv_force WITH SYNC MODE;
+
+-- Verify MV contains data
+SELECT * FROM partitioned_mv_force ORDER BY dt;
+
+-- Clean up
+DROP MATERIALIZED VIEW partitioned_mv_loose;
+DROP MATERIALIZED VIEW partitioned_mv_force;
+DROP DATABASE db_${uuid0};
+set catalog mv_iceberg_${uuid0};
+DROP DATABASE mv_iceberg_db_${uuid0};
+DROP CATALOG mv_iceberg_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
+++ b/test/sql/test_transparent_mv/T/test_partitioned_mv_with_dropped_partitions
@@ -100,5 +100,6 @@ DROP MATERIALIZED VIEW partitioned_mv_loose;
 DROP MATERIALIZED VIEW partitioned_mv_force;
 DROP DATABASE db_${uuid0};
 set catalog mv_iceberg_${uuid0};
-DROP DATABASE mv_iceberg_db_${uuid0};
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+DROP DATABASE mv_iceberg_db_${uuid0} FORCE;
 DROP CATALOG mv_iceberg_${uuid0};


### PR DESCRIPTION
This commit fixes a critical bug where Materialized View (MV) transparent rewrite would return stale data when partitions were dropped from the base Iceberg table.

Problem:
- When partitions are deleted from the base table, MV rewrite still used stale data
- For partitioned MVs: LOOSE and FORCE_MV modes didn't handle deleted partitions
- For non-partitioned MVs: No detection of deleted partitions at all
- Non-partitioned MV refresh was skipped when base table partitions were dropped

Solution:
1. For partitioned MVs (MVTimelinessArbiter):
   - Added handling for diff.getDeletes() in LOOSE mode
   - Added handling for diff.getDeletes() in FORCE_MV mode
   - Deleted partitions are now added to refresh list to exclude them from rewrite

2. For non-partitioned MVs (MVTimelinessNonPartitionArbiter):
   - Added hasDeletedPartitions() method to detect deleted partitions
   - Compares current partitions with previously refreshed partitions
   - Returns fullRefresh if any previously refreshed partition no longer exists

3. For MV refresh (MVPCTRefreshPartitioner):
   - Added hasDeletedPartitions() check in isNonPartitionedMVNeedToRefresh()
   - Ensures MV refresh is not skipped when base table partitions are dropped

Impact:
- MV transparent rewrite will now correctly detect deleted partitions
- MV refresh will correctly refresh when base table partitions are dropped
- Queries will not use stale MV data when base table partitions are dropped
- Ensures data consistency between base tables and MVs

Tests:
- Added dropPartitions() method to MockIcebergMetadata
- Added FE unit tests for non-partitioned and partitioned MVs
- Added SQL tester files for integration tests


Fix bugs in https://github.com/StarRocks/starrocks/pull/70113/


## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
