### PR TITLE
[BugFix] Fix out-of-bounds access in cal_new_base_version during schema change publish

### DIFF
--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -93,8 +93,8 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
     if (index_version > version) {
         // There is a possibility that the index version is newer than the version in remote storage.
         // Check whether the index version exists in remote storage. If not, clear and rebuild the index.
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version, true,
-                                                   txns[index_version - base_version - 1].gtid());
+        auto gtid = txns.size() == 1 ? txns[0].gtid() : txns[index_version - base_version - 1].gtid();
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version, true, gtid);
         if (res.ok()) {
             version = index_version;
         } else {


### PR DESCRIPTION
## Why I'm doing:
In `cal_new_base_version()`, the expression `txns[index_version - base_version - 1].gtid()` assumes `txns` covers all versions from `base_version+1` to `new_version`. This assumption breaks during schema change publish of shadow index (`LakeTableSchemaChangeJob.lakePublishVersion`), where `base_version=1`, `new_version=commitVersion` (can be large), but `txns.size()=1`, causing an out-of-bounds array access and SIGSEGV crash.

This bug was introduced by PR #54484 (2025-01-02), which changed `cal_new_base_version` from `tablet_metadata_exists(tablet_id, index_version)` to `get_tablet_metadata(tablet_id, index_version, true, txns[index_version - base_version - 1].gtid())` without bounds checking.

Triggered by: **shared-data + primary key table + schema change + file bundling enabled + table has accumulated many versions**.

## What I'm doing:
Add bounds check before accessing `txns` array in `cal_new_base_version()`. When the index is out of bounds, fall back to `gtid=0` (the default), which is equivalent to the behavior before the gtid feature was introduced in #54484.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4