### PR TITLE
[Tool] Fix macOS Homebrew prefix detection in build scripts

### DIFF
--- a/build-mac/build_thirdparty.sh
+++ b/build-mac/build_thirdparty.sh
@@ -36,6 +36,25 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+resolve_brew_prefix() {
+    local formula="$1"
+    local fallback="$2"
+    local prefix=""
+
+    prefix="$(brew --prefix "${formula}" 2>/dev/null || true)"
+    if [[ -n "${prefix}" && -d "${prefix}" ]]; then
+        echo "${prefix}"
+        return 0
+    fi
+
+    if [[ -n "${fallback}" && -d "${fallback}" ]]; then
+        echo "${fallback}"
+        return 0
+    fi
+
+    echo "${prefix:-$fallback}"
+}
+
 usage() {
     echo "Usage: $(basename "$0") [OPTIONS]"
     echo ""
@@ -114,12 +133,20 @@ if ! command -v brew >/dev/null 2>&1; then
 fi
 
 # Setup environment variables
-export HOMEBREW_PREFIX="/opt/homebrew"
-export CC="$HOMEBREW_PREFIX/opt/llvm/bin/clang"
-export CXX="$HOMEBREW_PREFIX/opt/llvm/bin/clang++"
-export AR="$HOMEBREW_PREFIX/opt/llvm/bin/llvm-ar"
-export RANLIB="$HOMEBREW_PREFIX/opt/llvm/bin/llvm-ranlib"
-export OPENSSL_ROOT_DIR="$HOMEBREW_PREFIX/opt/openssl@3"
+export HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix 2>/dev/null || true)}"
+if [[ -z "${HOMEBREW_PREFIX}" ]]; then
+    if [[ -d /opt/homebrew ]]; then
+        export HOMEBREW_PREFIX="/opt/homebrew"
+    else
+        export HOMEBREW_PREFIX="/usr/local"
+    fi
+fi
+export STARROCKS_LLVM_HOME="${STARROCKS_LLVM_HOME:-$(resolve_brew_prefix llvm "${HOMEBREW_PREFIX}/opt/llvm")}"
+export CC="$STARROCKS_LLVM_HOME/bin/clang"
+export CXX="$STARROCKS_LLVM_HOME/bin/clang++"
+export AR="$STARROCKS_LLVM_HOME/bin/llvm-ar"
+export RANLIB="$STARROCKS_LLVM_HOME/bin/llvm-ranlib"
+export OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$(resolve_brew_prefix openssl@3 "${HOMEBREW_PREFIX}/opt/openssl@3")}"
 export PKG_CONFIG_PATH="$OPENSSL_ROOT_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 export CFLAGS="-march=armv8-a -O3"
 export CXXFLAGS="-march=armv8-a -O3 -stdlib=libc++"
@@ -1352,8 +1379,8 @@ build_vectorscan() {
     fi
 
     # Set boost path for homebrew with detected version
-    export BOOST_ROOT="/opt/homebrew"
-    export Boost_DIR="/opt/homebrew/lib/cmake/Boost-$boost_version"
+    export BOOST_ROOT="${HOMEBREW_PREFIX}"
+    export Boost_DIR="${HOMEBREW_PREFIX}/lib/cmake/Boost-$boost_version"
 
     log_info "Using Boost version $boost_version"
 
@@ -1374,8 +1401,8 @@ build_vectorscan() {
         -DCORRECT_PCRE_VERSION=OFF \
         -DCMAKE_C_FLAGS="${CFLAGS} -Wno-error" \
         -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_LIBCPP_HAS_NO_HASH_MEMORY=1 -Wno-error" \
-        -DBOOST_ROOT="/opt/homebrew" \
-        -DBoost_DIR="/opt/homebrew/lib/cmake/Boost-$boost_version" \
+        -DBOOST_ROOT="${HOMEBREW_PREFIX}" \
+        -DBoost_DIR="${HOMEBREW_PREFIX}/lib/cmake/Boost-$boost_version" \
         -DBoost_NO_SYSTEM_PATHS=ON \
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 

--- a/build-mac/env_macos.sh
+++ b/build-mac/env_macos.sh
@@ -37,6 +37,25 @@ detect_parallelism() {
     echo "${cpu_count}"
 }
 
+resolve_brew_prefix() {
+    local formula="$1"
+    local fallback="$2"
+    local prefix=""
+
+    prefix="$(brew --prefix "${formula}" 2>/dev/null || true)"
+    if [[ -n "${prefix}" && -d "${prefix}" ]]; then
+        echo "${prefix}"
+        return 0
+    fi
+
+    if [[ -n "${fallback}" && -d "${fallback}" ]]; then
+        echo "${fallback}"
+        return 0
+    fi
+
+    echo "${prefix:-$fallback}"
+}
+
 # ============================================================================
 # BASIC PATHS
 # ============================================================================
@@ -74,7 +93,17 @@ fi
 # ============================================================================
 # HOMEBREW CONFIGURATION
 # ============================================================================
-export HOMEBREW_PREFIX="/opt/homebrew"
+if [[ -z "${HOMEBREW_PREFIX:-}" ]]; then
+    HOMEBREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+    if [[ -z "${HOMEBREW_PREFIX}" ]]; then
+        if [[ -d /opt/homebrew ]]; then
+            HOMEBREW_PREFIX="/opt/homebrew"
+        else
+            HOMEBREW_PREFIX="/usr/local"
+        fi
+    fi
+fi
+export HOMEBREW_PREFIX
 export HOMEBREW_NO_AUTO_UPDATE=1  # Speed up builds
 
 # Add Homebrew to PATH if not already there
@@ -86,7 +115,7 @@ fi
 # COMPILER CONFIGURATION
 # ============================================================================
 # Use Homebrew LLVM for consistent C++17 support
-export LLVM_HOME="$HOMEBREW_PREFIX/opt/llvm"
+export LLVM_HOME="${LLVM_HOME:-${STARROCKS_LLVM_HOME:-$(resolve_brew_prefix llvm "${HOMEBREW_PREFIX}/opt/llvm")}}"
 
 if [[ ! -d "$LLVM_HOME" ]]; then
     log_error "LLVM not found at $LLVM_HOME. Please run: brew install llvm"
@@ -157,7 +186,7 @@ log_info "Parallel jobs: $PARALLEL"
 # ============================================================================
 
 # OpenSSL (keg-only in Homebrew)
-export OPENSSL_ROOT_DIR="$HOMEBREW_PREFIX/opt/openssl@3"
+export OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$(resolve_brew_prefix openssl@3 "${HOMEBREW_PREFIX}/opt/openssl@3")}"
 if [[ -d "$OPENSSL_ROOT_DIR" ]]; then
     export PKG_CONFIG_PATH="$OPENSSL_ROOT_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
     export CPPFLAGS="-I$OPENSSL_ROOT_DIR/include $CPPFLAGS"
@@ -167,7 +196,7 @@ else
 fi
 
 # cURL (keg-only in Homebrew)
-export CURL_ROOT="$HOMEBREW_PREFIX/opt/curl"
+export CURL_ROOT="${CURL_ROOT:-$(resolve_brew_prefix curl "${HOMEBREW_PREFIX}/opt/curl")}"
 if [[ -d "$CURL_ROOT" ]]; then
     export PKG_CONFIG_PATH="$CURL_ROOT/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
     export CPPFLAGS="-I$CURL_ROOT/include $CPPFLAGS"
@@ -175,7 +204,7 @@ if [[ -d "$CURL_ROOT" ]]; then
 fi
 
 # ICU4C (keg-only in Homebrew)
-export ICU_ROOT="$HOMEBREW_PREFIX/opt/icu4c"
+export ICU_ROOT="${ICU_ROOT:-$(resolve_brew_prefix icu4c "${HOMEBREW_PREFIX}/opt/icu4c")}"
 if [[ -d "$ICU_ROOT" ]]; then
     export PKG_CONFIG_PATH="$ICU_ROOT/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
     export CPPFLAGS="-I$ICU_ROOT/include $CPPFLAGS"


### PR DESCRIPTION
## Why I'm doing:

The macOS build helper scripts hardcode Homebrew paths to `/opt/homebrew`. On machines where Homebrew is installed under `/usr/local`, the build fails during environment setup with errors like:

`LLVM not found at /opt/homebrew/opt/llvm`

This makes the FE/macOS build scripts unnecessarily dependent on a specific Homebrew layout.

## What I'm doing:

- Update `build-mac/env_macos.sh` to resolve Homebrew and formula prefixes dynamically with `brew --prefix`
- Add fallback logic for both `/opt/homebrew` and `/usr/local`
- Resolve `LLVM_HOME`, `OPENSSL_ROOT_DIR`, `CURL_ROOT`, and `ICU_ROOT` from the actual Homebrew installation instead of hardcoded paths
- Update `build-mac/build_thirdparty.sh` to use the same dynamic Homebrew prefix detection
- Replace the hardcoded Boost path used by vectorscan with a prefix derived from the detected Homebrew root

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
