### PR TITLE
[Enhancement] Auto trigger tablet merge for shared-data range distribution tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
@@ -152,7 +152,8 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                 for (PhysicalPartition physicalPartition : physicalPartitions) {
                     Map<Long, ReshardingMaterializedIndex> reshardingIndexes = new HashMap<>();
                     for (MaterializedIndex oldIndex : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
-                        List<List<Long>> mergeTabletGroupsForIndex = createMergeTabletGroups(oldIndex, targetSize);
+                        List<List<Long>> mergeTabletGroupsForIndex =
+                                createMergeTabletGroups(physicalPartition, oldIndex, targetSize);
                         if (mergeTabletGroupsForIndex.isEmpty()) {
                             continue;
                         }
@@ -254,16 +255,17 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
         return mergeTabletGroups;
     }
 
-    private List<List<Long>> createMergeTabletGroups(MaterializedIndex oldIndex, long targetSize) {
+    private List<List<Long>> createMergeTabletGroups(
+            PhysicalPartition physicalPartition, MaterializedIndex oldIndex, long targetSize) {
         // MaterializedIndex tablets are already ordered by range.
         List<Tablet> orderedTablets = oldIndex.getTablets();
         List<List<Long>> mergeTabletGroups = new ArrayList<>();
 
         List<Long> currentTabletGroup = new ArrayList<>();
         long currentSize = 0;
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
         for (Tablet tablet : orderedTablets) {
-            long dataSize = tablet.getDataSize(true);
-            if (dataSize >= targetSize) {
+            if (!(tablet instanceof LakeTablet)) {
                 if (currentTabletGroup.size() >= 2) {
                     mergeTabletGroups.add(currentTabletGroup);
                 }
@@ -272,13 +274,27 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                 continue;
             }
 
-            currentTabletGroup.add(tablet.getId());
-            currentSize += dataSize;
-            if (currentSize >= targetSize && currentTabletGroup.size() >= 2) {
-                mergeTabletGroups.add(currentTabletGroup);
+            long dataSize = tablet.getDataSize(true);
+            if (dataSize >= targetSize
+                    || ((LakeTablet) tablet).getDataSizeUpdateTime() < visibleVersionTime) {
+                if (currentTabletGroup.size() >= 2) {
+                    mergeTabletGroups.add(currentTabletGroup);
+                }
+                currentTabletGroup = new ArrayList<>();
+                currentSize = 0;
+                continue;
+            }
+
+            if (currentSize + dataSize > targetSize) {
+                if (currentTabletGroup.size() >= 2) {
+                    mergeTabletGroups.add(currentTabletGroup);
+                }
                 currentTabletGroup = new ArrayList<>();
                 currentSize = 0;
             }
+
+            currentTabletGroup.add(tablet.getId());
+            currentSize += dataSize;
         }
 
         if (currentTabletGroup.size() >= 2) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -22,6 +22,11 @@ public class TabletReshardUtils {
         return calcSplitCount(dataSize, Config.tablet_reshard_target_size) > 1;
     }
 
+    public static boolean needMerge(long minAdjacentTabletPairSize) {
+        long targetSize = Config.tablet_reshard_target_size;
+        return targetSize > 0 && minAdjacentTabletPairSize <= targetSize;
+    }
+
     /*
      * Return value > 1 if need split
      * Return value = 1 if not need split

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -57,6 +57,7 @@ import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.system.Backend;
@@ -136,6 +137,7 @@ public class TabletStatMgr extends FrontendDaemon {
 
                 long totalRowCount = 0L;
                 long maxTabletSize = 0L;
+                long minAdjacentTabletPairSize = Long.MAX_VALUE;
                 Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
                 OlapTable olapTable = (OlapTable) table;
@@ -144,13 +146,26 @@ public class TabletStatMgr extends FrontendDaemon {
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             long version = physicalPartition.getVisibleVersion();
+                            long visibleVersionTime = physicalPartition.getVisibleVersionTime();
                             for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(
                                     IndexExtState.VISIBLE)) {
                                 long indexRowCount = 0L;
+                                long prevFreshTabletSize = -1L;
                                 // NOTE: can take a rather long time to iterate lots of tablets
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
-                                    maxTabletSize = Math.max(maxTabletSize, tablet.getDataSize(true));
+                                    long dataSize = tablet.getDataSize(true);
+                                    maxTabletSize = Math.max(maxTabletSize, dataSize);
+                                    if (!(tablet instanceof LakeTablet)
+                                            || ((LakeTablet) tablet).getDataSizeUpdateTime() < visibleVersionTime) {
+                                        prevFreshTabletSize = -1L;
+                                        continue;
+                                    }
+                                    if (prevFreshTabletSize >= 0) {
+                                        minAdjacentTabletPairSize = Math.min(minAdjacentTabletPairSize,
+                                                prevFreshTabletSize + dataSize);
+                                    }
+                                    prevFreshTabletSize = dataSize;
                                 } // end for tablets
                                 indexRowCountMap.put(Pair.create(physicalPartition.getId(), index.getId()),
                                         indexRowCount);
@@ -188,7 +203,7 @@ public class TabletStatMgr extends FrontendDaemon {
 
                 // Trigger tablet reshard
                 if (GlobalStateMgr.getCurrentState().isLeader()) {
-                    triggerTabletReshard(db, olapTable, maxTabletSize);
+                    triggerTabletReshard(db, olapTable, maxTabletSize, minAdjacentTabletPairSize);
                 }
             }
         }
@@ -197,18 +212,30 @@ public class TabletStatMgr extends FrontendDaemon {
         lastWorkTimestamp = LocalDateTime.now();
     }
 
-    private static void triggerTabletReshard(Database db, OlapTable table, long maxTabletSize) {
-        if (table.isCloudNativeTableOrMaterializedView() && table.isRangeDistribution()
-                && TabletReshardUtils.needSplit(maxTabletSize)) {
-            try {
+    private static void triggerTabletReshard(Database db, OlapTable table,
+                                             long maxTabletSize, long minAdjacentTabletPairSize) {
+        if (!table.isCloudNativeTableOrMaterializedView() || !table.isRangeDistribution()) {
+            return;
+        }
+
+        try {
+            if (TabletReshardUtils.needSplit(maxTabletSize)) {
                 GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().createTabletReshardJob(
                         db, table, new SplitTabletClause());
                 LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
                         db.getFullName(), table.getName(), maxTabletSize);
-            } catch (Exception e) {
-                LOG.warn("Failed to create split tablet job for table {}.{}. ",
-                        db.getFullName(), table.getName(), e);
+                return;
             }
+
+            if (TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
+                GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().createTabletReshardJob(
+                        db, table, new MergeTabletClause());
+                LOG.info("Auto triggered merge tablet job for table {}.{}, minAdjacentTabletPairSize {}",
+                        db.getFullName(), table.getName(), minAdjacentTabletPairSize);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to create tablet reshard job for table {}.{}.",
+                    db.getFullName(), table.getName(), e);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -66,7 +67,7 @@ public class AutomaticTabletReshardTest {
         };
 
         Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
-                Config.tablet_reshard_target_size * 4);
+                Config.tablet_reshard_target_size * 4, Long.MAX_VALUE);
     }
 
     @Test
@@ -80,6 +81,20 @@ public class AutomaticTabletReshardTest {
         };
 
         Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
-                Config.tablet_reshard_target_size * 4);
+                Config.tablet_reshard_target_size * 4, Long.MAX_VALUE);
+    }
+
+    @Test
+    void testTriggerTabletMergeSuccess() {
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
+                    throws StarRocksException {
+                return;
+            }
+        };
+
+        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+                0L, Config.tablet_reshard_target_size);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -564,9 +564,17 @@ public class MergeTabletJobTest {
         MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
 
         List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
         for (int i = 0; i < orderedTablets.size(); i++) {
             LakeTablet tablet = (LakeTablet) orderedTablets.get(i);
-            tablet.setDataSize(i < 2 ? 60L : 200L);
+            if (i == 0) {
+                tablet.setDataSize(40L);
+            } else if (i == 1) {
+                tablet.setDataSize(60L);
+            } else {
+                tablet.setDataSize(200L);
+            }
+            tablet.setDataSizeUpdateTime(visibleVersionTime);
         }
 
         MergeTabletClause clause = new MergeTabletClause();
@@ -591,6 +599,73 @@ public class MergeTabletJobTest {
         Assertions.assertNotNull(mergingTablet);
         Assertions.assertEquals(List.of(orderedTablets.get(0).getId(), orderedTablets.get(1).getId()),
                 mergingTablet.getOldTabletIds());
+    }
+
+    @Test
+    public void testMergeTabletJobFactoryAutoMergeStopsAtTargetSize() throws Exception {
+        ensureTabletCount(4);
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
+        for (Tablet orderedTablet : orderedTablets) {
+            LakeTablet tablet = (LakeTablet) orderedTablet;
+            tablet.setDataSize(40L);
+            tablet.setDataSizeUpdateTime(visibleVersionTime);
+        }
+
+        MergeTabletClause clause = new MergeTabletClause();
+        clause.setTabletReshardTargetSize(100L);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        MergeTabletJob mergeJob = (MergeTabletJob) factory.createTabletReshardJob();
+
+        ReshardingPhysicalPartition reshardingPartition =
+                mergeJob.getReshardingPhysicalPartitions().get(physicalPartition.getId());
+        Assertions.assertNotNull(reshardingPartition);
+        ReshardingMaterializedIndex reshardingIndex =
+                reshardingPartition.getReshardingIndexes().get(oldIndex.getId());
+        Assertions.assertNotNull(reshardingIndex);
+
+        List<List<Long>> mergedTabletGroups = new ArrayList<>();
+        for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
+            if (reshardingTablet.getMergingTablet() != null) {
+                mergedTabletGroups.add(reshardingTablet.getMergingTablet().getOldTabletIds());
+            }
+        }
+
+        Assertions.assertEquals(List.of(
+                List.of(orderedTablets.get(0).getId(), orderedTablets.get(1).getId()),
+                List.of(orderedTablets.get(2).getId(), orderedTablets.get(3).getId())),
+                mergedTabletGroups);
+    }
+
+    @Test
+    public void testMergeTabletJobFactoryAutoMergeSkipsStaleTablet() throws Exception {
+        ensureTabletCount(3);
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        long visibleVersionTime = physicalPartition.getVisibleVersionTime();
+        for (int i = 0; i < orderedTablets.size(); i++) {
+            LakeTablet tablet = (LakeTablet) orderedTablets.get(i);
+            if (i == 0) {
+                tablet.setDataSize(40L);
+                tablet.setDataSizeUpdateTime(visibleVersionTime);
+            } else if (i == 1) {
+                tablet.setDataSize(40L);
+                tablet.setDataSizeUpdateTime(visibleVersionTime - 1);
+            } else {
+                tablet.setDataSize(200L);
+                tablet.setDataSizeUpdateTime(visibleVersionTime);
+            }
+        }
+
+        MergeTabletClause clause = new MergeTabletClause();
+        clause.setTabletReshardTargetSize(100L);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        Assertions.assertThrows(StarRocksException.class, factory::createTabletReshardJob);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
  Shared-data range distribution tables already support tablet split and merge, but only split can be auto-triggered.
  Merge still requires manual SQL, which leaves small adjacent tablets unmerged and increases tablet count over time.

  This change adds automatic merge triggering for shared-data range distribution tables and aligns the auto-trigger rule in `TabletStatMgr` with the auto-planning rule in `MergeTabletJobFactory`.

  ## What I'm doing:
  - Add `minAdjacentTabletPairSize` collection in `TabletStatMgr`
  - Add `TabletReshardUtils.needMerge(...)` for auto merge triggering
  - Keep auto trigger order as `split > merge`
  - Update `MergeTabletJobFactory` auto-merge planning to:
    - only merge contiguous tablets
    - require merged size `<= tablet_reshard_target_size`
    - skip tablets with stale stats using `dataSizeUpdateTime >= visibleVersionTime`
  - Keep manual merge with explicit tablet groups unchanged
  - Add FE unit tests for:
    - auto merge trigger
    - merge grouping capped by target size
    - stale tablet filtering


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
