### PR TITLE
[BugFix] set comment when creating hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -205,6 +205,7 @@ public class HiveMetastoreOperations {
                 .setProperties(stmt.getProperties())
                 .setStorageFormat(HiveStorageFormat.get(properties.getOrDefault(FILE_FORMAT, PARQUET.name())))
                 .setCreateTime(System.currentTimeMillis())
+                .setComment(stmt.getComment())
                 .setHiveTableType(tableType);
         Table table = builder.build();
         try {

--- a/test/sql/test_hive/R/test_hive_comment
+++ b/test/sql/test_hive/R/test_hive_comment
@@ -1,0 +1,40 @@
+-- name: test_hive_table_with_comment
+create external catalog hive_catalog_${uuid0} PROPERTIES (
+    "type"="hive",
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+create database hive_catalog_${uuid0}.test_hive_comment_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_catalog_${uuid0}/test_hive_comment_db_${uuid0}"
+);
+-- result:
+-- !result
+create table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test (
+    id int comment 'id column comment',
+    name varchar(20) comment 'name column comment'
+)
+comment 'table level comment';
+-- result:
+-- !result
+show create table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test;
+-- result:
+[REGEX]t_comment_test\s+CREATE TABLE `t_comment_test` \(
+\s+`id` int\(11\).*COMMENT "id column comment",
+\s+`name` varchar\(80\).*COMMENT "name column comment"
+\)
+COMMENT \("table level comment"\)
+\s*
+-- !result
+drop table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test force;
+-- result:
+-- !result
+drop database hive_catalog_${uuid0}.test_hive_comment_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_catalog_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_hive/T/test_hive_comment
+++ b/test/sql/test_hive/T/test_hive_comment
@@ -1,0 +1,25 @@
+-- name: test_hive_table_with_comment
+
+create external catalog hive_catalog_${uuid0} PROPERTIES (
+    "type"="hive",
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+create database hive_catalog_${uuid0}.test_hive_comment_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_catalog_${uuid0}/test_hive_comment_db_${uuid0}"
+);
+
+create table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test (
+    id int comment 'id column comment',
+    name varchar(20) comment 'name column comment'
+)
+comment 'table level comment';
+
+show create table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test;
+
+drop table hive_catalog_${uuid0}.test_hive_comment_db_${uuid0}.t_comment_test force;
+drop database hive_catalog_${uuid0}.test_hive_comment_db_${uuid0};
+drop catalog hive_catalog_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
When creating Hive external tables through StarRocks, table comments were not correctly written into the Hive metastore.

## What I'm doing:
Ensure that when StarRocks creates a Hive table, the table comments are properly set on the Hive side.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
