### PR TITLE
[BugFix] Fix brpc connection retry to handle wrapped NoSuchElementException

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -617,7 +617,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### `brpc_connection_pool_retry_wait_time_ms`
 
-- Default: 10000
+- Default: 10
 - Type: Int
 - Unit: ms
 - Is mutable: Yes

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -615,6 +615,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum length of time for which bRPC clients wait as in the idle state.
 - Introduced in: -
 
+##### `brpc_connection_pool_retry_wait_time_ms`
+
+- Default: 10000
+- Type: Int
+- Unit: ms
+- Is mutable: Yes
+- Description: The wait time before retrying when a bRPC connection pool exception occurs (e.g. SYN packet loss during TCP handshake). When `ChannelPool.getChannel()` throws a `NoSuchElementException` (directly or wrapped in a `RuntimeException`), the retry logic sleeps for this duration before attempting to reconnect.
+- Introduced in: -
+
 ##### `brpc_inner_reuse_pool`
 
 - Default: true

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1151,6 +1151,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: 下層の brpc RpcClient が短命の接続を使用するかどうかを制御します。有効な場合 (`true`)、RpcClientOptions.setShortConnection が設定され、要求完了後に接続が閉じられ、接続設定のオーバーヘッドが増加し、レイテンシーが増加する代わりに、長命のソケットの数が減少します。無効な場合 (`false`、デフォルト)、永続的な接続と接続プールが使用されます。このオプションを有効にすると、接続プール動作に影響するため、`brpc_connection_pool_size`、`brpc_idle_wait_max_time`、`brpc_min_evictable_idle_time_ms`、`brpc_reuse_addr`、および `brpc_inner_reuse_pool` と合わせて検討する必要があります。一般的な高スループットデプロイメントでは無効のままにし、ソケットのライフタイムを制限する必要がある場合や、ネットワークポリシーによって短命の接続が要求される場合にのみ有効にします。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
+##### `brpc_connection_pool_retry_wait_time_ms`
+
+- Default: 10
+- Type: Int
+- Unit: ms
+- Is mutable: Yes
+- Description: bRPC 接続プール例外（例: TCP ハンドシェイク時の SYN パケットロス）が発生した場合のリトライ待機時間。`ChannelPool.getChannel()` が `NoSuchElementException`（直接、または `RuntimeException` でラップされた形で）をスローした場合、リトライロジックはこの時間だけスリープしてから再接続を試みます。
+- Introduced in: -
+
 ##### `catalog_try_lock_timeout_ms`
 
 - Default: 5000

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -614,6 +614,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: bRPC 客户端在空闲状态下等待的最长时间。
 - 引入版本: -
 
+##### `brpc_connection_pool_retry_wait_time_ms`
+
+- 默认值: 10000
+- 类型: Int
+- 单位: 毫秒
+- 是否可变: Yes
+- 描述: bRPC 连接池异常时的重试等待时间。当 `ChannelPool.getChannel()` 抛出 `NoSuchElementException`（直接抛出或被 `RuntimeException` 包装）时，重试逻辑会等待该时间后再尝试重新连接。典型场景如 TCP 握手期间 SYN 包丢失导致的瞬时连接池故障。
+- 引入版本: -
+
 ##### `brpc_inner_reuse_pool`
 
 - 默认值: true

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -616,7 +616,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### `brpc_connection_pool_retry_wait_time_ms`
 
-- 默认值: 10000
+- 默认值: 10
 - 类型: Int
 - 单位: 毫秒
 - 是否可变: Yes

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -957,6 +957,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static int brpc_idle_wait_max_time = 10000;
 
+    // BRPC connection pool retry wait time (ms).
+    // When a connection pool exception occurs (e.g. SYN packet loss), the retry will wait
+    // this amount of time before attempting to reconnect. Default is 10000ms (10s).
+    @ConfField(mutable = true)
+    public static int brpc_connection_pool_retry_wait_time_ms = 10000;
+
     @ConfField(mutable = true)
     public static int brpc_send_plan_fragment_timeout_ms = 60000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -959,9 +959,9 @@ public class Config extends ConfigBase {
 
     // BRPC connection pool retry wait time (ms).
     // When a connection pool exception occurs (e.g. SYN packet loss), the retry will wait
-    // this amount of time before attempting to reconnect. Default is 10000ms (10s).
+    // this amount of time before attempting to reconnect. Default is 10ms.
     @ConfField(mutable = true)
-    public static int brpc_connection_pool_retry_wait_time_ms = 10000;
+    public static int brpc_connection_pool_retry_wait_time_ms = 10;
 
     @ConfField(mutable = true)
     public static int brpc_send_plan_fragment_timeout_ms = 60000;

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -75,6 +75,38 @@ import java.util.concurrent.Future;
 public class BackendServiceClient {
     private static final Logger LOG = LogManager.getLogger(BackendServiceClient.class);
 
+    // Check if the exception is a connection pool exception (NoSuchElementException),
+    // either thrown directly or wrapped in a RuntimeException.
+    //
+    // Call chain: BackendServiceClient → service.execPlanFragmentAsync(pRequest)
+    //   → ProtobufRpcProxy.invoke()          // JDK dynamic proxy (InvocationHandler)
+    //     → RpcChannel.getConnection()        // RpcChannel.java line 73
+    //       → ChannelPool.getChannel()        // ChannelPool.java line 77
+    //         → GenericObjectPool.borrowObject()  // throws NoSuchElementException
+    //
+    // ChannelPool.getChannel() catches all Exceptions and re-throws as RuntimeException:
+    //   } catch (Exception e) {
+    //       LOGGER.log(Level.SEVERE, e.getMessage(), e);
+    //       throw new RuntimeException(e.getMessage(), e);  // wraps NoSuchElementException
+    //   }
+    //
+    // ProtobufRpcProxy.invoke() does NOT catch or re-wrap this RuntimeException,
+    // so it propagates directly to BackendServiceClient.
+    //
+    // Source: https://github.com/baidu/Jprotobuf-rpc-socket (jprotobuf-rpc-core-4.2.1)
+    //   - ChannelPool.java: com.baidu.jprotobuf.pbrpc.transport.ChannelPool.getChannel()
+    //   - RpcChannel.java: com.baidu.jprotobuf.pbrpc.transport.RpcChannel.getConnection()
+    //   - ProtobufRpcProxy.java: com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy.invoke()
+    static boolean isConnectionPoolException(Throwable e) {
+        if (e instanceof NoSuchElementException) {
+            return true;
+        }
+        if (e instanceof RuntimeException && e.getCause() instanceof NoSuchElementException) {
+            return true;
+        }
+        return false;
+    }
+
     private BackendServiceClient() {
     }
 
@@ -91,22 +123,23 @@ public class BackendServiceClient {
             final PBackendService service = BrpcProxy.getBackendService(address);
             TalkTimeoutController.setTalkTimeout(Config.brpc_send_plan_fragment_timeout_ms);
             return serviceCall.apply(service);
-        } catch (NoSuchElementException e) {
-            try {
-                // retry
+        } catch (Throwable e) {
+            if (isConnectionPoolException(e)) {
+                // retry once for transient connection pool failures
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
-                final PBackendService service = BrpcProxy.getBackendService(address);
-                return serviceCall.apply(service);
-            } catch (NoSuchElementException noSuchElementException) {
-                LOG.warn("Execute plan fragment retry failed, address={}:{}",
-                        address.getHostname(), address.getPort(), noSuchElementException);
-                throw new RpcException(address.hostname, e.getMessage());
+                try {
+                    final PBackendService service = BrpcProxy.getBackendService(address);
+                    return serviceCall.apply(service);
+                } catch (Throwable retryException) {
+                    LOG.warn("Execute plan fragment retry failed, address={}:{}",
+                            address.getHostname(), address.getPort(), retryException);
+                    throw new RpcException(address.hostname, e.getMessage());
+                }
             }
-        } catch (Throwable e) {
             LOG.warn("Execute plan fragment catch a exception, address={}:{}",
                     address.getHostname(), address.getPort(), e);
             throw new RpcException(address.hostname, e.getMessage());
@@ -176,22 +209,23 @@ public class BackendServiceClient {
         try {
             final PBackendService service = BrpcProxy.getBackendService(address);
             return service.cancelPlanFragmentAsync(pRequest);
-        } catch (NoSuchElementException e) {
-            // retry
-            try {
+        } catch (Throwable e) {
+            if (isConnectionPoolException(e)) {
+                // retry once for transient connection pool failures
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
-                final PBackendService service = BrpcProxy.getBackendService(address);
-                return service.cancelPlanFragmentAsync(pRequest);
-            } catch (NoSuchElementException noSuchElementException) {
-                LOG.warn("Cancel plan fragment retry failed, address={}:{}",
-                        address.getHostname(), address.getPort(), noSuchElementException);
-                throw new RpcException(address.hostname, e.getMessage());
+                try {
+                    final PBackendService service = BrpcProxy.getBackendService(address);
+                    return service.cancelPlanFragmentAsync(pRequest);
+                } catch (Throwable retryException) {
+                    LOG.warn("Cancel plan fragment retry failed, address={}:{}",
+                            address.getHostname(), address.getPort(), retryException);
+                    throw new RpcException(address.hostname, e.getMessage());
+                }
             }
-        } catch (Throwable e) {
             LOG.warn("Cancel plan fragment catch a exception, address={}:{}",
                     address.getHostname(), address.getPort(), e);
             throw new RpcException(address.hostname, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -127,7 +127,7 @@ public class BackendServiceClient {
             if (isConnectionPoolException(e)) {
                 // retry once for transient connection pool failures
                 try {
-                    Thread.sleep(10);
+                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
@@ -213,7 +213,7 @@ public class BackendServiceClient {
             if (isConnectionPoolException(e)) {
                 // retry once for transient connection pool failures
                 try {
-                    Thread.sleep(10);
+                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
@@ -318,7 +318,7 @@ public class BackendServiceClient {
                     throw new RpcException(address.hostname, e.getMessage());
                 }
                 try {
-                    Thread.sleep(10);
+                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
                 } catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -129,7 +129,7 @@ public class BackendServiceClient {
                 try {
                     Thread.sleep(Math.max(0, Config.brpc_connection_pool_retry_wait_time_ms));
                 } catch (InterruptedException interruptedException) {
-                    // do nothing
+                    Thread.currentThread().interrupt();
                 }
                 try {
                     final PBackendService service = BrpcProxy.getBackendService(address);
@@ -137,7 +137,8 @@ public class BackendServiceClient {
                 } catch (Throwable retryException) {
                     LOG.warn("Execute plan fragment retry failed, address={}:{}",
                             address.getHostname(), address.getPort(), retryException);
-                    throw new RpcException(address.hostname, e.getMessage());
+                    throw new RpcException(retryException.getMessage() + ", host: " + address.hostname,
+                            retryException);
                 }
             }
             LOG.warn("Execute plan fragment catch a exception, address={}:{}",
@@ -215,7 +216,7 @@ public class BackendServiceClient {
                 try {
                     Thread.sleep(Math.max(0, Config.brpc_connection_pool_retry_wait_time_ms));
                 } catch (InterruptedException interruptedException) {
-                    // do nothing
+                    Thread.currentThread().interrupt();
                 }
                 try {
                     final PBackendService service = BrpcProxy.getBackendService(address);
@@ -223,7 +224,8 @@ public class BackendServiceClient {
                 } catch (Throwable retryException) {
                     LOG.warn("Cancel plan fragment retry failed, address={}:{}",
                             address.getHostname(), address.getPort(), retryException);
-                    throw new RpcException(address.hostname, e.getMessage());
+                    throw new RpcException(retryException.getMessage() + ", host: " + address.hostname,
+                            retryException);
                 }
             }
             LOG.warn("Cancel plan fragment catch a exception, address={}:{}",

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -127,7 +127,7 @@ public class BackendServiceClient {
             if (isConnectionPoolException(e)) {
                 // retry once for transient connection pool failures
                 try {
-                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
+                    Thread.sleep(Math.max(0, Config.brpc_connection_pool_retry_wait_time_ms));
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
@@ -213,7 +213,7 @@ public class BackendServiceClient {
             if (isConnectionPoolException(e)) {
                 // retry once for transient connection pool failures
                 try {
-                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
+                    Thread.sleep(Math.max(0, Config.brpc_connection_pool_retry_wait_time_ms));
                 } catch (InterruptedException interruptedException) {
                     // do nothing
                 }
@@ -318,7 +318,7 @@ public class BackendServiceClient {
                     throw new RpcException(address.hostname, e.getMessage());
                 }
                 try {
-                    Thread.sleep(Config.brpc_connection_pool_retry_wait_time_ms);
+                    Thread.sleep(10);
                 } catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/BackendServiceClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/BackendServiceClientTest.java
@@ -1,0 +1,308 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.rpc;
+
+import com.starrocks.common.Config;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TUniqueId;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class BackendServiceClientTest {
+
+    private static final TNetworkAddress BAD_ADDRESS = new TNetworkAddress("127.0.0.1", 1);
+
+    // ---------------------------------------------------------------
+    // Tests for isConnectionPoolException()
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testIsConnectionPoolException_directNoSuchElement() {
+        assertTrue(BackendServiceClient.isConnectionPoolException(
+                new NoSuchElementException("pool exhausted")));
+    }
+
+    @Test
+    public void testIsConnectionPoolException_wrappedNoSuchElement() {
+        // This is the exact pattern ChannelPool.getChannel() produces:
+        //   catch (Exception e) { throw new RuntimeException(e.getMessage(), e); }
+        NoSuchElementException cause = new NoSuchElementException("Unable to validate object");
+        RuntimeException wrapped = new RuntimeException(cause.getMessage(), cause);
+        assertTrue(BackendServiceClient.isConnectionPoolException(wrapped));
+    }
+
+    @Test
+    public void testIsConnectionPoolException_otherRuntimeException() {
+        assertFalse(BackendServiceClient.isConnectionPoolException(
+                new RuntimeException("some other error")));
+    }
+
+    @Test
+    public void testIsConnectionPoolException_unrelatedExceptions() {
+        assertFalse(BackendServiceClient.isConnectionPoolException(
+                new IllegalStateException("not a pool error")));
+        assertFalse(BackendServiceClient.isConnectionPoolException(
+                new NullPointerException()));
+        // RuntimeException wrapping a non-NoSuchElementException
+        assertFalse(BackendServiceClient.isConnectionPoolException(
+                new RuntimeException("wrap", new IllegalArgumentException("bad arg"))));
+    }
+
+    // ---------------------------------------------------------------
+    // Integration test: real brpc connection failure to a bad address
+    // ---------------------------------------------------------------
+
+    /**
+     * Verify that connecting to a non-existent address via the raw PBackendService proxy
+     * throws RuntimeException wrapping NoSuchElementException.
+     *
+     * This proves the exception wrapping behavior of ChannelPool.getChannel():
+     *   GenericObjectPool.borrowObject() throws NoSuchElementException
+     *   → ChannelPool.getChannel() catches and re-throws as RuntimeException(msg, cause)
+     *   → ProtobufRpcProxy.invoke() propagates it unchanged
+     *
+     * This is the exact exception pattern that our isConnectionPoolException() fix handles.
+     */
+    @Test
+    public void testRealConnectionFailureThrowsWrappedNoSuchElementException() {
+        PBackendService service = BrpcProxy.getBackendService(BAD_ADDRESS);
+        assertNotNull(service, "getBackendService should return a lazy proxy (no connection yet)");
+
+        PExecPlanFragmentRequest request = new PExecPlanFragmentRequest();
+        request.setRequest(new byte[0]);
+        request.setAttachmentProtocol("binary");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> service.execPlanFragmentAsync(request));
+
+        // Verify the exception is a RuntimeException wrapping NoSuchElementException,
+        // which is exactly the pattern our fix detects.
+        assertInstanceOf(NoSuchElementException.class, thrown.getCause(),
+                "ChannelPool.getChannel() should wrap NoSuchElementException in RuntimeException");
+        assertTrue(BackendServiceClient.isConnectionPoolException(thrown),
+                "isConnectionPoolException must detect the wrapped exception");
+    }
+
+    /**
+     * Verify that BackendServiceClient retries on connection pool failure and ultimately
+     * throws RpcException after both attempts fail (sendRequestAsync path).
+     */
+    @Test
+    public void testExecPlanFragmentRetriesOnConnectionPoolFailure() {
+        BackendServiceClient client = BackendServiceClient.getInstance();
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 0;
+        try {
+            RpcException thrown = assertThrows(RpcException.class,
+                    () -> client.execPlanFragmentAsync(BAD_ADDRESS, new byte[0], "binary"));
+            assertTrue(thrown.getMessage().contains("127.0.0.1"),
+                    "RpcException message should contain the target host");
+            // After retry failure, the cause chain should be preserved for debugging
+            assertNotNull(thrown.getCause(),
+                    "RpcException should preserve the retry failure cause for debugging");
+            assertTrue(BackendServiceClient.isConnectionPoolException(thrown.getCause()),
+                    "The cause should be the connection pool exception from the retry attempt");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+        }
+    }
+
+    /**
+     * Verify that cancelPlanFragmentAsync also retries on connection pool failure
+     * and throws RpcException with cause chain preserved.
+     */
+    @Test
+    public void testCancelPlanFragmentRetriesOnConnectionPoolFailure() {
+        BackendServiceClient client = BackendServiceClient.getInstance();
+        TUniqueId queryId = new TUniqueId(1L, 2L);
+        TUniqueId finstId = new TUniqueId(3L, 4L);
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 0;
+        try {
+            RpcException thrown = assertThrows(RpcException.class,
+                    () -> client.cancelPlanFragmentAsync(BAD_ADDRESS, queryId, finstId,
+                            PPlanFragmentCancelReason.INTERNAL_ERROR, true, null));
+            assertTrue(thrown.getMessage().contains("127.0.0.1"),
+                    "RpcException message should contain the target host");
+            assertNotNull(thrown.getCause(),
+                    "RpcException should preserve the retry failure cause for debugging");
+            assertTrue(BackendServiceClient.isConnectionPoolException(thrown.getCause()),
+                    "The cause should be the connection pool exception from the retry attempt");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Mock-based tests for retry-success and interrupt handling
+    // ---------------------------------------------------------------
+
+    /**
+     * Verify that sendRequestAsync retries once and succeeds when the first call fails
+     * with a connection pool exception but the second call succeeds.
+     */
+    @Test
+    public void testExecPlanFragmentRetrySucceeds() throws Exception {
+        PBackendService mockService = mock(PBackendService.class);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        when(mockService.execPlanFragmentAsync(any())).thenAnswer(invocation -> {
+            if (callCount.getAndIncrement() == 0) {
+                throw new RuntimeException("Unable to validate object",
+                        new NoSuchElementException("Unable to validate object"));
+            }
+            return CompletableFuture.completedFuture(new PExecPlanFragmentResult());
+        });
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 0;
+        try (MockedStatic<BrpcProxy> mockedBrpcProxy = mockStatic(BrpcProxy.class)) {
+            mockedBrpcProxy.when(() -> BrpcProxy.getBackendService(any()))
+                    .thenReturn(mockService);
+
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            assertNotNull(client.execPlanFragmentAsync(BAD_ADDRESS, new byte[0], "binary"));
+            assertTrue(callCount.get() >= 2, "Service should have been called at least twice (initial + retry)");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+        }
+    }
+
+    /**
+     * Verify that cancelPlanFragmentAsync retries once and succeeds when the first call
+     * fails with a connection pool exception but the second call succeeds.
+     */
+    @Test
+    public void testCancelPlanFragmentRetrySucceeds() throws Exception {
+        PBackendService mockService = mock(PBackendService.class);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        when(mockService.cancelPlanFragmentAsync(any())).thenAnswer(invocation -> {
+            if (callCount.getAndIncrement() == 0) {
+                throw new RuntimeException("Unable to validate object",
+                        new NoSuchElementException("Unable to validate object"));
+            }
+            return CompletableFuture.completedFuture(new PCancelPlanFragmentResult());
+        });
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 0;
+        try (MockedStatic<BrpcProxy> mockedBrpcProxy = mockStatic(BrpcProxy.class)) {
+            mockedBrpcProxy.when(() -> BrpcProxy.getBackendService(any()))
+                    .thenReturn(mockService);
+
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            TUniqueId queryId = new TUniqueId(1L, 2L);
+            TUniqueId finstId = new TUniqueId(3L, 4L);
+            assertNotNull(client.cancelPlanFragmentAsync(BAD_ADDRESS, queryId, finstId,
+                    PPlanFragmentCancelReason.INTERNAL_ERROR, true, null));
+            assertTrue(callCount.get() >= 2, "Service should have been called at least twice (initial + retry)");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+        }
+    }
+
+    /**
+     * Verify that the interrupt flag is restored when Thread.sleep is interrupted
+     * during retry wait in sendRequestAsync.
+     *
+     * Key insight: Thread.sleep() checks the interrupt flag on entry. If the flag
+     * is already set, it throws InterruptedException immediately without waiting.
+     * So we set the interrupt flag inside the first (failing) call, guaranteeing
+     * that the subsequent Thread.sleep() will be interrupted deterministically.
+     */
+    @Test
+    public void testRetrySleepInterruptRestoresFlag() throws Exception {
+        PBackendService mockService = mock(PBackendService.class);
+        when(mockService.execPlanFragmentAsync(any())).thenAnswer(invocation -> {
+            // Set interrupt flag before returning — the next Thread.sleep() will
+            // see it immediately and throw InterruptedException.
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Unable to validate object",
+                    new NoSuchElementException("Unable to validate object"));
+        });
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 10000;
+        try (MockedStatic<BrpcProxy> mockedBrpcProxy = mockStatic(BrpcProxy.class)) {
+            mockedBrpcProxy.when(() -> BrpcProxy.getBackendService(any()))
+                    .thenReturn(mockService);
+
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            assertThrows(RpcException.class,
+                    () -> client.execPlanFragmentAsync(BAD_ADDRESS, new byte[0], "binary"));
+
+            // The interrupt flag should have been restored by our fix
+            assertTrue(Thread.interrupted(),
+                    "Interrupt flag should be restored after InterruptedException in retry sleep");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+            Thread.interrupted();
+        }
+    }
+
+    /**
+     * Verify that the interrupt flag is restored when Thread.sleep is interrupted
+     * during retry wait in cancelPlanFragmentAsync.
+     */
+    @Test
+    public void testCancelRetrySleepInterruptRestoresFlag() throws Exception {
+        PBackendService mockService = mock(PBackendService.class);
+        when(mockService.cancelPlanFragmentAsync(any())).thenAnswer(invocation -> {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Unable to validate object",
+                    new NoSuchElementException("Unable to validate object"));
+        });
+
+        int originalWaitTime = Config.brpc_connection_pool_retry_wait_time_ms;
+        Config.brpc_connection_pool_retry_wait_time_ms = 10000;
+        try (MockedStatic<BrpcProxy> mockedBrpcProxy = mockStatic(BrpcProxy.class)) {
+            mockedBrpcProxy.when(() -> BrpcProxy.getBackendService(any()))
+                    .thenReturn(mockService);
+
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            TUniqueId queryId = new TUniqueId(1L, 2L);
+            TUniqueId finstId = new TUniqueId(3L, 4L);
+            assertThrows(RpcException.class,
+                    () -> client.cancelPlanFragmentAsync(BAD_ADDRESS, queryId, finstId,
+                            PPlanFragmentCancelReason.INTERNAL_ERROR, true, null));
+
+            assertTrue(Thread.interrupted(),
+                    "Interrupt flag should be restored after InterruptedException in cancel retry sleep");
+        } finally {
+            Config.brpc_connection_pool_retry_wait_time_ms = originalWaitTime;
+            Thread.interrupted();
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`ChannelPool.getChannel()` wraps `NoSuchElementException` into `RuntimeException(msg, cause=NoSuchElementException)`, but the retry logic only caught the direct `NoSuchElementException` form. This caused transient connection pool failures (e.g. SYN packet loss during TCP handshake) to not be retried, resulting in query failures.

## What I'm doing:

1. Add `isConnectionPoolException()` helper method to detect both direct and wrapped `NoSuchElementException` forms
2. Update `sendRequestAsync` and `cancelPlanFragmentAsync` to use the new helper for retry decisions
3. Add configurable `brpc_connection_pool_retry_wait_time_ms` parameter (default 10s, mutable at runtime) to replace the hardcoded 10ms sleep in retry logic

Fixes #70205

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4