### PR TITLE
[BugFix] Fix the issue that the iceberg initial-default value is ignored when reading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -429,8 +429,23 @@ public class IcebergTable extends Table {
         tIcebergTable.setLocation(getNativeTable().location());
 
         List<TColumn> tColumns = Lists.newArrayList();
+        Schema iceSchema = nativeTable.schema();
         for (Column column : getBaseSchema()) {
-            tColumns.add(column.toThrift());
+            TColumn tc = column.toThrift();
+            // Per Iceberg spec, the read path should ONLY use initial-default to backfill
+            // missing columns in historical files. write-default is irrelevant for reads.
+            Types.NestedField field = iceSchema.findField(column.getName());
+            if (field != null) {
+                String initialDefault = IcebergApiConverter.toInitialDefaultValueString(field);
+                if (initialDefault != null) {
+                    tc.setDefault_value(initialDefault);
+                } else {
+                    // initial-default not set: per spec, missing columns should be null.
+                    // Clear any write-default that Column.toThrift() may have set.
+                    tc.unsetDefault_value();
+                }
+            }
+            tColumns.add(tc);
         }
         tIcebergTable.setColumns(tColumns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -379,7 +379,7 @@ public class IcebergApiConverter {
         return fullSchema;
     }
 
-    private static String toInitialDefaultValueString(Types.NestedField field) {
+    public static String toInitialDefaultValueString(Types.NestedField field) {
         return toDefaultValueString(field, false);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -338,6 +338,65 @@ public class IcebergTableTest extends TableTestBase {
     }
 
     @Test
+    public void testToThriftUsesInitialDefaultNotWriteDefault() {
+        // Build an Iceberg schema where initial-default != write-default
+        Schema iceSchema = new Schema(
+                Types.NestedField.optional("c_both").withId(1)
+                        .ofType(Types.IntegerType.get()).withInitialDefault(5).withWriteDefault(10).build(),
+                Types.NestedField.optional("c_write_only").withId(2)
+                        .ofType(Types.IntegerType.get()).withWriteDefault(10).build(),
+                Types.NestedField.optional("c_initial_only").withId(3)
+                        .ofType(Types.IntegerType.get()).withInitialDefault(5).build(),
+                Types.NestedField.optional("c_no_default").withId(4)
+                        .ofType(Types.IntegerType.get()).build()
+        );
+
+        // Mock native table
+        org.apache.iceberg.BaseTable nativeTable = Mockito.mock(org.apache.iceberg.BaseTable.class);
+        Mockito.when(nativeTable.schema()).thenReturn(iceSchema);
+        Mockito.when(nativeTable.spec()).thenReturn(PartitionSpec.unpartitioned());
+        Mockito.when(nativeTable.location()).thenReturn("s3://bucket/table");
+        Mockito.when(nativeTable.sortOrder()).thenReturn(SortOrder.unsorted());
+
+        // Simulate what toFullSchemas does: Column.defaultValue = write-default (or fallback to initial-default)
+        Column cBoth = new Column("c_both", INT, true);
+        cBoth.setDefaultValue("10"); // write-default
+        Column cWriteOnly = new Column("c_write_only", INT, true);
+        cWriteOnly.setDefaultValue("10"); // write-default
+        Column cInitialOnly = new Column("c_initial_only", INT, true);
+        cInitialOnly.setDefaultValue("5"); // initial-default as fallback
+        Column cNoDefault = new Column("c_no_default", INT, true);
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(1)
+                .setSrTableName("t")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tbl")
+                .setFullSchema(Lists.newArrayList(cBoth, cWriteOnly, cInitialOnly, cNoDefault))
+                .setNativeTable(nativeTable)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+
+        TTableDescriptor desc = table.toThrift(new ArrayList<>());
+        List<com.starrocks.thrift.TColumn> tColumns = desc.getIcebergTable().getColumns();
+
+        // Case A: both defaults differ -> TColumn should use initial-default (5), not write-default (10)
+        Assertions.assertTrue(tColumns.get(0).isSetDefault_value());
+        Assertions.assertEquals("5", tColumns.get(0).getDefault_value());
+
+        // Case B: only write-default -> TColumn should have no default (cleared per spec)
+        Assertions.assertFalse(tColumns.get(1).isSetDefault_value());
+
+        // Case C: only initial-default -> TColumn should use initial-default (5)
+        Assertions.assertTrue(tColumns.get(2).isSetDefault_value());
+        Assertions.assertEquals("5", tColumns.get(2).getDefault_value());
+
+        // Case D: no default at all -> TColumn should have no default
+        Assertions.assertFalse(tColumns.get(3).isSetDefault_value());
+    }
+
+    @Test
     public void testGetNativeTableThrows() {
         org.apache.iceberg.Schema icebergSchema =
                 new org.apache.iceberg.Schema(

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -937,4 +937,31 @@ public class IcebergApiConverterTest {
         assertNotNull(field.initialDefault());
     }
 
+    @Test
+    public void testDifferingInitialAndWriteDefaults() {
+        // Case A: Both initial-default and write-default set to different values
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("c_both").withId(1)
+                .ofType(Types.IntegerType.get()).withInitialDefault(5).withWriteDefault(10).build());
+        // Case B: Only write-default (no initial-default)
+        fields.add(Types.NestedField.optional("c_write_only").withId(2)
+                .ofType(Types.IntegerType.get()).withWriteDefault(10).build());
+        // Case C: Only initial-default (no write-default)
+        fields.add(Types.NestedField.optional("c_initial_only").withId(3)
+                .ofType(Types.IntegerType.get()).withInitialDefault(5).build());
+
+        Schema schema = new Schema(fields);
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+
+        // toFullSchemas stores write-default (for INSERT path), falling back to initial-default
+        assertEquals("10", columns.get(0).getDefaultValue()); // write-default wins
+        assertEquals("10", columns.get(1).getDefaultValue()); // write-default only
+        assertEquals("5", columns.get(2).getDefaultValue());  // initial-default as fallback
+
+        // toInitialDefaultValueString returns ONLY the initial-default
+        assertEquals("5", IcebergApiConverter.toInitialDefaultValueString(schema.findField("c_both")));
+        assertNull(IcebergApiConverter.toInitialDefaultValueString(schema.findField("c_write_only")));
+        assertEquals("5", IcebergApiConverter.toInitialDefaultValueString(schema.findField("c_initial_only")));
+    }
+
 }


### PR DESCRIPTION
## What I'm doing:

This pull request improves the handling of default values for Iceberg table columns, ensuring compliance with the Iceberg specification. The main change is that the read path now correctly uses only the initial-default value for columns, ignoring write-defaults, and updates the conversion logic and tests accordingly.

### Default value handling improvements

* Updated `IcebergTable.toThrift()` to use only the initial-default value for each column when serializing to Thrift, clearing any write-default if initial-default is not set, per Iceberg spec.
* Made `IcebergApiConverter.toInitialDefaultValueString()` public to allow access to initial-default values from other classes.

### Testing enhancements

* Added a unit test in `IcebergTableTest` to verify that `toThrift()` uses initial-default values and ignores write-defaults for columns, covering all combinations of default settings.
* Added a test in `IcebergApiConverterTest` to validate that schema conversion logic stores write-default for inserts but falls back to initial-default, and that initial-default extraction behaves correctly.


Fixes [#issue](https://github.com/StarRocks/starrocks/issues/69709)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
