### PR TITLE
[BugFix] Assert if MODIFY column change the pos of the sort key column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -859,13 +859,15 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
 
                 if (sortKeyModified) {
-                    List<String> oldSortKey = indexMeta.getSortKeyIdxes().stream()
-                            .map(i -> indexMeta.getSchema().get(i).getName())
+                    List<ColumnId> oldSortKeyColumnIds = indexMeta.getSortKeyIdxes().stream()
+                            .map(i -> indexMeta.getSchema().get(i).getColumnId())
                             .collect(Collectors.toList());
-                    List<String> newSortKey = indexMeta.getSortKeyIdxes().stream()
-                            .map(i -> schemaForFinding.get(i).getName())
+                    Set<ColumnId> oldSortKeyColumnIdSet = new HashSet<>(oldSortKeyColumnIds);
+                    List<ColumnId> newSortKeyColumnIds = schemaForFinding.stream()
+                            .map(Column::getColumnId)
+                            .filter(oldSortKeyColumnIdSet::contains)
                             .collect(Collectors.toList());
-                    if (!oldSortKey.equals(newSortKey)) {
+                    if (!oldSortKeyColumnIds.equals(newSortKeyColumnIds)) {
                         throw new DdlException("Can not modify column[" + modColumn.getName() +
                             "] to change sort key order by ALTER TABLE MODIFY COLUMN, " +
                                 "please use ALTER TABLE ORDER BY instead");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -843,6 +843,38 @@ public class SchemaChangeHandler extends AlterHandler {
             schemaForFinding.set(modColIndex, modColumn);
         }
 
+        // assert if modify column with sort key if and only if (satisfy all):
+        // 1. User has specified ORDER BY clause by CREATE TABLE / ALTER TABLE ORDER BY
+        // 2. Try to modify a column has the same name with the sort key column
+        // 3. Try to modify the column pos between the sort key columns
+        if (hasColPos) {
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaIdForFindingColumn);
+            if (indexMeta.getSortKeyIdxes() != null && indexMeta.getSortKeyIdxes().size() > 1) {
+                boolean sortKeyModified = false;
+                for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
+                    if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
+                        sortKeyModified = true;
+                        break;
+                    }
+                }
+
+                if (sortKeyModified) {
+                    List<String> oldSortKey = indexMeta.getSortKeyIdxes().stream()
+                            .map(i -> indexMeta.getSchema().get(i).getName())
+                            .collect(Collectors.toList());
+                    List<String> newSortKey = indexMeta.getSortKeyIdxes().stream()
+                            .map(i -> schemaForFinding.get(i).getName())
+                            .collect(Collectors.toList());
+                    if (!oldSortKey.equals(newSortKey)) {
+                        throw new DdlException("Can not modify column[" + modColumn.getName() +
+                            "] to change sort key order by ALTER TABLE MODIFY COLUMN, " +
+                                "please use ALTER TABLE ORDER BY instead");
+
+                    }
+                }
+            }
+        }
+
         List<Column> otherIndexModifiedColumn = new ArrayList<>();
         // check if column being mod
         if (!modColumn.equals(oriColumn)) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -911,22 +911,97 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         createTable("CREATE TABLE test.sc_dup_sort_key_modify (\n"
                 + "k0 INT,\n"
                 + "k1 INT,\n"
-                + "v0 INT\n"
+                + "k2 INT,\n"
+                + "k3 INT,\n"
+                + "k4 INT\n"
                 + ") DUPLICATE KEY(k0)\n"
                 + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
-                + "ORDER BY(k1, k0)\n"
+                + "ORDER BY(k1, k4)\n"
                 + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), "sc_dup_sort_key_modify");
 
-        String alterSql = "ALTER TABLE test.sc_dup_sort_key_modify MODIFY COLUMN k1 INT AFTER k0";
-        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
-        SchemaChangeHandler handler = new SchemaChangeHandler();
-        DdlException exception = Assertions.assertThrows(DdlException.class, () ->
-                handler.process(alterStmt.getAlterClauseList(), db, tbl));
-        Assertions.assertTrue(exception.getMessage().contains("please use ALTER TABLE ORDER BY instead"),
-                exception.getMessage());
+        assertModifyColumnOrderChangeRejected(db, tbl,
+                "ALTER TABLE test.sc_dup_sort_key_modify MODIFY COLUMN k4 INT AFTER k0");
+    }
+
+    @Test
+    public void testModifyColumnAllowsSingleSortKeyPositionChange() throws Exception {
+        createTable("CREATE TABLE test.sc_dup_single_sort_key_modify (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "v0 INT\n"
+                + ") DUPLICATE KEY(k0)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_dup_single_sort_key_modify");
+
+        executeAlterAndWaitDone("ALTER TABLE test.sc_dup_single_sort_key_modify MODIFY COLUMN k1 INT AFTER v0");
+        assertSchema(tbl, "k0", "v0", "k1");
+        assertSortKey(tbl, Arrays.asList(2));
+    }
+
+    @Test
+    public void testModifyColumnAllowsSortKeyPositionChangeWithoutOrderChange() throws Exception {
+        createTable("CREATE TABLE test.sc_dup_non_contiguous_sort_key_modify (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "k2 INT,\n"
+                + "k3 INT,\n"
+                + "k4 INT\n"
+                + ") DUPLICATE KEY(k0)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1, k4)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_dup_non_contiguous_sort_key_modify");
+
+        executeAlterAndWaitDone(
+                "ALTER TABLE test.sc_dup_non_contiguous_sort_key_modify MODIFY COLUMN k4 INT AFTER k2");
+        assertSchema(tbl, "k0", "k1", "k2", "k4", "k3");
+        assertSortKey(tbl, Arrays.asList(1, 3));
+    }
+
+    @Test
+    public void testModifyColumnAllowsDescendingSortKeyPositionChangeWithoutOrderChange() throws Exception {
+        createTable("CREATE TABLE test.sc_uniq_desc_sort_key_modify (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "v0 VARCHAR(32)\n"
+                + ") UNIQUE KEY(k0, k1)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_uniq_desc_sort_key_modify");
+
+        executeAlterAndWaitDone("ALTER TABLE test.sc_uniq_desc_sort_key_modify MODIFY COLUMN k1 INT FIRST");
+        assertSchema(tbl, "k1", "k0", "v0");
+        assertSortKey(tbl, Arrays.asList(0, 1));
+    }
+
+    @Test
+    public void testModifyColumnRejectsDescendingSortKeyOrderChange() throws Exception {
+        createTable("CREATE TABLE test.sc_uniq_desc_sort_key_reject (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "v0 VARCHAR(32)\n"
+                + ") UNIQUE KEY(k0, k1)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_uniq_desc_sort_key_reject");
+
+        assertModifyColumnOrderChangeRejected(db, tbl,
+                "ALTER TABLE test.sc_uniq_desc_sort_key_reject MODIFY COLUMN k1 INT AFTER v0");
     }
 
     private void doTestSortKeyUpdatedAfterAddKeyColumn(OlapTable tbl, String qualifiedName) throws Exception {
@@ -964,6 +1039,22 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(columns.get(expectedSortKeyIndexes.get(i)).getUniqueId(),
                     (int) sortKeyUniqueIds.get(i));
         }
+    }
+
+    private void assertSchema(OlapTable tbl, String... expectedColumnNames) {
+        Assertions.assertEquals(expectedColumnNames.length, tbl.getBaseSchema().size());
+        for (int i = 0; i < expectedColumnNames.length; i++) {
+            Assertions.assertEquals(expectedColumnNames[i], tbl.getBaseSchema().get(i).getName());
+        }
+    }
+
+    private void assertModifyColumnOrderChangeRejected(Database db, OlapTable tbl, String alterSql) throws Exception {
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        SchemaChangeHandler handler = new SchemaChangeHandler();
+        DdlException exception = Assertions.assertThrows(DdlException.class, () ->
+                handler.process(alterStmt.getAlterClauseList(), db, tbl));
+        Assertions.assertTrue(exception.getMessage().contains("please use ALTER TABLE ORDER BY instead"),
+                exception.getMessage());
     }
 
     private void executeAlterAndWaitDone(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -906,6 +906,29 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         doTestSortKeyUpdatedAfterAddKeyColumn(tbl, "test.sc_uniq_sort_key");
     }
 
+    @Test
+    public void testModifyColumnRejectsSortKeyOrderChange() throws Exception {
+        createTable("CREATE TABLE test.sc_dup_sort_key_modify (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "v0 INT\n"
+                + ") DUPLICATE KEY(k0)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_dup_sort_key_modify");
+
+        String alterSql = "ALTER TABLE test.sc_dup_sort_key_modify MODIFY COLUMN k1 INT AFTER k0";
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        SchemaChangeHandler handler = new SchemaChangeHandler();
+        DdlException exception = Assertions.assertThrows(DdlException.class, () ->
+                handler.process(alterStmt.getAlterClauseList(), db, tbl));
+        Assertions.assertTrue(exception.getMessage().contains("please use ALTER TABLE ORDER BY instead"),
+                exception.getMessage());
+    }
+
     private void doTestSortKeyUpdatedAfterAddKeyColumn(OlapTable tbl, String qualifiedName) throws Exception {
         Assertions.assertEquals(Arrays.asList(3, 2, 1, 0), tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId()).getSortKeyIdxes());
 


### PR DESCRIPTION
## What I'm doing:
Currently, MODIFY COLUMN can change the column with pos by FIRST/AFTER clause. If the column is sort key column which is different from the key column, there is a extra metadata called sortKeyIdxes to keep the sort key column index. But MODIFY COLUMN will not update sortKeyIdxes, cause the new segment with the new schema will not be sorted in the new order.

We need to throw an exception in this case and print so info for using ALTER TABLE ORDER BY instead

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
