### PR TITLE
[Enhancement] Parallelize tablet file copy in shared-data cluster replication

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -218,6 +218,9 @@ CONF_mInt64(lake_replication_slow_log_ms, "30000");
 CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
 // Maximum retry count for non-segment file copy during lake-to-lake replication
 CONF_mInt32(lake_replication_max_file_copy_retry, "3");
+// Minimum number of files required to enable parallel copy in lake-to-lake replication.
+// Set to 0 to force disable parallel copy.
+CONF_mInt32(lake_replication_parallel_copy_min_file_count, "2");
 
 // The log dir.
 CONF_String(sys_log_dir, "${STARROCKS_HOME}/log");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -798,6 +798,7 @@
         "lake_replication_slow_log_ms",
         "lake_replication_read_buffer_size",
         "lake_replication_max_file_copy_retry",
+        "lake_replication_parallel_copy_min_file_count",
         "enable_lake_segment_metadata_filter",
         "lake_flush_thread_num_per_store",
         "lake_tablet_rows_splitted_ratio",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -20,9 +20,6 @@
 #include "common/configbase.h"
 
 namespace starrocks::config {
-// The count of threads for lake tablet metadata fetch operations (get_tablet_stats, get_tablet_metadatas).
-CONF_mInt32(lake_metadata_fetch_thread_count, "3");
-
 // The lake replication slow log threshold
 CONF_mInt64(lake_replication_slow_log_ms, "30000");
 
@@ -31,6 +28,10 @@ CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
 
 // Maximum retry count for non-segment file copy during lake-to-lake replication
 CONF_mInt32(lake_replication_max_file_copy_retry, "3");
+
+// Minimum number of files required to enable parallel copy in lake-to-lake replication.
+// Set to 0 to force disable parallel copy.
+CONF_mInt32(lake_replication_parallel_copy_min_file_count, "2");
 
 // Enable segment metadata filter for lake tables.
 // When enabled, segments whose sort key range does not intersect with query predicates will be skipped.
@@ -88,6 +89,9 @@ CONF_mBool(lake_clear_corrupted_cache_meta, "true");
 // if set to true, CACHE SELECT will only read file, save CPU time
 // if set to false, CACHE SELECT will behave like SELECT
 CONF_mBool(lake_cache_select_in_physical_way, "true");
+
+// The count of threads for lake tablet metadata fetch operations (get_tablet_stats, get_tablet_metadatas).
+CONF_mInt32(lake_metadata_fetch_thread_count, "3");
 
 // Experimental internal switch: whether to enable lake capture_tablet_and_rowsets for query cache stale entries.
 // This config is temporary and may be removed after the related lake capture implementation is fixed.

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -14,20 +14,26 @@
 
 #include "storage/lake/lake_replication_txn_manager.h"
 
+#include <atomic>
+#include <mutex>
+
+#include "agent/agent_server.h"
 #include "agent/master_info.h"
-#include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_rowset_fwd.h"
+#include "common/thread/threadpool.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_starlet.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "gen_cpp/Types_constants.h"
+#include "gen_cpp/Types_types.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "persistent_index_sstable.h"
 #include "replication_txn_manager.h"
+#include "runtime/exec_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet.h"
@@ -37,6 +43,12 @@
 #include "vacuum.h"
 
 namespace starrocks::lake {
+namespace {
+// Backlog guard for shared REPLICATE_SNAPSHOT thread pool.
+// Parallel copy is disabled when queue depth exceeds num_threads * this factor
+// to avoid adding more pressure to an already saturated pool.
+constexpr int kParallelCopyMaxQueuePerThread = 8;
+} // namespace
 
 #ifdef USE_STAROS
 std::string convert_s3_path_to_starlet_uri(std::string_view s3_path, int64_t shard_id) {
@@ -125,6 +137,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
               << ", has_full_path: " << has_full_path
               << (has_full_path ? ", src_partition_full_path: " + src_partition_full_path : "");
 
+    // step 1: validate request and locate source tablet metadata/files.
     std::vector<Version> missed_versions;
     for (auto v = data_version + 1; v <= src_visible_version; ++v) {
         missed_versions.emplace_back(v, v);
@@ -196,6 +209,8 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
             << ", data dir: " << src_data_dir << ", txn_id: " << txn_id << ", src_tablet_id: " << src_tablet_id
             << ", tablet_id: " << target_tablet_id;
 
+    // step 2: build target metadata and file mappings.
+
     // `file_locations` is the mapping between source and target file locations,
     // it contains all files that need to replicate from source to target storage
     std::map<std::string, std::string> file_locations;
@@ -242,21 +257,33 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     // Track which segments have size changes
     std::unordered_map<std::string, size_t> segment_size_changes;
 
+    // step 3: prepare copy mode and build per-file copy tasks.
     MonotonicStopWatch watch;
     watch.start();
-    size_t total_file_size = 0;
+    std::atomic<size_t> total_file_size{0};
 
+    ThreadPool* repl_pool = get_replicate_file_thread_pool();
+    bool use_parallel = should_use_parallel_copy(filename_map.size(), repl_pool);
+    std::mutex mu;
+    std::mutex* shared_mutex = nullptr;
+    FileConverterCreatorFunc active_file_converters = file_converters;
+    if (use_parallel) {
+        LOG(INFO) << "Start parallel file copy, file_count: " << filename_map.size() << ", txn_id: " << txn_id
+                  << ", tablet_id: " << target_tablet_id << ", pool num_threads: " << repl_pool->num_threads()
+                  << ", pool active_threads: " << repl_pool->active_threads()
+                  << ", pool queued_tasks: " << repl_pool->num_queued_tasks();
+        shared_mutex = &mu;
+        active_file_converters = [&file_converters, &mu](
+                                         const std::string& file_name,
+                                         uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
+            std::lock_guard lock(mu);
+            return file_converters(file_name, file_size);
+        };
+    }
+
+    std::vector<ReplicationTask> tasks;
+    tasks.reserve(filename_map.size());
     for (const auto& pair : filename_map) {
-        // Fast cancel: check if the transaction has been aborted
-        if (txn_id < get_master_info().min_active_txn_id) {
-            LOG(WARNING) << "Lake replication task cancelled, transaction is aborted"
-                         << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
-                         << ", min_active_txn_id: " << get_master_info().min_active_txn_id
-                         << ", copied files: " << files_to_delete.size() << "/" << filename_map.size();
-            return Status::Aborted("Lake replication cancelled, transaction is aborted");
-        }
-        TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy", nullptr);
-
         const auto& src_file_name = pair.first;
         auto src_file_location = join_path(src_data_dir, src_file_name);
         auto it = file_locations.find(src_file_location);
@@ -264,55 +291,112 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
             return Status::Corruption("Found invalid file location, src file location: " + src_file_location);
         }
         const auto& target_file_location = it->second;
-        LOG(INFO) << "Start replicate src file: " << src_file_location << ", target: " << target_file_location
-                  << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
-
-        // Create trace for this file replication
-        scoped_refptr<Trace> file_trace(new Trace);
-        ADOPT_TRACE(file_trace.get());
-        TRACE("Start replicate file, txn_id: $0, tablet_id: $1, src: $2, target: $3", txn_id, target_tablet_id,
-              src_file_location, target_file_location);
-        TRACE_COUNTER_INCREMENT("txn_id", txn_id);
-        TRACE_COUNTER_INCREMENT("tablet_id", target_tablet_id);
-
-        size_t final_file_size = 0;
-        auto start_ts = butil::gettimeofday_us();
-        if (is_segment(src_file_name)) {
-            // For segment files, use download_lake_segment_file which supports schema conversion
-            // via SegmentStreamConverter when column_unique_id_map is not empty.
-            // file_size might be available in segment_name_to_size_map
-            auto src_file_size = segment_name_to_size_map[src_file_name];
-            RETURN_IF_ERROR(ReplicationUtils::download_lake_segment_file(
-                    src_file_location, src_file_name, src_file_size, shared_src_fs, file_converters, &final_file_size));
-            // Update the segment size map with the actual converted file size
-            if (final_file_size > 0 && final_file_size != src_file_size) {
-                const auto& target_file_name = pair.second.first;
-                segment_size_changes[target_file_name] = final_file_size;
-                LOG(INFO) << "Segment file size changed after conversion, src_file: " << src_file_name
-                          << ", target_file: " << target_file_name << ", original size: " << src_file_size
-                          << ", final size: " << final_file_size;
-            }
-        } else {
-            // For non-segment files (.del, .sst, .delvec, .cols), copy with size verification and retry.
-            WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-            if (config::enable_transparent_data_encryption) {
-                opts.encryption_info = pair.second.second.info;
-            }
-            int max_retry = std::max(1, config::lake_replication_max_file_copy_retry);
-            ASSIGN_OR_RETURN(final_file_size, copy_non_segment_file_with_retry(src_file_location, shared_src_fs,
-                                                                               target_file_location, opts, max_retry));
-            files_to_delete.push_back(target_file_location);
+        size_t src_file_size = 0;
+        auto size_it = segment_name_to_size_map.find(src_file_name);
+        if (size_it != segment_name_to_size_map.end()) {
+            src_file_size = size_it->second;
         }
-        total_file_size += final_file_size;
-        auto cost = butil::gettimeofday_us() - start_ts;
-        auto is_slow = cost >= config::lake_replication_slow_log_ms * 1000;
-        TRACE("Finished replicate file, final_size: $0, cost_us: $1", final_file_size, cost);
+        bool is_seg = is_segment(src_file_name);
+        const auto& target_file_name = pair.second.first;
+        FileEncryptionInfo encryption_info;
+        if (config::enable_transparent_data_encryption) {
+            encryption_info = pair.second.second.info;
+        }
 
-        if (is_slow) {
-            LOG(INFO) << "Finished replicate src file: " << src_file_location << ", target: " << target_file_location
-                      << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id << ", size: " << final_file_size
-                      << ", cost(s): " << cost / 1000. / 1000. << "\n"
-                      << ",trace: " << file_trace->MetricsAsJSON();
+        tasks.emplace_back([&, src_file_name, src_file_location, target_file_location, target_file_name, src_file_size,
+                            is_seg, encryption_info]() -> Status {
+            // Fast cancel: check right before each file copy starts.
+            if (txn_id < get_master_info().min_active_txn_id) {
+                LOG(WARNING) << "Lake replication task cancelled before file copy, transaction is aborted"
+                             << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+                             << ", min_active_txn_id: " << get_master_info().min_active_txn_id
+                             << ", src_file: " << src_file_name;
+                return Status::Aborted("Lake replication cancelled, transaction is aborted");
+            }
+            TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy", nullptr);
+
+            LOG(INFO) << "Start replicate src file: " << src_file_location << ", target: " << target_file_location
+                      << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
+
+            size_t final_file_size = 0;
+            auto start_ts = butil::gettimeofday_us();
+            if (is_seg) {
+                TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_task::download_segment",
+                                         &final_file_size);
+                if (final_file_size == 0) {
+                    RETURN_IF_ERROR(ReplicationUtils::download_lake_segment_file(
+                            src_file_location, src_file_name, src_file_size, shared_src_fs, active_file_converters,
+                            &final_file_size));
+                }
+                if (final_file_size > 0 && final_file_size != src_file_size) {
+                    if (shared_mutex != nullptr) {
+                        std::lock_guard lock(*shared_mutex);
+                        segment_size_changes[target_file_name] = final_file_size;
+                    } else {
+                        segment_size_changes[target_file_name] = final_file_size;
+                    }
+                    LOG(INFO) << "Segment file size changed after conversion, src_file: " << src_file_name
+                              << ", target_file: " << target_file_name << ", original size: " << src_file_size
+                              << ", final size: " << final_file_size;
+                }
+            } else {
+                WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+                if (config::enable_transparent_data_encryption) {
+                    opts.encryption_info = encryption_info;
+                }
+                int max_retry = std::max(1, config::lake_replication_max_file_copy_retry);
+                TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                         &final_file_size);
+                if (final_file_size == 0) {
+                    ASSIGN_OR_RETURN(final_file_size,
+                                     copy_non_segment_file_with_retry(src_file_location, shared_src_fs,
+                                                                      target_file_location, opts, max_retry));
+                }
+                if (shared_mutex != nullptr) {
+                    std::lock_guard lock(*shared_mutex);
+                    files_to_delete.push_back(target_file_location);
+                } else {
+                    files_to_delete.push_back(target_file_location);
+                }
+            }
+
+            total_file_size.fetch_add(final_file_size, std::memory_order_relaxed);
+            auto cost = butil::gettimeofday_us() - start_ts;
+            auto is_slow = cost >= config::lake_replication_slow_log_ms * 1000;
+            if (is_slow) {
+                LOG(INFO) << "Finished replicate src file: " << src_file_location
+                          << ", target: " << target_file_location << ", txn_id: " << txn_id
+                          << ", tablet_id: " << target_tablet_id << ", size: " << final_file_size
+                          << ", cost(s): " << cost / 1000. / 1000.;
+            }
+            return Status::OK();
+        });
+    }
+    // step 4: execute tasks and collect copy metrics.
+    // Follow the ThreadPoolToken(CONCURRENT) + wait() pattern used in txn_manager.cpp.
+    if (use_parallel) {
+        auto token = repl_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+        std::vector<Status> task_results(tasks.size());
+        for (size_t i = 0; i < tasks.size(); i++) {
+            auto st =
+                    token->submit_func([&task_results, i, task = std::move(tasks[i])]() { task_results[i] = task(); });
+            if (!st.ok()) {
+                task_results[i] = std::move(st);
+            }
+        }
+        token->wait();
+        for (const auto& r : task_results) {
+            if (!r.ok()) {
+                LOG(WARNING) << "Parallel file copy failed, txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+                             << ", pool num_threads: " << repl_pool->num_threads()
+                             << ", pool active_threads: " << repl_pool->active_threads()
+                             << ", pool queued_tasks: " << repl_pool->num_queued_tasks() << ", error: " << r;
+                return r;
+            }
+        }
+    } else {
+        for (const auto& task : tasks) {
+            RETURN_IF_ERROR(task());
         }
     }
     double total_time_sec = watch.elapsed_time() / 1000. / 1000. / 1000.;
@@ -321,9 +405,11 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         copy_rate = (total_file_size / 1024. / 1024.) / total_time_sec;
     }
     LOG(INFO) << "Replicated tablet file count: " << filename_map.size() << ", total bytes: " << total_file_size
-              << ", cost: " << total_time_sec << "s, rate: " << copy_rate << "MB/s"
-              << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
+              << ", cost: " << total_time_sec << "s, rate: " << copy_rate
+              << "MB/s, parallel: " << (use_parallel ? "true" : "false") << ", txn_id: " << txn_id
+              << ", tablet_id: " << target_tablet_id;
 
+    // step 5: update metadata and write txn log.
     // Update segment sizes in tablet_metadata if there are any changes
     if (!segment_size_changes.empty()) {
         RETURN_IF_ERROR(update_tablet_metadata_segment_sizes(copied_target_tablet_meta, segment_size_changes));
@@ -350,6 +436,36 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
 
     clean_files.cancel();
     return Status::OK();
+}
+
+ThreadPool* LakeReplicationTxnManager::get_replicate_file_thread_pool() {
+    if (_replicate_file_thread_pool != nullptr) {
+        return _replicate_file_thread_pool;
+    }
+    auto* agent_srv = ExecEnv::GetInstance()->agent_server();
+    if (agent_srv == nullptr) {
+        return nullptr;
+    }
+    _replicate_file_thread_pool = agent_srv->get_thread_pool(TTaskType::REPLICATE_SNAPSHOT);
+    return _replicate_file_thread_pool;
+}
+
+bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool) {
+    if (thread_pool == nullptr) {
+        return false;
+    }
+    const int min_file_count = std::max(0, config::lake_replication_parallel_copy_min_file_count);
+    if (min_file_count == 0) {
+        return false;
+    }
+    if (file_count < static_cast<size_t>(min_file_count)) {
+        return false;
+    }
+    const int num_threads = thread_pool->num_threads();
+    if (num_threads <= 0) {
+        return false;
+    }
+    return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
 }
 
 StatusOr<size_t> LakeReplicationTxnManager::copy_non_segment_file_with_retry(

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <atomic>
+#include <functional>
+#include <vector>
+
 #include "common/status.h"
 #include "fs/encryption.h"
 #include "gen_cpp/AgentService_types.h"
@@ -26,6 +30,7 @@ struct FileEncryptionPair;
 struct WritableFileOptions;
 class TabletMetadataPB;
 class FileSystem;
+class ThreadPool;
 } // namespace starrocks
 
 using starrocks::FileConverterCreatorFunc;
@@ -35,6 +40,8 @@ class TabletManager;
 
 class LakeReplicationTxnManager {
 public:
+    using ReplicationTask = std::function<Status()>;
+
     explicit LakeReplicationTxnManager(lake::TabletManager* tablet_manager)
             : _tablet_manager(tablet_manager)
 #ifdef USE_STAROS
@@ -98,8 +105,15 @@ public:
                                                              const std::string& target_file_location,
                                                              const WritableFileOptions& opts, int max_retry);
 
+    // Decide whether to use parallel copy for current tablet files.
+    static bool should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool);
+
 private:
+    ThreadPool* get_replicate_file_thread_pool();
+
     TabletManager* _tablet_manager;
+    // Non-owning pointer managed by AgentServer.
+    ThreadPool* _replicate_file_thread_pool = nullptr;
 #ifdef USE_STAROS
     // Used for non-S3 storage types to construct relative paths
     // S3 storage type uses full path provided by FE instead

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -18,9 +18,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <random>
+#include <thread>
 
 #include "agent/master_info.h"
+#include "base/concurrency/countdown_latch.h"
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
@@ -38,6 +42,7 @@
 #include "common/config_lake_fwd.h"
 #include "common/config_rowset_fwd.h"
 #include "common/config_starlet_fwd.h"
+#include "common/thread/threadpool.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_starlet.h"
 #include "fs/fs_util.h"
@@ -438,6 +443,89 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_max_retry_clamped_to_at_least_one) 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 0);
     ASSERT_OK(result.status());
     EXPECT_EQ(*result, content.size());
+}
+
+class Int32ConfigGuard {
+public:
+    explicit Int32ConfigGuard(int32_t* config_ptr) : _config_ptr(config_ptr), _old_value(*config_ptr) {}
+    ~Int32ConfigGuard() { *_config_ptr = _old_value; }
+
+private:
+    int32_t* _config_ptr;
+    int32_t _old_value;
+};
+
+class BoolConfigGuard {
+public:
+    explicit BoolConfigGuard(bool* config_ptr) : _config_ptr(config_ptr), _old_value(*config_ptr) {}
+    ~BoolConfigGuard() { *_config_ptr = _old_value; }
+
+private:
+    bool* _config_ptr;
+    bool _old_value;
+};
+
+class Int64ConfigGuard {
+public:
+    explicit Int64ConfigGuard(int64_t* config_ptr) : _config_ptr(config_ptr), _old_value(*config_ptr) {}
+    ~Int64ConfigGuard() { *_config_ptr = _old_value; }
+
+private:
+    int64_t* _config_ptr;
+    int64_t _old_value;
+};
+
+TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_basic_gate) {
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 2;
+    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(2, nullptr));
+
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_gate")
+                      .set_min_threads(1)
+                      .set_max_threads(1)
+                      .set_max_queue_size(8)
+                      .build(&pool));
+    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(1, pool.get()));
+    EXPECT_TRUE(LakeReplicationTxnManager::should_use_parallel_copy(2, pool.get()));
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_queue_overloaded) {
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 2;
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_overload")
+                      .set_min_threads(1)
+                      .set_max_threads(1)
+                      .set_max_queue_size(32)
+                      .build(&pool));
+
+    CountDownLatch block(1);
+    ASSERT_OK(pool->submit_func([&]() { block.wait(); }));
+    for (int i = 0; i < 9; ++i) {
+        ASSERT_OK(pool->submit_func([&]() { block.wait(); }));
+    }
+
+    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(20, pool.get()));
+    block.count_down();
+    pool->wait();
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_can_disable_by_config) {
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 0;
+
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_disable")
+                      .set_min_threads(1)
+                      .set_max_threads(1)
+                      .set_max_queue_size(8)
+                      .build(&pool));
+
+    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(100, pool.get()));
+    pool->shutdown();
 }
 
 #ifdef USE_STAROS
@@ -1046,6 +1134,199 @@ TEST_F(LakeReplicationRemoteStorageTest, test_no_fast_cancel_when_txn_active) {
     // The file copy will fail due to the mock filesystem, but that's expected.
     EXPECT_TRUE(before_copy_invoked) << "before_copy SyncPoint should have been reached (fast cancel did not trigger)";
     EXPECT_FALSE(status.is_aborted()) << "Should not abort when min_active_txn_id <= txn_id, status: " << status;
+}
+
+// Test Case 9: Sequential copy with mocked file operations - covers task lambda body,
+// segment download path, non-segment copy path, size tracking, encryption, slow log.
+TEST_F(LakeReplicationRemoteStorageTest, test_sequential_copy_with_mocked_file_operations) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Create source metadata with segments (with segment_size) and delvec
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    rowset->add_segment_size(1024); // src_file_size for segment 1
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000002.dat");
+    rowset->add_segment_size(2048); // src_file_size for segment 2
+    // Add a delvec for non-segment path
+    auto* delvec_meta = src_meta_v2->mutable_delvec_meta();
+    auto& delvec_entry = (*delvec_meta->mutable_version_to_file())[2];
+    delvec_entry.set_name("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000003.delvec");
+    src_meta_v2->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+
+    // Mock segment download: set final_file_size=2048 so seg1 triggers size_changes (1024!=2048)
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) {
+                                              auto* file_size = static_cast<size_t*>(arg);
+                                              *file_size = 2048;
+                                          });
+
+    // Mock non-segment copy
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                          [&](void* arg) {
+                                              auto* file_size = static_cast<size_t*>(arg);
+                                              *file_size = 512;
+                                          });
+
+    // Set slow log threshold to 0 to cover slow log path
+    Int64ConfigGuard slow_log_guard(&config::lake_replication_slow_log_ms);
+    config::lake_replication_slow_log_ms = 0;
+
+    // Disable parallel to ensure sequential path
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 0;
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    (void)update_master_info(original_master_info);
+
+    ASSERT_OK(status);
+}
+
+// Test Case 10: Parallel copy with mocked file operations - covers parallel branch,
+// mutex-guarded segment_size_changes and files_to_delete paths.
+TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_with_mocked_file_operations) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    rowset->add_segment_size(1024);
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000002.dat");
+    rowset->add_segment_size(2048);
+    auto* delvec_meta = src_meta_v2->mutable_delvec_meta();
+    auto& delvec_entry = (*delvec_meta->mutable_version_to_file())[2];
+    delvec_entry.set_name("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000003.delvec");
+    src_meta_v2->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) {
+                                              auto* file_size = static_cast<size_t*>(arg);
+                                              *file_size = 2048;
+                                          });
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                          [&](void* arg) {
+                                              auto* file_size = static_cast<size_t*>(arg);
+                                              *file_size = 512;
+                                          });
+
+    // Enable parallel copy: min_file_count=2, we have 3 files (2 segments + 1 delvec)
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 2;
+
+    // Create thread pool and assign to replication manager
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_test_pool")
+                      .set_min_threads(2)
+                      .set_max_threads(4)
+                      .set_max_queue_size(16)
+                      .build(&pool));
+    _replication_txn_manager->_replicate_file_thread_pool = pool.get();
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    (void)update_master_info(original_master_info);
+    _replication_txn_manager->_replicate_file_thread_pool = nullptr;
+
+    ASSERT_OK(status);
+    pool->shutdown();
+}
+
+// Test Case 11: Parallel copy error handling - covers L370-376 (parallel error logging/return).
+TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000002.dat");
+    src_meta_v2->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+
+    // Do NOT register download_segment callback - actual download will fail with mock FS
+
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 2;
+
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_test_err_pool")
+                      .set_min_threads(2)
+                      .set_max_threads(4)
+                      .set_max_queue_size(16)
+                      .build(&pool));
+    _replication_txn_manager->_replicate_file_thread_pool = pool.get();
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    (void)update_master_info(original_master_info);
+    _replication_txn_manager->_replicate_file_thread_pool = nullptr;
+
+    // Parallel copy should fail because download_lake_segment_file fails with mock FS
+    EXPECT_FALSE(status.ok());
+    pool->shutdown();
 }
 #endif // USE_STAROS
 


### PR DESCRIPTION
## Why I'm doing:

During shared-data (lake-to-lake) cross-cluster replication, a single tablet may contain many segment and non-segment files. The previous implementation copies all files sequentially, which wastes available bandwidth and amplifies end-to-end replication latency.

Also, the file copy loop in `replicate_lake_remote_storage` had grown complex with inline error handling, retry logic, and mixed concerns, making it hard to maintain and test.

## What I'm doing:

### 1. Parallel file copy via shared thread pool

Refactored the file copy loop into a **task-based architecture**: each file copy is wrapped as a `ReplicationTask` (lambda → `Status`), and all tasks are either run sequentially or submitted to the existing `REPLICATE_SNAPSHOT` thread pool for parallel execution.

- **Parallel mode** uses `CountDownLatch` to wait for all submitted tasks, with atomic error flag + mutex-protected first-error capture.
- **Backlog guard**: parallel copy is automatically disabled when the thread pool queue depth exceeds `num_threads × 8`, preventing further pressure on an already saturated pool — falls back to sequential copy gracefully.
- **Fast cancel**: each task checks `min_active_txn_id` before starting the copy, so aborted transactions don't waste I/O.

### 2. Introduced new dynamic BE configs

| Config | Default | Description |
|---|---|---|
| `lake_replication_parallel_copy_min_file_count` | 2 | Min files to enable parallel copy; 0 = force disable |
| `lake_replication_max_file_copy_retry` | 3 | Max retry for non-segment file copy on failure or size mismatch |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4