### PR TITLE
[Enhancement] add support for FIXED_LEN_BYTE_ARRAY types to be read as VARCHAR(36) lazily

### DIFF
--- a/be/src/exec/parquet_schema_builder.cpp
+++ b/be/src/exec/parquet_schema_builder.cpp
@@ -108,8 +108,12 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
             auto decimal_logical_type = std::dynamic_pointer_cast<const parquet::DecimalLogicalType>(logical_type);
             *type_desc = TypeDescriptor::promote_decimal_type(decimal_logical_type->precision(),
                                                               decimal_logical_type->scale());
+        } else if (logical_type->is_UUID()) {
+            *type_desc = TypeDescriptor::create_varchar_type(36);
         } else {
-            *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            // INTERVAL (12B), BSON, and unannotated FLBA all carry raw binary data.
+            // VARBINARY is the correct SR type for all of these.
+            *type_desc = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
         }
         break;
     }

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -102,6 +102,14 @@ private:
     cctz::time_zone _ctz;
 };
 
+class FixedLenByteArrayToUUIDConverter final : public ColumnConverter {
+public:
+    FixedLenByteArrayToUUIDConverter() = default;
+    ~FixedLenByteArrayToUUIDConverter() override = default;
+
+    Status convert(const Column* src, Column* dst) override;
+};
+
 class Int64ToDateTimeConverter final : public ColumnConverter {
 public:
     Int64ToDateTimeConverter() = default;
@@ -357,6 +365,61 @@ private:
     int32_t _type_length = 0;
 };
 
+Status FixedLenByteArrayToUUIDConverter::convert(const Column* src, Column* dst) {
+    auto* src_nullable = ColumnHelper::as_raw_column<NullableColumn>(src);
+    auto* dst_nullable = down_cast<NullableColumn*>(dst);
+    auto* src_col = ColumnHelper::as_raw_column<BinaryColumn>(src_nullable->data_column());
+    auto* dst_col = ColumnHelper::as_raw_column<BinaryColumn>(dst_nullable->data_column_raw_ptr());
+
+    const auto& src_null = src_nullable->null_column()->get_data();
+    auto& dst_null = dst_nullable->null_column_raw_ptr()->get_data();
+
+    size_t n = src_col->size();
+    dst_null.resize(n);
+    memcpy(dst_null.data(), src_null.data(), n);
+
+    static constexpr char HEX[] = "0123456789abcdef";
+    char buf[36];
+
+    for (size_t i = 0; i < n; i++) {
+        if (src_null[i]) {
+            dst_col->append_default();
+            continue;
+        }
+        Slice s = src_col->get_slice(i);
+        DCHECK_EQ(s.size, 16);
+        const auto* bytes = reinterpret_cast<const uint8_t*>(s.data);
+        int p = 0;
+        for (int j = 0; j < 4; j++) {
+            buf[p++] = HEX[bytes[j] >> 4];
+            buf[p++] = HEX[bytes[j] & 0xf];
+        }
+        buf[p++] = '-';
+        for (int j = 4; j < 6; j++) {
+            buf[p++] = HEX[bytes[j] >> 4];
+            buf[p++] = HEX[bytes[j] & 0xf];
+        }
+        buf[p++] = '-';
+        for (int j = 6; j < 8; j++) {
+            buf[p++] = HEX[bytes[j] >> 4];
+            buf[p++] = HEX[bytes[j] & 0xf];
+        }
+        buf[p++] = '-';
+        for (int j = 8; j < 10; j++) {
+            buf[p++] = HEX[bytes[j] >> 4];
+            buf[p++] = HEX[bytes[j] & 0xf];
+        }
+        buf[p++] = '-';
+        for (int j = 10; j < 16; j++) {
+            buf[p++] = HEX[bytes[j] >> 4];
+            buf[p++] = HEX[bytes[j] & 0xf];
+        }
+        dst_col->append(Slice(buf, 36));
+    }
+    dst_nullable->set_has_null(src_nullable->has_null());
+    return Status::OK();
+}
+
 Status ColumnConverterFactory::create_converter(const ParquetField& field, const TypeDescriptor& typeDescriptor,
                                                 const std::string& timezone,
                                                 std::unique_ptr<ColumnConverter>* converter) {
@@ -486,7 +549,9 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
     }
     case tparquet::Type::type::FIXED_LEN_BYTE_ARRAY: {
         int32_t type_length = field.type_length;
-        if (col_type != LogicalType::TYPE_VARCHAR && col_type != LogicalType::TYPE_CHAR) {
+        bool is_uuid = schema_element.__isset.logicalType && schema_element.logicalType.__isset.UUID;
+        if (col_type != LogicalType::TYPE_VARCHAR && col_type != LogicalType::TYPE_CHAR &&
+            col_type != LogicalType::TYPE_VARBINARY) {
             need_convert = true;
         }
         switch (col_type) {
@@ -505,6 +570,13 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
         case LogicalType::TYPE_DECIMAL128:
             *converter = std::make_unique<BinaryToDecimalConverter<TYPE_DECIMAL128>>(field.scale, typeDescriptor.scale,
                                                                                      type_length);
+            break;
+        case LogicalType::TYPE_VARCHAR:
+        case LogicalType::TYPE_CHAR:
+            if (is_uuid) {
+                need_convert = true;
+                *converter = std::make_unique<FixedLenByteArrayToUUIDConverter>();
+            }
             break;
         default:
             break;

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -173,7 +173,8 @@ bool ColumnReader::check_type_can_apply_bloom_filter(const TypeDescriptor& col_t
             appliable = true;
         }
     } else if (type == LogicalType::TYPE_VARCHAR || type == LogicalType::TYPE_VARBINARY) {
-        if (parquet_type == tparquet::Type::type::BYTE_ARRAY) {
+        if (parquet_type == tparquet::Type::type::BYTE_ARRAY ||
+            (parquet_type == tparquet::Type::type::FIXED_LEN_BYTE_ARRAY && type == LogicalType::TYPE_VARBINARY)) {
             appliable = true;
         }
         //TODO: FLBA type should check the length and pad space.

--- a/be/test/exec/parquet_schema_builder_test.cpp
+++ b/be/test/exec/parquet_schema_builder_test.cpp
@@ -109,6 +109,44 @@ TEST_F(ParquetSchemaBuilderTest, PrimitiveTypes) {
     }
 }
 
+// Test FIXED_LEN_BYTE_ARRAY schema inference
+TEST_F(ParquetSchemaBuilderTest, FixedLenByteArrayTypes) {
+    TypeDescriptor type_desc;
+    Status st;
+
+    // FIXED_LEN_BYTE_ARRAY with UUID annotation -> VARCHAR(36)
+    {
+        auto node = ::parquet::schema::PrimitiveNode::Make("uuid_col", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::LogicalType::UUID(),
+                                                           ::parquet::Type::FIXED_LEN_BYTE_ARRAY, 16);
+        st = get_parquet_type(node, &type_desc);
+        ASSERT_TRUE(st.ok());
+        ASSERT_EQ(TYPE_VARCHAR, type_desc.type);
+        ASSERT_EQ(36, type_desc.len);
+    }
+
+    // FIXED_LEN_BYTE_ARRAY without annotation -> VARBINARY
+    {
+        auto node = ::parquet::schema::PrimitiveNode::Make("binary_col", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::LogicalType::None(),
+                                                           ::parquet::Type::FIXED_LEN_BYTE_ARRAY, 8);
+        st = get_parquet_type(node, &type_desc);
+        ASSERT_TRUE(st.ok());
+        ASSERT_EQ(TYPE_VARBINARY, type_desc.type);
+    }
+
+    // FIXED_LEN_BYTE_ARRAY with DECIMAL annotation -> DECIMAL (unchanged)
+    {
+        auto node = ::parquet::schema::PrimitiveNode::Make("decimal_col", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::DecimalLogicalType::Make(10, 2),
+                                                           ::parquet::Type::FIXED_LEN_BYTE_ARRAY, 8);
+        st = get_parquet_type(node, &type_desc);
+        ASSERT_TRUE(st.ok());
+        ASSERT_TRUE(type_desc.type == TYPE_DECIMAL32 || type_desc.type == TYPE_DECIMAL64 ||
+                    type_desc.type == TYPE_DECIMAL128);
+    }
+}
+
 // Test variant type with valid unshredded structure (2 fields: metadata and value)
 TEST_F(ParquetSchemaBuilderTest, VariantTypeUnshredded) {
     TypeDescriptor type_desc;

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -424,6 +424,11 @@ TEST_F(ColumnConverterTest, FLBATest) {
             const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
             check(file_path, col_type, col_name, "['abcDeFGhijkLmnOp']", expected_rows);
         }
+        {
+            // FIXED_LEN_BYTE_ARRAY (UUID) -> VARBINARY: raw 16 bytes pass through without conversion
+            const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARBINARY);
+            check(file_path, col_type, col_name, "['abcDeFGhijkLmnOp']", expected_rows);
+        }
     }
     {
         const std::string col_name = "decimal_flba";
@@ -462,6 +467,24 @@ TEST_F(ColumnConverterTest, FLBATest) {
         {
             const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_TIME);
             check(file_path, col_type, col_name, "[6809.6]", expected_rows, true);
+        }
+    }
+}
+
+// Tests FIXED_LEN_BYTE_ARRAY with UUID logical type annotation.
+// The parquet column carries raw 16-byte UUIDs; the converter must format them
+// as "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" strings.
+TEST_F(ColumnConverterTest, FLBAUUIDTest) {
+    const std::string file_path =
+            "./be/test/formats/parquet/test_data/column_converter/fixed_len_byte_array_uuid.parquet";
+    const size_t expected_rows = 5;
+
+    {
+        const std::string col_name = "uuid";
+        // UUID logical type -> VARCHAR: bytes formatted as xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        {
+            const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+            check(file_path, col_type, col_name, "['b4f20d71-755e-572f-95c1-518871b9ca71']", expected_rows);
         }
     }
 }

--- a/be/test/formats/parquet/column_reader_factory_test.cpp
+++ b/be/test/formats/parquet/column_reader_factory_test.cpp
@@ -18,7 +18,10 @@
 
 #include <sstream>
 
+#include "formats/parquet/column_reader.h"
 #include "formats/parquet/complex_column_reader.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks::parquet {
 
@@ -344,6 +347,44 @@ TEST(ColumnReaderFactoryTest, VariantShreddedCollectIoRangeAndSelectOffsetIndex)
     SparseRange<uint64_t> sparse_range;
     sparse_range.add(Range<uint64_t>(0, 8));
     st.value()->select_offset_index(sparse_range, 0);
+}
+
+// Minimal concrete subclass to allow instantiation of the abstract ColumnReader.
+class TestColumnReader : public ColumnReader {
+public:
+    explicit TestColumnReader(const ParquetField* field) : ColumnReader(field) {}
+    Status prepare() override { return Status::OK(); }
+    Status read_range(const Range<uint64_t>&, const Filter*, ColumnPtr&) override { return Status::OK(); }
+    void get_levels(level_t**, level_t**, size_t*) override {}
+    void set_need_parse_levels(bool) override {}
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>*, int64_t*, ColumnIOTypeFlags,
+                                 bool) override {}
+    void select_offset_index(const SparseRange<uint64_t>&, const uint64_t) override {}
+};
+
+// Covers the FIXED_LEN_BYTE_ARRAY condition added to check_type_can_apply_bloom_filter.
+TEST(ColumnReaderTest, CheckTypeCanApplyBloomFilterFixedLenByteArray) {
+    ParquetField field;
+    field.name = "col";
+    field.type = ColumnType::SCALAR;
+    field.physical_column_index = 0;
+
+    auto check = [&](LogicalType logical, tparquet::Type::type physical) -> bool {
+        field.physical_type = physical;
+        TestColumnReader reader(&field);
+        return reader.check_type_can_apply_bloom_filter(TypeDescriptor(logical), field);
+    };
+
+    // VARBINARY + FIXED_LEN_BYTE_ARRAY is applicable (the new condition)
+    EXPECT_TRUE(check(TYPE_VARBINARY, tparquet::Type::FIXED_LEN_BYTE_ARRAY));
+
+    // VARCHAR + FIXED_LEN_BYTE_ARRAY is not applicable
+    // UUID is stored as FIXED_LEN_BYTE_ARRAY and typically read as VARCHAR
+    EXPECT_FALSE(check(TYPE_VARCHAR, tparquet::Type::FIXED_LEN_BYTE_ARRAY));
+
+    // BYTE_ARRAY baseline: both VARCHAR and VARBINARY remain applicable
+    EXPECT_TRUE(check(TYPE_VARCHAR, tparquet::Type::BYTE_ARRAY));
+    EXPECT_TRUE(check(TYPE_VARBINARY, tparquet::Type::BYTE_ARRAY));
 }
 
 } // namespace starrocks::parquet

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -799,8 +799,9 @@ public class ColumnTypeConverter {
                 }
                 return new StructType(structFields);
             case BINARY:
-            case UUID:
                 return VarbinaryType.VARBINARY;
+            case UUID:
+                return TypeFactory.createVarcharType(36);
             case TIME:
                 return com.starrocks.type.DateType.TIME;
             case VARIANT:

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -118,7 +118,8 @@ public class IcebergApiConverterTest {
     public void testUUID() {
         org.apache.iceberg.types.Type icebergType = Types.UUIDType.get();
         Type resType = fromIcebergType(icebergType);
-        assertTrue(resType.isBinaryType());
+        assertTrue(resType.isStringType());
+        assertEquals(resType, TypeFactory.createVarcharType(36));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
I have an iceberg table with a `UUID` column that is stored in parquet as `FIXED_LEN_BYTE_ARRAY`. I cannot read from this table in Starrocks if I need to read that specific column.

## What I'm doing:
Support reading Parquet `FIXED_LEN_BYTE_ARRAY` physical and UUID logical types as `VARCHAR(36)` by adding lazy string conversion in the column converter.
Updated schema builder, column reader, and `FE` `ColumnTypeConverter` accordingly.
Updated unit tests for BE and FE.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
