### PR TITLE
[BugFix] Fix NPE when DataProperty is null during FE startup metadata loading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -389,9 +389,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             long partitionId = partition.getParentId();
             DataProperty dataProperty = olapTable.getPartitionInfo().getDataProperty(partitionId);
             if (dataProperty == null) {
-                LOG.warn("partition {} in table {} has no DataProperty, skip building tablet inverted index",
+                LOG.warn("partition {} in table {} has no DataProperty, use default HDD",
                         partitionId, tableId);
-                continue;
+                dataProperty = DataProperty.DEFAULT_DATA_PROPERTY;
             }
             TStorageMedium medium = dataProperty.getStorageMedium();
             long physicalPartitionId = partition.getId();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -387,8 +387,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long tableId = olapTable.getId();
         for (PhysicalPartition partition : olapTable.getAllPhysicalPartitions()) {
             long partitionId = partition.getParentId();
-            TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(
-                    partitionId).getStorageMedium();
+            DataProperty dataProperty = olapTable.getPartitionInfo().getDataProperty(partitionId);
+            if (dataProperty == null) {
+                LOG.warn("partition {} in table {} has no DataProperty, skip building tablet inverted index",
+                        partitionId, tableId);
+                continue;
+            }
+            TStorageMedium medium = dataProperty.getStorageMedium();
             long physicalPartitionId = partition.getId();
             for (MaterializedIndex index : partition.getAllMaterializedIndices(IndexExtState.ALL)) {
                 long indexId = index.getId();


### PR DESCRIPTION
## Why I'm doing:
FE fails to start with `NullPointerException` at `LocalMetastore.recreateOlapTableTabletInvertIndex()` when `PartitionInfo.getDataProperty(partitionId)` returns null. This can happen when partition metadata is inconsistent (e.g. temp partitions or corrupted metadata), causing the entire FE process to crash on startup.

## What I'm doing:
Add a null check for `DataProperty` before accessing `getStorageMedium()`. When null, log a warning and skip building the tablet inverted index for that partition instead of crashing.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4