### PR TITLE
[Enhancement] Support partial pushdown for AND compound predicates in Iceberg connector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -110,9 +110,12 @@ public class ScalarOperatorToIcebergExpr {
 
     public Expression convert(List<ScalarOperator> operators, IcebergContext context, boolean strict) {
         IcebergExprVisitor visitor = new IcebergExprVisitor();
+        IcebergContext effectiveContext = strict && !context.isStrict()
+                ? new IcebergContext(context.getSchema(), context.isInsideNot(), true)
+                : context;
         List<Expression> expressions = Lists.newArrayList();
         for (ScalarOperator operator : operators) {
-            Expression filterExpr = operator.accept(visitor, context);
+            Expression filterExpr = operator.accept(visitor, effectiveContext);
             if (filterExpr == null) {
                 if (strict) {
                     LOG.debug("Strict mode: cannot convert operator {}", operator.debugString());
@@ -141,13 +144,33 @@ public class ScalarOperatorToIcebergExpr {
 
     public static class IcebergContext {
         private final Types.StructType schema;
+        private final boolean insideNot;
+        private final boolean strict;
 
         public IcebergContext(Types.StructType schema) {
+            this(schema, false, false);
+        }
+
+        public IcebergContext(Types.StructType schema, boolean insideNot, boolean strict) {
             this.schema = schema;
+            this.insideNot = insideNot;
+            this.strict = strict;
         }
 
         public Types.StructType getSchema() {
             return schema;
+        }
+
+        public boolean isInsideNot() {
+            return insideNot;
+        }
+
+        public boolean isStrict() {
+            return strict;
+        }
+
+        public IcebergContext withInsideNot() {
+            return new IcebergContext(schema, true, strict);
         }
     }
 
@@ -185,7 +208,7 @@ public class ScalarOperatorToIcebergExpr {
                 if (operator.getChild(0) instanceof LikePredicateOperator) {
                     return null;
                 }
-                Expression expression = operator.getChild(0).accept(this, context);
+                Expression expression = operator.getChild(0).accept(this, context.withInsideNot());
 
                 if (expression != null) {
                     return not(expression);
@@ -195,6 +218,21 @@ public class ScalarOperatorToIcebergExpr {
                 Expression right = operator.getChild(1).accept(this, context);
                 if (left != null && right != null) {
                     return (op == CompoundPredicateOperator.CompoundType.OR) ? or(left, right) : and(left, right);
+                }
+                // For AND predicates outside of NOT, allow partial pushdown.
+                // If only one side converts successfully, push down that side alone.
+                // This is safe because AND(a, b) is more restrictive than just a (or just b),
+                // so pushing down one side still correctly filters data.
+                // This must NOT be done inside NOT, because NOT(AND(a, b)) = OR(NOT(a), NOT(b)),
+                // and pushing down NOT(a) alone would over-filter.
+                if (!context.isStrict() && !context.isInsideNot()
+                        && op == CompoundPredicateOperator.CompoundType.AND) {
+                    if (left != null) {
+                        return left;
+                    }
+                    if (right != null) {
+                        return right;
+                    }
                 }
             }
             return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -451,6 +451,92 @@ public class IcebergExprVisitorTest {
     }
 
     @Test
+    public void testAndPartialPushdown() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        // Build a convertible predicate: k1 > 10
+        BinaryPredicateOperator convertible = new BinaryPredicateOperator(
+                BinaryType.GT, K1, ConstantOperator.createInt(10));
+
+        // Build an unconvertible predicate: CAST(k6 AS INT) < 5
+        // CastOperator(INT, K6) where K6 is a string column causes getLiteralValue to return null
+        CastOperator cast = new CastOperator(IntegerType.INT, K6);
+        BinaryPredicateOperator unconvertible = new BinaryPredicateOperator(
+                BinaryType.LT, cast, ConstantOperator.createInt(5));
+
+        // Verify that the unconvertible predicate alone produces alwaysTrue
+        Expression unconvertibleExpr = converter.convert(Lists.newArrayList(unconvertible), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, unconvertibleExpr.op(),
+                "Unconvertible predicate should produce alwaysTrue");
+
+        Expression convertedExpr;
+        Expression expectedExpr;
+
+        // AND(convertible, unconvertible) -> returns the convertible side
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                        convertible, unconvertible)), context);
+        expectedExpr = Expressions.greaterThan("k1", 10);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "AND(convertible, unconvertible) should push down the convertible side");
+
+        // AND(unconvertible, convertible) -> returns the convertible side
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                        unconvertible, convertible)), context);
+        expectedExpr = Expressions.greaterThan("k1", 10);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "AND(unconvertible, convertible) should push down the convertible side");
+
+        // OR(convertible, unconvertible) -> returns alwaysTrue (no partial pushdown for OR)
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                        convertible, unconvertible)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "OR(convertible, unconvertible) should NOT do partial pushdown");
+
+        // NOT(AND(convertible, unconvertible)) -> returns alwaysTrue (no partial pushdown inside NOT)
+        CompoundPredicateOperator andOp = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, convertible, unconvertible);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, andOp)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "NOT(AND(convertible, unconvertible)) should NOT do partial pushdown");
+
+        // AND(convertible1, convertible2) -> returns and(left, right) (regression test)
+        BinaryPredicateOperator convertible2 = new BinaryPredicateOperator(
+                BinaryType.LT, K2, ConstantOperator.createInt(20));
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                        convertible, convertible2)), context);
+        expectedExpr = Expressions.and(
+                Expressions.greaterThan("k1", 10),
+                Expressions.lessThan("k2", 20));
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "AND(convertible1, convertible2) should return and(left, right)");
+
+        // Nested AND: AND(AND(convertible, unconvertible), convertible2) -> returns and(convertible, convertible2)
+        CompoundPredicateOperator innerAnd = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, convertible, unconvertible);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                        innerAnd, convertible2)), context);
+        expectedExpr = Expressions.and(
+                Expressions.greaterThan("k1", 10),
+                Expressions.lessThan("k2", 20));
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "AND(AND(convertible, unconvertible), convertible2) should return and(convertible, convertible2)");
+
+        // Strict mode: AND(convertible, unconvertible) -> returns null (no partial pushdown)
+        convertedExpr = converter.convertStrict(Lists.newArrayList(
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                        convertible, unconvertible)), context);
+        Assertions.assertNull(convertedExpr,
+                "Strict mode: AND(convertible, unconvertible) should return null");
+    }
+
+    @Test
     public void testConvertLastUpdatedSequenceNumberPredicate() {
         ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
         ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();


### PR DESCRIPTION
## Why I'm doing:

When converting StarRocks SQL predicates to Iceberg expressions in `ScalarOperatorToIcebergExpr.visitCompoundPredicate()`, if an `AND(left, right)` compound predicate has only one convertible side, the entire predicate is discarded. This is unnecessarily conservative -- for AND semantics, pushing down the convertible side alone is still a valid filter (it may include extra rows but never excludes valid ones). This missed optimization prevents partition pruning and data skipping in cases where at least one side of an AND predicate is pushable.

## What I'm doing:

1. **Added `insideNot` tracking to `IcebergContext`**: Added a `boolean insideNot` field with a `withInsideNot()` factory method. When visiting the child of a `NOT` expression, the context is marked as inside-NOT to prevent unsafe partial pushdown.

2. **Implemented AND partial pushdown in `visitCompoundPredicate()`**: After the existing check for both sides being non-null, added logic that returns the single convertible side when:
   - The operator is `AND` (not `OR`)
   - We are NOT inside a `NOT` expression (De Morgan safety: `NOT(AND(a,b)) = OR(NOT(a), NOT(b))`)

3. **Added comprehensive tests in `IcebergExprVisitorTest`**:
   - `AND(convertible, unconvertible)` returns the convertible side
   - `AND(unconvertible, convertible)` returns the convertible side
   - `OR(convertible, unconvertible)` still returns null (no partial pushdown)
   - `NOT(AND(convertible, unconvertible))` returns null (De Morgan safety)
   - `AND(convertible1, convertible2)` still returns `and(left, right)` (regression)
   - Nested `AND(AND(convertible, unconvertible), convertible2)` returns `and(convertible, convertible2)`

Fixes #70292

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4


