### PR TITLE
[BugFix] Ensure root user bypasses all Ranger permission checks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/RangerAccessController.java
@@ -113,6 +113,10 @@ public abstract class RangerAccessController extends ExternalAccessController im
     protected void hasPermission(RangerAccessResourceImpl resource, UserIdentity user, Set<String> groups,
                                  PrivilegeType privilegeType)
             throws AccessDeniedException {
+        // root user bypasses Ranger authorization entirely
+        if (UserIdentity.ROOT.equals(user)) {
+            return;
+        }
         String accessType;
         if (privilegeType.equals(PrivilegeType.ANY)) {
             accessType = RangerPolicyEngine.ANY_ACCESS;

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
@@ -209,9 +209,6 @@ public class RangerInterfaceTest {
         };
         RangerStarRocksAccessController rangerStarRocksAccessController = new RangerStarRocksAccessController();
 
-        ConnectContext connectContext = new ConnectContext();
-        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
-
         try {
             rangerStarRocksAccessController.hasPermission(
                     RangerStarRocksResource.builder().setSystem().build(), UserIdentity.ROOT, Set.of(), PrivilegeType.OPERATE);
@@ -230,7 +227,45 @@ public class RangerInterfaceTest {
         };
 
         Assertions.assertThrows(AccessDeniedException.class, () -> rangerStarRocksAccessController.hasPermission(
-                RangerStarRocksResource.builder().setSystem().build(), UserIdentity.ROOT, Set.of(), PrivilegeType.OPERATE));
+                RangerStarRocksResource.builder().setSystem().build(),
+                new UserIdentity("alice", "%"), Set.of(), PrivilegeType.OPERATE));
+    }
+
+    @Test
+    public void testRootUserBypassesRanger() {
+        // Mock Ranger to deny all requests
+        new MockUp<RangerBasePlugin>() {
+            @Mock
+            RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+                RangerAccessResult result = new RangerAccessResult(1, "starrocks",
+                        new RangerServiceDef(), new RangerAccessRequestImpl());
+                result.setIsAllowed(false);
+                return result;
+            }
+        };
+
+        RangerStarRocksAccessController controller = new RangerStarRocksAccessController();
+
+        // root user must bypass Ranger even when Ranger denies everything
+        Assertions.assertDoesNotThrow(() -> controller.hasPermission(
+                RangerStarRocksResource.builder().setSystem().build(),
+                UserIdentity.ROOT, Set.of(), PrivilegeType.OPERATE));
+        Assertions.assertDoesNotThrow(() -> controller.hasPermission(
+                RangerStarRocksResource.builder().setCatalog("hive_catalog").build(),
+                UserIdentity.ROOT, Set.of(), PrivilegeType.USAGE));
+        Assertions.assertDoesNotThrow(() -> controller.hasPermission(
+                RangerStarRocksResource.builder().setCatalog("default_catalog").setDatabase("db1").build(),
+                UserIdentity.ROOT, Set.of(), PrivilegeType.CREATE_TABLE));
+        Assertions.assertDoesNotThrow(() -> controller.hasPermission(
+                RangerStarRocksResource.builder()
+                        .setCatalog("default_catalog").setDatabase("db1").setTable("t1").build(),
+                UserIdentity.ROOT, Set.of(), PrivilegeType.SELECT));
+
+        // non-root user must still go through Ranger and be denied
+        UserIdentity normalUser = new UserIdentity("alice", "%");
+        Assertions.assertThrows(AccessDeniedException.class, () -> controller.hasPermission(
+                RangerStarRocksResource.builder().setSystem().build(),
+                normalUser, Set.of(), PrivilegeType.OPERATE));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request improves the authorization logic for the root user in the Ranger integration by ensuring that the root user bypasses all Ranger permission checks, regardless of the policies set in Ranger. It also adds comprehensive tests to verify this behavior and clarifies the expected handling for both root and non-root users.

Authorization logic changes:

* Updated `hasPermission` in `RangerAccessController` to allow the root user to bypass all Ranger authorization checks, returning immediately if the user is root.

Testing improvements:

* Added a new unit test `testRootUserBypassesRanger` in `RangerInterfaceTest.java` to verify that the root user is never denied access by Ranger, even if Ranger denies all requests, and to confirm that non-root users are still subject to Ranger checks and can be denied.
* Updated existing tests to use a non-root user when expecting access to be denied, ensuring test accuracy and separation of root/non-root scenarios.
* Cleaned up unnecessary `ConnectContext` setup for the root user in the test, as it's no longer needed with the new bypass logic.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
