### PR TITLE
[BugFix] Fix duplicated partition names in mv refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
@@ -32,6 +33,7 @@ import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.expression.LiteralExpr;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,6 +81,34 @@ public class CatalogUtils {
         }
     }
 
+    /**
+     * Format partition values from an existing partition for log comparison.
+     */
+    private static String formatExistedPartitionValues(OlapTable olapTable, Partition partition) {
+        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        long partitionId = partition.getId();
+        if (partitionInfo instanceof ListPartitionInfo) {
+            ListPartitionInfo listInfo = (ListPartitionInfo) partitionInfo;
+            List<String> values = MapUtils.emptyIfNull(listInfo.getIdToValues()).get(partitionId);
+            List<List<String>> multiValues = MapUtils.emptyIfNull(listInfo.getIdToMultiValues()).get(partitionId);
+            if (values != null && !values.isEmpty()) {
+                return "VALUES IN (" + values.stream().map(v -> "'" + v + "'")
+                        .collect(Collectors.joining(",")) + ")";
+            }
+            if (multiValues != null && !multiValues.isEmpty()) {
+                return "VALUES IN (" + multiValues.stream()
+                        .map(row -> "(" + row.stream().map(v -> "'" + v + "'")
+                                .collect(Collectors.joining(",")) + ")")
+                        .collect(Collectors.joining(",")) + ")";
+            }
+        } else if (partitionInfo instanceof RangePartitionInfo) {
+            RangePartitionInfo rangeInfo = (RangePartitionInfo) partitionInfo;
+            Range<PartitionKey> range = rangeInfo.getRange(partitionId);
+            return range != null ? range.toString() : "null";
+        }
+        return "unknown";
+    }
+
     public static Set<String> checkPartitionNameExistForAddPartitions(OlapTable olapTable,
                                                                       List<PartitionDesc> partitionDescs)
             throws DdlException {
@@ -91,8 +121,10 @@ public class CatalogUtils {
                 } else {
                     // add more information for user
                     Partition existedPartition = olapTable.getPartition(partitionName);
-                    LOG.warn("Duplicate partition name {}, existed partition:{}, current partition:{}", partitionName,
-                            existedPartition, partitionDesc);
+                    String existedValues = formatExistedPartitionValues(olapTable, existedPartition);
+                    String currentValues = partitionDesc.toString();
+                    LOG.warn("Duplicate partition name {}, existed values: {}, current values: {}", partitionName,
+                            existedValues, currentValues);
                     ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -33,7 +33,6 @@ import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.expression.LiteralExpr;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -89,8 +88,8 @@ public class CatalogUtils {
         long partitionId = partition.getId();
         if (partitionInfo instanceof ListPartitionInfo) {
             ListPartitionInfo listInfo = (ListPartitionInfo) partitionInfo;
-            List<String> values = MapUtils.emptyIfNull(listInfo.getIdToValues()).get(partitionId);
-            List<List<String>> multiValues = MapUtils.emptyIfNull(listInfo.getIdToMultiValues()).get(partitionId);
+            List<String> values = listInfo.getIdToValues().get(partitionId);
+            List<List<String>> multiValues = listInfo.getIdToMultiValues().get(partitionId);
             if (values != null && !values.isEmpty()) {
                 return "VALUES IN (" + values.stream().map(v -> "'" + v + "'")
                         .collect(Collectors.joining(",")) + ")";
@@ -120,8 +119,13 @@ public class CatalogUtils {
                     existPartitionNameSet.add(partitionName);
                 } else {
                     // add more information for user
+                    // checkPartitionNameExist checks both normal and temp partitions, so fall back to temp lookup
                     Partition existedPartition = olapTable.getPartition(partitionName);
-                    String existedValues = formatExistedPartitionValues(olapTable, existedPartition);
+                    if (existedPartition == null) {
+                        existedPartition = olapTable.getPartition(partitionName, true);
+                    }
+                    String existedValues = existedPartition != null
+                            ? formatExistedPartitionValues(olapTable, existedPartition) : "unknown";
                     String currentValues = partitionDesc.toString();
                     LOG.warn("Duplicate partition name {}, existed values: {}, current values: {}", partitionName,
                             existedValues, currentValues);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -46,7 +46,8 @@ public final class ListPartitionDiffer extends PartitionDiffer {
     }
 
     /**
-     * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into result.
+     * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into
+     * result.
      *
      * Compare the partition of the base table and the partition of the mv.
      * @param baseItems the partition name to its list partition cell of the base table
@@ -54,26 +55,27 @@ public final class ListPartitionDiffer extends PartitionDiffer {
      * @return the list partition diff between the base table and the mv
      */
     public static PartitionDiff getListPartitionDiff(PCellSortedSet baseItems,
-                                                     PCellSortedSet mvItems,
-                                                     Set<String> uniqueResultNames) {
+                                                     PCellSortedSet mvItems) {
         // This synchronization method has a one-to-one correspondence
         // between the base table and the partition of the mv.
         // for addition, we need to ensure the partition name is unique in case-insensitive
-        PCellSortedSet adds = diffList(baseItems, mvItems, uniqueResultNames);
+        PCellSortedSet adds = diffList(baseItems, mvItems, true);
         // for deletion, we don't need to ensure the partition name is unique since mvItems is used as the reference
-        PCellSortedSet deletes = diffList(mvItems, baseItems, null);
+        PCellSortedSet deletes = diffList(mvItems, baseItems, false);
         return new PartitionDiff(adds, deletes);
     }
 
     /**
-     * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into result.
-     * When `uniqueResultNames` is set, use it to ensure the output partition name is unique in case-insensitive.
-     * NOTE: Ensure output map keys are distinct in case-insensitive which is because the key is used for partition name,
-     * and StarRocks partition name is case-insensitive.
+     * Iterate srcListMap, if the partition name is not in dstListMap or the partition value is different, add into
+     * result.
+     * When `isEnsureUniqueResultNames` is true, ensure the output partition names are unique in case-insensitive
+     * by checking against both existing destination partitions and partitions generated in this diff.
+     * NOTE: StarRocks partition names are case-insensitive, so output map keys must also be distinct in
+     * case-insensitive when this option is enabled.
      */
     public static PCellSortedSet diffList(PCellSortedSet srcPCells,
                                           PCellSortedSet dstPCells,
-                                          Set<String> uniqueResultNames) {
+                                          boolean isEnsureUniqueResultNames) {
         if (srcPCells == null || srcPCells.isEmpty()) {
             return PCellSortedSet.of();
         }
@@ -89,6 +91,11 @@ public final class ListPartitionDiffer extends PartitionDiffer {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
                         (v1, v2) -> v1, Maps::newTreeMap));
         PCellSortedSet result = PCellSortedSet.of();
+        PCellSortedSet occupiedPartitions = null;
+        if (isEnsureUniqueResultNames) {
+            occupiedPartitions = PCellSortedSet.of();
+            occupiedPartitions.addAll(dstPCells);
+        }
         for (PCellWithName srcPCell : srcPCells.getPartitions()) {
             String pName = srcPCell.name();
             PListCell srcItem = (PListCell) srcPCell.cell();
@@ -107,15 +114,17 @@ public final class ListPartitionDiffer extends PartitionDiffer {
                         .map(items -> items.get(0))
                         .collect(Collectors.toList());
                 PListCell newSrcValue = new PListCell(newSrcItems);
-                // ensure the partition name is unique
-                if (uniqueResultNames != null && uniqueResultNames.contains(pName)) {
-                    try {
-                        // it's fine to use result to keep it unique here, since we always
-                        pName = AnalyzerUtils.calculateUniquePartitionName(pName, newSrcValue, result);
-                    } catch (Exception e) {
-                        throw new RuntimeException("Fail to calculate unique partition name: " + e.getMessage());
+                // Optionally ensure the output partition name is unique against both existing destination partitions
+                // and newly generated result partitions.
+                if (occupiedPartitions != null) {
+                    if (occupiedPartitions.containsName(pName)) {
+                        try {
+                            pName = AnalyzerUtils.calculateUniquePartitionName(pName, newSrcValue, occupiedPartitions);
+                        } catch (Exception e) {
+                            throw new RuntimeException("Fail to calculate unique partition name: " + e.getMessage());
+                        }
                     }
-                    uniqueResultNames.add(pName);
+                    occupiedPartitions.add(PCellWithName.of(pName, newSrcValue));
                 }
                 result.add(PCellWithName.of(pName, newSrcValue));
             }
@@ -371,12 +380,7 @@ public final class ListPartitionDiffer extends PartitionDiffer {
         // collect all base table partition cells
         PCellSortedSet allBasePartitionItems = collectBasePartitionCells(refBaseTablePartitionMap);
 
-        // ensure the result partition name is unique in case-insensitive
-        Set<String> uniqueResultNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        uniqueResultNames.addAll(mvPartitionNameToListMap.getPartitionNames());
-
-        PartitionDiff diff = ListPartitionDiffer.getListPartitionDiff(allBasePartitionItems,
-                mvPartitionNameToListMap, uniqueResultNames);
+        PartitionDiff diff = ListPartitionDiffer.getListPartitionDiff(allBasePartitionItems, mvPartitionNameToListMap);
 
         // collect external partition column mapping
         Map<Table, PartitionNameSetMap> externalPartitionMaps = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -216,8 +216,7 @@ public class SyncPartitionUtilsTest extends StarRocksTestBase {
 
     private Map<String, PListCell> diffList(PCellSortedSet baseListMap,
                                             PCellSortedSet mvListMap) {
-        PCellSortedSet result = ListPartitionDiffer.diffList(baseListMap, mvListMap,
-                mvListMap.getPartitionNames());
+        PCellSortedSet result = ListPartitionDiffer.diffList(baseListMap, mvListMap, true);
         return result.getPartitions().stream()
                 .collect(Collectors.toMap(PCellWithName::name, entry -> (PListCell) entry.cell()));
     }
@@ -323,6 +322,22 @@ public class SyncPartitionUtilsTest extends StarRocksTestBase {
 
         diff = diffList(baseListMap, mvListMap);
         Assertions.assertEquals(0, diff.size());
+    }
+
+    @Test
+    public void testDiffListWithExistingPartitionNameConflict() {
+        // Same partition name with different values (e.g. domain values that sanitize to same partition name)
+        PCellSortedSet baseListMap = PCellSortedSet.of();
+        addIntoListPartitionMap(baseListMap, "psampledomain2ecom", "sample-domain.com");
+
+        PCellSortedSet mvListMap = PCellSortedSet.of();
+        addIntoListPartitionMap(mvListMap, "psampledomain2ecom", "sample-domain2.com");
+
+        Map<String, PListCell> diff = diffList(baseListMap, mvListMap);
+        Assertions.assertEquals(1, diff.size());
+        Assertions.assertFalse(diff.containsKey("psampledomain2ecom"));
+        Assertions.assertEquals("sample-domain.com",
+                diff.values().iterator().next().getPartitionItems().iterator().next().get(0));
     }
 
     @Test

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_duplicated_partition_names2
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_duplicated_partition_names2
@@ -1,0 +1,69 @@
+-- name: test_mv_refresh_list_partitions_with_duplicated_partition_names2
+CREATE TABLE bt1 (
+    id BIGINT,
+    province VARCHAR(64) NOT NULL
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+    PARTITION psampledomain2ecom VALUES IN ("sample-domain2.com"),
+    PARTITION psampledomainecom VALUES IN ("sample-domain.com")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE bt2 (
+    id BIGINT,
+    province VARCHAR(64) NOT NULL
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+    PARTITION pother VALUES IN ("other.com")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO bt1 VALUES (1, "sample-domain.com");
+-- result:
+-- !result
+INSERT INTO bt1 VALUES (1, "sample-domain2.com");
+-- result:
+-- !result
+INSERT INTO bt2 VALUES (1, "other.com");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_dup_partition_name_repro
+PARTITION BY province
+DISTRIBUTED BY HASH(province) BUCKETS 1
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT bt1.province, bt2.id
+FROM bt1 LEFT JOIN bt2 ON bt1.province = bt2.province;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_dup_partition_name_repro WITH SYNC MODE;
+-- result:
+019cf9c0-6fa7-7d13-8894-3ef2c1aa1597
+-- !result
+SELECT * FROM mv_dup_partition_name_repro ORDER BY 1, 2;
+-- result:
+sample-domain.com	None
+sample-domain2.com	None
+-- !result
+ALTER TABLE bt2 ADD PARTITION psampledomain2ecom VALUES IN ("sample-domain.com");
+-- result:
+-- !result
+INSERT INTO bt2 VALUES (1, "sample-domain.com");
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_dup_partition_name_repro WITH SYNC MODE;
+-- result:
+019cf9c0-7b71-7f89-ae80-c110d0ae4df8
+-- !result
+SELECT * FROM mv_dup_partition_name_repro ORDER BY 1, 2;
+-- result:
+sample-domain.com	1
+sample-domain2.com	None
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_duplicated_partition_names2
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_duplicated_partition_names2
@@ -1,0 +1,50 @@
+-- name: test_mv_refresh_list_partitions_with_duplicated_partition_names2
+CREATE TABLE bt1 (
+    id BIGINT,
+    province VARCHAR(64) NOT NULL
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+    PARTITION psampledomain2ecom VALUES IN ("sample-domain2.com"),
+    PARTITION psampledomainecom VALUES IN ("sample-domain.com")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE bt2 (
+    id BIGINT,
+    province VARCHAR(64) NOT NULL
+)
+PRIMARY KEY(id, province)
+PARTITION BY LIST (province) (
+    PARTITION pother VALUES IN ("other.com")
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO bt1 VALUES (1, "sample-domain.com");
+INSERT INTO bt1 VALUES (1, "sample-domain2.com");
+INSERT INTO bt2 VALUES (1, "other.com");
+
+CREATE MATERIALIZED VIEW mv_dup_partition_name_repro
+PARTITION BY province
+DISTRIBUTED BY HASH(province) BUCKETS 1
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+SELECT bt1.province, bt2.id
+FROM bt1 LEFT JOIN bt2 ON bt1.province = bt2.province;
+
+-- first refresh: MV gets existing partition psampledomain2ecom
+[UC]REFRESH MATERIALIZED VIEW mv_dup_partition_name_repro WITH SYNC MODE;
+SELECT * FROM mv_dup_partition_name_repro ORDER BY 1, 2;
+
+-- add a partition with the same partition name but different partition value in another base table
+ALTER TABLE bt2 ADD PARTITION psampledomain2ecom VALUES IN ("sample-domain.com");
+INSERT INTO bt2 VALUES (1, "sample-domain.com");
+
+-- second refresh:
+-- before fix: fails with Duplicate partition name psampledomain2ecom
+-- after fix: succeeds and creates a renamed MV partition
+[UC]REFRESH MATERIALIZED VIEW mv_dup_partition_name_repro WITH SYNC MODE;
+SELECT * FROM mv_dup_partition_name_repro ORDER BY 1, 2;


### PR DESCRIPTION
## Why I'm doing:


A regression in the partition deduplication logic introduced by a prior bug fix ([PR #62446](https://github.com/StarRocks/starrocks/pull/62446)) caused the materialized view  to fail on every refresh attempt with a Duplicate partition name error. 
The root cause is that the previous fix only ensured uniqueness among partitions being added within a single refresh cycle, but did not validate the new partitions against partitions already existing on the materialized view. 



## What I'm doing:

backport from branch-3.5: https://github.com/StarRocks/starrocks/pull/70328

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
