### PR TITLE
[BugFix] Handle WindowSkewHint in OptExpressionDuplicator 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -524,6 +524,10 @@ public class OptExpressionDuplicator {
             }
             opBuilder.setWindowCall(newWindowCalls);
 
+            if (windowOperator.getSkewColumn() != null) {
+                opBuilder.setSkewColumn(getNewScalarOp(windowOperator.getSkewColumn()));
+            }
+
             processCommon(opBuilder);
 
             return OptExpression.create(opBuilder.build(), inputs);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -656,4 +656,21 @@ class WindowSkewTest extends PlanTestBase {
         String plan = getCostPlan(sql);
         assertPlanHasUnionAndAnalytic(plan, 4);
     }
+
+    @Test
+    void testWindowSkewDuplicatorRemapsSkewColumn() throws Exception {
+
+        String sql = "select p, s, " +
+                "sum(x) over ([skew|p(NULL)] partition by p order by s), " +
+                "avg(x) over ([skew|p(NULL)] partition by p order by x) " +
+                "from " + TABLE_NAME;
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+
+        assertContains(plan, "UNION");
+        assertContains(plan, "ANALYTIC");
+        assertNullSplit(plan);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Similar to https://github.com/StarRocks/starrocks/pull/68964, fixes issue where skew hint is not correctly rewritten.

## What I'm doing:
Adding support to rewrite skew hint column in the `OptExpressionDuplicator`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
