### PR TITLE
[Enhancement] Support colocate DDL parsing for range distribution tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.ColocatePropertyInfo;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
@@ -175,6 +176,15 @@ public class ColocateTableIndex implements Writable {
 
         if (olapTable.isCloudNativeTableOrMaterializedView() != expectLakeTable) {
             return false;
+        }
+
+        // For range distribution: parse colocate property and validate colocate columns
+        if (olapTable.getDefaultDistributionInfo() instanceof RangeDistributionInfo) {
+            ColocatePropertyInfo propertyInfo = ColocatePropertyInfo.of(colocateGroup);
+            MetaUtils.getRangeColocateColumns(olapTable, propertyInfo.getColocateColumnNames());
+            // TODO: create range colocate group after colocate_init is merged
+            olapTable.setColocateGroup(colocateGroup);
+            return true;
         }
 
         String fullGroupName = db.getId() + "_" + colocateGroup;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ColocatePropertyInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ColocatePropertyInfo.java
@@ -1,0 +1,103 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.base.Splitter;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parsed result of "colocate_with" property value.
+ *
+ * <p>Syntax:
+ * <ul>
+ *   <li>{@code "group_name"} -> colocateGroupName="group_name", colocateColumnNames=null</li>
+ *   <li>{@code "group_name:col1,col2"} -> colocateGroupName="group_name", colocateColumnNames=["col1","col2"]</li>
+ * </ul>
+ *
+ * <p>When colocateColumnNames is null, default colocate columns are all sort key columns.
+ *
+ * <p>{@link #of(String)} and {@link #toString()} are inverse operations:
+ * {@code ColocatePropertyInfo.of(info.toString())} produces an equivalent instance.
+ */
+public class ColocatePropertyInfo {
+    private final String colocateGroupName;
+    private final List<String> colocateColumnNames; // null = default (all sort key)
+
+    public ColocatePropertyInfo(String colocateGroupName, List<String> colocateColumnNames) {
+        this.colocateGroupName = Objects.requireNonNull(colocateGroupName,
+                "colocateGroupName must not be null");
+        this.colocateColumnNames = colocateColumnNames;
+    }
+
+    public String getColocateGroupName() {
+        return colocateGroupName;
+    }
+
+    public List<String> getColocateColumnNames() {
+        return colocateColumnNames;
+    }
+
+    /**
+     * Parses a "colocate_with" property value into a ColocatePropertyInfo.
+     *
+     * @param value the property value, e.g. "group1" or "group1:col1,col2"
+     * @return the parsed info, or null if value is null or empty
+     */
+    public static ColocatePropertyInfo of(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        int colonIndex = value.indexOf(':');
+        if (colonIndex < 0) {
+            return new ColocatePropertyInfo(value, null);
+        }
+        String groupName = value.substring(0, colonIndex).trim();
+        List<String> columnNames = Splitter.on(',').trimResults()
+                .splitToList(value.substring(colonIndex + 1));
+        return new ColocatePropertyInfo(groupName, columnNames);
+    }
+
+    /**
+     * Returns the original property string format.
+     * Inverse of {@link #of(String)}.
+     */
+    @Override
+    public String toString() {
+        if (colocateColumnNames == null || colocateColumnNames.isEmpty()) {
+            return colocateGroupName;
+        }
+        return colocateGroupName + ":" + String.join(",", colocateColumnNames);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        ColocatePropertyInfo other = (ColocatePropertyInfo) object;
+        return Objects.equals(colocateGroupName, other.colocateGroupName)
+                && Objects.equals(colocateColumnNames, other.colocateColumnNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(colocateGroupName, colocateColumnNames);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.TableOperation;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
@@ -284,6 +285,37 @@ public class MetaUtils {
             }
         }
         return columns;
+    }
+
+    /**
+     * Resolves the colocate columns for a range distribution table.
+     * Colocate columns must be a prefix of the sort key (range distribution columns).
+     *
+     * @param olapTable the table
+     * @param colocateColumnNames the explicitly specified colocate column names,
+     *                            or null for default (all sort key columns)
+     * @return the resolved colocate columns
+     * @throws DdlException if colocateColumnNames is not a valid prefix of sort key
+     */
+    public static List<Column> getRangeColocateColumns(OlapTable olapTable,
+                                                        List<String> colocateColumnNames) throws DdlException {
+        List<Column> sortKeyColumns = getRangeDistributionColumns(olapTable);
+        if (colocateColumnNames == null) {
+            return sortKeyColumns;
+        }
+        List<Column> result = new ArrayList<>();
+        for (int i = 0; i < colocateColumnNames.size(); i++) {
+            if (i >= sortKeyColumns.size()
+                    || !sortKeyColumns.get(i).getName()
+                        .equalsIgnoreCase(colocateColumnNames.get(i))) {
+                throw new DdlException(
+                        "Colocate columns must be a prefix of sort key columns. Sort key: "
+                        + sortKeyColumns.stream().map(Column::getName)
+                            .collect(Collectors.joining(",")));
+            }
+            result.add(sortKeyColumns.get(i));
+        }
+        return result;
     }
 
     public static List<String> getRangeDistributionColumnNames(OlapTable olapTable) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ColocatePropertyInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ColocatePropertyInfoTest.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class ColocatePropertyInfoTest {
+
+    @Test
+    public void testOfGroupNameOnly() {
+        ColocatePropertyInfo info = ColocatePropertyInfo.of("group1");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("group1", info.getColocateGroupName());
+        Assertions.assertNull(info.getColocateColumnNames());
+    }
+
+    @Test
+    public void testOfGroupNameWithColumns() {
+        ColocatePropertyInfo info = ColocatePropertyInfo.of("group1:tenant_id,created_time");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("group1", info.getColocateGroupName());
+        Assertions.assertEquals(Arrays.asList("tenant_id", "created_time"),
+                info.getColocateColumnNames());
+    }
+
+    @Test
+    public void testOfGroupNameWithSingleColumn() {
+        ColocatePropertyInfo info = ColocatePropertyInfo.of("grp1:tenant_id");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("grp1", info.getColocateGroupName());
+        Assertions.assertEquals(Arrays.asList("tenant_id"), info.getColocateColumnNames());
+    }
+
+    @Test
+    public void testOfGroupNameWithSpaces() {
+        ColocatePropertyInfo info = ColocatePropertyInfo.of("group1: col1 , col2 ");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("group1", info.getColocateGroupName());
+        Assertions.assertEquals(Arrays.asList("col1", "col2"), info.getColocateColumnNames());
+    }
+
+    @Test
+    public void testOfNull() {
+        Assertions.assertNull(ColocatePropertyInfo.of(null));
+    }
+
+    @Test
+    public void testOfEmpty() {
+        Assertions.assertNull(ColocatePropertyInfo.of(""));
+    }
+
+    @Test
+    public void testToStringGroupNameOnly() {
+        ColocatePropertyInfo info = new ColocatePropertyInfo("group1", null);
+        Assertions.assertEquals("group1", info.toString());
+    }
+
+    @Test
+    public void testToStringWithColumns() {
+        ColocatePropertyInfo info = new ColocatePropertyInfo("group1",
+                Arrays.asList("tenant_id", "created_time"));
+        Assertions.assertEquals("group1:tenant_id,created_time", info.toString());
+    }
+
+    @Test
+    public void testOfAndToStringRoundTrip() {
+        // Group name only
+        String value1 = "group1";
+        Assertions.assertEquals(value1, ColocatePropertyInfo.of(value1).toString());
+
+        // Group name with columns
+        String value2 = "group1:tenant_id,created_time";
+        Assertions.assertEquals(value2, ColocatePropertyInfo.of(value2).toString());
+    }
+
+    @Test
+    public void testEquals() {
+        ColocatePropertyInfo info1 = ColocatePropertyInfo.of("group1:col1,col2");
+        ColocatePropertyInfo info2 = ColocatePropertyInfo.of("group1:col1,col2");
+        ColocatePropertyInfo info3 = ColocatePropertyInfo.of("group1:col1");
+        ColocatePropertyInfo info4 = ColocatePropertyInfo.of("group2:col1,col2");
+        ColocatePropertyInfo info5 = ColocatePropertyInfo.of("group1");
+
+        Assertions.assertEquals(info1, info2);
+        Assertions.assertNotEquals(info1, info3);
+        Assertions.assertNotEquals(info1, info4);
+        Assertions.assertNotEquals(info1, info5);
+        Assertions.assertNotEquals(info1, null);
+    }
+
+    @Test
+    public void testHashCode() {
+        ColocatePropertyInfo info1 = ColocatePropertyInfo.of("group1:col1,col2");
+        ColocatePropertyInfo info2 = ColocatePropertyInfo.of("group1:col1,col2");
+        Assertions.assertEquals(info1.hashCode(), info2.hashCode());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/RangeColocateColumnsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/RangeColocateColumnsTest.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RangeColocateColumnsTest {
+
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+
+        String createDbStmtStr = "create database test_colocate_columns;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(
+                createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
+
+        // Create a range distribution table with sort key (k1, k2, k3)
+        String sql = "CREATE TABLE test_colocate_columns.t1 (\n" +
+                "    k1 INT,\n" +
+                "    k2 VARCHAR(32),\n" +
+                "    k3 BIGINT,\n" +
+                "    v1 INT\n" +
+                ") DUPLICATE KEY(k1, k2, k3)\n" +
+                "DISTRIBUTED BY HASH(k1)\n" +
+                "BUCKETS 4\n" +
+                "PROPERTIES(\"replication_num\" = \"1\");\n";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                sql, connectContext);
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private OlapTable getTable() {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb("test_colocate_columns").getTable("t1");
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsDefault() throws DdlException {
+        OlapTable table = getTable();
+        // null colocateColumnNames -> returns all sort key columns
+        List<Column> columns = MetaUtils.getRangeColocateColumns(table, null);
+        Assertions.assertFalse(columns.isEmpty());
+        // Should be the key columns: k1, k2, k3
+        Assertions.assertEquals("k1", columns.get(0).getName());
+        Assertions.assertEquals("k2", columns.get(1).getName());
+        Assertions.assertEquals("k3", columns.get(2).getName());
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsPrefix() throws DdlException {
+        OlapTable table = getTable();
+        // Specify first two columns as colocate columns
+        List<Column> columns = MetaUtils.getRangeColocateColumns(table,
+                Arrays.asList("k1", "k2"));
+        Assertions.assertEquals(2, columns.size());
+        Assertions.assertEquals("k1", columns.get(0).getName());
+        Assertions.assertEquals("k2", columns.get(1).getName());
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsSingleColumn() throws DdlException {
+        OlapTable table = getTable();
+        List<Column> columns = MetaUtils.getRangeColocateColumns(table,
+                Arrays.asList("k1"));
+        Assertions.assertEquals(1, columns.size());
+        Assertions.assertEquals("k1", columns.get(0).getName());
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsNotPrefix() {
+        OlapTable table = getTable();
+        // k2 is not the first sort key column
+        Assertions.assertThrows(DdlException.class,
+                () -> MetaUtils.getRangeColocateColumns(table, Arrays.asList("k2")));
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsWrongOrder() {
+        OlapTable table = getTable();
+        // k2, k1 is not a valid prefix (wrong order)
+        Assertions.assertThrows(DdlException.class,
+                () -> MetaUtils.getRangeColocateColumns(table, Arrays.asList("k2", "k1")));
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsTooMany() {
+        OlapTable table = getTable();
+        // More columns than sort key has
+        Assertions.assertThrows(DdlException.class,
+                () -> MetaUtils.getRangeColocateColumns(table,
+                        Arrays.asList("k1", "k2", "k3", "v1")));
+    }
+
+    @Test
+    public void testGetRangeColocateColumnsNonExistent() {
+        OlapTable table = getTable();
+        // Column that doesn't exist
+        Assertions.assertThrows(DdlException.class,
+                () -> MetaUtils.getRangeColocateColumns(table,
+                        Arrays.asList("nonexistent")));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

  Range distribution tables need to support colocate by sort key prefix columns. The colocate_with
  property syntax is extended to allow specifying colocate columns explicitly:
  `"colocate_with" = "group_name:col1,col2"`. This PR implements the DDL parsing and validation
  layer as the first step, without creating the actual colocate group (which depends on a separate
  metadata PR).

 ## What I'm doing:

  1. Add `ColocatePropertyInfo` class to parse the extended colocate_with syntax
     (`"group_name"` or `"group_name:col1,col2"`). `of()` and `toString()` are inverse
     operations for seamless conversion with the existing String-based interface.

  2. Add `MetaUtils.getRangeColocateColumns()` to resolve and validate that the specified
     colocate columns are a valid prefix of the table's sort key columns.

  3. Add a range distribution branch in `ColocateTableIndex.addTableToGroup()` that parses
     the colocate property and validates colocate columns. The hash distribution path is
     completely unchanged.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
