### PR TITLE
[Enhancement] Add fast cancel for lake replication file copy (backport #70222)

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -242,7 +242,18 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     MonotonicStopWatch watch;
     watch.start();
     size_t total_file_size = 0;
+
     for (const auto& pair : filename_map) {
+        // Fast cancel: check if the transaction has been aborted
+        if (txn_id < get_master_info().min_active_txn_id) {
+            LOG(WARNING) << "Lake replication task cancelled, transaction is aborted"
+                         << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
+                         << ", min_active_txn_id: " << get_master_info().min_active_txn_id
+                         << ", copied files: " << files_to_delete.size() << "/" << filename_map.size();
+            return Status::Aborted("Lake replication cancelled, transaction is aborted");
+        }
+        TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy", nullptr);
+
         const auto& src_file_name = pair.first;
         auto src_file_location = join_path(src_data_dir, src_file_name);
         auto it = file_locations.find(src_file_location);
@@ -307,8 +318,8 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         copy_rate = (total_file_size / 1024. / 1024.) / total_time_sec;
     }
     LOG(INFO) << "Replicated tablet file count: " << filename_map.size() << ", total bytes: " << total_file_size
-              << ", cost: " << total_time_sec << "s, rate: " << copy_rate << "MB/s, txn_id: " << txn_id
-              << ", tablet_id: " << target_tablet_id;
+              << ", cost: " << total_time_sec << "s, rate: " << copy_rate << "MB/s"
+              << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
 
     // Update segment sizes in tablet_metadata if there are any changes
     if (!segment_size_changes.empty()) {

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -941,7 +941,7 @@ protected:
         _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
-        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
         _replication_txn_manager = std::make_unique<lake::LakeReplicationTxnManager>(_tablet_mgr.get());
 
         _src_tablet_metadata = generate_simple_tablet_metadata(_src_tablet_id);
@@ -1146,8 +1146,8 @@ TEST_F(LakeReplicationRemoteStorageTest, test_fast_cancel_txn_aborted_before_cop
     rowset->set_overlapped(false);
     rowset->set_num_rows(10);
     rowset->set_data_size(1024);
-    rowset->add_segments("test_segment_001.dat");
-    rowset->add_segments("test_segment_002.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000002.dat");
     src_meta_v2->set_next_rowset_id(2);
 
     // Pre-populate the metacache with source tablet metadata at the starlet URI path
@@ -1195,8 +1195,8 @@ TEST_F(LakeReplicationRemoteStorageTest, test_fast_cancel_txn_aborted_during_cop
     rowset->set_overlapped(false);
     rowset->set_num_rows(10);
     rowset->set_data_size(1024);
-    rowset->add_segments("test_segment_001.dat");
-    rowset->add_segments("test_segment_002.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000002.dat");
     src_meta_v2->set_next_rowset_id(2);
 
     // Pre-populate the metacache with source tablet metadata at the starlet URI path
@@ -1262,7 +1262,7 @@ TEST_F(LakeReplicationRemoteStorageTest, test_no_fast_cancel_when_txn_active) {
     rowset->set_overlapped(false);
     rowset->set_num_rows(10);
     rowset->set_data_size(1024);
-    rowset->add_segments("test_segment_001.dat");
+    rowset->add_segments("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
     src_meta_v2->set_next_rowset_id(2);
 
     // Pre-populate the metacache with source tablet metadata at the starlet URI path

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -20,6 +20,7 @@
 
 #include <random>
 
+#include "agent/master_info.h"
 #include "testutil/sync_point.h"
 #ifdef USE_STAROS
 #include <fslib/file.h>
@@ -40,9 +41,11 @@
 #include "service/staros_worker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_reshard.h"
@@ -1121,6 +1124,175 @@ TEST_F(LakeReplicationRemoteStorageTest, test_has_full_path_non_s3_type_rejected
     EXPECT_FALSE(status.ok());
     EXPECT_TRUE(status.is_invalid_argument()) << status;
     EXPECT_NE(std::string::npos, status.message().find("Full path must be S3 type"));
+}
+
+// Test Case 6: Fast cancel - when min_active_txn_id > txn_id, replication should abort
+// before copying any files.
+TEST_F(LakeReplicationRemoteStorageTest, test_fast_cancel_txn_aborted_before_copy) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+
+    // Mock new_fs_starlet to return a valid filesystem
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Create source tablet metadata at version 2 with a rowset containing segment files.
+    // This is needed so that filename_map is non-empty and the file copy loop is entered.
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(1024);
+    rowset->add_segments("test_segment_001.dat");
+    rowset->add_segments("test_segment_002.dat");
+    src_meta_v2->set_next_rowset_id(2);
+
+    // Pre-populate the metacache with source tablet metadata at the starlet URI path
+    // that build_source_tablet_meta will look up (for has_full_path=false code path).
+    // RemoteStarletLocationProvider::metadata_root_location returns:
+    //   staros://{tablet_id}/db{db_id}/{table_id}/{partition_id}/meta
+    std::string src_meta_dir =
+            fmt::format("staros://{}/db{}/{}/{}/meta", _src_tablet_id, _src_db_id, _src_table_id, _src_partition_id);
+    std::string src_meta_path = lake::join_path(src_meta_dir, lake::tablet_metadata_filename(_src_tablet_id, 2));
+    _tablet_mgr->metacache()->cache_tablet_metadata(src_meta_path, src_meta_v2);
+
+    // Save original master info and set min_active_txn_id > txn_id to trigger fast cancel
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(_transaction_id + 1);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    // Restore original master info
+    update_master_info(original_master_info);
+
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_aborted()) << status;
+    EXPECT_NE(std::string::npos, status.message().find("Lake replication cancelled, transaction is aborted"));
+}
+
+// Test Case 7: Fast cancel - when min_active_txn_id advances during file copy (between
+// iterations), replication should abort after copying some files but before all files.
+TEST_F(LakeReplicationRemoteStorageTest, test_fast_cancel_txn_aborted_during_copy) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+
+    // Mock new_fs_starlet to return a valid filesystem
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Create source tablet metadata at version 2 with a rowset containing segment files
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(1024);
+    rowset->add_segments("test_segment_001.dat");
+    rowset->add_segments("test_segment_002.dat");
+    src_meta_v2->set_next_rowset_id(2);
+
+    // Pre-populate the metacache with source tablet metadata at the starlet URI path
+    std::string src_meta_dir =
+            fmt::format("staros://{}/db{}/{}/{}/meta", _src_tablet_id, _src_db_id, _src_table_id, _src_partition_id);
+    std::string src_meta_path = lake::join_path(src_meta_dir, lake::tablet_metadata_filename(_src_tablet_id, 2));
+    _tablet_mgr->metacache()->cache_tablet_metadata(src_meta_path, src_meta_v2);
+
+    // Save original master info. Start with min_active_txn_id <= txn_id (no abort yet).
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    // In the before_copy SyncPoint callback, advance min_active_txn_id past txn_id
+    // after the first file copy iteration. The next iteration's fast cancel check
+    // will detect the abort.
+    int before_copy_count = 0;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy",
+                                          [&](void*) {
+                                              before_copy_count++;
+                                              if (before_copy_count == 1) {
+                                                  // Advance min_active_txn_id past txn_id during first file's copy
+                                                  TMasterInfo updated_info = get_master_info();
+                                                  updated_info.__set_min_active_txn_id(_transaction_id + 1);
+                                                  update_master_info(updated_info);
+                                              }
+                                          });
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    // Restore original master info
+    update_master_info(original_master_info);
+
+    // The first iteration's before_copy callback runs (file copy attempt happens but may
+    // fail due to mock filesystem). Either:
+    // a) The first file copy fails (IOError from mock fs) - this is acceptable, OR
+    // b) If we somehow get past the first copy, the second iteration detects the abort.
+    //
+    // In practice with the mock filesystem, the first file copy will fail.
+    // But the before_copy callback was still invoked, verifying the SyncPoint is reachable.
+    EXPECT_FALSE(status.ok());
+    EXPECT_GE(before_copy_count, 1) << "SyncPoint before_copy should have been invoked at least once";
+}
+
+// Test Case 8: No fast cancel - when min_active_txn_id <= txn_id, the fast cancel check
+// should NOT abort the replication (it should proceed to the file copy step).
+TEST_F(LakeReplicationRemoteStorageTest, test_no_fast_cancel_when_txn_active) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+
+    // Mock new_fs_starlet to return a valid filesystem
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Create source tablet metadata at version 2 with a rowset containing a segment file
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(1024);
+    rowset->add_segments("test_segment_001.dat");
+    src_meta_v2->set_next_rowset_id(2);
+
+    // Pre-populate the metacache with source tablet metadata at the starlet URI path
+    std::string src_meta_dir =
+            fmt::format("staros://{}/db{}/{}/{}/meta", _src_tablet_id, _src_db_id, _src_table_id, _src_partition_id);
+    std::string src_meta_path = lake::join_path(src_meta_dir, lake::tablet_metadata_filename(_src_tablet_id, 2));
+    _tablet_mgr->metacache()->cache_tablet_metadata(src_meta_path, src_meta_v2);
+
+    // Set min_active_txn_id <= txn_id so fast cancel does NOT trigger
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(_transaction_id); // equal, not greater
+    ASSERT_TRUE(update_master_info(info));
+
+    bool before_copy_invoked = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy",
+                                          [&](void*) { before_copy_invoked = true; });
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+
+    // Restore original master info
+    update_master_info(original_master_info);
+
+    // The fast cancel check should NOT have triggered. The function should proceed past
+    // the fast cancel check to the before_copy SyncPoint and then to file copy.
+    // The file copy will fail due to the mock filesystem, but that's expected.
+    EXPECT_TRUE(before_copy_invoked) << "before_copy SyncPoint should have been reached (fast cancel did not trigger)";
+    // The status should NOT be Aborted (it should be some other error from file copy)
+    EXPECT_FALSE(status.is_aborted()) << "Should not abort when min_active_txn_id <= txn_id, status: " << status;
 }
 #endif // USE_STAROS
 

--- a/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
@@ -164,8 +164,10 @@ public class LakeReplicationJob extends ReplicationJob implements GsonPreProcess
             }
         }
         taskNum = runningTasks.size();
-        LOG.info("Send lake replicate snapshot task, task num: {}, database id: {}, table id: {}, transaction id: {}",
-                taskNum, super.getDatabaseId(), super.getTableId(), super.getTransactionId());
+        LOG.info("Send lake replicate snapshot task, task num: {}, partition num: {},"
+                        + " database id: {}, table id: {}, transaction id: {}",
+                taskNum, super.getPartitionInfos().size(), super.getDatabaseId(),
+                super.getTableId(), super.getTransactionId());
         sendRunningTasks();
     }
 


### PR DESCRIPTION
## Why I'm doing:

When FE aborts a lake replication transaction (e.g., user drops the table), the CN side file copy loop continues copying all files with no cancellation check, wasting resources and time for large tables.

## What I'm doing:

This change adds:

Fast cancel: min_active_txn_id check at the beginning of each file copy iteration to detect transaction abort promptly and stop copying, consistent with the existing pattern in ReplicationTxnManager::build_file_converters().
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

