### PR TITLE
[Enhancement] Enable file bundling for multi-statement transactions

### DIFF
--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -352,9 +352,9 @@ private:
 //   cast STRUCT<tinyint, tinyint> to STRUCT<int, int>
 class CastStructExpr final : public Expr {
 public:
-    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts,
-                   std::vector<int> source_field_indices)
-            : Expr(node), _field_casts(std::move(field_casts)),
+    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts, std::vector<int> source_field_indices)
+            : Expr(node),
+              _field_casts(std::move(field_casts)),
               _source_field_indices(std::move(source_field_indices)) {}
 
     ~CastStructExpr() override = default;

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -779,27 +779,16 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
     bool multi_stmt = _is_multi_statements_txn(params);
     for (const PTabletWithPartition& tablet : params.tablets()) {
         BundleWritableFileContext* bundle_writable_file_context = nullptr;
-        // Do NOT enable bundle write for a multi-statements transaction.
-        // Rationale:
-        //   A multi-statements txn may invoke multiple open/add_chunk cycles and flush segments in batches.
-        //   If some early segments are appended into a bundle file while later segments are flushed as
-        //   standalone segment files (because a subsequent writer/open does not attach to the previous
-        //   bundle context), the final Rowset metadata will contain a mixed set: a subset of segments with
-        //   bundle offsets recorded and the remaining without any offsets. Downstream rowset load logic
-        //   assumes a 1:1 correspondence between the 'segments' list and 'bundle_file_offsets' when the
-        //   latter is present. A partial list therefore triggers size mismatch errors when loading.
-        // Mitigation Strategy:
-        //   Disable bundling entirely for multi-statements txns so every segment is materialized as an
-        //   independent file, guaranteeing consistent metadata and eliminating offset mismatch risk.
-        // NOTE: If future optimization desires bundling + multi-stmt, it must introduce an atomic merge
-        //   mechanism ensuring offsets array completeness before publish.
-        if (!multi_stmt && _is_data_file_bundle_enabled(params)) {
+        // Enable bundle write for both single-statement and multi-statement transactions.
+        // Each statement in a multi-statement txn creates its own LoadChannel with an independent
+        // BundleWritableFileContext, so segments within each statement's TxnLog maintain the required
+        // 1:1 correspondence between 'segments' and 'bundle_file_offsets'. The NonPrimaryKeyTxnLogApplier
+        // merges bundle_file_offsets from multiple TxnLogs when creating the combined rowset during publish.
+        if (_is_data_file_bundle_enabled(params)) {
             if (_bundle_wfile_ctx_by_partition.count(tablet.partition_id()) == 0) {
                 _bundle_wfile_ctx_by_partition[tablet.partition_id()] = std::make_unique<BundleWritableFileContext>();
             }
             bundle_writable_file_context = _bundle_wfile_ctx_by_partition[tablet.partition_id()].get();
-        } else if (multi_stmt && _is_data_file_bundle_enabled(params)) {
-            VLOG(1) << "disable bundle write for multi statements txn partition=" << tablet.partition_id();
         }
         if (_delta_writers.count(tablet.tablet_id()) != 0) {
             // already created for the tablet, usually in incremental open case

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -14,6 +14,8 @@
 
 #include "meta_file.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <memory>
 
@@ -891,6 +893,11 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
             // Remap segment_idx to the merged rowset's local segment id space.
             segment_meta->set_segment_idx(_pending_rowset_data.assigned_segment_idx + get_segment_idx(rowset_pb, i));
         }
+        // Merge bundle_file_offsets for bundled data files.
+        // Must maintain 1:1 correspondence with segments.
+        for (int i = 0; i < rowset_pb.bundle_file_offsets_size(); i++) {
+            _pending_rowset_data.rowset_pb.add_bundle_file_offsets(rowset_pb.bundle_file_offsets(i));
+        }
     }
 
     // Merge replace_segments
@@ -911,9 +918,9 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
     _pending_rowset_data.assigned_segment_idx += get_rowset_id_step(rowset_pb);
 }
 
-void MetaFileBuilder::set_final_rowset() {
+Status MetaFileBuilder::set_final_rowset() {
     if (_pending_rowset_data.rowset_pb.segments_size() == 0 && _pending_rowset_data.dels.empty()) {
-        return; // Nothing to do
+        return Status::OK(); // Nothing to do
     }
 
     auto rowset = _tablet_meta->add_rowsets();
@@ -924,6 +931,17 @@ void MetaFileBuilder::set_final_rowset() {
     LOG_IF(ERROR, segment_size_size > 0 && segment_size_size != segment_file_size)
             << "segment_size size != segment file size, tablet: " << _tablet.id() << ", rowset: " << rowset->id()
             << ", segment file size: " << segment_file_size << ", segment_size size: " << segment_size_size;
+
+    // Validate bundle_file_offsets 1:1 correspondence with segments before applying replace_segments.
+    // During batch apply of multiple opwrites, some may have offsets and some may not, leading to
+    // inconsistent counts. This is an error that must abort publish to prevent data corruption —
+    // silently clearing offsets would leave bundled segment paths without positional info.
+    if (rowset->bundle_file_offsets_size() > 0 && rowset->bundle_file_offsets_size() != rowset->segments_size()) {
+        return Status::InternalError(
+                fmt::format("bundle_file_offsets count mismatch in merged rowset for tablet {}: "
+                            "offsets={} segments={}. Aborting publish to prevent data corruption.",
+                            _tablet.id(), rowset->bundle_file_offsets_size(), rowset->segments_size()));
+    }
 
     // Apply replace_segments
     for (const auto& replace_seg : _pending_rowset_data.replace_segments) {
@@ -972,6 +990,8 @@ void MetaFileBuilder::set_final_rowset() {
 
     // Clear pending cache
     _pending_rowset_data = PendingRowsetData{};
+
+    return Status::OK();
 }
 
 void MetaFileBuilder::batch_apply_opwrite(const TxnLogPB_OpWrite& op_write,

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -68,7 +68,7 @@ public:
     void add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
                     const std::vector<FileMetaPB>& orphan_files, const std::vector<std::string>& dels,
                     const std::vector<std::string>& del_encryption_metas);
-    void set_final_rowset();
+    Status set_final_rowset();
 
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -303,7 +303,7 @@ public:
                 }
             }
         }
-        _builder.set_final_rowset();
+        RETURN_IF_ERROR(_builder.set_final_rowset());
 
         return Status::OK();
     }
@@ -770,6 +770,9 @@ public:
         std::vector<int64_t> all_segment_sizes;
         std::vector<std::string> all_segment_encryption_metas;
         std::vector<SegmentMetadataPB> all_segment_metas;
+        std::vector<int64_t> all_bundle_file_offsets;
+        bool has_bundle_offsets = false;
+        bool has_segments_without_bundle_offsets = false;
         uint32_t assigned_segment_idx = 0;
 
         // Traverse all transaction logs and collect op_write information
@@ -827,6 +830,26 @@ public:
                         all_segment_metas.back().set_segment_idx(assigned_segment_idx + get_segment_idx(rowset, i));
                     }
                     assigned_segment_idx += get_rowset_id_step(rowset);
+
+                    // Collect bundle file offsets for bundled data files.
+                    // Each TxnLog's rowset either has all offsets (bundled) or none (standalone).
+                    if (rowset.bundle_file_offsets_size() > 0) {
+                        if (rowset.bundle_file_offsets_size() != rowset.segments_size()) {
+                            return Status::InternalError(fmt::format(
+                                    "bundle_file_offsets size mismatch in txn log for tablet {}: "
+                                    "offsets={} segments={}",
+                                    _tablet.id(), rowset.bundle_file_offsets_size(), rowset.segments_size()));
+                        } else {
+                            has_bundle_offsets = true;
+                            all_bundle_file_offsets.reserve(all_bundle_file_offsets.size() +
+                                                            rowset.bundle_file_offsets_size());
+                            for (int i = 0; i < rowset.bundle_file_offsets_size(); i++) {
+                                all_bundle_file_offsets.emplace_back(rowset.bundle_file_offsets(i));
+                            }
+                        }
+                    } else if (rowset.segments_size() > 0) {
+                        has_segments_without_bundle_offsets = true;
+                    }
                 }
             } else {
                 return Status::NotSupported(
@@ -866,6 +889,26 @@ public:
         // Set segment metas
         for (const auto& segment_meta : all_segment_metas) {
             merged_rowset->add_segment_metas()->CopyFrom(segment_meta);
+        }
+
+        // Validate bundle file offsets consistency across all TxnLogs.
+        // All TxnLogs must consistently either have or lack bundle_file_offsets.
+        // Mixing bundled and non-bundled rowsets is an error because downstream readers
+        // require offsets to locate segments within bundle files. Silently dropping offsets
+        // would leave bundled segment paths without positional info, causing data corruption.
+        if (has_bundle_offsets && has_segments_without_bundle_offsets) {
+            return Status::InternalError(
+                    fmt::format("Inconsistent bundle_file_offsets across txn logs for tablet {}: "
+                                "some logs have offsets, some don't. Cannot safely merge rowsets.",
+                                _tablet.id()));
+        }
+
+        // Set bundle file offsets if all TxnLogs consistently have them.
+        if (has_bundle_offsets) {
+            DCHECK_EQ(all_bundle_file_offsets.size(), static_cast<size_t>(merged_rowset->segments_size()));
+            for (int64_t offset : all_bundle_file_offsets) {
+                merged_rowset->add_bundle_file_offsets(offset);
+            }
         }
 
         // Set rowset ID and update next_rowset_id

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -859,7 +859,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_set_final_rowset_basic) {
     ASSERT_TRUE(builder.update_num_del_stat(segid_to_add_dels).ok());
 
     // Seal pending rowset
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     EXPECT_EQ(110, final_rowset.id());
@@ -910,7 +910,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_merge_dels) {
     op_write2.add_dels("d3.del");
     builder.batch_apply_opwrite(op_write2, {}, {});
 
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     EXPECT_EQ(500, final_rowset.id());
@@ -965,7 +965,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_mixed_segment_meta_presence) {
     op_write2.add_dels("d2.del");
     builder.batch_apply_opwrite(op_write2, {}, {});
 
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     ASSERT_EQ(3, final_rowset.segments_size());

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -81,6 +81,18 @@ std::shared_ptr<TxnLogPB> make_op_write_log(int64_t tablet_id, int64_t txn_id, i
     return log;
 }
 
+// Create an op_write txn log with bundle file offsets (bundled data files)
+std::shared_ptr<TxnLogPB> make_op_write_log_with_bundle(int64_t tablet_id, int64_t txn_id, int64_t num_rows,
+                                                        int64_t data_size, const std::vector<std::string>& segments,
+                                                        const std::vector<int64_t>& bundle_offsets) {
+    auto log = make_op_write_log(tablet_id, txn_id, num_rows, data_size, segments);
+    auto* rowset = log->mutable_op_write()->mutable_rowset();
+    for (auto offset : bundle_offsets) {
+        rowset->add_bundle_file_offsets(offset);
+    }
+    return log;
+}
+
 // Build a Tablet instance (minimal requirements for non-primary key path)
 bool make_tablet(int64_t tablet_id, Tablet* out_tablet) {
     auto mgr = ExecEnv::GetInstance()->lake_tablet_manager();
@@ -366,6 +378,105 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyLakeReplicationApply) {
     EXPECT_EQ(200, meta->rowsets(0).num_rows());
     EXPECT_EQ(4096, meta->rowsets(0).data_size());
     EXPECT_EQ(15u, meta->next_rowset_id());
+}
+
+// Test that bundle_file_offsets from multiple TxnLogs are correctly merged into the combined rowset.
+// This verifies multi-statement transaction support for file bundling.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeBundleFileOffsets) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10010);
+    auto meta = build_non_pk_metadata(10010);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    // Simulate two statements in a multi-statement transaction, each with bundled segments
+    TxnLogVector logs;
+    logs.push_back(make_op_write_log_with_bundle(10010, 10, 5, 100, {"seg_a"}, {0}));
+    logs.push_back(make_op_write_log_with_bundle(10010, 11, 7, 140, {"seg_b"}, {1024}));
+    logs.push_back(make_op_write_log_with_bundle(10010, 12, 3, 60, {"seg_c"}, {2048}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->rowsets_size());
+    const auto& rs = meta->rowsets(0);
+    EXPECT_EQ(15, rs.num_rows());
+    EXPECT_EQ(300, rs.data_size());
+    EXPECT_EQ(3, rs.segments_size());
+
+    // Verify bundle_file_offsets are preserved with 1:1 correspondence
+    ASSERT_EQ(3, rs.bundle_file_offsets_size());
+    EXPECT_EQ(0, rs.bundle_file_offsets(0));
+    EXPECT_EQ(1024, rs.bundle_file_offsets(1));
+    EXPECT_EQ(2048, rs.bundle_file_offsets(2));
+}
+
+// Test that when no TxnLogs have bundle_file_offsets, the merged rowset also has none.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeNoBundleOffsets) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10011);
+    auto meta = build_non_pk_metadata(10011);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    logs.push_back(make_op_write_log(10011, 10, 5, 100, {"seg_a"}));
+    logs.push_back(make_op_write_log(10011, 11, 7, 140, {"seg_b"}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->rowsets_size());
+    const auto& rs = meta->rowsets(0);
+    EXPECT_EQ(2, rs.segments_size());
+    EXPECT_EQ(0, rs.bundle_file_offsets_size());
+}
+
+// Test that mixed bundle_file_offsets (some TxnLogs with, some without) returns error to prevent
+// data corruption — silently dropping offsets would leave bundled segment paths unresolvable.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReturnsError) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10012);
+    auto meta = build_non_pk_metadata(10012);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    // First log has bundle offsets
+    logs.push_back(make_op_write_log_with_bundle(10012, 10, 5, 100, {"seg_a"}, {0}));
+    // Second log does NOT have bundle offsets
+    logs.push_back(make_op_write_log(10012, 11, 7, 140, {"seg_b"}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("Inconsistent bundle_file_offsets"));
+}
+
+// Test reverse order: first TxnLog has no offsets, second has offsets.
+// This must also be detected as inconsistent and return error.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReverseReturnsError) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10013);
+    auto meta = build_non_pk_metadata(10013);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    // First log does NOT have bundle offsets
+    logs.push_back(make_op_write_log(10013, 10, 5, 100, {"seg_a", "seg_b"}));
+    // Second log has bundle offsets
+    logs.push_back(make_op_write_log_with_bundle(10013, 11, 7, 140, {"seg_c"}, {0}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("Inconsistent bundle_file_offsets"));
+}
+
+// Test that a single TxnLog with mismatched offset/segment count returns error.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeBundleOffsetSizeMismatchReturnsError) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10014);
+    auto meta = build_non_pk_metadata(10014);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    // 2 segments but only 1 offset → mismatch within single TxnLog
+    logs.push_back(make_op_write_log_with_bundle(10014, 10, 5, 100, {"seg_a", "seg_b"}, {0}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("mismatch"));
 }
 
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyReplicationWithoutTabletMetaSparseSegmentIdStep) {

--- a/test/sql/test_file_bundling_txn/R/test_multi_stmt_txn_bundling
+++ b/test/sql/test_file_bundling_txn/R/test_multi_stmt_txn_bundling
@@ -1,0 +1,220 @@
+-- name: test_multi_stmt_txn_dup_table_with_bundling @cloud
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_dup (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+-- result:
+-- !result
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(2001, 3000));
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select count(*) from t_dup;
+-- result:
+3000
+-- !result
+select count(distinct k1) from t_dup;
+-- result:
+3000
+-- !result
+select * from t_dup where k1 in (1, 500, 1000, 1500, 2000, 2500, 3000) order by k1;
+-- result:
+1	val_1
+500	val_500
+1000	val_1000
+1500	val_1500
+2000	val_2000
+2500	val_2500
+3000	val_3000
+-- !result
+set enable_sql_transaction = false;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+-- name: test_multi_stmt_txn_pk_table_with_bundling @cloud
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_pk (k1 int, v1 string)
+    primary key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+-- result:
+-- !result
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(2001, 3000));
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select count(*) from t_pk;
+-- result:
+3000
+-- !result
+select * from t_pk where k1 in (1, 500, 1000, 1500, 2000, 2500, 3000) order by k1;
+-- result:
+1	val_1
+500	val_500
+1000	val_1000
+1500	val_1500
+2000	val_2000
+2500	val_2500
+3000	val_3000
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_pk select generate_series, concat('updated_', generate_series) from TABLE(generate_series(500, 600));
+-- result:
+-- !result
+insert into t_pk select generate_series, concat('new_', generate_series) from TABLE(generate_series(3001, 3500));
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select count(*) from t_pk;
+-- result:
+3500
+-- !result
+select * from t_pk where k1 in (499, 500, 550, 600, 601, 3000, 3001, 3500) order by k1;
+-- result:
+499	val_499
+500	updated_500
+550	updated_550
+600	updated_600
+601	val_601
+3000	val_3000
+3001	new_3001
+3500	new_3500
+-- !result
+set enable_sql_transaction = false;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+-- name: test_multi_stmt_txn_rollback_with_bundling @cloud
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_rollback (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+-- result:
+-- !result
+insert into t_rollback select generate_series, concat('original_', generate_series) from TABLE(generate_series(1, 500));
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_rollback select generate_series, concat('should_disappear_', generate_series) from TABLE(generate_series(501, 1000));
+-- result:
+-- !result
+insert into t_rollback select generate_series, concat('also_disappear_', generate_series) from TABLE(generate_series(1001, 1500));
+-- result:
+-- !result
+rollback;
+-- result:
+-- !result
+select count(*) from t_rollback;
+-- result:
+500
+-- !result
+select min(k1), max(k1) from t_rollback;
+-- result:
+1	500
+-- !result
+set enable_sql_transaction = false;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+-- name: test_multi_stmt_txn_bundling_disabled @cloud
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_nobundle (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'false');
+-- result:
+-- !result
+set enable_sql_transaction = true;
+-- result:
+-- !result
+begin;
+-- result:
+-- !result
+insert into t_nobundle select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t_nobundle select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select count(*) from t_nobundle;
+-- result:
+2000
+-- !result
+select count(distinct k1) from t_nobundle;
+-- result:
+2000
+-- !result
+set enable_sql_transaction = false;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_file_bundling_txn/T/test_multi_stmt_txn_bundling
+++ b/test/sql/test_file_bundling_txn/T/test_multi_stmt_txn_bundling
@@ -1,0 +1,97 @@
+-- name: test_multi_stmt_txn_dup_table_with_bundling @cloud
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_dup (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+
+set enable_sql_transaction = true;
+begin;
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+insert into t_dup select generate_series, concat('val_', generate_series) from TABLE(generate_series(2001, 3000));
+commit;
+
+select count(*) from t_dup;
+select count(distinct k1) from t_dup;
+select * from t_dup where k1 in (1, 500, 1000, 1500, 2000, 2500, 3000) order by k1;
+
+set enable_sql_transaction = false;
+drop database db_${uuid0} force;
+
+-- name: test_multi_stmt_txn_pk_table_with_bundling @cloud
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_pk (k1 int, v1 string)
+    primary key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+
+set enable_sql_transaction = true;
+begin;
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+insert into t_pk select generate_series, concat('val_', generate_series) from TABLE(generate_series(2001, 3000));
+commit;
+
+select count(*) from t_pk;
+select * from t_pk where k1 in (1, 500, 1000, 1500, 2000, 2500, 3000) order by k1;
+
+-- Verify update within same transaction
+begin;
+insert into t_pk select generate_series, concat('updated_', generate_series) from TABLE(generate_series(500, 600));
+insert into t_pk select generate_series, concat('new_', generate_series) from TABLE(generate_series(3001, 3500));
+commit;
+
+select count(*) from t_pk;
+select * from t_pk where k1 in (499, 500, 550, 600, 601, 3000, 3001, 3500) order by k1;
+
+set enable_sql_transaction = false;
+drop database db_${uuid0} force;
+
+-- name: test_multi_stmt_txn_rollback_with_bundling @cloud
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_rollback (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+
+insert into t_rollback select generate_series, concat('original_', generate_series) from TABLE(generate_series(1, 500));
+
+set enable_sql_transaction = true;
+begin;
+insert into t_rollback select generate_series, concat('should_disappear_', generate_series) from TABLE(generate_series(501, 1000));
+insert into t_rollback select generate_series, concat('also_disappear_', generate_series) from TABLE(generate_series(1001, 1500));
+rollback;
+
+select count(*) from t_rollback;
+select min(k1), max(k1) from t_rollback;
+
+set enable_sql_transaction = false;
+drop database db_${uuid0} force;
+
+-- name: test_multi_stmt_txn_bundling_disabled @cloud
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t_nobundle (k1 int, v1 string)
+    duplicate key(k1)
+    distributed by hash(k1) buckets 16
+    properties('replication_num' = '1', 'file_bundling' = 'false');
+
+set enable_sql_transaction = true;
+begin;
+insert into t_nobundle select generate_series, concat('val_', generate_series) from TABLE(generate_series(1, 1000));
+insert into t_nobundle select generate_series, concat('val_', generate_series) from TABLE(generate_series(1001, 2000));
+commit;
+
+select count(*) from t_nobundle;
+select count(distinct k1) from t_nobundle;
+
+set enable_sql_transaction = false;
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Enable file bundling for multi-statement transactions to reduce small file count and improve load performance in shared-data mode
- Fix mixed bundle offset detection for order-independent correctness when applying transaction logs
- Fix PK table bundle_file_offsets merge logic for proper segment mapping
- Add SQL integration tests for multi-statement transaction file bundling

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
