### PR TITLE
[BugFix] Fix CN crash when scanning empty tablet with physical split enabled

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -515,11 +515,22 @@ rowid_t PhysicalSplitMorselQueue::_upper_bound_ordinal(Segment* segment, const S
 }
 
 BaseRowset* PhysicalSplitMorselQueue::_cur_rowset() {
+    // Boundary check to prevent out-of-bounds access when tablet has no rowsets
+    if (_tablet_idx >= _tablet_rowsets.size()) {
+        return nullptr;
+    }
+    if (_rowset_idx >= _tablet_rowsets[_tablet_idx].size()) {
+        return nullptr;
+    }
     return _tablet_rowsets[_tablet_idx][_rowset_idx].get();
 }
 
 Segment* PhysicalSplitMorselQueue::_cur_segment() {
-    const auto& segments = _cur_rowset()->get_segments();
+    auto* rowset = _cur_rowset();
+    if (rowset == nullptr) {
+        return nullptr;
+    }
+    const auto& segments = rowset->get_segments();
     return _segment_idx >= segments.size() ? nullptr : segments[_segment_idx].get();
 }
 
@@ -544,7 +555,11 @@ bool PhysicalSplitMorselQueue::_is_last_split_of_current_morsel() {
     }
 
     // Check if reach the last segment of the current rowset.
-    const size_t num_segments = _tablet_rowsets[_tablet_idx][_rowset_idx]->get_segments().size();
+    auto* rowset = _cur_rowset();
+    if (rowset == nullptr) {
+        return true;
+    }
+    const size_t num_segments = rowset->get_segments().size();
     if (_segment_idx + 1 < num_segments) {
         return false;
     }
@@ -558,7 +573,13 @@ bool PhysicalSplitMorselQueue::_next_segment() {
         _has_init_any_segment = true;
     } else {
         // Read the next segment of the current rowset.
-        if (++_segment_idx >= _cur_rowset()->get_segments().size()) {
+        auto* rowset = _cur_rowset();
+        // If current tablet has no rowsets, skip to next tablet
+        if (rowset == nullptr) {
+            _segment_idx = 0;
+            _rowset_idx = 0;
+            ++_tablet_idx;
+        } else if (++_segment_idx >= rowset->get_segments().size()) {
             _segment_idx = 0;
             // Read the next rowset of the current tablet.
             if (++_rowset_idx >= _tablet_rowsets[_tablet_idx].size()) {
@@ -596,7 +617,12 @@ Status PhysicalSplitMorselQueue::_init_segment() {
             }
         }
         // Read a new rowset.
-        RETURN_IF_ERROR(_cur_rowset()->load());
+        auto* rowset = _cur_rowset();
+        // If current tablet has no rowsets, return early
+        if (rowset == nullptr) {
+            return Status::OK();
+        }
+        RETURN_IF_ERROR(rowset->load());
     }
 
     _num_segment_rest_rows = 0;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -146,6 +146,12 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
             rss.emplace_back(rowset);
         }
 
+        // Do not split if tablet has no rowsets (empty tablet)
+        if (_rowsets.empty()) {
+            _need_split = false;
+            return init_collector(read_params);
+        }
+
         // not split for data skew between tablet
         if (tablet_num_rows < read_params.splitted_scan_rows * config::lake_tablet_rows_splitted_ratio) {
             // set _need_split false to make iterator can get data this round if split do not happen,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXEC_FILES
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
         ./exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+        ./exec/pipeline/scan/physical_split_morsel_queue_test.cpp
         ./exec/query_spill_manager_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp

--- a/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "exec/pipeline/scan/morsel.h"
+#include "gen_cpp/InternalService_types.h"
+#include "storage/lake/tablet.h"
+
+namespace starrocks::pipeline {
+
+class PhysicalSplitMorselQueueTest : public ::testing::Test {
+public:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// Test case: PhysicalSplitMorselQueue crashes when tablet has no rowsets
+// This test directly verifies the boundary checks in PhysicalSplitMorselQueue methods:
+// _cur_rowset, _cur_segment, _is_last_split_of_current_morsel, _next_segment, _init_segment
+TEST_F(PhysicalSplitMorselQueueTest, test_empty_rowset) {
+    // Create scan range for the morsel
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = 10001;
+    internal_scan_range.version = "1";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    // Create morsels
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, scan_range));
+
+    // Create PhysicalSplitMorselQueue
+    PhysicalSplitMorselQueue queue(std::move(morsels), 1, 1024);
+
+    // Create a lake tablet for testing (nullptr TabletManager is allowed)
+    auto tablet = std::make_shared<lake::Tablet>(nullptr, 10001);
+    std::vector<BaseTabletSharedPtr> tablets;
+    tablets.push_back(tablet);
+    queue.set_tablets(tablets);
+
+    // Set up tablet_rowsets with empty rowsets (key scenario for issue #70280)
+    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
+    tablet_rowsets.emplace_back(); // Empty rowsets for the tablet
+    queue.set_tablet_rowsets(tablet_rowsets);
+
+    // Call try_get, this should not crash with empty rowsets
+    auto result = queue.try_get();
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(result.value(), nullptr);
+    ASSERT_TRUE(queue.empty());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
@@ -56,6 +56,10 @@ TEST_F(PhysicalSplitMorselQueueTest, test_empty_rowset) {
     tablet_rowsets.emplace_back(); // Empty rowsets for the tablet
     queue.set_tablet_rowsets(tablet_rowsets);
 
+    // Set a non-null tablet schema to avoid null dereference in _init_segment
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    queue.set_tablet_schema(tablet_schema);
+
     // Call try_get, this should not crash with empty rowsets
     auto result = queue.try_get();
     ASSERT_TRUE(result.ok());

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -1131,4 +1131,33 @@ TEST_F(LakeDuplicateTablet10kColumnReaderTest, DISABLED_test_bench_5kcolumn_init
                  << "ns. Perf diff times: " << std::setprecision(3) << (double)total_time_ns_false / total_time_ns_true
                  << "x";
 }
+// Test case for issue: PhysicalSplitMorselQueue crashes when tablet has no rowsets
+// This test verifies that TabletReader::open correctly handles empty rowsets
+// when need_split is true, preventing SIGSEGV in PhysicalSplitMorselQueue::_cur_rowset
+TEST_F(LakeDuplicateTabletReaderTest, test_read_empty_tablet_with_split) {
+    // Create a tablet metadata without any rowsets (empty tablet)
+    // Do not add any rowsets to _tablet_metadata
+
+    // write tablet metadata (version 2, but no rowsets)
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    // test reader with need_split = true
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema,
+                                                 /*need_split=*/true, /*could_split_physically=*/true);
+    ASSERT_OK(reader->prepare());
+
+    TabletReaderParams params;
+    params.splitted_scan_rows = 16384; // Set a non-zero value
+    // This should not crash even with need_split=true and empty rowsets
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    read_chunk_ptr->reset();
+    // Should return end of file immediately for empty tablet
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -1163,41 +1163,4 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_empty_tablet_with_split) {
     reader->close();
 }
 
-// Test case for issue: PhysicalSplitMorselQueue crashes when tablet has no rowsets
-// This test directly verifies the boundary checks in PhysicalSplitMorselQueue methods:
-// _cur_rowset, _cur_segment, _is_last_split_of_current_morsel, _next_segment, _init_segment
-TEST_F(LakeDuplicateTabletReaderTest, test_physical_split_morsel_queue_with_empty_rowset) {
-    // Create scan range for the morsel
-    TScanRange scan_range;
-    TInternalScanRange internal_scan_range;
-    internal_scan_range.tablet_id = _tablet_metadata->id();
-    internal_scan_range.version = "1";
-    internal_scan_range.partition_id = 1;
-    scan_range.__set_internal_scan_range(internal_scan_range);
-
-    // Create morsels
-    pipeline::Morsels morsels;
-    morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(1, scan_range));
-
-    // Create PhysicalSplitMorselQueue
-    pipeline::PhysicalSplitMorselQueue queue(std::move(morsels), 1, 1024);
-
-    // Create a lake tablet for testing
-    auto tablet = std::make_shared<Tablet>(_tablet_mgr.get(), _tablet_metadata->id());
-    std::vector<BaseTabletSharedPtr> tablets;
-    tablets.push_back(tablet);
-    queue.set_tablets(tablets);
-
-    // Set up tablet_rowsets with empty rowsets (key scenario for issue #70280)
-    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
-    tablet_rowsets.emplace_back(); // Empty rowsets for the tablet
-    queue.set_tablet_rowsets(tablet_rowsets);
-
-    // Call try_get, this should not crash with empty rowsets
-    auto result = queue.try_get();
-    ASSERT_TRUE(result.ok());
-    ASSERT_EQ(result.value(), nullptr);
-    ASSERT_TRUE(queue.empty());
-}
-
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -31,7 +31,9 @@
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/logging.h"
+#include "exec/pipeline/scan/morsel.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/versioned_tablet.h"
@@ -1131,6 +1133,7 @@ TEST_F(LakeDuplicateTablet10kColumnReaderTest, DISABLED_test_bench_5kcolumn_init
                  << "ns. Perf diff times: " << std::setprecision(3) << (double)total_time_ns_false / total_time_ns_true
                  << "x";
 }
+
 // Test case for issue: PhysicalSplitMorselQueue crashes when tablet has no rowsets
 // This test verifies that TabletReader::open correctly handles empty rowsets
 // when need_split is true, preventing SIGSEGV in PhysicalSplitMorselQueue::_cur_rowset
@@ -1158,6 +1161,43 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_empty_tablet_with_split) {
     ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
 
     reader->close();
+}
+
+// Test case for issue: PhysicalSplitMorselQueue crashes when tablet has no rowsets
+// This test directly verifies the boundary checks in PhysicalSplitMorselQueue methods:
+// _cur_rowset, _cur_segment, _is_last_split_of_current_morsel, _next_segment, _init_segment
+TEST_F(LakeDuplicateTabletReaderTest, test_physical_split_morsel_queue_with_empty_rowset) {
+    // Create scan range for the morsel
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = _tablet_metadata->id();
+    internal_scan_range.version = "1";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    // Create morsels
+    pipeline::Morsels morsels;
+    morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(1, scan_range));
+
+    // Create PhysicalSplitMorselQueue
+    pipeline::PhysicalSplitMorselQueue queue(std::move(morsels), 1, 1024);
+
+    // Create a lake tablet for testing
+    auto tablet = std::make_shared<Tablet>(_tablet_mgr.get(), _tablet_metadata->id());
+    std::vector<BaseTabletSharedPtr> tablets;
+    tablets.push_back(tablet);
+    queue.set_tablets(tablets);
+
+    // Set up tablet_rowsets with empty rowsets (key scenario for issue #70280)
+    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
+    tablet_rowsets.emplace_back(); // Empty rowsets for the tablet
+    queue.set_tablet_rowsets(tablet_rowsets);
+
+    // Call try_get, this should not crash with empty rowsets
+    auto result = queue.try_get();
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(result.value(), nullptr);
+    ASSERT_TRUE(queue.empty());
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Fixes #70280 

## What I'm doing:

When a tablet has no rowsets (empty tablet) but PhysicalSplitMorselQueue
is created with need_split=true, accessing _tablet_rowsets[_tablet_idx][_rowset_idx]
in _cur_rowset() causes array out-of-bounds access, resulting in SIGSEGV.
 
This fix adds:
1. Boundary checks in _cur_rowset() and related functions to handle empty
   inner vectors gracefully
2. Early return in TabletReader::open() when _rowsets is empty to prevent
   creating PhysicalSplitMorselQueue with empty rowsets
3. Unit test for empty tablet scenario with split enabled

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
