### PR TITLE
[BugFix] LeaderOpExecutor forward no ldap user groups bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -933,6 +933,10 @@ public class ConnectProcessor {
             return result;
         }
 
+        if (request.isSetUser_groups()) {
+            ctx.setGroups(new HashSet<>(request.getUser_groups()));
+        }
+
         if (request.isSetUser_roles()) {
             List<Long> roleIds = request.getUser_roles().getRole_id_list();
             ctx.setCurrentRoleIds(new HashSet<>(roleIds));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -329,6 +329,8 @@ public class LeaderOpExecutor {
         params.setSession_id(ctx.getSessionId().toString());
         params.setConnectionId(ctx.getConnectionId());
 
+        params.setUser_groups(new ArrayList<>(ctx.getGroups()));
+
         TUserRoles currentRoles = new TUserRoles();
         Preconditions.checkState(ctx.getCurrentRoleIds() != null);
         currentRoles.setRole_id_list(new ArrayList<>(ctx.getCurrentRoleIds()));

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -851,6 +851,8 @@ struct TMasterOpRequest {
 
     39: optional bool is_arrow_flight_sql;
 
+    40: optional list<string> user_groups;
+
     101: optional i64 warehouse_id    // begin from 101, in case of conflict with other's change
 }
 


### PR DESCRIPTION
## Why I'm doing:
CREATE Paimon view on Follower FE fails Ranger auth on Leader FE due to missing LDAP user groups in LeaderOpExecutor forward.

## What I'm doing:
- Pass user LDAP groups in LeaderOpExecutor.forward() via the request.
- In ConnectProcessor, retrieve groups from params and use them to initialize ConnectContext (ctx).
- Add new field to FrontendService.thrift:
  40: optional list<string> user_groups;

This ensures group-based permissions (e.g., Ranger authorization) are preserved during forwarding from Follower FE to Leader FE, fixing permission loss issues for operations like CREATE VIEW on external catalogs.

Fixes #70255

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
