### PR TITLE
[BugFix] Fix array types support and cardinality and array_intersect functions in TRANSLATE TRINO

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -759,7 +759,28 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         } else {
             exprs = Collections.emptyList();
         }
-        return new ArrayExpr(null, exprs);
+
+        Type arrayType = null;
+        if (!exprs.isEmpty()) {
+            try {
+                Expr firstNonNullExpr = null;
+                for (Expr expr : exprs) {
+                    if (!(expr instanceof NullLiteral)) {
+                        firstNonNullExpr = expr;
+                        break;
+                    }
+                }
+
+                if (firstNonNullExpr != null) {
+                    if (firstNonNullExpr.getType() != null) {
+                        arrayType = new ArrayType(firstNonNullExpr.getType());
+                    }
+                }
+            } catch (Exception e) {
+            }
+        }
+
+        return new ArrayExpr(arrayType, exprs);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -139,6 +139,12 @@ public class Trino2SRFunctionCallTransformer {
         // contains_sequence -> array_contains_seq
         registerFunctionTransformer("contains_sequence", 2, "array_contains_seq",
                 List.of(Expr.class, Expr.class));
+        // cardinality -> array_length (cardinality is an alias for array_length in StarRocks)
+        registerFunctionTransformer("cardinality", 1, "cardinality",
+                List.of(Expr.class));
+        // array_intersect -> array_intersect (direct mapping with variable arguments)
+        registerFunctionTransformerWithVarArgs("array_intersect", "array_intersect",
+                List.of(Expr.class));
     }
 
     private static void registerDateFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
@@ -93,6 +93,15 @@ public class AnalyzeTranslateTest {
         assertTranslateTrinoSQL("translate trino select approx_set(\"tc\") from tall",
                 "SELECT hll_hash(`tc`)\nFROM `tall`");
 
+        assertTranslateTrinoSQL("translate trino select array[2,3]",
+                "SELECT ARRAY<TINYINT>[2, 3]");
+
+        assertTranslateTrinoSQL("translate trino select cardinality(array[1,2,3])",
+                "SELECT cardinality(ARRAY<TINYINT>[1, 2, 3])");
+
+        assertTranslateTrinoSQL("translate trino select cardinality(array_intersect(array[1,2,3], array[3,4,5]))",
+                "SELECT cardinality(array_intersect(ARRAY<TINYINT>[1, 2, 3], ARRAY<TINYINT>[3, 4, 5]))");
+
         // test TPCH query
         assertTranslateTrinoSQL("translate trino select\n" +
                 "  o_orderpriority,\n" +


### PR DESCRIPTION
## Why I'm doing:
Functionality with array types and some array functions is not working


## What I'm doing:
Registering `cardinality` and `array_intersect` function in Trino to Starrocks Transformer.
Additionally we are also enhancing the ArrayType creation in the `ASTBuilder`

Fixes #issue
https://github.com/StarRocks/starrocks/issues/64324

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3