### PR TITLE
[BugFix] Align lake tablet split range stats with FE tablet stats

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -20,8 +20,6 @@
 #include <vector>
 
 #include "common/logging.h"
-#include "storage/del_vector.h"
-#include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/tablet_range.h"
@@ -41,8 +39,8 @@ struct TabletRangeInfo {
     std::unordered_map<uint32_t, Statistic> rowset_stats;
 };
 
-Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges) {
+Status get_tablet_split_ranges(const TabletMetadataPtr& tablet_metadata, int32_t split_count,
+                               std::vector<TabletRangeInfo>* split_ranges) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
@@ -54,7 +52,6 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
         Statistic stat;
     };
 
-    const bool use_delvec = is_primary_key(*tablet_metadata) && tablet_metadata->has_delvec_meta();
     std::vector<SegmentInfo> segment_infos;
     for (const auto& rowset : tablet_metadata->rowsets()) {
         if (rowset.segments_size() != rowset.segment_size_size() ||
@@ -69,23 +66,6 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
             RETURN_IF_ERROR(segment_info.max.from_proto(segment_meta.sort_key_max()));
             segment_info.stat.num_rows = segment_meta.num_rows();
             segment_info.stat.data_size = rowset.segment_size(i);
-            if (use_delvec) {
-                const uint32_t segment_id = rowset.id() + get_segment_idx(rowset, i);
-                DelVector delvec;
-                LakeIOOptions lake_io_opts{.fill_data_cache = false};
-                auto st = lake::get_del_vec(tablet_manager, *tablet_metadata, segment_id, false, lake_io_opts, &delvec);
-                if (!st.ok()) {
-                    LOG(WARNING) << "Failed to get delvec for tablet " << tablet_metadata->id() << ", segment_id "
-                                 << segment_id << ", status: " << st;
-                    continue;
-                }
-                const int64_t total_rows = segment_info.stat.num_rows;
-                const int64_t deleted_rows = delvec.cardinality();
-                const int64_t live_rows = std::max<int64_t>(0, total_rows - deleted_rows);
-                const int64_t live_size = total_rows > 0 ? segment_info.stat.data_size * live_rows / total_rows : 0;
-                segment_info.stat.num_rows = live_rows;
-                segment_info.stat.data_size = live_size;
-            }
         }
     }
 
@@ -293,8 +273,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
 
     std::vector<TabletRangeInfo> split_ranges;
-    Status status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
-                                            &split_ranges);
+    Status status = get_tablet_split_ranges(old_tablet_metadata, splitting_tablet.new_tablet_ids_size(), &split_ranges);
     if (!status.ok()) {
         LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: " << old_tablet_metadata->id()
                      << ", version: " << old_tablet_metadata->version() << ", txn_id: " << txn_info.txn_id()

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1225,8 +1225,9 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
         total_rows += new_metadata->rowsets(0).num_rows();
         total_size += new_metadata->rowsets(0).data_size();
     }
-    EXPECT_EQ(100, total_rows);
-    EXPECT_EQ(1000, total_size);
+    // Split metadata keeps the raw rowset stats. Delete vectors are applied later by get_tablet_stats().
+    EXPECT_EQ(150, total_rows);
+    EXPECT_EQ(1500, total_size);
 }
 
 TEST_F(LakeServiceTest, test_splitting_tablet_split_count_too_large_fallback) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -28,6 +28,7 @@
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
+#include "storage/del_vector.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
@@ -380,6 +381,77 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_with_gap_boundary) {
         EXPECT_GT(meta->rowsets(0).num_rows(), 0);
         EXPECT_GT(meta->rowsets(0).data_size(), 0);
     }
+}
+
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_keeps_raw_rowset_stats) {
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t tablet_id = next_id();
+
+    prepare_tablet_dirs(tablet_id);
+
+    TabletMetadataPB metadata;
+    metadata.set_id(tablet_id);
+    metadata.set_version(base_version);
+    set_primary_key_schema(&metadata, 1);
+    add_historical_schema(&metadata, 1);
+
+    auto* rowset = metadata.add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(true);
+    rowset->set_num_rows(8);
+    rowset->set_data_size(800);
+
+    rowset->add_segments("segment_0.dat");
+    rowset->add_segment_size(400);
+    auto* segment_meta0 = rowset->add_segment_metas();
+    segment_meta0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment_meta0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+    segment_meta0->set_num_rows(4);
+
+    rowset->add_segments("segment_1.dat");
+    rowset->add_segment_size(400);
+    auto* segment_meta1 = rowset->add_segment_metas();
+    segment_meta1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+    segment_meta1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    segment_meta1->set_num_rows(4);
+
+    DelVector delvec;
+    const uint32_t deleted_rows[] = {0, 1, 2};
+    delvec.init(base_version, deleted_rows, 3);
+    add_delvec(&metadata, tablet_id, base_version, rowset->id(), "test.delvec", delvec.save());
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& splitting_tablet = *resharding_tablet.mutable_splitting_tablet_info();
+    splitting_tablet.set_old_tablet_id(tablet_id);
+    const int64_t new_tablet_id_1 = next_id();
+    const int64_t new_tablet_id_2 = next_id();
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_1);
+    splitting_tablet.add_new_tablet_ids(new_tablet_id_2);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    int64_t total_child_num_rows = 0;
+    int64_t total_child_data_size = 0;
+    for (auto new_tablet_id : {new_tablet_id_1, new_tablet_id_2}) {
+        auto it = tablet_metadatas.find(new_tablet_id);
+        ASSERT_TRUE(it != tablet_metadatas.end());
+        ASSERT_EQ(1, it->second->rowsets_size());
+        total_child_num_rows += it->second->rowsets(0).num_rows();
+        total_child_data_size += it->second->rowsets(0).data_size();
+    }
+
+    EXPECT_EQ(8, total_child_num_rows);
+    EXPECT_EQ(800, total_child_data_size);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {


### PR DESCRIPTION
## Why I'm doing:
  In shared-data mode, range distribution table split uses the tablet data size reported by `get_tablet_stats()` to calculate split count on FE.

  However, `get_tablet_split_ranges()` in BE additionally deducts delete vector impact when estimating split ranges for PK tablets. This makes the split-range estimation inconsistent with the split-count input on FE. It can also cause the child tablet `num_rows`
  written during split to effectively account for delete vectors twice after split.

## What I'm doing:
  Remove delete-vector-based adjustments from `get_tablet_split_ranges()` so split range estimation stays aligned with the rowset metadata stats used by FE.

  Also add a regression test for PK tablet split with delete vectors to verify the child tablet rowset stats keep the raw metadata values during split.


Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
