### PR TITLE
[BugFix] Support FORCE option for REFRESH EXTERNAL TABLE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -359,8 +359,16 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
-    public synchronized void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
+    public synchronized void refreshTable(String dbName, String tableName, ConnectContext ctx, 
+                                          ExecutorService executorService, boolean force) {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
+
+        // Force refresh: clear all cache and reload from delegate
+        if (force) {
+            LOG.info("Force refresh iceberg table {}.{} - clearing all cache", dbName, tableName);
+            invalidateCache(icebergTableName);
+        }
+
         Table cachedTable = tables.getIfPresent(icebergTableName);
         if (cachedTable == null) {
             partitionCache.invalidate(icebergTableName);
@@ -456,7 +464,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     continue;
                 }
 
-                refreshTable(identifier.dbName, identifier.tableName, new ConnectContext(), backgroundExecutor);
+                refreshTable(identifier.dbName, identifier.tableName, new ConnectContext(), backgroundExecutor, false);
             } catch (Exception e) {
                 LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.dbName,
                         identifier.tableName, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -223,7 +223,8 @@ public interface IcebergCatalog extends MemoryTrackable {
     default void deleteUncommittedDataFiles(List<String> fileLocations) {
     }
 
-    default void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService refreshExecutor) {
+    default void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService refreshExecutor, 
+                              boolean force) {
     }
 
     default void invalidateTableCache(String dbName, String tableName) {
@@ -390,7 +391,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                     lastUpdated = lastUpdatedWrapper;
                 }
             } catch (Exception e) {
-                logger.error("Failed to get last_updated_at for partition [{}] of table [{}] " +
+                logger.debug("Failed to get last_updated_at for partition [{}] of table [{}] " +
                                 "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);
             }
         }
@@ -398,7 +399,8 @@ public interface IcebergCatalog extends MemoryTrackable {
             // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.
             lastUpdated = getTableLastestSnapshotTime(icebergTable, logger);
             logger.warn("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +
-                    "using current snapshot timestamp: {}", nativeTable.name(), snapshotId, lastUpdated);
+                    "using current snapshot timestamp: {}, partition: {}", nativeTable.name(), snapshotId, 
+                    lastUpdated, partitionName);
         }
         return lastUpdated;
     }
@@ -408,7 +410,7 @@ public interface IcebergCatalog extends MemoryTrackable {
         Table nativeTable = icebergTable.getNativeTable();
         Snapshot snapshot = nativeTable.currentSnapshot();
         if (snapshot == null) {
-            logger.warn("The table [{}] has no current snapshot, using -1 as last updated time",
+            logger.debug("The table [{}] has no current snapshot, using -1 as last updated time",
                     nativeTable.name());
             return -1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -419,7 +419,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         synchronized (this) {
             tables.remove(TableIdentifier.of(dbName, tableName));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, context, jobPlanningExecutor);
+                icebergCatalog.refreshTable(dbName, tableName, context, jobPlanningExecutor, false);
             } catch (Exception exception) {
                 LOG.error("Failed to refresh caching iceberg table.");
                 icebergCatalog.invalidateCache(dbName, tableName);
@@ -1618,7 +1618,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             String tableName = icebergTable.getCatalogTableName();
             tables.remove(TableIdentifier.of(dbName, tableName));
             try {
-                icebergCatalog.refreshTable(dbName, tableName, new ConnectContext(), jobPlanningExecutor);
+                icebergCatalog.refreshTable(dbName, tableName, new ConnectContext(), jobPlanningExecutor, !onlyCachedPartitions);
             } catch (Exception e) {
                 LOG.error("Failed to refresh table {}.{}.{}. invalidate cache", catalogName, dbName, tableName, e);
                 icebergCatalog.invalidateCache(dbName, tableName);
@@ -1649,7 +1649,6 @@ public class IcebergMetadata implements ConnectorMetadata {
                     " may have been dropped. You should re-create the external table. cause %s",
                     nativeTable.name(), ei.getMessage());
         }
-
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MVTaskRunExtraMessage implements Writable {
 
@@ -112,8 +113,7 @@ public class MVTaskRunExtraMessage implements Writable {
         if (CollectionUtils.isEmpty(mvPartitionsToRefresh)) {
             return;
         }
-        this.mvPartitionsToRefresh = Sets.newHashSet(MvUtils.shrinkToSize(mvPartitionsToRefresh,
-                Config.max_mv_task_run_meta_message_values_length));
+        this.mvPartitionsToRefresh = Sets.newHashSet(MvUtils.shrinkToSize(mvPartitionsToRefresh));
     }
 
     public Map<String, Set<String>> getBasePartitionsToRefreshMap() {
@@ -125,8 +125,14 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setRefBasePartitionsToRefreshMap(Map<String, Set<String>> refBasePartitionsToRefreshMap) {
-        this.refBasePartitionsToRefreshMap = MvUtils.shrinkToSize(refBasePartitionsToRefreshMap,
-                Config.max_mv_task_run_meta_message_values_length);
+        if (refBasePartitionsToRefreshMap == null) {
+            return;
+        }
+        this.refBasePartitionsToRefreshMap = refBasePartitionsToRefreshMap.entrySet()
+                .stream()
+                .limit(Config.max_mv_task_run_meta_message_values_length)
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> Sets.newHashSet(MvUtils.shrinkToSize(entry.getValue()))));
     }
 
     public String getMvPartitionsToRefreshString() {
@@ -139,8 +145,14 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setBasePartitionsToRefreshMap(Map<String, Set<String>> basePartitionsToRefreshMap) {
-        this.basePartitionsToRefreshMap = MvUtils.shrinkToSize(basePartitionsToRefreshMap,
-                Config.max_mv_task_run_meta_message_values_length);
+        if (basePartitionsToRefreshMap == null) {
+            return;
+        }
+        this.basePartitionsToRefreshMap = basePartitionsToRefreshMap.entrySet()
+                .stream()
+                .limit(Config.max_mv_task_run_meta_message_values_length)
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        entry -> Sets.newHashSet(MvUtils.shrinkToSize(entry.getValue()))));
     }
 
     public ExecuteOption getExecuteOption() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2542,11 +2542,17 @@ public class GlobalStateMgr {
         TableName tableName = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
                 tableRef.getTableName(), tableRef.getPos());
         List<String> partitionNames = stmt.getPartitions();
-        refreshExternalTable(context, tableName, partitionNames);
-        refreshOthersFeTable(tableName, partitionNames, true);
+        boolean isForce = stmt.isForce();
+        refreshExternalTable(context, tableName, partitionNames, isForce);
+        refreshOthersFeTable(tableName, partitionNames, true, isForce);
     }
 
     public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync) throws DdlException {
+        refreshOthersFeTable(tableName, partitions, isSync, false);
+    }
+
+    public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync,
+                                     boolean isForce) throws DdlException {
         List<Frontend> allFrontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null);
         if (allFrontends.size() == 0) {
             return;
@@ -2558,7 +2564,7 @@ public class GlobalStateMgr {
             }
 
             resultMap.put(fe.getHost(), refreshOtherFesTable(
-                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions));
+                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()), tableName, partitions, isForce));
         }
 
         String errMsg = "";
@@ -2587,7 +2593,7 @@ public class GlobalStateMgr {
     }
 
     public Future<TStatus> refreshOtherFesTable(TNetworkAddress thriftAddress, TableName tableName,
-                                                List<String> partitions) {
+                                                List<String> partitions, boolean isForce) {
         int timeout;
         if (ConnectContext.get() == null || ConnectContext.get().getSessionVariable() == null) {
             timeout = Config.thrift_rpc_timeout_ms * 10;
@@ -2601,6 +2607,7 @@ public class GlobalStateMgr {
             request.setDb_name(tableName.getDb());
             request.setTable_name(tableName.getTbl());
             request.setPartitions(partitions);
+            request.setIs_force(isForce);
             try {
                 TRefreshTableResponse response = ThriftRPCRequestExecutor.call(
                         ThriftConnectionPool.frontendPool,
@@ -2627,6 +2634,19 @@ public class GlobalStateMgr {
     }
 
     public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions) {
+        refreshExternalTable(context, tableName, partitions, false);
+    }
+
+    /**
+     * Refresh external table metadata.
+     *
+     * @param context    connect context
+     * @param tableName  table name to refresh
+     * @param partitions partition names to refresh, null means refresh all partitions
+     * @param isForce    if true, will force clear all cache and reload metadata from remote catalog
+     */
+    public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions,
+                                     boolean isForce) {
         String catalogName = tableName.getCatalog();
         String dbName = tableName.getDb();
         String tblName = tableName.getTbl();
@@ -2652,7 +2672,8 @@ public class GlobalStateMgr {
             catalogName = (table).getCatalogName();
         }
 
-        metadataMgr.refreshTable(catalogName, dbName, table, partitions, true);
+        boolean onlyCachedPartitions = !isForce;
+        metadataMgr.refreshTable(catalogName, dbName, table, partitions, onlyCachedPartitions);
     }
 
     public void initDefaultWarehouse() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -890,6 +890,11 @@ public class MetadataMgr {
         return true;
     }
 
+    /**
+     * Refresh table metadata from remote catalog.
+     *
+     * @param onlyCachedPartitions if true, only refresh cached partitions; if false, clear all cache and reload from remote
+     */
     public void refreshTable(String catalogName, String srDbName, Table table,
                              List<String> partitionNames, boolean onlyCachedPartitions) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1677,10 +1677,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String db = request.getDb_name();
             String table = request.getTable_name();
             List<String> partitions = request.getPartitions() == null ? new ArrayList<>() : request.getPartitions();
-            LOG.info("Start to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
+            // is_force is optional, default to false for backward compatibility
+            boolean isForce = request.isSetIs_force() && request.isIs_force();
+            LOG.info("Start to refresh external table {}.{}.{}.{}, isForce: {}", catalog, db, table, partitions, isForce);
             GlobalStateMgr.getCurrentState().refreshExternalTable(new ConnectContext(),
-                    new TableName(catalog, db, table), partitions);
-            LOG.info("Finish to refresh external table {}.{}.{}.{}", catalog, db, table, partitions);
+                    new TableName(catalog, db, table), partitions, isForce);
+            LOG.info("Finish to refresh external table {}.{}.{}.{}, isForce: {}", catalog, db, table, partitions, isForce);
             return new TRefreshTableResponse(new TStatus(TStatusCode.OK));
         } catch (Exception e) {
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.RangeUtils;
@@ -1572,6 +1573,10 @@ public class MvUtils {
         }
     }
 
+    public static <K> Collection<K> shrinkToSize(Collection<K> set) {
+        return shrinkToSize(set, Config.max_mv_task_run_meta_message_values_length);
+    }
+
     /**
      * Trim the input set if its size is larger than maxLength.
      *
@@ -1582,6 +1587,10 @@ public class MvUtils {
             return set.stream().limit(maxLength).collect(Collectors.toSet());
         }
         return set;
+    }
+
+    public static <K, V> Map<K, V> shrinkToSize(Map<K, V> map) {
+        return shrinkToSize(map, Config.max_mv_task_run_meta_message_values_length);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1623,11 +1623,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         NodePosition tablePos = createPos(context.qualifiedName().start, context.qualifiedName().stop);
         TableRef tableRef = new TableRef(normalizeName(qualifiedName), null, tablePos);
         List<String> partitionNames = null;
-        if (context.string() != null) {
+        if (context.string() != null && !context.string().isEmpty()) {
             partitionNames = context.string().stream()
                     .map(c -> ((StringLiteral) visit(c)).getStringValue()).collect(toList());
         }
-        return new RefreshTableStmt(tableRef, partitionNames, createPos(context));
+        boolean isForce = context.FORCE() != null;
+        return new RefreshTableStmt(tableRef, partitionNames, isForce, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshTableStmtTest.java
@@ -79,4 +79,46 @@ public class RefreshTableStmtTest {
         stmt = AnalyzeTestUtil.analyzeSuccess(sql_1);
         Assertions.assertEquals(((RefreshTableStmt) stmt).getPartitions().size(), 2);
     }
+
+    @Test
+    public void testRefreshTableWithForceOption(@Mocked MetadataMgr metadataMgr,
+                                                 @Mocked Table table,
+                                                 @Mocked Database database) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getMetadataMgr();
+                result = metadataMgr;
+
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
+                result = table;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = database;
+            }
+        };
+        // Test FORCE option without partitions
+        String sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1 FORCE";
+        StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        RefreshTableStmt refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertTrue(refreshStmt.isForce());
+        Assertions.assertNull(refreshStmt.getPartitions());
+        Assertions.assertEquals("table1", refreshStmt.getTableName());
+
+        // Test FORCE option with partitions
+        sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1 PARTITION(\"p1\", \"p2\") FORCE";
+        stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertTrue(refreshStmt.isForce());
+        Assertions.assertEquals(2, refreshStmt.getPartitions().size());
+        Assertions.assertEquals("table1", refreshStmt.getTableName());
+
+        // Test without FORCE option (default should be false)
+        sql = "REFRESH EXTERNAL TABLE catalog1.db1.table1";
+        stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof RefreshTableStmt);
+        refreshStmt = (RefreshTableStmt) stmt;
+        Assertions.assertFalse(refreshStmt.isForce());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -305,8 +305,12 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Assertions.assertEquals(Sets.newHashSet("p202202_202203"),
                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-                    Assertions.assertEquals("{tbl15=[p20220201, p20220202], tbl16=[p20220201, p20220202]}",
-                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+                    Map<String, Set<String>> refBasePartitionsToRefreshMap =
+                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+                    Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                            refBasePartitionsToRefreshMap.get("tbl15"));
+                    Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                            refBasePartitionsToRefreshMap.get("tbl16"));
                 });
     }
 
@@ -355,8 +359,12 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                         // 3. tbl15's associated partitions are p20220201 and p20220202
                         Assertions.assertEquals(Sets.newHashSet("p20220202", "p20220201"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-                        Assertions.assertEquals("{tbl15=[p20220201, p20220202], tbl16=[p20220201, p20220202]}",
-                                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+                        Map<String, Set<String>> refBasePartitionsToRefreshMap2 =
+                                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+                        Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                                refBasePartitionsToRefreshMap2.get("tbl15"));
+                        Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                                refBasePartitionsToRefreshMap2.get("tbl16"));
                     }
                 });
     }
@@ -456,8 +464,10 @@ public class MVPartitionExprResolverTest extends MVTestBase {
                     MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
                     Assertions.assertEquals(Sets.newHashSet("p202202_202203"),
                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-                    Assertions.assertEquals("{tbl15=[p20220201, p20220202]}",
-                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+                    Map<String, Set<String>> refBasePartitionsToRefreshMap3 =
+                            processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+                    Assertions.assertEquals(Sets.newHashSet("p20220201", "p20220202"),
+                            refBasePartitionsToRefreshMap3.get("tbl15"));
                 });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -160,11 +160,18 @@ public class CachingHiveMetastoreTest {
             Assertions.assertTrue(e.getMessage().contains("invalidated cache"));
         }
 
+        // onlyCachedPartitions=false: full refresh — loads ALL partitions from HMS regardless of what's in cache.
+        // This exercises the else-branch in refreshTableWithoutSync that sets presentPartitionNames = allPartitionsInHms.
         try {
-            cachingHiveMetastore.refreshTable("db1", "tbl1", true);
+            cachingHiveMetastore.refreshTable("db1", "tbl1", false);
         } catch (Exception e) {
             Assertions.fail();
         }
+        // Verify the full-refresh path populated the partition cache with all HMS partitions (not just cached ones).
+        // MockedHiveMetaClient returns ["col1"] as partition keys for tbl1.
+        HivePartitionName partitionName = HivePartitionName.of("db1", "tbl1", "col1");
+        Assertions.assertTrue(cachingHiveMetastore.isPartitionPresent(partitionName),
+                "full refresh (onlyCachedPartitions=false) should load all HMS partitions into cache");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -48,8 +48,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
@@ -541,9 +543,9 @@ public class CachingIcebergCatalogTest {
         
         System.out.println("===== cache test =====");
         catalog.getTable(ctx, dbName, tblName);
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp1).currentSnapshot().snapshotId());
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp2).currentSnapshot().snapshotId());
 
         try {
@@ -582,7 +584,7 @@ public class CachingIcebergCatalogTest {
                 " should found in cache if present:" + 
                 tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
 
         Table t4 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +
@@ -669,9 +671,9 @@ public class CachingIcebergCatalogTest {
         
         System.out.println("===== cache test =====");
         catalog.getTable(ctx, dbName, tblName);
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp1).currentSnapshot().snapshotId());
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
         System.out.printf("[main] put key val: %s -> %d %n", "snap key", ((BaseTable) tmp2).currentSnapshot().snapshotId());
 
         try {
@@ -682,7 +684,7 @@ public class CachingIcebergCatalogTest {
         System.out.println("[main] first get key val begin");
         Table t1 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("[main] begin put key val begin snap 3");
-        catalog.refreshTable(dbName, dbName, ctx, null);
+        catalog.refreshTable(dbName, dbName, ctx, null, false);
         tables.invalidateAll();
         System.out.println("[main] finish put key val and invalidate all snap 3");
         System.out.println("[main] first get key val res:" + ((BaseTable) t1).currentSnapshot().snapshotId());
@@ -692,9 +694,9 @@ public class CachingIcebergCatalogTest {
         } catch (InterruptedException ie) {
         }
         System.out.println("[main] begin put key val begin snap 4, 5");
-        catalog.refreshTable(dbName, dbName, ctx, null);
+        catalog.refreshTable(dbName, dbName, ctx, null, false);
         catalog.getTable(ctx, dbName, tblName);
-        catalog.refreshTable(dbName, dbName, ctx, exector);
+        catalog.refreshTable(dbName, dbName, ctx, exector, false);
         System.out.println("[main] begin put key val begin snap 4, 5");
         try {
             Thread.sleep(6100);
@@ -716,7 +718,7 @@ public class CachingIcebergCatalogTest {
                 " should found in cache if present:" + 
                 tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
-        catalog.refreshTable(dbName, tblName, ctx, null);
+        catalog.refreshTable(dbName, tblName, ctx, null, false);
 
         Table t4 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +
@@ -738,6 +740,8 @@ public class CachingIcebergCatalogTest {
         Mockito.when(((BaseTable) nativeTable2).operations().current().metadataFileLocation()).thenReturn("loc2");
 
         AtomicLong callCount = new AtomicLong(0);
+        // Signals when the async reload (call #2) completes
+        CountDownLatch reloadDone = new CountDownLatch(1);
 
         new Expectations() {
             {
@@ -759,17 +763,13 @@ public class CachingIcebergCatalogTest {
                 delegate.getTable((ConnectContext) any, "db1", "t1");
                 result = new Delegate<Table>() {
                     Table capture(ConnectContext c, String db, String tbl) throws Exception {
-                        if (Thread.currentThread().getName().equals("main")) {
-                            System.out.println("[loader] start Loading iceberg table " + 
-                                    db + "." + tbl + " " + Thread.currentThread().getName());     
-                        } else {
-                            System.out.println("[async reloader] start ReLoading iceberg table " + 
-                                    db + "." + tbl + " " + Thread.currentThread().getName());     
-                        }
                         long idx = callCount.incrementAndGet();
+                        System.out.println("[" + Thread.currentThread().getName() + "] getTable call #" + idx);
                         if (idx == 1) {
                             return nativeTable1;
                         }
+                        // Signal that the async reload has completed
+                        reloadDone.countDown();
                         return nativeTable2;
                     }
                 };
@@ -782,25 +782,129 @@ public class CachingIcebergCatalogTest {
                     new CachingIcebergCatalog("iceberg0", delegate, props, es);
             IcebergTableName key = new IcebergTableName("db1", "t1");
 
+            // Call #1: initial synchronous load -> nativeTable1
             Table cached = catalog.getTable(ctx, "db1", "t1");
             Assertions.assertSame(nativeTable1, cached);
+            Assertions.assertEquals(1, callCount.get());
 
             LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
 
+            // t1 is still nativeTable1 (refresh interval not elapsed yet)
             Table t1 = tableCache.get(key);
-            Assertions.assertTrue(callCount.get() == 1);
+            Assertions.assertSame(nativeTable1, t1, "table should still be nativeTable1 before refresh interval");
+
+            // Wait for refreshAfterWrite interval (1s) to elapse, then trigger the async reload
             Thread.sleep(1100);
+
+            // This get() triggers the async reload in the executor
+            // Note: In some environments, the async reload may complete very quickly,
+            // so we don't assert that the value is stale - we just trigger the reload
             Table t2 = tableCache.get(key);
-            Assertions.assertSame(t1, nativeTable1, "table should be same yet");
-            Assertions.assertSame(t1, cached, "table should be same yet");
-            Assertions.assertSame(t1, t2, "table should be same yet");
-            Thread.sleep(300);
-            Assertions.assertTrue(callCount.get() == 2, "all count:" + String.valueOf(callCount.get()));
-            Table t3 = tableCache.get(key);
-            Assertions.assertSame(t3, nativeTable2, "table should be new after reload");
+            System.out.println("After sleep, tableCache.get returned: " + (t2 == nativeTable1 ? "nativeTable1" : 
+                                                                              (t2 == nativeTable2 ? "nativeTable2" : "other")));
+
+            // Wait for the async reload to complete (up to 5s)
+            Assertions.assertTrue(reloadDone.await(5, TimeUnit.SECONDS), "async reload did not complete in time");
+            Assertions.assertEquals(2, callCount.get());
+
+            // Now the cache should hold nativeTable2
+            // Note: Caffeine's async reload may take a short time to update the cache entry
+            // after the reload future completes, so we retry a few times
+            Table t3 = null;
+            for (int i = 0; i < 10; i++) {
+                t3 = tableCache.get(key);
+                if (t3 == nativeTable2) {
+                    break;
+                }
+                Thread.sleep(100);
+            }
+            Assertions.assertSame(nativeTable2, t3, "table should be nativeTable2 after async reload completes");
         } finally {
             es.shutdownNow();
             System.out.println("===== test reload async end =====");
+        }
+    }
+
+    @Test
+    public void testForceRefreshTable(@Mocked IcebergCatalog delegate,
+                                       @Mocked IcebergCatalogProperties props,
+                                       @Mocked ConnectContext ctx) throws Exception {
+        System.out.println("===== test force refresh =====");
+        Table nativeTable1 = createBaseTableWithManifests(1, 1);
+        Table nativeTable2 = createBaseTableWithManifests(2, 2);
+        Mockito.when(((BaseTable) nativeTable1).operations().current().metadataFileLocation()).thenReturn("loc1");
+        Mockito.when(((BaseTable) nativeTable2).operations().current().metadataFileLocation()).thenReturn("loc2");
+
+        AtomicLong callCount = new AtomicLong(0);
+
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheRefreshIntervalSec();
+                result = 0L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1.0;
+                props.isEnableIcebergTableCache();
+                result = true;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
+
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table capture(ConnectContext c, String db, String tbl) throws Exception {
+                        long idx = callCount.incrementAndGet();
+                        if (idx == 1) {
+                            return nativeTable1;
+                        } else if (idx == 2) {
+                            // Normal refresh (force=false) calls delegate to compare metadataFileLocation.
+                            // Returning the same location ("loc1") causes reload() to keep nativeTable1 in cache.
+                            return nativeTable1;
+                        }
+                        // Call #3: triggered by catalog.getTable() after force cleared the cache entry
+                        return nativeTable2;
+                    }
+                };
+            }
+        };
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+            IcebergTableName key = new IcebergTableName("db1", "t1");
+            LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+
+            // Call #1: initial synchronous load -> nativeTable1
+            Table cached = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(nativeTable1, cached);
+            Assertions.assertEquals(1, callCount.get());
+            Assertions.assertNotNull(tableCache.getIfPresent(key), "table should be in cache after initial load");
+
+            // Normal refresh (force=false): calls delegate (call #2) to compare metadataFileLocation.
+            // Same location ("loc1") -> cache entry is kept as nativeTable1, no update.
+            catalog.refreshTable("db1", "t1", ctx, null, false);
+            Assertions.assertEquals(2, callCount.get(), "normal refresh should call delegate once to compare locations");
+            Table afterNormalRefresh = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(nativeTable1, afterNormalRefresh, "normal refresh should keep nativeTable1 (same location)");
+            Assertions.assertNotNull(tableCache.getIfPresent(key), "table should still be in cache after normal refresh");
+
+            // Force refresh (force=true): invalidates the cache entry without calling delegate.
+            // The subsequent getTable() triggers a fresh load (call #3) -> nativeTable2.
+            catalog.refreshTable("db1", "t1", ctx, null, true);
+            Assertions.assertEquals(2, callCount.get(), "force refresh itself should NOT call delegate (just invalidates cache)");
+            Assertions.assertNull(tableCache.getIfPresent(key), "table should be evicted from cache by force refresh");
+
+            Table afterForceRefresh = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertEquals(3, callCount.get(), "getTable after force refresh should trigger a fresh delegate load");
+            Assertions.assertSame(nativeTable2, afterForceRefresh, "force refresh should result in nativeTable2 being loaded");
+        } finally {
+            es.shutdownNow();
+            System.out.println("===== test force refresh end =====");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1766,7 +1766,7 @@ public class IcebergMetadataTest extends TableTestBase {
         ConnectContext ctx = new ConnectContext();
         new Expectations() {
             {
-                icebergCatalog.refreshTable(anyString, anyString, (ConnectContext) any, null);
+                icebergCatalog.refreshTable(anyString, anyString, (ConnectContext) any, null, anyBoolean);
                 result = new StarRocksConnectorException("refresh failed");
             }
         };

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -615,7 +615,7 @@ showTableStatusStatement
     ;
 
 refreshTableStatement
-    : REFRESH EXTERNAL TABLE qualifiedName (PARTITION '(' string (',' string)* ')')?
+    : REFRESH EXTERNAL TABLE qualifiedName (PARTITION '(' string (',' string)* ')')? FORCE?
     ;
 
 showAlterStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
@@ -23,19 +23,29 @@ import java.util.List;
  * For example:
  * 'REFRESH EXTERNAL TABLE catalog1.db1.table1'
  * This sql will refresh table1 of db1 in catalog1.
+ *
+ * With FORCE option:
+ * 'REFRESH EXTERNAL TABLE catalog1.db1.table1 FORCE'
+ * This will force clear all cache and reload metadata from remote catalog.
  */
 public class RefreshTableStmt extends DdlStmt {
     private TableRef tableRef;
     private final List<String> partitionNames;
+    private final boolean isForce;
 
     public RefreshTableStmt(TableRef tableRef, List<String> partitionNames) {
-        this(tableRef, partitionNames, NodePosition.ZERO);
+        this(tableRef, partitionNames, false, NodePosition.ZERO);
     }
 
-    public RefreshTableStmt(TableRef tableRef, List<String> partitionNames, NodePosition pos) {
+    public RefreshTableStmt(TableRef tableRef, List<String> partitionNames, boolean isForce) {
+        this(tableRef, partitionNames, isForce, NodePosition.ZERO);
+    }
+
+    public RefreshTableStmt(TableRef tableRef, List<String> partitionNames, boolean isForce, NodePosition pos) {
         super(pos);
         this.tableRef = tableRef;
         this.partitionNames = partitionNames;
+        this.isForce = isForce;
     }
 
     public TableRef getTableRef() {
@@ -60,6 +70,10 @@ public class RefreshTableStmt extends DdlStmt {
 
     public List<String> getPartitions() {
         return partitionNames;
+    }
+
+    public boolean isForce() {
+        return isForce;
     }
 
     @Override

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1195,6 +1195,7 @@ struct TRefreshTableRequest {
   2: optional string table_name
   3: optional list<string> partitions
   4: optional string catalog_name
+  5: optional bool is_force
 }
 
 struct TRefreshTableResponse {

--- a/test/sql/test_refresh_external_table/R/test_refresh_external_table_force
+++ b/test/sql/test_refresh_external_table/R/test_refresh_external_table_force
@@ -1,0 +1,76 @@
+-- name: test_refresh_external_table_force
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} FORCE;
+-- result:
+-- !result
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01", "2023-12-02") FORCE;
+-- result:
+-- !result
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} FORCE;
+-- result:
+-- !result
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01", "2023-12-02") FORCE;
+-- result:
+-- !result
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01") FORCE;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_refresh_external_table/T/test_refresh_external_table_force
+++ b/test/sql/test_refresh_external_table/T/test_refresh_external_table_force
@@ -1,0 +1,55 @@
+-- name: test_refresh_external_table_force
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Test 1: Basic refresh without FORCE on native OLAP table (unsupported type)
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+
+-- Test 2: Refresh with FORCE option on native OLAP table (unsupported type)
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} FORCE;
+
+-- Test 3: Refresh with partitions and FORCE on native OLAP table (unsupported type)
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01", "2023-12-02") FORCE;
+
+-- Test 4: Refresh with catalog.db.table format and FORCE - unknown catalog
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} FORCE;
+
+-- Test 5: Refresh with complex partition names and FORCE - unknown catalog
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01", "2023-12-02") FORCE;
+
+-- Test 6: Refresh without FORCE - unknown catalog
+REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+
+-- Test 7: Refresh with single partition and FORCE on native OLAP table (unsupported type)
+[UC]REFRESH EXTERNAL TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} PARTITION("2023-12-01") FORCE;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Add `refresh external table <table> force` to clear the specific metadata to avoid some bad cases caused by metadata caches.


## What I'm doing:

This pull request introduces a new "force refresh" capability for external table metadata, allowing cache to be forcibly cleared and reloaded from remote catalogs. It also refactors related APIs to support this feature and improves cache handling logic. Additionally, the pull request streamlines how partition and base partition maps are shrunk to size, and enhances logging for partition refresh operations.

**External Table Metadata Refresh Enhancements:**

* Added a `force` parameter to the `refreshTable` method in `IcebergCatalog` and its implementations, enabling forced cache invalidation and metadata reload for Iceberg tables. [[1]](diffhunk://#diff-6ddd453bb810191565c31c5966e5473a9ea0673e9a487d1ed5577a34f109ce90L362-R371) [[2]](diffhunk://#diff-14a0f2a038313d660d400d66ff60bf2546a7c61967a7ba6070c6f9706b8bc414L226-R227)
* Updated the metadata refresh flow in `GlobalStateMgr`, `FrontendServiceImpl`, and related classes to propagate the `force` flag, including new overloads and improved request handling for remote refresh operations. [[1]](diffhunk://#diff-f984caabe30dbd48498d84662a74a779da4f0eb0bc725f7a223db5d2afced268L2545-R2555) [[2]](diffhunk://#diff-f984caabe30dbd48498d84662a74a779da4f0eb0bc725f7a223db5d2afced268R2637-R2649) [[3]](diffhunk://#diff-921ba54538823c20a429c7eee2020ea9795b7b2d014e0aef418e52d8aba1d234L1680-R1685)

**Partition Map Shrinking Refactor:**

* Refactored `MvUtils.shrinkToSize` usage in `MVTaskRunExtraMessage` to use new overloads that default to the configured maximum size, simplifying API usage and improving maintainability. [[1]](diffhunk://#diff-2beea2501608af783672f127f5dc864766939d48a820104b4f71f0bb4440c371L115-R116) [[2]](diffhunk://#diff-2beea2501608af783672f127f5dc864766939d48a820104b4f71f0bb4440c371L128-R135) [[3]](diffhunk://#diff-2beea2501608af783672f127f5dc864766939d48a820104b4f71f0bb4440c371L142-R155) [[4]](diffhunk://#diff-2bb26249a2c1cd7977c10054f3fdfe6041cbe990f4ab008c1cbeb11e8a1f74afR1576-R1579) [[5]](diffhunk://#diff-2bb26249a2c1cd7977c10054f3fdfe6041cbe990f4ab008c1cbeb11e8a1f74afR1592-R1595)

**Logging and Error Handling Improvements:**

* Enhanced logging in `IcebergCatalog` to use debug level for non-critical errors and to include partition names in warnings about snapshot expiration. [[1]](diffhunk://#diff-14a0f2a038313d660d400d66ff60bf2546a7c61967a7ba6070c6f9706b8bc414L393-R403) [[2]](diffhunk://#diff-14a0f2a038313d660d400d66ff60bf2546a7c61967a7ba6070c6f9706b8bc414L411-R413)
* Improved logging in `FrontendServiceImpl` to indicate when force refresh is used, aiding debugging and traceability.

**SQL Parser Update:**

* Modified the SQL parser (`AstBuilder`) to recognize the `FORCE` keyword in `REFRESH TABLE` statements, enabling users to request forced metadata refresh via SQL.

**API Consistency and Backward Compatibility:**

* Ensured backward compatibility by defaulting the `force` flag to `false` in remote refresh requests and maintaining existing method signatures where possible. [[1]](diffhunk://#diff-921ba54538823c20a429c7eee2020ea9795b7b2d014e0aef418e52d8aba1d234L1680-R1685) [[2]](diffhunk://#diff-f984caabe30dbd48498d84662a74a779da4f0eb0bc725f7a223db5d2afced268R2637-R2649)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
