### PR TITLE
[Enhancement] Add file integrity verification for shared-data cross-cluster replication with non-segment file copy (backport #70093)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -209,6 +209,8 @@ CONF_mInt32(clear_expired_replication_snapshots_interval_seconds, "3600");
 CONF_mInt64(lake_replication_slow_log_ms, "30000");
 // The buffer size used for reading remote data during lake replication
 CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
+// Maximum retry count for non-segment file copy during lake-to-lake replication
+CONF_mInt32(lake_replication_max_file_copy_retry, "3");
 
 // The log dir.
 CONF_String(sys_log_dir, "${STARROCKS_HOME}/log");

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/lake_replication_txn_manager.h"
 
 #include "agent/master_info.h"
+#include "common/config.h"
 #include "fs/fs_starlet.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
@@ -27,6 +28,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/segment_stream_converter.h"
+#include "testutil/sync_point.h"
 #include "util/dynamic_cache.h"
 #include "util/trace.h"
 #include "vacuum.h"
@@ -277,17 +279,14 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                           << ", final size: " << final_file_size;
             }
         } else {
-            // For non-segment files (.del, .sst, .delvec, .cols), use streaming copy with encryption support.
-            // These files are typically small, so streaming copy is efficient and avoids an extra
-            // remote IO call to get file size (which would increase object storage IOPS cost).
+            // For non-segment files (.del, .sst, .delvec, .cols), copy with size verification and retry.
             WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
             if (config::enable_transparent_data_encryption) {
-                // Apply encryption info from filename_map to ensure file content matches metadata
                 opts.encryption_info = pair.second.second.info;
             }
-            ASSIGN_OR_RETURN(final_file_size, fs::copy_file(src_file_location, shared_src_fs, target_file_location,
-                                                            nullptr, opts, 1024 * 1024));
-            // Track this file for cleanup on failure, similar to how segment files are tracked via file_converters
+            int max_retry = std::max(1, config::lake_replication_max_file_copy_retry);
+            ASSIGN_OR_RETURN(final_file_size, copy_non_segment_file_with_retry(src_file_location, shared_src_fs,
+                                                                               target_file_location, opts, max_retry));
             files_to_delete.push_back(target_file_location);
         }
         total_file_size += final_file_size;
@@ -337,6 +336,37 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
 
     clean_files.cancel();
     return Status::OK();
+}
+
+StatusOr<size_t> LakeReplicationTxnManager::copy_non_segment_file_with_retry(
+        const std::string& src_file_location, const std::shared_ptr<FileSystem>& shared_src_fs,
+        const std::string& target_file_location, const WritableFileOptions& opts, int max_retry) {
+    ASSIGN_OR_RETURN(auto expected_size, shared_src_fs->get_file_size(src_file_location));
+
+    const size_t buff_size = std::max<size_t>(
+            std::min<size_t>(expected_size, config::lake_replication_read_buffer_size), 1 * 1024 * 1024);
+
+    max_retry = std::max(1, max_retry);
+    Status copy_status;
+    size_t final_file_size = 0;
+    for (int retry = 0; retry < max_retry; ++retry) {
+        auto res = fs::copy_file(src_file_location, shared_src_fs, target_file_location, nullptr, opts, buff_size);
+        if (!res.ok()) {
+            copy_status = res.status();
+            LOG(WARNING) << "Failed to copy file " << src_file_location << " to " << target_file_location
+                         << ", retry=" << retry << ", error: " << copy_status;
+            continue;
+        }
+        final_file_size = *res;
+        TEST_SYNC_POINT_CALLBACK("lake_replication_non_segment_copy_size", &final_file_size);
+        if (static_cast<int64_t>(final_file_size) == static_cast<int64_t>(expected_size)) {
+            return final_file_size;
+        }
+        copy_status = Status::Corruption(fmt::format("File size mismatch after copy: expected={}, actual={}, src={}",
+                                                     expected_size, final_file_size, src_file_location));
+        LOG(WARNING) << copy_status.message() << ", retry=" << retry;
+    }
+    return copy_status;
 }
 
 StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::build_source_tablet_meta(

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -23,6 +23,7 @@
 
 namespace starrocks {
 struct FileEncryptionPair;
+struct WritableFileOptions;
 class TabletMetadataPB;
 class FileSystem;
 } // namespace starrocks
@@ -88,6 +89,14 @@ public:
     // This is needed because segment file size may change after footer rewriting
     Status update_tablet_metadata_segment_sizes(const std::shared_ptr<TabletMetadataPB>& tablet_metadata,
                                                 const std::unordered_map<std::string, size_t>& segment_size_changes);
+
+    // Copy a non-segment file (e.g. .del, .sst, .delvec, .cols) with size verification and retry.
+    // Gets source file size first, then copies with retry on failure or size mismatch.
+    // Returns the actual file size after a successful copy.
+    static StatusOr<size_t> copy_non_segment_file_with_retry(const std::string& src_file_location,
+                                                             const std::shared_ptr<FileSystem>& shared_src_fs,
+                                                             const std::string& target_file_location,
+                                                             const WritableFileOptions& opts, int max_retry);
 
 private:
     TabletManager* _tablet_manager;

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -550,7 +550,7 @@ protected:
 
     Status create_test_file(const std::string& path, const std::string& content) {
         WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-        ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(path));
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
         ASSIGN_OR_RETURN(auto wf, fs->new_writable_file(opts, path));
         RETURN_IF_ERROR(wf->append(content));
         return wf->close();
@@ -566,7 +566,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_success_no_retry_needed) {
     std::string content(4096, 'A');
     ASSERT_OK(create_test_file(src_path, content));
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
@@ -588,7 +588,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_error_retry_succeeds) {
         }
     });
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
@@ -608,7 +608,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_error_exhausts_all_retries) {
         *st = Status::IOError("Persistent copy error");
     });
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
@@ -627,7 +627,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_size_mismatch_exhausts_retries
         *size = *size / 2;
     });
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     int max_retry = std::max(1, config::lake_replication_max_file_copy_retry);
@@ -652,7 +652,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_size_mismatch_then_succeeds) {
         }
     });
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
@@ -667,7 +667,7 @@ TEST_F(CopyNonSegmentFileWithRetryTest, test_max_retry_clamped_to_at_least_one) 
     std::string content(1024, 'E');
     ASSERT_OK(create_test_file(src_path, content));
 
-    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    ASSIGN_OR_ABORT(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
 
     auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 0);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -33,6 +33,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "fs/fs_starlet.h"
+#include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "gutil/strings/join.h"
 #include "runtime/exec_env.h"
@@ -531,6 +532,149 @@ TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal_encrypted) {
     // old_rowsets is empty, so compaction_inputs should also be empty.
     EXPECT_EQ(0, status_or.value()->compaction_inputs_size());
 }
+
+// Tests for LakeReplicationTxnManager::copy_non_segment_file_with_retry
+class CopyNonSegmentFileWithRetryTest : public testing::Test {
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(_test_dir));
+        SyncPoint::GetInstance()->EnableProcessing();
+    }
+
+    void TearDown() override {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+        (void)fs::remove_all(_test_dir);
+    }
+
+    Status create_test_file(const std::string& path, const std::string& content) {
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(path));
+        ASSIGN_OR_RETURN(auto wf, fs->new_writable_file(opts, path));
+        RETURN_IF_ERROR(wf->append(content));
+        return wf->close();
+    }
+
+    static constexpr const char* kTestDirectory = "test_non_segment_copy_retry";
+    std::string _test_dir = kTestDirectory;
+};
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_success_no_retry_needed) {
+    std::string src_path = lake::join_path(_test_dir, "test.sst");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.sst");
+    std::string content(4096, 'A');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
+    ASSERT_OK(result.status());
+    EXPECT_EQ(*result, content.size());
+}
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_error_retry_succeeds) {
+    std::string src_path = lake::join_path(_test_dir, "test.sst");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.sst");
+    std::string content(4096, 'A');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    int call_count = 0;
+    SyncPoint::GetInstance()->SetCallBack("fs::copy_file", [&](void* arg) {
+        auto* st = static_cast<Status*>(arg);
+        if (call_count++ == 0) {
+            *st = Status::IOError("Injected transient copy error");
+        }
+    });
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
+    ASSERT_OK(result.status());
+    EXPECT_EQ(*result, content.size());
+    EXPECT_EQ(call_count, 2);
+}
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_error_exhausts_all_retries) {
+    std::string src_path = lake::join_path(_test_dir, "test.delvec");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.delvec");
+    std::string content(4096, 'C');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    SyncPoint::GetInstance()->SetCallBack("fs::copy_file", [&](void* arg) {
+        auto* st = static_cast<Status*>(arg);
+        *st = Status::IOError("Persistent copy error");
+    });
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_io_error()) << result.status();
+}
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_size_mismatch_exhausts_retries) {
+    std::string src_path = lake::join_path(_test_dir, "test.delvec");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.delvec");
+    std::string content(8192, 'B');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    SyncPoint::GetInstance()->SetCallBack("lake_replication_non_segment_copy_size", [&](void* arg) {
+        auto* size = static_cast<size_t*>(arg);
+        *size = *size / 2;
+    });
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    int max_retry = std::max(1, config::lake_replication_max_file_copy_retry);
+    auto result =
+            LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, max_retry);
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    EXPECT_NE(std::string::npos, result.status().message().find("File size mismatch after copy"));
+}
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_copy_size_mismatch_then_succeeds) {
+    std::string src_path = lake::join_path(_test_dir, "test.cols");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.cols");
+    std::string content(2048, 'D');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    int call_count = 0;
+    SyncPoint::GetInstance()->SetCallBack("lake_replication_non_segment_copy_size", [&](void* arg) {
+        if (call_count++ == 0) {
+            auto* size = static_cast<size_t*>(arg);
+            *size = *size / 2;
+        }
+    });
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 3);
+    ASSERT_OK(result.status());
+    EXPECT_EQ(*result, content.size());
+    EXPECT_EQ(call_count, 2);
+}
+
+TEST_F(CopyNonSegmentFileWithRetryTest, test_max_retry_clamped_to_at_least_one) {
+    std::string src_path = lake::join_path(_test_dir, "test.del");
+    std::string dst_path = lake::join_path(_test_dir, "test_copy.del");
+    std::string content(1024, 'E');
+    ASSERT_OK(create_test_file(src_path, content));
+
+    ASSIGN_OR_ABORT(auto src_fs, FileSystemFactory::CreateSharedFromString(src_path));
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto result = LakeReplicationTxnManager::copy_non_segment_file_with_retry(src_path, src_fs, dst_path, opts, 0);
+    ASSERT_OK(result.status());
+    EXPECT_EQ(*result, content.size());
+}
+
 #ifdef USE_STAROS
 TEST(LakeReplicationTxnManagerTest, test_convert_s3_path_to_starlet_uri) {
     // Test case from user: convert S3 path to starlet URI

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -3319,6 +3319,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The read buffer size used when downloading lake segment files during lake replication. This value determines the per-read allocation for reading remote files; the implementation uses the larger of this setting and a 1 MB minimum. A larger value reduces the number of read calls and can improve throughput but increases memory used per concurrent download; a smaller value lowers memory usage at the cost of more I/O calls. Tune according to network bandwidth, storage I/O characteristics, and the number of parallel replication threads.
 - Introduced in: -
 
+##### lake_replication_max_file_copy_retry
+
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Maximum number of retry attempts for non-segment file copy (`.sst`, `.delvec`, `.del`, `.cols`) during lake-to-lake (shared-data) cross-cluster replication. Each attempt verifies the copied file size matches the source to detect truncated copies caused by transient object storage issues. Increase this value if experiencing intermittent file corruption during replication over unreliable storage.
+- Introduced in: -
+
 ##### lake_service_max_concurrency
 
 - Default: 0


### PR DESCRIPTION
## Why I'm doing:
In shared-data cross-cluster replication, non-segment files (.sst, .delvec, .del, .cols) were copied via fs::copy_file() without size verification or retry. The underlying SequentialFile::read() exits when nread == 0 but cannot distinguish normal EOF from abnormal truncation caused by transient object storage issues, which can cause SST file corruption.

## What I'm doing:

This change adds:

* Size verification: get source file size before copy, compare after copy
* Retry logic: configurable max retry (lake_replication_max_file_copy_retry, default 3) for transient failures
* Adaptive buffer sizing: max(min(src_size, read_buffer_size), 1MB)
* Status::Corruption error with descriptive message on size mismatch

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4