### PR TITLE
[Enhancement] Disable split and reverse scan ranges for descending topn rf when config::desc_hint_split_range <= 0

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -904,7 +904,8 @@ Status SegmentIterator::_init_internal() {
     RETURN_IF_ERROR(_init_context());
 
     // reverse scan_range
-    if (!_opts.asc_hint) {
+    // when desc_hint_split_range is not greater than 0, we don't split and reverse the scan_range
+    if (!_opts.asc_hint && config::desc_hint_split_range > 0) {
         _scan_range.split_and_reverse(config::desc_hint_split_range, config::vector_chunk_size);
     }
 


### PR DESCRIPTION
## Why I'm doing:
In storage-compute-separation env, when a query contains descending topn runtime filter and other predicates on scan node and these other predicates can generate lots of  ranges(100K+), reverse this scan ranges can cause a drastic performance regression.  the ascending topn rf vs descending one is 60s vs 0.25s.

so we allow user to set desc_hint_split_range in be.conf to disable spliting and reversing scan ranges for descending topn rf.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
