### PR TITLE
[Enhancement] Use more sophisticated statistics to infer skew for GroupByCountDistinctDataSkewEliminateRule (backport #66640)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -774,6 +774,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // control on/off of this bucketization optimization.
     public static final String DISTINCT_COLUMN_BUCKETS = "count_distinct_column_buckets";
     public static final String ENABLE_DISTINCT_COLUMN_BUCKETIZATION = "enable_distinct_column_bucketization";
+    public static final String DATA_SKEW_ROW_PERCENTAGE_THRESHOLD = "data_skew_row_percentage_threshold";
     public static final String HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE = "hdfs_backend_selector_scan_range_shuffle";
 
     public static final String SQL_QUOTE_SHOW_CREATE = "sql_quote_show_create";
@@ -2452,6 +2453,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_DISTINCT_COLUMN_BUCKETIZATION)
     private boolean enableDistinctColumnBucketization = false;
 
+    @VariableMgr.VarAttr(name = DATA_SKEW_ROW_PERCENTAGE_THRESHOLD)
+    private double dataSkewRowPercentageThreshold = 0.2;
+
     @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean hdfsBackendSelectorScanRangeShuffle = false;
 
@@ -2955,6 +2959,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableDistinctColumnBucketization() {
         return enableDistinctColumnBucketization;
+    }
+
+    public void setDataSkewRowPercentageThreshold(double threshold) {
+        dataSkewRowPercentageThreshold = threshold;
+    }
+
+    public double getDataSkewRowPercentageThreshold() {
+        return dataSkewRowPercentageThreshold;
     }
 
     public boolean getHudiMORForceJNIReader() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -34,7 +34,6 @@ import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
-import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
@@ -57,7 +56,10 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.skew.DataSkew;
+import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
@@ -68,6 +70,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -177,7 +180,6 @@ public class CostModel {
                     return adjustCostForMV(context);
                 }
             }
-
             return CostEstimate.of(statistics.getComputeSize(), 0, 0);
         }
 
@@ -241,15 +243,77 @@ public class CostModel {
                     0);
         }
 
+        private List<ColumnRefOperator> getGroupBysWithoutDistinctColumn(List<ColumnRefOperator> groupByList,
+                                                                         ColumnRefOperator distinctColRef) {
+            return groupByList.stream()
+                    .filter(groupBy -> !groupBy.equals(distinctColRef)) //
+                    .collect(Collectors.toList());
+        }
+
+        private boolean isGroupBySkewed(List<ColumnStatistic> groupByStats, Statistics statistics) {
+            // For now, we assume that if all group by columns are skewed that they are skewed "the same way" so we get
+            // large groups. This is of course a simplification.
+            if (groupByStats.isEmpty()) {
+                return false;
+            }
+
+            final var dataSkewRowPercentageThreshold =
+                    ConnectContext.get().getSessionVariable().getDataSkewRowPercentageThreshold();
+            final var skewThresholds = DataSkew.Thresholds.withRelativeRowThreshold(dataSkewRowPercentageThreshold);
+
+            return groupByStats.stream()
+                    .allMatch(groupByStat -> {
+                        return DataSkew.isColumnSkewed(statistics, groupByStat, skewThresholds);
+                    });
+        }
+
+        private boolean isGroupByLowCardinality(List<ColumnStatistic> groupByStatistics, Statistics statistics,
+                                                ColumnRefOperator distinctColumn) {
+            if (statistics.getOutputRowCount() < 1) {
+                return false;
+            }
+
+            if (groupByStatistics.stream().anyMatch(groupByStat -> groupByStat.isUnknown() || groupByStat.isUnknownValue())) {
+                // At least one group by column does not have statistics.
+                return false;
+            }
+
+            final var distColStat = statistics.getColumnStatistic(distinctColumn);
+            if (distColStat.isUnknown() || distColStat.isUnknownValue()) {
+                // No statistics on the distinct column.
+                return false;
+            }
+
+            double groupByColDistinctValues = groupByStatistics.stream()
+                    .mapToDouble(ColumnStatistic::getDistinctValuesCount) //
+                    .reduce(1, (lhsStat, rhsStat) -> lhsStat * rhsStat);
+
+            groupByColDistinctValues =
+                    Math.max(1.0, Math.min(groupByColDistinctValues, statistics.getOutputRowCount()));
+
+            final double groupByColDistinctHighWaterMark = 10000;
+            final double groupByColDistinctLowWaterMark = 100;
+            final double distColDistinctValuesCountWaterMark = 10000000;
+            final double distColDistinctValuesCount = distColStat.getDistinctValuesCount();
+            final double avgDistValuesPerGroup = distColDistinctValuesCount / groupByColDistinctValues;
+
+            return distColDistinctValuesCount > distColDistinctValuesCountWaterMark &&
+                    ((groupByColDistinctValues <= groupByColDistinctLowWaterMark) ||
+                            (groupByColDistinctValues < groupByColDistinctHighWaterMark &&
+                                    avgDistValuesPerGroup > 100));
+        }
+
         // Compute penalty factor for GroupByCountDistinctDataSkewEliminateRule
         // Reward good cases(give a penaltyFactor=0.5) while punish bad cases(give a penaltyFactor=1.5)
-        // Good cases as follows:
-        // 1. distinct cardinality of group-by column is less than 100
-        // 2. distinct cardinality of group-by column is less than 10000 and avgDistValuesPerGroup > 100
-        // Bad cases as follows: this Rule is conservative, the cases except good cases are all bad cases.
+        // We try to find good cases by looking at the
+        //  1) null fractions of the group by columns
+        //  2) histogram of the group by columns
+        //  3) distinct cardinality of group-by column is less than 100
+        //  4) distinct cardinality of group-by column is less than 10000 and avgDistValuesPerGroup > 100
         private double computeDataSkewPenaltyOfGroupByCountDistinct(PhysicalHashAggregateOperator node,
                                                                     Statistics inputStatistics) {
             DataSkewInfo skewInfo = node.getDistinctColumnDataSkew();
+
             if (skewInfo.getStage() != 1) {
                 return skewInfo.getPenaltyFactor();
             }
@@ -258,35 +322,25 @@ public class CostModel {
                 return 1.5;
             }
 
-            ColumnStatistic distColStat = inputStatistics.getColumnStatistic(skewInfo.getSkewColumnRef());
-            List<ColumnStatistic> groupByStats = node.getGroupBys().subList(0, node.getGroupBys().size() - 1)
-                    .stream().map(inputStatistics::getColumnStatistic).collect(Collectors.toList());
+            final var countDistinctColumnRef = skewInfo.getSkewColumnRef();
+            final var groupBys = getGroupBysWithoutDistinctColumn(node.getGroupBys(), countDistinctColumnRef);
+            final var groupByStatistics = groupBys.stream()
+                    .map(inputStatistics::getColumnStatistic) //
+                    .filter(Objects::nonNull) //
+                    .collect(Collectors.toList());
 
-            if (distColStat.isUnknownValue() || distColStat.isUnknown() ||
-                    groupByStats.stream().anyMatch(groupStat -> groupStat.isUnknown() || groupStat.isUnknownValue())) {
-                return 1.5;
+            // Basic skew detection on the group by columns. We are weighting this heavily if we know
+            // that group by columns are skewed since this optimization has significant speed up then.
+            if (isGroupBySkewed(groupByStatistics, inputStatistics)) {
+                return 0.2;
             }
-            double groupByColDistinctValues = 1.0;
-            for (ColumnStatistic groupStat : groupByStats) {
-                groupByColDistinctValues *= groupStat.getDistinctValuesCount();
-            }
-            groupByColDistinctValues =
-                    Math.max(1.0, Math.min(groupByColDistinctValues, inputStatistics.getOutputRowCount()));
 
-            final double groupByColDistinctHighWaterMark = 10000;
-            final double groupByColDistinctLowWaterMark = 100;
-            final double distColDistinctValuesCountWaterMark = 10000000;
-            final double distColDistinctValuesCount = distColStat.getDistinctValuesCount();
-            final double avgDistValuesPerGroup = distColDistinctValuesCount / groupByColDistinctValues;
-
-            if (distColDistinctValuesCount > distColDistinctValuesCountWaterMark &&
-                    ((groupByColDistinctValues <= groupByColDistinctLowWaterMark) ||
-                            (groupByColDistinctValues < groupByColDistinctHighWaterMark &&
-                                    avgDistValuesPerGroup > 100))) {
+            // Checking for the cardinality of the group by columns.
+            if (isGroupByLowCardinality(groupByStatistics, inputStatistics, skewInfo.getSkewColumnRef())) {
                 return 0.5;
-            } else {
-                return 1.5;
             }
+
+            return 1.5;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
-import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -37,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.property.DomainProperty;
 import com.starrocks.sql.optimizer.property.DomainPropertyDeriver;
+import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -27,13 +27,13 @@ import com.starrocks.sql.optimizer.RowOutputInfo;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
-import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.skew;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+
+public class DataSkew {
+    private static final int DEFAULT_MCV_LIMIT = 5;
+    private static final double DEFAULT_RELATIVE_ROW_THRESHOLD = 0.2;
+    private static final Thresholds DEFAULT_THRESHOLDS = new Thresholds(DEFAULT_MCV_LIMIT, DEFAULT_RELATIVE_ROW_THRESHOLD);
+
+    public record Thresholds(int mcvLimit, double relativeRowThreshold) {
+        public static Thresholds withRelativeRowThreshold(double relativeRowThreshold) {
+            return new Thresholds(DEFAULT_MCV_LIMIT, relativeRowThreshold);
+        }
+
+        public static Thresholds withMcvLimit(int mcvLimit) {
+            return new Thresholds(mcvLimit, DEFAULT_RELATIVE_ROW_THRESHOLD);
+        }
+    }
+
+    /**
+     * Utility method to check if a certain column is skewed based on statistics.
+     */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                         Thresholds thresholds) {
+        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
+            // A lot of NULL values also indicate skew.
+            return true;
+        }
+
+        final var rowCount = statistics.getOutputRowCount();
+        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1 || columnStatistic.isUnknown() ||
+                columnStatistic.isUnknownValue()) {
+            // Without sufficient information we can not make a decision.
+            return false;
+        }
+
+        final var histogram = columnStatistic.getHistogram();
+        if (histogram != null) {
+            final var mcv = histogram.getMCV();
+
+            if (mcv != null) {
+                List<Pair<String, Long>> mcvs = Lists.newArrayList();
+                int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
+                mcv.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
+                        .limit(mcvLimit)
+                        .forEach(entry -> {
+                            mcvs.add(Pair.create(entry.getKey(), entry.getValue()));
+                        });
+
+                long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
+                return ((double) rowCountOfMcvs / rowCount) > thresholds.relativeRowThreshold;
+            }
+        }
+
+        // No histogram information, can not deduce skew.
+        return false;
+    }
+
+    /* Always using default thresholds */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
+        return isColumnSkewed(statistics, columnStatistic, DEFAULT_THRESHOLDS);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkewInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkewInfo.java
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.operator;
+package com.starrocks.sql.optimizer.skew;
 
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 public class DataSkewInfo {
     private ColumnRefOperator skewColumnRef;
-    private double penaltyFactor = 1.0;
-    private int stage = 0;
+    private double penaltyFactor;
+    private int stage;
 
     public ColumnRefOperator getSkewColumnRef() {
         return skewColumnRef;
-    }
-
-    public void setSkewColumnRef(ColumnRefOperator skewColumnRef) {
-        this.skewColumnRef = skewColumnRef;
     }
 
     public double getPenaltyFactor() {
@@ -43,6 +39,10 @@ public class DataSkewInfo {
 
     public void setStage(int stage) {
         this.stage = stage;
+    }
+
+    public void setSkewColumnRef(ColumnRefOperator skewColumnRef) {
+        this.skewColumnRef = skewColumnRef;
     }
 
     public DataSkewInfo(ColumnRefOperator skewColumnRef, double penaltyFactor, int stage) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -1,0 +1,164 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.skew;
+
+import com.google.crypto.tink.subtle.Random;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.Bucket;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Histogram;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataSkewTest {
+
+    private static ColumnRefOperator createNewTestColumn() {
+        return new ColumnRefOperator(Random.randInt(), Type.INT, UUID.randomUUID().toString(), true);
+    }
+
+    @Test
+    void itShouldDetectNullSkew() {
+        // GIVEN
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.9 /* heavily null skewed */) //
+                .build();
+
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.1 /* not null skewed */) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats));
+    }
+
+    @Test
+    void itShouldReturnFalseWhenNoStatistics() {
+        // GIVEN
+        final var col = createNewTestColumn();
+        final var colStats = ColumnStatistic.unknown();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(col, colStats) //
+                .build();
+
+        // WHEN / THEN
+        assertFalse(DataSkew.isColumnSkewed(stats, colStats));
+    }
+
+    @Test
+    void itShouldRespectCustomThresholds() {
+        // GIVEN
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.7) //
+                .build();
+
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.6) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats, new DataSkew.Thresholds(5, 0.7)));
+        assertFalse(DataSkew.isColumnSkewed(stats, skewedColStats, new DataSkew.Thresholds(5, 0.71)));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats, new DataSkew.Thresholds(5, 0.7)));
+    }
+
+    @Test
+    void itShouldDetectHistogramSkew() {
+        // GIVEN
+        final var skewedHistogram = getSkewedHistogram();
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.01) //
+                .setHistogram(skewedHistogram) //
+                .build();
+
+        final var nonSkewedHistogram = getNonSkewedHistogram();
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.02) //
+                .setHistogram(nonSkewedHistogram) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .setOutputRowCount(100_000)
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats));
+    }
+
+    private static Histogram getSkewedHistogram() {
+        List<Bucket> skewedBuckets = List.of(
+                new Bucket(6, 20, 1000L, 50L), // skew
+                new Bucket(21, 100, 1200L, 10L),
+                new Bucket(101, 1000, 1250L, 1L),
+                new Bucket(1001, 10000, 1260L, 1L)
+        );
+
+        Map<String, Long> skewedMcv = Map.of(
+                "1", 50000L,  // skew
+                "2", 20000L,
+                "3", 10000L,
+                "4", 5000L,
+                "5", 500L
+        );
+
+        return new Histogram(skewedBuckets, skewedMcv);
+    }
+
+    private static Histogram getNonSkewedHistogram() {
+        Map<String, Long> uniformMcv = Map.of(
+                "50", 10L,
+                "150", 10L,
+                "250", 10L,
+                "350", 10L
+        );
+
+        List<Bucket> uniformBuckets = List.of(
+                new Bucket(0, 99, 990L, 10L),
+                new Bucket(100, 199, 1980L, 10L),
+                new Bucket(200, 299, 2970L, 10L),
+                new Bucket(300, 399, 3960L, 10L)
+        );
+
+        return new Histogram(uniformBuckets, uniformMcv);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class DistinctAggSkewTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+
+        connectContext.getGlobalStateMgr().setStatisticStorage(new CachedStatisticStorage());
+
+        starRocksAssert.withTable("CREATE TABLE `null_skew_table` (\n" +
+                "  `id` bigint NULL COMMENT \"\",\n" +
+                "  `group` bigint NULL COMMENT \"\",\n" +
+                "  `value` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`id`, `group`, `value`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+    }
+
+    @Test
+    void testDistinctWithNullSkew() throws Exception {
+        String sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.8).build();
+        final var nonSkewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.01).build();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", skewedColumnStat);
+        statisticStorage.addColumnStatistic(table, "value", nonSkewedColumnStat);
+
+        connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+        setTableStatistics(table, 1337);
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: group\n" +
+                "  |  <slot 3> : 3: value\n" +
+                "  |  <slot 5> : CAST(murmur_hash3_32(CAST(3: value AS VARCHAR)) % 512 AS SMALLINT)");
+    }
+
+    @Test
+    void testDistinctWithoutNullSkew() throws Exception {
+        String sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        final var nonSkewedColumnStat = ColumnStatistic.unknown();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", nonSkewedColumnStat);
+        statisticStorage.addColumnStatistic(table, "value", nonSkewedColumnStat);
+
+        connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+        setTableStatistics(table, 1337);
+
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: group\n" +
+                "  |  <slot 3> : 3: value\n" +
+                "  |  <slot 5> : CAST(murmur_hash3_32(CAST(3: value AS VARCHAR)) % 512 AS SMALLINT)");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

This is a backport to 3.5-cc for #66640.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

