### PR TITLE
[Enhancement] Support group by all syntax

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -270,6 +270,11 @@ public class AggregationAnalyzer {
                         node.getPos());
             }
 
+            // GROUP BY ALL folds GROUPING(...) to 0 in the non-grouping-sets path.
+            if (analyzeState.getGroupingSetsList() == null) {
+                return true;
+            }
+
             if (node.getChildren().stream().anyMatch(argument -> !analyzeState.getGroupBy().contains(argument))) {
                 throw new SemanticException(PARSER_ERROR_MSG.argsCanOnlyFromGroupBy(), node.getPos());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -123,9 +123,11 @@ public class SelectAnalyzer {
 
         List<FunctionCallExpr> aggregates = analyzeAggregations(analyzeState, sourceScope,
                 Stream.concat(sourceExpressions.stream(), orderByExpressions.stream()).collect(Collectors.toList()));
-        if (AnalyzerUtils.isAggregate(aggregates, groupByExpressions)) {
-            boolean isGroupByAll = groupByClause != null
-                    && groupByClause.getGroupingType().equals(GroupByClause.GroupingType.GROUP_BY_ALL);
+        boolean isGroupByAll = groupByClause != null
+                && groupByClause.getGroupingType().equals(GroupByClause.GroupingType.GROUP_BY_ALL);
+        boolean isAggregationQuery = AnalyzerUtils.isAggregate(aggregates, groupByExpressions) ||
+                (isGroupByAll && !analyzeState.getGroupingFunctionCallExprs().isEmpty());
+        if (isAggregationQuery) {
             if (!groupByExpressions.isEmpty() &&
                     selectList.getItems().stream().anyMatch(SelectListItem::isStar) &&
                     !selectList.isDistinct() &&
@@ -173,7 +175,7 @@ public class SelectAnalyzer {
 
         analyzeWindowFunctions(analyzeState, outputExpressions, orderByExpressions);
 
-        if (AnalyzerUtils.isAggregate(aggregates, groupByExpressions) &&
+        if (isAggregationQuery &&
                 (sortClause != null || havingClause != null)) {
             /*
              * Create scope for order by when aggregation is present.
@@ -609,19 +611,19 @@ public class SelectAnalyzer {
 
                     analyzeState.setGroupingSetsList(groupingSets);
                 } else if (groupByClause.getGroupingType().equals(GroupByClause.GroupingType.GROUP_BY_ALL)) {
-                    // filter other agg columns, all the remain is group by columns
+                    // Collect implicit grouping keys from non-aggregate output expressions.
+                    // GROUPING(expr...) itself is not a grouping key, but its arguments must participate in grouping.
                     for (Expr outputExpr : outputExpressions) {
-                        if (!ExprUtils.containsAggregate(outputExpr)) {
-                            if (groupByExpressions.contains(outputExpr)) {
-                                continue;
+                        if (ExprUtils.containsAggregate(outputExpr)) {
+                            continue;
+                        }
+
+                        if (outputExpr instanceof GroupingFunctionCallExpr groupingExpr) {
+                            for (Expr argument : groupingExpr.getChildren()) {
+                                addGroupByAllExpression(argument, groupByExpressions, analyzeState, sourceScope);
                             }
-                            analyzeExpression(outputExpr, analyzeState, sourceScope);
-                            if (!outputExpr.getType().canGroupBy()) {
-                                throw new SemanticException(Type.NOT_SUPPORT_GROUP_BY_ERROR_MSG);
-                            }
-                            AnalyzerUtils.verifyNoWindowFunctions(outputExpr, "GROUP BY");
-                            AnalyzerUtils.verifyNoGroupingFunctions(outputExpr, "GROUP BY");
-                            groupByExpressions.add(outputExpr);
+                        } else {
+                            addGroupByAllExpression(outputExpr, groupByExpressions, analyzeState, sourceScope);
                         }
                     }
                 } else {
@@ -631,6 +633,21 @@ public class SelectAnalyzer {
         }
         analyzeState.setGroupBy(groupByExpressions);
         return groupByExpressions;
+    }
+
+    private void addGroupByAllExpression(Expr expression, List<Expr> groupByExpressions,
+                                         AnalyzeState analyzeState, Scope sourceScope) {
+        if (groupByExpressions.contains(expression)) {
+            return;
+        }
+        analyzeExpression(expression, analyzeState, sourceScope);
+        if (!expression.getType().canGroupBy()) {
+            throw new SemanticException(Type.NOT_SUPPORT_GROUP_BY_ERROR_MSG);
+        }
+        AnalyzerUtils.verifyNoAggregateFunctions(expression, "GROUP BY");
+        AnalyzerUtils.verifyNoWindowFunctions(expression, "GROUP BY");
+        AnalyzerUtils.verifyNoGroupingFunctions(expression, "GROUP BY");
+        groupByExpressions.add(expression);
     }
 
     private List<Expr> rewriteGroupByAlias(List<Expr> groupingExprs, AnalyzeState analyzeState, Scope sourceScope,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -124,9 +124,12 @@ public class SelectAnalyzer {
         List<FunctionCallExpr> aggregates = analyzeAggregations(analyzeState, sourceScope,
                 Stream.concat(sourceExpressions.stream(), orderByExpressions.stream()).collect(Collectors.toList()));
         if (AnalyzerUtils.isAggregate(aggregates, groupByExpressions)) {
+            boolean isGroupByAll = groupByClause != null
+                    && groupByClause.getGroupingType().equals(GroupByClause.GroupingType.GROUP_BY_ALL);
             if (!groupByExpressions.isEmpty() &&
                     selectList.getItems().stream().anyMatch(SelectListItem::isStar) &&
-                    !selectList.isDistinct()) {
+                    !selectList.isDistinct() &&
+                    !isGroupByAll) {
                 throw new SemanticException("cannot combine '*' in select list with GROUP BY: *");
             }
 
@@ -381,7 +384,6 @@ public class SelectAnalyzer {
             return Collections.emptyList();
         }
 
-
         // Expand ORDER BY ALL to individual columns
         if (orderByElements.size() == 1 && orderByElements.get(0).isOrderByAll()) {
             orderByElements = expandOrderByAll(orderByElements.get(0), outputExpressions);
@@ -606,6 +608,22 @@ public class SelectAnalyzer {
                             .mapToObj(i -> rewriteOriGrouping.subList(0, i)).collect(Collectors.toList());
 
                     analyzeState.setGroupingSetsList(groupingSets);
+                } else if (groupByClause.getGroupingType().equals(GroupByClause.GroupingType.GROUP_BY_ALL)) {
+                    // filter other agg columns, all the remain is group by columns
+                    for (Expr outputExpr : outputExpressions) {
+                        if (!ExprUtils.containsAggregate(outputExpr)) {
+                            if (groupByExpressions.contains(outputExpr)) {
+                                continue;
+                            }
+                            analyzeExpression(outputExpr, analyzeState, sourceScope);
+                            if (!outputExpr.getType().canGroupBy()) {
+                                throw new SemanticException(Type.NOT_SUPPORT_GROUP_BY_ERROR_MSG);
+                            }
+                            AnalyzerUtils.verifyNoWindowFunctions(outputExpr, "GROUP BY");
+                            AnalyzerUtils.verifyNoGroupingFunctions(outputExpr, "GROUP BY");
+                            groupByExpressions.add(outputExpr);
+                        }
+                    }
                 } else {
                     throw new StarRocksPlannerException("unknown grouping type", INTERNAL_ERROR);
                 }
@@ -1019,4 +1037,3 @@ public class SelectAnalyzer {
         return result;
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/GroupByClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/GroupByClause.java
@@ -255,6 +255,9 @@ public class GroupByClause implements ParseNode {
                     strBuilder.append(")");
                 }
                 break;
+            case GROUP_BY_ALL:
+                strBuilder.append("ALL");
+                break;
             default:
                 break;
         }
@@ -306,6 +309,9 @@ public class GroupByClause implements ParseNode {
                     strBuilder.append(")");
                 }
                 break;
+            case GROUP_BY_ALL:
+                strBuilder.append("ALL");
+                break;
             default:
                 break;
         }
@@ -318,6 +324,9 @@ public class GroupByClause implements ParseNode {
     }
 
     public boolean isEmpty() {
+        if (groupingType == GroupingType.GROUP_BY_ALL) {
+            return false;
+        }
         return CollectionUtils.isEmpty(groupingExprs);
     }
 
@@ -325,7 +334,8 @@ public class GroupByClause implements ParseNode {
         GROUP_BY,
         GROUPING_SETS,
         ROLLUP,
-        CUBE
+        CUBE,
+        GROUP_BY_ALL
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -1535,6 +1535,9 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
                     strBuilder.append(")");
                 }
                 break;
+            case GROUP_BY_ALL:
+                strBuilder.append("ALL");
+                break;
             default:
                 break;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.type.IntegerType;
@@ -496,6 +497,14 @@ public class QueryTransformer {
             // the output key -> value pair must use the original aggregate expr as key, because
             // the top node may ref the original aggregate expr
             groupingTranslations.put(aggregates.get(i), colRef);
+        }
+
+        if (groupingSetsList == null) {
+            for (Expr groupingFunction : groupingFunctionCallExprs) {
+                ColumnRefOperator grouping = columnRefFactory.create(GROUPING, IntegerType.BIGINT, false);
+                groupingTranslations.put(groupingFunction, grouping);
+                groupingTranslations.putConstOperator(grouping, ConstantOperator.createBigint(0));
+            }
         }
 
         //Add repeatOperator to support grouping sets

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.SubqueryUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -62,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator.findOrCreateColumnRefForExpr;
 
 public class QueryTransformer {
@@ -159,8 +161,19 @@ public class QueryTransformer {
                                                           ColumnRefFactory columnRefFactory) {
         List<ColumnRefOperator> outputs = new ArrayList<>();
         for (Expr expression : outputExpressions) {
-            outputs.add((ColumnRefOperator) SqlToScalarOperatorTranslator
-                    .translate(expression, builder.getExpressionMapping(), columnRefFactory));
+            ColumnRefOperator outputColumn = builder.getExpressionMapping().get(expression);
+            if (outputColumn != null) {
+                outputs.add(outputColumn);
+                continue;
+            }
+
+            ScalarOperator scalarOperator = SqlToScalarOperatorTranslator
+                    .translate(expression, builder.getExpressionMapping(), columnRefFactory);
+            if (!scalarOperator.isColumnRef()) {
+                throw new StarRocksPlannerException("output expression not translate to column reference",
+                        INTERNAL_ERROR);
+            }
+            outputs.add((ColumnRefOperator) scalarOperator);
         }
         return outputs;
     }
@@ -182,6 +195,8 @@ public class QueryTransformer {
         Scope scope = queryBlock.getOrderScope();
         ExpressionMapping outputTranslations = new ExpressionMapping(scope);
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        Map<Expr, ColumnRefOperator> currentExpressionMappings = Maps.newHashMap();
+        Map<ColumnRefOperator, ScalarOperator> currentConstOperators = Maps.newHashMap();
         List<Expr> outputExprList = Lists.newArrayList(outputExpression);
 
         int outputExprIdx = 0;
@@ -199,6 +214,7 @@ public class QueryTransformer {
 
             if (outputExprInOrderByScope.contains(outputExprIdx)) {
                 outputTranslations.put(expression, columnRefOperator);
+                currentExpressionMappings.put(expression, columnRefOperator);
                 TableName resolveTableName = queryBlock.getResolveTableName();
                 if (expression instanceof SlotRef) {
                     resolveTableName = queryBlock.getRelation().getResolveTableName();
@@ -217,12 +233,19 @@ public class QueryTransformer {
                 if (scope.getRelationFields().resolveFields(alias).size() > 1) {
                     outputTranslations.getExpressionToColumns()
                             .put(new SlotRef(resolveTableName, outputNames.get(outputExprIdx)), columnRefOperator);
+                    currentExpressionMappings.put(new SlotRef(resolveTableName, outputNames.get(outputExprIdx)),
+                            columnRefOperator);
                 } else {
                     outputTranslations.put(alias, columnRefOperator);
+                    currentExpressionMappings.put(alias, columnRefOperator);
                 }
 
             } else {
                 outputTranslations.put(expression, columnRefOperator);
+                currentExpressionMappings.put(expression, columnRefOperator);
+            }
+            if (scalarOperator.isConstant()) {
+                currentConstOperators.put(columnRefOperator, scalarOperator);
             }
             outputExprIdx++;
         }
@@ -251,6 +274,8 @@ public class QueryTransformer {
         outputTranslations.addExpressionToColumns(subOpt.getExpressionMapping().getExpressionToColumns());
         outputTranslations.addColumnRefToConstOperators(subOpt.getColumnRefToConstOperators());
         outputTranslations.addGeneratedColumnExprOpToColumnRef(subOpt.getGeneratedColumnExprOpToColumnRef());
+        outputTranslations.addExpressionToColumns(currentExpressionMappings);
+        outputTranslations.addColumnRefToConstOperators(currentConstOperators);
 
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections);
         return new OptExprBuilder(projectOperator, Lists.newArrayList(subOpt), outputTranslations);
@@ -265,6 +290,8 @@ public class QueryTransformer {
                 subOpt.getColumnRefToConstOperators());
 
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        Map<Expr, ColumnRefOperator> currentExpressionMappings = Maps.newHashMap();
+        Map<ColumnRefOperator, ScalarOperator> currentConstOperators = Maps.newHashMap();
         for (Expr expression : expressions) {
             Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders = Maps.newHashMap();
             ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expression,
@@ -277,14 +304,17 @@ public class QueryTransformer {
             ColumnRefOperator columnRefOperator = getOrCreateColumnRefOperator(expression, scalarOperator, projections);
             projections.put(columnRefOperator, scalarOperator);
             outputTranslations.put(expression, columnRefOperator);
+            currentExpressionMappings.put(expression, columnRefOperator);
             if (scalarOperator.isConstant()) {
-                outputTranslations.putConstOperator(columnRefOperator, scalarOperator);
+                currentConstOperators.put(columnRefOperator, scalarOperator);
             }
         }
 
         outputTranslations.addExpressionToColumns(subOpt.getExpressionMapping().getExpressionToColumns());
         outputTranslations.addColumnRefToConstOperators(subOpt.getColumnRefToConstOperators());
         outputTranslations.addGeneratedColumnExprOpToColumnRef(subOpt.getGeneratedColumnExprOpToColumnRef());
+        outputTranslations.addExpressionToColumns(currentExpressionMappings);
+        outputTranslations.addColumnRefToConstOperators(currentConstOperators);
 
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections, limit);
         return new OptExprBuilder(projectOperator, Lists.newArrayList(subOpt), outputTranslations);
@@ -424,7 +454,7 @@ public class QueryTransformer {
     public OptExprBuilder aggregate(OptExprBuilder subOpt,
                                      List<Expr> groupByExpressions, List<FunctionCallExpr> aggregates,
                                      List<List<Expr>> groupingSetsList, List<Expr> groupingFunctionCallExprs) {
-        if (aggregates.isEmpty() && groupByExpressions.isEmpty()) {
+        if (aggregates.isEmpty() && groupByExpressions.isEmpty() && groupingFunctionCallExprs.isEmpty()) {
             return subOpt;
         }
 
@@ -504,6 +534,13 @@ public class QueryTransformer {
                 ColumnRefOperator grouping = columnRefFactory.create(GROUPING, IntegerType.BIGINT, false);
                 groupingTranslations.put(groupingFunction, grouping);
                 groupingTranslations.putConstOperator(grouping, ConstantOperator.createBigint(0));
+            }
+
+            if (!groupingFunctionCallExprs.isEmpty() && groupByColumnRefs.isEmpty() && aggregationsMap.isEmpty()) {
+                CallOperator countRows = SubqueryUtils.createCountRowsOperator();
+                ColumnRefOperator countRowsRef =
+                        columnRefFactory.create(countRows.getFnName(), countRows.getType(), countRows.isNullable());
+                aggregationsMap.put(countRowsRef, countRows);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -186,6 +186,10 @@ public final class SqlToScalarOperatorTranslator {
                                            boolean useSemiAnti) {
         ColumnRefOperator columnRefOperator = expressionMapping.get(expression);
         if (columnRefOperator != null) {
+            if (expression instanceof GroupingFunctionCallExpr) {
+                ScalarOperator constOperator = expressionMapping.getConstOperator(columnRefOperator);
+                return constOperator == null ? columnRefOperator : constOperator;
+            }
             return columnRefOperator;
         }
 
@@ -373,8 +377,7 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitFieldReference(FieldReference node, Context context) {
-            ColumnRefOperator scalarOperator = expressionMapping.getColumnRefWithIndex(node.getFieldIndex());
-            return scalarOperator;
+            return expressionMapping.getColumnRefWithIndex(node.getFieldIndex());
         }
 
         @Override
@@ -851,7 +854,8 @@ public final class SqlToScalarOperatorTranslator {
                         ErrorType.INTERNAL_ERROR);
             }
 
-            return columnRef;
+            ScalarOperator constOperator = expressionMapping.getConstOperator(columnRef);
+            return constOperator == null ? columnRef : constOperator;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -859,7 +859,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         ShowDataDistributionStmt stmt =
                 new ShowDataDistributionStmt(new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop)),
-                createPos(context));
+                        createPos(context));
         visitShowPredicateClauses(context.showPredicateClauses(), stmt);
         return stmt;
     }
@@ -1902,7 +1902,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 (QueryStatement) visit(context.queryStatement()),
                 createPos(context),
                 getCaseInsensitiveProperties(context.properties())
-                );
+        );
         stmt.setQueryStartIndex(context.queryStatement().start.getStartIndex());
         stmt.setQueryStopIndex(context.queryStatement().stop.getStopIndex() + 1);
         return stmt;
@@ -2425,7 +2425,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.swapTableClause() != null) {
             alterTableClause = (SwapTableClause) visit(context.swapTableClause());
         }
-        
+
         // add column to materialized view
         if (context.addMVColumnClause() != null) {
             alterTableClause = (AddMVColumnClause) visit(context.addMVColumnClause());
@@ -2435,7 +2435,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.dropMVColumnClause() != null) {
             alterTableClause = (DropMVColumnClause) visit(context.dropMVColumnClause());
         }
-        
+
         return new AlterMaterializedViewStmt(mvTableRef, alterTableClause, createPos(context));
     }
 
@@ -6129,11 +6129,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         SelectList selectList = new SelectList(selectItems, isDistinct);
         selectList.setHintNodes(hintMap.get(context));
 
+        GroupByClause groupByClause;
+        if (context.groupByAll != null) {
+            groupByClause = new GroupByClause(new ArrayList<Expr>(),
+                    GroupByClause.GroupingType.GROUP_BY_ALL, createPos(context.groupByAll, context.groupByAll));
+        } else {
+            groupByClause = (GroupByClause) visitIfPresent(context.groupingElement());
+        }
+
         SelectRelation resultSelectRelation = new SelectRelation(
                 selectList,
                 from,
                 (Expr) visitIfPresent(context.where),
-                (GroupByClause) visitIfPresent(context.groupingElement()),
+                groupByClause,
                 (Expr) visitIfPresent(context.having),
                 createPos(context));
 
@@ -6581,7 +6589,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             if (context.bracketHint().generalLiteralExpressionList() != null) {
                 joinRelation.setSkewValues(
                         visit(context.bracketHint().generalLiteralExpressionList().generalLiteralExpression(),
-                        Expr.class));
+                                Expr.class));
             }
         }
 
@@ -6612,8 +6620,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     }
 
     private NamedArgument buildNamedArgument(ParserRuleContext identifierCtx,
-                                              ParserRuleContext expressionCtx,
-                                              ParserRuleContext fullCtx) {
+                                             ParserRuleContext expressionCtx,
+                                             ParserRuleContext fullCtx) {
         String name = ((Identifier) visit(identifierCtx)).getValue();
         if (name == null || name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
@@ -7686,7 +7694,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         Expr compareExpr = (Expr) visit(context.value);
 
         ConnectContext connectContext = ConnectContext.get();
-        
+
         List<com.starrocks.sql.parser.StarRocksParser.StringContext> stringNodes = context.stringList().string();
         int literalCount = stringNodes.size();
         List<Expr> stringExprList = visit(stringNodes, Expr.class);
@@ -7709,7 +7717,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         Expr compareExpr = (Expr) visit(context.value);
 
         com.starrocks.qe.ConnectContext connectContext = com.starrocks.qe.ConnectContext.get();
-        
+
         List<org.antlr.v4.runtime.tree.TerminalNode> integerNodes = context.integerList().INTEGER_VALUE();
         int literalCount = integerNodes.size();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -189,7 +189,7 @@ public class AnalyzeAggregateTest {
         analyzeFail("select distinct vs.a, vs1.b from ttypes group by vs");
         analyzeSuccess("select distinct vs.a, vs1.b from ttypes group by vs.a, vs1.b");
     }
-    
+
     @Test
     public void testDistinctAggOnComplexTypes() {
         analyzeSuccess("select count(distinct va) from ttypes group by v1");
@@ -458,5 +458,75 @@ public class AnalyzeAggregateTest {
                 "The second parameter of min_n cannot exceed 10000");
         analyzeFail("select max_n(v1, 10001) from t0",
                 "The second parameter of max_n cannot exceed 10000");
+    }
+
+    @Test
+    public void testGroupByAll() {
+        // basic: non-agg columns auto-collected as group by keys
+        analyzeSuccess("select v1, v2, sum(v3) from t0 group by all");
+        analyzeSuccess("select v1, sum(v2) from t0 group by all");
+
+        // only aggregate functions in select list — group by all yields empty group by (scalar agg)
+        analyzeSuccess("select sum(v1), count(v2) from t0 group by all");
+
+        // no aggregate functions — group by all collects all columns
+        analyzeSuccess("select v1, v2, v3 from t0 group by all");
+
+        // expression that contains aggregate: sum(v1)+1 should NOT be a group by key
+        analyzeSuccess("select v1, sum(v1) + 1 from t0 group by all");
+
+        // expression without aggregate: v1+v2 should be a group by key
+        analyzeSuccess("select v1 + v2, sum(v3) from t0 group by all");
+
+        // nested agg expression: count(*) is aggregate, should be excluded
+        analyzeSuccess("select v1, v2, count(*) from t0 group by all");
+
+        // multiple agg functions mixed with non-agg
+        analyzeSuccess("select v1, sum(v2), avg(v3), count(*) from t0 group by all");
+
+        // alias in select list — group by all should work with aliased expressions
+        analyzeSuccess("select v1 as id, sum(v2) as total from t0 group by all");
+
+        // having clause combined with group by all
+        analyzeSuccess("select v1, sum(v2) from t0 group by all having sum(v2) > 0");
+
+        // subquery in from clause
+        analyzeSuccess("select a, sum(b) from (select v1 as a, v2 as b from t0) t group by all");
+
+        // join with group by all
+        analyzeSuccess("select t0.v1, t1.v4, sum(t0.v2) from t0 join t1 on t0.v1 = t1.v4 group by all");
+
+        // group by all with order by
+        analyzeSuccess("select v1, sum(v2) from t0 group by all order by v1");
+
+        // group by all with limit
+        analyzeSuccess("select v1, sum(v2) from t0 group by all limit 10");
+
+        // group by all with where clause
+        analyzeSuccess("select v1, sum(v2) from t0 where v3 > 0 group by all");
+
+        // window function in select — window expr should NOT be a group by key
+        analyzeFail("select v1, sum(v2) over(), sum(v3) from t0 group by all",
+                "GROUP BY clause cannot contain window function");
+
+        // group by all should reject window functions as group by keys
+        analyzeFail("select v1, sum(v2) over() from t0 group by all",
+                "GROUP BY clause cannot contain window function");
+
+        // group by all with star projection should be supported
+        analyzeSuccess("select *, sum(v1) from t0 group by all");
+        analyzeSuccess("select * exclude(v3), sum(v1) from t0 group by all");
+        analyzeSuccess("select *, sum(v1) from t0 group by all having sum(v1) > 0");
+
+        // duplicate non-aggregate expressions should be deduplicated as group by keys
+        analyzeSuccess("select v1, v1, sum(v2) from t0 group by all");
+        analyzeSuccess("select v1 as a, v1 as b, sum(v2) from t0 group by all");
+
+    }
+
+    @Test
+    public void testGroupByAllRegressionCases() {
+        analyzeSuccess("select v1, sum(v2) + grouping(v1) from t0 group by all");
+        analyzeSuccess("select *, sum(v1) from t0 group by all");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -527,6 +527,8 @@ public class AnalyzeAggregateTest {
     @Test
     public void testGroupByAllRegressionCases() {
         analyzeSuccess("select v1, sum(v2) + grouping(v1) from t0 group by all");
+        analyzeSuccess("select grouping(v1), sum(v2) from t0 group by all");
+        analyzeSuccess("select grouping(v1) from t0 group by all");
         analyzeSuccess("select *, sum(v1) from t0 group by all");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3603,6 +3603,22 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testGroupByAllWithStandaloneGroupingFunction() throws Exception {
+        String sql = "select grouping(v1), sum(v2) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "output: sum(2: v2)");
+        assertContains(plan, "group by: 1: v1");
+    }
+
+    @Test
+    public void testGroupByAllWithOnlyGroupingFunction() throws Exception {
+        String sql = "select grouping(v1) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "0");
+    }
+
+    @Test
     public void testGroupByAllWithStarProjection() throws Exception {
         String sql = "select *, sum(v1) from t0 group by all";
         String plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2049,8 +2049,8 @@ public class AggregateTest extends PlanTestBase {
         sql = "select count(distinct v1, v2) from t0;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
-                        "  |  STREAMING\n" +
-                        "  |  group by: 1: v1, 2: v2");
+                "  |  STREAMING\n" +
+                "  |  group by: 1: v1, 2: v2");
         connectContext.getSessionVariable().setCountDistinctImplementation("default");
     }
 
@@ -3362,7 +3362,7 @@ public class AggregateTest extends PlanTestBase {
 
             // distinct avg cannot merge two phase agg to one phase agg.
             sql = "select avg(distinct v2) from t0 group by v1";
-            plan  = getFragmentPlan(sql);
+            plan = getFragmentPlan(sql);
             assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                     "  |  output: avg(2: v2)\n" +
                     "  |  group by: 1: v1\n" +
@@ -3487,5 +3487,126 @@ public class AggregateTest extends PlanTestBase {
                 "  6:AGGREGATE (update serialize)\n" +
                 "  |  output: count(*)\n" +
                 "  |  group by: ");
+    }
+
+    @Test
+    public void testGroupByAllBasic() throws Exception {
+        // basic: v1, v2 are non-agg, should become group by keys; sum(v3) is agg
+        String sql = "select v1, v2, sum(v3) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1, 2: v2");
+        assertContains(plan, "output: sum(3: v3)");
+    }
+
+    @Test
+    public void testGroupByAllSingleNonAgg() throws Exception {
+        // single non-agg column with one agg function
+        String sql = "select v1, sum(v2) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "output: sum(2: v2)");
+    }
+
+    @Test
+    public void testGroupByAllOnlyAgg() throws Exception {
+        // all columns are aggregate — group by all yields scalar aggregation (empty group by)
+        String sql = "select sum(v1), count(v2) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "output: sum(1: v1), count(2: v2)");
+        assertContains(plan, "group by: \n");
+    }
+
+    @Test
+    public void testGroupByAllNoAgg() throws Exception {
+        // no aggregate functions — group by all collects all columns, equivalent to GROUP BY v1, v2, v3
+        String sql = "select v1, v2, v3 from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1, 2: v2, 3: v3");
+    }
+
+    @Test
+    public void testGroupByAllAggExpression() throws Exception {
+        // sum(v1)+1 contains aggregate — should NOT be a group by key
+        String sql = "select v1, sum(v1) + 1 from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "output: sum(1: v1)");
+    }
+
+    @Test
+    public void testGroupByAllMultipleAgg() throws Exception {
+        // multiple agg functions: only v1 is non-agg
+        String sql = "select v1, sum(v2), avg(v3), count(*) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "output: sum(2: v2), avg(3: v3), count(*)");
+    }
+
+    @Test
+    public void testGroupByAllWithHaving() throws Exception {
+        // having clause should work normally with group by all
+        String sql = "select v1, sum(v2) from t0 group by all having sum(v2) > 10";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "having: 4: sum > 10");
+    }
+
+    @Test
+    public void testGroupByAllWithWhere() throws Exception {
+        // where clause should be pushed down, group by all still works
+        String sql = "select v1, sum(v2) from t0 where v3 > 0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 3: v3 > 0");
+        assertContains(plan, "group by: 1: v1");
+    }
+
+    @Test
+    public void testGroupByAllWithJoin() throws Exception {
+        // join: non-agg columns from both sides become group by keys
+        String sql = "select t0.v1, t1.v4, sum(t0.v2) from t0 join t1 on t0.v1 = t1.v4 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "output: sum(2: v2)");
+        assertContains(plan, "group by: 1: v1, 4: v4");
+    }
+
+    @Test
+    public void testGroupByAllWithSubquery() throws Exception {
+        // subquery in from clause
+        String sql = "select a, sum(b) from (select v1 as a, v2 as b from t0) t group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "output: sum(2: v2)");
+    }
+
+    @Test
+    public void testGroupByAllWithLimit() throws Exception {
+        // limit should not affect group by all behavior
+        String sql = "select v1, sum(v2) from t0 group by all limit 5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "limit: 5");
+    }
+
+    @Test
+    public void testGroupByAllDeduplicateKeys() throws Exception {
+        String sql = "select v1, v1, sum(v2) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1\n");
+    }
+
+    @Test
+    public void testGroupByAllWithGroupingFunction() throws Exception {
+        String sql = "select v1, sum(v2) + grouping(v1) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1");
+        assertContains(plan, "output: sum(2: v2)");
+    }
+
+    @Test
+    public void testGroupByAllWithStarProjection() throws Exception {
+        String sql = "select *, sum(v1) from t0 group by all";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "group by: 1: v1, 2: v2, 3: v3");
+        assertContains(plan, "output: sum(1: v1)");
     }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2438,7 +2438,7 @@ limitElement
 querySpecification
     : SELECT setQuantifier? selectItem (',' selectItem)*
       fromClause
-      ((WHERE where=expression)? (GROUP BY groupingElement)? (HAVING having=expression)?
+      ((WHERE where=expression)? (GROUP BY (groupByAll=ALL | groupingElement))? (HAVING having=expression)?
        (QUALIFY qualifyFunction=selectItem comparisonOperator limit=INTEGER_VALUE)?)
     ;
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FieldReference.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FieldReference.java
@@ -47,6 +47,11 @@ public class FieldReference extends Expr {
     }
 
     @Override
+    protected boolean isConstantImpl() {
+        return false;
+    }
+
+    @Override
     public boolean equalsWithoutChild(Object o) {
         if (this == o) {
             return true;


### PR DESCRIPTION
## Why I'm doing:

Fix issue #69953

Currently, StarRocks does not support the `GROUP BY ALL` syntax, while other databases like `SQL Server` have already implemented it. Therefore, this PR implements the `GROUP BY ALL` syntactic sugar and includes the necessary test cases.


## What I'm doing:

This PR mainly implements the frontend (FE) logic for parsing GROUP BY ALL.

### Frontend (FE):
Added the GROUP BY ALL syntax support in starrocks.g4.
Implemented the handling logic in SelectAnalyzer, such as extracting all slot columns from expressions and filtering out aggregate and window functions.

### Test Plan:
Unit Tests:
Added test cases in AnalyzeAggregateTest and AggregateTest to verify syntax parsing and execution plan generation, respectively.

### Implementation Result:
See the screenshot below for the manual verification using MySQL Client:

<img width="1891" height="1197" alt="image" src="https://github.com/user-attachments/assets/a4b263c9-ad58-4825-9034-44118b88bb6c" />


Fix issue #69953

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
