### PR TITLE
[BugFix] Fix crash in ProjectOperator when unpacking ConstColumn with nullable data

### DIFF
--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -67,9 +67,15 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
                 result_columns[i] = std::move(mutable_col);
             } else if (result_columns[i]->is_constant()) {
                 // Note: we must create a new column every time here,
-                // because result_columns[i] is shared_ptr
-                MutableColumnPtr new_column = ColumnHelper::create_column(_expr_ctxs[i]->root()->type(), false);
+                // because result_columns[i] is shared_ptr.
+                // Use clone_empty() instead of create_column(type, false) to preserve
+                // the data column's actual type (e.g., NullableColumn<ArrayColumn<...>>).
+                // create_column(type, false) always creates a non-nullable column, which
+                // causes a type mismatch crash when the const data is nullable — the
+                // down_cast inside ArrayColumn::append would reinterpret NullableColumn
+                // members as ArrayColumn members, leading to SIGSEGV.
                 auto* const_column = down_cast<const ConstColumn*>(result_columns[i].get());
+                auto new_column = const_column->data_column()->clone_empty();
                 new_column->append(*const_column->data_column(), 0, 1);
                 new_column->assign(num_rows, 0);
                 result_columns[i] = std::move(new_column);


### PR DESCRIPTION
## Why I'm doing:

When an expression like `array_map` with constant array input returns `ConstColumn<NullableColumn<ArrayColumn<...>>>`, `ProjectOperator::push_chunk` crashes with SIGSEGV.

**Root cause:** The code creates a non-nullable destination column via `create_column(type, false)`, then calls `append(*const_column->data_column(), 0, 1)` where `data_column()` is `NullableColumn<ArrayColumn<...>>`. Inside `ArrayColumn::append`, `down_cast<const ArrayColumn&>(src)` on a `NullableColumn` is undefined behavior — it reinterprets `_null_column` as `_offsets`, producing garbage values that cascade down to `BinaryColumnBase::append` and cause SIGSEGV at address 0x0.

## What I'm doing:

Replace `create_column(type, false)` with `data_column->clone_empty()`, which creates a type-compatible destination column preserving the original nullable wrapper, ensuring correct virtual dispatch in `append()`.

## How to reproduce:

```sql
SELECT cast(array_map(x->cast(json_query(x, '$.Id') as varchar), ['a','b']) as array<varchar>);
-- BE crashes with SIGSEGV before the fix, returns [null, null] after the fix.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4