### PR TITLE
[BugFix] Check distribute columns for different partitions in OlapTableSink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -859,6 +859,12 @@ public class OlapTableSink extends DataSink {
                 throw new StarRocksException("different distribute types in two different partitions, type1="
                         + selectedDistInfo.getType() + ", type2=" + distInfo.getType());
             }
+            List<String> selectedDistColumns = getDistColumns(selectedDistInfo, table);
+            List<String> currentDistColumns = getDistColumns(distInfo, table);
+            if (!selectedDistColumns.equals(currentDistColumns)) {
+                throw new StarRocksException("different distribute columns in two different partitions, columns1="
+                        + selectedDistColumns + ", columns2=" + currentDistColumns);
+            }
         }
         return selectedDistInfo;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
@@ -14,7 +14,11 @@
 
 package com.starrocks.planner;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -26,6 +30,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
 import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -33,6 +38,9 @@ import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class OlapTableSinkTest2 {
     private static StarRocksAssert starRocksAssert;
@@ -47,6 +55,22 @@ public class OlapTableSinkTest2 {
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("db2");
         starRocksAssert.withTable(createTblStmtStr);
+
+        String createRangeTableStmt = "create table db2.tbl_range(k1 int, k2 int, v1 int) " +
+                "DUPLICATE KEY(k1) " +
+                "PARTITION BY RANGE(k1) (" +
+                "  PARTITION p1 VALUES LESS THAN ('10')," +
+                "  PARTITION p2 VALUES LESS THAN ('20')" +
+                ") DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num' = '1');";
+        starRocksAssert.withTable(createRangeTableStmt);
+
+        String createListTableStmt = "create table db2.tbl_list(k1 int, k2 int, v1 int) " +
+                "DUPLICATE KEY(k1) " +
+                "PARTITION BY LIST(k1) (" +
+                "  PARTITION p1 VALUES IN ('1', '2', '3')," +
+                "  PARTITION p2 VALUES IN ('4', '5', '6')" +
+                ") DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num' = '1');";
+        starRocksAssert.withTable(createListTableStmt);
     }
 
     @Test
@@ -78,5 +102,70 @@ public class OlapTableSinkTest2 {
             return;
         }
         Assertions.fail("must throw UserException");
+    }
+
+    @Test
+    public void testRangePartitionWithDifferentDistributionColumns() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "tbl_range");
+
+        // Get two partitions
+        Partition p1 = olapTable.getPartition("p1");
+        Partition p2 = olapTable.getPartition("p2");
+        Assertions.assertNotNull(p1);
+        Assertions.assertNotNull(p2);
+
+        // Save original distribution info for p2 to restore later
+        DistributionInfo originalDistInfo = p2.getDistributionInfo();
+
+        try {
+            // Change p2's distribution columns to k2 (different from p1's k1)
+            HashDistributionInfo differentDistInfo = new HashDistributionInfo(
+                    3, Lists.newArrayList(new Column("k2", IntegerType.INT)));
+            p2.setDistributionInfo(differentDistInfo);
+
+            List<Long> partitionIds = olapTable.getPartitions().stream()
+                    .map(Partition::getId).collect(Collectors.toList());
+
+            StarRocksException exception = Assertions.assertThrows(StarRocksException.class, () -> {
+                OlapTableSink.createPartition(db.getId(), olapTable, null,
+                        false, 0, partitionIds, null);
+            });
+            Assertions.assertTrue(exception.getMessage().contains("different distribute columns"));
+        } finally {
+            p2.setDistributionInfo(originalDistInfo);
+        }
+    }
+
+    @Test
+    public void testListPartitionWithDifferentDistributionColumns() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "tbl_list");
+
+        Partition p1 = olapTable.getPartition("p1");
+        Partition p2 = olapTable.getPartition("p2");
+        Assertions.assertNotNull(p1);
+        Assertions.assertNotNull(p2);
+
+        DistributionInfo originalDistInfo = p2.getDistributionInfo();
+
+        try {
+            HashDistributionInfo differentDistInfo = new HashDistributionInfo(
+                    3, Lists.newArrayList(new Column("k2", IntegerType.INT)));
+            p2.setDistributionInfo(differentDistInfo);
+
+            List<Long> partitionIds = olapTable.getPartitions().stream()
+                    .map(Partition::getId).collect(Collectors.toList());
+
+            StarRocksException exception = Assertions.assertThrows(StarRocksException.class, () -> {
+                OlapTableSink.createPartition(db.getId(), olapTable, null,
+                        false, 0, partitionIds, null);
+            });
+            Assertions.assertTrue(exception.getMessage().contains("different distribute columns"));
+        } finally {
+            p2.setDistributionInfo(originalDistInfo);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Check distribute columns for different partitions in OlapTableSink to avoid using wrong distribution column(Due to bugs in historical versions, different partitions may have different distribution columns.)

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
