### PR TITLE
[Enhancement] Expose variant subfield access paths for HDFS and Iceberg scans

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -166,6 +166,7 @@ public class HdfsScanNode extends ScanNode {
             HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
 
             output.append(explainColumnDict(prefix));
+            output.append(explainColumnAccessPath(prefix));
 
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
@@ -198,6 +199,9 @@ public class HdfsScanNode extends ScanNode {
         setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         setNonPartitionConjunctsToThrift(msg, this, this.getScanNodePredicates());
         setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
+        if (columnAccessPaths != null && !columnAccessPaths.isEmpty()) {
+            tHdfsScanNode.setColumn_access_paths(columnAccessPathToThrift());
+        }
     }
 
     public static void appendDataCacheOptionsInExplain(StringBuilder output, String prefix, DataCacheOptions dataCacheOptions) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -337,9 +337,10 @@ public class IcebergScanNode extends ScanNode {
             HdfsScanNode.appendDataCacheOptionsInExplain(output, prefix, dataCacheOptions);
             // for global dict
             output.append(explainColumnDict(prefix));
+            output.append(explainColumnAccessPath(prefix));
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
-                if (type.isComplexType()) {
+                if (type.isComplexType() || type.isVariantType()) {
                     output.append(prefix)
                             .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
                 }
@@ -411,6 +412,9 @@ public class IcebergScanNode extends ScanNode {
         HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
+        if (columnAccessPaths != null && !columnAccessPaths.isEmpty()) {
+            tHdfsScanNode.setColumn_access_paths(columnAccessPathToThrift());
+        }
         bucketProperties.ifPresent(properties -> HdfsScanNode.setBucketProperties(tHdfsScanNode, properties));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -58,11 +58,25 @@ public class PruneSubfieldRule extends TransformationRule {
             .add(FunctionSet.JSON_LENGTH)
             .build();
 
+    public static final List<String> SUPPORT_VARIANT_FUNCTIONS = ImmutableList
+            .<String>builder()
+            // arguments: Variant, path
+            .add(FunctionSet.VARIANT_QUERY)
+            .add(FunctionSet.GET_VARIANT_BOOL)
+            .add(FunctionSet.GET_VARIANT_INT)
+            .add(FunctionSet.GET_VARIANT_DOUBLE)
+            .add(FunctionSet.GET_VARIANT_STRING)
+            .add(FunctionSet.GET_VARIANT_DATE)
+            .add(FunctionSet.GET_VARIANT_DATETIME)
+            .add(FunctionSet.GET_VARIANT_TIME)
+            .build();
+
     public static final List<String> PRUNE_FUNCTIONS = ImmutableList.<String>builder()
             .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE)
             .add(FunctionSet.ARRAY_LENGTH)
             .add(FunctionSet.CARDINALITY)
             .addAll(SUPPORT_JSON_FUNCTIONS)
+            .addAll(SUPPORT_VARIANT_FUNCTIONS)
             .build();
 
     public static final List<String> PUSHDOWN_FUNCTIONS = ImmutableList.<String>builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -29,6 +29,7 @@ import com.starrocks.thrift.TAccessPathType;
 import com.starrocks.type.InvalidType;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.Type;
+import com.starrocks.type.VariantType;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrTokenizer;
 
@@ -235,9 +236,11 @@ public class SubfieldAccessPathNormalizer {
                 String path = ((ConstantOperator) call.getArguments().get(1)).getVarchar();
                 return childrenAccessPaths.get(0).map(p -> {
                     List<String> flatPaths = Lists.newArrayList();
-                    formatJsonPath(path, flatPaths); // reuse same JSONPath format: $.a.b.c
+                    boolean isOverflown = formatJsonPath(path, flatPaths); // reuse same JSONPath format: $.a.b.c
                     p.appendFieldNames(flatPaths);
-                    p.setValueType(call.getType());
+                    // If the path is truncated to an intermediate node, keep the leaf as variant
+                    // instead of a typed scalar to avoid incorrect typed subfield reads.
+                    p.setValueType(isOverflown ? VariantType.VARIANT : call.getType());
                     return p;
                 });
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -83,7 +83,6 @@ public class SubfieldAccessPathNormalizer {
         }
     }
 
-
     public ColumnAccessPath normalizePath(ColumnRefOperator root, String columnName) {
         List<AccessPath> paths = allAccessPaths.stream().filter(path -> path.root().equals(root))
                 .sorted((o1, o2) -> Integer.compare(o2.paths.size(), o1.paths.size()))
@@ -108,7 +107,7 @@ public class SubfieldAccessPathNormalizer {
                         childPath.setType(isOffsetOrKey ? TAccessPathType.KEY : TAccessPathType.ALL);
                     }
                     childPath.setValueType(
-                            deriverCompatibleJsonType(childPath.getValueType(), accessPath.getValueType()));
+                            deriveCompatibleValueType(root, childPath.getValueType(), accessPath.getValueType()));
                     parentPath = childPath;
                 } else {
                     ColumnAccessPath childPath = new ColumnAccessPath(accessPath.pathTypes.get(i),
@@ -128,7 +127,7 @@ public class SubfieldAccessPathNormalizer {
      * select get_json_int(j1, "$.a"), get_json_string(j1, "$.a") from js
      * j1->"$.a" read as int/string at the sametime, so need use the compatible type to read from storage
      */
-    private Type deriverCompatibleJsonType(Type first, Type second) {
+    private Type deriveCompatibleValueType(ColumnRefOperator root, Type first, Type second) {
         // only json type used, other semi-type are explicit types, so we set INVALID
         if (first == InvalidType.INVALID || second == InvalidType.INVALID) {
             return InvalidType.INVALID;
@@ -138,8 +137,14 @@ public class SubfieldAccessPathNormalizer {
             return first;
         }
 
-        // the compatible type of two types use JSON,
-        // the be can't promise cast(cast(xx as IntermediateType) as TargetType) is same as cast(xx as TargetType)
+        // For variant root columns, keep the merged path as variant so the explain/thrift
+        // still reflects the original source semantics when multiple typed accesses conflict.
+        if (root.getType().isVariantType()) {
+            return root.getType();
+        }
+
+        // The compatible type of two json-derived scalar reads uses JSON,
+        // the BE can't promise cast(cast(xx as IntermediateType) as TargetType) is same as cast(xx as TargetType)
         // e.g: cast(cast("1.1" as double) as int) is different with cast("1.1" as int)
         // so we use JSON as the compatible type
         return JsonType.JSON;
@@ -165,7 +170,8 @@ public class SubfieldAccessPathNormalizer {
         @Override
         public Optional<AccessPath> visitVariableReference(ColumnRefOperator variable,
                                                            List<Optional<AccessPath>> childrenAccessPaths) {
-            if (variable.getType().isComplexType() || variable.getType().isJsonType()) {
+            if (variable.getType().isComplexType() || variable.getType().isJsonType()
+                    || variable.getType().isVariantType()) {
                 return Optional.of(new AccessPath(variable));
             }
             return Optional.empty();
@@ -222,6 +228,16 @@ public class SubfieldAccessPathNormalizer {
                     } else {
                         p.setValueType(call.getType());
                     }
+                    return p;
+                });
+            } else if (PruneSubfieldRule.SUPPORT_VARIANT_FUNCTIONS.contains(call.getFnName())
+                    && call.getArguments().size() > 1 && call.getArguments().get(1).isConstantRef()) {
+                String path = ((ConstantOperator) call.getArguments().get(1)).getVarchar();
+                return childrenAccessPaths.get(0).map(p -> {
+                    List<String> flatPaths = Lists.newArrayList();
+                    formatJsonPath(path, flatPaths); // reuse same JSONPath format: $.a.b.c
+                    p.appendFieldNames(flatPaths);
+                    p.setValueType(call.getType());
                     return p;
                 });
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -73,7 +73,8 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitVariableReference(ColumnRefOperator variable, Void context) {
-        if (variable.getType().isComplexType() || variable.getType().isJsonType()) {
+        if (variable.getType().isComplexType() || variable.getType().isJsonType()
+                || variable.getType().isVariantType()) {
             complexExpressions.add(variable);
         }
         return null;
@@ -123,6 +124,14 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
             }
             Type[] args = call.getFunction().getArgs();
             if (args.length <= 1 || !args[0].isJsonType() || !args[1].isStringType()) {
+                return visit(call, context);
+            }
+        }
+
+        // Variant function has multi-version, support use path version
+        if (PruneSubfieldRule.SUPPORT_VARIANT_FUNCTIONS.contains(call.getFnName())) {
+            Type[] args = call.getFunction().getArgs();
+            if (args.length <= 1 || !args[0].isVariantType() || !args[1].isStringType()) {
                 return visit(call, context);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1612,6 +1612,7 @@ public class PlanFragmentBuilder {
             }
 
             icebergScanNode.setScanOptimizeOption(node.getScanOptimizeOption());
+            icebergScanNode.setColumnAccessPaths(node.getColumnAccessPaths());
             icebergScanNode.computeStatistics(expression.getStatistics());
             currentExecGroup.add(icebergScanNode, true);
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
+import com.starrocks.type.VariantType;
 import com.starrocks.type.VarcharType;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.iceberg.DataFile;
@@ -77,6 +78,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_TRANSFORMS_DB_NAME = "partitioned_transforms_db";
 
     public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
+    public static final String MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME = "variant_t0";
     public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "t1";
     // date partition table
     public static final String MOCKED_PARTITIONED_TABLE_NAME2 = "t2";
@@ -164,32 +166,42 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         MOCK_TABLE_MAP.putIfAbsent(MOCKED_UNPARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
         Map<String, IcebergTableInfo> icebergTableInfoMap = MOCK_TABLE_MAP.get(MOCKED_UNPARTITIONED_DB_NAME);
 
-        List<Column> schemas = ImmutableList.of(new Column("id", IntegerType.INT, true),
-                new Column("data", StringType.STRING, true),
-                new Column("date", StringType.STRING, true));
-        schemas = addMetaColumns(schemas);
-
-        Schema schema =
+        registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_TABLE_NAME0,
+                ImmutableList.of(new Column("id", IntegerType.INT, true),
+                        new Column("data", StringType.STRING, true),
+                        new Column("date", StringType.STRING, true)),
                 new Schema(required(3, "id", Types.IntegerType.get()),
                         required(4, "data", Types.StringType.get()),
-                        required(5, "date", Types.StringType.get()));
-        PartitionSpec spec =
-                PartitionSpec.builderFor(schema).build();
+                        required(5, "date", Types.StringType.get())),
+                3);
+        registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME,
+                ImmutableList.of(new Column("id", IntegerType.INT, true),
+                        new Column("v", VariantType.VARIANT, true)),
+                new Schema(required(3, "id", Types.IntegerType.get()),
+                        required(4, "v", Types.VariantType.get())),
+                3);
+    }
+
+    private static void registerUnpartitionedTable(Map<String, IcebergTableInfo> icebergTableInfoMap,
+                                                   String tableName,
+                                                   List<Column> schemas,
+                                                   Schema schema,
+                                                   int formatVersion) throws IOException {
+        List<Column> fullSchemas = addMetaColumns(schemas);
+        PartitionSpec spec = PartitionSpec.builderFor(schema).build();
         TestTables.TestTable baseTable = TestTables.create(
-                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" +
-                        MOCKED_UNPARTITIONED_TABLE_NAME0), MOCKED_UNPARTITIONED_TABLE_NAME0,
-                schema, spec, 3);
+                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" + tableName),
+                tableName, schema, spec, formatVersion);
 
-        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, MOCKED_UNPARTITIONED_TABLE_NAME0,
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(tableName.hashCode(), tableName,
                 MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
-                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, null, "");
+                tableName, fullSchemas, baseTable, null, "");
 
-        Map<String, ColumnStatistic> columnStatisticMap;
-        List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
-        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
+        List<String> colNames = fullSchemas.stream().map(Column::getName).collect(Collectors.toList());
+        Map<String, ColumnStatistic> columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
                 col -> ColumnStatistic.unknown()));
 
-        icebergTableInfoMap.put(MOCKED_UNPARTITIONED_TABLE_NAME0,
+        icebergTableInfoMap.put(tableName,
                 new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100, columnStatisticMap));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -43,8 +43,8 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
-import com.starrocks.type.VariantType;
 import com.starrocks.type.VarcharType;
+import com.starrocks.type.VariantType;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -524,9 +524,9 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             }
             MockIcebergTable t = tableInfo.icebergTable;
             MockIcebergTable t1 = new MockIcebergTable(t.getId(), t.getName(), t.getCatalogName(), t.getResourceName(),
-                        t.getCatalogDBName(), t.getCatalogTableName(),
-                        t.getBaseSchema(), t.getNativeTable(), t.getIcebergProperties(),
-                        t.getComment());
+                    t.getCatalogDBName(), t.getCatalogTableName(),
+                    t.getBaseSchema(), t.getNativeTable(), t.getIcebergProperties(),
+                    t.getComment());
             ConnectorTableInfo info = GlobalStateMgr.getCurrentState()
                     .getConnectorTblMetaInfoMgr()
                     .getConnectorTableInfo(t.getCatalogName(), t.getCatalogDBName(), t.getTableIdentifier());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergVariantSubfieldPrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergVariantSubfieldPrunePlanTest.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.thrift.TPlan;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class IcebergVariantSubfieldPrunePlanTest extends ConnectorPlanTestBase {
+
+    @Test
+    public void testVariantColumnAccessPathInExplainAndThrift() throws Exception {
+        connectContext.getSessionVariable().setCboPruneSubfield(true);
+
+        String sql = "select get_variant_int(v, '$.a.b'), get_variant_string(v, '$.profile.department') " +
+                "from iceberg0.unpartitioned_db.variant_t0";
+
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a/b(bigint(20)), /v/profile/department(varchar)]");
+
+        ExecPlan execPlan = getExecPlan(sql);
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+        Assertions.assertEquals(1, scanNodes.size());
+        Assertions.assertInstanceOf(IcebergScanNode.class, scanNodes.get(0));
+
+        IcebergScanNode scanNode = (IcebergScanNode) scanNodes.get(0);
+        Assertions.assertNotNull(scanNode.getColumnAccessPaths());
+        Assertions.assertFalse(scanNode.getColumnAccessPaths().isEmpty());
+        Assertions.assertTrue(scanNode.getColumnAccessPaths().stream()
+                .anyMatch(path -> "/v/a/b(bigint(20)), /v/profile/department(varchar)".equals(path.explain())));
+
+        TPlan thrift = scanNode.treeToThrift();
+        Assertions.assertTrue(thrift.getNodes().get(0).getHdfs_scan_node().isSetColumn_access_paths());
+        Assertions.assertTrue(thrift.getNodes().get(0).getHdfs_scan_node().getColumn_access_pathsSize() >= 1);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergVariantSubfieldPrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergVariantSubfieldPrunePlanTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.thrift.TColumnAccessPath;
 import com.starrocks.thrift.TPlan;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -48,5 +49,41 @@ public class IcebergVariantSubfieldPrunePlanTest extends ConnectorPlanTestBase {
         TPlan thrift = scanNode.treeToThrift();
         Assertions.assertTrue(thrift.getNodes().get(0).getHdfs_scan_node().isSetColumn_access_paths());
         Assertions.assertTrue(thrift.getNodes().get(0).getHdfs_scan_node().getColumn_access_pathsSize() >= 1);
+    }
+
+    @Test
+    public void testVariantColumnAccessPathFallbackCasesInExplainAndThrift() throws Exception {
+        connectContext.getSessionVariable().setCboPruneSubfield(true);
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
+
+        String sql = "select get_variant_int(v, 'a.b'), get_variant_string(v, '$.\"profile.name\".first'), " +
+                "variant_query(v, '$.mixed.path'), get_variant_double(v, '$.mixed.path') " +
+                "from iceberg0.unpartitioned_db.variant_t0";
+
+        String plan = getVerboseExplain(sql);
+        assertContains(plan,
+                "ColumnAccessPath: [/v/\"profile.name\"/first(varchar), /v/a/b(bigint(20)), /v/mixed/path(variant)]");
+
+        ExecPlan execPlan = getExecPlan(sql);
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+        Assertions.assertEquals(1, scanNodes.size());
+        Assertions.assertInstanceOf(IcebergScanNode.class, scanNodes.get(0));
+
+        IcebergScanNode scanNode = (IcebergScanNode) scanNodes.get(0);
+        Assertions.assertNotNull(scanNode.getColumnAccessPaths());
+        Assertions.assertEquals(1, scanNode.getColumnAccessPaths().size());
+        Assertions.assertEquals("/v/\"profile.name\"/first(varchar), /v/a/b(bigint(20)), /v/mixed/path(variant)",
+                scanNode.getColumnAccessPaths().get(0).explain());
+
+        TPlan thrift = scanNode.treeToThrift();
+        List<TColumnAccessPath> columnAccessPaths = thrift.getNodes().get(0).getHdfs_scan_node().getColumn_access_paths();
+        Assertions.assertEquals(1, columnAccessPaths.size());
+
+        TColumnAccessPath root = columnAccessPaths.get(0);
+        Assertions.assertEquals(3, root.getChildrenSize());
+
+        List<TColumnAccessPath> topLevelChildren = root.getChildren();
+        Assertions.assertEquals(3, topLevelChildren.size());
+        Assertions.assertTrue(topLevelChildren.stream().anyMatch(child -> child.getChildren().size() == 1));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1170,6 +1170,16 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         sql = "select variant_query(v, '$.profile.rank') from variant0";
         plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/v/profile/rank(variant)]");
+
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(1);
+
+        sql = "select get_variant_int(v, '$.a.b') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+        sql = "select get_variant_int(v, '$.a[0]') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1180,6 +1180,20 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         sql = "select get_variant_int(v, '$.a[0]') from variant0";
         plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+        connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(20);
+
+        sql = "select get_variant_int(v, 'a.b'), get_variant_string(v, '$.\"profile.name\".first') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/\"profile.name\"/first(varchar), /v/a/b(bigint(20))]");
+
+        sql = "select variant_query(v, '$.a.b'), get_variant_string(v, '$.a.b') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
+
+        sql = "select get_variant_int(v, '$.a.b'), get_variant_double(v, '$.a.b') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a/b(variant)]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -103,6 +103,17 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
+        starRocksAssert.withTable("CREATE TABLE `variant0` (\n" +
+                "  `v1` bigint NULL, \n" +
+                "  `v` VARIANT NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS t1(\n" +
                 "    tenant_id BIGINT NOT NULL,\n" +
                 "    id BIGINT NOT NULL,\n" +
@@ -753,7 +764,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "  |  <slot 15> : row(1, 2, 3).col2[true] IS NULL");
     }
 
-
     @Test
     public void testForceReuseCTE1() throws Exception {
         String sql = "with cte1 as (select array_map((x -> uuid()), t.a1) c1, t.map1 c2 from pc0 t) " +
@@ -1015,7 +1025,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "from js0;";
         plan = getVerboseExplain(sql);
         assertNotContains(plan, "ColumnAccessPath");
-        
+
         sql = "select " +
                 "get_json_int(j1, '$.') " +
                 "from js0;";
@@ -1145,6 +1155,21 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String sql = "select get_json_bool(j1, 'a') from js0";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
+    }
+
+    @Test
+    public void testVariantSubfieldPruning() throws Exception {
+        String sql = "select get_variant_int(v, '$.a.b'), get_variant_string(v, '$.c') from variant0";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a/b(bigint(20)), /v/c(varchar)]");
+
+        sql = "select get_variant_int(v, '$.a'), get_variant_string(v, '$.a') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/a(variant)]");
+
+        sql = "select variant_query(v, '$.profile.rank') from variant0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/v/profile/rank(variant)]");
     }
 
     @Test

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1301,6 +1301,8 @@ struct THdfsScanNode {
 
     26: optional bool enable_global_late_materialization
     27: optional i64 scan_node_id
+
+    28: optional list<TColumnAccessPath> column_access_paths
 }
 
 struct TProjectNode {

--- a/test/sql/test_iceberg/R/test_iceberg_shredding_variant_query
+++ b/test/sql/test_iceberg/R/test_iceberg_shredding_variant_query
@@ -46,7 +46,7 @@ shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_noshredding.par
 alter table test_noshredding_variant execute add_files(location='oss://${oss_bucket}/test_iceberg_shredding_variant_query/${uuid0}/data/noshredding.parquet', file_format='parquet');
 -- result:
 -- !result
-function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(int(11)), /data/profile/department(varchar)]")
+function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(bigint(20)), /data/profile/department(varchar)]")
 -- result:
 True
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_shredding_variant_query
+++ b/test/sql/test_iceberg/R/test_iceberg_shredding_variant_query
@@ -46,6 +46,10 @@ shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_noshredding.par
 alter table test_noshredding_variant execute add_files(location='oss://${oss_bucket}/test_iceberg_shredding_variant_query/${uuid0}/data/noshredding.parquet', file_format='parquet');
 -- result:
 -- !result
+function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(int(11)), /data/profile/department(varchar)]")
+-- result:
+True
+-- !result
 SELECT 
     get_variant_int(data, '$.id') as id,
     get_variant_int(data, '$.age') as age,

--- a/test/sql/test_iceberg/T/test_iceberg_shredding_variant_query
+++ b/test/sql/test_iceberg/T/test_iceberg_shredding_variant_query
@@ -41,6 +41,11 @@ shell: ossutil64 cp ../be/test/formats/parquet/test_data/variant_noshredding.par
 alter table test_noshredding_variant execute add_files(location='oss://${oss_bucket}/test_iceberg_shredding_variant_query/${uuid0}/data/noshredding.parquet', file_format='parquet');
 
 -- ========================================
+-- Explain: FE should expose pushed variant access paths
+-- ========================================
+function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(int(11)), /data/profile/department(varchar)]")
+
+-- ========================================
 -- Query 1: Basic field extraction (Shredded)
 -- ========================================
 SELECT 

--- a/test/sql/test_iceberg/T/test_iceberg_shredding_variant_query
+++ b/test/sql/test_iceberg/T/test_iceberg_shredding_variant_query
@@ -43,7 +43,7 @@ alter table test_noshredding_variant execute add_files(location='oss://${oss_buc
 -- ========================================
 -- Explain: FE should expose pushed variant access paths
 -- ========================================
-function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(int(11)), /data/profile/department(varchar)]")
+function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') as id, get_variant_string(data, '$.profile.department') as dept from test_shredding_variant", "ColumnAccessPath: [/data/id(bigint(20)), /data/profile/department(varchar)]")
 
 -- ========================================
 -- Query 1: Basic field extraction (Shredded)


### PR DESCRIPTION
## Why I'm doing

This change extends FE-side subfield pruning so variant path usage in SQL can be reflected in scan planning for external tables, especially Iceberg and HDFS-based scans.

Previously, variant access paths were not fully propagated through these scan nodes. As a result, FE could not describe which nested variant fields were actually needed by the query, which limited later BE-side optimizations for subfield-aware reading and pruning.

## What I'm doing

This PR adds FE support to collect, normalize, and expose variant subfield access paths for external scans.

- Extend subfield pruning rules to recognize variant access functions such as `variant_query` and `get_variant_*`.
- Normalize variant access paths into `ColumnAccessPath`, including fallback behavior for truncated or conflicting typed reads.
- Propagate `column_access_paths` into `HdfsScanNode` and `IcebergScanNode` thrift output.
- Show variant access paths in verbose explain output for HDFS and Iceberg scans.
- Pass column access paths from physical Iceberg scan operators into plan fragments.
- Add FE plan tests and SQL tests covering variant access path generation, explain output, and thrift serialization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
