### PR TITLE
[BugFix] Fix standalone sstable fileset_id mismatch after persistent index reload

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -737,19 +737,24 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
         RETURN_IF_ERROR(new_sstable_fileset->init(new_sstables));
     }
 
-    std::unordered_set<std::string> standalone_sstable_filename;
+    // Collect all input sstable filenames unconditionally, so that standalone filesets
+    // (which match by filename) can always be found — even when the input sstable has a
+    // fileset_id. This handles the case where an sstable was written with fileset_id but
+    // the in-memory fileset is classified as standalone (no range field), which would
+    // previously cause "no matching sstable fileset found" errors.
+    std::unordered_set<std::string> input_sstable_filenames;
     std::unordered_set<UniqueId> fileset_ids;
     for (const auto& input_sstable : op_compaction.input_sstables()) {
+        input_sstable_filenames.insert(input_sstable.filename());
         if (input_sstable.has_fileset_id()) {
             fileset_ids.insert(input_sstable.fileset_id());
-        } else {
-            standalone_sstable_filename.insert(input_sstable.filename());
         }
     }
     // Whether contains this fileset.
+    // Standalone filesets (no range) are matched by filename; non-standalone by fileset_id.
     auto fileset_contains_func = [&](const std::unique_ptr<PersistentIndexSstableFileset>& fileset) {
         if (fileset->is_standalone_sstable()) {
-            return standalone_sstable_filename.contains(fileset->standalone_sstable_filename());
+            return input_sstable_filenames.contains(fileset->standalone_sstable_filename());
         }
         return fileset_ids.contains(fileset->fileset_id());
     };

--- a/be/src/storage/lake/persistent_index_sstable_fileset.cpp
+++ b/be/src/storage/lake/persistent_index_sstable_fileset.cpp
@@ -48,8 +48,16 @@ Status PersistentIndexSstableFileset::init(std::vector<std::unique_ptr<Persisten
             if (_standalone_sstable != nullptr) {
                 return Status::InternalError("more than one standalone sstable in fileset");
             }
-            _fileset_id = UniqueId::gen_uid();
-            sstable->set_fileset_id(_fileset_id);
+            // Preserve the existing fileset_id from metadata if present, to keep it
+            // consistent with what compaction txn_log records. Only generate a new
+            // random ID for truly legacy sstables (e.g., created before fileset_id
+            // was introduced).
+            if (sstable->sstable_pb().has_fileset_id()) {
+                _fileset_id = sstable->sstable_pb().fileset_id();
+            } else {
+                _fileset_id = UniqueId::gen_uid();
+                sstable->set_fileset_id(_fileset_id);
+            }
             _standalone_sstable = std::move(sstable);
         }
     }
@@ -73,8 +81,13 @@ Status PersistentIndexSstableFileset::init(std::unique_ptr<PersistentIndexSstabl
         std::string end_key = sstable->sstable_pb().range().end_key();
         _sstable_map.emplace(std::make_pair(std::move(start_key), std::move(end_key)), std::move(sstable));
     } else {
-        _fileset_id = UniqueId::gen_uid();
-        sstable->set_fileset_id(_fileset_id);
+        // Preserve the existing fileset_id from metadata if present (same reason as above).
+        if (sstable->sstable_pb().has_fileset_id()) {
+            _fileset_id = sstable->sstable_pb().fileset_id();
+        } else {
+            _fileset_id = UniqueId::gen_uid();
+            sstable->set_fileset_id(_fileset_id);
+        }
         _standalone_sstable = std::move(sstable);
     }
     return Status::OK();

--- a/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
@@ -284,6 +284,65 @@ TEST_F(LakePersistentIndexFilesetTest, test_fileset_init_standalone_sstable) {
     ASSERT_EQ("standalone.sst", fileset.standalone_sstable_filename());
 }
 
+// Test that standalone sstable (no range) preserves fileset_id from metadata
+// when it already has one. This is the upgrade scenario: sstables created in
+// older versions (e.g., 3.5) have no range but get a fileset_id written by 4.1
+// during a previous publish. On reload, the fileset_id must be preserved so
+// that compaction txn logs referencing it can still match.
+TEST_F(LakePersistentIndexFilesetTest, test_standalone_sstable_preserves_existing_fileset_id) {
+    auto original_fileset_id = UniqueId::gen_uid();
+
+    // Create sstable with fileset_id but clear range (simulating upgrade from 3.5)
+    PersistentIndexSstablePB sst_pb;
+    ASSERT_OK(create_test_sstable("upgraded.sst", 0, 100, &sst_pb, &original_fileset_id));
+    sst_pb.clear_range(); // Remove range to simulate old-version sstable
+
+    ASSIGN_OR_ABORT(auto sst, open_sstable(sst_pb));
+
+    // Single-sstable init overload
+    PersistentIndexSstableFileset fileset;
+    ASSERT_OK(fileset.init(sst));
+
+    ASSERT_TRUE(fileset.is_standalone_sstable());
+    // The fileset_id must match the original, not a newly generated random one
+    ASSERT_EQ(original_fileset_id.to_string(), fileset.fileset_id().to_string());
+}
+
+TEST_F(LakePersistentIndexFilesetTest, test_standalone_sstable_preserves_existing_fileset_id_vector_init) {
+    auto original_fileset_id = UniqueId::gen_uid();
+
+    PersistentIndexSstablePB sst_pb;
+    ASSERT_OK(create_test_sstable("upgraded_vec.sst", 0, 100, &sst_pb, &original_fileset_id));
+    sst_pb.clear_range();
+
+    ASSIGN_OR_ABORT(auto sst, open_sstable(sst_pb));
+    std::vector<std::unique_ptr<PersistentIndexSstable>> sstables;
+    sstables.push_back(std::move(sst));
+
+    // Vector init overload
+    PersistentIndexSstableFileset fileset;
+    ASSERT_OK(fileset.init(sstables));
+
+    ASSERT_TRUE(fileset.is_standalone_sstable());
+    ASSERT_EQ(original_fileset_id.to_string(), fileset.fileset_id().to_string());
+}
+
+// Test that standalone sstable without fileset_id still gets a generated one
+TEST_F(LakePersistentIndexFilesetTest, test_standalone_sstable_without_fileset_id_generates_new_one) {
+    PersistentIndexSstablePB sst_pb;
+    ASSERT_OK(create_test_sstable("legacy.sst", 0, 100, &sst_pb, nullptr));
+    sst_pb.clear_range();
+
+    ASSIGN_OR_ABORT(auto sst, open_sstable(sst_pb));
+
+    PersistentIndexSstableFileset fileset;
+    ASSERT_OK(fileset.init(sst));
+
+    ASSERT_TRUE(fileset.is_standalone_sstable());
+    // Should have a valid (non-zero) generated fileset_id
+    ASSERT_NE(UniqueId(0, 0).to_string(), fileset.fileset_id().to_string());
+}
+
 TEST_F(LakePersistentIndexFilesetTest, test_fileset_multiple_standalone_error) {
     std::vector<std::unique_ptr<PersistentIndexSstable>> sstables;
 


### PR DESCRIPTION
## Why I'm doing:

After a persistent index reload (triggered by base version adjustment, cache eviction, etc.), `apply_opcompaction()` may fail with `"no matching sstable fileset found for compaction"`. This is caused by two related issues:

**Issue 1: fileset_id mismatch after reload**

When loading SSTables without a key range (e.g., created before the `range` field was introduced), `PersistentIndexSstableFileset::init()` unconditionally generates a new random `fileset_id`, even if the SSTable metadata already contains a valid `fileset_id` from a previous publish.

**Issue 2: standalone fileset matching gap in `apply_opcompaction()`**

In `apply_opcompaction()`, the input SST collection logic only adds filenames to `standalone_sstable_filename` when the input SST has **no** `fileset_id`. But the in-memory fileset may be classified as standalone (no `range` field) and thus matched by filename. When an input SST has `fileset_id` but the in-memory fileset is standalone, neither matching path finds it:
- The `fileset_ids` path doesn't match because the fileset is standalone
- The `standalone_sstable_filename` path doesn't match because the filename was never collected (input SST has `fileset_id`)

**Reproduction sequence:**
1. SSTable is created without `range` field (standalone) but with `fileset_id` in metadata
2. Persistent index loads it as standalone fileset
3. Compaction records the `fileset_id` in its txn_log `input_sstables`
4. On publish, `apply_opcompaction()` sees `fileset_id` → puts it in `fileset_ids` set only (not in filename set)
5. Matching function checks standalone fileset against filename set → empty → no match → error

## What I'm doing:

**Fix 1** (`persistent_index_sstable_fileset.cpp`): In both `init()` overloads, preserve the existing `fileset_id` from SSTable metadata when available for standalone SSTables. Only generate a new random ID when the SSTable truly has no `fileset_id`.

**Fix 2** (`lake_persistent_index.cpp`): Collect all input SST filenames unconditionally into `input_sstable_filenames` (renamed from `standalone_sstable_filename`), regardless of whether the input SST has a `fileset_id`. This ensures standalone filesets can always be matched by filename.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4