### PR TITLE
[Enhancement] WIP: Reuse common sub-expressions during query optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -93,8 +93,18 @@ import java.util.stream.Collectors;
 public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     private String appendProjectionAndPredicate(Operator op) {
         StringBuilder sb = new StringBuilder();
-        if (op.getProjection() != null && !op.getProjection().getColumnRefMap().isEmpty()) {
-            sb.append(appendProject(op.getProjection().getColumnRefMap()));
+        if (op.getProjection() != null) {
+            if (!op.getProjection().getColumnRefMap().isEmpty()) {
+                sb.append(appendProject(op.getProjection().getColumnRefMap()));
+                if (!op.getProjection().getCommonSubOperatorMap().isEmpty()) {
+                    sb.append(", ");
+                    String subExprStr = op.getProjection().getCommonSubOperatorMap().entrySet()
+                            .stream()
+                            .map(e -> e.getKey() + "->" + e.getValue())
+                            .collect(Collectors.joining(", ", "commonSubOperatorMap=[", "]"));
+                    sb.append(subExprStr);
+                }
+            }
         }
         if (op.getPredicate() != null) {
             sb.append(", predicate=").append(op.getPredicate());
@@ -150,7 +160,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
                 ", outputColumns=" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) +
                 ", prunedPartitionPredicates=" + node.getPrunedPartitionPredicates() +
                 ", limit=" + node.getLimit() +
-                appendProjectionAndPredicate(node) +
+                ", " + appendProjectionAndPredicate(node) +
                 "}";
     }
 
@@ -160,7 +170,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
                 ", outputColumns=" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) +
                 ", predicates=" + node.getScanOperatorPredicates() +
                 ", limit=" + node.getLimit() +
-                appendProjectionAndPredicate(node) +
+                ", " + appendProjectionAndPredicate(node) +
                 "}";
     }
 
@@ -222,6 +232,13 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     public String visitLogicalProject(LogicalProjectOperator node, Void context) {
         StringBuilder sb = new StringBuilder("LogicalProjectOperator {");
         sb.append(appendProject(node.getColumnRefMap()));
+        if (!node.getCommonSubOperatorMap().isEmpty()) {
+            String subExprStr = node.getCommonSubOperatorMap().entrySet()
+                    .stream()
+                    .map(e -> e.getKey() + "->" + e.getValue())
+                    .collect(Collectors.joining(", ", "subExprs=[", "]"));
+            sb.append(", ").append(subExprStr);
+        }
         sb.append("}");
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -123,6 +123,7 @@ public class MaterializedViewOptimizer {
                 return new MvPlanContext(false, "No query plan for it");
             }
             OptExpression mvPlan = plans.first;
+            QueryOptimizer.eliminateAllCommonSubOperatorMaps(mvPlan);
             boolean isValidPlan = MvUtils.isValidMVPlan(mvPlan);
             // not set it invalid plan if text match rewrite is on because text match rewrite can support all query pattern.
             String invalidPlanReason = "";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.cost.feature.PlanFeatures;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
@@ -428,6 +429,8 @@ public class QueryOptimizer extends Optimizer {
         }
         context.getQueryMaterializationContext().setCurrentRewriteStage(MvRewriteStrategy.MVRewriteStage.PHASE2);
 
+        eliminateAllCommonSubOperatorMaps(tree);
+
         // do rule based mv rewrite if needed
         if (context.getQueryMaterializationContext().isNeedsFurtherMVRewrite()) {
             doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
@@ -490,6 +493,8 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+
+        eliminateAllCommonSubOperatorMaps(tree);
 
         // do rule based mv rewrite
         doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
@@ -659,6 +664,8 @@ public class QueryOptimizer extends Optimizer {
         if (!optimizerOptions.isRuleDisable(TF_MATERIALIZED_VIEW)
                 && sessionVariable.isEnableSyncMaterializedViewRewrite()
                 && !context.getQueryMaterializationContext().hasRewrittenSuccess()) {
+            eliminateAllCommonSubOperatorMaps(tree);
+
             // Split or predicates to union all so can be used by mv rewrite to choose the best sort key indexes.
             // TODO: support adaptive for or-predicates to union all.
             if (SplitScanORToUnionRule.isForceRewrite()) {
@@ -781,6 +788,7 @@ public class QueryOptimizer extends Optimizer {
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "try VIEW_BASED_MV_REWRITE");
             // Clone the tree to avoid modifying the original tree stored in QueryMaterializationContext
             OptExpression treeWithView = MvUtils.cloneExpression(queryMaterializationContext.getQueryOptPlanWithView());
+            eliminateAllCommonSubOperatorMaps(treeWithView);
             // Derive logical property for the cloned tree to ensure it has complete metadata
             MvUtils.deriveLogicalProperty(treeWithView);
             OptimizerTraceUtil.logOptExpression("before ViewBasedMvRuleRewrite:\n%s", tree);
@@ -1119,5 +1127,27 @@ public class QueryOptimizer extends Optimizer {
             scheduler.pushTask(new PrepareCollectMetaTask(rootTaskContext, tree));
             scheduler.executeTasks(rootTaskContext);
         }
+    }
+
+    private static final OptExpressionVisitor<Void, Void> ELIMINATE_COMMON_SUB_OPS_VISITOR =
+            new OptExpressionVisitor<Void, Void>() {
+                @Override
+                public Void visit(OptExpression opt, Void context) {
+                    Operator op = opt.getOp();
+                    if (op.getProjection() != null) {
+                        op.getProjection().eliminateSubColumnRefMap();
+                    }
+                    if (op instanceof LogicalProjectOperator) {
+                        ((LogicalProjectOperator) op).eliminateCommonSubOperatorMap();
+                    }
+                    for (OptExpression child : opt.getInputs()) {
+                        child.getOp().accept(this, child, null);
+                    }
+                    return null;
+                }
+            };
+
+    public static void eliminateAllCommonSubOperatorMaps(OptExpression tree) {
+        tree.getOp().accept(ELIMINATE_COMMON_SUB_OPS_VISITOR, tree, null);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
@@ -132,8 +132,8 @@ public class RowOutputInfo {
         return Lists.newArrayList(chooseOutputMap().values());
     }
 
-    public List<ColumnOutputInfo> getCommonColInfo() {
-        return Lists.newArrayList(commonColInfo.values());
+    public Map<Integer, ColumnOutputInfo> getCommonColInfo() {
+        return commonColInfo;
     }
 
     public List<ColumnRefOperator> getOutputColRefs() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnOutputInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnOutputInfo.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.operator;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 
 import java.util.Map;
 
@@ -61,6 +62,9 @@ public class ColumnOutputInfo {
         return scalarOperator.getUsedColumns();
     }
 
+    public ColumnRefSet getUsedInputColumns(Map<Integer, ScalarOperator> commonSubOperatorById) {
+        return ScalarOperatorUtil.getUsedInputColumns(scalarOperator, commonSubOperatorById);
+    }
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.operator;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 
 import java.util.ArrayList;
@@ -73,13 +74,12 @@ public class Projection {
         return new ArrayList<>(columnRefMap.keySet());
     }
 
-    public ColumnRefSet getUsedColumns() {
-        final ColumnRefSet usedColumns = new ColumnRefSet();
-        columnRefMap.values().stream().forEach(e -> usedColumns.union(e.getUsedColumns()));
-        commonSubOperatorMap.values().stream().forEach(e -> usedColumns.union(e.getUsedColumns()));
-        // remove some of columnRefMap's used columns which are from commonSubOperatorMap's output column
-        commonSubOperatorMap.keySet().stream().forEach(e -> usedColumns.except(e.getUsedColumns()));
-        return usedColumns;
+    /**
+     * Returns the set of input (child) column references used by this projection's expressions, excluding columns produced by
+     * common sub-operators.
+     */
+    public ColumnRefSet getUsedInputColumns() {
+        return ScalarOperatorUtil.getUsedInputColumns(columnRefMap, commonSubOperatorMap);
     }
 
     public ScalarOperator resolveColumnRef(ColumnRefOperator ref) {
@@ -95,6 +95,14 @@ public class Projection {
 
     public Map<ColumnRefOperator, ScalarOperator> getCommonSubOperatorMap() {
         return commonSubOperatorMap;
+    }
+
+    public void eliminateSubColumnRefMap() {
+        ScalarOperatorUtil.eliminateCommonSubOperatorMap(columnRefMap, commonSubOperatorMap);
+    }
+
+    public List<Map.Entry<ColumnRefOperator, ScalarOperator>> getCommonSubOperatorMapInDependencyOrder() {
+        return ScalarOperatorUtil.topologicalSortCommonSubOperatorMap(commonSubOperatorMap);
     }
 
     public Map<ColumnRefOperator, ScalarOperator> getAllMaps() {
@@ -171,7 +179,11 @@ public class Projection {
 
     @Override
     public String toString() {
-        return columnRefMap.values().toString();
+        String result = "columnRefMap=" + columnRefMap;
+        if (!commonSubOperatorMap.isEmpty()) {
+            result += ", commonSubOperatorMap=" + commonSubOperatorMap;
+        }
+        return result;
     }
 
     public Projection deepClone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
@@ -249,10 +249,11 @@ public class LogicalJoinOperator extends LogicalOperator {
 
     @Override
     public String toString() {
-        return "LOGICAL_JOIN" + " {" +
-                joinType.toString() +
-                ", onPredicate = " + onPredicate + ' ' +
-                ", Predicate = " + predicate +
+        return "LogicalJoinOperator" + " {" +
+                "joinType='" + joinType + '\'' +
+                ", onPredicate='" + onPredicate + '\'' +
+                ", predicate='" + predicate + '\'' +
+                ", projection='" + projection + '\'' +
                 '}';
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.property.DomainProperty;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -35,16 +36,36 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class LogicalProjectOperator extends LogicalOperator {
+    // Output columns
     private Map<ColumnRefOperator, ScalarOperator> columnRefMap;
+    // Hidden columns which might be referenced by output or other hidden columns
+    private Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap;
 
     public LogicalProjectOperator(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
         super(OperatorType.LOGICAL_PROJECT);
         this.columnRefMap = columnRefMap;
+        this.commonSubOperatorMap = Maps.newHashMap();
     }
 
     public LogicalProjectOperator(Map<ColumnRefOperator, ScalarOperator> columnRefMap, long limit) {
         super(OperatorType.LOGICAL_PROJECT);
         this.columnRefMap = columnRefMap;
+        this.commonSubOperatorMap = Maps.newHashMap();
+        this.limit = limit;
+    }
+
+    public LogicalProjectOperator(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                  Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        super(OperatorType.LOGICAL_PROJECT);
+        this.columnRefMap = columnRefMap;
+        this.commonSubOperatorMap = commonSubOperatorMap;
+    }
+
+    public LogicalProjectOperator(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                  Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap, long limit) {
+        super(OperatorType.LOGICAL_PROJECT);
+        this.columnRefMap = columnRefMap;
+        this.commonSubOperatorMap = commonSubOperatorMap;
         this.limit = limit;
     }
 
@@ -54,6 +75,26 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
     public Map<ColumnRefOperator, ScalarOperator> getColumnRefMap() {
         return columnRefMap;
+    }
+
+    public Map<ColumnRefOperator, ScalarOperator> getCommonSubOperatorMap() {
+        return commonSubOperatorMap;
+    }
+
+    public List<Map.Entry<ColumnRefOperator, ScalarOperator>> getCommonSubOperatorMapInDependencyOrder() {
+        return ScalarOperatorUtil.topologicalSortCommonSubOperatorMap(commonSubOperatorMap);
+    }
+
+    public void compactCommonSubOperatorMap() {
+        ScalarOperatorUtil.compactCommonSubOperatorMap(columnRefMap, commonSubOperatorMap);
+    }
+
+    public void eliminateCommonSubOperatorMap() {
+        ScalarOperatorUtil.eliminateCommonSubOperatorMap(columnRefMap, commonSubOperatorMap);
+    }
+
+    public ColumnRefSet getUsedInputColumns() {
+        return ScalarOperatorUtil.getUsedInputColumns(columnRefMap, commonSubOperatorMap);
     }
 
     @Override
@@ -67,7 +108,7 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
     @Override
     public RowOutputInfo deriveRowOutputInfo(List<OptExpression> inputs) {
-        return new RowOutputInfo(columnRefMap, Maps.newHashMap());
+        return new RowOutputInfo(columnRefMap, commonSubOperatorMap);
     }
 
     @Override
@@ -76,13 +117,15 @@ public final class LogicalProjectOperator extends LogicalOperator {
             return new DomainProperty(Map.of());
         }
         DomainProperty childDomainProperty = inputs.get(0).getDomainProperty();
-
+        if (!commonSubOperatorMap.isEmpty()) {
+            childDomainProperty = childDomainProperty.projectDomainProperty(commonSubOperatorMap);
+        }
         return childDomainProperty.projectDomainProperty(columnRefMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), opType, columnRefMap);
+        return Objects.hash(super.hashCode(), opType, columnRefMap, commonSubOperatorMap);
     }
 
     @Override
@@ -97,12 +140,16 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
         LogicalProjectOperator that = (LogicalProjectOperator) o;
 
-        return columnRefMap.keySet().equals(that.columnRefMap.keySet());
+        return columnRefMap.keySet().equals(that.columnRefMap.keySet())
+                && commonSubOperatorMap.keySet().equals(that.commonSubOperatorMap.keySet());
     }
 
     @Override
     public String toString() {
-        return "LogicalProjectOperator " + columnRefMap.keySet();
+        if (commonSubOperatorMap.isEmpty()) {
+            return "LogicalProjectOperator " + columnRefMap.keySet();
+        }
+        return "LogicalProjectOperator " + columnRefMap.keySet() + "; subExprs: " + commonSubOperatorMap.keySet();
     }
 
     @Override
@@ -130,11 +177,17 @@ public final class LogicalProjectOperator extends LogicalOperator {
         public Builder withOperator(LogicalProjectOperator operator) {
             super.withOperator(operator);
             builder.columnRefMap = operator.getColumnRefMap();
+            builder.commonSubOperatorMap = operator.getCommonSubOperatorMap();
             return this;
         }
 
         public Builder setColumnRefMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
             builder.columnRefMap = columnRefMap;
+            return this;
+        }
+
+        public Builder setCommonSubOperatorMap(Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+            builder.commonSubOperatorMap = commonSubOperatorMap;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -60,11 +60,11 @@ public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
 
     @Override
     public String toString() {
-        return "PhysicalHashJoinOperator{" +
-                "joinType=" + joinType +
-                ", joinPredicate=" + onPredicate +
-                ", limit=" + limit +
-                ", predicate=" + predicate +
+        return "PhysicalHashJoinOperator" + " {" +
+                "joinType='" + joinType + '\'' +
+                ", onPredicate='" + onPredicate + '\'' +
+                ", predicate='" + predicate + '\'' +
+                ", projection='" + projection + '\'' +
                 '}';
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
@@ -49,11 +49,11 @@ public class PhysicalMergeJoinOperator extends PhysicalJoinOperator {
 
     @Override
     public String toString() {
-        return "PhysicalMergeJoinOperator{" +
-                "joinType=" + joinType +
-                ", joinPredicate=" + onPredicate +
-                ", limit=" + limit +
-                ", predicate=" + predicate +
+        return "PhysicalMergeJoinOperator" + " {" +
+                "joinType='" + joinType + '\'' +
+                ", onPredicate='" + onPredicate + '\'' +
+                ", predicate='" + predicate + '\'' +
+                ", projection='" + projection + '\'' +
                 '}';
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNestLoopJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNestLoopJoinOperator.java
@@ -47,11 +47,11 @@ public class PhysicalNestLoopJoinOperator extends PhysicalJoinOperator {
 
     @Override
     public String toString() {
-        return "PhysicalNestLoopJoinOperator{" +
-                "joinType=" + joinType +
-                ", joinPredicate=" + onPredicate +
-                ", limit=" + limit +
-                ", predicate=" + predicate +
+        return "PhysicalNestLoopJoinOperator" + " {" +
+                "joinType='" + joinType + '\'' +
+                ", onPredicate='" + onPredicate + '\'' +
+                ", predicate='" + predicate + '\'' +
+                ", projection='" + projection + '\'' +
                 '}';
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +48,10 @@ public class PhysicalProjectOperator extends PhysicalOperator {
 
     public Map<ColumnRefOperator, ScalarOperator> getCommonSubOperatorMap() {
         return commonSubOperatorMap;
+    }
+
+    public List<Map.Entry<ColumnRefOperator, ScalarOperator>> getCommonSubOperatorMapInDependencyOrder() {
+        return ScalarOperatorUtil.topologicalSortCommonSubOperatorMap(commonSubOperatorMap);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionName;
@@ -23,6 +24,8 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.InvalidType;
@@ -32,6 +35,12 @@ import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -146,5 +155,256 @@ public class ScalarOperatorUtil {
     public static Stream<ScalarOperator> getStream(ScalarOperator operator) {
         return Stream.concat(Stream.of(operator),
                 operator.getChildren().stream().flatMap(ScalarOperatorUtil::getStream));
+    }
+
+    /**
+     * Compacts a common sub-operator map by removing unnecessary entries and inlining trivial ones.
+     *
+     * <p>This method performs three transformations on {@code commonSubOperatorMap} in order:
+     * <ol>
+     *   <li><b>Cleanup:</b> removes self-referencing entries (key == value).</li>
+     *   <li><b>Dead-column elimination:</b> computes the transitive closure of column refs
+     *       reachable from {@code columnRefMap} via BFS and removes any entries from
+     *       {@code commonSubOperatorMap} that are not reachable.</li>
+     *   <li><b>Inlining:</b> entries whose values are constant or are referenced exactly once
+     *       across both maps are substituted directly into the expressions that use them and
+     *       then removed from {@code commonSubOperatorMap}.</li>
+     * </ol>
+     *
+     * <p>Both maps are modified in place.
+     *
+     * @param columnRefMap         output column refs mapped to their defining scalar expressions
+     * @param commonSubOperatorMap common sub-expression column refs mapped to their definitions;
+     *                             entries may be removed or have their values rewritten
+     */
+    public static void compactCommonSubOperatorMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                                   Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        if (commonSubOperatorMap.isEmpty()) {
+            return;
+        }
+
+        Map<ColumnRefOperator, Integer> refCounts = new HashMap<>(commonSubOperatorMap.size());
+        for (Iterator<Map.Entry<ColumnRefOperator, ScalarOperator>> it = commonSubOperatorMap.entrySet().iterator();
+                it.hasNext(); ) {
+            Map.Entry<ColumnRefOperator, ScalarOperator> entry = it.next();
+            if (entry.getKey().equals(entry.getValue())) {
+                it.remove();
+            } else {
+                refCounts.put(entry.getKey(), 0);
+            }
+        }
+        for (ScalarOperator expr : columnRefMap.values()) {
+            countRefs(expr, refCounts, commonSubOperatorMap);
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> inlineMap = new HashMap<>();
+        for (Iterator<Map.Entry<ColumnRefOperator, ScalarOperator>> it = commonSubOperatorMap.entrySet().iterator();
+                it.hasNext(); ) {
+            Map.Entry<ColumnRefOperator, ScalarOperator> entry = it.next();
+            int count = refCounts.getOrDefault(entry.getKey(), 0);
+            if (count == 0) {
+                it.remove();
+            } else if (entry.getValue().isConstant() || count == 1) {
+                inlineMap.put(entry.getKey(), entry.getValue());
+                it.remove();
+            }
+        }
+
+        if (!inlineMap.isEmpty()) {
+            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(inlineMap, true);
+            ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+
+            columnRefMap.replaceAll((k, v) -> {
+                ScalarOperator result = rewriter.rewrite(v);
+                if (result.isConstant()) {
+                    result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+                }
+                return result;
+            });
+
+            commonSubOperatorMap.replaceAll((k, v) -> {
+                ScalarOperator result = rewriter.rewrite(v);
+                if (result.isConstant()) {
+                    result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+                }
+                return result;
+            });
+        }
+    }
+
+    /**
+     * Eliminates the common sub-expression map by inlining all of its definitions into
+     * {@code columnRefMap} and then clearing the map. After this call, every value in
+     * {@code columnRefMap} is self-contained (no references to common sub-expression column
+     * refs remain) and {@code commonSubOperatorMap} is empty.
+     *
+     * <p>Constant-foldable results are simplified via {@link ScalarOperatorRewriter}.
+     *
+     * @param columnRefMap         map of output column refs to their scalar expressions;
+     *                             updated in place with inlined definitions
+     * @param commonSubOperatorMap map of common sub-expression column refs to their
+     *                             definitions; cleared after all entries are inlined
+     */
+    public static void eliminateCommonSubOperatorMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                                     Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        if (commonSubOperatorMap.isEmpty()) {
+            return;
+        }
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(commonSubOperatorMap, true);
+        ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+        columnRefMap.replaceAll((k, v) -> {
+            ScalarOperator result = rewriter.rewrite(v);
+            if (result.isConstant()) {
+                result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+            }
+            return result;
+        });
+        commonSubOperatorMap.clear();
+    }
+
+    /**
+     * Returns the entries of a common sub-operator map in dependency order: entries that are
+     * depended upon appear before the entries that reference them. When iterating the result,
+     * every entry's dependencies are guaranteed to have been seen already.
+     *
+     * @param commonSubOperatorMap common sub-expression column refs mapped to their definitions
+     * @return list of (columnRef, scalarOperator) entries in topological (dependency) order
+     * @throws IllegalStateException if a cycle exists among the entries
+     */
+    public static List<Map.Entry<ColumnRefOperator, ScalarOperator>> topologicalSortCommonSubOperatorMap(
+            Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        if (commonSubOperatorMap.isEmpty()) {
+            return new ArrayList<>();
+        }
+        int size = commonSubOperatorMap.size();
+        ColumnRefSet keyIds = new ColumnRefSet(commonSubOperatorMap.keySet());
+        Map<Integer, ColumnRefOperator> idToKey = new HashMap<>(size);
+        for (ColumnRefOperator key : commonSubOperatorMap.keySet()) {
+            idToKey.put(key.getId(), key);
+        }
+
+        Map<ColumnRefOperator, Integer> inDegree = new HashMap<>(size);
+        Map<ColumnRefOperator, List<ColumnRefOperator>> dependents = new HashMap<>();
+
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : commonSubOperatorMap.entrySet()) {
+            ColumnRefOperator ref = entry.getKey();
+            int refId = ref.getId();
+            ColumnRefSet depIds = entry.getValue().getUsedColumns();
+            int depCount = 0;
+            for (int depId : depIds.getColumnIds()) {
+                if (depId != refId && keyIds.contains(depId)) {
+                    depCount++;
+                    dependents.computeIfAbsent(idToKey.get(depId), k -> new ArrayList<>()).add(ref);
+                }
+            }
+            inDegree.put(ref, depCount);
+        }
+
+        Deque<ColumnRefOperator> queue = new ArrayDeque<>();
+        for (Map.Entry<ColumnRefOperator, Integer> e : inDegree.entrySet()) {
+            if (e.getValue() == 0) {
+                queue.add(e.getKey());
+            }
+        }
+
+        List<Map.Entry<ColumnRefOperator, ScalarOperator>> result = new ArrayList<>(size);
+        while (!queue.isEmpty()) {
+            ColumnRefOperator n = queue.remove();
+            result.add(Maps.immutableEntry(n, commonSubOperatorMap.get(n)));
+            for (ColumnRefOperator m : dependents.getOrDefault(n, Collections.emptyList())) {
+                inDegree.merge(m, -1, Integer::sum);
+                if (inDegree.get(m) == 0) {
+                    queue.add(m);
+                }
+            }
+        }
+
+        if (result.size() != commonSubOperatorMap.size()) {
+            throw new IllegalStateException(
+                    "Cycle in common sub operator map: dependency graph has a cycle");
+        }
+        return result;
+    }
+
+    /**
+     * Returns the set of column refs that are used as inputs by the given column and common
+     * sub-expression maps, excluding refs that are defined locally in {@code commonSubOperatorMap}.
+     *
+     * <p>That is, this is the set of "external" columns the expressions depend on (e.g. from the
+     * child operator), not the column refs that are defined by {@code commonSubOperatorMap} itself.
+     *
+     * @param columnRefMap         map of output column refs to their scalar expressions
+     * @param commonSubOperatorMap map of common sub-expression column refs to their definitions
+     *                             (keys are excluded from the result)
+     * @return set of column ref IDs that are used as inputs
+     */
+    public static ColumnRefSet getUsedInputColumns(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                                   Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        ColumnRefSet result = new ColumnRefSet();
+        columnRefMap.values().forEach(e -> result.union(e.getUsedColumns()));
+        commonSubOperatorMap.values().forEach(e -> result.union(e.getUsedColumns()));
+        commonSubOperatorMap.keySet().forEach(e -> result.except(e.getUsedColumns()));
+        return result;
+    }
+
+    /**
+     * Returns the set of "external" input column refs that {@code scalarOperator} transitively depends on,
+     * resolving references through the common sub-expression map via BFS.
+     *
+     * <p>Column refs that appear as keys in {@code commonSubOperatorById} are considered locally
+     * defined and are expanded into their constituent columns. Column refs <em>not</em> in the map
+     * are treated as true inputs (e.g. columns from a child operator) and included in the result.
+     *
+     * @param scalarOperator        the scalar expression to analyze
+     * @param commonSubOperatorById map from column ref ID to its defining sub-expression;
+     *                              keys are local definitions that will be expanded, not returned
+     * @return a fresh {@link ColumnRefSet} containing only the externally-supplied column ref IDs
+     */
+    public static ColumnRefSet getUsedInputColumns(ScalarOperator scalarOperator,
+                                                   Map<Integer, ScalarOperator> commonSubOperatorById) {
+        if (commonSubOperatorById.isEmpty()) {
+            return scalarOperator.getUsedColumns();
+        }
+        ColumnRefSet result = new ColumnRefSet();
+        ColumnRefSet visited = new ColumnRefSet();
+        Deque<Integer> queue = new ArrayDeque<>();
+        for (int id : scalarOperator.getUsedColumns().getColumnIds()) {
+            visited.union(id);
+            queue.add(id);
+        }
+
+        while (!queue.isEmpty()) {
+            int colId = queue.remove();
+            ScalarOperator subExpr = commonSubOperatorById.get(colId);
+            if (subExpr != null) {
+                for (int depId : subExpr.getUsedColumns().getColumnIds()) {
+                    if (!visited.contains(depId)) {
+                        visited.union(depId);
+                        queue.add(depId);
+                    }
+                }
+            } else {
+                result.union(colId);
+            }
+        }
+        return result;
+    }
+
+    private static void countRefs(ScalarOperator op, Map<ColumnRefOperator, Integer> refCounts,
+                                  Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
+        if (op.isColumnRef()) {
+            ColumnRefOperator colRef = (ColumnRefOperator) op;
+            Integer oldCount = refCounts.get(colRef);
+            if (oldCount != null) {
+                refCounts.put(colRef, oldCount + 1);
+                if (oldCount == 0) {
+                    countRefs(commonSubOperatorMap.get(colRef), refCounts, commonSubOperatorMap);
+                }
+            }
+        } else {
+            for (ScalarOperator child : op.getChildren()) {
+                countRefs(child, refCounts, commonSubOperatorMap);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/ProjectImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/ProjectImplementationRule.java
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -38,7 +36,7 @@ public class ProjectImplementationRule extends ImplementationRule {
         LogicalProjectOperator projectOperator = (LogicalProjectOperator) input.getOp();
         PhysicalProjectOperator physicalProject = new PhysicalProjectOperator(
                 projectOperator.getColumnRefMap(),
-                Maps.newHashMap());
+                projectOperator.getCommonSubOperatorMap());
         return Lists.newArrayList(OptExpression.create(physicalProject, input.getInputs()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderHelper.java
@@ -23,7 +23,9 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,14 +57,20 @@ public class JoinReorderHelper {
                 rightCols.union(right.getOutputColumns());
             }
         } else {
+            Map<Integer, ScalarOperator> commonSubOperatorById = new HashMap<>(projection.getCommonSubOperatorMap().size());
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getCommonSubOperatorMap().entrySet()) {
+                commonSubOperatorById.put(entry.getKey().getId(), entry.getValue());
+            }
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
                 ColumnRefOperator columnRefOperator = entry.getKey();
                 ScalarOperator scalarOperator = entry.getValue();
                 if (scalarOperator.getUsedColumns().isEmpty()) {
                     // do nothing
-                } else if (left.getOutputColumns().containsAll(scalarOperator.getUsedColumns())) {
+                } else if (left.getOutputColumns()
+                        .containsAll(ScalarOperatorUtil.getUsedInputColumns(scalarOperator, commonSubOperatorById))) {
                     leftCols.union(columnRefOperator.getId());
-                } else if (right.getOutputColumns().containsAll(scalarOperator.getUsedColumns())) {
+                } else if (right.getOutputColumns()
+                        .containsAll(ScalarOperatorUtil.getUsedInputColumns(scalarOperator, commonSubOperatorById))) {
                     rightCols.union(columnRefOperator.getId());
                 } else {
                     refBothChildCols.union(columnRefOperator.getId());
@@ -71,7 +79,6 @@ public class JoinReorderHelper {
         }
         return Lists.newArrayList(leftCols, rightCols, refBothChildCols);
     }
-
 
     public static boolean isAssoc(OptExpression bottomJoinExpr, OptExpression topJoinExpr) {
         LogicalJoinOperator topJoin = (LogicalJoinOperator) topJoinExpr.getOp();
@@ -99,7 +106,6 @@ public class JoinReorderHelper {
                     && !topJoinOnConditionCols.isIntersect(splitCols.get(0));
         }
     }
-
 
     public static boolean isLeftAsscom(OptExpression bottomJoinExpr, OptExpression topJoinExpr, boolean isInnerMode) {
         LogicalJoinOperator topJoin = (LogicalJoinOperator) topJoinExpr.getOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeferProjectAfterTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeferProjectAfterTopNRule.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -28,6 +29,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.Collections;
@@ -71,6 +73,7 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
         OptExpression projectExpression = input.getInputs().get(0);
         LogicalProjectOperator projectOperator = projectExpression.getOp().cast();
         Map<ColumnRefOperator, ScalarOperator> projectMap = projectOperator.getColumnRefMap();
+        Map<ColumnRefOperator, ScalarOperator> projectCommonMap = projectOperator.getCommonSubOperatorMap();
 
         ColumnRefSet topNRequiredInputColumns = topNOperator.getRequiredChildInputColumns();
 
@@ -109,6 +112,10 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
 
         Map<ColumnRefOperator, ScalarOperator> postProjectionMap = new HashMap<>(projectOperator.getColumnRefMap());
 
+        Map<Integer, ScalarOperator> commonSubOperatorById = new HashMap<>(projectCommonMap.size());
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projectCommonMap.entrySet()) {
+            commonSubOperatorById.put(entry.getKey().getId(), entry.getValue());
+        }
         projectOperator.getColumnRefMap().forEach((columnRefOperator, scalarOperator) -> {
             if (topNRequiredInputColumns.contains(columnRefOperator) ||
                     mayBenefitFromPruningSubField(context, columnsWithAccessPath, scalarOperator)) {
@@ -125,13 +132,18 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
                 return;
             }
 
-            scalarOperator.getUsedColumns().getColumnRefOperators(context.getColumnRefFactory()).forEach(k -> {
-                preProjectionMap.put(k, k);
-            });
+            ScalarOperatorUtil.getUsedInputColumns(scalarOperator, commonSubOperatorById)
+                    .getColumnRefOperators(context.getColumnRefFactory()).forEach(k -> {
+                        preProjectionMap.put(k, k);
+                    });
         });
 
-        LogicalProjectOperator preProjectOperator = new LogicalProjectOperator(preProjectionMap);
-        LogicalProjectOperator postProjectOperator = new LogicalProjectOperator(postProjectionMap);
+        LogicalProjectOperator preProjectOperator =
+                new LogicalProjectOperator(preProjectionMap, Maps.newHashMap(projectCommonMap));
+        LogicalProjectOperator postProjectOperator =
+                new LogicalProjectOperator(postProjectionMap, Maps.newHashMap(projectCommonMap));
+        preProjectOperator.compactCommonSubOperatorMap();
+        postProjectOperator.compactCommonSubOperatorMap();
 
         OptExpression result = OptExpression.create(
                 postProjectOperator, OptExpression.create(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggFunctionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggFunctionRule.java
@@ -103,7 +103,7 @@ public class EliminateAggFunctionRule extends TransformationRule {
 
         newAggCallMap.forEach((k, v) -> newProjectMap.put(k, k));
 
-        LogicalProjectOperator newProjectOp = LogicalProjectOperator.builder().setColumnRefMap(newProjectMap).build();
+        LogicalProjectOperator newProjectOp = new LogicalProjectOperator(newProjectMap);
 
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newProjectMap);
         final ScalarOperator newPredicate = rewriter.rewrite(aggOp.getPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggRule.java
@@ -127,7 +127,7 @@ public class EliminateAggRule extends TransformationRule {
             newProjectMap.put(aggColumnRef, newOperator);
         }
         aggOp.getGroupingKeys().forEach(ref -> newProjectMap.put(ref, ref));
-        LogicalProjectOperator newProjectOp = LogicalProjectOperator.builder().setColumnRefMap(newProjectMap).build();
+        LogicalProjectOperator newProjectOp = new LogicalProjectOperator(newProjectMap);
 
         if (aggOp.getPredicate() != null) {
             return List.of(OptExpression.create(new LogicalFilterOperator(aggOp.getPredicate()),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateGroupByConstantRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateGroupByConstantRule.java
@@ -105,7 +105,8 @@ public class EliminateGroupByConstantRule extends TransformationRule {
 
         newAggCallMap.keySet().forEach(e -> topMap.put(e, e));
         newGroupByKeys.forEach(e -> topMap.put(e, e));
-        LogicalProjectOperator newProjectOp = LogicalProjectOperator.builder().setColumnRefMap(topMap).build();
+        // topMap contains constant values only. it doesn't need common map.
+        LogicalProjectOperator newProjectOp = new LogicalProjectOperator(topMap);
 
         LogicalAggregationOperator newAggOp = LogicalAggregationOperator.builder()
                 .withOperator(aggOp)
@@ -121,7 +122,8 @@ public class EliminateGroupByConstantRule extends TransformationRule {
             result = OptExpression.create(newProjectOp,
                     OptExpression.create(newAggOp, input.inputAt(0).getInputs()));
         } else {
-            LogicalProjectOperator bottomProject = new LogicalProjectOperator(bottomMap);
+            LogicalProjectOperator bottomProject =
+                    new LogicalProjectOperator(bottomMap, Maps.newHashMap(projectOp.getCommonSubOperatorMap()));
             result = OptExpression.create(newProjectOp,
                     OptExpression.create(newAggOp,
                             OptExpression.create(bottomProject,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/HoistHeavyCostExprsUponTopnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/HoistHeavyCostExprsUponTopnRule.java
@@ -15,12 +15,13 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.Ordering;
-import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
@@ -28,11 +29,12 @@ import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.type.PrimitiveType;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,7 +47,7 @@ public class HoistHeavyCostExprsUponTopnRule extends TransformationRule {
                 Pattern.create(OperatorType.LOGICAL_TOPN, OperatorType.LOGICAL_PROJECT));
     }
 
-    private boolean isHeavyCost(ScalarOperator op) {
+    private boolean isHeavyCost(ScalarOperator op, Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
         if (op instanceof CallOperator) {
             CallOperator call = op.cast();
             if (call.getFnName().equals(ArithmeticExpr.Operator.DIVIDE.getName()) && (
@@ -54,7 +56,11 @@ public class HoistHeavyCostExprsUponTopnRule extends TransformationRule {
                 return true;
             }
         }
-        return op.getChildren().stream().anyMatch(this::isHeavyCost);
+        if (op instanceof ColumnRefOperator) {
+            ScalarOperator resolved = commonSubOperatorMap.get(op);
+            return resolved != null && isHeavyCost(resolved, commonSubOperatorMap);
+        }
+        return op.getChildren().stream().anyMatch(child -> isHeavyCost(child, commonSubOperatorMap));
     }
 
     @Override
@@ -67,9 +73,13 @@ public class HoistHeavyCostExprsUponTopnRule extends TransformationRule {
             return false;
         }
         OptExpression child = input.inputAt(0);
+        Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap = child.getRowOutputInfo().getCommonColInfo()
+                .values().stream()
+                .collect(Collectors.toMap(ColumnOutputInfo::getColumnRef, ColumnOutputInfo::getScalarOp));
+
         Set<ColumnRefOperator> heavyCostColumnRefs = child.getRowOutputInfo().getColumnRefMap().entrySet()
                 .stream()
-                .filter(e -> isHeavyCost(e.getValue()))
+                .filter(e -> isHeavyCost(e.getValue(), commonSubOperatorMap))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
 
@@ -101,39 +111,53 @@ public class HoistHeavyCostExprsUponTopnRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalTopNOperator topnOp = input.getOp().cast();
         OptExpression child = input.inputAt(0);
+        LogicalProjectOperator projectOp = child.getOp().cast();
+        Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap = child.getRowOutputInfo().getCommonColInfo()
+                .values().stream()
+                .collect(Collectors.toMap(ColumnOutputInfo::getColumnRef, ColumnOutputInfo::getScalarOp));
+
         Map<Boolean, Map<ColumnRefOperator, ScalarOperator>> columnRefMaps =
                 child.getRowOutputInfo().getColumnRefMap().entrySet()
                         .stream()
-                        .collect(Collectors.partitioningBy(e -> isHeavyCost(e.getValue()),
+                        .collect(Collectors.partitioningBy(
+                                e -> isHeavyCost(e.getValue(), commonSubOperatorMap),
                                 Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
         Map<ColumnRefOperator, ScalarOperator> heavyCostColumnRefMap = columnRefMaps.get(true);
         Map<ColumnRefOperator, ScalarOperator> childColumnRefMap = columnRefMaps.get(false);
 
-        Set<ColumnRefOperator> usedColumnRefs = heavyCostColumnRefMap.values().stream()
-                .map(ScalarOperator::getColumnRefs)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
+        Map<Integer, ScalarOperator> commonSubOperatorById = new HashMap<>(commonSubOperatorMap.size());
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : commonSubOperatorMap.entrySet()) {
+            commonSubOperatorById.put(entry.getKey().getId(), entry.getValue());
+        }
 
-        if (!childColumnRefMap.keySet().containsAll(usedColumnRefs)) {
+        ColumnRefSet heavyExternalInputs = new ColumnRefSet();
+        for (ScalarOperator expr : heavyCostColumnRefMap.values()) {
+            heavyExternalInputs.union(ScalarOperatorUtil.getUsedInputColumns(expr, commonSubOperatorById));
+        }
+
+        ColumnRefSet lightOutputColumns = new ColumnRefSet(childColumnRefMap.keySet());
+        heavyExternalInputs.except(lightOutputColumns);
+        if (!heavyExternalInputs.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Map<ColumnRefOperator, ScalarOperator> topnColumnRefMap = input.getRowOutputInfo().getColumnRefMap();
-        topnColumnRefMap.putAll(columnRefMaps.get(true));
-        LogicalProjectOperator projectOp = child.getOp().cast();
-
-        Operator newProjectOp = LogicalProjectOperator.builder().withOperator(projectOp)
+        LogicalProjectOperator newLowerProject = (LogicalProjectOperator) LogicalProjectOperator.builder()
+                .withOperator(projectOp)
                 .setColumnRefMap(childColumnRefMap)
+                .setCommonSubOperatorMap(Maps.newHashMap(commonSubOperatorMap))
                 .build();
-
-        OptExpression newChild = OptExpression.builder().setOp(newProjectOp).setInputs(child.getInputs()).build();
-        Operator upperProjectOp = LogicalProjectOperator.builder()
-                .setColumnRefMap(topnColumnRefMap).build();
-
+        newLowerProject.compactCommonSubOperatorMap();
+        OptExpression newChild = OptExpression.builder().setOp(newLowerProject).setInputs(child.getInputs()).build();
         OptExpression newTopn =
                 OptExpression.builder().setOp(topnOp).setInputs(Lists.newArrayList(newChild)).build();
 
-        return Collections.singletonList(OptExpression.create(upperProjectOp, newTopn));
+        Map<ColumnRefOperator, ScalarOperator> topnColumnRefMap = input.getRowOutputInfo().getColumnRefMap();
+        topnColumnRefMap.putAll(heavyCostColumnRefMap);
+        LogicalProjectOperator newUpperProject =
+                new LogicalProjectOperator(topnColumnRefMap, Maps.newHashMap(commonSubOperatorMap));
+        newUpperProject.compactCommonSubOperatorMap();
+
+        return Collections.singletonList(OptExpression.create(newUpperProject, newTopn));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/InnerToSemiRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/InnerToSemiRule.java
@@ -71,7 +71,7 @@ public class InnerToSemiRule extends TransformationRule {
                 if (opt.getOp().getProjection() != null) {
                     // in this case, opt.getOutputColumns will return column output by projection
                     // instead of column output by join operator
-                    joinOpOutputCols = opt.getOp().getProjection().getUsedColumns();
+                    joinOpOutputCols = opt.getOp().getProjection().getUsedInputColumns();
                 } else {
                     joinOpOutputCols = opt.getOutputColumns();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociateBaseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociateBaseRule.java
@@ -42,6 +42,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.compactCommonSubOperatorMap;
 
 public abstract class JoinAssociateBaseRule extends TransformationRule {
 
@@ -128,13 +131,34 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
         OptExpression newTopJoinChild = input.inputAt(newTopJoinChildLoc[0]).inputAt(newTopJoinChildLoc[1]);
 
         if (CollectionUtils.isNotEmpty(splitter.getTopJoinChildCols())) {
-            RowOutputInfo mergedRow = newTopJoinChild.getRowOutputInfo().addColsToRow(
-                    splitter.getTopJoinChildCols(),
-                    newTopJoinChild.getOp().getProjection() != null);
+            Map<ColumnRefOperator, ScalarOperator> newTopJoinChildColumnRefMap = Maps.newHashMap();
+            Map<ColumnRefOperator, ScalarOperator> newTopJoinChildCommonSubOperatorMap = Maps.newHashMap();
+            splitter.getTopJoinChildCols().forEach(col -> {
+                newTopJoinChildColumnRefMap.put(col.getColumnRef(), col.getScalarOp());
+            });
+            splitter.getCommonColInfo().forEach((k, v) -> {
+                newTopJoinChildCommonSubOperatorMap.put(v.getColumnRef(), v.getScalarOp());
+            });
+            compactCommonSubOperatorMap(newTopJoinChildColumnRefMap, newTopJoinChildCommonSubOperatorMap);
+
+            RowOutputInfo oldRowOutput = newTopJoinChild.getRowOutputInfo();
+
+            Map<ColumnRefOperator, ScalarOperator> oldColumnRefMap = oldRowOutput.getColumnRefMap();
+            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(oldColumnRefMap, false);
+            newTopJoinChildColumnRefMap.replaceAll((k, v) -> rewriter.rewrite(v));
+            newTopJoinChildCommonSubOperatorMap.replaceAll((k, v) -> rewriter.rewrite(v));
+
+            newTopJoinChildColumnRefMap.putAll(oldColumnRefMap);
+
+            oldRowOutput.getCommonColInfo()
+                    .forEach((k, v) -> newTopJoinChildCommonSubOperatorMap.put(v.getColumnRef(), v.getScalarOp()));
+
+            compactCommonSubOperatorMap(newTopJoinChildColumnRefMap, newTopJoinChildCommonSubOperatorMap);
+
             Operator.Builder builder = OperatorBuilderFactory.build(newTopJoinChild.getOp());
 
             Operator childOp = builder.withOperator(newTopJoinChild.getOp())
-                    .setProjection(new Projection(mergedRow.getColumnRefMap())).build();
+                    .setProjection(new Projection(newTopJoinChildColumnRefMap, newTopJoinChildCommonSubOperatorMap)).build();
             newTopJoinChild = OptExpression.create(childOp, newTopJoinChild.getInputs());
         }
 
@@ -142,13 +166,35 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
         OptExpression newBotJoinRightChild = input.inputAt(newBotJoinRightChildLoc[0]);
 
         if (CollectionUtils.isNotEmpty(splitter.getBotJoinChildCols())) {
-            RowOutputInfo mergedRow = newBotJoinLeftChild.getRowOutputInfo().addColsToRow(
-                    splitter.getBotJoinChildCols(),
-                    newBotJoinLeftChild.getOp().getProjection() != null);
+            Map<ColumnRefOperator, ScalarOperator> newBotJoinLeftChildColumnRefMap = Maps.newHashMap();
+            Map<ColumnRefOperator, ScalarOperator> newBotJoinLeftChildCommonSubOperatorMap = Maps.newHashMap();
+            splitter.getBotJoinChildCols().forEach(col -> {
+                newBotJoinLeftChildColumnRefMap.put(col.getColumnRef(), col.getScalarOp());
+            });
+            splitter.getCommonColInfo().forEach((k, v) -> {
+                newBotJoinLeftChildCommonSubOperatorMap.put(v.getColumnRef(), v.getScalarOp());
+            });
+            compactCommonSubOperatorMap(newBotJoinLeftChildColumnRefMap, newBotJoinLeftChildCommonSubOperatorMap);
+
+            RowOutputInfo oldRowOutput = newBotJoinLeftChild.getRowOutputInfo();
+
+            Map<ColumnRefOperator, ScalarOperator> oldColumnRefMap = oldRowOutput.getColumnRefMap();
+            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(oldColumnRefMap, false);
+            newBotJoinLeftChildColumnRefMap.replaceAll((k, v) -> rewriter.rewrite(v));
+            newBotJoinLeftChildCommonSubOperatorMap.replaceAll((k, v) -> rewriter.rewrite(v));
+
+            newBotJoinLeftChildColumnRefMap.putAll(oldColumnRefMap);
+
+            oldRowOutput.getCommonColInfo()
+                    .forEach((k, v) -> newBotJoinLeftChildCommonSubOperatorMap.put(v.getColumnRef(), v.getScalarOp()));
+
+            compactCommonSubOperatorMap(newBotJoinLeftChildColumnRefMap, newBotJoinLeftChildCommonSubOperatorMap);
+
             Operator.Builder builder = OperatorBuilderFactory.build(newBotJoinLeftChild.getOp());
 
             Operator newBotJoinLeftChildOp = builder.withOperator(newBotJoinLeftChild.getOp())
-                    .setProjection(new Projection(mergedRow.getColumnRefMap())).build();
+                    .setProjection(new Projection(newBotJoinLeftChildColumnRefMap, newBotJoinLeftChildCommonSubOperatorMap))
+                    .build();
             newBotJoinLeftChild = OptExpression.create(newBotJoinLeftChildOp, newBotJoinLeftChild.getInputs());
         }
 
@@ -157,7 +203,13 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
 
         Projection newBotJoinProjection = null;
         if (needProject(newBotJoinRowInfo, newBotJoinLeftChild, newBotJoinRightChild)) {
-            newBotJoinProjection = new Projection(newBotJoinRowInfo.getColumnRefMap());
+            Map<ColumnRefOperator, ScalarOperator> newBotJoinColumnRefMap = Maps.newHashMap(newBotJoinRowInfo.getColumnRefMap());
+            Map<ColumnRefOperator, ScalarOperator> newBotJoinCommonSubOperatorMap = Maps.newHashMap();
+            splitter.getCommonColInfo().forEach((k, v) -> {
+                newBotJoinCommonSubOperatorMap.put(v.getColumnRef(), v.getScalarOp());
+            });
+            compactCommonSubOperatorMap(newBotJoinColumnRefMap, newBotJoinCommonSubOperatorMap);
+            newBotJoinProjection = new Projection(newBotJoinColumnRefMap, newBotJoinCommonSubOperatorMap);
         }
 
         LogicalJoinOperator newBotJoin = newBottomJoinBuilder.setJoinType(newBotJoinType)
@@ -170,7 +222,10 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
         Projection newTopJoinProjection = null;
 
         if (needProject(input.getRowOutputInfo(), newTopJoinChild, newBotJoinExpr)) {
-            newTopJoinProjection = new Projection(input.getRowOutputInfo().getColumnRefMap());
+            newTopJoinProjection = new Projection(input.getRowOutputInfo().getColumnRefMap(),
+                    input.getRowOutputInfo().getCommonColInfo().entrySet().stream().collect(
+                            Collectors.toMap(e -> e.getValue().getColumnRef(), e -> e.getValue().getScalarOp())
+                    ));
         }
 
         LogicalJoinOperator newTopJoin = newTopJoinBuilder.withOperator(topJoin)
@@ -191,13 +246,14 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
         return Lists.newArrayList(newTopJoinExpr);
     }
 
-
     protected ColumnRefSet deriveTopJoinChildOutputCols(OptExpression input) {
         OptExpression newTopJoinChildOpt = input.inputAt(newTopJoinChildLoc[0]).inputAt(newTopJoinChildLoc[1]);
         RowOutputInfo oldBotJoinOutput = input.inputAt(0).getRowOutputInfo();
         ColumnRefSet cols = newTopJoinChildOpt.getRowOutputInfo().getOutputColumnRefSet();
+        Map<Integer, ScalarOperator> commonSubOperatorById =
+                Maps.transformValues(oldBotJoinOutput.getCommonColInfo(), ColumnOutputInfo::getScalarOp);
         for (ColumnOutputInfo entry : oldBotJoinOutput.getColumnOutputInfo()) {
-            if (entry.getUsedColumns().isIntersect(cols)) {
+            if (entry.getUsedInputColumns(commonSubOperatorById).isIntersect(cols)) {
                 cols.union(entry.getColumnRef());
             }
         }
@@ -207,14 +263,15 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
     protected ColumnRefSet deriveNewBotJoinColSet(RowOutputInfo topRow, ScalarOperator onCondition,
                                                   ScalarOperator predicate, ColumnRefSet columnRefSet) {
         ColumnRefSet requiredCols = new ColumnRefSet();
-
+        Map<Integer, ScalarOperator> commonSubOperatorById =
+                Maps.transformValues(topRow.getCommonColInfo(), ColumnOutputInfo::getScalarOp);
         if (!topRow.getColOutputInfo().isEmpty()) {
             for (ColumnOutputInfo col : topRow.getColOutputInfo().values()) {
-                requiredCols.union(col.getUsedColumns());
+                requiredCols.union(col.getUsedInputColumns(commonSubOperatorById));
             }
         } else {
             for (ColumnOutputInfo col : topRow.getOriginalColOutputInfo().values()) {
-                requiredCols.union(col.getUsedColumns());
+                requiredCols.union(col.getUsedInputColumns(commonSubOperatorById));
             }
         }
 
@@ -310,9 +367,14 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
         // save columnOutputInfo which is constant
         List<ColumnOutputInfo> constCols = Lists.newArrayList();
 
+        // save common column info of the original projection
+        private final Map<Integer, ColumnOutputInfo> commonColInfo;
 
         public ProjectionSplitter(OptExpression input, ScalarOperator newBotJoinOnCondition) {
             RowOutputInfo rowOutputInfo = input.inputAt(0).getRowOutputInfo();
+            commonColInfo = Maps.newHashMap(rowOutputInfo.getCommonColInfo());
+            Map<Integer, ScalarOperator> commonSubOperatorById =
+                    Maps.transformValues(commonColInfo, ColumnOutputInfo::getScalarOp);
             OptExpression newBotJoinLeftChildOpt = input.
                     inputAt(newBotJoinLeftChildLoc[0]).inputAt(newBotJoinLeftChildLoc[1]);
             if (input.inputAt(0).getOp().getProjection() == null) {
@@ -323,9 +385,10 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
                 ColumnRefOperator columnRef = columnOutputInfo.getColumnRef();
                 ScalarOperator scalarOp = columnOutputInfo.getScalarOp();
                 if (!columnRef.equals(scalarOp)) {
-                    if (scalarOp.getUsedColumns().isEmpty()) {
+                    ColumnRefSet usedInputColumns = columnOutputInfo.getUsedInputColumns(commonSubOperatorById);
+                    if (usedInputColumns.isEmpty()) {
                         constCols.add(columnOutputInfo);
-                    } else if (leftChildCols.containsAll(scalarOp.getUsedColumns())) {
+                    } else if (leftChildCols.containsAll(usedInputColumns)) {
                         if (needPushToChild(newBotJoinOnCondition, columnOutputInfo)) {
                             botJoinChildCols.add(columnOutputInfo);
                         } else {
@@ -344,6 +407,7 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
                 return false;
             }
 
+            // predicates don't have projection-related common sub-expression, so no need to use getUsedInputColumns here.
             return newBotJoinOnCondition.getUsedColumns().contains(columnOutputInfo.getColumnRef());
         }
 
@@ -361,6 +425,10 @@ public abstract class JoinAssociateBaseRule extends TransformationRule {
 
         public List<ColumnOutputInfo> getConstCols() {
             return constCols;
+        }
+
+        public Map<Integer, ColumnOutputInfo> getCommonColInfo() {
+            return commonColInfo;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
@@ -80,7 +80,8 @@ public class MergeProjectWithChildRule extends TransformationRule {
             return Lists.newArrayList(OptExpression.create(builder.build(), input.inputAt(0).getInputs()));
         }
 
-        builder.setProjection(new Projection(logicalProjectOperator.getColumnRefMap()));
+        builder.setProjection(
+                new Projection(logicalProjectOperator.getColumnRefMap(), logicalProjectOperator.getCommonSubOperatorMap()));
 
         return Lists.newArrayList(OptExpression.create(builder.build(), input.inputAt(0).getInputs()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
@@ -26,7 +26,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -44,27 +43,28 @@ public class MergeTwoProjectRule extends TransformationRule {
         LogicalProjectOperator firstProject = (LogicalProjectOperator) input.getOp();
         LogicalProjectOperator secondProject = (LogicalProjectOperator) input.getInputs().get(0).getOp();
 
-        ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
-        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(secondProject.getColumnRefMap());
-        Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
-        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : firstProject.getColumnRefMap().entrySet()) {
-            ScalarOperator result = rewriter.rewrite(entry.getValue());
-            if (result.isConstant()) {
-                // better to rewrite all expression, but it's unnecessary
-                result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
-            }
-            resultMap.put(entry.getKey(), result);
-        }
+        Map<ColumnRefOperator, ScalarOperator> resultOutputMap = Maps.newHashMap(firstProject.getColumnRefMap());
+        Map<ColumnRefOperator, ScalarOperator> resultCommonMap = Maps.newHashMap(firstProject.getCommonSubOperatorMap());
+
+        Map<ColumnRefOperator, ScalarOperator> promotedAssertTrues = Maps.newHashMap();
 
         // ASSERT_TRUE must be executed in the runtime, so it should be kept anyway.
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : secondProject.getColumnRefMap().entrySet()) {
-            if (entry.getValue() instanceof CallOperator) {
-                CallOperator callOp = entry.getValue().cast();
-                if (FunctionSet.ASSERT_TRUE.equals(callOp.getFnName())) {
-                    resultMap.put(entry.getKey(), entry.getValue());
-                }
+            if (entry.getValue() instanceof CallOperator &&
+                    FunctionSet.ASSERT_TRUE.equals(((CallOperator) entry.getValue()).getFnName())) {
+                promotedAssertTrues.put(entry.getKey(), entry.getValue());
+            } else {
+                resultCommonMap.put(entry.getKey(), entry.getValue());
             }
         }
+        if (!promotedAssertTrues.isEmpty()) {
+            ReplaceColumnRefRewriter promotedRewriter = new ReplaceColumnRefRewriter(promotedAssertTrues, false);
+            resultOutputMap.replaceAll((k, v) -> promotedRewriter.rewrite(v));
+            resultCommonMap.replaceAll((k, v) -> promotedRewriter.rewrite(v));
+            resultOutputMap.putAll(promotedAssertTrues);
+        }
+
+        resultCommonMap.putAll(secondProject.getCommonSubOperatorMap());
 
         // minimum value of limits on projections, but have to exclude unlimited(-1) case
         long limit = Stream.of(firstProject.getLimit(), secondProject.getLimit())
@@ -72,8 +72,10 @@ public class MergeTwoProjectRule extends TransformationRule {
                 .min(Long::compare)
                 .orElse(-1L);
 
-        OptExpression optExpression = new OptExpression(
-                new LogicalProjectOperator(resultMap, limit));
+        LogicalProjectOperator resultProject = new LogicalProjectOperator(resultOutputMap, resultCommonMap, limit);
+        resultProject.compactCommonSubOperatorMap();
+
+        OptExpression optExpression = new OptExpression(resultProject);
         optExpression.getInputs().addAll(input.getInputs().get(0).getInputs());
         return Lists.newArrayList(optExpression);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByCTERewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByCTERewriter.java
@@ -179,10 +179,8 @@ public class MultiDistinctByCTERewriter {
         }
 
         // Add project node
-        LogicalProjectOperator.Builder builder = new LogicalProjectOperator.Builder();
-        builder.setColumnRefMap(columnRefMap);
-
-        OptExpression rightTree = OptExpression.create(builder.build(), allCteConsumes.get(0));
+        OptExpression rightTree =
+                OptExpression.create(new LogicalProjectOperator(columnRefMap, Maps.newHashMap()), allCteConsumes.get(0));
 
         // Add filter node
         if (aggregate.getPredicate() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
@@ -33,6 +33,7 @@ import com.starrocks.type.IntegerType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PruneProjectColumnsRule extends TransformationRule {
 
@@ -45,40 +46,36 @@ public class PruneProjectColumnsRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalProjectOperator projectOperator = (LogicalProjectOperator) input.getOp();
 
-        ColumnRefSet requiredInputColumns = new ColumnRefSet();
         ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
-        Map<ColumnRefOperator, ScalarOperator> newMap = Maps.newHashMap();
-        projectOperator.getColumnRefMap().forEach(((columnRefOperator, operator) -> {
-            if (requiredOutputColumns.contains(columnRefOperator)) {
-                requiredInputColumns.union(operator.getUsedColumns());
-                newMap.put(columnRefOperator, operator);
-            }
-            if (operator instanceof CallOperator) {
-                CallOperator callOperator = operator.cast();
-                if (FunctionSet.ASSERT_TRUE.equals(callOperator.getFnName())) {
-                    requiredInputColumns.union(operator.getUsedColumns());
-                    newMap.put(columnRefOperator, operator);
-                }
-            }
-        }));
+        Map<ColumnRefOperator, ScalarOperator> newMap = projectOperator.getColumnRefMap().entrySet().stream()
+                .filter(entry -> requiredOutputColumns.contains(entry.getKey()) || (entry.getValue() instanceof CallOperator &&
+                        FunctionSet.ASSERT_TRUE.equals(((CallOperator) entry.getValue()).getFnName())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (newMap.isEmpty()) {
             ColumnRefOperator constCol = context.getColumnRefFactory()
                     .create("auto_fill_col", IntegerType.TINYINT, false);
             newMap.put(constCol, ConstantOperator.createTinyInt((byte) 1));
-        } else if (newMap.equals(projectOperator.getColumnRefMap()) && context.getOptimizerOptions().isShortCircuit()) {
+            LogicalProjectOperator newProjectOperator =
+                    new LogicalProjectOperator(newMap, Maps.newHashMap(), projectOperator.getLimit());
+            return Lists.newArrayList(OptExpression.create(newProjectOperator, input.getInputs()));
+        }
+        if (newMap.equals(projectOperator.getColumnRefMap()) && context.getOptimizerOptions().isShortCircuit()) {
             // Change the requiredOutputColumns in context
-            requiredOutputColumns.union(requiredInputColumns);
+            requiredOutputColumns.union(projectOperator.getUsedInputColumns());
             // make sure this rule only executed once
             return Collections.emptyList();
         }
 
-        // Change the requiredOutputColumns in context
-        requiredOutputColumns.union(requiredInputColumns);
+        LogicalProjectOperator newProjectOperator =
+                new LogicalProjectOperator(newMap, Maps.newHashMap(projectOperator.getCommonSubOperatorMap()),
+                        projectOperator.getLimit());
+        newProjectOperator.compactCommonSubOperatorMap();
 
-        return Lists.newArrayList(OptExpression.create(
-                LogicalProjectOperator.builder().withOperator(projectOperator).setColumnRefMap(newMap).build(),
-                input.getInputs()));
+        // Change the requiredOutputColumns in context
+        requiredOutputColumns.union(newProjectOperator.getUsedInputColumns());
+
+        return Lists.newArrayList(OptExpression.create(newProjectOperator, input.getInputs()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUKFKJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUKFKJoinRule.java
@@ -208,10 +208,19 @@ public class PruneUKFKJoinRule extends TransformationRule {
                 projectMap.put(entry.getKey(), entry.getValue());
             }
         }
+        Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projectOp.getCommonSubOperatorMap().entrySet()) {
+            if (entry.getValue().getUsedColumns().contains(property.ukColumnRef)) {
+                commonSubOperatorMap.put(entry.getKey(), rewriter.rewrite(entry.getValue()));
+            } else {
+                commonSubOperatorMap.put(entry.getKey(), entry.getValue());
+            }
+        }
 
         LogicalProjectOperator newProjectOp = new LogicalProjectOperator.Builder()
                 .withOperator(projectOp)
                 .setColumnRefMap(projectMap)
+                .setCommonSubOperatorMap(commonSubOperatorMap)
                 .build();
         return OptExpression.create(newProjectOp, filterOpt);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -95,6 +95,7 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         OptExpression child = input.getInputs().get(0);
 
         LogicalProjectOperator project = (LogicalProjectOperator) (child.getOp());
+        project.eliminateCommonSubOperatorMap();
 
         if (!context.getSessionVariable().getEnableLambdaPushDown()) {
             Map<ColumnRefOperator, ScalarOperator> m = project.getColumnRefMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
@@ -240,10 +240,9 @@ public class PushDownPredicateRankingWindowRule extends TransformationRule {
                         .forEach(columnRef -> {
                             columnRefMap.put(columnRef, columnRef);
                         });
-                LogicalProjectOperator.Builder builder = new LogicalProjectOperator.Builder();
-                builder.setColumnRefMap(columnRefMap);
 
-                OptExpression projectOpt = OptExpression.create(builder.build(), rankRelatedOptExp);
+                OptExpression projectOpt =
+                        OptExpression.create(new LogicalProjectOperator(columnRefMap, Maps.newHashMap()), rankRelatedOptExp);
 
                 return Collections.singletonList(OptExpression.create(filterOperator, projectOpt));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRule.java
@@ -43,7 +43,8 @@ public class SeparateProjectRule implements TreeRewriteRule {
             // Clear statistics to recompute statistics when calculating statistics later,
             // because some operators only recompute statistics when statistics is null.
             root.setStatistics(null);
-            return OptExpression.create(new LogicalProjectOperator(projection.getColumnRefMap()), root);
+            return OptExpression.create(
+                    new LogicalProjectOperator(projection.getColumnRefMap(), projection.getCommonSubOperatorMap()), root);
         } else {
             return root;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -107,7 +107,7 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
         }
         // aggregate's projection
         if (aggOperator.getProjection() != null) {
-            usedCols.union(aggOperator.getProjection().getUsedColumns());
+            usedCols.union(aggOperator.getProjection().getUsedInputColumns());
         }
         // except aggregate's column refs
         usedCols.except(aggOperator.getAggregations().keySet());
@@ -128,7 +128,7 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
             usedCols.union(joinOperator.getPredicate().getUsedColumns());
         }
         if (joinOperator.getProjection() != null) {
-            usedCols.union(joinOperator.getProjection().getUsedColumns());
+            usedCols.union(joinOperator.getProjection().getUsedInputColumns());
         }
         return checkInputCols(inputCols, usedCols, "with join operator");
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -79,6 +79,7 @@ import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.OptimizerOptions;
 import com.starrocks.sql.optimizer.OptimizerTraceUtil;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
+import com.starrocks.sql.optimizer.QueryOptimizer;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -1781,6 +1782,7 @@ public class MvUtils {
                 OptimizerFactory.initContext(connectContext, columnRefFactory, optimizerOptions));
         OptExpression optimizedViewPlan = optimizer.optimize(logicalTree,
                 new PhysicalPropertySet(), requiredColumns);
+        QueryOptimizer.eliminateAllCommonSubOperatorMaps(optimizedViewPlan);
         return optimizedViewPlan;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
@@ -358,7 +358,7 @@ public class CboTablePruneRule extends TransformationRule {
     List<OptExpression> handleLeftOrRightJoin(OptExpression joinOpt, OptExpression retainOpt) {
         Optional<Projection> joinProjection = Optional.ofNullable(joinOpt.getOp().getProjection());
         ColumnRefSet usedColRefSet =
-                joinProjection.map(Projection::getUsedColumns).orElse(joinOpt.getRowOutputInfo().getUsedColumnRefSet());
+                joinProjection.map(Projection::getUsedInputColumns).orElse(joinOpt.getRowOutputInfo().getUsedColumnRefSet());
 
         // If not all of used columns of output exprs of join operator only references retain-side
         // column refs, prune-side ScanOperator can not be pruned.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -277,7 +277,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 Projection projection = optExpression.getOp().getProjection();
                 ColumnRefSet encodedStringCols = ColumnRefSet.createByIds(context.getEncodedStringCols());
 
-                if (!projection.getUsedColumns().isIntersect(encodedStringCols)) {
+                if (!projection.getUsedInputColumns().isIntersect(encodedStringCols)) {
                     context.clear();
                 } else if (couldApplyStringDict(context, projection)) {
                     Projection newProjection = rewriteProjectOperator(projection, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/InlineCteProjectPruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/InlineCteProjectPruneRule.java
@@ -54,7 +54,7 @@ public class InlineCteProjectPruneRule implements TreeRewriteRule {
             }
 
             Projection childProjection = child.getProjection();
-            if (!parentProjection.getUsedColumns().containsAny(childProjection.getOutputColumns())) {
+            if (!parentProjection.getUsedInputColumns().containsAny(childProjection.getOutputColumns())) {
                 child.setProjection(null);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
@@ -94,6 +94,13 @@ public class ScalarOperatorsReuse {
         return operator.accept(rewriter, null);
     }
 
+    public static Map<Integer, Map<ScalarOperator, ColumnRefOperator>> collectCommonSubScalarOperators(
+            Projection projection,
+            List<ScalarOperator> scalarOperators,
+            ColumnRefFactory columnRefFactory) {
+        return collectCommonSubScalarOperators(projection, scalarOperators, Maps.newHashMap(), columnRefFactory);
+    }
+
     /**
      * Collect the common sub operators for the input operators
      * For [a+b, a+b+c, a+b+d], the common sub operators is [a + b]
@@ -101,9 +108,10 @@ public class ScalarOperatorsReuse {
     public static Map<Integer, Map<ScalarOperator, ColumnRefOperator>> collectCommonSubScalarOperators(
             Projection projection,
             List<ScalarOperator> scalarOperators,
+            Map<ColumnRefOperator, ScalarOperator> existingCommonMap,
             ColumnRefFactory columnRefFactory) {
         // 1. Recursively collect common sub operators for the input operators
-        CommonSubScalarOperatorCollector operatorCollector = new CommonSubScalarOperatorCollector();
+        CommonSubScalarOperatorCollector operatorCollector = new CommonSubScalarOperatorCollector(existingCommonMap);
         for (ScalarOperator operator : scalarOperators) {
             // To avoid stack overflow if the operator tree is too deep(eg: contains too many `or` functions), set a
             // limit to the depth of the operator tree.
@@ -172,6 +180,11 @@ public class ScalarOperatorsReuse {
                 return commonOperatorsMap.get(operator);
             }
             return operator;
+        }
+
+        @Override
+        public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+            return tryRewrite(variable);
         }
 
         @Override
@@ -269,7 +282,7 @@ public class ScalarOperatorsReuse {
             // only rewrite subfield operator if and only if child is DictionaryGetOperator
             if (predicate.getChild(0) instanceof DictionaryGetOperator) {
                 ScalarOperator operator = new SubfieldOperator(predicate.getChild(0).accept(this, null),
-                                predicate.getType(), predicate.getFieldNames(), predicate.getCopyFlag());
+                        predicate.getType(), predicate.getFieldNames(), predicate.getCopyFlag());
                 return tryRewrite(operator);
             }
             return predicate;
@@ -279,9 +292,9 @@ public class ScalarOperatorsReuse {
         public ScalarOperator visitDictionaryGetOperator(DictionaryGetOperator predicate, Void context) {
             ScalarOperator operator = new DictionaryGetOperator(
                     predicate.getChildren().stream().map(
-                        argument -> argument.accept(this, null)).collect(Collectors.toList()),
-                            predicate.getType(), predicate.getDictionaryId(),
-                                predicate.getDictionaryTxnId(), predicate.getKeySize(), predicate.getNullIfNotExist());
+                            argument -> argument.accept(this, null)).collect(Collectors.toList()),
+                    predicate.getType(), predicate.getDictionaryId(),
+                    predicate.getDictionaryTxnId(), predicate.getKeySize(), predicate.getNullIfNotExist());
             return tryRewrite(operator);
         }
 
@@ -330,7 +343,8 @@ public class ScalarOperatorsReuse {
         }
     }
 
-    record CommonResult(int depth, List<Integer> childrenGroup) {}
+    record CommonResult(int depth, List<Integer> childrenGroup) {
+    }
 
     private static class CommonSubScalarOperatorCollector
             extends ScalarOperatorVisitor<CommonResult, CommonOperatorContext> {
@@ -361,10 +375,15 @@ public class ScalarOperatorsReuse {
         // {[1] -> [a + b]}
         private final Map<Integer, Map<OperatorId, Integer>> operatorsByDepth = new HashMap<>();
         private final Map<Integer, Set<OperatorId>> commonOperatorsByDepth = new HashMap<>();
+        private final Map<ColumnRefOperator, ScalarOperator> existingCommonSubOperatorMap;
         private int currentId = 0;
 
         // enable some special logic codes only for lambda functions.
         private boolean hasLambdaFunction;
+
+        public CommonSubScalarOperatorCollector(Map<ColumnRefOperator, ScalarOperator> existingCommonSubOperatorMap) {
+            this.existingCommonSubOperatorMap = existingCommonSubOperatorMap;
+        }
 
         public boolean hasLambdaFunction() {
             return hasLambdaFunction;
@@ -405,6 +424,24 @@ public class ScalarOperatorsReuse {
 
         @Override
         public CommonResult visit(ScalarOperator scalarOperator, CommonOperatorContext context) {
+            if (scalarOperator.isColumnRef()) {
+                ColumnRefOperator columnRef = (ColumnRefOperator) scalarOperator;
+                if (existingCommonSubOperatorMap.containsKey(columnRef)) {
+                    CommonResult result = visitChildren(existingCommonSubOperatorMap.get(columnRef), context);
+                    OperatorId id = new OperatorId(scalarOperator, result.childrenGroup);
+                    Map<OperatorId, Integer> level = operatorsByDepth.computeIfAbsent(result.depth + 1, c -> Maps.newHashMap());
+                    int group = level.computeIfAbsent(id, k -> currentId++);
+                    Set<OperatorId> commonGroup =
+                            commonOperatorsByDepth.computeIfAbsent(result.depth + 1, c -> Sets.newLinkedHashSet());
+                    commonGroup.add(id);
+                    return new CommonResult(result.depth + 1, List.of(group));
+                } else {
+                    OperatorId id = new OperatorId(scalarOperator, List.of());
+                    Map<OperatorId, Integer> level = operatorsByDepth.computeIfAbsent(0, c -> Maps.newLinkedHashMap());
+                    int group = level.computeIfAbsent(id, k -> currentId++);
+                    return new CommonResult(0, List.of(group));
+                }
+            }
             if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 // leaf node
                 OperatorId id = new OperatorId(scalarOperator, List.of());
@@ -486,9 +523,12 @@ public class ScalarOperatorsReuse {
 
     public static Projection rewriteProjectionOrLambdaExpr(Projection projection, ColumnRefFactory columnRefFactory) {
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = projection.getColumnRefMap();
+        Map<ColumnRefOperator, ScalarOperator> existingCommonMap = projection.getCommonSubOperatorMap();
+
         List<ScalarOperator> scalarOperators = Lists.newArrayList(columnRefMap.values());
+
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubOperatorsByDepth = ScalarOperatorsReuse
-                .collectCommonSubScalarOperators(projection, scalarOperators,
+                .collectCommonSubScalarOperators(projection, scalarOperators, existingCommonMap,
                         columnRefFactory);
 
         Map<ScalarOperator, ColumnRefOperator> commonSubOperators =
@@ -523,6 +563,17 @@ public class ScalarOperatorsReuse {
             }
         }
 
+        if (!hasRewritten) {
+            for (ScalarOperator operator : existingCommonMap.values()) {
+                ScalarOperator rewriteOperator =
+                        ScalarOperatorsReuse.rewriteOperatorWithCommonOperator(operator, commonSubOperators);
+                if (!rewriteOperator.equals(operator)) {
+                    hasRewritten = true;
+                    break;
+                }
+            }
+        }
+
         /*
          * 1. Rewrite the operator with the common sub operators
          * 2. Put the common sub operators to projection, we need to compute
@@ -549,13 +600,22 @@ public class ScalarOperatorsReuse {
                     newMap.put(kv.getKey(), rewriteOperator);
                 }
             }
+            existingCommonMap.replaceAll((k, v) -> {
+                ScalarOperator rewriteOperator =
+                        ScalarOperatorsReuse.rewriteOperatorWithCommonOperator(v, commonSubOperators);
+                return rewriter.rewrite(rewriteOperator, rules);
+            });
 
             Map<ColumnRefOperator, ScalarOperator> newCommonMap =
                     Maps.newTreeMap(Comparator.comparingInt(ColumnRefOperator::getId));
             for (Map.Entry<ScalarOperator, ColumnRefOperator> kv : commonSubOperators.entrySet()) {
                 Preconditions.checkState(!newMap.containsKey(kv.getValue()));
-                ScalarOperator rewrittenOperator = rewriter.rewrite(kv.getKey(), rules);
-                newCommonMap.put(kv.getValue(), rewrittenOperator);
+                if (kv.getKey().isColumnRef() && existingCommonMap.containsKey(kv.getKey())) {
+                    newCommonMap.put(kv.getValue(), existingCommonMap.get(kv.getKey()));
+                } else {
+                    ScalarOperator rewrittenOperator = rewriter.rewrite(kv.getKey(), rules);
+                    newCommonMap.put(kv.getValue(), rewrittenOperator);
+                }
             }
 
             return new Projection(newMap, newCommonMap, projection.needReuseLambdaDependentExpr());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -102,7 +102,9 @@ public class PruneSubfieldRule extends TransformationRule {
             NormalizeCastJsonExpr normalizer = new NormalizeCastJsonExpr();
             Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
             project.getColumnRefMap().forEach((k, v) -> projectMap.put(k, v.accept(normalizer, null)));
-            project = new LogicalProjectOperator(projectMap);
+            Map<ColumnRefOperator, ScalarOperator> subProjectMap = Maps.newHashMap();
+            project.getCommonSubOperatorMap().forEach((k, v) -> subProjectMap.put(k, v.accept(normalizer, null)));
+            project = new LogicalProjectOperator(projectMap, subProjectMap);
 
             if (predicate != null) {
                 predicate = predicate.accept(normalizer, null);
@@ -113,6 +115,9 @@ public class PruneSubfieldRule extends TransformationRule {
         SubfieldExpressionCollector collector =
                 new SubfieldExpressionCollector(context.getSessionVariable().isCboPruneJsonSubfield());
         for (ScalarOperator value : project.getColumnRefMap().values()) {
+            value.accept(collector, null);
+        }
+        for (ScalarOperator value : project.getCommonSubOperatorMap().values()) {
             value.accept(collector, null);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -210,6 +210,7 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
 
             LogicalProjectOperator lpo = optExpression.getOp().cast();
             Map<ColumnRefOperator, ScalarOperator> pushDownProject = lpo.getColumnRefMap();
+            Map<ColumnRefOperator, ScalarOperator> commonMap = lpo.getCommonSubOperatorMap();
             ColumnRefSet pushDownExprUsedColumns = new ColumnRefSet();
 
             if (!context.pushDownExprRefs.isEmpty()) {
@@ -228,7 +229,7 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
             }
 
             // collect push down expression
-            SubfieldExpressionCollector collector = SubfieldExpressionCollector.buildPushdownCollector();
+            SubfieldExpressionCollector collector = SubfieldExpressionCollector.buildPushdownCollector(commonMap);
             for (ScalarOperator value : pushDownProject.values()) {
                 // check repeat put complex column, like that
                 //      project( columnB: structA.b.c.d )
@@ -265,6 +266,7 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                     // parent has push down expression, must rewrite project node
                     optExpression = OptExpression.create(LogicalProjectOperator.builder().withOperator(lpo)
                             .setColumnRefMap(pushDownProject)
+                            .setCommonSubOperatorMap(Maps.newHashMap())
                             .build(), optExpression.getInputs());
                 }
                 return visitChildren(optExpression, childContext);
@@ -274,9 +276,12 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
             ExpressionReplacer replacer = new ExpressionReplacer(childContext.pushDownExprRefsIndex);
             Map<ColumnRefOperator, ScalarOperator> newProjectMap = Maps.newHashMap();
             pushDownProject.forEach((k, v) -> newProjectMap.put(k, v.accept(replacer, null)));
+            Map<ColumnRefOperator, ScalarOperator> newCommonMap = Maps.newHashMap();
+            commonMap.forEach((k, v) -> newCommonMap.put(k, v.accept(replacer, null)));
 
             optExpression = OptExpression.create(LogicalProjectOperator.builder().withOperator(lpo)
                     .setColumnRefMap(newProjectMap)
+                    .setCommonSubOperatorMap(newCommonMap)
                     .build(), optExpression.getInputs());
             return visitChildren(optExpression, childContext);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -25,7 +26,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.type.Type;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /*
@@ -36,6 +39,8 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
     private Set<String> checkFunctions;
     private final boolean enableJsonCollect;
     private boolean forPushDownSubFiled;
+    private Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap = Map.of();
+    private ColumnRefSet commonSubOperatorColumns = new ColumnRefSet();
 
     public List<ScalarOperator> getComplexExpressions() {
         return complexExpressions;
@@ -56,10 +61,13 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
         return collector;
     }
 
-    public static SubfieldExpressionCollector buildPushdownCollector() {
+    public static SubfieldExpressionCollector buildPushdownCollector(
+            Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap) {
         SubfieldExpressionCollector collector = new SubfieldExpressionCollector();
         collector.checkFunctions = Sets.newHashSet(PruneSubfieldRule.PUSHDOWN_FUNCTIONS);
         collector.forPushDownSubFiled = true;
+        collector.commonSubOperatorMap = Collections.unmodifiableMap(commonSubOperatorMap);
+        collector.commonSubOperatorColumns = new ColumnRefSet(commonSubOperatorMap.keySet());
         return collector;
     }
 
@@ -73,6 +81,9 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitVariableReference(ColumnRefOperator variable, Void context) {
+        if (commonSubOperatorMap.containsKey(variable)) {
+            visit(commonSubOperatorMap.get(variable), context);
+        }
         if (variable.getType().isComplexType() || variable.getType().isJsonType()
                 || variable.getType().isVariantType()) {
             complexExpressions.add(variable);
@@ -82,16 +93,19 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitCollectionElement(CollectionElementOperator collectionElementOp, Void context) {
-        if (collectionElementOp.getUsedColumns().isEmpty()) {
+        ColumnRefSet usedColumns = collectionElementOp.getUsedColumns();
+        if (usedColumns.isEmpty() || usedColumns.isIntersect(commonSubOperatorColumns)) {
             return null;
         }
+
         complexExpressions.add(collectionElementOp);
         return null;
     }
 
     @Override
     public Void visitSubfield(SubfieldOperator subfieldOperator, Void context) {
-        if (subfieldOperator.getUsedColumns().isEmpty()) {
+        ColumnRefSet usedColumns = subfieldOperator.getUsedColumns();
+        if (usedColumns.isEmpty() || usedColumns.isIntersect(commonSubOperatorColumns)) {
             return null;
         }
         complexExpressions.add(subfieldOperator);
@@ -109,7 +123,8 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitCall(CallOperator call, Void context) {
-        if (call.getUsedColumns().isEmpty()) {
+        ColumnRefSet usedColumns = call.getUsedColumns();
+        if (usedColumns.isEmpty() || usedColumns.isIntersect(commonSubOperatorColumns)) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -283,8 +283,20 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         Projection projection = node.getProjection();
         if (projection != null) {
+            Map<ColumnRefOperator, SubfieldOperator> commonSubfieldColumns = Maps.newHashMap();
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getCommonSubOperatorMapInDependencyOrder()) {
+                if (entry.getValue() instanceof SubfieldOperator && (node instanceof LogicalScanOperator ||
+                        node instanceof PhysicalScanOperator)) {
+                    commonSubfieldColumns.put(entry.getKey(), (SubfieldOperator) entry.getValue());
+                } else {
+                    statisticsBuilder.addColumnStatistic(entry.getKey(),
+                            ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
+                }
+            }
+            if (!commonSubfieldColumns.isEmpty()) {
+                addSubFiledStatistics(node, commonSubfieldColumns, statisticsBuilder);
+            }
             Map<ColumnRefOperator, SubfieldOperator> subfieldColumns = Maps.newHashMap();
-            Preconditions.checkState(projection.getCommonSubOperatorMap().isEmpty());
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
                 if (entry.getValue() instanceof SubfieldOperator && (node instanceof LogicalScanOperator ||
                         node instanceof PhysicalScanOperator)) {
@@ -294,7 +306,6 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                             ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
                 }
             }
-            // for subfield operator, we get the statistics from statistics storage
             if (!subfieldColumns.isEmpty()) {
                 addSubFiledStatistics(node, subfieldColumns, statisticsBuilder);
             }
@@ -1024,15 +1035,16 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     @Override
     public Void visitLogicalProject(LogicalProjectOperator node, ExpressionContext context) {
-        return computeProjectNode(context, node.getColumnRefMap());
+        return computeProjectNode(context, node.getColumnRefMap(), node.getCommonSubOperatorMapInDependencyOrder());
     }
 
     @Override
     public Void visitPhysicalProject(PhysicalProjectOperator node, ExpressionContext context) {
-        return computeProjectNode(context, node.getColumnRefMap());
+        return computeProjectNode(context, node.getColumnRefMap(), node.getCommonSubOperatorMapInDependencyOrder());
     }
 
-    private Void computeProjectNode(ExpressionContext context, Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
+    private Void computeProjectNode(ExpressionContext context, Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                                    List<Map.Entry<ColumnRefOperator, ScalarOperator>> commonSubOperatorMapInDependencyOrder) {
         Preconditions.checkState(context.arity() == 1);
 
         Statistics.Builder builder = Statistics.builder();
@@ -1042,6 +1054,20 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         Statistics.Builder allBuilder = Statistics.builder();
         allBuilder.setOutputRowCount(inputStatistics.getOutputRowCount());
         allBuilder.addColumnStatistics(inputStatistics.getColumnStatistics());
+
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : commonSubOperatorMapInDependencyOrder) {
+            if (entry.getValue() instanceof SubfieldOperator && context.getOptExpression() != null) {
+                Operator child = context.getOptExpression().inputAt(0).getOp();
+                if (child instanceof LogicalScanOperator || child instanceof PhysicalScanOperator) {
+                    addSubFiledStatistics(child, ImmutableMap.of(entry.getKey(),
+                            (SubfieldOperator) entry.getValue()), allBuilder);
+                    continue;
+                }
+            }
+            ColumnStatistic outputStatistic =
+                    ExpressionStatisticCalculator.calculate(entry.getValue(), allBuilder.build());
+            allBuilder.addColumnStatistic(entry.getKey(), outputStatistic);
+        }
 
         for (ColumnRefOperator requiredColumnRefOperator : columnRefMap.keySet()) {
             ScalarOperator mapOperator = columnRefMap.get(requiredColumnRefOperator);
@@ -2034,10 +2060,15 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             Projection projection = node.getProjection();
             if (projection != null) {
                 Statistics.Builder statisticsBuilder = Statistics.buildFrom(context.getStatistics());
+                for (Map.Entry<ColumnRefOperator, ScalarOperator> entry :
+                        projection.getCommonSubOperatorMapInDependencyOrder()) {
+                    statisticsBuilder.addColumnStatistic(entry.getKey(),
+                            ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
+                }
                 for (ColumnRefOperator columnRefOperator : projection.getColumnRefMap().keySet()) {
                     ScalarOperator mapOperator = projection.getColumnRefMap().get(columnRefOperator);
                     statisticsBuilder.addColumnStatistic(columnRefOperator,
-                            ExpressionStatisticCalculator.calculate(mapOperator, context.getStatistics()));
+                            ExpressionStatisticCalculator.calculate(mapOperator, statisticsBuilder.build()));
                 }
                 context.setStatistics(statisticsBuilder.build());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -124,11 +124,11 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
                 for (ColumnOutputInfo col : rowOutputInfo.getColumnOutputInfo()) {
                     usedCols.union(col.getUsedColumns());
                 }
-                for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo()) {
+                for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo().values()) {
                     usedCols.union(col.getUsedColumns());
                 }
 
-                for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo()) {
+                for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo().values()) {
                     usedCols.except(col.getColumnRef().getUsedColumns());
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
@@ -1229,8 +1229,8 @@ public class MaterializedViewAggPushDownRewriteTest extends MaterializedViewTest
         PlanTestBase.assertContains(plan, "mv1",
                 "  2:AGGREGATE (update serialize)\n" +
                         "  |  STREAMING\n" +
-                        "  |  output: sum(40: sum(l.LO_REVENUE + 1)), max(41: max(l.LO_REVENUE + 1)), " +
-                        "bitmap_union(43: bitmap_agg(l.LO_REVENUE + 1))\n" +
+                        "  |  output: max(41: max(l.LO_REVENUE + 1)), bitmap_union(43: bitmap_agg(l.LO_REVENUE + 1)), " +
+                        "sum(40: sum(l.LO_REVENUE + 1))\n" +
                         "  |  group by: 57: cast, 39: LO_ORDERDATE");
         starRocksAssert.dropMaterializedView("mv1");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PushDownSubfieldHashJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PushDownSubfieldHashJoinTest.java
@@ -112,15 +112,15 @@ public class PushDownSubfieldHashJoinTest {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 3: fk = 1: fk\n" +
                 "  |  other predicates: CAST(array_sum(array_map(<slot 8> -> <slot 8> != 'A', " +
-                "if(array_length(26: array_filter) = 0, ['C'], 26: array_filter))) AS BOOLEAN)\n" +
+                "if(array_length(25: array_filter) = 0, ['C'], 25: array_filter))) AS BOOLEAN)\n" +
                 "  |    common sub expr:\n" +
-                "  |    <slot 20> : 2: col_int = 1\n" +
-                "  |    <slot 21> : 4: id IS NOT NULL\n" +
-                "  |    <slot 22> : (20: expr) AND (21: expr)\n" +
-                "  |    <slot 23> : CAST(22: expr AS TINYINT)\n" +
-                "  |    <slot 24> : [0,CAST((2: col_int = 1) AND (4: id IS NOT NULL) AS TINYINT)]\n" +
-                "  |    <slot 25> : CAST([0,CAST((2: col_int = 1) AND (4: id IS NOT NULL) AS TINYINT)] AS ARRAY<BOOLEAN>)\n" +
-                "  |    <slot 26> : array_filter(['A','B'], 25: cast)"));
+                "  |    <slot 19> : 2: col_int = 1\n" +
+                "  |    <slot 20> : 4: id IS NOT NULL\n" +
+                "  |    <slot 21> : (19: expr) AND (20: expr)\n" +
+                "  |    <slot 22> : CAST(21: expr AS TINYINT)\n" +
+                "  |    <slot 23> : [0,CAST((2: col_int = 1) AND (4: id IS NOT NULL) AS TINYINT)]\n" +
+                "  |    <slot 24> : CAST([0,CAST((2: col_int = 1) AND (4: id IS NOT NULL) AS TINYINT)] AS ARRAY<BOOLEAN>)\n" +
+                "  |    <slot 25> : array_filter(['A','B'], 24: cast)"));
 
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -682,11 +682,11 @@ class SelectStmtWithCaseWhenTest {
         PlanTestBase.assertContains(plan, "6:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  equal join conjunct: [9: cast, DOUBLE, true] = [10: add, DOUBLE, true]\n" +
-                "  |  other predicates: CASE WHEN [16: array_length, INT, true] < 2 THEN 'bucket1' " +
-                "WHEN ([16: array_length, INT, true] >= 2) AND ([16: array_length, INT, true] < 4) " +
+                "  |  other predicates: CASE WHEN [15: array_length, INT, true] < 2 THEN 'bucket1' " +
+                "WHEN ([15: array_length, INT, true] >= 2) AND ([15: array_length, INT, true] < 4) " +
                 "THEN 'bucket2' ELSE NULL END IS NOT NULL\n" +
                 "  |    common sub expr:\n" +
-                "  |    <slot 16> : array_length(15: array_concat)\n" +
-                "  |    <slot 15> : array_concat(4: col_arr, 6: col_arr)");
+                "  |    <slot 14> : array_concat(4: col_arr, 6: col_arr)\n" +
+                "  |    <slot 15> : array_length(14: array_concat)");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -720,22 +720,22 @@ public class ExpressionTest extends PlanTestBase {
                 "AS actions FROM action1 GROUP BY uid) AS t ) AS t1) AS t2;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 20> : array_sort(4: array_agg)\n" +
-                "  |  <slot 21> : array_sortby(5: array_agg, 4: array_agg)\n" +
-                "  |  <slot 22> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') " +
+                "  |  <slot 17> : array_sort(4: array_agg)\n" +
+                "  |  <slot 18> : array_sortby(5: array_agg, 4: array_agg)\n" +
+                "  |  <slot 19> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') " +
                 "AND ((<slot 8> >= '2020-01-02 00:00:00') AND (<slot 8> <= '2020-01-02 23:59:59')), " +
-                "20: array_sort, 21: array_sortby)\n" +
-                "  |  <slot 23> : array_filter(20: array_sort, 22: array_map)\n" +
-                "  |  <slot 24> : 23: array_filter[1]\n" +
-                "  |  <slot 25> : minutes_add(24: expr, 90)\n" +
-                "  |  <slot 26> : 24: expr != '2020-01-01 00:00:00'\n" +
-                "  |  <slot 27> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') " +
-                "AND ((<slot 11> >= 24: expr) AND (<slot 11> <= 25: minutes_add))) " +
-                "AND (26: expr), 20: array_sort, 21: array_sortby)\n" +
-                "  |  <slot 28> : array_filter(20: array_sort, 27: array_map)\n" +
-                "  |  <slot 29> : 28: array_filter[1]\n" +
-                "  |  <slot 30> : minutes_add(29: expr, 90)\n" +
-                "  |  <slot 31> : 29: expr != '2020-01-01 00:00:00'");
+                "17: array_sort, 18: array_sortby)\n" +
+                "  |  <slot 20> : array_filter(17: array_sort, 19: array_map)\n" +
+                "  |  <slot 21> : 20: array_filter[1]\n" +
+                "  |  <slot 22> : minutes_add(21: expr, 90)\n" +
+                "  |  <slot 23> : 21: expr != '2020-01-01 00:00:00'\n" +
+                "  |  <slot 24> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') " +
+                "AND ((<slot 11> >= 21: expr) AND (<slot 11> <= 22: minutes_add))) " +
+                "AND (23: expr), 17: array_sort, 18: array_sortby)\n" +
+                "  |  <slot 25> : array_filter(17: array_sort, 24: array_map)\n" +
+                "  |  <slot 26> : 25: array_filter[1]\n" +
+                "  |  <slot 27> : minutes_add(26: expr, 90)\n" +
+                "  |  <slot 28> : 26: expr != '2020-01-01 00:00:00'");
     }
 
     @Test
@@ -835,7 +835,6 @@ public class ExpressionTest extends PlanTestBase {
                 "        lambda common expressions:{<slot 8> <-> array_length(<slot 2>)}\n" +
                 "        , <slot 2>), [[[1,23],[4,3,2]],[[3]]])");
     }
-
 
     @Test
     public void testInPredicateNormalize() throws Exception {
@@ -1611,7 +1610,6 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "bool_or");
     }
-
 
     @Test
     public void testConstantFoldInLikeFunction() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ProjectCommonSubExprPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ProjectCommonSubExprPlanTest.java
@@ -1,0 +1,2042 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Tests for the commonSubOperatorMap field in LogicalProjectOperator.
+ * <p>
+ * A non-empty commonSubOperatorMap arises when MergeTwoProjectRule merges two stacked
+ * LogicalProjectOperators and the inner project defines a non-trivial expression that is
+ * referenced 2+ times in the outer project.  compactSubColumnRefMap() keeps such entries
+ * (inlining constants and single-reference entries).
+ * <p>
+ * All tests below use subqueries or CTEs to create stacked projects so the inner-project
+ * derived columns end up in commonSubOperatorMap rather than being handled by
+ * ScalarOperatorsReuse (which operates on a single projection level).
+ */
+public class ProjectCommonSubExprPlanTest extends PlanTestBase {
+
+    /**
+     * Disable optimizer timeout to avoid StarRocksPlannerException when complex SQL
+     * takes long in the memo phase (e.g. new_planner_optimize_timeout).
+     */
+    @BeforeAll
+    public static void disableOptimizerTimeout() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        // Table for HoistHeavyCostExprsUponTopnRule: DECIMAL128 division triggers the rule.
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `t_hoist_heavy` (\n"
+                + "  `k` bigint NULL COMMENT \"\",\n"
+                + "  `d1` decimal(20,2) NULL COMMENT \"\",\n"
+                + "  `d2` decimal(20,2) NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k`)\n"
+                + "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n"
+                + "PROPERTIES (\"replication_num\" = \"1\");");
+    }
+
+    private String currentTestName;
+    private String lastSql;
+    private String lastPlan;
+
+    @BeforeEach
+    public void initTracer(TestInfo testInfo) {
+        currentTestName = testInfo.getDisplayName();
+        Tracers.register(connectContext);
+        Tracers.init(connectContext, "TIMING", "Optimizer");
+    }
+
+    @AfterEach
+    public void closeTracer() {
+        String traceAll = Tracers.printLogs();
+        System.out.println("====== TRACE for " + currentTestName + " ======");
+        System.out.println(traceAll);
+        System.out.println("====== END TRACE ======\n");
+        Tracers.close();
+        if (lastSql != null) {
+            System.out.println("====== SQL ======");
+            System.out.println(lastSql);
+            System.out.println("====== PLAN ======");
+            System.out.println(lastPlan);
+            lastSql = null;
+            lastPlan = null;
+        }
+    }
+
+    private void printSqlAndPlan(String sql, String plan) {
+        lastSql = sql;
+        lastPlan = plan;
+    }
+
+    // -----------------------------------------------------------------------
+    // CTE-based stacked projects: inner CASE bucket referenced 2+ times
+    // in outer CASE branches → kept in commonSubOperatorMap
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCTECaseWhenBucketPassedThrough() throws Exception {
+        String sql = """
+                WITH cte1 AS (
+                  SELECT v1, v2,
+                    CASE
+                      WHEN v1 = 10 AND v3 < 10 THEN 1
+                      WHEN v1 = 10 AND v3 >= 10 THEN 2
+                      ELSE 3
+                    END AS bucket
+                  FROM t0
+                ),
+                cte2 AS (
+                  SELECT v1, v2,
+                    CASE
+                      WHEN bucket * 10 = 10 AND v2 > 0 THEN 'a'
+                      WHEN bucket * 10 = 20 AND v2 > 0 THEN 'b'
+                      ELSE NULL
+                    END AS label
+                  FROM cte1
+                )
+                SELECT * FROM cte2
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "Project");
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testCTECaseWhenBucketUsedOnlyInOuterCase() throws Exception {
+        String sql = """
+                WITH cte1 AS (
+                  SELECT v1, v2,
+                    CASE
+                      WHEN v1 < 10 THEN 1
+                      WHEN v1 < 20 THEN 2
+                      ELSE 3
+                    END AS bucket
+                  FROM t0
+                ),
+                cte2 AS (
+                  SELECT v1, v2,
+                    CASE
+                      WHEN bucket = 1 AND v2 > 0 THEN 'a'
+                      WHEN bucket = 2 AND v2 > 0 THEN 'b'
+                      ELSE NULL
+                    END AS label
+                  FROM cte1
+                )
+                SELECT * FROM cte2
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testDuplicateCaseWhenInSubqueryProducesCommonExpr() throws Exception {
+        String sql = """
+                SELECT id, region, priority FROM (
+                  SELECT v1 AS id, v2 AS region,
+                    CASE
+                      WHEN (CASE WHEN v1 < 5 THEN 1 WHEN v1 < 10 THEN 2 ELSE 3 END) = 1 AND v2 > 0 THEN 'p1'
+                      WHEN (CASE WHEN v1 < 5 THEN 1 WHEN v1 < 10 THEN 2 ELSE 3 END) = 2 AND v2 > 0 THEN 'p2'
+                      ELSE NULL
+                    END AS priority
+                  FROM t0
+                ) t WHERE priority IS NOT NULL
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "Project");
+        assertContains(plan, "if(");
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery-based: inner derived expression used 2+ times in outer SELECT
+    // (MergeTwoProjectRule merges stacked projects; compactSubColumnRefMap
+    // keeps the inner expression because refcount >= 2)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDerivedColumnUsedTwice() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT v1 * v2 AS a FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testSubqueryDerivedColumnUsedThreeTimes() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2, a - 3 FROM (
+                  SELECT v1 + v2 AS a FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testSubqueryCaseWhenUsedTwice() throws Exception {
+        String sql = """
+                SELECT bucket + 1, bucket * 2 FROM (
+                  SELECT CASE WHEN v1 < 10 THEN 1
+                              WHEN v1 < 20 THEN 2
+                              ELSE 3 END AS bucket
+                  FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testSubqueryMultipleDerivedColumnsEachUsedTwice() throws Exception {
+        String sql = """
+                SELECT a + b, a - b, a * b FROM (
+                  SELECT v1 + v2 AS a, v2 * v3 AS b FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testSubqueryDerivedColumnInSelectAndWhere() throws Exception {
+        String sql = """
+                SELECT product, product + 1 FROM (
+                  SELECT v1 * v2 AS product FROM t0
+                ) sub
+                WHERE product > 100
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "Project");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative case: inner expression used only once → inlined by compaction,
+    // commonSubOperatorMap becomes empty
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDerivedColumnUsedOnce_NoCommonExpr() throws Exception {
+        String sql = """
+                SELECT a + 1 FROM (
+                  SELECT v1 * v2 AS a FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertNotContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testIdentitySubquery_NoCommonExpr() throws Exception {
+        String sql = """
+                SELECT v1, v2 FROM (
+                  SELECT v1, v2 FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertNotContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // CTE-based: CTE defines derived expression referenced 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCTEDerivedColumnUsedTwice() throws Exception {
+        String sql = """
+                WITH cte AS (
+                  SELECT v1, v2, v1 + v2 AS sum12 FROM t0
+                )
+                SELECT sum12 + 1, sum12 * 2 FROM cte
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testCTEDerivedColumnUsedInMultipleExprs() throws Exception {
+        String sql = """
+                WITH cte AS (
+                  SELECT v1, v2, v1 * v2 AS product FROM t0
+                )
+                SELECT product, product + v1, product - v2 FROM cte
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testCTECaseWhenUsedMultipleTimes() throws Exception {
+        String sql = """
+                WITH cte AS (
+                  SELECT v1, v2,
+                    CASE WHEN v1 < 10 THEN 1
+                         WHEN v1 < 20 THEN 2
+                         ELSE 3 END AS bucket
+                  FROM t0
+                )
+                SELECT
+                  bucket,
+                  bucket + 1 AS next_bucket,
+                  CASE bucket WHEN 1 THEN 'low'
+                              WHEN 2 THEN 'mid'
+                              ELSE 'high' END AS label
+                FROM cte
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "Project");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    @Test
+    public void testCTECoalesceUsedMultipleTimes() throws Exception {
+        String sql = """
+                WITH cte AS (
+                  SELECT v1, coalesce(v2, 0) + coalesce(v3, 0) AS total FROM t0
+                )
+                SELECT total, total * 2, total > 100 FROM cte
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-level nested subqueries: MergeTwoProjectRule fires multiple times
+    // producing a chain of entries in commonSubOperatorMap
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testTwoLevelNestedSubquery() throws Exception {
+        String sql = """
+                SELECT x + 1, x * 2 FROM (
+                  SELECT y + 10 AS x FROM (
+                    SELECT v1 * v2 AS y FROM t0
+                  ) q1
+                ) q2
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testThreeLevelNestedSubquery() throws Exception {
+        String sql = """
+                SELECT z + 1, z * 2 FROM (
+                  SELECT y + 100 AS z FROM (
+                    SELECT x + 10 AS y FROM (
+                      SELECT v1 * v2 AS x FROM t0
+                    ) q1
+                  ) q2
+                ) q3
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-level CTE chains: each level adds a derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testThreeLevelCTEChain() throws Exception {
+        String sql = """
+                WITH
+                  level1 AS (
+                    SELECT v1, v2, v1 + v2 AS sum12 FROM t0
+                  ),
+                  level2 AS (
+                    SELECT v1, sum12,
+                      CASE WHEN sum12 > 100 THEN 'high' ELSE 'low' END AS tier
+                    FROM level1
+                  ),
+                  level3 AS (
+                    SELECT sum12, tier,
+                      CASE WHEN tier = 'high' THEN sum12 * 2 ELSE sum12 END AS adjusted
+                    FROM level2
+                  )
+                SELECT sum12, tier, adjusted FROM level3
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testCTEWithMultipleDerivedColumnsPerLevel() throws Exception {
+        String sql = """
+                WITH
+                  base AS (
+                    SELECT v1, v2, v3,
+                      v1 + v2 AS s, v1 * v2 AS p
+                    FROM t0
+                  ),
+                  derived AS (
+                    SELECT s, p,
+                      s + p AS sp_sum,
+                      s * p AS sp_prod
+                    FROM base
+                  )
+                SELECT sp_sum + 1, sp_sum * 2, sp_prod + 1, sp_prod * 2 FROM derived
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery CASE WHEN where condition expression is used multiple times
+    // in the outer query (e.g., referenced in multiple outer CASE branches)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryCaseWhenConditionReferencedInOuterCaseBranches() throws Exception {
+        String sql = """
+                SELECT
+                  CASE WHEN bucket = 1 THEN v2 * 10
+                       WHEN bucket = 2 THEN v2 * 20
+                       ELSE v2 END AS weighted
+                FROM (
+                  SELECT v1, v2,
+                    CASE WHEN v1 < 5 THEN 1
+                         WHEN v1 < 15 THEN 2
+                         ELSE 3 END AS bucket
+                  FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "Project");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    @Test
+    public void testSubqueryDerivedExprInMultipleOuterCaseColumns() throws Exception {
+        String sql = """
+                SELECT
+                  CASE WHEN bucket = 1 AND v2 > 0 THEN 'a'
+                       WHEN bucket = 2 AND v2 > 0 THEN 'b'
+                       ELSE 'c' END AS label,
+                  CASE WHEN bucket = 1 THEN v2 * 10
+                       WHEN bucket = 2 THEN v2 * 20
+                       ELSE v2 * 30 END AS weight
+                FROM (
+                  SELECT v1, v2,
+                    CASE WHEN v1 < 10 THEN 1
+                         WHEN v1 < 20 THEN 2
+                         ELSE 3 END AS bucket
+                  FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "Project");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    // -----------------------------------------------------------------------
+    // Derived column from subquery used in GROUP BY context
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDerivedColumnInGroupBy() throws Exception {
+        String sql = """
+                SELECT bucket, count(*), sum(v2) FROM (
+                  SELECT v1, v2,
+                    CASE WHEN v1 < 10 THEN 1
+                         WHEN v1 < 20 THEN 2
+                         ELSE 3 END AS bucket
+                  FROM t0
+                ) sub
+                GROUP BY bucket
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "AGGREGATE");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    @Test
+    public void testSubqueryDerivedColumnInGroupByAndHaving() throws Exception {
+        String sql = """
+                SELECT bucket, count(*) AS cnt FROM (
+                  SELECT v1 + v2 AS bucket FROM t0
+                ) sub
+                GROUP BY bucket
+                HAVING count(*) > 1
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "AGGREGATE");
+    }
+
+    // -----------------------------------------------------------------------
+    // Derived column used in ORDER BY context
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDerivedColumnInOrderBy() throws Exception {
+        String sql = """
+                SELECT a, a + 1 FROM (
+                  SELECT v1 * v2 AS a FROM t0
+                ) sub
+                ORDER BY a
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "SORT");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with function-call-based derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryAbsFunctionUsedTwice() throws Exception {
+        String sql = """
+                SELECT abs_v1 + 1, abs_v1 * 2 FROM (
+                  SELECT abs(v1) AS abs_v1 FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "abs");
+    }
+
+    @Test
+    public void testSubqueryComplexFunctionUsedTwice() throws Exception {
+        String sql = """
+                SELECT computed + 1, computed - 1 FROM (
+                  SELECT abs(v1 - v2) + abs(v2 - v3) AS computed FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with CAST-based derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryCastUsedTwice() throws Exception {
+        String sql = """
+                SELECT d + 1.0, d * 2.0 FROM (
+                  SELECT CAST(v1 AS DOUBLE) AS d FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with IF/COALESCE derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryIfUsedTwice() throws Exception {
+        String sql = """
+                SELECT val + 1, val * 10 FROM (
+                  SELECT IF(v1 > 0, v2, v3) AS val FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "if(");
+    }
+
+    @Test
+    public void testSubqueryCoalesceUsedTwice() throws Exception {
+        String sql = """
+                SELECT c + 1, c * 2 FROM (
+                  SELECT COALESCE(v1, v2, v3) AS c FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "coalesce");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with string function derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryStringConcatUsedTwice() throws Exception {
+        String sql = """
+                SELECT full_name, length(full_name) FROM (
+                  SELECT concat(k1, '-', k2) AS full_name FROM t7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "concat");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with arithmetic chain producing deeper common sub expr
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDeepArithmeticChain() throws Exception {
+        String sql = """
+                SELECT s * s, s + 100, s - 50 FROM (
+                  SELECT (v1 + v2) * (v1 - v2) AS s FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with boolean derived column used multiple times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryBooleanExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT
+                  IF(is_positive, v2 * 2, v2) AS adjusted,
+                  IF(is_positive, 'yes', 'no') AS label
+                FROM (
+                  SELECT v2, v1 > 0 AS is_positive FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "if(");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-table subquery: derived expr from join result used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryFromJoinUsedTwice() throws Exception {
+        String sql = """
+                SELECT total + 1, total * 2 FROM (
+                  SELECT t0.v1 + t1.v4 AS total
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Left outer join: derived expr from nullable side used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testLeftJoinDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT total + 1, total * 2 FROM (
+                  SELECT IFNULL(t0.v1 + t1.v4, 0) AS total
+                  FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "LEFT OUTER JOIN");
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Self-join with a derived expression referenced multiple times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSelfJoinDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT diff + 1, diff * 3 FROM (
+                  SELECT a.v1 - b.v1 AS diff
+                  FROM t0 a JOIN t0 b ON a.v2 = b.v2
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Three-table join with derived expression used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testThreeTableJoinDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT s + 1, s * 2 FROM (
+                  SELECT t0.v1 + t1.v4 + t0.v3 AS s
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t0 t2 ON t1.v4 = t2.v1
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Three-way join across distinct tables with derived expressions
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testThreeWayJoinDerivedExprFromAllTables() throws Exception {
+        String sql = """
+                SELECT score + 1, score * 2, score - 10 FROM (
+                  SELECT t0.v1 + t1.v5 + t2.v9 AS score
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testThreeWayJoinCTEWithCaseWhen() throws Exception {
+        String sql = """
+                WITH joined AS (
+                  SELECT t0.v1, t1.v5, t2.v9,
+                    CASE
+                      WHEN t0.v1 > t1.v5 AND t1.v5 > t2.v9 THEN 1
+                      WHEN t0.v1 > t2.v9 THEN 2
+                      ELSE 3
+                    END AS rank_bucket
+                  FROM t0
+                  JOIN t1 ON t0.v2 = t1.v5
+                  JOIN t2 ON t1.v6 = t2.v8
+                )
+                SELECT
+                  rank_bucket,
+                  rank_bucket + 10 AS shifted,
+                  CASE rank_bucket WHEN 1 THEN 'top'
+                                   WHEN 2 THEN 'mid'
+                                   ELSE 'low' END AS tier
+                FROM joined
+                """;
+
+        //        String plan = getFragmentPlan(sql);
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+        //        assertContains(plan, "HASH JOIN");
+        //        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testThreeWayJoinCTEWithCaseWhen1() throws Exception {
+        String sql = """
+                WITH t0_t1 AS (
+                  SELECT t1.v6,
+                    CASE
+                      WHEN t0.v1 + t1.v4 > 10 THEN 1
+                      WHEN (t0.v1 + t1.v4) * 2 > 100 THEN 2
+                      ELSE 3
+                    END AS rank_bucket
+                  FROM t0
+                  JOIN t1 ON t0.v2 = t1.v5
+                )
+                SELECT
+                  rank_bucket,
+                  t2.v7
+                FROM t0_t1
+                JOIN t2 ON t0_t1.v6 = t2.v8
+                """;
+
+        //        String plan = getFragmentPlan(sql);
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+        //        assertContains(plan, "HASH JOIN");
+        //        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testThreeWayJoinCTEWithCaseWhen2() throws Exception {
+        String sql = """
+                WITH t0_0 AS (
+                  SELECT v1 + 10 AS v1_0, v2 FROM t0
+                ),
+                t0_1 AS (
+                  SELECT v1_0 * 2 AS v1_1, v1_0 / 2 AS v1_2, v2 FROM t0_0
+                ),
+                t0_t1 AS (
+                  SELECT t0_1.v1_1 AS f1, t0_1.v1_2 AS f2, t1.v6
+                  FROM t0_1
+                  JOIN t1 ON t0_1.v2 = t1.v5
+                )
+                SELECT
+                  f1,
+                  f2,
+                  t2.v7
+                FROM t0_t1
+                JOIN t2 ON t0_t1.v6 = t2.v8
+                """;
+
+        //        String plan = getFragmentPlan(sql);
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+        //        assertContains(plan, "HASH JOIN");
+        //        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testThreeWayJoinCTEWithCaseWhen3() throws Exception {
+        String sql = """
+                WITH t0_t1 AS (
+                  SELECT t1.v6,
+                    CASE
+                      WHEN (t0.v1 + 10) > 10 THEN 1
+                      WHEN (t0.v1 + 10) * 2 > 100 THEN 2
+                      ELSE 3
+                    END AS rank_bucket
+                  FROM t0
+                  JOIN t1 ON t0.v2 = t1.v5
+                )
+                SELECT
+                  rank_bucket,
+                  t2.v7
+                FROM t0_t1
+                JOIN t2 ON t0_t1.v6 = t2.v8
+                """;
+
+        //        String plan = getFragmentPlan(sql);
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+        //        assertContains(plan, "HASH JOIN");
+        //        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testTwoWay() throws Exception {
+        String sql = """
+                WITH t0_t1 AS (
+                  SELECT t0.v1 AS v1, t0.v2 * 10 AS v2, t1.v5 AS v5
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                )
+                SELECT
+                  t0_t1.v1,
+                  t0_t1.v2 + 1 AS v2_plus,
+                  t0_t1.v2 * 2 AS v2_double,
+                  t0_t1.v5
+                FROM t0_t1
+                """;
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+    }
+
+    @Test
+    public void testJoinAssociativityRuleBottomJoinWithCommSub() throws Exception {
+        String sql = """
+                WITH t0_t1 AS (
+                  SELECT t0.v1 AS v1, t0.v2 * 10 AS v2, t1.v5 AS v5
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                ),
+                t0_t1_project AS (
+                  SELECT
+                    t0_t1.v1,
+                    t0_t1.v2 + 1 AS v2_plus,
+                    t0_t1.v2 * 2 AS v2_double,
+                    t0_t1.v5
+                  FROM t0_t1
+                )
+                SELECT
+                  t0_t1_project.v1,
+                  t0_t1_project.v2_plus,
+                  t0_t1_project.v2_double,
+                  t0_t1_project.v5,
+                  t2.v9
+                FROM t0_t1_project
+                JOIN t2 ON t0_t1_project.v1 = t2.v8
+                """;
+
+        //        String plan = getFragmentPlan(sql);
+        String plan = getExecPlan(sql).getExplainString(StatementBase.ExplainLevel.LOGICAL);
+        printSqlAndPlan(sql, plan);
+        //        assertContains(plan, "HASH JOIN");
+        //        assertContains(plan, "Project");
+    }
+
+    @Test
+    public void testThreeWayJoinMixedJoinTypes() throws Exception {
+        String sql = """
+                SELECT combo + 1, combo * 3 FROM (
+                  SELECT COALESCE(t0.v2, 0) + COALESCE(t2.v8, 0) AS combo
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  LEFT JOIN t2 ON t1.v6 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testThreeWayJoinWithAggAndDerivedExpr() throws Exception {
+        String sql = """
+                SELECT total + 1, total * 2 FROM (
+                  SELECT SUM(t0.v2 + t1.v5 + t2.v9) AS total
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                  GROUP BY t0.v1
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "AGGREGATE");
+    }
+
+    // -----------------------------------------------------------------------
+    // CTE over a join: derived expression used multiple times in outer query
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCTEOverJoinDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                WITH joined AS (
+                  SELECT t0.v1 * t1.v5 AS product
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                )
+                SELECT product + 10, product * 5, product - 1
+                FROM joined
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Join with aggregation: derived expr from grouped join used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testJoinAggDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT total_sum + 1, total_sum * 2 FROM (
+                  SELECT SUM(t0.v2 + t1.v5) AS total_sum
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                  GROUP BY t0.v1
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "AGGREGATE");
+        //        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Right join: derived expr on the nullable side used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testRightJoinDerivedExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT val + 1, val * 2 FROM (
+                  SELECT COALESCE(t0.v2, 0) + t1.v5 AS val
+                  FROM t0 RIGHT JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "RIGHT OUTER JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Join with CASE WHEN on join columns used multiple times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testJoinCaseWhenDerivedUsedTwice() throws Exception {
+        String sql = """
+                SELECT
+                  IF(flag = 1, v2, v5) AS picked,
+                  flag + 10 AS flag_plus
+                FROM (
+                  SELECT t0.v2, t1.v5,
+                    CASE WHEN t0.v1 > t1.v4 THEN 1 ELSE 0 END AS flag
+                  FROM t0 JOIN t1 ON t0.v3 = t1.v6
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with NULLIF/IFNULL used multiple times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryNullIfUsedTwice() throws Exception {
+        String sql = """
+                SELECT safe_val + 1, safe_val * 2 FROM (
+                  SELECT nullif(v1, 0) AS safe_val FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    @Test
+    public void testSubqueryIfNullUsedTwice() throws Exception {
+        String sql = """
+                SELECT filled + 1, filled * 2 FROM (
+                  SELECT ifnull(v1, -1) AS filled FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Verbose explain output verification
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testVerboseExplainShowsCommonExprFromSubquery() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT v1 * v2 AS a FROM t0
+                ) sub
+                """;
+
+        String plan = getVerboseExplain(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with multiple stacked derived expressions, outer uses both
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryTwoDerivedBothUsedTwice() throws Exception {
+        String sql = """
+                SELECT x + y, x - y, x * y, x / y FROM (
+                  SELECT v1 + v2 AS x, v2 + v3 AS y FROM t0
+                ) sub
+                WHERE y != 0
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // CTE with complex CASE returning string, used in multiple string ops
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCTEStringCaseUsedInMultipleStringOps() throws Exception {
+        String sql = """
+                WITH cte AS (
+                  SELECT v1,
+                    CASE WHEN v1 < 10 THEN 'alpha'
+                         WHEN v1 < 20 THEN 'beta'
+                         ELSE 'gamma' END AS category
+                  FROM t0
+                )
+                SELECT
+                  upper(category),
+                  length(category),
+                  concat(category, '-suffix')
+                FROM cte
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // LIMIT combined with stacked project common sub expr
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryWithLimitPreservesCommonExpr() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT v1 * v2 AS a FROM t0
+                ) sub
+                LIMIT 10
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "limit: 10");
+    }
+
+    @Test
+    public void testInnerLimitAndOuterCommonExpr() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT v1 * v2 AS a FROM t0 LIMIT 100
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery derived column used in window function partition/order
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryDerivedColumnInWindowPartition() throws Exception {
+        String sql = """
+                SELECT bucket, v2,
+                  sum(v2) OVER (PARTITION BY bucket ORDER BY v2) AS window_sum
+                FROM (
+                  SELECT v1, v2,
+                    CASE WHEN v1 < 10 THEN 1 ELSE 2 END AS bucket
+                  FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "ANALYTIC");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with modulo-based bucketing used multiple times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryModuloBucketUsedMultipleTimes() throws Exception {
+        String sql = """
+                SELECT
+                  bucket,
+                  bucket + 1,
+                  CASE bucket
+                    WHEN 0 THEN 'zero'
+                    WHEN 1 THEN 'one'
+                    WHEN 2 THEN 'two'
+                    ELSE 'other'
+                  END AS bucket_name
+                FROM (
+                  SELECT v1, CAST(v1 % 3 AS INT) AS bucket FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "Project");
+        assertContains(plan, "TABLE: t0");
+    }
+
+    // -----------------------------------------------------------------------
+    // UNION ALL where each branch has its own stacked project
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUnionAllWithSubqueryDerivedColumns() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT v1 + v2 AS a FROM t0
+                ) s1
+                UNION ALL
+                SELECT b + 1, b * 2 FROM (
+                  SELECT v4 + v5 AS b FROM t1
+                ) s2
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "UNION");
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with power/exponent derived column
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryPowerExprUsedTwice() throws Exception {
+        String sql = """
+                SELECT sq + 1, sq * 3 FROM (
+                  SELECT v1 * v1 AS sq FROM t0
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // Subquery with mixed types derived column (implicit cast chains)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSubqueryMixedTypeDerivedColumn() throws Exception {
+        String sql = """
+                SELECT d + 0.5, d * 3 FROM (
+                  SELECT CAST(t1b AS DOUBLE) + CAST(t1c AS DOUBLE) AS d
+                  FROM test_all_type
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+    }
+
+    // -----------------------------------------------------------------------
+    // MergeProjectWithChildRule no-op: when the child of a Project is a
+    // LOGICAL_META_SCAN, the rule's check() returns false so the Project is
+    // preserved for PushDownAggToMetaScanRule to consume.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMergeProjectWithChildRuleNoOpForMetaScan() throws Exception {
+        String sql = "SELECT max(v1), min(v2) FROM t0 [_META_]";
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "MetaScan");
+    }
+
+    // -----------------------------------------------------------------------
+    // Traditional (single-level) common subexpression reuse via
+    // ScalarOperatorsReuse — these must keep working with the new
+    // commonSubOperatorMap plumbing.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testTraditionalSameLevelExpressionReuse() throws Exception {
+        String sql = "select v1 + v2, v1 + v2 + v3, v1 + v2 + v3 + 1 from t0";
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "1: v1 + 2: v2");
+    }
+
+    @Test
+    public void testTraditionalCastReuse() throws Exception {
+        String sql = """
+                SELECT
+                  CAST(v1 * v1 AS DOUBLE) / CAST(v1 AS DOUBLE) % CAST(v1 AS DOUBLE)
+                    + CAST(v1 AS DOUBLE) - CAST(v1 DIV v1 AS DOUBLE),
+                  v2 & ~ v1 | v3 ^ 1
+                FROM t0
+                """;
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "common expressions:");
+        assertContains(plan, "CAST(1: v1 AS DOUBLE)");
+    }
+
+    // =======================================================================
+    // Join reorder + common sub-expression interaction tests.
+    //
+    // These exercise the code path where:
+    //   1. MergeTwoProjectRule creates a LogicalProjectOperator whose
+    //      commonSubOperatorMap is non-empty.
+    //   2. MergeProjectWithChildRule pushes that Projection onto a
+    //      LogicalJoinOperator.
+    //   3. JoinAssociativityRule or JoinLeftAsscomRule rearranges the joins.
+    //
+    // If JoinAssociateBaseRule silently drops commonSubOperatorMap entries,
+    // planning will either fail or produce wrong results.
+    // =======================================================================
+
+    // -----------------------------------------------------------------------
+    // Associativity: (A ⋈ B) ⋈ C  →  A ⋈ (B ⋈ C)
+    // CSE defined on the inner join projection, used 2+ times in outer SELECT
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testAssociativityTwoTableCSEUsedTwice() throws Exception {
+        String sql = """
+                SELECT total + 1, total * 2 FROM (
+                  SELECT t0.v1 + t1.v4 AS total
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.total = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "TABLE: t1");
+        assertContains(plan, "TABLE: t2");
+    }
+
+    @Test
+    public void testAssociativityCSEFromBothSidesOfInnerJoin() throws Exception {
+        String sql = """
+                SELECT combo + 10, combo * 5, combo - 1 FROM (
+                  SELECT t0.v2 + t1.v5 AS combo
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.combo = t2.v8
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testAssociativityCSECaseWhenOnJoin() throws Exception {
+        String sql = """
+                SELECT bucket + 1, bucket * 3,
+                       CASE bucket WHEN 1 THEN 'low' WHEN 2 THEN 'mid' ELSE 'high' END
+                FROM (
+                  SELECT CASE WHEN t0.v1 > t1.v4 THEN 1
+                              WHEN t0.v1 = t1.v4 THEN 2
+                              ELSE 3 END AS bucket
+                  FROM t0 JOIN t1 ON t0.v2 = t1.v5
+                ) sub
+                JOIN t2 ON sub.bucket = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Three-table inner join with CSE across all three tables.
+    // The optimizer may explore associativity: (t0 ⋈ t1) ⋈ t2
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testThreeTableInnerJoinCSEAcrossAllTables() throws Exception {
+        String sql = """
+                SELECT score + 1, score * 2 FROM (
+                  SELECT t0.v1 + t1.v5 + t2.v9 AS score
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testThreeTableInnerJoinCSEFromTwoTables() throws Exception {
+        String sql = """
+                SELECT product + 1, product * 2, product - 3 FROM (
+                  SELECT t0.v2 * t1.v5 AS product
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t0.v1 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Four-table joins: more exploration surface for associativity/left-asscom
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testFourTableJoinCSEUsedTwice() throws Exception {
+        String sql = """
+                SELECT x + 1, x * 2 FROM (
+                  SELECT t0.v1 + t1.v5 AS x
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                  JOIN t3 ON t2.v7 = t3.v10
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "TABLE: t3");
+    }
+
+    @Test
+    public void testFourTableJoinCSECaseWhen() throws Exception {
+        String sql = """
+                SELECT bucket, bucket + 100,
+                       CASE bucket WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END
+                FROM (
+                  SELECT CASE WHEN t0.v1 + t1.v4 > 100 THEN 1
+                              WHEN t2.v7 + t3.v10 > 100 THEN 2
+                              ELSE 3 END AS bucket
+                  FROM t0
+                  JOIN t1 ON t0.v2 = t1.v5
+                  JOIN t2 ON t1.v4 = t2.v7
+                  JOIN t3 ON t2.v8 = t3.v11
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Left-asscom: (t0 ⋈ t1) ⋈ t2  →  (t0 ⋈ t2) ⋈ t1
+    // Using LEFT/SEMI joins that trigger left-asscom rather than associativity
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testLeftJoinAssociativityCSEUsedTwice() throws Exception {
+        String sql = """
+                SELECT val + 1, val * 2 FROM (
+                  SELECT COALESCE(t0.v2 + t1.v5, 0) AS val
+                  FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.val = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    @Test
+    public void testLeftJoinThreeTableCSE() throws Exception {
+        String sql = """
+                SELECT combo + 1, combo * 3 FROM (
+                  SELECT COALESCE(t0.v2, 0) + COALESCE(t1.v5, 0) AS combo
+                  FROM t0
+                  LEFT JOIN t1 ON t0.v1 = t1.v4
+                  LEFT JOIN t2 ON t0.v1 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    @Test
+    public void testSemiJoinWithCSEOnOuterJoin() throws Exception {
+        String sql = """
+                SELECT total + 1, total * 2 FROM (
+                  SELECT t0.v1 + t0.v2 AS total
+                  FROM t0
+                  WHERE t0.v1 IN (SELECT t1.v4 FROM t1)
+                ) sub
+                JOIN t2 ON sub.total = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Mixed join types: inner + left/right
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMixedInnerLeftJoinCSE() throws Exception {
+        String sql = """
+                SELECT d + 1, d * 2, d - 5 FROM (
+                  SELECT COALESCE(t0.v2, 0) + COALESCE(t2.v8, 0) AS d
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  LEFT JOIN t2 ON t1.v6 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    @Test
+    public void testMixedInnerRightJoinCSE() throws Exception {
+        String sql = """
+                SELECT r + 10, r * 3 FROM (
+                  SELECT COALESCE(t0.v2, 0) + t1.v5 AS r
+                  FROM t0
+                  RIGHT JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CTE over multi-table join: CSE gets merged into the join's projection,
+    // then join reordering fires during exploration
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCTEOverThreeTableJoinCSEUsedTwice() throws Exception {
+        String sql = """
+                WITH base AS (
+                  SELECT t0.v1 * t1.v5 AS product, t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                )
+                SELECT product + 10, product * 5, product - v9
+                FROM base
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testCTEOverFourTableJoinCSECaseWhen() throws Exception {
+        String sql = """
+                WITH ranked AS (
+                  SELECT t0.v1, t1.v5, t2.v9,
+                    CASE
+                      WHEN t0.v1 > t1.v5 THEN 1
+                      WHEN t0.v1 > t2.v9 THEN 2
+                      ELSE 3
+                    END AS rank_bucket
+                  FROM t0
+                  JOIN t1 ON t0.v2 = t1.v5
+                  JOIN t2 ON t1.v6 = t2.v8
+                  JOIN t3 ON t2.v7 = t3.v10
+                )
+                SELECT
+                  rank_bucket,
+                  rank_bucket + 10 AS shifted,
+                  CASE rank_bucket WHEN 1 THEN 'top'
+                                   WHEN 2 THEN 'mid'
+                                   ELSE 'low' END AS tier
+                FROM ranked
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested subquery over join: two project merges creating a deeper
+    // commonSubOperatorMap chain, followed by join reorder
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNestedSubqueryOverJoinCSE() throws Exception {
+        String sql = """
+                SELECT z + 1, z * 2 FROM (
+                  SELECT y + 100 AS z FROM (
+                    SELECT t0.v1 * t1.v5 AS y
+                    FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                  ) inner_sub
+                ) outer_sub
+                JOIN t2 ON outer_sub.z = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testTwoLevelNestedSubqueryOverThreeTableJoin() throws Exception {
+        String sql = """
+                SELECT w + 1, w * 2, w - 10 FROM (
+                  SELECT x + y AS w FROM (
+                    SELECT t0.v1 + t1.v5 AS x, t2.v9 AS y
+                    FROM t0
+                    JOIN t1 ON t0.v1 = t1.v4
+                    JOIN t2 ON t1.v4 = t2.v7
+                  ) q1
+                ) q2
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE in join ON condition context: derived column from inner join used
+    // in the ON condition of a subsequent join
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEInJoinOnCondition() throws Exception {
+        String sql = """
+                SELECT sub.s, t2.v8 FROM (
+                  SELECT t0.v1, t0.v2 + t1.v5 AS s
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.s = t2.v7 AND sub.s > t2.v8
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE in WHERE predicate combined with join reorder
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEInWherePredicateWithJoinReorder() throws Exception {
+        String sql = """
+                SELECT total FROM (
+                  SELECT t0.v1 + t1.v5 AS total, t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                WHERE total > 100 AND total < 1000
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE with aggregate on top of a join that may be reordered
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEWithAggOverReorderableJoin() throws Exception {
+        String sql = """
+                SELECT bucket, count(*), sum(v9) FROM (
+                  SELECT CASE WHEN t0.v1 + t1.v5 > 100 THEN 1 ELSE 2 END AS bucket, t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                GROUP BY bucket
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+        assertContains(plan, "AGGREGATE");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE with function calls (abs, coalesce, etc.) on join result
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEAbsFunctionOnJoinResultWithReorder() throws Exception {
+        String sql = """
+                SELECT abs_diff + 1, abs_diff * 2 FROM (
+                  SELECT abs(t0.v2 - t1.v5) AS abs_diff
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.abs_diff = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    @Test
+    public void testCSECoalesceOnJoinResultWithReorder() throws Exception {
+        String sql = """
+                SELECT c + 1, c * 5 FROM (
+                  SELECT COALESCE(t0.v2, t1.v5, 0) AS c
+                  FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.c = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple CSEs from the same join, each used 2+ times
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testMultipleCSEsFromSameJoinReorder() throws Exception {
+        String sql = """
+                SELECT a + b, a - b, a * b FROM (
+                  SELECT t0.v1 + t1.v4 AS a, t0.v2 * t1.v5 AS b
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.a = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testMultipleCSEsInCTEOverJoinReorder() throws Exception {
+        String sql = """
+                WITH base AS (
+                  SELECT t0.v1 + t1.v4 AS sum_val,
+                         t0.v2 * t1.v5 AS prod_val,
+                         t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                )
+                SELECT sum_val + prod_val, sum_val - prod_val,
+                       sum_val * 2, prod_val * 3
+                FROM base
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE where the derived column is used in both SELECT and the ON
+    // condition of a subsequent join (split across top/bot join)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEUsedInSelectAndSubsequentJoinOn() throws Exception {
+        String sql = """
+                SELECT sub.derived_col + 1, sub.derived_col * 2, t2.v8
+                FROM (
+                  SELECT t0.v1, t0.v2 * t1.v5 AS derived_col
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.derived_col = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE with CAST on join columns — exercises the JoinOnConditionShuttle
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEWithCastOnJoinColumnsReorder() throws Exception {
+        String sql = """
+                SELECT d + 1.0, d * 2.0 FROM (
+                  SELECT CAST(t0.v1 AS DOUBLE) + CAST(t1.v5 AS DOUBLE) AS d
+                  FROM t0 JOIN t1 ON t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON CAST(sub.d AS BIGINT) = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE with join reorder disabled: baseline to compare against
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEOverJoinWithReorderDisabled() throws Exception {
+        connectContext.getSessionVariable().disableJoinReorder();
+        try {
+            String sql = """
+                    SELECT product + 1, product * 2 FROM (
+                      SELECT t0.v1 * t1.v5 AS product
+                      FROM t0
+                      JOIN t1 ON t0.v1 = t1.v4
+                      JOIN t2 ON t1.v4 = t2.v7
+                    ) sub
+                    """;
+
+            String plan = getFragmentPlan(sql);
+            printSqlAndPlan(sql, plan);
+            assertContains(plan, "HASH JOIN");
+        } finally {
+            connectContext.getSessionVariable().enableJoinReorder();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross join promoted to inner join when CSE becomes ON condition
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEOnCrossJoinPromotedToInner() throws Exception {
+        String sql = """
+                SELECT x + 1, x * 2 FROM (
+                  SELECT t0.v1 + t0.v2 AS x, t1.v4
+                  FROM t0, t1
+                  WHERE t0.v1 = t1.v4
+                ) sub
+                JOIN t2 ON sub.x = t2.v7
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE constant expression on a join projection (constCols bucket in
+    // ProjectionSplitter)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEConstantExprOnJoinProjection() throws Exception {
+        String sql = """
+                SELECT c + v9, c * 2, c - v9 FROM (
+                  SELECT 42 AS c, t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE on join with ORDER BY + LIMIT: verifies plan survives the
+    // full optimization pipeline
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEOnJoinWithOrderByLimit() throws Exception {
+        String sql = """
+                SELECT s + 1, s * 2 FROM (
+                  SELECT t0.v1 + t1.v5 AS s
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                ORDER BY s
+                LIMIT 10
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    @Test
+    public void testCSEOnJoinWithOrderByLimit1() throws Exception {
+        String sql = """
+                SELECT a + 1, a * 2 FROM (
+                  SELECT t0.v1 + t1.v5 AS a, t0.v2 AS b
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                ORDER BY b
+                LIMIT 10
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "HASH JOIN");
+    }
+
+    // -----------------------------------------------------------------------
+    // CSE involving window function partitioned by a derived column
+    // from a multi-table join
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCSEWindowFunctionOverJoinReorder() throws Exception {
+        String sql = """
+                SELECT bucket, v9,
+                       sum(v9) OVER (PARTITION BY bucket ORDER BY v9) AS wsum
+                FROM (
+                  SELECT CASE WHEN t0.v1 + t1.v5 > 50 THEN 1 ELSE 2 END AS bucket,
+                         t2.v9
+                  FROM t0
+                  JOIN t1 ON t0.v1 = t1.v4
+                  JOIN t2 ON t1.v4 = t2.v7
+                ) sub
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "JOIN");
+        assertContains(plan, "ANALYTIC");
+    }
+
+    @Test
+    public void testEliminateAggFunctionRule() throws Exception {
+        String sql = """
+                SELECT max(v1) FROM t0 GROUP BY v1
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+    }
+
+    // -----------------------------------------------------------------------
+    // HoistHeavyCostExprsUponTopnRule: hoist DECIMAL128/LARGEINT division
+    // above TopN so the heavy expr is computed only on the limited result.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHoistHeavyCostExprsUponTopnRule() throws Exception {
+        // TopN (ORDER BY k LIMIT 10) over Project(k, d1, d2, d1/d2). The division
+        // d1/d2 is DECIMAL128 and not used in ORDER BY, so the rule hoists it
+        // above TopN (computed after limit).
+        String sql = """
+                SELECT k, d1, d2, d1 / d2
+                FROM t_hoist_heavy
+                ORDER BY k
+                LIMIT 10
+                """;
+
+        String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "table: t_hoist_heavy");
+        assertContains(plan, "limit: 10");
+        // When the rule fires, the Project that outputs the division sits above
+        // the TopN and has "limit: 10" in its fragment (division computed after limit).
+        assertContains(plan, "/");
+        assertContains(plan, "DECIMAL128");
+    }
+
+    // -----------------------------------------------------------------------
+    // Join with scalar subquery in WHERE correlating with both t0 and t1
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testScalarSubquery() throws Exception {
+        String sql = """
+                SELECT * FROM t0 JOIN t1
+                WHERE v1 + v4 = (
+                  SELECT max(t1d) FROM test_all_type
+                  WHERE t1c = 1
+                    AND t1c + t0.v2 = t0.v1 + t1c
+                    AND t1d + t0.v3 = t1.v5 + t1d
+                )
+                """;
+
+        String plan = getFragmentPlan(sql);
+        printSqlAndPlan(sql, plan);
+        assertContains(plan, "TABLE: t0");
+        assertContains(plan, "TABLE: t1");
+        assertContains(plan, "test_all_type");
+    }
+}


### PR DESCRIPTION
# 🚧 WORK IN PROGRESS 🚧
---
# Overview
Existing CSE (common sub-expression elimination) is applied at the final physical rewrite phase. Before that, and throughout the query optimization phase, common sub-expressions are inlined.

For queries containing nested case-when expressions, this inlining leads to an multiplying effect on the number of expression nodes, which is inefficient both time-wise and memory-wise. We came across relevant failures (`Expression too complex` and `Expression CaseWhen too complex`) for some of our workloads, similar to what's mentioned in https://github.com/StarRocks/starrocks/issues/66325 and https://github.com/StarRocks/starrocks/pull/66324. In an extreme case, we had to increase `Config.max_scalar_operator_flat_children` to 2million so that one query can pass, and its planning took 38s.

This change aims to support reusing common sue-expressions throughout the query optimization phase.
<!-- 
- Introduce `commonSubOperatorMap` to `LogicalProjectOperator`.
- Update `MergeTwoProjectRule` to compose rather than inline sub-expressions when they're referenced more than once.
- Update `MergeProjectWithChildRule` to build projections with existing common maps
- Update `ScalarOperatorsReuse` to recognize common sub-expressions when performing the final physical-level CSE.
- Add several helpers to `ScalarOperatorUtil` for managing common sub-expressions
- Update various transformation rules so that they can work with common sub-expressions (TODO: enumerate the rules extensively: join reordering, subfield pruning, etc.)
- Eliminate common sub-expressions when MV rewrites happen.
-->

# Core Change
The core change is to introduce a common sub-expression map to projections. This includes both `LogicalProjectNode` and `Projection`. Note that `Projection` already has an existing common sub-expression map but today it's always empty before the physical rewrite phase.

## Core Operations to Be Considered
### Merge
```
top output column map
top common column map
                          ---->  merged output column map
bottom output column map         merged common column map       
bottom common column map
```
Used by `MergeTwoProjectRule`, `JoinAssociateBaseRule`.

In some cases, some bottom output columns may be "promoted" into the merged output column map.

### Split
**Vertical split**
```
                          top output column map
                          top common column map
output column map  ---->
common column map
                          bottom output column map
                          bottom common column map 
```
Used by `HoistHeavyCostExprsUponTopnRule`

**Horizontal split**
```
output column map  ----> first output column map   +   second output column map
common column map        first common column map       second common column map
```

### Traverse
Happens in stats calculation.

### Calculate Inputs
Happens when the input columns are needed.

# Required Changes
## Project Merging and Physical CSE Rewriting
Key files:
- `MergeTwoProjectRule`
- `MergeProjectWithChildRule`
- `ScalarOperatorsReuse`
## Join Reordering
## Subfield Pruning
## MV Rewriting
## Stats Estimation
## TODO: How to make sure everything is covered?


# Alternative Solutions
- Make the scalar expression a DAG rather than a tree?
- Today, before CBO, adjacent `LogicalProjectOperator`s are merged and incorporated to its child as a `Projection`, is it okay to retain `LogicalProjectOperator`s after RBO?