### PR TITLE
[BugFix] Fix the use-after-free of ExprContext when node init failed

### DIFF
--- a/be/src/base/status.h
+++ b/be/src/base/status.h
@@ -431,15 +431,6 @@ struct StatusInstance {
 
 #define SET_STATUS_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUS_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
 
-#define SET_STATUS_AND_RETURN_IF_ERROR(err_status, stmt)                                                      \
-    do {                                                                                                      \
-        auto&& status__ = (stmt);                                                                             \
-        if (UNLIKELY(!status__.ok())) {                                                                       \
-            err_status = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt));   \
-            return err_status;                                                                                \
-        }                                                                                                     \
-    } while (false)
-
 #define EXIT_IF_ERROR(stmt)                   \
     do {                                      \
         auto&& status__ = (stmt);             \

--- a/be/src/base/status.h
+++ b/be/src/base/status.h
@@ -420,7 +420,7 @@ struct StatusInstance {
 #define RETURN_IF_ERROR(stmt) RETURN_IF_ERROR_INTERNAL(stmt)
 #endif
 
-#define SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)                                           \
+#define SET_STATUS_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)                                           \
     do {                                                                                                    \
         auto&& status__ = (stmt);                                                                           \
         if (UNLIKELY(!status__.ok())) {                                                                     \
@@ -429,7 +429,16 @@ struct StatusInstance {
         }                                                                                                   \
     } while (false)
 
-#define SET_STATUE_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
+#define SET_STATUS_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUS_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
+
+#define SET_STATUS_AND_RETURN_IF_ERROR(err_status, stmt)                                                      \
+    do {                                                                                                      \
+        auto&& status__ = (stmt);                                                                             \
+        if (UNLIKELY(!status__.ok())) {                                                                       \
+            err_status = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt));   \
+            return err_status;                                                                                \
+        }                                                                                                     \
+    } while (false)
 
 #define EXIT_IF_ERROR(stmt)                   \
     do {                                      \

--- a/be/src/base/status.h
+++ b/be/src/base/status.h
@@ -12,13 +12,10 @@
 #include "base/logging.h"
 #include "gen_cpp/StatusCode_types.h" // for TStatus
 
-#define DEFINE_STATUS(name, code)              \
-    static Status name(std::string_view msg) { \
-        return Status(TStatusCode::code, msg); \
-    }                                          \
-    template <typename FMT, typename... Args>  \
-        requires(sizeof...(Args) > 0)          \
-    static Status name(FMT&& fmt, Args&&... args);
+#define DEFINE_STATUS(name, code)                                                       \
+    static Status name(std::string_view msg) { return Status(TStatusCode::code, msg); } \
+    template <typename FMT, typename... Args>                                           \
+    requires(sizeof...(Args) > 0) static Status name(FMT&& fmt, Args&&... args);
 
 namespace starrocks {
 
@@ -515,9 +512,7 @@ struct StatusInstance {
 #define RETURN_IF_EXCEPTION(stmt)                   \
     do {                                            \
         try {                                       \
-            {                                       \
-                stmt;                               \
-            }                                       \
+            { stmt; }                               \
         } catch (const std::exception& e) {         \
             return Status::InternalError(e.what()); \
         }                                           \

--- a/be/src/base/status.h
+++ b/be/src/base/status.h
@@ -12,10 +12,13 @@
 #include "base/logging.h"
 #include "gen_cpp/StatusCode_types.h" // for TStatus
 
-#define DEFINE_STATUS(name, code)                                                       \
-    static Status name(std::string_view msg) { return Status(TStatusCode::code, msg); } \
-    template <typename FMT, typename... Args>                                           \
-    requires(sizeof...(Args) > 0) static Status name(FMT&& fmt, Args&&... args);
+#define DEFINE_STATUS(name, code)              \
+    static Status name(std::string_view msg) { \
+        return Status(TStatusCode::code, msg); \
+    }                                          \
+    template <typename FMT, typename... Args>  \
+        requires(sizeof...(Args) > 0)          \
+    static Status name(FMT&& fmt, Args&&... args);
 
 namespace starrocks {
 
@@ -431,6 +434,17 @@ struct StatusInstance {
 
 #define SET_STATUE_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
 
+#define SET_AND_RETURN_STATUS_IF_ERROR_INTERNAL(err_status, stmt)                                           \
+    do {                                                                                                    \
+        auto&& status__ = (stmt);                                                                           \
+        if (UNLIKELY(!status__.ok())) {                                                                     \
+            err_status = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+            return err_status;                                                                              \
+        }                                                                                                   \
+    } while (false)
+
+#define SET_AND_RETURN_STATUS_IF_ERROR(err_status, stmt) SET_AND_RETURN_STATUS_IF_ERROR_INTERNAL(err_status, stmt)
+
 #define EXIT_IF_ERROR(stmt)                   \
     do {                                      \
         auto&& status__ = (stmt);             \
@@ -501,7 +515,9 @@ struct StatusInstance {
 #define RETURN_IF_EXCEPTION(stmt)                   \
     do {                                            \
         try {                                       \
-            { stmt; }                               \
+            {                                       \
+                stmt;                               \
+            }                                       \
         } catch (const std::exception& e) {         \
             return Status::InternalError(e.what()); \
         }                                           \

--- a/be/src/base/status.h
+++ b/be/src/base/status.h
@@ -420,7 +420,7 @@ struct StatusInstance {
 #define RETURN_IF_ERROR(stmt) RETURN_IF_ERROR_INTERNAL(stmt)
 #endif
 
-#define SET_STATUS_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)                                           \
+#define SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)                                           \
     do {                                                                                                    \
         auto&& status__ = (stmt);                                                                           \
         if (UNLIKELY(!status__.ok())) {                                                                     \
@@ -429,7 +429,7 @@ struct StatusInstance {
         }                                                                                                   \
     } while (false)
 
-#define SET_STATUS_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUS_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
+#define SET_STATUE_AND_RETURN_IF_ERROR(err_status, stmt) SET_STATUE_AND_RETURN_IF_ERROR_INTERNAL(err_status, stmt)
 
 #define EXIT_IF_ERROR(stmt)                   \
     do {                                      \

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -113,6 +113,12 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
     ExecNode* node = nullptr;
     RETURN_IF_ERROR(check_tuple_ids_in_descs(descs, tnode));
     RETURN_IF_ERROR(ExecFactory::create_vectorized_node(state, pool, tnode, descs, &node));
+    // Both the Node and ExprContext are allocated from the pool. If they are both allocated successfully
+    // but Node::init() fails, and *root is not set, the FragmentContext's plan will be nullptr, so the
+    // ExprContext will not be explicitly closed. During pool destruction, the ExprContext is destroyed
+    // before the Node (LIFO order). The Node's destructor then tries to close the already-destroyed
+    // ExprContext, causing a use-after-free.
+    *root = node;
 
     std::vector<ExecNode*> children;
     children.reserve(tnode.num_children);
@@ -144,7 +150,6 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
         node->runtime_profile()->add_child(node_children[0]->runtime_profile(), true, nullptr);
     }
 
-    *root = node;
     return Status::OK();
 }
 

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -154,7 +154,6 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
         node->runtime_profile()->add_child(node_children[0]->runtime_profile(), true, nullptr);
     }
     *root = node;
-
     return Status::OK();
 }
 

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -120,13 +120,16 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
     // ExprContext, causing a use-after-free.
     *root = node;
 
-    std::vector<ExecNode*> children;
-    children.reserve(tnode.num_children);
+    node->reserve_children(tnode.num_children);
     for (int i = 0; i < tnode.num_children; i++) {
         ++*node_idx;
         ExecNode* child = nullptr;
-        RETURN_IF_ERROR(create_tree_helper(state, pool, tnodes, descs, node_idx, &child));
-        children.emplace_back(child);
+        if (Status st = create_tree_helper(state, pool, tnodes, descs, node_idx, &child); !st.ok()) {
+            if (child != nullptr) {
+                child->close(state);
+            }
+        }
+        node->add_child(child);
 
         // we are expecting a child, but have used all nodes
         // this means we have been given a bad tree and must fail
@@ -135,7 +138,6 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
             return Status::InternalError("Failed to reconstruct plan tree from thrift.");
         }
     }
-    node->set_children(std::move(children));
 
     RETURN_IF_ERROR(node->init(tnode, state));
 

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -113,34 +113,35 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
     ExecNode* node = nullptr;
     RETURN_IF_ERROR(check_tuple_ids_in_descs(descs, tnode));
     RETURN_IF_ERROR(ExecFactory::create_vectorized_node(state, pool, tnode, descs, &node));
-    // Both the Node and ExprContext are allocated from the pool. If they are both allocated successfully
-    // but Node::init() fails, and *root is not set, the FragmentContext's plan will be nullptr, so the
-    // ExprContext will not be explicitly closed. During pool destruction, the ExprContext is destroyed
-    // before the Node (LIFO order). The Node's destructor then tries to close the already-destroyed
-    // ExprContext, causing a use-after-free.
-    *root = node;
+
+    Status st = Status::OK();
+    DeferOp defer([&] {
+        if (!st.ok()) {
+            // Both the Node and ExprContext are allocated from the pool. If they are both allocated successfully
+            // but Node::init() fails, and *root is not set, the FragmentContext's plan will be nullptr, so the
+            // ExprContext will not be explicitly closed. During pool destruction, the ExprContext is destroyed
+            // before the Node (LIFO order). The Node's destructor then tries to close the already-destroyed
+            // ExprContext, causing a use-after-free.
+            node->close(state);
+        }
+    });
 
     node->reserve_children(tnode.num_children);
     for (int i = 0; i < tnode.num_children; i++) {
         ++*node_idx;
         ExecNode* child = nullptr;
-        if (Status st = create_tree_helper(state, pool, tnodes, descs, node_idx, &child); !st.ok()) {
-            if (child != nullptr) {
-                child->close(state);
-            }
-            return st;
-        }
+        RETURN_IF_ERROR(create_tree_helper(state, pool, tnodes, descs, node_idx, &child)));
         node->add_child(child);
 
         // we are expecting a child, but have used all nodes
         // this means we have been given a bad tree and must fail
         if (*node_idx >= tnodes.size()) {
             // TODO: print thrift msg
-            return Status::InternalError("Failed to reconstruct plan tree from thrift.");
+            SET_STATUS_AND_RETURN_IF_ERROR(st, Status::InternalError("Failed to reconstruct plan tree from thrift."));
         }
     }
 
-    RETURN_IF_ERROR(node->init(tnode, state));
+    SET_STATUS_AND_RETURN_IF_ERROR(st, node->init(tnode, state));
 
     // build up tree of profiles; add children >0 first, so that when we print
     // the profile, child 0 is printed last (makes the output more readable)
@@ -152,6 +153,7 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
     if (!node_children.empty()) {
         node->runtime_profile()->add_child(node_children[0]->runtime_profile(), true, nullptr);
     }
+    *root = node;
 
     return Status::OK();
 }

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -128,6 +128,7 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
             if (child != nullptr) {
                 child->close(state);
             }
+            return st;
         }
         node->add_child(child);
 

--- a/be/src/exec/exec_factory.cpp
+++ b/be/src/exec/exec_factory.cpp
@@ -130,18 +130,18 @@ Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vect
     for (int i = 0; i < tnode.num_children; i++) {
         ++*node_idx;
         ExecNode* child = nullptr;
-        RETURN_IF_ERROR(create_tree_helper(state, pool, tnodes, descs, node_idx, &child)));
+        SET_AND_RETURN_STATUS_IF_ERROR(st, create_tree_helper(state, pool, tnodes, descs, node_idx, &child));
         node->add_child(child);
 
         // we are expecting a child, but have used all nodes
         // this means we have been given a bad tree and must fail
         if (*node_idx >= tnodes.size()) {
             // TODO: print thrift msg
-            SET_STATUS_AND_RETURN_IF_ERROR(st, Status::InternalError("Failed to reconstruct plan tree from thrift."));
+            SET_AND_RETURN_STATUS_IF_ERROR(st, Status::InternalError("Failed to reconstruct plan tree from thrift."));
         }
     }
 
-    SET_STATUS_AND_RETURN_IF_ERROR(st, node->init(tnode, state));
+    SET_AND_RETURN_STATUS_IF_ERROR(st, node->init(tnode, state));
 
     // build up tree of profiles; add children >0 first, so that when we print
     // the profile, child 0 is printed last (makes the output more readable)

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -226,6 +226,8 @@ public:
     void set_children(std::vector<ExecNode*>&& children) { _children = std::move(children); }
 
     const std::vector<ExecNode*>& children() const { return _children; }
+    void reserve_children(size_t n) { _children.reserve(n); }
+    void add_child(ExecNode* child) { _children.emplace_back(child); }
 
 protected:
     friend class DataSink;

--- a/be/test/exec/exec_factory_test.cpp
+++ b/be/test/exec/exec_factory_test.cpp
@@ -207,4 +207,48 @@ TEST_F(ExecFactoryTest, test_create_tree_malformed_or_partial_tree) {
     }
 }
 
+// Build a minimal boolean literal TExpr (used as a conjunct to force ExprContext
+// allocation in the pool during node::init(), which is necessary to expose the UAF).
+static TExpr make_bool_literal_expr(bool value) {
+    TTypeNode type_node;
+    type_node.type = TTypeNodeType::SCALAR;
+    TScalarType scalar_type;
+    scalar_type.type = TPrimitiveType::BOOLEAN;
+    type_node.__set_scalar_type(scalar_type);
+    TTypeDesc type_desc;
+    type_desc.types.push_back(type_node);
+
+    TBoolLiteral bool_literal;
+    bool_literal.value = value;
+
+    TExprNode expr_node;
+    expr_node.node_type = TExprNodeType::BOOL_LITERAL;
+    expr_node.num_children = 0;
+    expr_node.type = type_desc;
+    expr_node.is_nullable = false;
+    expr_node.__set_bool_literal(bool_literal);
+
+    TExpr expr;
+    expr.nodes.push_back(expr_node);
+    return expr;
+}
+
+TEST_F(ExecFactoryTest, test_create_tree_child_failure_triggers_cleanup) {
+    // child[0]: has a conjunct, so ExprContext is allocated in obj_pool during init()
+    TPlanNode child0 = make_base_plan_node(TPlanNodeType::EMPTY_SET_NODE, 11, 0);
+    child0.conjuncts.push_back(make_bool_literal_expr(true));
+
+    // Parent expects 2 children; only child[0] is provided.
+    // When the loop tries to process child[1], node_idx goes out of bounds → error.
+    TPlan plan;
+    plan.nodes.emplace_back(make_base_plan_node(TPlanNodeType::SELECT_NODE, 10, 2));
+    plan.nodes.emplace_back(child0);
+
+    ExecNode* root = nullptr;
+    Status st = ExecFactory::create_tree(&_runtime_state, &_object_pool, plan, *_desc_tbl, &root);
+    // Must return an error (not crash)
+    ASSERT_ERROR(st);
+    ASSERT_TRUE(st.is_internal_error());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Both the Node and ExprContext are allocated from the pool. If they are both allocated successfully, but Node::init() fails, and *root is not set, the FragmentContext's plan will be nullptr, so the ExprContext will not be explicitly closed. During pool destruction, the ExprContext is destroyed before the Node (LIFO order). The Node's destructor then tries to close the already-destroyed ExprContext, causing a use-after-free.

Fix https://github.com/StarRocks/StarRocksTest/issues/11088

```
Crash Log: 
==3108==ERROR: AddressSanitizer: heap-use-after-free on address 0x506001b12771 at pc 0x000028788bce bp 0x2b7034b151f0 sp 0x2b7034b151e8
READ of size 1 at 0x506001b12771 thread T259
   #0 0x28788bcd in starrocks::ExprContext::close(starrocks::RuntimeState*) be/src/exprs/expr_context.cpp:103
   #1 0x2a526a72 in starrocks::ExprExecutor::close(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::RuntimeState*) be/src/exprs/expr_executor.cpp:52
   #2 0x1e73b8aa in starrocks::ExecNode::close(starrocks::RuntimeState*) be/src/exec/exec_node.cpp:314
   #3 0x1eb5d641 in starrocks::OlapScanNode::close(starrocks::RuntimeState*) be/src/exec/olap_scan_node.cpp:275
   #4 0x1eb5d81f in starrocks::OlapScanNode::~OlapScanNode() be/src/exec/olap_scan_node.cpp:280
   #5 0x1eb5da5f in starrocks::OlapScanNode::~OlapScanNode() be/src/exec/olap_scan_node.cpp:283
   #6 0x1e706762 in starrocks::ObjectPool::add<starrocks::OlapScanNode>(starrocks::OlapScanNode*)::{lambda(void*)#1}::operator()(void*) const (/home/disk1/sr/be/lib/starrocks_be+0x1e706762)
   #7 0x1e706782 in starrocks::ObjectPool::add<starrocks::OlapScanNode>(starrocks::OlapScanNode*)::{lambda(void*)#1}::_FUN(void*) (/home/disk1/sr/be/lib/starrocks_be+0x1e706782)
   #8 0x19c55257 in starrocks::ObjectPool::clear() be/src/common/object_pool.h:55
   #9 0x19c55117 in starrocks::ObjectPool::~ObjectPool() be/src/common/object_pool.h:35
   #10 0x2a8b903a in std::_Sp_counted_ptr<starrocks::ObjectPool*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:428
   #11 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #12 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #13 0x2a8b391d in std::__shared_ptr<starrocks::ObjectPool, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #14 0x2a8b3939 in std::shared_ptr<starrocks::ObjectPool>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #15 0x2a8af746 in starrocks::RuntimeState::~RuntimeState() be/src/runtime/runtime_state.cpp:144
   #16 0x1af8bdd7 in std::default_delete<starrocks::RuntimeState>::operator()(starrocks::RuntimeState*) const (/home/disk1/sr/be/lib/starrocks_be+0x1af8bdd7)
   #17 0x1fcee24e in std::_Sp_counted_deleter<starrocks::RuntimeState*, std::default_delete<starrocks::RuntimeState>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:527
   #18 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #19 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #20 0x1db3e651 in std::__shared_ptr<starrocks::RuntimeState, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #21 0x1db3e66d in std::shared_ptr<starrocks::RuntimeState>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #22 0x200bfdaf in starrocks::pipeline::FragmentContext::~FragmentContext() be/src/exec/pipeline/fragment_context.cpp:64
   #23 0x1fcee703 in void std::destroy_at<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #24 0x1fcee5da in void std::_Destroy<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #25 0x1fcedd9f in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::FragmentContext>(std::allocator<void>&, starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #26 0x1fcedd9f in std::_Sp_counted_ptr_inplace<starrocks::pipeline::FragmentContext, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #27 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #28 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #29 0x1db3e0bb in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #30 0x1fcd2e80 in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::reset() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1643
   #31 0x1fcc2966 in starrocks::pipeline::FragmentExecutor::_fail_cleanup(bool) be/src/exec/pipeline/fragment_executor.cpp:1020
   #32 0x1fcbf5b5 in operator() be/src/exec/pipeline/fragment_executor.cpp:932
   #33 0x1fcc6a4d in ~DeferOp be/src/base/utility/defer_op.h:49
   #34 0x1fcc164a in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:981
   #35 0x275572cb in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/service/internal_service.cpp:602
   #36 0x27556ca1 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*) be/src/service/internal_service.cpp:582
   #37 0x2754dcef in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*) be/src/service/internal_service.cpp:314
   #38 0x2755df9d in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const be/src/service/internal_service.cpp:294
   #39 0x2756fa03 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:61
   #40 0x2756bf69 in std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:111
   #41 0x275665f6 in std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_function.h:290
   #42 0x1b288593 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_function.h:591
   #43 0x1daa9982 in starrocks::PriorityThreadPool::work_thread(int) (/home/disk1/sr/be/lib/starrocks_be+0x1daa9982)
   #44 0x1daf6c3f in void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:74
   #45 0x1daf6afa in std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:96
   #46 0x1daf6a96 in decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::PriorityThreadPool*&, int&) const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:177
   #47 0x1daf6a0f in void std::__invoke_impl<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) (/home/disk1/sr/be/lib/starrocks_be+0x1daf6a0f)
   #48 0x1daf6966 in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:111
   #49 0x1daf57b1 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:661
   #50 0x1daf2851 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::operator()<>() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:720
   #51 0x1daf0e39 in boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run() /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:120
   #52 0x2f41b086 in thread_proxy libs/thread/src/pthread/thread.cpp:179
   #53 0x144fa3d1 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234
   #54 0x2b6f7679aea4 in start_thread (/lib64/libpthread.so.0+0x7ea4) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)
   #55 0x2b6f7893db0c in clone (/lib64/libc.so.6+0xfeb0c) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

0x506001b12771 is located 49 bytes inside of 56-byte region [0x506001b12740,0x506001b12778)
freed by thread T259 here:
   #0 0x14592fc0 in operator delete(void*) ../../.././libsanitizer/asan/asan_new_delete.cpp:152
   #1 0x1d3a5377 in starrocks::ObjectPool::add<starrocks::ExprContext>(starrocks::ExprContext*)::{lambda(void*)#1}::operator()(void*) const be/src/common/object_pool.h:47
   #2 0x1d3a539b in starrocks::ObjectPool::add<starrocks::ExprContext>(starrocks::ExprContext*)::{lambda(void*)#1}::_FUN(void*) be/src/common/object_pool.h:47
   #3 0x19c55257 in starrocks::ObjectPool::clear() be/src/common/object_pool.h:55
   #4 0x19c55117 in starrocks::ObjectPool::~ObjectPool() be/src/common/object_pool.h:35
   #5 0x2a8b903a in std::_Sp_counted_ptr<starrocks::ObjectPool*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:428
   #6 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #7 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #8 0x2a8b391d in std::__shared_ptr<starrocks::ObjectPool, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #9 0x2a8b3939 in std::shared_ptr<starrocks::ObjectPool>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #10 0x2a8af746 in starrocks::RuntimeState::~RuntimeState() be/src/runtime/runtime_state.cpp:144
   #11 0x1af8bdd7 in std::default_delete<starrocks::RuntimeState>::operator()(starrocks::RuntimeState*) const (/home/disk1/sr/be/lib/starrocks_be+0x1af8bdd7)
   #12 0x1fcee24e in std::_Sp_counted_deleter<starrocks::RuntimeState*, std::default_delete<starrocks::RuntimeState>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:527
   #13 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #14 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #15 0x1db3e651 in std::__shared_ptr<starrocks::RuntimeState, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #16 0x1db3e66d in std::shared_ptr<starrocks::RuntimeState>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #17 0x200bfdaf in starrocks::pipeline::FragmentContext::~FragmentContext() be/src/exec/pipeline/fragment_context.cpp:64
   #18 0x1fcee703 in void std::destroy_at<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #19 0x1fcee5da in void std::_Destroy<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #20 0x1fcedd9f in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::FragmentContext>(std::allocator<void>&, starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #21 0x1fcedd9f in std::_Sp_counted_ptr_inplace<starrocks::pipeline::FragmentContext, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #22 0x145ee723 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #23 0x14600d39 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #24 0x1db3e0bb in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #25 0x1fcd2e80 in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::reset() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1643
   #26 0x1fcc2966 in starrocks::pipeline::FragmentExecutor::_fail_cleanup(bool) be/src/exec/pipeline/fragment_executor.cpp:1020
   #27 0x1fcbf5b5 in operator() be/src/exec/pipeline/fragment_executor.cpp:932
   #28 0x1fcc6a4d in ~DeferOp be/src/base/utility/defer_op.h:49
   #29 0x1fcc164a in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:981
   #30 0x275572cb in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/service/internal_service.cpp:602

previously allocated by thread T259 here:
   #0 0x14592588 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:95
   #1 0x2a52340e in starrocks::ExprFactory::create_expr_trees(starrocks::ObjectPool*, std::vector<starrocks::TExpr, std::allocator<starrocks::TExpr> > const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> >*, starrocks::RuntimeState*, bool) be/src/exprs/expr_factory.cpp:356
   #2 0x1e737e63 in starrocks::ExecNode::init(starrocks::TPlanNode const&, starrocks::RuntimeState*) be/src/exec/exec_node.cpp:171
   #3 0x1e765399 in starrocks::ScanNode::init(starrocks::TPlanNode const&, starrocks::RuntimeState*) be/src/exec/scan_node.cpp:59
   #4 0x1eb58db3 in starrocks::OlapScanNode::init(starrocks::TPlanNode const&, starrocks::RuntimeState*) be/src/exec/olap_scan_node.cpp:64
   #5 0x1e6ff1fd in create_tree_helper be/src/exec/exec_factory.cpp:134
   #6 0x1e6feef7 in create_tree_helper be/src/exec/exec_factory.cpp:122
   #7 0x1e6ff7b3 in starrocks::ExecFactory::create_tree(starrocks::RuntimeState*, starrocks::ObjectPool*, starrocks::TPlan const&, starrocks::DescriptorTbl const&, starrocks::ExecNode**) be/src/exec/exec_factory.cpp:161
   #8 0x1fcb5670 in starrocks::pipeline::FragmentExecutor::_prepare_exec_plan(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:469
   #9 0x1fcc0ffc in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/exec/pipeline/fragment_executor.cpp:961
   #10 0x275572cb in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) be/src/service/internal_service.cpp:602
   #11 0x27556ca1 in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*) be/src/service/internal_service.cpp:582
   #12 0x2754dcef in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*) be/src/service/internal_service.cpp:314
   #13 0x2755df9d in starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const be/src/service/internal_service.cpp:294
   #14 0x2756fa03 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:61
   #15 0x2756bf69 in std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&>(starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:111
   #16 0x275665f6 in std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_function.h:290
   #17 0x1b288593 in std::function<void ()>::operator()() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_function.h:591
   #18 0x1daa9982 in starrocks::PriorityThreadPool::work_thread(int) (/home/disk1/sr/be/lib/starrocks_be+0x1daa9982)
   #19 0x1daf6c3f in void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:74
   #20 0x1daf6afa in std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:96
   #21 0x1daf6a96 in decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::PriorityThreadPool*&, int&) const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:177
   #22 0x1daf6a0f in void std::__invoke_impl<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) (/home/disk1/sr/be/lib/starrocks_be+0x1daf6a0f)
   #23 0x1daf6966 in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:111
   #24 0x1daf57b1 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:661
   #25 0x1daf2851 in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::operator()<>() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/functional:720
   #26 0x1daf0e39 in boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run() /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:120
   #27 0x2f41b086 in thread_proxy libs/thread/src/pthread/thread.cpp:179

Thread T259 created by T0 here:
   #0 0x145899fd in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
   #1 0x2f41a5a8 in boost::thread::start_thread_noexcept() libs/thread/src/pthread/thread.cpp:263
   #2 0x1dabb8f2 in boost::thread::thread<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>&>(std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>&) /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:269
   #3 0x1dab207b in boost::thread* boost::thread_group::create_thread<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >(std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>) /var/local/thirdparty/installed/include/boost/thread/detail/thread_group.hpp:79
   #4 0x1daa9403 in starrocks::PriorityThreadPool::new_thread(int) be/src/util/priority_thread_pool.hpp:177
   #5 0x1daa8ffc in starrocks::PriorityThreadPool::PriorityThreadPool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int) (/home/disk1/sr/be/lib/starrocks_be+0x1daa8ffc)
   #6 0x1da81f7c in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:432
   #7 0x1df33aeb in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:129
   #8 0x145eb0dd in main be/src/service/starrocks_main.cpp:269
   #9 0x2b6f78861554 in __libc_start_main (/lib64/libc.so.6+0x22554) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

SUMMARY: AddressSanitizer: heap-use-after-free be/src/exprs/expr_context.cpp:103 in starrocks::ExprContext::close(starrocks::RuntimeState*)
Shadow bytes around the buggy address:
 0x506001b12480: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
 0x506001b12500: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
 0x506001b12580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x506001b12600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x506001b12680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x506001b12700: fa fa fa fa fa fa fa fa fd fd fd fd fd fd[fd]fa
 0x506001b12780: fa fa fa fa 00 00 00 00 00 00 01 fa fa fa fa fa
 0x506001b12800: 00 00 00 00 00 00 01 fa fa fa fa fa fa fa fa fa
 0x506001b12880: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
 0x506001b12900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x506001b12980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
 Addressable:           00
 Partially addressable: 01 02 03 04 05 06 07 
 Heap left redzone:       fa
 Freed heap region:       fd
 Stack left redzone:      f1
 Stack mid redzone:       f2
 Stack right redzone:     f3
 Stack after return:      f5
 Stack use after scope:   f8
 Global redzone:          f9
 Global init order:       f6
 Poisoned by user:        f7
 Container overflow:      fc
 Array cookie:            ac
 Intra object redzone:    bb
 ASan internal:           fe
 Left alloca redzone:     ca
 Right alloca redzone:    cb
==3108==ABORTING
```

## What I'm doing:

Fix the use-after-free of ExprContext when node init failed

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
