### PR TITLE
[BugFix] Expose warehouse name in task_runs system table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -82,6 +82,7 @@ public class TaskRunsSystemTable extends SystemTable {
                         .column("FINISH_TIME", DATETIME)
                         .column("STATE", TypeFactory.createVarcharType(16))
                         .column("CATALOG", TypeFactory.createVarcharType(64))
+                        .column("WAREHOUSE", TypeFactory.createVarcharType(64))
                         .column("DATABASE", TypeFactory.createVarcharType(64))
                         .column("DEFINITION", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", DATETIME)
@@ -203,6 +204,7 @@ public class TaskRunsSystemTable extends SystemTable {
             info.setFinish_time(status.getFinishTime() / 1000);
             info.setState(status.getState().toString());
             info.setCatalog(status.getCatalogName());
+            info.setWarehouse(status.getWarehouseName());
             info.setDatabase(ClusterNamespace.getNameFromFullName(status.getDbName()));
             if (!Strings.isEmpty(status.getDefinition())) {
                 if (Config.enable_task_info_mask_credential) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -22,9 +22,11 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskRun;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
@@ -224,6 +226,15 @@ public class TaskRunStatus implements Writable {
 
     public void setCatalogName(String catalogName) {
         this.catalogName = catalogName;
+    }
+
+    public String getWarehouseName() {
+        if (properties != null) {
+            return properties.getOrDefault(PropertyAnalyzer.PROPERTIES_WAREHOUSE,
+                    WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+        } else {
+            return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        }
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TaskRunsSystemTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TaskRunsSystemTableTest.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.google.common.collect.Lists;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.thrift.TGetTaskRunInfoResult;
+import com.starrocks.thrift.TGetTasksParams;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TaskRunsSystemTableTest {
+
+    @Test
+    public void testSchemaContainsWarehouseColumn() {
+        SystemTable table = TaskRunsSystemTable.getInstance();
+        boolean hasWarehouse = table.getBaseSchema().stream()
+                .map(Column::getName)
+                .anyMatch("WAREHOUSE"::equalsIgnoreCase);
+        Assertions.assertTrue(hasWarehouse, "task_runs system table should have a WAREHOUSE column");
+    }
+
+    @Test
+    public void testQuerySetsWarehouseFromStatus(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked TaskManager taskManager) {
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("q1");
+        status.setTaskName("task1");
+        status.setDbName("db1");
+        Map<String, String> props = new HashMap<>();
+        props.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE, "my_warehouse");
+        status.setProperties(props);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getTaskManager();
+                minTimes = 0;
+                result = taskManager;
+
+                taskManager.getMatchedTaskRunStatus((TGetTasksParams) any);
+                result = Lists.newArrayList(status);
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext context, String catalogName, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        TGetTaskRunInfoResult result = TaskRunsSystemTable.query(new TGetTasksParams());
+
+        Assertions.assertEquals(1, result.getTask_runs().size());
+        Assertions.assertEquals("my_warehouse", result.getTask_runs().get(0).getWarehouse());
+    }
+
+    @Test
+    public void testQuerySetsDefaultWarehouseWhenPropertiesAbsent(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked TaskManager taskManager) {
+        TaskRunStatus status = new TaskRunStatus();
+        status.setQueryId("q2");
+        status.setTaskName("task2");
+        status.setDbName("db1");
+        // no properties → getWarehouseName() returns DEFAULT_WAREHOUSE_NAME
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getTaskManager();
+                minTimes = 0;
+                result = taskManager;
+
+                taskManager.getMatchedTaskRunStatus((TGetTasksParams) any);
+                result = Lists.newArrayList(status);
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext context, String catalogName, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        TGetTaskRunInfoResult result = TaskRunsSystemTable.query(new TGetTasksParams());
+
+        Assertions.assertEquals(1, result.getTask_runs().size());
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME,
+                result.getTask_runs().get(0).getWarehouse());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunStatusTest.java
@@ -15,12 +15,40 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.server.WarehouseManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class TaskRunStatusTest {
+
+    @Test
+    public void testGetWarehouseNameReturnsDefaultWhenPropertiesNull() {
+        TaskRunStatus status = new TaskRunStatus();
+        // properties is null by default
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, status.getWarehouseName());
+    }
+
+    @Test
+    public void testGetWarehouseNameReturnsDefaultWhenWarehouseKeyAbsent() {
+        TaskRunStatus status = new TaskRunStatus();
+        status.setProperties(new HashMap<>());
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, status.getWarehouseName());
+    }
+
+    @Test
+    public void testGetWarehouseNameReturnsValueFromProperties() {
+        TaskRunStatus status = new TaskRunStatus();
+        Map<String, String> props = new HashMap<>();
+        props.put(PropertyAnalyzer.PROPERTIES_WAREHOUSE, "my_warehouse");
+        status.setProperties(props);
+        Assertions.assertEquals("my_warehouse", status.getWarehouseName());
+    }
 
     @Test
     public void getLastRefreshStateReturnsStateWhenNotMVTask() {

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -381,8 +381,8 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         starRocksAssert.query("select * from information_schema.task_runs where task_name = 't_1024' ")
                 .explainContains("     constant exprs: ",
                         "NULL | 't_1024' | '2024-01-02 03:04:05' | '2024-01-02 03:04:05' | 'SUCCESS' | " +
-                                "NULL | 'd1' | 'insert into t1 select * from t1' | '2024-01-02 03:04:05' | 0 | " +
-                                "NULL | '0%' | '' | NULL");
+                                "NULL | 'default_warehouse' | 'd1' | 'insert into t1 select * from t1' | " +
+                                "'2024-01-02 03:04:05' | 0 | NULL | '0%' | '' | NULL | NULL | '1970-01-01 08:00:00'");
         starRocksAssert.query("select state, error_message" +
                         " from information_schema.task_runs where task_name = 't_1024' ")
                 .explainContains("     constant exprs: ",

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -532,8 +532,10 @@ struct TTaskRunInfo {
     13: optional string properties
 
     14: optional string catalog
-    15: optional string job_id
-    16: optional i64 process_time
+    15: optional string warehouse
+
+    16: optional string job_id
+    17: optional i64 process_time
 }
 
 struct TGetTaskRunInfoResult {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request adds support for tracking and exposing the warehouse information associated with task runs in the StarRocks system. The changes update the schema, query logic, and data model to include a new `WAREHOUSE` column, and ensure that this information is correctly retrieved and defaults are handled. Comprehensive tests are also added to verify the new functionality.

Schema and API changes:

* Added a `WAREHOUSE` column to the `task_runs` system table schema (`TaskRunsSystemTable.java`, `FrontendService.thrift`). [[1]](diffhunk://#diff-a27eee3cda29e617b12d0349a71af414006bbfa85afed422df4f9a5de6f6f945R85) [[2]](diffhunk://#diff-495a460155960d9f0436a79b9d25a7cab6af0baee4bd1895839abb357104ed82L535-R538)
* Updated the `query` method in `TaskRunsSystemTable` to set the warehouse field from task run status (`TaskRunsSystemTable.java`).

Data model changes:

* Introduced the `getWarehouseName()` method in `TaskRunStatus` to retrieve the warehouse name from properties, with fallback to the default warehouse name (`TaskRunStatus.java`).
* Added necessary imports for warehouse support in `TaskRunStatus` (`TaskRunStatus.java`).

Testing improvements:

* Added unit tests to verify the presence of the `WAREHOUSE` column, correct warehouse value assignment, and default behavior when warehouse information is absent (`TaskRunsSystemTableTest.java`, `TaskRunStatusTest.java`). [[1]](diffhunk://#diff-1e9455ad35bdbfbc797584e0c9119349de178fa2ea889953d14f9a3e59706ddaR1-R129) [[2]](diffhunk://#diff-68d174cf433c5891f819d1b540a20a04e940fb97a62e32409c89f307d61abcf2R18-R52)
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
