### PR TITLE
[Enhancement] push variant column access paths to parquet shredded readers

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -703,8 +703,7 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerParams* params) {
             std::stringstream ss;
             ss << "slot_id: " << slot->id() << " global dict: ";
             for (const auto& kv : dict_map) {
-                ss << "<" << kv.first << " " << kv.second << ">"
-                   << ", ";
+                ss << "<" << kv.first << " " << kv.second << ">" << ", ";
             }
             LOG(INFO) << ss.str();
 #endif
@@ -742,6 +741,16 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
     HdfsScannerParams scanner_params;
+    if (hdfs_scan_node.__isset.column_access_paths && _column_access_paths.empty()) {
+        for (const auto& thrift_path : hdfs_scan_node.column_access_paths) {
+            auto st = ColumnAccessPath::create(thrift_path, state, state->obj_pool());
+            if (LIKELY(st.ok())) {
+                _column_access_paths.emplace_back(std::move(st.value()));
+            } else {
+                LOG(WARNING) << "Failed to create column access path: " << st.status();
+            }
+        }
+    }
     RETURN_IF_ERROR(_init_global_dicts(&scanner_params));
     scanner_params.runtime_filter_collector = _runtime_filters;
     scanner_params.scan_range = &scan_range;
@@ -811,6 +820,9 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.use_min_max_opt = _use_min_max_opt;
     scanner_params.use_count_opt = _use_count_opt;
     scanner_params.all_conjunct_ctxs = _all_conjunct_ctxs;
+    if (!_column_access_paths.empty()) {
+        scanner_params.column_access_paths = &_column_access_paths;
+    }
 
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -703,7 +703,8 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerParams* params) {
             std::stringstream ss;
             ss << "slot_id: " << slot->id() << " global dict: ";
             for (const auto& kv : dict_map) {
-                ss << "<" << kv.first << " " << kv.second << ">" << ", ";
+                ss << "<" << kv.first << " " << kv.second << ">"
+                   << ", ";
             }
             LOG(INFO) << ss.str();
 #endif

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -16,6 +16,7 @@
 
 #include <unordered_map>
 
+#include "column/column_access_path.h"
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
 #include "exec/connector_scan_node.h"
@@ -189,6 +190,7 @@ private:
     bool _use_partition_column_value_only = false;
     // only used in global late materialization
     int32_t _scan_range_id = -1;
+    std::vector<ColumnAccessPathPtr> _column_access_paths;
 
     // ======================================
     // The following are profile metrics

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -204,6 +204,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.use_file_pagecache = _scanner_params.use_file_pagecache;
     ctx.timezone = _runtime_state->timezone();
     ctx.lake_schema = _scanner_params.lake_schema;
+    ctx.column_access_paths = _scanner_params.column_access_paths;
     ctx.stats = &_app_stats;
     ctx.lazy_column_coalesce_counter = _scanner_params.lazy_column_coalesce_counter;
     ctx.split_context = _scanner_params.split_context;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -18,6 +18,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "cache/cache_options.h"
+#include "column/column_access_path.h"
 #include "common/runtime_profile.h"
 #include "connector/deletion_vector/deletion_bitmap.h"
 #include "exec/olap_scan_prepare.h"
@@ -268,6 +269,7 @@ struct HdfsScannerParams {
     std::shared_ptr<TDeletionVectorDescriptor> deletion_vector_descriptor = nullptr;
 
     const TIcebergSchema* lake_schema = nullptr;
+    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     bool is_lazy_materialization_slot(SlotId slot_id) const;
 
@@ -371,6 +373,7 @@ struct HdfsScannerContext {
     std::string timezone;
 
     const TIcebergSchema* lake_schema = nullptr;
+    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     HdfsScanStats* stats = nullptr;
 

--- a/be/src/formats/parquet/column_reader_factory.h
+++ b/be/src/formats/parquet/column_reader_factory.h
@@ -41,6 +41,10 @@ public:
     static StatusOr<ColumnReaderPtr> create(ColumnReaderPtr raw_reader, const GlobalDictMap* dict, const SlotId slot_id,
                                             int64_t num_rows);
 
+    static StatusOr<ColumnReaderPtr> create_variant_column_reader(const ColumnReaderOptions& opts,
+                                                                  const ParquetField* variant_field,
+                                                                  const VariantShreddedReadHints& hints = {});
+
 private:
     // for struct type without schema change
     static void get_subfield_pos_with_pruned_type(const ParquetField& field, const TypeDescriptor& col_type,
@@ -51,10 +55,6 @@ private:
                                                   bool case_sensitive, const TIcebergSchemaField* lake_schema_field,
                                                   std::vector<int32_t>& pos,
                                                   std::vector<const TIcebergSchemaField*>& lake_schema_subfield);
-
-    static StatusOr<ColumnReaderPtr> create_variant_column_reader(const ColumnReaderOptions& opts,
-                                                                  const ParquetField* variant_field,
-                                                                  const VariantShreddedReadHints& hints = {});
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -268,6 +268,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.min_max_conjunct_ctxs = fd_scanner_ctx.min_max_conjunct_ctxs;
     _group_reader_param.predicate_tree = &fd_scanner_ctx.predicate_tree;
     _group_reader_param.global_dictmaps = fd_scanner_ctx.global_dictmaps;
+    _group_reader_param.column_access_paths = fd_scanner_ctx.column_access_paths;
     _group_reader_param.modification_time = _datacache_options.modification_time;
     _group_reader_param.file_size = _file_size;
     _group_reader_param.datacache_options = &_datacache_options;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include "agent/master_info.h"
@@ -25,6 +26,7 @@
 #include "base/simd/simd.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
+#include "column/variant_path_parser.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/runtime_profile.h"
 #include "common/status.h"
@@ -48,6 +50,37 @@
 #include "utils.h"
 
 namespace starrocks::parquet {
+
+namespace {
+
+bool collect_variant_leaf_paths(const ColumnAccessPath* node, std::vector<VariantSegment>* segments,
+                                std::vector<std::string>* shredded_paths) {
+    if (!node->is_field() || node->path().empty()) {
+        return false;
+    }
+
+    segments->emplace_back(VariantSegment::make_object(node->path()));
+    if (node->children().empty()) {
+        VariantPath path(*segments);
+        auto shredded_path = path.to_shredded_path();
+        if (!shredded_path.has_value()) {
+            segments->pop_back();
+            return false;
+        }
+        shredded_paths->emplace_back(std::move(*shredded_path));
+        segments->pop_back();
+        return true;
+    }
+
+    bool valid = true;
+    for (const auto& child : node->children()) {
+        valid = collect_variant_leaf_paths(child.get(), segments, shredded_paths) && valid;
+    }
+    segments->pop_back();
+    return valid;
+}
+
+} // namespace
 
 GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, SkipRowsContextPtr skip_rows_ctx,
                          int64_t row_group_first_row)
@@ -384,6 +417,43 @@ StatusOr<int64_t> GroupReader::_get_extended_bigint_value(SlotId slot_id) const 
     return node.int_literal.value;
 }
 
+VariantShreddedReadHints GroupReader::_get_variant_shredded_hints(const std::string& column_name) const {
+    VariantShreddedReadHints hints;
+    if (_param.column_access_paths == nullptr || _param.column_access_paths->empty()) {
+        return hints;
+    }
+
+    std::unordered_set<std::string> unique_paths;
+    for (const auto& access_path : *_param.column_access_paths) {
+        if (access_path == nullptr || access_path->path() != column_name) {
+            continue;
+        }
+        if (access_path->children().empty()) {
+            hints.shredded_paths.clear();
+            return hints;
+        }
+
+        std::vector<VariantSegment> segments;
+        for (const auto& child : access_path->children()) {
+            size_t old_size = hints.shredded_paths.size();
+            if (!collect_variant_leaf_paths(child.get(), &segments, &hints.shredded_paths)) {
+                hints.shredded_paths.clear();
+                return hints;
+            }
+            for (size_t i = old_size; i < hints.shredded_paths.size(); ++i) {
+                if (!unique_paths.emplace(hints.shredded_paths[i]).second) {
+                    hints.shredded_paths[i].clear();
+                }
+            }
+        }
+    }
+
+    hints.shredded_paths.erase(std::remove_if(hints.shredded_paths.begin(), hints.shredded_paths.end(),
+                                              [](const std::string& path) { return path.empty(); }),
+                               hints.shredded_paths.end());
+    return hints;
+}
+
 Status GroupReader::_create_column_readers() {
     SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
     // ColumnReaderOptions is used by all column readers in one row group
@@ -469,7 +539,12 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
     std::unique_ptr<ColumnReader> column_reader = nullptr;
     const auto* schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.idx_in_parquet);
     {
-        if (column.t_lake_schema_field == nullptr) {
+        if (column.slot_type().type == LogicalType::TYPE_VARIANT && schema_node != nullptr &&
+            schema_node->type == ColumnType::STRUCT && column.t_lake_schema_field == nullptr) {
+            VariantShreddedReadHints hints = _get_variant_shredded_hints(column.slot_desc->col_name());
+            ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create_variant_column_reader(_column_reader_opts,
+                                                                                              schema_node, hints));
+        } else if (column.t_lake_schema_field == nullptr) {
             ASSIGN_OR_RETURN(column_reader,
                              ColumnReaderFactory::create(_column_reader_opts, schema_node, column.slot_type()));
         } else {

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "column/column_access_path.h"
 #include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
@@ -29,6 +30,7 @@
 #include "exprs/expr_context.h"
 #include "formats/parquet/column_read_order_ctx.h"
 #include "formats/parquet/column_reader.h"
+#include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/utils.h"
 #include "gen_cpp/parquet_types.h"
@@ -111,6 +113,7 @@ struct GroupReaderParam {
     const std::vector<SlotDescriptor*>* reserved_field_slots = nullptr;
     // used for global low cardinality optimization
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
+    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     int32_t scan_range_id = -1;
     const THdfsScanRange* scan_range = nullptr;
@@ -160,6 +163,7 @@ private:
     StatusOr<ColumnReaderPtr> _create_reserved_iceberg_column_reader(const SlotDescriptor* slot, int32_t field_id);
     StatusOr<int64_t> _get_extended_bigint_value(SlotId slot_id) const;
     StatusOr<ColumnReaderPtr> _create_column_reader(const GroupReaderParam::Column& column);
+    VariantShreddedReadHints _get_variant_shredded_hints(const std::string& column_name) const;
     Status _prepare_column_readers() const;
     ChunkPtr _create_read_chunk(const std::vector<int>& column_indices, bool ignore_reserved_field = false);
     // Extract dict filter columns and conjuncts

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2875,7 +2875,8 @@ TEST_F(FileReaderTest, bloom_filter_reader) {
     // status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
-    std::cout << "bloom filter meta info," << " offset is set:"
+    std::cout << "bloom filter meta info,"
+              << " offset is set:"
               << file_reader->get_file_metadata()
                          ->t_metadata()
                          .row_groups[0]

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -25,6 +25,7 @@
 #include "cache/disk_cache/starcache_engine.h"
 #include "cache/disk_cache/test_cache_utils.h"
 #include "cache/mem_cache/lrucache_engine.h"
+#include "column/column_access_path.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
@@ -2874,8 +2875,7 @@ TEST_F(FileReaderTest, bloom_filter_reader) {
     // status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
-    std::cout << "bloom filter meta info,"
-              << " offset is set:"
+    std::cout << "bloom filter meta info," << " offset is set:"
               << file_reader->get_file_metadata()
                          ->t_metadata()
                          .row_groups[0]
@@ -4470,6 +4470,145 @@ TEST_F(FileReaderTest, test_read_variant_shredding) {
     ASSERT_TRUE(row1_json.value().find("\"score\":\"S81\"") != std::string::npos);
     ASSERT_TRUE(row1_json.value().find("\"rank\":\"L2\"") != std::string::npos);
     ASSERT_TRUE(row1_json.value().find("\"numbers\":[2,3,4]") != std::string::npos);
+}
+
+TEST_F(FileReaderTest, test_read_variant_shredding_with_access_paths) {
+    const std::string variant_file_path = "./be/test/formats/parquet/test_data/variant_shredding.parquet";
+    auto file_reader = _create_file_reader(variant_file_path);
+
+    TypeDescriptor variant_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT);
+    Utils::SlotDesc slot_descs[] = {{"data", variant_type}, {""}};
+    auto ctx = _create_scan_context(slot_descs, variant_file_path);
+
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+    auto root_or = ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0);
+    ASSERT_TRUE(root_or.ok()) << root_or.status().to_string();
+    auto root = std::move(root_or).value();
+    auto id_or = ColumnAccessPath::create(TAccessPathType::FIELD, "id", 0, root->absolute_path());
+    ASSERT_TRUE(id_or.ok()) << id_or.status().to_string();
+    root->children().emplace_back(std::move(id_or).value());
+    auto profile_or = ColumnAccessPath::create(TAccessPathType::FIELD, "profile", 0, root->absolute_path());
+    ASSERT_TRUE(profile_or.ok()) << profile_or.status().to_string();
+    auto profile = std::move(profile_or).value();
+    auto salary_or = ColumnAccessPath::create(TAccessPathType::FIELD, "salary", 0, profile->absolute_path());
+    ASSERT_TRUE(salary_or.ok()) << salary_or.status().to_string();
+    profile->children().emplace_back(std::move(salary_or).value());
+    root->children().emplace_back(std::move(profile));
+    column_access_paths.emplace_back(std::move(root));
+    ctx->column_access_paths = &column_access_paths;
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok()) << status.message();
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(variant_type, true), chunk->num_columns());
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok()) << status.message();
+    ASSERT_EQ(5, chunk->num_rows());
+
+    const auto* nullable = down_cast<const NullableColumn*>(chunk->get_column_by_index(0).get());
+    ASSERT_NE(nullable, nullptr);
+    const auto* variant_col = down_cast<const VariantColumn*>(nullable->data_column().get());
+    ASSERT_NE(variant_col, nullptr);
+    ASSERT_TRUE(variant_col->is_shredded_variant());
+    ASSERT_EQ(2u, variant_col->shredded_paths().size());
+    ASSERT_EQ(2u, variant_col->typed_columns().size());
+    ASSERT_TRUE(variant_col->has_metadata_column());
+    ASSERT_TRUE(variant_col->has_remain_value());
+    ASSERT_NE(-1, variant_col->find_shredded_path("id"));
+    ASSERT_NE(-1, variant_col->find_shredded_path("profile.salary"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("age"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("score"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("events"));
+
+    VariantRowValue row0;
+    ASSERT_NE(variant_col->get_row_value(0, &row0), nullptr);
+    auto row0_json = row0.to_json();
+    ASSERT_TRUE(row0_json.ok());
+    ASSERT_TRUE(row0_json.value().find("\"id\":1000") != std::string::npos);
+    ASSERT_TRUE(row0_json.value().find("\"salary\":50000.0") != std::string::npos);
+}
+
+TEST_F(FileReaderTest, test_read_variant_shredding_with_prefix_access_path) {
+    const std::string variant_file_path = "./be/test/formats/parquet/test_data/variant_shredding.parquet";
+    auto file_reader = _create_file_reader(variant_file_path);
+
+    TypeDescriptor variant_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT);
+    Utils::SlotDesc slot_descs[] = {{"data", variant_type}, {""}};
+    auto ctx = _create_scan_context(slot_descs, variant_file_path);
+
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+    auto root_or = ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0);
+    ASSERT_TRUE(root_or.ok()) << root_or.status().to_string();
+    auto root = std::move(root_or).value();
+    auto profile_or = ColumnAccessPath::create(TAccessPathType::FIELD, "profile", 0, root->absolute_path());
+    ASSERT_TRUE(profile_or.ok()) << profile_or.status().to_string();
+    root->children().emplace_back(std::move(profile_or).value());
+    column_access_paths.emplace_back(std::move(root));
+    ctx->column_access_paths = &column_access_paths;
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok()) << status.message();
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(variant_type, true), chunk->num_columns());
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok()) << status.message();
+    ASSERT_EQ(5, chunk->num_rows());
+
+    const auto* nullable = down_cast<const NullableColumn*>(chunk->get_column_by_index(0).get());
+    ASSERT_NE(nullable, nullptr);
+    const auto* variant_col = down_cast<const VariantColumn*>(nullable->data_column().get());
+    ASSERT_NE(variant_col, nullptr);
+    ASSERT_TRUE(variant_col->is_shredded_variant());
+    ASSERT_EQ(1u, variant_col->shredded_paths().size());
+    ASSERT_EQ(1u, variant_col->typed_columns().size());
+    ASSERT_NE(-1, variant_col->find_shredded_path("profile"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("profile.salary"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("profile.department"));
+    ASSERT_EQ(-1, variant_col->find_shredded_path("id"));
+
+    VariantRowValue row0;
+    ASSERT_NE(variant_col->get_row_value(0, &row0), nullptr);
+    auto row0_json = row0.to_json();
+    ASSERT_TRUE(row0_json.ok());
+    ASSERT_TRUE(row0_json.value().find("\"salary\":50000.0") != std::string::npos);
+    ASSERT_TRUE(row0_json.value().find("\"department\":\"dept_0\"") != std::string::npos);
+}
+
+TEST_F(FileReaderTest, test_read_variant_shredding_with_whole_column_access_path) {
+    const std::string variant_file_path = "./be/test/formats/parquet/test_data/variant_shredding.parquet";
+    auto file_reader = _create_file_reader(variant_file_path);
+
+    TypeDescriptor variant_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT);
+    Utils::SlotDesc slot_descs[] = {{"data", variant_type}, {""}};
+    auto ctx = _create_scan_context(slot_descs, variant_file_path);
+
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+    auto root_or = ColumnAccessPath::create(TAccessPathType::ROOT, "data", 0);
+    ASSERT_TRUE(root_or.ok()) << root_or.status().to_string();
+    column_access_paths.emplace_back(std::move(root_or).value());
+    ctx->column_access_paths = &column_access_paths;
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok()) << status.message();
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(variant_type, true), chunk->num_columns());
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok()) << status.message();
+    ASSERT_EQ(5, chunk->num_rows());
+
+    const auto* nullable = down_cast<const NullableColumn*>(chunk->get_column_by_index(0).get());
+    ASSERT_NE(nullable, nullptr);
+    const auto* variant_col = down_cast<const VariantColumn*>(nullable->data_column().get());
+    ASSERT_NE(variant_col, nullptr);
+    ASSERT_TRUE(variant_col->is_shredded_variant());
+    ASSERT_GT(variant_col->shredded_paths().size(), 2u);
+    ASSERT_NE(-1, variant_col->find_shredded_path("id"));
+    ASSERT_NE(-1, variant_col->find_shredded_path("age"));
+    ASSERT_NE(-1, variant_col->find_shredded_path("profile.salary"));
+    ASSERT_NE(-1, variant_col->find_shredded_path("events"));
 }
 
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing

FE already extracts variant subfield access paths and sends them through `THdfsScanNode.column_access_paths`, but BE was not consuming them during parquet variant reads.

As a result, variant parquet scans still auto-discovered and materialized all shredded typed columns even when the query only accessed a small subset of subpaths. That left the FE pruning work incomplete and prevented BE from treating the requested
paths as the effective typed columns to read.

This change completes that FE-to-BE path so variant shredding reads can be narrowed to the requested access paths while preserving the existing fallback behavior for full-column reads.

## What I'm doing

This PR wires `column_access_paths` through the BE HDFS/parquet scan path and uses them to guide variant shredded column materialization. 
- Thread `column_access_paths` from `HiveDataSource` through `HdfsScannerParams`, `HdfsScannerContext`, `FileReader`, and `GroupReader`.
- Add variant-specific handling in `GroupReader` so top-level `VARIANT` parquet struct columns create readers via `create_variant_column_reader(...)` with shredded-path hints.
- Convert FE `ColumnAccessPath` trees into canonical parquet variant shredded paths per top-level variant column.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
