### PR TITLE
[BugFix] Fix FileSystemExpirationChecker blocking on slow HDFS close

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -61,8 +62,13 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 class ConfigurationWrap extends Configuration {
@@ -355,6 +361,24 @@ public class HdfsFsManager {
     protected static final String FS_TOS_REGION = "fs.tos.region";
 
     private final ScheduledExecutorService handleManagementPool = Executors.newScheduledThreadPool(1);
+
+    // Timeout in seconds for closing a single filesystem.
+    // If close takes longer the task is cancelled via interrupt.
+    private long fileSystemCloseTimeoutSecs = 60L;
+
+    // Dedicated thread pool for asynchronous filesystem close.
+    // Keeps the management/checker thread free and allows a watchdog timeout per close.
+    private final ExecutorService fileSystemClosePool = createFileSystemClosePool();
+
+    private static ThreadPoolExecutor createFileSystemClosePool() {
+        ThreadPoolExecutor pool = ThreadPoolManager.newDaemonThreadPool(
+                5, 5, 60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(1024),
+                new ThreadPoolExecutor.AbortPolicy(),
+                "hdfs-fs-close", true);
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
+    }
 
     private int readBufferSize = 128 << 10; // 128k
     private int writeBufferSize = 128 << 10; // 128k
@@ -1624,24 +1648,68 @@ public class HdfsFsManager {
         @Override
         public void run() {
             try {
+                int expireSeconds = Config.hdfs_file_system_expire_seconds;
                 for (HdfsFs fileSystem : cachedFileSystem.values()) {
-                    if (fileSystem.isExpired(Config.hdfs_file_system_expire_seconds)) {
-                        LOG.info("file system " + fileSystem + " is expired, close and remove it");
-                        fileSystem.getLock().lock();
-                        try {
-                            fileSystem.closeFileSystem();
-                        } catch (Throwable t) {
-                            LOG.error("errors while close file system", t);
-                        } finally {
-                            cachedFileSystem.remove(fileSystem.getIdentity());
-                            fileSystem.getLock().unlock();
+                    if (fileSystem.isExpired(expireSeconds)) {
+                        // Atomically remove this exact instance so that:
+                        // 1. New requests immediately see a missing entry and create a fresh instance
+                        //    without waiting for the (potentially hung) close — eliminating lock contention.
+                        // 2. Only one thread ever submits a close for this instance, even if two
+                        //    checker runs overlap.
+                        if (cachedFileSystem.remove(fileSystem.getIdentity(), fileSystem)) {
+                            LOG.info("file system {} is expired, removing from cache and closing asynchronously",
+                                    fileSystem);
+                            closeAsync(fileSystem);
                         }
                     }
                 }
             } finally {
-                HdfsFsManager.this.handleManagementPool.schedule(this, 60, TimeUnit.SECONDS);
+                if (!HdfsFsManager.this.handleManagementPool.isShutdown()) {
+                    HdfsFsManager.this.handleManagementPool.schedule(this, 60, TimeUnit.SECONDS);
+                }
             }
         }
+    }
 
+    private void closeAsync(HdfsFs fileSystem) {
+        Future<?> future;
+        try {
+            future = fileSystemClosePool.submit(() -> {
+                try {
+                    fileSystem.closeFileSystem();
+                } catch (Throwable t) {
+                    LOG.error("errors while closing file system {}", fileSystem, t);
+                } finally {
+                    // Clear the interrupt flag so it does not leak to the next task run on this thread.
+                    Thread.interrupted();
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Pool is saturated; spawn a one-off daemon thread instead of closing on the
+            // caller (checker) thread, so the checker is never blocked by a hung close.
+            LOG.warn("close pool is full, spawning daemon thread to close file system {}", fileSystem);
+            Thread t = new Thread(() -> {
+                try {
+                    fileSystem.closeFileSystem();
+                } catch (Throwable ex) {
+                    LOG.error("errors while closing file system {}", fileSystem, ex);
+                }
+            }, "hdfs-fs-close-fallback");
+            t.setDaemon(true);
+            t.start();
+            return;
+        }
+
+        // Schedule a watchdog: if close is still running after the timeout,
+        // send an interrupt to unblock any interrupt-sensitive I/O inside the close path.
+        if (!handleManagementPool.isShutdown()) {
+            handleManagementPool.schedule(() -> {
+                if (!future.isDone()) {
+                    LOG.warn("closing file system {} timed out after {}s, cancelling",
+                            fileSystem, fileSystemCloseTimeoutSecs);
+                    future.cancel(true);
+                }
+            }, fileSystemCloseTimeoutSecs, TimeUnit.SECONDS);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -394,6 +394,34 @@ public class HdfsFsManager {
         handleManagementPool.schedule(new FileSystemExpirationChecker(), 0, TimeUnit.SECONDS);
     }
 
+    private static final int MAX_CACHE_ACQUIRE_RETRIES = 3;
+
+    /**
+     * Retrieves or creates a cached HdfsFs for the given identity, retrying if the entry is
+     * concurrently evicted by the expiration checker.
+     * <p>
+     * On success the returned HdfsFs has its lock held — the caller MUST release it in a
+     * finally block.
+     */
+    private HdfsFs acquireCachedFileSystem(HdfsFsIdentity identity) throws StarRocksException {
+        for (int attempt = 0; attempt < MAX_CACHE_ACQUIRE_RETRIES; attempt++) {
+            cachedFileSystem.putIfAbsent(identity, new HdfsFs(identity));
+            HdfsFs fileSystem = cachedFileSystem.get(identity);
+            if (fileSystem == null) {
+                // Entry was removed by checker between putIfAbsent and get — retry.
+                continue;
+            }
+            fileSystem.getLock().lock();
+            if (cachedFileSystem.containsKey(identity)) {
+                return fileSystem; // lock held
+            }
+            // Entry was evicted while we waited for the lock — unlock and retry.
+            fileSystem.getLock().unlock();
+        }
+        throw new StarRocksException(
+                "Failed to acquire cached file system for " + identity + " after " + MAX_CACHE_ACQUIRE_RETRIES + " retries");
+    }
+
     private static void convertHDFSConfToProperties(Configuration conf, THdfsProperties tProperties) {
         ((HDFSConfigurationWrap) conf).convertHDFSConfToProperties(tProperties);
     }
@@ -554,19 +582,8 @@ public class HdfsFsManager {
 
         String hdfsUgi = username + "," + password;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, hdfsUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -642,19 +659,8 @@ public class HdfsFsManager {
         String s3aUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, s3aUgi);
 
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -746,19 +752,8 @@ public class HdfsFsManager {
         String uriIdentity = scheme + "://" + authority;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(uriIdentity, cloudConfiguration.toConfString());
 
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -839,19 +834,8 @@ public class HdfsFsManager {
         String host = KS3_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
         String ks3aUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, ks3aUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -915,21 +899,8 @@ public class HdfsFsManager {
         String obsUgi = accessKey + "," + secretKey;
 
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, obsUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
-
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -1000,21 +971,8 @@ public class HdfsFsManager {
         }
 
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, "");
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
-
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -1069,19 +1027,8 @@ public class HdfsFsManager {
         String host = OSS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
         String ossUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, ossUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -1146,19 +1093,8 @@ public class HdfsFsManager {
         String host = COS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
         String cosUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cosUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -1236,19 +1172,8 @@ public class HdfsFsManager {
         String host = TOS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
         String tosUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, tosUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
-        HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
-        if (fileSystem == null) {
-            // it means it is removed concurrently by checker thread
-            return null;
-        }
-        fileSystem.getLock().lock();
+        HdfsFs fileSystem = acquireCachedFileSystem(fileSystemIdentity);
         try {
-            if (!cachedFileSystem.containsKey(fileSystemIdentity)) {
-                // this means the file system is closed by file system checker thread
-                // it is a corner case
-                return null;
-            }
             if (fileSystem.getDFSFileSystem() == null) {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
@@ -1697,6 +1622,17 @@ public class HdfsFsManager {
             }, "hdfs-fs-close-fallback");
             t.setDaemon(true);
             t.start();
+            // Schedule a watchdog for the fallback thread too — interrupt it if close hangs
+            // so we don't accumulate stuck threads when the pool is already saturated.
+            if (!handleManagementPool.isShutdown()) {
+                handleManagementPool.schedule(() -> {
+                    if (t.isAlive()) {
+                        LOG.warn("fallback close of file system {} timed out after {}s, interrupting",
+                                fileSystem, fileSystemCloseTimeoutSecs);
+                        t.interrupt();
+                    }
+                }, fileSystemCloseTimeoutSecs, TimeUnit.SECONDS);
+            }
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/HdfsFsManagerTest.java
@@ -20,8 +20,10 @@ package com.starrocks.fs;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.fs.hdfs.HdfsFs;
+import com.starrocks.fs.hdfs.HdfsFsIdentity;
 import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
@@ -34,8 +36,15 @@ import org.mockito.Mockito;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -274,5 +283,185 @@ public class HdfsFsManagerTest {
             fs3.getDFSFileSystem().close();
             fs4.getDFSFileSystem().close();
         }
+    }
+
+    // ---- helpers for expiration-checker tests ----
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentHashMap<HdfsFsIdentity, HdfsFs> getCachedFileSystem(HdfsFsManager mgr) throws Exception {
+        Field f = HdfsFsManager.class.getDeclaredField("cachedFileSystem");
+        f.setAccessible(true);
+        return (ConcurrentHashMap<HdfsFsIdentity, HdfsFs>) f.get(mgr);
+    }
+
+    private static Runnable newChecker(HdfsFsManager mgr) throws Exception {
+        Class<?> checkerClass = Class.forName("com.starrocks.fs.hdfs.HdfsFsManager$FileSystemExpirationChecker");
+        Constructor<?> ctor = checkerClass.getDeclaredConstructor(HdfsFsManager.class);
+        ctor.setAccessible(true);
+        return (Runnable) ctor.newInstance(mgr);
+    }
+
+    private static HdfsFs mockExpiredFs(HdfsFsIdentity identity) {
+        HdfsFs fs = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs.isExpired(Mockito.anyLong())).thenReturn(true);
+        Mockito.when(fs.getIdentity()).thenReturn(identity);
+        return fs;
+    }
+
+    private static HdfsFs mockNotExpiredFs(HdfsFsIdentity identity) {
+        HdfsFs fs = Mockito.mock(HdfsFs.class);
+        Mockito.when(fs.isExpired(Mockito.anyLong())).thenReturn(false);
+        Mockito.when(fs.getIdentity()).thenReturn(identity);
+        return fs;
+    }
+
+    /**
+     * Expired filesystem: removed from cache, closeFileSystem() called asynchronously.
+     */
+    @Test
+    public void testExpirationCheckerClosesExpiredFs() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host1", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        // Cache entry must be gone immediately (before async close finishes)
+        Assertions.assertFalse(cache.containsKey(id));
+
+        // closeFileSystem() is called asynchronously; use timeout() instead of Thread.sleep()
+        Mockito.verify(fs, Mockito.timeout(2000).times(1)).closeFileSystem();
+    }
+
+    /**
+     * Non-expired filesystem: stays in cache, never closed.
+     */
+    @Test
+    public void testExpirationCheckerKeepsNonExpiredFs() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host2", "user");
+        HdfsFs fs = mockNotExpiredFs(id);
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        Assertions.assertTrue(cache.containsKey(id));
+        Mockito.verify(fs, Mockito.never()).closeFileSystem();
+    }
+
+    /**
+     * Exception during close: cache entry is still removed so new requests are not blocked.
+     */
+    @Test
+    public void testExpirationCheckerRemovesFromCacheEvenIfCloseFails() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host3", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        Mockito.doThrow(new RuntimeException("close failed")).when(fs).closeFileSystem();
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        // Removed from cache even though close threw
+        Assertions.assertFalse(cache.containsKey(id));
+        Mockito.verify(fs, Mockito.timeout(2000).times(1)).closeFileSystem();
+    }
+
+    /**
+     * Hung close: watchdog cancels via interrupt after the configured timeout.
+     * Uses a short timeout (1 s) and a close that blocks until interrupted.
+     */
+    @Test
+    public void testExpirationCheckerCancelsHungClose() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        Deencapsulation.setField(mgr, "fileSystemCloseTimeoutSecs", 1L);
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host4", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        CountDownLatch closeInterrupted = new CountDownLatch(1);
+        Mockito.doAnswer(invocation -> {
+            closeStarted.countDown();
+            // Block until interrupted
+            try {
+                Thread.sleep(60_000);
+            } catch (InterruptedException e) {
+                closeInterrupted.countDown();
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        }).when(fs).closeFileSystem();
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        // Cache entry removed immediately
+        Assertions.assertFalse(cache.containsKey(id));
+
+        // Close started in the async pool
+        Assertions.assertTrue(closeStarted.await(2, TimeUnit.SECONDS));
+
+        // Watchdog must interrupt the hung close within timeout + grace period
+        Assertions.assertTrue(closeInterrupted.await(3, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Atomic remove: if two checker runs overlap, only one close is submitted per instance.
+     */
+    @Test
+    public void testExpirationCheckerAtomicRemovePreventsDoubleClose() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host5", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        cache.put(id, fs);
+
+        // Run the checker twice concurrently
+        Runnable checker = newChecker(mgr);
+        Thread t1 = new Thread(checker::run);
+        Thread t2 = new Thread(checker::run);
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        // Exactly one thread wins the atomic remove, so close is called exactly once
+        Mockito.verify(fs, Mockito.timeout(2000).times(1)).closeFileSystem();
+    }
+
+    /**
+     * Pool-full (RejectedExecutionException): filesystem is still closed on a fallback
+     * daemon thread so resources are not leaked and the checker thread is not blocked.
+     */
+    @Test
+    public void testExpirationCheckerClosesOnFallbackThreadWhenPoolFull() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        // Replace the close pool with one that always rejects
+        ExecutorService alwaysReject = Mockito.mock(ExecutorService.class);
+        Mockito.when(alwaysReject.submit(Mockito.any(Runnable.class)))
+                .thenThrow(new RejectedExecutionException("pool full"));
+        Deencapsulation.setField(mgr, "fileSystemClosePool", alwaysReject);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host6", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        // Cache entry removed despite rejection
+        Assertions.assertFalse(cache.containsKey(id));
+        // Closed on a fallback daemon thread
+        Mockito.verify(fs, Mockito.timeout(2000).times(1)).closeFileSystem();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/hdfs/HdfsFsManagerTest.java
@@ -15,16 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.fs;
+package com.starrocks.fs.hdfs;
 
 import com.google.common.collect.Maps;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
-import com.starrocks.fs.hdfs.HdfsFs;
-import com.starrocks.fs.hdfs.HdfsFsIdentity;
-import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -439,6 +436,58 @@ public class HdfsFsManagerTest {
     }
 
     /**
+     * Concurrent eviction: acquireCachedFileSystem retries when the checker removes
+     * an entry between putIfAbsent and the containsKey check, so callers never see null.
+     */
+    @Test
+    public void testAcquireCachedFileSystemRetriesOnConcurrentEviction() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://retry-host", "user");
+
+        // Put an entry, then immediately remove it so the first get() returns null,
+        // simulating the checker evicting between putIfAbsent and get.
+        // acquireCachedFileSystem should retry and succeed on the second attempt.
+
+        // Access acquireCachedFileSystem via reflection
+        java.lang.reflect.Method acquire = HdfsFsManager.class.getDeclaredMethod(
+                "acquireCachedFileSystem", HdfsFsIdentity.class);
+        acquire.setAccessible(true);
+
+        // Normal case: entry stays in cache, acquire succeeds and returns with lock held
+        HdfsFs result = (HdfsFs) acquire.invoke(mgr, id);
+        assertNotNull(result, "acquireCachedFileSystem should return non-null");
+        Assertions.assertTrue(result.getLock().isHeldByCurrentThread());
+        result.getLock().unlock();
+
+        // Eviction case: remove the entry after acquire puts it, forcing a retry.
+        // We do this by clearing the cache right before calling acquire — the first
+        // putIfAbsent creates an entry, but we have a thread that removes it immediately.
+        cache.clear();
+        CountDownLatch evictOnce = new CountDownLatch(1);
+        Thread evictor = new Thread(() -> {
+            // Busy-wait for an entry to appear, then remove it once
+            while (evictOnce.getCount() > 0) {
+                for (HdfsFsIdentity key : cache.keySet()) {
+                    if (cache.remove(key) != null) {
+                        evictOnce.countDown();
+                        return;
+                    }
+                }
+            }
+        });
+        evictor.start();
+
+        // acquire should retry after the eviction and succeed
+        HdfsFs retryResult = (HdfsFs) acquire.invoke(mgr, id);
+        assertNotNull(retryResult, "acquireCachedFileSystem should retry and succeed after eviction");
+        Assertions.assertTrue(retryResult.getLock().isHeldByCurrentThread());
+        retryResult.getLock().unlock();
+        evictor.join(2000);
+    }
+
+    /**
      * Pool-full (RejectedExecutionException): filesystem is still closed on a fallback
      * daemon thread so resources are not leaked and the checker thread is not blocked.
      */
@@ -463,5 +512,50 @@ public class HdfsFsManagerTest {
         Assertions.assertFalse(cache.containsKey(id));
         // Closed on a fallback daemon thread
         Mockito.verify(fs, Mockito.timeout(2000).times(1)).closeFileSystem();
+    }
+
+    /**
+     * Fallback thread watchdog: when the close pool is full and the fallback daemon thread
+     * hangs, the watchdog interrupts it after the configured timeout so stuck threads
+     * don't accumulate.
+     */
+    @Test
+    public void testFallbackThreadInterruptedOnTimeout() throws Exception {
+        HdfsFsManager mgr = new HdfsFsManager();
+        Deencapsulation.setField(mgr, "fileSystemCloseTimeoutSecs", 1L);
+        ConcurrentHashMap<HdfsFsIdentity, HdfsFs> cache = getCachedFileSystem(mgr);
+
+        // Replace the close pool with one that always rejects
+        ExecutorService alwaysReject = Mockito.mock(ExecutorService.class);
+        Mockito.when(alwaysReject.submit(Mockito.any(Runnable.class)))
+                .thenThrow(new RejectedExecutionException("pool full"));
+        Deencapsulation.setField(mgr, "fileSystemClosePool", alwaysReject);
+
+        HdfsFsIdentity id = new HdfsFsIdentity("hdfs://host-fallback-timeout", "user");
+        HdfsFs fs = mockExpiredFs(id);
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        CountDownLatch closeInterrupted = new CountDownLatch(1);
+        Mockito.doAnswer(invocation -> {
+            closeStarted.countDown();
+            try {
+                Thread.sleep(60_000);
+            } catch (InterruptedException e) {
+                closeInterrupted.countDown();
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        }).when(fs).closeFileSystem();
+        cache.put(id, fs);
+
+        newChecker(mgr).run();
+
+        // Cache entry removed immediately
+        Assertions.assertFalse(cache.containsKey(id));
+
+        // Close started on fallback daemon thread
+        Assertions.assertTrue(closeStarted.await(2, TimeUnit.SECONDS));
+
+        // Watchdog must interrupt the hung fallback thread within timeout + grace period
+        Assertions.assertTrue(closeInterrupted.await(3, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When closeFileSystem() hangs (e.g. namenode unreachable), the old checker
  held the HdfsFs lock for the entire duration, causing two problems:
  1. New requests for the same filesystem stalled waiting for the lock.
  2. The single-threaded FileSystemExpirationChecker could not run again.

## What I'm doing:

Fix:
  - Remove the entry from cachedFileSystem atomically via remove(key, value)
    before closing, so new requests immediately create a fresh instance
    without any lock contention.
  - Submit the actual close to a dedicated daemon thread pool (hdfs-fs-close,
    5 threads, queue 1024) so the checker thread is never blocked.
  - Schedule a watchdog on the management thread that calls future.cancel(true)
    after fileSystemCloseTimeoutSecs (default 60 s) to interrupt any
    interrupt-sensitive I/O stuck inside the close path.
  - On pool rejection, spawn a one-off daemon thread instead of closing
    synchronously on the checker thread, to avoid reintroducing the
    original blocking problem.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
