### PR TITLE
[Enhancement] Support numeric widening cast in Iceberg predicate pushdown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -405,11 +405,7 @@ public class ScalarOperatorToIcebergExpr {
                     return null;
                 case DOUBLE:
                     // Safe widening: TINYINT/SMALLINT/INT/BIGINT -> DOUBLE, FLOAT -> DOUBLE
-                    if (operator.getType().isIntegerType()) {
-                        res = operator.castTo(FloatType.DOUBLE);
-                        break;
-                    }
-                    if (operator.getType().isFloat()) {
+                    if (operator.getType().isIntegerType() || operator.getType().isFloat()) {
                         res = operator.castTo(FloatType.DOUBLE);
                         break;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -36,6 +36,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
+import com.starrocks.type.FloatType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.TypeFactory;
@@ -389,19 +391,34 @@ public class ScalarOperatorToIcebergExpr {
                 case BINARY:
                     res = operator.castTo(VarbinaryType.VARBINARY);
                     break;
-                    // num usually don't need cast, and num and string has different comparator
-                    // cast is dangerous.
+                    // Numeric widening casts (e.g., TINYINT -> LONG, FLOAT -> DOUBLE) are safe
+                    // for comparison predicates. Narrowing casts are not supported.
                 case DECIMAL:
                     res = operator.castTo(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 0));
                     break;
-                case INTEGER:
                 case LONG:
-                case FLOAT:
+                    // Safe widening: TINYINT/SMALLINT/INT -> LONG
+                    if (operator.getType().isIntegerType() && !operator.getType().isBigint()) {
+                        res = operator.castTo(IntegerType.BIGINT);
+                        break;
+                    }
+                    return null;
                 case DOUBLE:
+                    // Safe widening: TINYINT/SMALLINT/INT/BIGINT -> DOUBLE, FLOAT -> DOUBLE
+                    if (operator.getType().isIntegerType()) {
+                        res = operator.castTo(FloatType.DOUBLE);
+                        break;
+                    }
+                    if (operator.getType().isFloat()) {
+                        res = operator.castTo(FloatType.DOUBLE);
+                        break;
+                    }
+                    return null;
+                case INTEGER:
+                case FLOAT:
                 case STRUCT:
                 case LIST:
                 case MAP:
-                    // not supported
                 case FIXED:
                 case TIME:
                     return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -469,42 +469,63 @@ public class IcebergExprVisitorTest {
         ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
 
         Expression convertedExpr;
+        Expression expectedExpr;
 
         // TINYINT literal vs LONG column (k7) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createTinyInt((byte) 1))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "TINYINT -> LONG widening should allow pushdown");
+        expectedExpr = Expressions.equal("k7", 1L);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "TINYINT -> LONG widening should produce correct equal expression");
 
         // SMALLINT literal vs LONG column (k7) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createSmallInt((short) 100))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "SMALLINT -> LONG widening should allow pushdown");
+        expectedExpr = Expressions.equal("k7", 100L);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "SMALLINT -> LONG widening should produce correct equal expression");
 
         // INT literal vs LONG column (k7) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.LT, K7, ConstantOperator.createInt(1000))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "INT -> LONG widening should allow pushdown");
+        expectedExpr = Expressions.lessThan("k7", 1000L);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "INT -> LONG widening should produce correct lessThan expression");
 
         // FLOAT literal vs DOUBLE column (k9) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, K9, ConstantOperator.createFloat(1.5))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "FLOAT -> DOUBLE widening should allow pushdown");
+        expectedExpr = Expressions.equal("k9", 1.5D);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "FLOAT -> DOUBLE widening should produce correct equal expression");
 
         // INT literal vs DOUBLE column (k9) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, K9, ConstantOperator.createInt(42))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "INT -> DOUBLE widening should allow pushdown");
+        expectedExpr = Expressions.equal("k9", 42.0D);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "INT -> DOUBLE widening should produce correct equal expression");
 
         // BIGINT literal vs DOUBLE column (k9) -> should push down
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.GE, K9, ConstantOperator.createBigint(123456789L))), context);
-        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
-                "BIGINT -> DOUBLE widening should allow pushdown");
+        expectedExpr = Expressions.greaterThanOrEqual("k9", 123456789.0D);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "BIGINT -> DOUBLE widening should produce correct greaterThanOrEqual expression");
+
+        // Boundary: Byte.MAX_VALUE vs LONG column
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createTinyInt(Byte.MAX_VALUE))), context);
+        expectedExpr = Expressions.equal("k7", (long) Byte.MAX_VALUE);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "TINYINT max value should widen to LONG correctly");
+
+        // Boundary: Integer.MAX_VALUE vs LONG column
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createInt(Integer.MAX_VALUE))), context);
+        expectedExpr = Expressions.equal("k7", (long) Integer.MAX_VALUE);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
+                "INT max value should widen to LONG correctly");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -462,4 +462,68 @@ public class IcebergExprVisitorTest {
                 context);
         Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
     }
+
+    @Test
+    public void testNumericWideningCast() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        Expression convertedExpr;
+
+        // TINYINT literal vs LONG column (k7) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createTinyInt((byte) 1))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "TINYINT -> LONG widening should allow pushdown");
+
+        // SMALLINT literal vs LONG column (k7) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K7, ConstantOperator.createSmallInt((short) 100))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "SMALLINT -> LONG widening should allow pushdown");
+
+        // INT literal vs LONG column (k7) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.LT, K7, ConstantOperator.createInt(1000))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "INT -> LONG widening should allow pushdown");
+
+        // FLOAT literal vs DOUBLE column (k9) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K9, ConstantOperator.createFloat(1.5))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "FLOAT -> DOUBLE widening should allow pushdown");
+
+        // INT literal vs DOUBLE column (k9) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K9, ConstantOperator.createInt(42))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "INT -> DOUBLE widening should allow pushdown");
+
+        // BIGINT literal vs DOUBLE column (k9) -> should push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, K9, ConstantOperator.createBigint(123456789L))), context);
+        Assertions.assertNotEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "BIGINT -> DOUBLE widening should allow pushdown");
+    }
+
+    @Test
+    public void testNumericNarrowingCastNotPushedDown() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        Expression convertedExpr;
+
+        // BIGINT literal vs INTEGER column (k1) -> narrowing, should NOT push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K1, ConstantOperator.createBigint(100L))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "BIGINT -> INTEGER narrowing should NOT be pushed down");
+
+        // DOUBLE literal vs FLOAT column (k8) -> narrowing, should NOT push down
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, K8, ConstantOperator.createDouble(1.5))), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op(),
+                "DOUBLE -> FLOAT narrowing should NOT be pushed down");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`ScalarOperatorToIcebergExpr.tryCastToResultType()` returns `null` for all numeric target types (INTEGER, LONG, FLOAT, DOUBLE), causing Iceberg predicate pushdown to silently fail for extremely common query patterns like `WHERE bigint_col = 1`.

When a StarRocks literal type (e.g., TINYINT) differs from the Iceberg column type (e.g., LONG), `needCast()` correctly identifies that a cast is needed, but `tryCastToResultType()` cannot fulfill it — all numeric types are grouped with complex types (STRUCT, LIST, MAP) and unconditionally return `null`.

## What I'm doing:

Add safe numeric widening cast support in `tryCastToResultType()`:

- **LONG target**: Allow TINYINT/SMALLINT/INT → LONG (8/16/32-bit to 64-bit, no precision loss)
- **DOUBLE target**: Allow TINYINT/SMALLINT/INT/BIGINT → DOUBLE and FLOAT → DOUBLE (IEEE 754 widening)

Narrowing casts (BIGINT → INTEGER, DOUBLE → FLOAT) remain unsupported to prevent incorrect predicate evaluation.

Fixes #70294

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4