### PR TITLE
[UT] Support mock journal for shared-data mock cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.staros;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.staros.manager.StarManager;
 import com.staros.manager.StarManagerServer;
 import com.staros.metrics.MetricsSystem;
@@ -25,7 +26,6 @@ import com.starrocks.ha.StateChangeExecution;
 import com.starrocks.journal.CheckpointWorker;
 import com.starrocks.journal.StarMgrCheckpointWorker;
 import com.starrocks.journal.bdbje.BDBEnvironment;
-import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.metric.MetricVisitor;
@@ -108,7 +108,7 @@ public class StarMgrServer {
     }
 
     // for checkpoint thread only
-    public StarMgrServer(BDBJEJournal journal) {
+    public StarMgrServer(com.starrocks.journal.Journal journal) {
         journalSystem = new StarOSBDBJEJournalSystem(journal);
         starMgrServer = new StarManagerServer(journalSystem);
     }
@@ -125,8 +125,21 @@ public class StarMgrServer {
         return execution;
     }
 
+    /**
+     * NOTE: Only used by UtFrameUtils to construct a StarMgrServer with MockedJournal for testing.
+     */
+    @VisibleForTesting
+    public void initializeForTest(StarOSBDBJEJournalSystem bdbJournalSystem, String baseImageDir) throws IOException {
+        initializeImpl(bdbJournalSystem, baseImageDir);
+    }
+
     public void initialize(BDBEnvironment environment, String baseImageDir) throws IOException {
-        journalSystem = new StarOSBDBJEJournalSystem(environment);
+        StarOSBDBJEJournalSystem bdbJournalSystem = new StarOSBDBJEJournalSystem(environment);
+        initializeImpl(bdbJournalSystem, baseImageDir);
+    }
+
+    private void initializeImpl(StarOSBDBJEJournalSystem bdbJournalSystem, String baseImageDir) throws IOException {
+        this.journalSystem = bdbJournalSystem;
         imageDir = baseImageDir + IMAGE_SUBDIR;
 
         // TODO: remove separate deployment capability for now

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
@@ -15,13 +15,14 @@
 
 package com.starrocks.staros;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.staros.exception.ExceptionCode;
 import com.staros.exception.StarException;
-import com.staros.journal.Journal;
 import com.staros.journal.JournalSystem;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.Util;
+import com.starrocks.journal.Journal;
 import com.starrocks.journal.JournalCursor;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalException;
@@ -45,7 +46,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
     private static final int REPLAY_INTERVAL_MS = 1;
     private static final Logger LOG = LogManager.getLogger(StarOSBDBJEJournalSystem.class);
 
-    private BDBJEJournal bdbjeJournal;
+    private Journal bdbjeJournal;
     private JournalWriter journalWriter;
     private EditLog editLog;
     private AtomicLong replayedJournalId;
@@ -64,8 +65,17 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
         replayer = null;
     }
 
+    @VisibleForTesting
+    public static StarOSBDBJEJournalSystem forTest(Journal journal) {
+        BlockingQueue<JournalTask> journalQueue = new ArrayBlockingQueue<JournalTask>(Config.metadata_journal_queue_size);
+        StarOSBDBJEJournalSystem journalSystem = new StarOSBDBJEJournalSystem(journal);
+        journalSystem.journalWriter = new JournalWriter(journalSystem.bdbjeJournal, journalQueue);
+        journalSystem.editLog = new EditLog(journalQueue);
+        return journalSystem;
+    }
+
     // for checkpoint thread only
-    public StarOSBDBJEJournalSystem(BDBJEJournal journal) {
+    public StarOSBDBJEJournalSystem(Journal journal) {
         bdbjeJournal = journal;
         replayedJournalId = new AtomicLong(0L);
         editLog = new EditLog(null);
@@ -157,7 +167,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
         }
     }
 
-    public void write(Journal journal) throws StarException {
+    public void write(com.staros.journal.Journal journal) throws StarException {
         try {
             editLog.logStarMgrOperation(new StarMgrJournal(journal));
         } catch (Exception e) {
@@ -166,7 +176,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
     }
 
     @Override
-    public Future<Boolean> writeAsync(Journal journal) throws StarException {
+    public Future<Boolean> writeAsync(com.staros.journal.Journal journal) throws StarException {
         try {
             return editLog.logStarMgrOperationNoWait(new StarMgrJournal(journal));
         } catch (Exception e) {
@@ -228,7 +238,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
         return false;
     }
 
-    public BDBJEJournal getJournal() {
+    public Journal getJournal() {
         return bdbjeJournal;
     }
 
@@ -236,4 +246,3 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
         return journalWriter;
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
@@ -277,18 +277,20 @@ public class PseudoFrontend {
 
     private void waitForCatalogReady() throws FeStartException {
         int tryCount = 0;
-        while (!GlobalStateMgr.getCurrentState().isReady() && tryCount < 600) {
+        while (!GlobalStateMgr.getCurrentState().isReady() && tryCount < 6000) {
             try {
                 tryCount++;
-                Thread.sleep(1000);
-                System.out.println("globalStateMgr is not ready, wait for 1 second");
+                Thread.sleep(100);
+                if (tryCount % 10 == 0) {
+                    LOG.warn("globalStateMgr is not ready, wait for 1 second");
+                }
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
         }
 
         if (!GlobalStateMgr.getCurrentState().isReady()) {
-            System.err.println("globalStateMgr is not ready");
+            LOG.error("globalStateMgr is not ready");
             throw new FeStartException("fe start failed");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
@@ -52,9 +52,11 @@ import com.starrocks.server.RunMode;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.staros.StarMgrServer;
+import com.starrocks.staros.StarOSBDBJEJournalSystem;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.jupiter.api.Assertions;
 
@@ -99,6 +101,8 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  */
 public class MockedFrontend {
+    private static final Logger LOG = LogManager.getLogger(MockedFrontend.class);
+
     public static final String FE_PROCESS = "fe";
 
     // the running dir of this mocked frontend.
@@ -266,12 +270,18 @@ public class MockedFrontend {
                 GlobalStateMgr.getCurrentState().initialize(null);
 
                 if (RunMode.isSharedDataMode()) {
-                    // setup and start StarManager service
-                    Journal journal = GlobalStateMgr.getCurrentState().getJournal();
-                    // TODO: support MockJournal in StarMgrServer
-                    Preconditions.checkState(journal instanceof BDBJEJournal);
-                    BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
-                    StarMgrServer.getCurrentState().initialize(bdbEnvironment, GlobalStateMgr.getImageDirPath());
+                    if (startBDB) {
+                        // setup and start StarManager service
+                        Journal journal = GlobalStateMgr.getCurrentState().getJournal();
+                        Preconditions.checkState(journal instanceof BDBJEJournal);
+                        BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
+                        StarMgrServer.getCurrentState().initialize(bdbEnvironment, GlobalStateMgr.getImageDirPath());
+                    } else {
+                        // setup mock journal and start StarManager service
+                        Journal journal = new MockJournal();
+                        StarOSBDBJEJournalSystem journalSystem = StarOSBDBJEJournalSystem.forTest(journal);
+                        StarMgrServer.getCurrentState().initializeForTest(journalSystem, GlobalStateMgr.getImageDirPath());
+                    }
                     StateChangeExecutor.getInstance().registerStateChangeExecution(
                             StarMgrServer.getCurrentState().getStateChangeExecution());
                 }
@@ -316,7 +326,7 @@ public class MockedFrontend {
                 tryCount++;
                 Thread.sleep(100);
                 if (tryCount % 10 == 0) {
-                    System.out.println("globalStateMgr is not ready, wait for 1 second");
+                    LOG.warn("globalStateMgr is not ready, wait for 1 second");
                 }
             } catch (InterruptedException e) {
                 e.printStackTrace();
@@ -324,7 +334,7 @@ public class MockedFrontend {
         }
 
         if (!GlobalStateMgr.getCurrentState().isReady()) {
-            System.err.println("globalStateMgr is not ready");
+            LOG.error("globalStateMgr is not ready");
             throw new FeStartException("fe start failed");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/SharedDataClusterWithBdbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/SharedDataClusterWithBdbTest.java
@@ -1,0 +1,22 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.utframe;
+
+public class SharedDataClusterWithBdbTest extends SharedDataClusterTest {
+    @Override
+    protected void createStarrocksCluster() {
+        UtFrameUtils.createMinStarRocksCluster(true, runMode);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/TestWithFeService.java
@@ -157,7 +157,7 @@ public abstract class TestWithFeService {
     }
 
     protected void createStarrocksCluster() {
-        UtFrameUtils.createMinStarRocksCluster(true, runMode);
+        UtFrameUtils.createMinStarRocksCluster(false, runMode);
     }
 
     protected void cleanStarrocksFeDir() {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -64,7 +64,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.common.io.DataOutputBuffer;
@@ -307,10 +306,6 @@ public class UtFrameUtils {
         // start fe in "STARROCKS_HOME/fe/mocked/"
         MockedFrontend frontend = MockedFrontend.getInstance();
         Map<String, String> feConfMap = Maps.newHashMap();
-        // TODO: support startBDB = false in shared-data mode
-        if (!startBDB && runMode == RunMode.SHARED_DATA) {
-            throw new NotImplementedException("Have to set 'startBDB = true' when creating a shared-data cluster");
-        }
         // set additional fe config
         if (startBDB) {
             feConfMap.put("edit_log_port", String.valueOf(findValidPort()));
@@ -396,9 +391,7 @@ public class UtFrameUtils {
 
     // create a min starrocks cluster with the given runMode
     public static void createMinStarRocksCluster(RunMode runMode) {
-        // TODO: support creating shared-data cluster without the real BDBJE journal
-        boolean startBdb = (runMode == RunMode.SHARED_DATA);
-        createMinStarRocksCluster(startBdb, runMode);
+        createMinStarRocksCluster(false, runMode);
     }
 
     public static Backend addMockBackend(int backendId, String host, int beThriftPort) throws Exception {


### PR DESCRIPTION
Enable shared-data mock cluster startup with MockJournal for StarMgr and add a dedicated BDB-backed test variant to keep real BDB coverage.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
