### PR TITLE
[BugFix] Add Ranger Hive access controller support for Paimon views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/hive/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/ranger/hive/RangerHiveAccessController.java
@@ -92,6 +92,29 @@ public class RangerHiveAccessController extends RangerAccessController {
     }
 
     @Override
+    public void checkViewAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType)
+            throws AccessDeniedException {
+        hasPermission(RangerHiveResource.builder()
+                        .setDatabase(tableName.getDb())
+                        .setTable(tableName.getTbl())
+                        .build(),
+                context.getCurrentUserIdentity(),
+                context.getGroups(),
+                privilegeType);
+    }
+
+    @Override
+    public void checkAnyActionOnView(ConnectContext context, TableName tableName) throws AccessDeniedException {
+        hasPermission(RangerHiveResource.builder()
+                        .setDatabase(tableName.getDb())
+                        .setTable(tableName.getTbl())
+                        .build(),
+                context.getCurrentUserIdentity(),
+                context.getGroups(),
+                PrivilegeType.ANY);
+    }
+
+    @Override
     public Map<String, Expr> getColumnMaskingPolicy(ConnectContext context, TableName tableName, List<Column> columns) {
         Map<String, Expr> maskingExprMap = Maps.newHashMap();
         for (Column column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
@@ -147,13 +147,13 @@ public class Authorizer {
 
     public static void checkViewAction(ConnectContext context, TableName tableName,
                                        PrivilegeType privilegeType) throws AccessDeniedException {
-        getInstance().getAccessControlOrDefault(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)
+        getInstance().getAccessControlOrDefault(tableName.getCatalog())
                 .checkViewAction(context, tableName, privilegeType);
     }
 
     public static void checkAnyActionOnView(ConnectContext context, TableName tableName)
             throws AccessDeniedException {
-        getInstance().getAccessControlOrDefault(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)
+        getInstance().getAccessControlOrDefault(tableName.getCatalog())
                 .checkAnyActionOnView(context, tableName);
     }
 


### PR DESCRIPTION
## Why I'm doing:
When delete a Paimon view from StarRocks, checkViewAction uses default_catalog (internal catalog) instead of the external Paimon catalog. This results in an Access denied error.

## What I'm doing:
In Authorizer, use the external Paimon catalog instead of default_catalog (internal catalog) in checkViewAction.

Add checkViewAction and checkAnyActionOnView support in RangerHiveAccessController.

Fixes #70264

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
