### PR TITLE
[BugFix] Fix AuditEventProcessor thread exit caused by OutOfMemoryException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/failpoint.btm
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/failpoint.btm
@@ -40,3 +40,12 @@ HELPER com.starrocks.failpoint.FailPointHelper
 IF shouldTrigger("thrift_server_accept_exception")
 DO throw new OutOfMemoryError("failpoint triggered");
 ENDRULE
+
+# Audit event processor throw exception
+RULE audit_event_processor_oom
+CLASS com.starrocks.qe.AuditLogBuilder
+METHOD exec(AuditEvent)
+HELPER com.starrocks.failpoint.FailPointHelper
+IF shouldTrigger("audit_event_processor_oom")
+DO throw new OutOfMemoryError("failpoint triggered");
+ENDRULE

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/failpoint.btm
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/failpoint.btm
@@ -41,7 +41,7 @@ IF shouldTrigger("thrift_server_accept_exception")
 DO throw new OutOfMemoryError("failpoint triggered");
 ENDRULE
 
-# Audit event processor throw exception
+# Audit event processor throws OOM exception
 RULE audit_event_processor_oom
 CLASS com.starrocks.qe.AuditLogBuilder
 METHOD exec(AuditEvent)

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
@@ -231,7 +231,6 @@ public class PluginMgr implements Writable {
      * For built-in Plugin register
      */
     public boolean registerBuiltinPlugin(PluginInfo pluginInfo, Plugin plugin) {
-        LOG.error("LXH register plugin");
         if (Objects.isNull(pluginInfo) || Objects.isNull(plugin) || Objects.isNull(pluginInfo.getType())
                 || Strings.isNullOrEmpty(pluginInfo.getName())) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
@@ -231,6 +231,7 @@ public class PluginMgr implements Writable {
      * For built-in Plugin register
      */
     public boolean registerBuiltinPlugin(PluginInfo pluginInfo, Plugin plugin) {
+        LOG.error("LXH register plugin");
         if (Objects.isNull(pluginInfo) || Objects.isNull(plugin) || Objects.isNull(pluginInfo.getType())
                 || Strings.isNullOrEmpty(pluginInfo.getName())) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
@@ -111,7 +111,7 @@ public class AuditEventProcessor {
                         LOG.warn("encounter exception when processing audit event.", e);
                     }
                 } catch (Throwable t) {
-                    // TODO: If plugin.exec throw OutOfMemoryException, the audit log will be lost,
+                    // TODO: If plugin.exec throw OutOfMemoryError, the audit log will be lost,
                     // this scene should be considered later
                     LOG.warn("Error occurred during processing audit event.", t);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
@@ -111,8 +111,8 @@ public class AuditEventProcessor {
                         LOG.warn("encounter exception when processing audit event.", e);
                     }
                 } catch (Throwable t) {
-                    // TODO: If plugin.exec throw OutOfMemoryError, the audit log will be lost,
-                    // this scene should be considered later
+                    // TODO: If plugin.exec throws OutOfMemoryError, the corresponding audit event
+                    // (i.e., that audit log entry) will be lost; this scenario should be considered later.
                     LOG.warn("Error occurred during processing audit event.", t);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditEventProcessor.java
@@ -82,32 +82,38 @@ public class AuditEventProcessor {
         public void run() {
             AuditEvent auditEvent;
             while (!isStopped) {
-                // update audit plugin list every UPDATE_PLUGIN_INTERVAL_MS.
-                // because some of plugins may be installed or uninstalled at runtime.
-                if (auditPlugins == null || System.currentTimeMillis() - lastUpdateTime > UPDATE_PLUGIN_INTERVAL_MS) {
-                    auditPlugins = pluginMgr.getActivePluginList(PluginType.AUDIT);
-                    lastUpdateTime = System.currentTimeMillis();
-                    LOG.debug("update audit plugins. num: {}", auditPlugins.size());
-                }
-
                 try {
-                    auditEvent = eventQueue.poll(5, TimeUnit.SECONDS);
-                    if (auditEvent == null) {
+                    // update audit plugin list every UPDATE_PLUGIN_INTERVAL_MS.
+                    // because some of plugins may be installed or uninstalled at runtime.
+                    if (auditPlugins == null || System.currentTimeMillis() - lastUpdateTime > UPDATE_PLUGIN_INTERVAL_MS) {
+                        auditPlugins = pluginMgr.getActivePluginList(PluginType.AUDIT);
+                        lastUpdateTime = System.currentTimeMillis();
+                        LOG.debug("update audit plugins. num: {}", auditPlugins.size());
+                    }
+
+                    try {
+                        auditEvent = eventQueue.poll(5, TimeUnit.SECONDS);
+                        if (auditEvent == null) {
+                            continue;
+                        }
+                    } catch (InterruptedException e) {
+                        LOG.warn("encounter exception when getting audit event from queue, ignore", e);
                         continue;
                     }
-                } catch (InterruptedException e) {
-                    LOG.warn("encounter exception when getting audit event from queue, ignore", e);
-                    continue;
-                }
 
-                try {
-                    for (Plugin plugin : auditPlugins) {
-                        if (((AuditPlugin) plugin).eventFilter(auditEvent.type)) {
-                            ((AuditPlugin) plugin).exec(auditEvent);
+                    try {
+                        for (Plugin plugin : auditPlugins) {
+                            if (((AuditPlugin) plugin).eventFilter(auditEvent.type)) {
+                                ((AuditPlugin) plugin).exec(auditEvent);
+                            }
                         }
+                    } catch (Exception e) {
+                        LOG.warn("encounter exception when processing audit event.", e);
                     }
-                } catch (Exception e) {
-                    LOG.warn("encounter exception when processing audit event.", e);
+                } catch (Throwable t) {
+                    // TODO: If plugin.exec throw OutOfMemoryException, the audit log will be lost,
+                    // this scene should be considered later
+                    LOG.warn("Error occurred during processing audit event.", t);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -110,9 +110,8 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         continue;
                     }
                 }
-                if (value instanceof String) {
-                    String stringValue = (String) value;
-                    if ((stringValue == null || stringValue.isEmpty()) && af.ignore_empty()) {
+                if (value instanceof String stringValue) {
+                    if (stringValue.isEmpty() && af.ignore_empty()) {
                         continue;
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
@@ -38,15 +38,24 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.DigitalVersion;
 import com.starrocks.plugin.AuditEvent;
 import com.starrocks.plugin.AuditEvent.EventType;
+import com.starrocks.plugin.AuditPlugin;
+import com.starrocks.plugin.Plugin;
 import com.starrocks.plugin.PluginInfo;
+import com.starrocks.plugin.PluginInfo.PluginType;
+import com.starrocks.plugin.PluginMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class AuditEventProcessorTest extends StarRocksTestBase {
 
@@ -159,6 +168,61 @@ public class AuditEventProcessorTest extends StarRocksTestBase {
             }
             long total = System.currentTimeMillis() - start;
             logSysInfo("total(ms): " + total + ", avg: " + total / 10000.0);
+        }
+    }
+
+    // A plugin that throws OOM on the first exec() call, succeeds afterwards.
+    private static class OomOnFirstExecPlugin extends Plugin implements AuditPlugin {
+        private final CountDownLatch processedLatch;
+        private boolean firstCall = true;
+
+        OomOnFirstExecPlugin(CountDownLatch processedLatch) {
+            this.processedLatch = processedLatch;
+        }
+
+        @Override
+        public boolean eventFilter(AuditEvent.EventType type) {
+            return true;
+        }
+
+        @Override
+        public void exec(AuditEvent event) {
+            if (firstCall) {
+                firstCall = false;
+                throw new OutOfMemoryError("simulated OOM in audit plugin");
+            }
+            processedLatch.countDown();
+        }
+    }
+
+    @Test
+    public void testWorkerSurvivesOOMInPluginExec(@Mocked PluginMgr mockPluginMgr) throws Exception {
+        CountDownLatch processedLatch = new CountDownLatch(2);
+        try (OomOnFirstExecPlugin fakePlugin = new OomOnFirstExecPlugin(processedLatch)) {
+            new Expectations() {{
+                    mockPluginMgr.getActivePluginList(PluginType.AUDIT);
+                    result = Collections.singletonList(fakePlugin);
+                }};
+
+            AuditEventProcessor processor = new AuditEventProcessor(mockPluginMgr);
+            processor.start();
+            try {
+                AuditEvent event = new AuditEvent.AuditEventBuilder()
+                        .setEventType(EventType.AFTER_QUERY)
+                        .setTimestamp(System.currentTimeMillis())
+                        .setClientIp("127.0.0.1")
+                        .setUser("user1")
+                        .setDb("db1")
+                        .setStmt("select 1")
+                        .build();
+                for (int i = 0; i < 5; i++) {
+                    processor.handleAuditEvent(event);
+                }
+                Assertions.assertTrue(processedLatch.await(10, TimeUnit.SECONDS),
+                        "Worker should survive OOM and continue processing subsequent events");
+            } finally {
+                processor.stop();
+            }
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

```
[141630.381s][warning][gc,alloc] AuditEventProcessor: Retried waiting for GCLocker too often allocating 258 words
Exception in thread "AuditEventProcessor" [141630.396s][warning][gc,alloc] iceberg_catalog-sr-iceberg-worker-pool-3: Retried waiting for GCLocker too often allocating 252589 words
```

Thread AuditEventProcessor will exit when encountering an OutOfMemoryException, So we should catch the Throwable to avoid this.

## What I'm doing:

Fix AuditEventProcessor thread exit caused by OutOfMemoryException

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
