### PR TITLE
[BugFix] Make Iceberg MV refresh tolerate non-monotonic snapshot timestamps

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -276,8 +276,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
 
         public static BasePartitionInfo fromExternalTable(com.starrocks.connector.PartitionInfo info) {
-            // TODO: id and version
-            return new BasePartitionInfo(-1, -1, info.getModifiedTime());
+            return new BasePartitionInfo(-1, info.getVersion(), info.getModifiedTime());
         }
 
         public static BasePartitionInfo fromOlapTable(Partition partition) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionInfo.java
@@ -21,6 +21,12 @@ import java.util.concurrent.TimeUnit;
 public interface PartitionInfo {
     long getModifiedTime();
 
+    // Version is the change token used by MV refresh detection. Most connectors can reuse modifiedTime, but
+    // connectors with non-monotonic timestamps may override this with a more stable identifier.
+    default long getVersion() {
+        return getModifiedTime();
+    }
+
     default TimeUnit getModifiedTimeUnit()  {
         return TimeUnit.SECONDS;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.starrocks.catalog.IcebergView.STARROCKS_DIALECT;
@@ -316,16 +317,19 @@ public interface IcebergCatalog extends MemoryTrackable {
                             // Use Long wrapper to avoid NPE during auto-unboxing.
                             long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row, 7,
                                     EMPTY_PARTITION_NAME, snapshotId);
-                            partition = new Partition(lastUpdated);
+                            long version = getPartitionVersion(icebergTable, row, 8,
+                                    EMPTY_PARTITION_NAME, snapshotId);
+                            partition = new Partition(lastUpdated, version);
                             break;
                         }
                     }
                 }
                 if (partition == null) {
                     long tableLastestSnapshotTime = getTableLastestSnapshotTime(icebergTable, logger);
+                    long tableLatestSnapshotVersion = getTableLatestSnapshotVersion(icebergTable, logger);
                     logger.warn("The unpartitioned table [{}] has no partitions in PartitionsTable, " +
                             "using {} as last updated time", nativeTable.name(), tableLastestSnapshotTime);
-                    partition = new Partition(tableLastestSnapshotTime);
+                    partition = new Partition(tableLastestSnapshotTime, tableLatestSnapshotVersion);
                 }
                 partitionMap.put(EMPTY_PARTITION_NAME, partition);
             } catch (IOException e) {
@@ -363,7 +367,8 @@ public interface IcebergCatalog extends MemoryTrackable {
                                     PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
                             long lastUpdated =
                                     getPartitionLastUpdatedTime(icebergTable, row, 9, partitionName, snapshotId);
-                            Partition partition = new Partition(lastUpdated, specId);
+                            long version = getPartitionVersion(icebergTable, row, 10, partitionName, snapshotId);
+                            Partition partition = new Partition(lastUpdated, version, specId);
                             partitionMap.put(partitionName, partition);
                         }
                     }
@@ -380,8 +385,11 @@ public interface IcebergCatalog extends MemoryTrackable {
                                              long snapshotId) {
         Table nativeTable = icebergTable.getNativeTable();
         Logger logger = getLogger();
-        // last_updated_at can be null if the referenced snapshot has been expired.
-        // Use Long wrapper to avoid NPE during auto-unboxing.
+        // Iceberg PARTITIONS metadata table exposes last_updated_at in microseconds. Keep the fallback path in the
+        // same unit because com.starrocks.connector.iceberg.Partition reports MICROSECONDS to downstream callers.
+        //
+        // last_updated_at can be null if the referenced snapshot has been expired. Use Long wrapper to avoid NPE
+        // during auto-unboxing.
         long lastUpdated = -1;
         if (row != null) {
             try {
@@ -403,16 +411,59 @@ public interface IcebergCatalog extends MemoryTrackable {
         return lastUpdated;
     }
 
+    private long getPartitionVersion(IcebergTable icebergTable, StructLike row,
+                                     int columnIndex, String partitionName,
+                                     long snapshotId) {
+        Table nativeTable = icebergTable.getNativeTable();
+        Logger logger = getLogger();
+        Long lastUpdatedSnapshotId = null;
+        if (row != null) {
+            try {
+                lastUpdatedSnapshotId = row.get(columnIndex, Long.class);
+            } catch (Exception e) {
+                logger.error("Failed to get last_updated_snapshot_id for partition [{}] of table [{}] " +
+                                "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);
+            }
+        }
+        if (lastUpdatedSnapshotId != null) {
+            Snapshot updateSnapshot = nativeTable.snapshot(lastUpdatedSnapshotId);
+            if (updateSnapshot != null) {
+                return updateSnapshot.sequenceNumber();
+            }
+            // The snapshot may already be expired from table metadata. Keep using the snapshot id as an opaque
+            // version token so refresh detection still observes snapshot changes even if the wall-clock timestamp
+            // is null or non-monotonic.
+            return lastUpdatedSnapshotId;
+        }
+        return getTableLatestSnapshotVersion(icebergTable, logger);
+    }
+
     private long getTableLastestSnapshotTime(IcebergTable icebergTable,
                                              Logger logger) {
         Table nativeTable = icebergTable.getNativeTable();
+        // currentSnapshot() is Iceberg's canonical pointer to the latest snapshot in the table's current metadata.
+        // We intentionally do not scan table.snapshots(): the fallback only needs the current head snapshot time.
         Snapshot snapshot = nativeTable.currentSnapshot();
         if (snapshot == null) {
             logger.warn("The table [{}] has no current snapshot, using -1 as last updated time",
                     nativeTable.name());
             return -1;
         }
-        return snapshot.timestampMillis();
+        // Keep the same unit as PARTITIONS.last_updated_at and Partition#getModifiedTimeUnit().
+        return TimeUnit.MILLISECONDS.toMicros(snapshot.timestampMillis());
+    }
+
+    private long getTableLatestSnapshotVersion(IcebergTable icebergTable,
+                                               Logger logger) {
+        Table nativeTable = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTable.currentSnapshot();
+        if (snapshot == null) {
+            logger.warn("The table [{}] has no current snapshot, using -1 as version", nativeTable.name());
+            return -1;
+        }
+        // sequenceNumber is Iceberg's monotonic snapshot version within a table. Use it for MV refresh detection
+        // because snapshot timestamps are not guaranteed to be strictly increasing.
+        return snapshot.sequenceNumber();
     }
 
     default List<String> listPartitionNames(IcebergTable icebergTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -70,6 +70,13 @@ import static org.apache.iceberg.StarRocksIcebergTableScan.newTableScanContext;
 public interface IcebergCatalog extends MemoryTrackable {
     Logger DEFAULT_LOGGER = LogManager.getLogger(IcebergCatalog.class);
     String EMPTY_PARTITION_NAME = "";
+    // Iceberg PARTITIONS metadata table column offsets.
+    int UNPARTITIONED_LAST_UPDATED_AT_COLUMN_INDEX = 7;
+    int UNPARTITIONED_LAST_UPDATED_SNAPSHOT_ID_COLUMN_INDEX = 8;
+    int PARTITION_DATA_COLUMN_INDEX = 0;
+    int SPEC_ID_COLUMN_INDEX = 1;
+    int PARTITION_LAST_UPDATED_AT_COLUMN_INDEX = 9;
+    int PARTITION_LAST_UPDATED_SNAPSHOT_ID_COLUMN_INDEX = 10;
 
     default Logger getLogger() {
         return DEFAULT_LOGGER;
@@ -315,9 +322,11 @@ public interface IcebergCatalog extends MemoryTrackable {
                             // Get the last updated time of the table according to the table schema
                             // last_updated_at can be null if the referenced snapshot has been expired.
                             // Use Long wrapper to avoid NPE during auto-unboxing.
-                            long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row, 7,
+                            long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row,
+                                    UNPARTITIONED_LAST_UPDATED_AT_COLUMN_INDEX,
                                     EMPTY_PARTITION_NAME, snapshotId);
-                            long version = getPartitionVersion(icebergTable, row, 8,
+                            long version = getPartitionVersion(icebergTable, row,
+                                    UNPARTITIONED_LAST_UPDATED_SNAPSHOT_ID_COLUMN_INDEX,
                                     EMPTY_PARTITION_NAME, snapshotId);
                             partition = new Partition(lastUpdated, version);
                             break;
@@ -325,11 +334,11 @@ public interface IcebergCatalog extends MemoryTrackable {
                     }
                 }
                 if (partition == null) {
-                    long tableLastestSnapshotTime = getTableLastestSnapshotTime(icebergTable, logger);
+                    long tableLatestSnapshotTime = getTableLatestSnapshotTime(icebergTable, logger);
                     long tableLatestSnapshotVersion = getTableLatestSnapshotVersion(icebergTable, logger);
                     logger.warn("The unpartitioned table [{}] has no partitions in PartitionsTable, " +
-                            "using {} as last updated time", nativeTable.name(), tableLastestSnapshotTime);
-                    partition = new Partition(tableLastestSnapshotTime, tableLatestSnapshotVersion);
+                            "using {} as last updated time", nativeTable.name(), tableLatestSnapshotTime);
+                    partition = new Partition(tableLatestSnapshotTime, tableLatestSnapshotVersion);
                 }
                 partitionMap.put(EMPTY_PARTITION_NAME, partition);
             } catch (IOException e) {
@@ -354,8 +363,8 @@ public interface IcebergCatalog extends MemoryTrackable {
                     try (CloseableIterable<StructLike> rows = task.asDataTask().rows()) {
                         for (StructLike row : rows) {
                             // Get the partition data/spec id/last updated time according to the table schema
-                            StructProjection partitionData = row.get(0, StructProjection.class);
-                            int specId = row.get(1, Integer.class);
+                            StructProjection partitionData = row.get(PARTITION_DATA_COLUMN_INDEX, StructProjection.class);
+                            int specId = row.get(SPEC_ID_COLUMN_INDEX, Integer.class);
                             PartitionSpec spec = nativeTable.specs().get(specId);
 
                             // Old partition specs may be referenced in metadata even if they have been deleted. Skip them.
@@ -366,8 +375,10 @@ public interface IcebergCatalog extends MemoryTrackable {
                             String partitionName =
                                     PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
                             long lastUpdated =
-                                    getPartitionLastUpdatedTime(icebergTable, row, 9, partitionName, snapshotId);
-                            long version = getPartitionVersion(icebergTable, row, 10, partitionName, snapshotId);
+                                    getPartitionLastUpdatedTime(icebergTable, row, PARTITION_LAST_UPDATED_AT_COLUMN_INDEX,
+                                            partitionName, snapshotId);
+                            long version = getPartitionVersion(icebergTable, row,
+                                    PARTITION_LAST_UPDATED_SNAPSHOT_ID_COLUMN_INDEX, partitionName, snapshotId);
                             Partition partition = new Partition(lastUpdated, version, specId);
                             partitionMap.put(partitionName, partition);
                         }
@@ -404,7 +415,7 @@ public interface IcebergCatalog extends MemoryTrackable {
         }
         if (lastUpdated == -1) {
             // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.
-            lastUpdated = getTableLastestSnapshotTime(icebergTable, logger);
+            lastUpdated = getTableLatestSnapshotTime(icebergTable, logger);
             logger.warn("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +
                     "using current snapshot timestamp: {}", nativeTable.name(), snapshotId, lastUpdated);
         }
@@ -438,8 +449,8 @@ public interface IcebergCatalog extends MemoryTrackable {
         return getTableLatestSnapshotVersion(icebergTable, logger);
     }
 
-    private long getTableLastestSnapshotTime(IcebergTable icebergTable,
-                                             Logger logger) {
+    private long getTableLatestSnapshotTime(IcebergTable icebergTable,
+                                            Logger logger) {
         Table nativeTable = icebergTable.getNativeTable();
         // currentSnapshot() is Iceberg's canonical pointer to the latest snapshot in the table's current metadata.
         // We intentionally do not scan table.snapshots(): the fallback only needs the current head snapshot time.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
@@ -20,11 +20,17 @@ import java.util.concurrent.TimeUnit;
 
 public class Partition implements PartitionInfo {
     private final long modifiedTime;
+    private final long version;
     private int specId;
 
     @Override
     public long getModifiedTime() {
         return modifiedTime;
+    }
+
+    @Override
+    public long getVersion() {
+        return version;
     }
 
     @Override
@@ -37,12 +43,20 @@ public class Partition implements PartitionInfo {
     }
 
     public Partition(long modifiedTime) {
-        this.modifiedTime = modifiedTime;
-        this.specId = -1;
+        this(modifiedTime, modifiedTime, -1);
     }
 
     public Partition(long modifiedTime, int specId) {
+        this(modifiedTime, modifiedTime, specId);
+    }
+
+    public Partition(long modifiedTime, long version) {
+        this(modifiedTime, version, -1);
+    }
+
+    public Partition(long modifiedTime, long version, int specId) {
         this.modifiedTime = modifiedTime;
+        this.version = version;
         this.specId = specId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -186,7 +186,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                             normalizeIcebergModifiedTimeToMicros(basePartitionModifiedTime);
                     long normalizedLatestPartitionModifiedTime =
                             normalizeIcebergModifiedTimeToMicros(latestPartitionModifiedTime);
-                    if (basePartitionVersion == basePartitionModifiedTime) {
+                    if (basePartitionVersion == -1 || basePartitionVersion == basePartitionModifiedTime) {
                         // 1. for historical iceberg mv, the version is the modified time
                         if (normalizedLatestPartitionModifiedTime >= 0
                                 && normalizedLatestPartitionModifiedTime != normalizedBasePartitionModifiedTime) {
@@ -194,8 +194,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                         }
                     } else {
                         // 2. for new iceberg mv, the version is the snapshot sequence number
-                        if (latestPartitionVersion >= 0 && (latestPartitionVersion > basePartitionVersion 
-                                || normalizedLatestPartitionModifiedTime != normalizedBasePartitionModifiedTime)) {
+                        if (latestPartitionVersion >= 0 && (latestPartitionVersion > basePartitionVersion)) {
                             result.add(basePartitionName);
                         }
                     }
@@ -219,22 +218,6 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
         // Iceberg partition metadata uses microseconds, but some historical MV metadata and fallback paths may
         // persist epoch milliseconds. Normalize the legacy comparison branch to micros to avoid false positives.
         return modifiedTime < 100_000_000_000_000L ? TimeUnit.MILLISECONDS.toMicros(modifiedTime) : modifiedTime;
-    }
-
-    private long getComparablePartitionVersion(MaterializedView.BasePartitionInfo basePartitionInfo,
-                                               PartitionInfo latestPartitionInfo) {
-        if (basePartitionInfo == null) {
-            return latestPartitionInfo.getVersion();
-        }
-        // Historical Iceberg MV metadata stored external partition version as modifiedTime. Keep the legacy
-        // comparison until that partition is refreshed once and rewritten with the new version token.
-        if (table.getType() == Table.TableType.ICEBERG
-                && basePartitionInfo.getVersion() == basePartitionInfo.getLastRefreshTime()) {
-            return latestPartitionInfo.getModifiedTime();
-        }
-        // Compare the connector-specific version token instead of modifiedTime directly. Some external systems
-        // (for example Iceberg) may expose timestamps that are not strictly monotonic across commits.
-        return latestPartitionInfo.getVersion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -167,13 +167,39 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                     // If this partition is dropped, ignore it.
                     continue;
                 }
+                long latestPartitionInfo = latestPartitionInfo.get(basePartitionName);
+
                 MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
-                long basePartitionVersion = getComparablePartitionVersion(
-                        basePartitionInfo, latestPartitionInfo.get(basePartitionName));
-                // basePartitionVersion less than 0 is illegal
-                if ((basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion())
-                        && basePartitionVersion >= 0) {
+                if (basePartitionInfo == null) {
+                    // if mv does not have this partition, add it to the result
                     result.add(basePartitionName);
+                    continue;
+                }
+
+                if (table.getType() == Table.TableType.ICEBERG) {
+                    long basePartitionVersion = basePartitionInfo.getVersion();
+                    long basePartitionModifiedTime = basePartitionInfo.getLastRefreshTime();
+                    long latestPartitionVersion = latestPartitionInfo.getVersion();
+                    long latestPartitionModifiedTime = latestPartitionInfo.getModifiedTime();
+                    if (basePartitionVersion == basePartitionModifiedTime) {
+                        // 1. for historical iceberg mv, the version is the modified time
+                        if (latestPartitionModifiedTime >= 0 && latestPartitionModifiedTime != basePartitionModifiedTime) {
+                            result.add(basePartitionName);
+                        }
+                    } else {
+                        // 2. for new iceberg mv, the version is the snapshot sequence number
+                        if (latestPartitionVersion >= 0 && (latestPartitionVersion != basePartitionVersion 
+                                || latestPartitionModifiedTime > basePartitionModifiedTime)) {
+                            result.add(basePartitionName);
+                        }
+                    }
+                } else {
+                    // TODO: correct the logic here by comparing version and modified time
+                    long latestPartitionVersion = latestPartitionInfo.getModifiedTime();
+                    // basePartitionVersion less than 0 is illegal
+                    if (latestPartitionVersion >= 0 && latestPartitionVersion != basePartitionInfo.getVersion()) {
+                        result.add(basePartitionName);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -194,7 +194,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                         }
                     } else {
                         // 2. for new iceberg mv, the version is the snapshot sequence number
-                        if (latestPartitionVersion >= 0 && (latestPartitionVersion > basePartitionVersion)) {
+                        if (latestPartitionVersion >= 0 && latestPartitionVersion != basePartitionVersion) {
                             result.add(basePartitionName);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public abstract class DefaultTraits extends ConnectorPartitionTraits {
@@ -167,7 +168,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                     // If this partition is dropped, ignore it.
                     continue;
                 }
-                long latestPartitionInfo = latestPartitionInfo.get(basePartitionName);
+                PartitionInfo latestPartition = latestPartitionInfo.get(basePartitionName);
 
                 MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
                 if (basePartitionInfo == null) {
@@ -179,23 +180,28 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                 if (table.getType() == Table.TableType.ICEBERG) {
                     long basePartitionVersion = basePartitionInfo.getVersion();
                     long basePartitionModifiedTime = basePartitionInfo.getLastRefreshTime();
-                    long latestPartitionVersion = latestPartitionInfo.getVersion();
-                    long latestPartitionModifiedTime = latestPartitionInfo.getModifiedTime();
+                    long latestPartitionVersion = latestPartition.getVersion();
+                    long latestPartitionModifiedTime = latestPartition.getModifiedTime();
+                    long normalizedBasePartitionModifiedTime =
+                            normalizeIcebergModifiedTimeToMicros(basePartitionModifiedTime);
+                    long normalizedLatestPartitionModifiedTime =
+                            normalizeIcebergModifiedTimeToMicros(latestPartitionModifiedTime);
                     if (basePartitionVersion == basePartitionModifiedTime) {
                         // 1. for historical iceberg mv, the version is the modified time
-                        if (latestPartitionModifiedTime >= 0 && latestPartitionModifiedTime != basePartitionModifiedTime) {
+                        if (normalizedLatestPartitionModifiedTime >= 0
+                                && normalizedLatestPartitionModifiedTime != normalizedBasePartitionModifiedTime) {
                             result.add(basePartitionName);
                         }
                     } else {
                         // 2. for new iceberg mv, the version is the snapshot sequence number
-                        if (latestPartitionVersion >= 0 && (latestPartitionVersion != basePartitionVersion 
-                                || latestPartitionModifiedTime > basePartitionModifiedTime)) {
+                        if (latestPartitionVersion >= 0 && (latestPartitionVersion > basePartitionVersion 
+                                || normalizedLatestPartitionModifiedTime != normalizedBasePartitionModifiedTime)) {
                             result.add(basePartitionName);
                         }
                     }
                 } else {
                     // TODO: correct the logic here by comparing version and modified time
-                    long latestPartitionVersion = latestPartitionInfo.getModifiedTime();
+                    long latestPartitionVersion = latestPartition.getModifiedTime();
                     // basePartitionVersion less than 0 is illegal
                     if (latestPartitionVersion >= 0 && latestPartitionVersion != basePartitionInfo.getVersion()) {
                         result.add(basePartitionName);
@@ -204,6 +210,15 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
             }
         }
         return result;
+    }
+
+    private long normalizeIcebergModifiedTimeToMicros(long modifiedTime) {
+        if (modifiedTime < 0) {
+            return modifiedTime;
+        }
+        // Iceberg partition metadata uses microseconds, but some historical MV metadata and fallback paths may
+        // persist epoch milliseconds. Normalize the legacy comparison branch to micros to avoid false positives.
+        return modifiedTime < 100_000_000_000_000L ? TimeUnit.MILLISECONDS.toMicros(modifiedTime) : modifiedTime;
     }
 
     private long getComparablePartitionVersion(MaterializedView.BasePartitionInfo basePartitionInfo,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -167,9 +167,9 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
                     // If this partition is dropped, ignore it.
                     continue;
                 }
-                long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();
-
                 MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
+                long basePartitionVersion = getComparablePartitionVersion(
+                        basePartitionInfo, latestPartitionInfo.get(basePartitionName));
                 // basePartitionVersion less than 0 is illegal
                 if ((basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion())
                         && basePartitionVersion >= 0) {
@@ -178,6 +178,22 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
             }
         }
         return result;
+    }
+
+    private long getComparablePartitionVersion(MaterializedView.BasePartitionInfo basePartitionInfo,
+                                               PartitionInfo latestPartitionInfo) {
+        if (basePartitionInfo == null) {
+            return latestPartitionInfo.getVersion();
+        }
+        // Historical Iceberg MV metadata stored external partition version as modifiedTime. Keep the legacy
+        // comparison until that partition is refreshed once and rewritten with the new version token.
+        if (table.getType() == Table.TableType.ICEBERG
+                && basePartitionInfo.getVersion() == basePartitionInfo.getLastRefreshTime()) {
+            return latestPartitionInfo.getModifiedTime();
+        }
+        // Compare the connector-specific version token instead of modifiedTime directly. Some external systems
+        // (for example Iceberg) may expose timestamps that are not strictly monotonic across commits.
+        return latestPartitionInfo.getVersion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -216,7 +216,9 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits {
             return modifiedTime;
         }
         // Iceberg partition metadata uses microseconds, but some historical MV metadata and fallback paths may
-        // persist epoch milliseconds. Normalize the legacy comparison branch to micros to avoid false positives.
+        // persist epoch milliseconds. 1e14 micros is about 1973-03-03, so any present-day epoch timestamp below
+        // that threshold is almost certainly millis rather than micros. Normalize the legacy comparison branch to
+        // micros to avoid false positives.
         return modifiedTime < 100_000_000_000_000L ? TimeUnit.MILLISECONDS.toMicros(modifiedTime) : modifiedTime;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -193,7 +193,7 @@ public class MVMetaVersionRepairer {
                     MaterializedView.BasePartitionInfo oldBasePartitionInfo = entry.getValue();
                     com.starrocks.connector.PartitionInfo newPartitionInfo = newPartitionInfos.get(entry.getKey());
                     MaterializedView.BasePartitionInfo newBasePartitionInfo = new MaterializedView.BasePartitionInfo(
-                            entry.getValue().getId(), newPartitionInfo.getModifiedTime(), newPartitionInfo.getModifiedTime());
+                            entry.getValue().getId(), newPartitionInfo.getVersion(), newPartitionInfo.getModifiedTime());
                     newBasePartitionInfo.setExtLastFileModifiedTime(oldBasePartitionInfo.getExtLastFileModifiedTime());
                     newBasePartitionInfo.setFileNumber(oldBasePartitionInfo.getFileNumber());
                     newPartitionInfoMap.put(entry.getKey(), newBasePartitionInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -15,13 +15,19 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
@@ -40,11 +46,15 @@ import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import com.starrocks.sql.common.PCell;
 
 public class ConnectorPartitionTraitsTest {
 
@@ -125,13 +135,169 @@ public class ConnectorPartitionTraitsTest {
         ConnectorPartitionTraits connectorPartitionTraits = ConnectorPartitionTraits.build(icebergTable);
         Assertions.assertEquals(connectorPartitionTraits.getTableName(), "icebergTable");
         try {
-            PartitionKey key = connectorPartitionTraits.createPartitionKeyWithType(Lists.newArrayList("123.3"), 
+            PartitionKey key = connectorPartitionTraits.createPartitionKeyWithType(Lists.newArrayList("123.3"),
                     Lists.newArrayList(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6)));
-            Assertions.assertEquals(key.getKeys().get(0).getType(), 
+            Assertions.assertEquals(key.getKeys().get(0).getType(),
                     TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6));
         } catch (Exception e) {
             throw new RuntimeException("createPartitionKeyWithType failed", e);
         }
     }
-    
+
+    @Test
+    public void testDefaultTraitsDetectsExternalRefreshByVersion() {
+        DefaultTraits traits = new DefaultTraits() {
+            @Override
+            public boolean isSupportPCTRefresh() {
+                return true;
+            }
+
+            @Override
+            public PartitionKey createEmptyKey() {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns) {
+                return null;
+            }
+
+            @Override
+            public List<String> getPartitionNames() {
+                return List.of("p1");
+            }
+
+            @Override
+            public List<Column> getPartitionColumns() {
+                return List.of();
+            }
+
+            @Override
+            public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, PCell> getPartitionCells(List<Column> partitionColumns) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+                return Map.of("p1", new PartitionInfo() {
+                    @Override
+                    public long getModifiedTime() {
+                        return 100L;
+                    }
+
+                    @Override
+                    public long getVersion() {
+                        return 2L;
+                    }
+                });
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
+                return getPartitionNameWithPartitionInfo();
+            }
+        };
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.getTableIdentifier()).thenReturn("identifier");
+        Mockito.when(table.getType()).thenReturn(Table.TableType.ICEBERG);
+        traits.table = table;
+
+        BaseTableInfo baseTableInfo = new BaseTableInfo("iceberg", "db", "tbl", "identifier");
+        MaterializedView.AsyncRefreshContext context = new MaterializedView.AsyncRefreshContext();
+        context.getBaseTableRefreshInfo(baseTableInfo)
+                .put("p1", new MaterializedView.BasePartitionInfo(-1, 1L, 100L));
+
+        Set<String> updated = traits.getUpdatedPartitionNames(List.of(baseTableInfo), context);
+        Assertions.assertEquals(Set.of("p1"), updated);
+    }
+
+    @Test
+    public void testDefaultTraitsKeepsLegacyIcebergPartitionInfoCompatible() {
+        DefaultTraits traits = new DefaultTraits() {
+            @Override
+            public boolean isSupportPCTRefresh() {
+                return true;
+            }
+
+            @Override
+            public PartitionKey createEmptyKey() {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns) {
+                return null;
+            }
+
+            @Override
+            public List<String> getPartitionNames() {
+                return List.of("p1");
+            }
+
+            @Override
+            public List<Column> getPartitionColumns() {
+                return List.of();
+            }
+
+            @Override
+            public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, PCell> getPartitionCells(List<Column> partitionColumns) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+                return Map.of("p1", new PartitionInfo() {
+                    @Override
+                    public long getModifiedTime() {
+                        return 100L;
+                    }
+
+                    @Override
+                    public long getVersion() {
+                        return 2L;
+                    }
+                });
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
+                return getPartitionNameWithPartitionInfo();
+            }
+        };
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.getTableIdentifier()).thenReturn("identifier");
+        Mockito.when(table.getType()).thenReturn(Table.TableType.ICEBERG);
+        traits.table = table;
+
+        BaseTableInfo baseTableInfo = new BaseTableInfo("iceberg", "db", "tbl", "identifier");
+        MaterializedView.AsyncRefreshContext context = new MaterializedView.AsyncRefreshContext();
+        // Legacy external-table metadata stored version == lastRefreshTime == modifiedTime.
+        context.getBaseTableRefreshInfo(baseTableInfo)
+                .put("p1", new MaterializedView.BasePartitionInfo(-1, 100L, 100L));
+
+        Set<String> updated = traits.getUpdatedPartitionNames(List.of(baseTableInfo), context);
+        Assertions.assertEquals(Set.of(), updated);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -17,8 +17,6 @@ package com.starrocks.connector;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Range;
-import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveTable;
@@ -27,7 +25,6 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.Type;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
@@ -39,8 +36,10 @@ import com.starrocks.connector.partitiontraits.KuduPartitionTraits;
 import com.starrocks.connector.partitiontraits.OdpsPartitionTraits;
 import com.starrocks.connector.partitiontraits.OlapPartitionTraits;
 import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
-import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import mockit.Mock;
 import mockit.MockUp;
@@ -177,13 +176,13 @@ public class ConnectorPartitionTraitsTest {
             }
 
             @Override
-            public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
-                return Map.of();
+            public PCellSortedSet getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+                return null;
             }
 
             @Override
-            public Map<String, PCell> getPartitionCells(List<Column> partitionColumns) {
-                return Map.of();
+            public PCellSortedSet getPartitionCells(List<Column> partitionColumns) {
+                return null;
             }
 
             @Override
@@ -255,13 +254,13 @@ public class ConnectorPartitionTraitsTest {
             }
 
             @Override
-            public Map<String, Range<PartitionKey>> getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
-                return Map.of();
+            public PCellSortedSet getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+                return null;
             }
 
             @Override
-            public Map<String, PCell> getPartitionCells(List<Column> partitionColumns) {
-                return Map.of();
+            public PCellSortedSet getPartitionCells(List<Column> partitionColumns) {
+                return null;
             }
 
             @Override
@@ -293,6 +292,86 @@ public class ConnectorPartitionTraitsTest {
         BaseTableInfo baseTableInfo = new BaseTableInfo("iceberg", "db", "tbl", "identifier");
         MaterializedView.AsyncRefreshContext context = new MaterializedView.AsyncRefreshContext();
         // Legacy external-table metadata stored version == lastRefreshTime == modifiedTime.
+        context.getBaseTableRefreshInfo(baseTableInfo)
+                .put("p1", new MaterializedView.BasePartitionInfo(-1, 100L, 100L));
+
+        Set<String> updated = traits.getUpdatedPartitionNames(List.of(baseTableInfo), context);
+        Assertions.assertEquals(Set.of(), updated);
+    }
+
+    @Test
+    public void testDefaultTraitsKeepsLegacyIcebergMillisAndMicrosCompatible() {
+        DefaultTraits traits = new DefaultTraits() {
+            @Override
+            public boolean isSupportPCTRefresh() {
+                return true;
+            }
+
+            @Override
+            public PartitionKey createEmptyKey() {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) {
+                return null;
+            }
+
+            @Override
+            public PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns) {
+                return null;
+            }
+
+            @Override
+            public List<String> getPartitionNames() {
+                return List.of("p1");
+            }
+
+            @Override
+            public List<Column> getPartitionColumns() {
+                return List.of();
+            }
+
+            @Override
+            public PCellSortedSet getPartitionKeyRange(Column partitionColumn, Expr partitionExpr) {
+                return null;
+            }
+
+            @Override
+            public PCellSortedSet getPartitionCells(List<Column> partitionColumns) {
+                return null;
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+                return Map.of("p1", new PartitionInfo() {
+                    @Override
+                    public long getModifiedTime() {
+                        return 100_000L;
+                    }
+
+                    @Override
+                    public long getVersion() {
+                        return 2L;
+                    }
+                });
+            }
+
+            @Override
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo(List<String> partitionNames) {
+                return getPartitionNameWithPartitionInfo();
+            }
+        };
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.getTableIdentifier()).thenReturn("identifier");
+        Mockito.when(table.getType()).thenReturn(Table.TableType.ICEBERG);
+        traits.table = table;
+
+        BaseTableInfo baseTableInfo = new BaseTableInfo("iceberg", "db", "tbl", "identifier");
+        MaterializedView.AsyncRefreshContext context = new MaterializedView.AsyncRefreshContext();
+        // Historical metadata may have stored modifiedTime in milliseconds while current Iceberg partition
+        // metadata uses microseconds for the same wall-clock instant.
         context.getBaseTableRefreshInfo(baseTableInfo)
                 .put("p1", new MaterializedView.BasePartitionInfo(-1, 100L, 100L));
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -301,6 +301,8 @@ public class ConnectorPartitionTraitsTest {
 
     @Test
     public void testDefaultTraitsKeepsLegacyIcebergMillisAndMicrosCompatible() {
+        long legacyModifiedTimeMillis = 1_710_000_000_000L;
+        long latestModifiedTimeMicros = 1_710_000_000_000_000L;
         DefaultTraits traits = new DefaultTraits() {
             @Override
             public boolean isSupportPCTRefresh() {
@@ -347,7 +349,7 @@ public class ConnectorPartitionTraitsTest {
                 return Map.of("p1", new PartitionInfo() {
                     @Override
                     public long getModifiedTime() {
-                        return 100_000L;
+                        return latestModifiedTimeMicros;
                     }
 
                     @Override
@@ -373,7 +375,8 @@ public class ConnectorPartitionTraitsTest {
         // Historical metadata may have stored modifiedTime in milliseconds while current Iceberg partition
         // metadata uses microseconds for the same wall-clock instant.
         context.getBaseTableRefreshInfo(baseTableInfo)
-                .put("p1", new MaterializedView.BasePartitionInfo(-1, 100L, 100L));
+                .put("p1", new MaterializedView.BasePartitionInfo(-1, legacyModifiedTimeMillis,
+                        legacyModifiedTimeMillis));
 
         Set<String> updated = traits.getUpdatedPartitionNames(List.of(baseTableInfo), context);
         Assertions.assertEquals(Set.of(), updated);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -15,9 +15,9 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Range;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
@@ -39,6 +39,7 @@ import com.starrocks.connector.partitiontraits.KuduPartitionTraits;
 import com.starrocks.connector.partitiontraits.OdpsPartitionTraits;
 import com.starrocks.connector.partitiontraits.OlapPartitionTraits;
 import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
+import com.starrocks.sql.common.PCell;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.TypeFactory;
 import mockit.Mock;
@@ -53,8 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import com.starrocks.sql.common.PCell;
 
 public class ConnectorPartitionTraitsTest {
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -152,26 +152,26 @@ public class CachingIcebergCatalogTest {
             }
 
             @Override
-            public List<String> listAllDatabases() {
+            public List<String> listAllDatabases(ConnectContext context) {
                 return List.of();
             }
 
             @Override
-            public Database getDB(String dbName) {
+            public Database getDB(ConnectContext context, String dbName) {
                 return null;
             }
 
             @Override
-            public List<String> listTables(String dbName) {
+            public List<String> listTables(ConnectContext context, String dbName) {
                 return List.of();
             }
 
             @Override
-            public void renameTable(String dbName, String tblName, String newTblName) {
+            public void renameTable(ConnectContext context, String dbName, String tblName, String newTblName) {
             }
 
             @Override
-            public Table getTable(String dbName, String tableName) {
+            public Table getTable(ConnectContext context, String dbName, String tableName) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -33,14 +33,20 @@ import mockit.Mocked;
 import mockit.Verifications;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionsTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -50,6 +56,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
@@ -133,6 +140,75 @@ public class CachingIcebergCatalogTest {
             requestContext.setQueryMVRewrite(true);
             List<String> res = cachingIcebergCatalog.listPartitionNames(table, requestContext, null);
             Assertions.assertEquals(res.size(), 0);
+        }
+    }
+
+    @Test
+    public void testGetPartitionsUsesCurrentSnapshotMicrosForUnpartitionedFallback() {
+        IcebergCatalog catalog = new IcebergCatalog() {
+            @Override
+            public IcebergCatalogType getIcebergCatalogType() {
+                return IcebergCatalogType.HIVE_CATALOG;
+            }
+
+            @Override
+            public List<String> listAllDatabases() {
+                return List.of();
+            }
+
+            @Override
+            public Database getDB(String dbName) {
+                return null;
+            }
+
+            @Override
+            public List<String> listTables(String dbName) {
+                return List.of();
+            }
+
+            @Override
+            public void renameTable(String dbName, String tblName, String newTblName) {
+            }
+
+            @Override
+            public Table getTable(String dbName, String tableName) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        Table nativeTable = Mockito.mock(Table.class);
+        PartitionSpec spec = Mockito.mock(PartitionSpec.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        PartitionsTable partitionsTable = Mockito.mock(PartitionsTable.class);
+        TableScan tableScan = Mockito.mock(TableScan.class);
+
+        Mockito.when(nativeTable.spec()).thenReturn(spec);
+        Mockito.when(spec.isUnpartitioned()).thenReturn(true);
+        Mockito.when(nativeTable.currentSnapshot()).thenReturn(snapshot);
+        Mockito.when(nativeTable.name()).thenReturn("db.test");
+        Mockito.when(snapshot.timestampMillis()).thenReturn(1234L);
+        Mockito.when(snapshot.sequenceNumber()).thenReturn(9L);
+        Mockito.when(partitionsTable.newScan()).thenReturn(tableScan);
+        Mockito.when(tableScan.planFiles()).thenReturn(CloseableIterable.empty());
+
+        try (MockedStatic<MetadataTableUtils> metadataTableUtils = Mockito.mockStatic(MetadataTableUtils.class)) {
+            metadataTableUtils.when(() -> MetadataTableUtils.createMetadataTableInstance(
+                    nativeTable, MetadataTableType.PARTITIONS)).thenReturn(partitionsTable);
+
+            IcebergTable table = IcebergTable.builder()
+                    .setSrTableName("test")
+                    .setCatalogDBName("db")
+                    .setCatalogTableName("test")
+                    .setNativeTable(nativeTable)
+                    .build();
+
+            Map<String, Partition> partitions = catalog.getPartitions(table, -1, null);
+            Partition partition = partitions.get(IcebergCatalog.EMPTY_PARTITION_NAME);
+
+            Assertions.assertNotNull(partition);
+            Assertions.assertEquals(TimeUnit.MICROSECONDS, partition.getModifiedTimeUnit());
+            Assertions.assertEquals(TimeUnit.MILLISECONDS.toMicros(1234L), partition.getModifiedTime());
+            Assertions.assertEquals(9L, partition.getVersion());
         }
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite_with_expired
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite_with_expired
@@ -80,11 +80,20 @@ create database db_${uuid0};
 use db_${uuid0};
 -- result:
 -- !result
+set enable_materialized_view_rewrite=false;
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019d002b-c799-7275-b7dd-ac79bb68b96f
+-- !result
 select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 -- result:
 8
@@ -92,18 +101,17 @@ select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
 -- !result
-select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+[UC]select inspect_mv_refresh_info("test_mv1");
 -- result:
-8
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":{"dt\u003d2023-12-02":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019d002b-d124-7f93-80eb-59c4be13640b
 -- !result
 [UC]select inspect_mv_refresh_info("test_mv1");
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327221000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150326843000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327468000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
--- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv1");
--- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327221000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150326843000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327468000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824361242000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":{"dt\u003d2023-12-02":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1773824361242000,"lastRefreshTime":1773824361242000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
 select count(1) from test_mv1;
 -- result:
@@ -112,14 +120,16 @@ select count(1) from test_mv1;
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
 -- result:
 -- !result
-[UC]select inspect_mv_refresh_info("test_mv1");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
-{"tableToUpdatePartitions":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":["dt\u003d2023-12-05","dt\u003d2023-12-02","dt\u003d2023-12-01","dt\u003d2023-12-03"]},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv1");
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150333496000,"lastRefreshTime":1764150333496000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+019d002b-d418-71c4-b225-4d81bb93a8a2
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+9
 -- !result
 select count(1) from test_mv1;
 -- result:
@@ -128,24 +138,50 @@ select count(1) from test_mv1;
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
 -- result:
 -- !result
-[UC]select inspect_mv_refresh_info("test_mv1");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
-{"tableToUpdatePartitions":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":["dt\u003d2023-12-05","dt\u003d2023-12-02","dt\u003d2023-12-01","dt\u003d2023-12-03"]},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150333496000,"lastRefreshTime":1764150333496000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv1");
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+019d002b-dea9-702a-9f03-9c308dc34444
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+10
 -- !result
 select count(1) from test_mv1;
 -- result:
 10
 -- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-06');
+-- result:
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019d002b-e698-79e3-b876-22d4efa4ebc6
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+11
+-- !result
+select count(1) from test_mv1;
+-- result:
+11
+-- !result
 CREATE MATERIALIZED VIEW test_mv2 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+019d002b-f12a-7730-80b1-1f654ce120fa
+-- !result
 select count(1) from test_mv2;
 -- result:
 8
@@ -157,104 +193,157 @@ select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 execute expire_snapshots(now());
 -- result:
 -- !result
-select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+[UC]select inspect_mv_refresh_info("test_mv2");
 -- result:
-8
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824362178000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.t1":{"t1":{"id":-1,"version":1773824362178000,"lastRefreshTime":1773824362178000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+019d002b-f46e-7c9a-bb01-215ba866df41
 -- !result
 [UC]select inspect_mv_refresh_info("test_mv2");
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150329103000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
--- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
--- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150329103000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":4,\"lastRefreshTime\":1773824362178000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.t1":{"t1":{"id":-1,"version":1773824362178000,"lastRefreshTime":1773824362178000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
 select count(1) from test_mv2;
 -- result:
 8
 -- !result
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-05');
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+8
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-04');
 -- result:
 -- !result
-[UC]select inspect_mv_refresh_info("test_mv2");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
-{"tableToUpdatePartitions":{"t1":["t1"]},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150338599000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150338599000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150338599000,"lastRefreshTime":1764150338599000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+019d002b-f6d8-72b3-90f8-1deeb63ccf6a
 -- !result
 select count(1) from test_mv2;
 -- result:
 9
 -- !result
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-06');
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+9
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-05');
 -- result:
 -- !result
-[UC]select inspect_mv_refresh_info("test_mv2");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
-{"tableToUpdatePartitions":{"t1":["t1"]},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150339885000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150338599000,"lastRefreshTime":1764150338599000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150339885000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150339885000,"lastRefreshTime":1764150339885000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+019d002b-fce0-758b-9d66-c84d66f7b9a8
 -- !result
 select count(1) from test_mv2;
 -- result:
 10
 -- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+10
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-06');
+-- result:
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+019d002c-00a7-7a05-902f-df6dbcbc0d06
+-- !result
+select count(1) from test_mv2;
+-- result:
+11
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+11
+-- !result
 CREATE MATERIALIZED VIEW test_mv3 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv3");
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
--- !result
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv3");
--- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
--- !result
-select count(1) from test_mv3;
--- result:
-10
+019d002c-03c4-752c-b2f9-9c9de85a1e06
 -- !result
 [UC]select inspect_mv_refresh_info("test_mv3");
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":"{\"dt\u003d2023-12-06\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":{"dt\u003d2023-12-06":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-02":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 -- result:
+019d002c-0739-74d8-ac7b-603282f1d822
 -- !result
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 [UC]select inspect_mv_refresh_info("test_mv3");
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150342593000,"lastRefreshTime":1764150342593000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":"{\"dt\u003d2023-12-06\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":7,\"lastRefreshTime\":1773824370143000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_35825e056caf4bf19debad9751e23f8c.mv_ice_db_35825e056caf4bf19debad9751e23f8c.mv_ice_tbl_35825e056caf4bf19debad9751e23f8c":{"dt\u003d2023-12-06":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-02":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1773824370143000,"lastRefreshTime":1773824370143000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
 -- !result
 select count(1) from test_mv3;
 -- result:
 11
 -- !result
-[UC]select inspect_mv_refresh_info("test_mv3");
--- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150342593000,"lastRefreshTime":1764150342593000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
--- !result
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv3");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 -- result:
-{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150344209000,"lastRefreshTime":1764150344209000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+-- result:
+019d002c-0aa0-75e3-9752-53ec29c341e4
 -- !result
 select count(1) from test_mv3;
 -- result:
 12
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+12
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+-- result:
+019d002c-10bc-79bb-8b41-64cd19e3dd46
+-- !result
+select count(1) from test_mv3;
+-- result:
+13
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+13
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-07');
+-- result:
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+-- result:
+019d002c-147b-7bd5-8202-ea6b9e54d0f0
+-- !result
+select count(1) from test_mv3;
+-- result:
+14
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+14
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite_with_expired
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite_with_expired
@@ -51,84 +51,113 @@ set catalog default_catalog;
 create database db_${uuid0};
 use db_${uuid0};
 
+set enable_materialized_view_rewrite=false;
+
 -- test partitioned mv
 CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 
-select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
--- select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}$snapshots;
 alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
 select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
--- select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}$snapshots;
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
 
 [UC]select inspect_mv_refresh_info("test_mv1");
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 [UC]select inspect_mv_refresh_info("test_mv1");
 select count(1) from test_mv1;
 
+-- 1st time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
-
-[UC]select inspect_mv_refresh_info("test_mv1");
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv1");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 select count(1) from test_mv1;
 
+-- 2nd time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
-[UC]select inspect_mv_refresh_info("test_mv1");
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv1");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+select count(1) from test_mv1;
+
+-- 3nd time expire snapshot
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-06');
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 select count(1) from test_mv1;
 
 -- test non-partitioned mv
 CREATE MATERIALIZED VIEW test_mv2 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 
 select count(1) from test_mv2;
 select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 execute expire_snapshots(now());
+
+[UC]select inspect_mv_refresh_info("test_mv2");
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+select count(1) from test_mv2;
 select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 
-[UC]select inspect_mv_refresh_info("test_mv2");
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
+-- 1th time expire snapshot
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-04');
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 select count(1) from test_mv2;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 
+
+-- 2th time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-05');
-
-[UC]select inspect_mv_refresh_info("test_mv2");
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 select count(1) from test_mv2;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 
+-- 3th time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-06');
-[UC]select inspect_mv_refresh_info("test_mv2");
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv2");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
 select count(1) from test_mv2;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
 
 -- test partitioned mv
 CREATE MATERIALIZED VIEW test_mv3 
 REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 
 [UC]select inspect_mv_refresh_info("test_mv3");
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 [UC]select inspect_mv_refresh_info("test_mv3");
 select count(1) from test_mv3;
 
-[UC]select inspect_mv_refresh_info("test_mv3");
+-- 1th time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv3");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 select count(1) from test_mv3;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 
-[UC]select inspect_mv_refresh_info("test_mv3");
+-- 2th time expire snapshot
 insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
-REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
-[UC]select inspect_mv_refresh_info("test_mv3");
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
 select count(1) from test_mv3;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+
+-- 3th time expire snapshot
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-07');
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+[UC]REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+select count(1) from test_mv3;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 drop materialized view default_catalog.db_${uuid0}.test_mv2;


### PR DESCRIPTION
## Why I'm doing:

Issue 1 — Unit mismatch in last_updated_at
When fetching the last_updated_at of an Iceberg partition from the Iceberg metatable fails, the code falls back to currentSnapshot.timestampMillis(). However, the unit of this fallback value is not aligned with the last_updated_at used in the normal code path — the expected unit is microseconds (Micro), not milliseconds (Millis).

Issue 2 — timestampMillis() is not strictly monotonically increasing
Log analysis reveals that currentSnapshot.timestampMillis() itself is not strictly increasing, which makes it unreliable as a change-detection signal. (See attached logs for reference.)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
