### PR TITLE
[Enhancement] Make create text file table can add delimeter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -110,7 +110,13 @@ import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
 public class HiveMetastoreApiConverter {
     private static final Logger LOG = LogManager.getLogger(HiveMetastoreApiConverter.class);
     private static final String SPARK_SQL_SOURCE_PROVIDER = "spark.sql.sources.provider";
+    private static final String HIVE2_COLLECTION_DELIM = "colelction.delim";
     private static final Set<String> STATS_PROPERTIES = ImmutableSet.of(ROW_COUNT, TOTAL_SIZE, NUM_FILES);
+    private static final ImmutableList<String> SERDE_PROPERTY_KEYS = ImmutableList.of(
+            serdeConstants.FIELD_DELIM, serdeConstants.LINE_DELIM,
+            serdeConstants.COLLECTION_DELIM, serdeConstants.MAPKEY_DELIM,
+            OpenCSVSerde.SEPARATORCHAR, serdeConstants.HEADER_COUNT,
+            serdeConstants.SERIALIZATION_FORMAT, HIVE2_COLLECTION_DELIM);
 
     private static boolean isDeltaLakeTable(Map<String, String> tableParams) {
         return tableParams.containsKey(SPARK_SQL_SOURCE_PROVIDER) &&
@@ -231,6 +237,7 @@ public class HiveMetastoreApiConverter {
         serdeInfo.setName(table.getCatalogTableName());
         HiveStorageFormat storageFormat = table.getStorageFormat();
         serdeInfo.setSerializationLib(storageFormat.getSerde());
+        serdeInfo.setParameters(table.getSerdeProperties());
 
         StorageDescriptor sd = new StorageDescriptor();
         sd.setLocation(table.getTableLocation());
@@ -581,6 +588,16 @@ public class HiveMetastoreApiConverter {
         return RemoteFileInputFormat.fromHdfsInputFormatClass(inputFormat);
     }
 
+    public static Map<String, String> extractSerdeProperties(Map<String, String> properties) {
+        Map<String, String> serdeProps = Maps.newHashMap();
+        for (String key : SERDE_PROPERTY_KEYS) {
+            if (properties.containsKey(key)) {
+                serdeProps.put(key, properties.get(key));
+            }
+        }
+        return serdeProps;
+    }
+
     public static TextFileFormatDesc toTextFileFormatDesc(Map<String, String> parameters) {
         // Get properties 'field.delim', 'line.delim', 'collection.delim' and 'mapkey.delim' from StorageDescriptor
         // Detail refer to:
@@ -590,8 +607,8 @@ public class HiveMetastoreApiConverter {
         // There is a typo in Hive 2.x version, and fixed in Hive 3.x version.
         // https://issues.apache.org/jira/browse/HIVE-16922
         String collectionDelim;
-        if (parameters.containsKey("colelction.delim")) {
-            collectionDelim = parameters.getOrDefault("colelction.delim", "");
+        if (parameters.containsKey(HIVE2_COLLECTION_DELIM)) {
+            collectionDelim = parameters.getOrDefault(HIVE2_COLLECTION_DELIM, "");
         } else {
             collectionDelim = parameters.getOrDefault(serdeConstants.COLLECTION_DELIM, "");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -175,6 +175,7 @@ public class HiveMetastoreOperations {
         }
 
         HiveStorageFormat.check(properties);
+        Map<String, String> serdeProps = HiveMetastoreApiConverter.extractSerdeProperties(properties);
 
         List<String> partitionColNames;
         if (partitionColumns.isEmpty()) {
@@ -204,6 +205,7 @@ public class HiveMetastoreOperations {
                 .setTableLocation(tablePath == null ? null : tablePath.toString())
                 .setProperties(stmt.getProperties())
                 .setStorageFormat(HiveStorageFormat.get(properties.getOrDefault(FILE_FORMAT, PARQUET.name())))
+                .setSerdeProperties(serdeProps)
                 .setCreateTime(System.currentTimeMillis())
                 .setHiveTableType(tableType);
         Table table = builder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/HiveMetastoreApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/HiveMetastoreApiConverterTest.java
@@ -225,6 +225,64 @@ public class HiveMetastoreApiConverterTest {
     }
 
     @Test
+    public void testToMetastoreApiTableWithSerdeProperties() {
+        Map<String, String> serdeProperties = new HashMap<>();
+        serdeProperties.put("field.delim", ",");
+        serdeProperties.put("collection.delim", "|");
+        serdeProperties.put("mapkey.delim", ":");
+        serdeProperties.put("line.delim", "\n");
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setCatalogName("hive_catalog")
+                .setHiveDbName("hive_db")
+                .setHiveTableName("text_table")
+                .setPartitionColumnNames(Lists.newArrayList("p1"))
+                .setFullSchema(Lists.newArrayList(new Column("c1", IntegerType.INT), new Column("p1", IntegerType.INT)))
+                .setDataColumnNames(Lists.newArrayList("c1"))
+                .setTableLocation("table_location")
+                .setStorageFormat(HiveStorageFormat.TEXTFILE)
+                .setSerdeProperties(serdeProperties)
+                .build();
+
+        Table table = HiveMetastoreApiConverter.toMetastoreApiTable(hiveTable);
+        Map<String, String> serdeParams = table.getSd().getSerdeInfo().getParameters();
+        Assertions.assertNotNull(serdeParams);
+        Assertions.assertEquals(",", serdeParams.get("field.delim"));
+        Assertions.assertEquals("|", serdeParams.get("collection.delim"));
+        Assertions.assertEquals(":", serdeParams.get("mapkey.delim"));
+        Assertions.assertEquals("\n", serdeParams.get("line.delim"));
+    }
+
+    @Test
+    public void testExtractSerdeProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("file_format", "textfile");
+        properties.put("field.delim", ",");
+        properties.put("collection.delim", "|");
+        properties.put("mapkey.delim", ":");
+        properties.put("line.delim", "\n");
+        properties.put("some_other_prop", "value");
+
+        Map<String, String> serdeProps = HiveMetastoreApiConverter.extractSerdeProperties(properties);
+        Assertions.assertEquals(4, serdeProps.size());
+        Assertions.assertEquals(",", serdeProps.get("field.delim"));
+        Assertions.assertEquals("|", serdeProps.get("collection.delim"));
+        Assertions.assertEquals(":", serdeProps.get("mapkey.delim"));
+        Assertions.assertEquals("\n", serdeProps.get("line.delim"));
+        Assertions.assertFalse(serdeProps.containsKey("file_format"));
+        Assertions.assertFalse(serdeProps.containsKey("some_other_prop"));
+    }
+
+    @Test
+    public void testExtractSerdePropertiesEmpty() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("file_format", "parquet");
+
+        Map<String, String> serdeProps = HiveMetastoreApiConverter.extractSerdeProperties(properties);
+        Assertions.assertTrue(serdeProps.isEmpty());
+    }
+
+    @Test
     public void testToApiTableProperties() {
         HiveTable hiveTable = HiveTable.builder()
                 .setCatalogName("hive_catalog")


### PR DESCRIPTION
## Why I'm doing:
Currently StarRocks can not create Hive text table with user defined delimeter.
In this patch I will implement this one.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
