### PR TITLE
[Enhancement] Add colocate metadata for range distribution colocate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateGroupSchema.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateGroupSchema.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
+import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -60,16 +61,20 @@ public class ColocateGroupSchema implements Writable {
     private int bucketsNum;
     @SerializedName("rn")
     private short replicationNum;
+    @SerializedName("dt")
+    private DistributionInfoType distributionType = DistributionInfoType.HASH;
 
     private ColocateGroupSchema() {
 
     }
 
-    public ColocateGroupSchema(GroupId groupId, List<Column> distributionCols, int bucketsNum, short replicationNum) {
+    public ColocateGroupSchema(GroupId groupId, List<Column> distributionCols, int bucketsNum,
+                                short replicationNum, DistributionInfoType distributionType) {
         this.groupId = groupId;
         this.distributionColTypes = distributionCols.stream().map(c -> c.getType()).collect(Collectors.toList());
         this.bucketsNum = bucketsNum;
         this.replicationNum = replicationNum;
+        this.distributionType = distributionType;
     }
 
     public GroupId getGroupId() {
@@ -88,13 +93,35 @@ public class ColocateGroupSchema implements Writable {
         return distributionColTypes;
     }
 
+    public DistributionInfoType getDistributionType() {
+        return distributionType;
+    }
+
+    public boolean isRangeColocate() {
+        return distributionType == DistributionInfoType.RANGE;
+    }
+
+    /**
+     * Returns the number of colocate columns (sort key prefix length) for range colocate groups,
+     * or the number of hash distribution columns for hash colocate groups.
+     */
+    public int getColocateColumnCount() {
+        return distributionColTypes.size();
+    }
+
     public void checkColocateSchema(OlapTable tbl) throws DdlException {
-        checkDistribution(tbl.getIdToColumn(), tbl.getDefaultDistributionInfo());
+        checkDistribution(tbl, tbl.getDefaultDistributionInfo());
         checkReplicationNum(tbl.getPartitionInfo());
     }
 
-    public void checkDistribution(Map<ColumnId, Column> idToColumn, DistributionInfo distributionInfo)
+    public void checkDistribution(OlapTable table, DistributionInfo distributionInfo)
             throws DdlException {
+        // check distribution type consistency
+        if (distributionInfo.getType() != distributionType) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_TYPE,
+                    groupId.toString(), distributionType.name(), distributionInfo.getType().name());
+        }
+
         if (distributionInfo instanceof HashDistributionInfo) {
             HashDistributionInfo info = (HashDistributionInfo) distributionInfo;
             // buckets num
@@ -108,6 +135,7 @@ public class ColocateGroupSchema implements Writable {
                         distributionColTypes.size(), groupId.toString(), info.toString());
             }
             // distribution col type
+            Map<ColumnId, Column> idToColumn = table.getIdToColumn();
             List<Column> distributionColumns = MetaUtils.getColumnsByColumnIds(
                     idToColumn, distributionInfo.getDistributionColumns());
             for (int i = 0; i < distributionColTypes.size(); i++) {
@@ -115,6 +143,24 @@ public class ColocateGroupSchema implements Writable {
                 if (!targetColType.equals(distributionColumns.get(i).getType())) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE,
                             groupId.toString(), distributionColumns.get(i).getName(), targetColType, info.toString());
+                }
+            }
+        } else if (distributionInfo instanceof RangeDistributionInfo) {
+            // For range distribution colocate, the colocate columns are the sort key prefix.
+            List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
+            // colocate column count
+            if (sortKeyColumns.size() < distributionColTypes.size()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_SIZE,
+                        distributionColTypes.size(), groupId.toString(),
+                        "sort key columns: " + sortKeyColumns.size());
+            }
+            // colocate column type
+            for (int i = 0; i < distributionColTypes.size(); i++) {
+                Type expectedType = distributionColTypes.get(i);
+                if (!expectedType.equals(sortKeyColumns.get(i).getType())) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE,
+                            groupId.toString(), sortKeyColumns.get(i).getName(),
+                            expectedType, "sort key prefix");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRange.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Range;
+
+import java.util.Objects;
+
+/**
+ * Represents a colocate range interval and its corresponding PACK shard group.
+ *
+ * <p>In a range distribution colocate group, data is partitioned into colocate ranges
+ * based on colocate column (sort key prefix) values. Each colocate range is mapped to
+ * a PACK shard group, and all tablets within the same colocate range across different
+ * partitions/tables are scheduled to the same compute node by StarOS.
+ *
+ * <p>Implements {@code Comparable<Range<Tuple>>} by delegating to the internal range's
+ * {@link Range#compareTo(Range)}, which returns 0 for overlapping ranges. This enables
+ * direct use of {@link java.util.Collections#binarySearch} on a sorted list of
+ * ColocateRange with a point range as the search key.
+ */
+public class ColocateRange implements Comparable<Range<Tuple>> {
+
+    @SerializedName("r")
+    private final Range<Tuple> range;
+
+    @SerializedName("sg")
+    private final long shardGroupId;
+
+    public ColocateRange(Range<Tuple> range, long shardGroupId) {
+        this.range = Objects.requireNonNull(range, "range must not be null");
+        this.shardGroupId = shardGroupId;
+    }
+
+    public Range<Tuple> getRange() {
+        return range;
+    }
+
+    public long getShardGroupId() {
+        return shardGroupId;
+    }
+
+    @Override
+    public int compareTo(Range<Tuple> other) {
+        return range.compareTo(other);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        ColocateRange other = (ColocateRange) object;
+        return shardGroupId == other.shardGroupId && Objects.equals(range, other.range);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(range, shardGroupId);
+    }
+
+    @Override
+    public String toString() {
+        return range.toString() + " -> shardGroup=" + shardGroupId;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeMgr.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Range;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manages colocate ranges for range distribution colocate groups.
+ *
+ * <p>Each colocate group (identified by colocateGroupId, i.e., GroupId.grpId) maintains
+ * an ordered list of {@link ColocateRange} entries that:
+ * <ul>
+ *   <li>Cover the full value domain [MIN, MAX)</li>
+ *   <li>Are non-overlapping, ordered, and contiguous</li>
+ *   <li>Each map to a unique PACK shard group ID</li>
+ * </ul>
+ *
+ * <p>This structure is shared across databases: tables in different databases with the
+ * same colocateGroupId share the same colocate ranges and PACK shard groups.
+ */
+public class ColocateRangeMgr {
+
+    @SerializedName("cr")
+    private Map<Long, List<ColocateRange>> colocateGroupToRanges = Maps.newHashMap();
+
+    // ---- Query ----
+
+    /**
+     * Returns all colocate ranges for the given colocate group.
+     *
+     * @param colocateGroupId the colocate group id (GroupId.grpId)
+     * @return ordered list of ColocateRange, or empty list if group not found
+     */
+    public List<ColocateRange> getColocateRanges(long colocateGroupId) {
+        return colocateGroupToRanges.getOrDefault(colocateGroupId, Collections.emptyList());
+    }
+
+    /**
+     * Finds the ColocateRange that contains the given colocate value using binary search.
+     *
+     * <p>Creates a point range [value, value] and uses {@link Collections#binarySearch}.
+     * This works because {@link ColocateRange} implements {@code Comparable<Range<Tuple>>}
+     * by delegating to {@link Range#compareTo(Range)}, which returns 0 for overlapping ranges.
+     *
+     * @param colocateGroupId the colocate group id
+     * @param colocateValue the colocate column value to look up
+     * @return the ColocateRange containing the value, or null if not found
+     */
+    public ColocateRange getColocateRange(long colocateGroupId, Tuple colocateValue) {
+        List<ColocateRange> colocateRanges = colocateGroupToRanges.get(colocateGroupId);
+        if (colocateRanges == null || colocateRanges.isEmpty()) {
+            return null;
+        }
+        Range<Tuple> pointRange = Range.gele(colocateValue, colocateValue);
+        int index = Collections.binarySearch(colocateRanges, pointRange);
+        return index >= 0 ? colocateRanges.get(index) : null;
+    }
+
+    /**
+     * Returns true if the given colocate group exists.
+     */
+    public boolean containsColocateGroup(long colocateGroupId) {
+        return colocateGroupToRanges.containsKey(colocateGroupId);
+    }
+
+    // ---- Initialize ----
+
+    /**
+     * Initializes a new colocate group with a single range covering the full value domain.
+     *
+     * @param colocateGroupId the colocate group id
+     * @param shardGroupId the PACK shard group id for the initial full range
+     */
+    public void initColocateGroup(long colocateGroupId, long shardGroupId) {
+        List<ColocateRange> ranges = new ArrayList<>();
+        ranges.add(new ColocateRange(Range.all(), shardGroupId));
+        List<ColocateRange> existing = colocateGroupToRanges.putIfAbsent(colocateGroupId, ranges);
+        if (existing != null) {
+            throw new IllegalArgumentException("Colocate group " + colocateGroupId + " already exists");
+        }
+    }
+
+    // ---- Set (for replay) ----
+
+    /**
+     * Directly sets the colocate ranges for a group. Used during edit log replay and image loading.
+     */
+    public void setColocateRanges(long colocateGroupId, List<ColocateRange> ranges) {
+        colocateGroupToRanges.put(colocateGroupId, new ArrayList<>(ranges));
+    }
+
+    // ---- Remove ----
+
+    /**
+     * Removes the colocate group and all its ranges.
+     */
+    public void removeColocateGroup(long colocateGroupId) {
+        colocateGroupToRanges.remove(colocateGroupId);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -234,7 +234,8 @@ public class ColocateTableIndex implements Writable {
                 ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId,
                         MetaUtils.getColumnsByColumnIds(tbl, distributionInfo.getDistributionColumns()),
                         distributionInfo.getBucketNum(),
-                        tbl.getDefaultReplicationNum());
+                        tbl.getDefaultReplicationNum(),
+                        distributionInfo.getType());
                 groupName2Id.put(fullGroupName, groupId);
                 group2Schema.put(groupId, groupSchema);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1080,7 +1080,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             String fullGroupName = db.getId() + "_" + olapTable.getColocateGroup();
             ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(fullGroupName);
             Preconditions.checkNotNull(groupSchema);
-            groupSchema.checkDistribution(olapTable.getIdToColumn(), distributionInfo);
+            groupSchema.checkDistribution(olapTable, distributionInfo);
             for (PartitionDesc partitionDesc : partitionDescs) {
                 groupSchema.checkReplicationNum(partitionDesc.getReplicationNum());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateGroupSchemaRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateGroupSchemaRangeTest.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.ColocateTableIndex.GroupId;
+import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class ColocateGroupSchemaRangeTest {
+
+    @Test
+    public void testRangeColocateConstructor() {
+        GroupId groupId = new GroupId(1L, 100L);
+        List<Column> colocateColumns = Lists.newArrayList(
+                new Column("tenant_id", IntegerType.INT),
+                new Column("created_time", IntegerType.BIGINT));
+
+        ColocateGroupSchema schema = new ColocateGroupSchema(
+                groupId, colocateColumns, 0, (short) 1, DistributionInfoType.RANGE);
+
+        Assertions.assertTrue(schema.isRangeColocate());
+        Assertions.assertEquals(DistributionInfoType.RANGE, schema.getDistributionType());
+        Assertions.assertEquals(2, schema.getColocateColumnCount());
+        Assertions.assertEquals(0, schema.getBucketsNum());
+        Assertions.assertEquals(1, schema.getReplicationNum());
+        Assertions.assertEquals(groupId, schema.getGroupId());
+    }
+
+    @Test
+    public void testHashColocateConstructor() {
+        GroupId groupId = new GroupId(1L, 200L);
+        List<Column> distributionColumns = Lists.newArrayList(
+                new Column("k1", IntegerType.INT));
+
+        ColocateGroupSchema schema = new ColocateGroupSchema(
+                groupId, distributionColumns, 4, (short) 1, DistributionInfoType.HASH);
+
+        Assertions.assertFalse(schema.isRangeColocate());
+        Assertions.assertEquals(DistributionInfoType.HASH, schema.getDistributionType());
+        Assertions.assertEquals(1, schema.getColocateColumnCount());
+        Assertions.assertEquals(4, schema.getBucketsNum());
+    }
+
+    @Test
+    public void testDistributionColTypesReusedForRangeColocate() {
+        GroupId groupId = new GroupId(1L, 100L);
+        List<Column> colocateColumns = Lists.newArrayList(
+                new Column("tenant_id", IntegerType.INT),
+                new Column("name", VarcharType.VARCHAR));
+
+        ColocateGroupSchema schema = new ColocateGroupSchema(
+                groupId, colocateColumns, 0, (short) 1, DistributionInfoType.RANGE);
+
+        // distributionColTypes stores the colocate column types
+        List<com.starrocks.type.Type> colTypes = schema.getDistributionColTypes();
+        Assertions.assertEquals(2, colTypes.size());
+        Assertions.assertEquals(IntegerType.INT, colTypes.get(0));
+        Assertions.assertEquals(VarcharType.VARCHAR, colTypes.get(1));
+    }
+
+    @Test
+    public void testGsonSerializationRangeColocate() {
+        GroupId groupId = new GroupId(1L, 100L);
+        List<Column> colocateColumns = Lists.newArrayList(
+                new Column("tenant_id", IntegerType.INT),
+                new Column("name", VarcharType.VARCHAR));
+
+        ColocateGroupSchema original = new ColocateGroupSchema(
+                groupId, colocateColumns, 0, (short) 1, DistributionInfoType.RANGE);
+
+        String json = GsonUtils.GSON.toJson(original);
+        ColocateGroupSchema deserialized = GsonUtils.GSON.fromJson(json, ColocateGroupSchema.class);
+
+        Assertions.assertTrue(deserialized.isRangeColocate());
+        Assertions.assertEquals(DistributionInfoType.RANGE, deserialized.getDistributionType());
+        Assertions.assertEquals(2, deserialized.getColocateColumnCount());
+        Assertions.assertEquals(0, deserialized.getBucketsNum());
+        Assertions.assertEquals(1, deserialized.getReplicationNum());
+        Assertions.assertEquals(groupId, deserialized.getGroupId());
+    }
+
+    @Test
+    public void testGsonSerializationHashColocateBackwardCompatible() {
+        // Simulate old serialized data without distributionType field
+        // The default should be HASH
+        GroupId groupId = new GroupId(1L, 200L);
+        List<Column> distributionColumns = Lists.newArrayList(
+                new Column("k1", IntegerType.INT));
+
+        ColocateGroupSchema original = new ColocateGroupSchema(
+                groupId, distributionColumns, 4, (short) 1, DistributionInfoType.HASH);
+
+        String json = GsonUtils.GSON.toJson(original);
+        ColocateGroupSchema deserialized = GsonUtils.GSON.fromJson(json, ColocateGroupSchema.class);
+
+        Assertions.assertFalse(deserialized.isRangeColocate());
+        Assertions.assertEquals(DistributionInfoType.HASH, deserialized.getDistributionType());
+        Assertions.assertEquals(4, deserialized.getBucketsNum());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeMgrTest.java
@@ -1,0 +1,252 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.Range;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ColocateRangeMgrTest {
+
+    private ColocateRangeMgr colocateRangeMgr;
+    private static final long COLOCATE_GROUP_ID = 100L;
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        colocateRangeMgr = new ColocateRangeMgr();
+    }
+
+    // ---- initColocateGroup ----
+
+    @Test
+    public void testInitColocateGroup() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+
+        List<ColocateRange> ranges = colocateRangeMgr.getColocateRanges(COLOCATE_GROUP_ID);
+        Assertions.assertEquals(1, ranges.size());
+        Assertions.assertTrue(ranges.get(0).getRange().isAll());
+        Assertions.assertEquals(1001L, ranges.get(0).getShardGroupId());
+    }
+
+    @Test
+    public void testInitColocateGroupDuplicate() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1002L));
+    }
+
+    // ---- containsColocateGroup ----
+
+    @Test
+    public void testContainsColocateGroup() {
+        Assertions.assertFalse(colocateRangeMgr.containsColocateGroup(COLOCATE_GROUP_ID));
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+        Assertions.assertTrue(colocateRangeMgr.containsColocateGroup(COLOCATE_GROUP_ID));
+    }
+
+    // ---- getColocateRanges ----
+
+    @Test
+    public void testGetColocateRangesNonExistent() {
+        List<ColocateRange> ranges = colocateRangeMgr.getColocateRanges(999L);
+        Assertions.assertTrue(ranges.isEmpty());
+    }
+
+    // ---- getColocateRange ----
+
+    @Test
+    public void testGetColocateRangeInAllRange() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+
+        ColocateRange found = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(500));
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(1001L, found.getShardGroupId());
+    }
+
+    @Test
+    public void testGetColocateRangeNonExistentGroup() {
+        ColocateRange found = colocateRangeMgr.getColocateRange(999L, makeTuple(100));
+        Assertions.assertNull(found);
+    }
+
+    @Test
+    public void testGetColocateRangeAfterSetColocateRanges() {
+        // Set up 3 ranges via setColocateRanges: (-inf,100), [100,200), [200,+inf)
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1002L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1003L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        // Find in (-inf, 100) range
+        ColocateRange found50 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(50));
+        Assertions.assertNotNull(found50);
+        Assertions.assertEquals(1001L, found50.getShardGroupId());
+
+        // Find in [100, 200) range
+        ColocateRange found150 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(150));
+        Assertions.assertNotNull(found150);
+        Assertions.assertEquals(1002L, found150.getShardGroupId());
+
+        // Find at boundary 100 (should be in [100, 200))
+        ColocateRange found100 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(100));
+        Assertions.assertNotNull(found100);
+        Assertions.assertEquals(1002L, found100.getShardGroupId());
+
+        // Find in [200, +inf) range
+        ColocateRange found500 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(500));
+        Assertions.assertNotNull(found500);
+        Assertions.assertEquals(1003L, found500.getShardGroupId());
+    }
+
+    // ---- removeColocateGroup ----
+
+    @Test
+    public void testRemoveColocateGroup() {
+        colocateRangeMgr.initColocateGroup(COLOCATE_GROUP_ID, 1001L);
+        Assertions.assertTrue(colocateRangeMgr.containsColocateGroup(COLOCATE_GROUP_ID));
+
+        colocateRangeMgr.removeColocateGroup(COLOCATE_GROUP_ID);
+        Assertions.assertFalse(colocateRangeMgr.containsColocateGroup(COLOCATE_GROUP_ID));
+        Assertions.assertTrue(colocateRangeMgr.getColocateRanges(COLOCATE_GROUP_ID).isEmpty());
+    }
+
+    // ---- setColocateRanges (replay) ----
+
+    @Test
+    public void testSetColocateRanges() {
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(200)), 1001L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1002L));
+
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        List<ColocateRange> retrieved = colocateRangeMgr.getColocateRanges(COLOCATE_GROUP_ID);
+        Assertions.assertEquals(2, retrieved.size());
+        Assertions.assertEquals(1001L, retrieved.get(0).getShardGroupId());
+        Assertions.assertEquals(1002L, retrieved.get(1).getShardGroupId());
+    }
+
+    // ---- Gson Serialization ----
+
+    @Test
+    public void testGsonSerialization() {
+        // Set up 3 ranges via setColocateRanges
+        List<ColocateRange> ranges = Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 1001L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 1003L),
+                new ColocateRange(Range.ge(makeTuple(200)), 1002L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        // Serialize
+        String json = GsonUtils.GSON.toJson(colocateRangeMgr);
+
+        // Deserialize
+        ColocateRangeMgr deserialized = GsonUtils.GSON.fromJson(json, ColocateRangeMgr.class);
+
+        // Verify
+        List<ColocateRange> deserializedRanges = deserialized.getColocateRanges(COLOCATE_GROUP_ID);
+        Assertions.assertEquals(3, deserializedRanges.size());
+        Assertions.assertEquals(1001L, deserializedRanges.get(0).getShardGroupId());
+        Assertions.assertEquals(1003L, deserializedRanges.get(1).getShardGroupId());
+        Assertions.assertEquals(1002L, deserializedRanges.get(2).getShardGroupId());
+
+        // Verify getColocateRange works after deserialization
+        ColocateRange found = deserialized.getColocateRange(COLOCATE_GROUP_ID, makeTuple(150));
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(1003L, found.getShardGroupId());
+    }
+
+    // ---- Binary search correctness ----
+
+    @Test
+    public void testGetColocateRangeBinarySearchManyRanges() {
+        // Build 100 ranges: (-inf,10), [10,20), [20,30), ..., [990,+inf)
+        List<ColocateRange> ranges = new ArrayList<>();
+        ranges.add(new ColocateRange(Range.lt(makeTuple(10)), 1000L));
+        for (int i = 10; i < 990; i += 10) {
+            ranges.add(new ColocateRange(Range.gelt(makeTuple(i), makeTuple(i + 10)), 1000L + i));
+        }
+        ranges.add(new ColocateRange(Range.ge(makeTuple(990)), 1990L));
+        colocateRangeMgr.setColocateRanges(COLOCATE_GROUP_ID, ranges);
+
+        Assertions.assertEquals(100, colocateRangeMgr.getColocateRanges(COLOCATE_GROUP_ID).size());
+
+        // Value 5 should be in first range (-inf, 10) -> shardGroup 1000
+        ColocateRange found5 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(5));
+        Assertions.assertNotNull(found5);
+        Assertions.assertEquals(1000L, found5.getShardGroupId());
+
+        // Value 10 should be in [10, 20) -> shardGroup 1010
+        ColocateRange found10 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(10));
+        Assertions.assertNotNull(found10);
+        Assertions.assertEquals(1010L, found10.getShardGroupId());
+
+        // Value 15 should be in [10, 20) -> shardGroup 1010
+        ColocateRange found15 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(15));
+        Assertions.assertNotNull(found15);
+        Assertions.assertEquals(1010L, found15.getShardGroupId());
+
+        // Value 555 should be in [550, 560) -> shardGroup 1550
+        ColocateRange found555 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(555));
+        Assertions.assertNotNull(found555);
+        Assertions.assertEquals(1550L, found555.getShardGroupId());
+
+        // Value 990 should be in [990, +inf) -> shardGroup 1990
+        ColocateRange found990 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(990));
+        Assertions.assertNotNull(found990);
+        Assertions.assertEquals(1990L, found990.getShardGroupId());
+
+        // Value 99999 should be in [990, +inf) -> shardGroup 1990
+        ColocateRange found99999 = colocateRangeMgr.getColocateRange(COLOCATE_GROUP_ID, makeTuple(99999));
+        Assertions.assertNotNull(found99999);
+        Assertions.assertEquals(1990L, found99999.getShardGroupId());
+    }
+
+    // ---- Multiple colocate groups ----
+
+    @Test
+    public void testMultipleColocateGroups() {
+        long groupId1 = 100L;
+        long groupId2 = 200L;
+
+        colocateRangeMgr.initColocateGroup(groupId1, 1001L);
+        colocateRangeMgr.initColocateGroup(groupId2, 2001L);
+
+        // Group 1 has 1 range
+        Assertions.assertEquals(1, colocateRangeMgr.getColocateRanges(groupId1).size());
+        // Group 2 has 1 range
+        Assertions.assertEquals(1, colocateRangeMgr.getColocateRanges(groupId2).size());
+
+        // Find in group 1
+        ColocateRange found1 = colocateRangeMgr.getColocateRange(groupId1, makeTuple(100));
+        Assertions.assertEquals(1001L, found1.getShardGroupId());
+
+        // Find in group 2
+        ColocateRange found2 = colocateRangeMgr.getColocateRange(groupId2, makeTuple(100));
+        Assertions.assertEquals(2001L, found2.getShardGroupId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeTest.java
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.Range;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class ColocateRangeTest {
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @Test
+    public void testBasicProperties() {
+        Range<Tuple> range = Range.gelt(makeTuple(100), makeTuple(200));
+        ColocateRange colocateRange = new ColocateRange(range, 1001L);
+
+        Assertions.assertEquals(range, colocateRange.getRange());
+        Assertions.assertEquals(1001L, colocateRange.getShardGroupId());
+    }
+
+    @Test
+    public void testAllRange() {
+        Range<Tuple> allRange = Range.all();
+        ColocateRange colocateRange = new ColocateRange(allRange, 2001L);
+
+        Assertions.assertTrue(colocateRange.getRange().isAll());
+        Assertions.assertEquals(2001L, colocateRange.getShardGroupId());
+    }
+
+    @Test
+    public void testEquals() {
+        Range<Tuple> range1 = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> range2 = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> range3 = Range.gelt(makeTuple(200), makeTuple(300));
+
+        ColocateRange cr1 = new ColocateRange(range1, 1001L);
+        ColocateRange cr2 = new ColocateRange(range2, 1001L);
+        ColocateRange cr3 = new ColocateRange(range3, 1001L);
+        ColocateRange cr4 = new ColocateRange(range1, 1002L);
+
+        Assertions.assertEquals(cr1, cr2);
+        Assertions.assertNotEquals(cr1, cr3);
+        Assertions.assertNotEquals(cr1, cr4);
+        Assertions.assertNotEquals(cr1, null);
+    }
+
+    @Test
+    public void testHashCode() {
+        Range<Tuple> range1 = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> range2 = Range.gelt(makeTuple(100), makeTuple(200));
+
+        ColocateRange cr1 = new ColocateRange(range1, 1001L);
+        ColocateRange cr2 = new ColocateRange(range2, 1001L);
+
+        Assertions.assertEquals(cr1.hashCode(), cr2.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        Range<Tuple> range = Range.gelt(makeTuple(100), makeTuple(200));
+        ColocateRange colocateRange = new ColocateRange(range, 1001L);
+
+        String str = colocateRange.toString();
+        Assertions.assertTrue(str.contains("1001"));
+        Assertions.assertTrue(str.contains("shardGroup"));
+    }
+
+    @Test
+    public void testGsonSerialization() {
+        Range<Tuple> range = Range.gelt(makeTuple(100), makeTuple(200));
+        ColocateRange original = new ColocateRange(range, 1001L);
+
+        String json = GsonUtils.GSON.toJson(original);
+        ColocateRange deserialized = GsonUtils.GSON.fromJson(json, ColocateRange.class);
+
+        Assertions.assertEquals(original.getShardGroupId(), deserialized.getShardGroupId());
+        Assertions.assertEquals(original.getRange(), deserialized.getRange());
+    }
+
+    @Test
+    public void testGsonSerializationAllRange() {
+        ColocateRange original = new ColocateRange(Range.all(), 2001L);
+
+        String json = GsonUtils.GSON.toJson(original);
+        ColocateRange deserialized = GsonUtils.GSON.fromJson(json, ColocateRange.class);
+
+        Assertions.assertEquals(2001L, deserialized.getShardGroupId());
+        Assertions.assertTrue(deserialized.getRange().isAll());
+    }
+
+    @Test
+    public void testNullRangeThrows() {
+        Assertions.assertThrows(NullPointerException.class, () -> new ColocateRange(null, 1001L));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -408,7 +409,8 @@ public class ColocateTableBalancerTest {
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", IntegerType.INT));
-        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5, (short) 3);
+        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5,
+                (short) 3, DistributionInfo.DistributionInfoType.HASH);
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
 
@@ -525,7 +527,8 @@ public class ColocateTableBalancerTest {
         for (GroupId groupId : groupIds) {
             List<Column> distributionCols = Lists.newArrayList();
             distributionCols.add(new Column("k1", IntegerType.INT));
-            ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 3, (short) 1);
+            ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 3,
+                    (short) 1, DistributionInfo.DistributionInfoType.HASH);
             group2Schema.put(groupId, groupSchema);
         }
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
@@ -570,7 +573,8 @@ public class ColocateTableBalancerTest {
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", IntegerType.INT));
         ColocateGroupSchema groupSchema =
-                    new ColocateGroupSchema(groupId, distributionCols, bucketNum, replicationNum);
+                    new ColocateGroupSchema(groupId, distributionCols, bucketNum, replicationNum,
+                            DistributionInfo.DistributionInfoType.HASH);
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
@@ -785,7 +789,8 @@ public class ColocateTableBalancerTest {
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", IntegerType.INT));
-        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5, (short) 1);
+        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5,
+                (short) 1, DistributionInfo.DistributionInfoType.HASH);
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
 
@@ -1041,7 +1046,8 @@ public class ColocateTableBalancerTest {
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", IntegerType.INT));
-        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5, (short) 3);
+        ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5,
+                (short) 3, DistributionInfo.DistributionInfoType.HASH);
         Map<GroupId, ColocateGroupSchema> group2Schema = Maps.newHashMap();
         group2Schema.put(groupId, groupSchema);
 

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -172,6 +172,9 @@ public enum ErrorCode {
     ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE(5063, new byte[] {'4', '2', '0', '0', '0'},
             "Colocate tables distribution columns must have the same data type with group %s," +
                     " current col: %s, should be: %s, current info %s"),
+    ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_TYPE(5063, new byte[] {'4', '2', '0', '0', '0'},
+            "Colocate tables must have the same distribution type with group %s," +
+                    " expected: %s, actual: %s"),
     ERR_COLOCATE_NOT_COLOCATE_TABLE(5064, new byte[] {'4', '2', '0', '0', '0'},
             "Table %s is not a colocated table"),
     ERROR_DYNAMIC_PARTITION_TIME_UNIT(5065, new byte[] {'4', '2', '0', '0', '0'},


### PR DESCRIPTION
## Why I'm doing:

  Range distribution tables currently do not support colocate. To enable colocate join
  for range distribution tables, we need data structures to manage colocate range
  boundaries and their mapping to PACK shard groups. This PR introduces the foundational
  data structures and extends ColocateGroupSchema to support range distribution type.

  ## What I'm doing:

  1. Add `ColocateRange` class: represents a colocate range interval and its corresponding
     PACK shard group ID.
  2. Add `ColocateRangeMgr` class: manages colocate ranges per colocate group, supporting
     O(log n) binary search lookup.
  3. Extend `ColocateGroupSchema`: add `distributionType` field to distinguish HASH vs RANGE
     colocate groups. Reuse `distributionColTypes` to store colocate column types for range
     colocate. Extend `checkDistribution()` for sort key prefix validation.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
