### PR TITLE
[BugFix] Fix partition name collision in automatic list partitioning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1507,9 +1507,20 @@ public class AnalyzerUtils {
 
             // table partitions for check
             PCellSortedSet tablePartitions = olapTable.getListPartitionItems();
-            Set<String> partitionNameSet = Sets.newHashSet();
+            Set<PListCell> partitionValueSet = Sets.newHashSet();
             List<PartitionDesc> partitionDescs = Lists.newArrayList();
             for (List<String> partitionValue : partitionValues) {
+                List<List<String>> partitionItems = Collections.singletonList(partitionValue);
+                PListCell cell = new PListCell(partitionItems);
+
+                // Deduplicate by partition value, not by partition name.
+                // Different values may produce the same partition name via getFormatPartitionValue()
+                // (e.g., "a-b" and "ab" both format to "ab"), so name-based dedup would incorrectly
+                // skip the second value. Value-based dedup ensures every distinct value gets a partition.
+                if (partitionValueSet.contains(cell)) {
+                    continue;
+                }
+
                 List<String> formattedPartitionValue = Lists.newArrayList();
                 for (String value : partitionValue) {
                     String formatValue = getFormatPartitionValue(value);
@@ -1527,21 +1538,18 @@ public class AnalyzerUtils {
                     }
                     partitionName = partitionNamePrefix + PARTITION_NAME_PREFIX_SPLIT + partitionName;
                 }
-                if (!partitionNameSet.contains(partitionName)) {
-                    List<List<String>> partitionItems = Collections.singletonList(partitionValue);
-                    PListCell cell = new PListCell(partitionItems);
-                    partitionName = calculateUniquePartitionName(partitionName, cell, tablePartitions);
-                    MultiItemListPartitionDesc multiItemListPartitionDesc = new MultiItemListPartitionDesc(true,
-                            partitionName, partitionItems, partitionProperties);
-                    multiItemListPartitionDesc.setSystem(true);
-                    partitionDescs.add(multiItemListPartitionDesc);
-                    partitionNameSet.add(partitionName);
+                partitionName = calculateUniquePartitionName(partitionName, cell, tablePartitions);
+                MultiItemListPartitionDesc multiItemListPartitionDesc = new MultiItemListPartitionDesc(true,
+                        partitionName, partitionItems, partitionProperties);
+                multiItemListPartitionDesc.setSystem(true);
+                partitionDescs.add(multiItemListPartitionDesc);
+                partitionValueSet.add(cell);
 
-                    // update table partition
-                    tablePartitions.add(partitionName, cell);
-                }
+                // update table partition
+                tablePartitions.add(partitionName, cell);
             }
-            List<String> partitionNames = Lists.newArrayList(partitionNameSet);
+            List<String> partitionNames = partitionDescs.stream()
+                    .map(PartitionDesc::getPartitionName).collect(Collectors.toList());
             ListPartitionDesc listPartitionDesc = new ListPartitionDesc(Lists.newArrayList(), partitionDescs);
             listPartitionDesc.setPartitionNames(partitionNames);
             listPartitionDesc.setSystem(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
@@ -28,6 +28,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
+import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -459,6 +461,108 @@ public class AnalyzeUtilTest {
                 Assertions.assertTrue(partitionNames.get(desc.getPartitionName()) != null);
             }
         }
+    }
+
+    /**
+     * Test that different partition values which produce the same formatted name
+     * (due to hyphen stripping in getFormatPartitionValue) each get their own partition
+     * with a unique name, rather than having the second value silently skipped.
+     */
+    @Test
+    public void testPartitionNameCollisionWithHyphens() throws Exception {
+        OlapTable t1 = (OlapTable) starRocksAssert.getTable(DB_NAME, "auto_tbl1");
+
+        // These two values produce the same formatted partition name because hyphens are stripped:
+        // "eightfolddemo-hiring-test.com" -> "eightfolddemohiringtest2ecom"
+        // "eightfolddemo-hiringtest.com"  -> "eightfolddemohiringtest2ecom"
+        List<List<String>> partitionValues = Lists.newArrayList();
+        partitionValues.add(Lists.newArrayList("eightfolddemo-hiring-test.com"));
+        partitionValues.add(Lists.newArrayList("eightfolddemo-hiringtest.com"));
+
+        AddPartitionClause clause =
+                AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, null);
+        ListPartitionDesc listPartitionDesc = (ListPartitionDesc) clause.getPartitionDesc();
+        List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+
+        // Both values must produce a partition (not just one)
+        Assertions.assertEquals(2, descs.size());
+
+        // Partition names must be unique
+        Set<String> names = new HashSet<>();
+        for (PartitionDesc desc : descs) {
+            Assertions.assertTrue(names.add(desc.getPartitionName()),
+                    "Duplicate partition name: " + desc.getPartitionName());
+        }
+
+        // Each partition must have the correct value
+        Set<String> values = new HashSet<>();
+        for (PartitionDesc desc : descs) {
+            MultiItemListPartitionDesc multiDesc = (MultiItemListPartitionDesc) desc;
+            List<List<String>> multiValues = multiDesc.getMultiValues();
+            Assertions.assertEquals(1, multiValues.size());
+            values.add(multiValues.get(0).get(0));
+        }
+        Assertions.assertTrue(values.contains("eightfolddemo-hiring-test.com"));
+        Assertions.assertTrue(values.contains("eightfolddemo-hiringtest.com"));
+    }
+
+    /**
+     * Test deduplication works correctly: identical partition values in the same batch
+     * should be deduplicated (only one partition created).
+     */
+    @Test
+    public void testPartitionValueDeduplication() throws Exception {
+        OlapTable t1 = (OlapTable) starRocksAssert.getTable(DB_NAME, "auto_tbl1");
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        partitionValues.add(Lists.newArrayList("same-value"));
+        partitionValues.add(Lists.newArrayList("same-value"));
+        partitionValues.add(Lists.newArrayList("different-value"));
+
+        AddPartitionClause clause =
+                AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, null);
+        ListPartitionDesc listPartitionDesc = (ListPartitionDesc) clause.getPartitionDesc();
+        List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+
+        // Duplicate value should be deduplicated, leaving 2 distinct partitions
+        Assertions.assertEquals(2, descs.size());
+    }
+
+    /**
+     * Test multiple different values that all collide on the same formatted partition name.
+     * e.g., "a-b", "a:b", "a b", "ab" all format to "ab".
+     */
+    @Test
+    public void testMultiplePartitionNameCollisions() throws Exception {
+        OlapTable t1 = (OlapTable) starRocksAssert.getTable(DB_NAME, "auto_tbl1");
+
+        // All these values format to "ab" because hyphens, colons, and spaces are stripped
+        List<List<String>> partitionValues = Lists.newArrayList();
+        partitionValues.add(Lists.newArrayList("ab"));
+        partitionValues.add(Lists.newArrayList("a-b"));
+        partitionValues.add(Lists.newArrayList("a:b"));
+        partitionValues.add(Lists.newArrayList("a b"));
+
+        AddPartitionClause clause =
+                AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, null);
+        ListPartitionDesc listPartitionDesc = (ListPartitionDesc) clause.getPartitionDesc();
+        List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+
+        // All 4 distinct values must each get a partition
+        Assertions.assertEquals(4, descs.size());
+
+        // All partition names must be unique
+        Set<String> names = new HashSet<>();
+        for (PartitionDesc desc : descs) {
+            Assertions.assertTrue(names.add(desc.getPartitionName()),
+                    "Duplicate partition name: " + desc.getPartitionName());
+        }
+
+        // All values must be present
+        Set<String> values = descs.stream()
+                .map(d -> ((MultiItemListPartitionDesc) d).getMultiValues().get(0).get(0))
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(Set.of("ab", "a-b", "a:b", "a b"), values);
     }
 
     @Test

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_list_name_collision
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_list_name_collision
@@ -44,7 +44,13 @@ SELECT count(distinct group_id) FROM position_v6;
 -- result:
 2
 -- !result
+DROP DATABASE test_auto_part_collision_${uuid0} FORCE;
+-- result:
+-- !result
 -- name: test_auto_partition_colon_space_collision
+CREATE DATABASE test_auto_part_collision_${uuid0};
+-- result:
+-- !result
 USE test_auto_part_collision_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_list_name_collision
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_list_name_collision
@@ -1,0 +1,90 @@
+-- name: test_auto_partition_varchar_hyphen_collision
+CREATE DATABASE test_auto_part_collision_${uuid0};
+-- result:
+-- !result
+USE test_auto_part_collision_${uuid0};
+-- result:
+-- !result
+CREATE TABLE position_v6 (
+  `group_id` varchar(100) NOT NULL,
+  `position_id` bigint(20) NOT NULL,
+  `location_country` varchar(100) NULL,
+  `job_function` varchar(100) NULL,
+  `business_unit` varchar(100) NULL,
+  `position_type` varchar(50) NULL
+) ENGINE=OLAP
+PRIMARY KEY(`group_id`, `position_id`)
+PARTITION BY (`group_id`)
+DISTRIBUTED BY HASH(`position_id`) BUCKETS 2
+ORDER BY(`location_country`, `job_function`, `business_unit`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO position_v6 (group_id, position_id, position_type, location_country, job_function, business_unit) VALUES
+  ('eightfolddemo-hiring-test.com', 1001, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiringtest.com', 1002, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiringtest.com', 1003, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiring-test.com', 1004, 'role', 'US', 'eng', 'hr');
+-- result:
+-- !result
+SELECT count(*) FROM position_v6;
+-- result:
+4
+-- !result
+SELECT group_id, position_id FROM position_v6 ORDER BY position_id;
+-- result:
+eightfolddemo-hiring-test.com	1001
+eightfolddemo-hiringtest.com	1002
+eightfolddemo-hiringtest.com	1003
+eightfolddemo-hiring-test.com	1004
+-- !result
+SELECT count(distinct group_id) FROM position_v6;
+-- result:
+2
+-- !result
+-- name: test_auto_partition_colon_space_collision
+USE test_auto_part_collision_${uuid0};
+-- result:
+-- !result
+CREATE TABLE collision_tbl (
+  `key_col` varchar(100) NOT NULL,
+  `val` int NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`key_col`)
+PARTITION BY (`key_col`)
+DISTRIBUTED BY HASH(`key_col`) BUCKETS 2
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO collision_tbl VALUES
+  ('ab', 1),
+  ('a-b', 2),
+  ('a:b', 3),
+  ('a b', 4);
+-- result:
+-- !result
+SELECT count(*) FROM collision_tbl;
+-- result:
+4
+-- !result
+SELECT * FROM collision_tbl ORDER BY val;
+-- result:
+ab	1
+a-b	2
+a:b	3
+a b	4
+-- !result
+INSERT INTO collision_tbl VALUES ('a-b', 5);
+-- result:
+-- !result
+SELECT * FROM collision_tbl WHERE key_col = 'a-b' ORDER BY val;
+-- result:
+a-b	5
+-- !result
+DROP DATABASE test_auto_part_collision_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_list_name_collision
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_list_name_collision
@@ -1,0 +1,65 @@
+-- name: test_auto_partition_varchar_hyphen_collision
+CREATE DATABASE test_auto_part_collision_${uuid0};
+USE test_auto_part_collision_${uuid0};
+
+CREATE TABLE position_v6 (
+  `group_id` varchar(100) NOT NULL,
+  `position_id` bigint(20) NOT NULL,
+  `location_country` varchar(100) NULL,
+  `job_function` varchar(100) NULL,
+  `business_unit` varchar(100) NULL,
+  `position_type` varchar(50) NULL
+) ENGINE=OLAP
+PRIMARY KEY(`group_id`, `position_id`)
+PARTITION BY (`group_id`)
+DISTRIBUTED BY HASH(`position_id`) BUCKETS 2
+ORDER BY(`location_country`, `job_function`, `business_unit`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- Insert rows with two group_id values that differ only in hyphens.
+-- "eightfolddemo-hiring-test.com" and "eightfolddemo-hiringtest.com"
+-- both format to the same partition name because hyphens are stripped,
+-- but they must each get their own partition.
+INSERT INTO position_v6 (group_id, position_id, position_type, location_country, job_function, business_unit) VALUES
+  ('eightfolddemo-hiring-test.com', 1001, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiringtest.com', 1002, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiringtest.com', 1003, 'role', 'US', 'eng', 'hr'),
+  ('eightfolddemo-hiring-test.com', 1004, 'role', 'US', 'eng', 'hr');
+
+SELECT count(*) FROM position_v6;
+SELECT group_id, position_id FROM position_v6 ORDER BY position_id;
+
+-- Verify both group_id values have their own partitions
+SELECT count(distinct group_id) FROM position_v6;
+
+-- name: test_auto_partition_colon_space_collision
+USE test_auto_part_collision_${uuid0};
+
+CREATE TABLE collision_tbl (
+  `key_col` varchar(100) NOT NULL,
+  `val` int NOT NULL
+) ENGINE=OLAP
+PRIMARY KEY(`key_col`)
+PARTITION BY (`key_col`)
+DISTRIBUTED BY HASH(`key_col`) BUCKETS 2
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- "a-b", "a:b", "a b", "ab" all format to the same partition name "ab"
+INSERT INTO collision_tbl VALUES
+  ('ab', 1),
+  ('a-b', 2),
+  ('a:b', 3),
+  ('a b', 4);
+
+SELECT count(*) FROM collision_tbl;
+SELECT * FROM collision_tbl ORDER BY val;
+
+-- Verify additional inserts into the same partition values still work
+INSERT INTO collision_tbl VALUES ('a-b', 5);
+SELECT * FROM collision_tbl WHERE key_col = 'a-b' ORDER BY val;
+
+DROP DATABASE test_auto_part_collision_${uuid0} FORCE;

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_list_name_collision
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_list_name_collision
@@ -34,7 +34,10 @@ SELECT group_id, position_id FROM position_v6 ORDER BY position_id;
 -- Verify both group_id values have their own partitions
 SELECT count(distinct group_id) FROM position_v6;
 
+DROP DATABASE test_auto_part_collision_${uuid0} FORCE;
+
 -- name: test_auto_partition_colon_space_collision
+CREATE DATABASE test_auto_part_collision_${uuid0};
 USE test_auto_part_collision_${uuid0};
 
 CREATE TABLE collision_tbl (


### PR DESCRIPTION
## Why I'm doing:

When using automatic list partitioning with varchar columns, partition values that differ only in special characters (hyphens, colons, spaces) were being incorrectly deduplicated. For example, "eightfolddemo-hiring-test.com" and "eightfolddemo-hiringtest.com" both format to the same partition name "eightfolddemohiringtest2ecom" due to character stripping in `getFormatPartitionValue()`. This caused the second value to be silently skipped, resulting in data loss or incorrect partitioning.

## What I'm doing:

Changed the deduplication logic in `AnalyzerUtils.getAddPartitionClauseFromPartitionValues()` to deduplicate by **partition value** instead of by **partition name**. This ensures that:

1. Distinct partition values each get their own partition, even if they format to the same partition name
2. Identical partition values in the same batch are still deduplicated (only one partition created)
3. Partition names are made unique via `calculateUniquePartitionName()` when collisions occur

**Key changes:**
- Changed from `Set<String> partitionNameSet` to `Set<PListCell> partitionValueSet` for deduplication
- Moved deduplication check before partition name formatting
- Ensured `calculateUniquePartitionName()` is always called to handle name collisions
- Updated partition name collection to use stream from partition descriptors

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - Added unit tests: `testPartitionNameCollisionWithHyphens()`, `testPartitionValueDeduplication()`, `testMultiplePartitionNameCollisions()`
  - Added integration tests: `test_automatic_partition_list_name_collision.test`
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

https://claude.ai/code/session_018vZ5m2bhdpE9HYWtVxNzbC