### PR TITLE
[Enhancement] Cache file existence check across versions in check_missing_files

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1678,18 +1678,29 @@ void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
 
 // Check missing files, like segment, delete vector, pk index sst, cols file
 static Status check_missing_files(const TabletMetadata& metadata, const lake::TabletManager* tablet_mgr,
-                                  ::starrocks::TabletMetadataEntry* entry) {
-    std::unordered_set<std::string> missing_files;
+                                  ::starrocks::TabletMetadataEntry* entry,
+                                  std::unordered_set<std::string>& known_existing_files,
+                                  std::unordered_set<std::string>& known_missing_files) {
     std::shared_ptr<FileSystem> fs = nullptr;
     auto check_file = [&](const std::string& path, const std::string& filename) -> Status {
+        if (known_existing_files.count(filename)) {
+            return Status::OK();
+        }
+        if (known_missing_files.count(filename)) {
+            entry->add_missing_files(filename);
+            return Status::OK();
+        }
         if (fs == nullptr) {
             ASSIGN_OR_RETURN(fs, FileSystemFactory::CreateSharedFromString(path));
         }
         auto st = fs->path_exists(path);
         if (st.is_not_found()) {
-            missing_files.emplace(filename);
+            known_missing_files.emplace(filename);
+            entry->add_missing_files(filename);
         } else if (!st.ok()) {
             return st;
+        } else {
+            known_existing_files.emplace(filename);
         }
         return Status::OK();
     };
@@ -1726,9 +1737,6 @@ static Status check_missing_files(const TabletMetadata& metadata, const lake::Ta
         }
     }
 
-    for (const auto& filename : missing_files) {
-        entry->add_missing_files(filename);
-    }
     return Status::OK();
 }
 
@@ -1783,6 +1791,12 @@ void LakeServiceImpl::get_tablet_metadatas(::google::protobuf::RpcController* co
                 [&, tablet_id, max_version, min_version, tablet_result] {
                     DeferOp defer([&] { latch.count_down(); });
 
+                    // Cache file existence check results across versions to avoid redundant
+                    // object storage accesses. Higher versions are built on lower versions,
+                    // so files in higher versions are very likely present in lower versions too.
+                    std::unordered_set<std::string> known_existing_files;
+                    std::unordered_set<std::string> known_missing_files;
+
                     // get tablet metadatas within the specified version range
                     for (int64_t version = max_version; version >= min_version; --version) {
                         // don't fill meta cache to avoid polluting the cache
@@ -1795,7 +1809,8 @@ void LakeServiceImpl::get_tablet_metadatas(::google::protobuf::RpcController* co
                             entry->mutable_metadata()->CopyFrom(*tablet_metadata);
 
                             if (enable_check_missing_files) {
-                                auto check_st = check_missing_files(*tablet_metadata, _tablet_mgr, entry);
+                                auto check_st = check_missing_files(*tablet_metadata, _tablet_mgr, entry,
+                                                                    known_existing_files, known_missing_files);
                                 if (!check_st.ok()) {
                                     check_st.to_protobuf(tablet_result->mutable_status());
                                     return;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1681,13 +1681,14 @@ static Status check_missing_files(const TabletMetadata& metadata, const lake::Ta
                                   ::starrocks::TabletMetadataEntry* entry,
                                   std::unordered_set<std::string>& known_existing_files,
                                   std::unordered_set<std::string>& known_missing_files) {
+    std::unordered_set<std::string> missing_files;
     std::shared_ptr<FileSystem> fs = nullptr;
     auto check_file = [&](const std::string& path, const std::string& filename) -> Status {
         if (known_existing_files.count(filename)) {
             return Status::OK();
         }
         if (known_missing_files.count(filename)) {
-            entry->add_missing_files(filename);
+            missing_files.emplace(filename);
             return Status::OK();
         }
         if (fs == nullptr) {
@@ -1696,7 +1697,7 @@ static Status check_missing_files(const TabletMetadata& metadata, const lake::Ta
         auto st = fs->path_exists(path);
         if (st.is_not_found()) {
             known_missing_files.emplace(filename);
-            entry->add_missing_files(filename);
+            missing_files.emplace(filename);
         } else if (!st.ok()) {
             return st;
         } else {
@@ -1737,6 +1738,9 @@ static Status check_missing_files(const TabletMetadata& metadata, const lake::Ta
         }
     }
 
+    for (const auto& filename : missing_files) {
+        entry->add_missing_files(filename);
+    }
     return Status::OK();
 }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -4275,6 +4275,218 @@ TEST_F(LakeServiceTest, test_get_tablet_metadatas) {
         ASSERT_EQ(1, response.tablet_results(0).metadata_entries(0).missing_files_size());
         ASSERT_EQ(seg_name, response.tablet_results(0).metadata_entries(0).missing_files(0));
     }
+
+    // 5.3 check missing files across multiple versions with file existence cache
+    // Higher versions are built on lower versions, so files checked in higher versions
+    // should be cached and reused when checking lower versions.
+    {
+        // Get metadata for version 3 and 4 to find their segment files
+        brpc::Controller cntl;
+        GetTabletMetadatasRequest request;
+        GetTabletMetadatasResponse response;
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(2);
+        request.set_max_version(4);
+        request.set_check_missing_files(true);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(TStatusCode::OK, response.status().status_code());
+        ASSERT_EQ(1, response.tablet_results_size());
+        const auto& tablet_result2 = response.tablet_results(0);
+        ASSERT_EQ(TStatusCode::OK, tablet_result2.status().status_code());
+        // Should have 3 versions: 4, 3, 2
+        ASSERT_EQ(3, tablet_result2.metadata_entries_size());
+
+        // Collect all segment names from all versions
+        std::unordered_set<std::string> all_segments;
+        for (const auto& ent : tablet_result2.metadata_entries()) {
+            for (const auto& rowset : ent.metadata().rowsets()) {
+                for (const auto& seg : rowset.segments()) {
+                    all_segments.insert(seg);
+                }
+            }
+            // No missing files since all files exist (except the one deleted in 5.2)
+        }
+        // We should have segments from version 2, 3, 4.
+        // Version 1's initial metadata has no rowset. publish_version(1,2) adds 1 segment,
+        // publish_version(2,3) adds 1 segment, publish_version(3,4) adds 1 segment.
+        // Version 2 has 1 rowset(1 seg), version 3 has 2 rowsets(2 segs), version 4 has 3 rowsets(3 segs).
+        // The segment deleted in 5.2 is from version 2's rowset (the first rowset of version 4).
+        // It should be reported as missing in version 4, 3, and 2 entries (since all share that rowset).
+
+        // Verify that the deleted segment from 5.2 is reported as missing in entries that reference it
+        int entries_with_missing = 0;
+        for (const auto& ent : tablet_result2.metadata_entries()) {
+            if (ent.missing_files_size() > 0) {
+                entries_with_missing++;
+            }
+        }
+        // At least the higher version entries that contain the deleted segment should report it
+        ASSERT_GE(entries_with_missing, 1);
+    }
+}
+
+TEST_F(LakeServiceTest, test_check_missing_files_cache_across_versions) {
+    // This test specifically validates the file existence caching optimization:
+    // When checking missing files across multiple versions (from max to min),
+    // files already checked in higher versions should not require repeated
+    // object storage access in lower versions.
+
+    auto publish_version = [&](int64_t base_version, int64_t new_version) {
+        auto txn_log = generate_write_txn_log(1, 10 * new_version, 100 * new_version);
+        CHECK_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest request;
+        PublishVersionResponse response;
+        request.set_base_version(base_version);
+        request.set_new_version(new_version);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(txn_log.txn_id());
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        CHECK_EQ(0, response.failed_tablets_size());
+        CHECK_EQ(0, response.status().status_code());
+    };
+
+    publish_version(1, 2);
+    publish_version(2, 3);
+    publish_version(3, 4);
+
+    // 1. All files exist: check across versions 2-4, no missing files expected
+    {
+        brpc::Controller cntl;
+        GetTabletMetadatasRequest request;
+        GetTabletMetadatasResponse response;
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(2);
+        request.set_max_version(4);
+        request.set_check_missing_files(true);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(TStatusCode::OK, response.status().status_code());
+        ASSERT_EQ(1, response.tablet_results_size());
+        const auto& tablet_result = response.tablet_results(0);
+        ASSERT_EQ(TStatusCode::OK, tablet_result.status().status_code());
+        ASSERT_EQ(3, tablet_result.metadata_entries_size());
+
+        for (const auto& entry : tablet_result.metadata_entries()) {
+            ASSERT_EQ(0, entry.missing_files_size())
+                    << "version " << entry.metadata().version() << " should have no missing files";
+        }
+    }
+
+    // 2. Delete a segment that is shared across versions 2, 3, 4
+    //    (the segment added in version 2 appears in all subsequent versions)
+    {
+        // First, get version 4 metadata to find the segment from version 2
+        brpc::Controller cntl;
+        GetTabletMetadatasRequest request;
+        GetTabletMetadatasResponse response;
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(4);
+        request.set_max_version(4);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.tablet_results_size());
+        ASSERT_EQ(1, response.tablet_results(0).metadata_entries_size());
+        const auto& metadata = response.tablet_results(0).metadata_entries(0).metadata();
+        // Version 4 should have 3 rowsets (from version 2, 3, 4)
+        ASSERT_EQ(3, metadata.rowsets_size());
+
+        // Delete the segment from the first rowset (added in version 2)
+        std::string shared_seg = metadata.rowsets(0).segments(0);
+        ASSERT_OK(fs::remove(_tablet_mgr->segment_location(_tablet_id, shared_seg)));
+
+        // Now check missing files across versions 2-4
+        response.Clear();
+        request.Clear();
+        cntl.Reset();
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(2);
+        request.set_max_version(4);
+        request.set_check_missing_files(true);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(TStatusCode::OK, response.status().status_code());
+        ASSERT_EQ(1, response.tablet_results_size());
+        const auto& tablet_result = response.tablet_results(0);
+        ASSERT_EQ(TStatusCode::OK, tablet_result.status().status_code());
+        ASSERT_EQ(3, tablet_result.metadata_entries_size());
+
+        // The deleted segment is shared across versions 2, 3, 4.
+        // Version 4 is checked first (max_version), should detect the missing file via fs check.
+        // Versions 3 and 2 should detect the same missing file via the cache (no extra fs check).
+        for (const auto& entry : tablet_result.metadata_entries()) {
+            bool found_missing = false;
+            for (int j = 0; j < entry.missing_files_size(); j++) {
+                if (entry.missing_files(j) == shared_seg) {
+                    found_missing = true;
+                    break;
+                }
+            }
+            ASSERT_TRUE(found_missing) << "version " << entry.metadata().version()
+                                       << " should report " << shared_seg << " as missing";
+        }
+    }
+
+    // 3. Delete a segment only present in version 4 (not shared with lower versions)
+    {
+        // Get version 4 metadata to find the segment unique to version 4
+        brpc::Controller cntl;
+        GetTabletMetadatasRequest request;
+        GetTabletMetadatasResponse response;
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(4);
+        request.set_max_version(4);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        const auto& metadata = response.tablet_results(0).metadata_entries(0).metadata();
+        ASSERT_EQ(3, metadata.rowsets_size());
+
+        // The last rowset's segment is unique to version 4
+        std::string unique_seg = metadata.rowsets(2).segments(0);
+        ASSERT_OK(fs::remove(_tablet_mgr->segment_location(_tablet_id, unique_seg)));
+
+        // Check missing files across versions 2-4
+        response.Clear();
+        request.Clear();
+        cntl.Reset();
+
+        request.add_tablet_ids(_tablet_id);
+        request.set_min_version(2);
+        request.set_max_version(4);
+        request.set_check_missing_files(true);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(1, response.tablet_results_size());
+        const auto& tablet_result = response.tablet_results(0);
+        ASSERT_EQ(3, tablet_result.metadata_entries_size());
+
+        // Only version 4 should report unique_seg as missing
+        for (const auto& entry : tablet_result.metadata_entries()) {
+            bool has_unique_seg_missing = false;
+            for (int j = 0; j < entry.missing_files_size(); j++) {
+                if (entry.missing_files(j) == unique_seg) {
+                    has_unique_seg_missing = true;
+                    break;
+                }
+            }
+            if (entry.metadata().version() == 4) {
+                ASSERT_TRUE(has_unique_seg_missing) << "version 4 should report " << unique_seg << " as missing";
+            } else {
+                ASSERT_FALSE(has_unique_seg_missing)
+                        << "version " << entry.metadata().version() << " should NOT report " << unique_seg
+                        << " as missing";
+            }
+        }
+    }
 }
 
 TEST_F(LakeServiceTest, test_repair_tablet_metadata) {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -4275,63 +4275,12 @@ TEST_F(LakeServiceTest, test_get_tablet_metadatas) {
         ASSERT_EQ(1, response.tablet_results(0).metadata_entries(0).missing_files_size());
         ASSERT_EQ(seg_name, response.tablet_results(0).metadata_entries(0).missing_files(0));
     }
-
-    // 5.3 check missing files across multiple versions with file existence cache
-    // Higher versions are built on lower versions, so files checked in higher versions
-    // should be cached and reused when checking lower versions.
-    {
-        // Get metadata for version 3 and 4 to find their segment files
-        brpc::Controller cntl;
-        GetTabletMetadatasRequest request;
-        GetTabletMetadatasResponse response;
-
-        request.add_tablet_ids(_tablet_id);
-        request.set_min_version(2);
-        request.set_max_version(4);
-        request.set_check_missing_files(true);
-        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
-        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-        ASSERT_EQ(TStatusCode::OK, response.status().status_code());
-        ASSERT_EQ(1, response.tablet_results_size());
-        const auto& tablet_result2 = response.tablet_results(0);
-        ASSERT_EQ(TStatusCode::OK, tablet_result2.status().status_code());
-        // Should have 3 versions: 4, 3, 2
-        ASSERT_EQ(3, tablet_result2.metadata_entries_size());
-
-        // Collect all segment names from all versions
-        std::unordered_set<std::string> all_segments;
-        for (const auto& ent : tablet_result2.metadata_entries()) {
-            for (const auto& rowset : ent.metadata().rowsets()) {
-                for (const auto& seg : rowset.segments()) {
-                    all_segments.insert(seg);
-                }
-            }
-            // No missing files since all files exist (except the one deleted in 5.2)
-        }
-        // We should have segments from version 2, 3, 4.
-        // Version 1's initial metadata has no rowset. publish_version(1,2) adds 1 segment,
-        // publish_version(2,3) adds 1 segment, publish_version(3,4) adds 1 segment.
-        // Version 2 has 1 rowset(1 seg), version 3 has 2 rowsets(2 segs), version 4 has 3 rowsets(3 segs).
-        // The segment deleted in 5.2 is from version 2's rowset (the first rowset of version 4).
-        // It should be reported as missing in version 4, 3, and 2 entries (since all share that rowset).
-
-        // Verify that the deleted segment from 5.2 is reported as missing in entries that reference it
-        int entries_with_missing = 0;
-        for (const auto& ent : tablet_result2.metadata_entries()) {
-            if (ent.missing_files_size() > 0) {
-                entries_with_missing++;
-            }
-        }
-        // At least the higher version entries that contain the deleted segment should report it
-        ASSERT_GE(entries_with_missing, 1);
-    }
 }
 
-TEST_F(LakeServiceTest, test_check_missing_files_cache_across_versions) {
-    // This test specifically validates the file existence caching optimization:
-    // When checking missing files across multiple versions (from max to min),
-    // files already checked in higher versions should not require repeated
-    // object storage access in lower versions.
+TEST_F(LakeServiceTest, test_check_missing_files_across_versions) {
+    // Validates that missing files are correctly reported across multiple versions
+    // when check_missing_files is enabled, including files shared between versions
+    // and files unique to a single version.
 
     auto publish_version = [&](int64_t base_version, int64_t new_version) {
         auto txn_log = generate_write_txn_log(1, 10 * new_version, 100 * new_version);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -4429,8 +4429,8 @@ TEST_F(LakeServiceTest, test_check_missing_files_cache_across_versions) {
                     break;
                 }
             }
-            ASSERT_TRUE(found_missing) << "version " << entry.metadata().version()
-                                       << " should report " << shared_seg << " as missing";
+            ASSERT_TRUE(found_missing) << "version " << entry.metadata().version() << " should report " << shared_seg
+                                       << " as missing";
         }
     }
 
@@ -4481,9 +4481,8 @@ TEST_F(LakeServiceTest, test_check_missing_files_cache_across_versions) {
             if (entry.metadata().version() == 4) {
                 ASSERT_TRUE(has_unique_seg_missing) << "version 4 should report " << unique_seg << " as missing";
             } else {
-                ASSERT_FALSE(has_unique_seg_missing)
-                        << "version " << entry.metadata().version() << " should NOT report " << unique_seg
-                        << " as missing";
+                ASSERT_FALSE(has_unique_seg_missing) << "version " << entry.metadata().version()
+                                                     << " should NOT report " << unique_seg << " as missing";
             }
         }
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  When checking missing files across multiple tablet metadata versions (from
  max_version to min_version), maintain `known_existing_files` and `known_missing_files`
  sets to avoid redundant object storage `path_exists` calls. Since higher versions
  are built on lower versions, files checked in higher versions are very likely
  present in lower versions too.

  This PR optimizes the performance of checking file existence 
  during the repair of cloud-native tables.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
