### PR TITLE
[BugFix] fix dataVersion not set when restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -308,8 +308,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     public void updateVersionForRestore(long visibleVersion) {
         this.setVisibleVersion(visibleVersion, System.currentTimeMillis());
         this.nextVersion = this.visibleVersion + 1;
-        LOG.info("update partition {} version for restore: visible: {}, next: {}",
-                id, visibleVersion, nextVersion);
+        this.dataVersion = this.visibleVersion;
+        this.nextDataVersion = this.nextVersion;
+        LOG.info("update partition {} version for restore: visible: {}, next: {}, dataVersion: {}, nextDataVersion: {}",
+                id, visibleVersion, nextVersion, dataVersion, nextDataVersion);
     }
 
     public void updateVisibleVersion(long visibleVersion) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

introduced by https://github.com/StarRocks/starrocks/pull/69751
fix https://github.com/StarRocks/StarRocksTest/issues/11114
dataVersion should also be set when doing RESTORE SNAPSHOT

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
