### PR TITLE
[BugFix] : Fix(python-client) Add to_diff_tuple for Alembic alter operations

### DIFF
--- a/contrib/starrocks-python-client/starrocks/alembic/ops.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/ops.py
@@ -664,6 +664,9 @@ class AlterTableEngineOp(ops.AlterTableOp):
                f"engine={self.engine!r}, schema={self.schema!r}, "
                f"existing_engine={self.existing_engine!r})")
 
+    def to_diff_tuple(self):
+        return ("alter_table_engine", self.schema, self.table_name, self.engine)
+
 @Operations.register_operation("alter_table_key")
 class AlterTableKeyOp(ops.AlterTableOp):
     """Represent an ALTER TABLE KEY operation for StarRocks."""
@@ -722,6 +725,9 @@ class AlterTableKeyOp(ops.AlterTableOp):
                f"key_type={self.key_type!r}, key_columns={self.key_columns!r}, "
                f"schema={self.schema!r}, existing_key_type={self.existing_key_type!r}, "
                f"existing_key_columns={self.existing_key_columns!r})")
+
+    def to_diff_tuple(self):
+        return ("alter_table_key", self.schema, self.table_name, self.key_type, self.key_columns)
 
 @Operations.register_operation("alter_table_partition")
 class AlterTablePartitionOp(ops.AlterTableOp):
@@ -784,6 +790,9 @@ class AlterTablePartitionOp(ops.AlterTableOp):
         return (f"AlterTablePartitionOp(table_name={self.table_name!r}, "
                f"partition_method={self.partition_method!r}, schema={self.schema!r}, "
                f"existing_partition_method={self.existing_partition_method!r})")
+
+    def to_diff_tuple(self):
+        return ("alter_table_partition", self.schema, self.table_name, self.partition_method)
 
 @Operations.register_operation("alter_table_distribution")
 class AlterTableDistributionOp(ops.AlterTableOp):
@@ -860,6 +869,9 @@ class AlterTableDistributionOp(ops.AlterTableOp):
                f"schema={self.schema!r}, existing_distribution_method={self.existing_distribution_method!r}, "
                f"existing_buckets={self.existing_buckets!r})")
 
+    def to_diff_tuple(self):
+        return ("alter_table_distribution", self.schema, self.table_name, self.distribution_method, self.buckets)
+
 
 @Operations.register_operation("alter_table_order")
 class AlterTableOrderOp(ops.AlterTableOp):
@@ -904,6 +916,9 @@ class AlterTableOrderOp(ops.AlterTableOp):
                f"order_by={self.order_by!r}, schema={self.schema!r}, "
                f"existing_order_by={self.existing_order_by!r})")
 
+    def to_diff_tuple(self):
+        return ("alter_table_order", self.schema, self.table_name, self.order_by)
+
 
 @Operations.register_operation("alter_table_properties")
 class AlterTablePropertiesOp(ops.AlterTableOp):
@@ -947,3 +962,6 @@ class AlterTablePropertiesOp(ops.AlterTableOp):
         return (f"AlterTablePropertiesOp(table_name={self.table_name!r}, "
                f"properties={self.properties!r}, schema={self.schema!r}, "
                f"existing_properties={self.existing_properties!r})")
+
+    def to_diff_tuple(self):
+        return ("alter_table_properties", self.schema, self.table_name, self.properties)

--- a/contrib/starrocks-python-client/starrocks/alembic/ops.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/ops.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from alembic.operations import Operations, ops
 from sqlalchemy import MetaData, Table
@@ -179,6 +179,9 @@ class AlterViewOp(ops.MigrateOperation):
             f"existing_security={self.existing_security})"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("alter_view", self.schema, self.view_name)
 
 @Operations.register_operation("create_view")
 class CreateViewOp(ops.MigrateOperation):
@@ -267,6 +270,9 @@ class CreateViewOp(ops.MigrateOperation):
             f"kwargs={self.kwargs!r}"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("create_view", self.schema, self.view_name)
 
 @Operations.register_operation("drop_view")
 class DropViewOp(ops.MigrateOperation):
@@ -349,6 +355,9 @@ class DropViewOp(ops.MigrateOperation):
             f"kwargs=({self.kwargs!r})"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("drop_view", self.schema, self.view_name)
 
 @Operations.register_operation("alter_materialized_view")
 class AlterMaterializedViewOp(ops.MigrateOperation):
@@ -428,6 +437,9 @@ class AlterMaterializedViewOp(ops.MigrateOperation):
             f"existing_properties={self.existing_properties!r})"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("alter_materialized_view", self.schema, self.view_name)
 
 @Operations.register_operation("create_materialized_view")
 class CreateMaterializedViewOp(CreateViewOp):
@@ -541,6 +553,9 @@ class CreateMaterializedViewOp(CreateViewOp):
             f"kwargs={self.kwargs!r})"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("create_materialized_view", self.schema, self.view_name)
 
 @Operations.register_operation("drop_materialized_view")
 class DropMaterializedViewOp(DropViewOp):
@@ -618,6 +633,9 @@ class DropMaterializedViewOp(DropViewOp):
             f"kwargs={self.kwargs!r})"
         )
 
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
+        return ("drop_materialized_view", self.schema, self.view_name)
 
 # Operation classes ordered according to StarRocks grammar:
 # engine → key → (comment) → partition → distribution → order by → properties
@@ -664,7 +682,8 @@ class AlterTableEngineOp(ops.AlterTableOp):
                f"engine={self.engine!r}, schema={self.schema!r}, "
                f"existing_engine={self.existing_engine!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_engine", self.schema, self.table_name, self.engine)
 
 @Operations.register_operation("alter_table_key")
@@ -726,7 +745,8 @@ class AlterTableKeyOp(ops.AlterTableOp):
                f"schema={self.schema!r}, existing_key_type={self.existing_key_type!r}, "
                f"existing_key_columns={self.existing_key_columns!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_key", self.schema, self.table_name, self.key_type, self.key_columns)
 
 @Operations.register_operation("alter_table_partition")
@@ -791,7 +811,8 @@ class AlterTablePartitionOp(ops.AlterTableOp):
                f"partition_method={self.partition_method!r}, schema={self.schema!r}, "
                f"existing_partition_method={self.existing_partition_method!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_partition", self.schema, self.table_name, self.partition_method)
 
 @Operations.register_operation("alter_table_distribution")
@@ -869,7 +890,8 @@ class AlterTableDistributionOp(ops.AlterTableOp):
                f"schema={self.schema!r}, existing_distribution_method={self.existing_distribution_method!r}, "
                f"existing_buckets={self.existing_buckets!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_distribution", self.schema, self.table_name, self.distribution_method, self.buckets)
 
 
@@ -916,7 +938,8 @@ class AlterTableOrderOp(ops.AlterTableOp):
                f"order_by={self.order_by!r}, schema={self.schema!r}, "
                f"existing_order_by={self.existing_order_by!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_order", self.schema, self.table_name, self.order_by)
 
 
@@ -963,5 +986,6 @@ class AlterTablePropertiesOp(ops.AlterTableOp):
                f"properties={self.properties!r}, schema={self.schema!r}, "
                f"existing_properties={self.existing_properties!r})")
 
-    def to_diff_tuple(self):
+    def to_diff_tuple(self) -> Tuple[Any, ...]:
+        """Return Alembic diff tuple."""
         return ("alter_table_properties", self.schema, self.table_name, self.properties)

--- a/contrib/starrocks-python-client/test/unit/test_alter_table_operations.py
+++ b/contrib/starrocks-python-client/test/unit/test_alter_table_operations.py
@@ -118,3 +118,50 @@ class TestPropertiesOrderPreservation:
         keys = list(ddl.properties.keys())
         expected_keys = ["replication_num", "storage_medium", "dynamic_partition.enable"]
         assert keys == expected_keys
+
+class TestAlembicToDiffTuple:
+    """Test to_diff_tuple implementations for Alembic autogenerate diffs."""
+
+    def test_alter_table_operations_diff_tuple(self):
+        """Test that AlterTable operations correctly return a diff tuple instead of raising NotImplementedError."""
+        from starrocks.alembic.ops import (
+            AlterTablePropertiesOp,
+            AlterTableEngineOp,
+            AlterTableKeyOp,
+            AlterTablePartitionOp,
+            AlterTableDistributionOp,
+            AlterTableOrderOp
+        )
+
+        prop_op = AlterTablePropertiesOp("tbl", {"bloom_filter_columns": "c1"}, schema="sch")
+        assert prop_op.to_diff_tuple() == ("alter_table_properties", "sch", "tbl", {"bloom_filter_columns": "c1"})
+
+        engine_op = AlterTableEngineOp("tbl", "OLAP", schema="sch")
+        assert engine_op.to_diff_tuple() == ("alter_table_engine", "sch", "tbl", "OLAP")
+
+        key_op = AlterTableKeyOp("tbl", "PRIMARY KEY", "id", schema="sch")
+        assert key_op.to_diff_tuple() == ("alter_table_key", "sch", "tbl", "PRIMARY KEY", "id")
+
+        part_op = AlterTablePartitionOp("tbl", "RANGE(dt)", schema="sch")
+        assert part_op.to_diff_tuple() == ("alter_table_partition", "sch", "tbl", "RANGE(dt)")
+
+        dist_op = AlterTableDistributionOp("tbl", "HASH(id)", buckets=10, schema="sch")
+        assert dist_op.to_diff_tuple() == ("alter_table_distribution", "sch", "tbl", "HASH(id)", 10)
+
+        order_op = AlterTableOrderOp("tbl", "dt", schema="sch")
+        assert order_op.to_diff_tuple() == ("alter_table_order", "sch", "tbl", "dt")
+
+    def test_view_operations_diff_tuple(self):
+        """Test that View/MV operations correctly return a diff tuple."""
+        from starrocks.alembic.ops import (
+            AlterViewOp, CreateViewOp, DropViewOp,
+            AlterMaterializedViewOp, CreateMaterializedViewOp, DropMaterializedViewOp
+        )
+
+        assert AlterViewOp("v1", "SELECT 1", schema="s1").to_diff_tuple() == ("alter_view", "s1", "v1")
+        assert CreateViewOp("v1", "SELECT 1", schema="s1").to_diff_tuple() == ("create_view", "s1", "v1")
+        assert DropViewOp("v1", schema="s1").to_diff_tuple() == ("drop_view", "s1", "v1")
+
+        assert AlterMaterializedViewOp("mv1", schema="s1").to_diff_tuple() == ("alter_materialized_view", "s1", "mv1")
+        assert CreateMaterializedViewOp("mv1", "SELECT 1", schema="s1").to_diff_tuple() == ("create_materialized_view", "s1", "mv1")
+        assert DropMaterializedViewOp("mv1", schema="s1").to_diff_tuple() == ("drop_materialized_view", "s1", "mv1")


### PR DESCRIPTION
## Why I'm doing:
When modifying StarRocks-specific table properties (such as adding a bloom filter) in SQLAlchemy models, running `alembic check` crashes with a `NotImplementedError`. This happens because Alembic internally calls `to_diff_tuple()` on the operation objects to evaluate and print the differences. However, the custom StarRocks `AlterTable` operation classes in the `starrocks-python-client` lacked the implementation for this required method.

## What I'm doing:
Added the missing `to_diff_tuple()` method to all `AlterTable*Op` classes (e.g., `AlterTablePropertiesOp`, `AlterTableEngineOp`, `AlterTablePartitionOp`, etc.) in `starrocks/alembic/ops.py`. These methods now correctly return the operation signatures in the expected tuple format `("alter_table_...", schema, table_name, ...)` so Alembic can successfully generate, evaluate, and print the diffs.

Fixes #69264

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4