### PR TITLE
[Enhancement] support dump plan when query exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -376,7 +376,7 @@ public class Config extends ConfigBase {
      * Which failure types are logged is controlled by {@code plan_log_failure_types}.
      */
     @ConfField(mutable = true)
-    public static boolean log_plan_on_query_failure = true;
+    public static boolean log_plan_on_query_failure = false;
 
     /**
      * When enabled, a full query dump (JSON with table metadata, statistics, plan, etc.)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -215,12 +215,9 @@ public class Config extends ConfigBase {
     public static boolean internal_log_json_format = false;
 
     /**
-     * dump_log_dir:
-     * This specifies FE dump log dir.
-     * Dump log fe.dump.log contains all dump information which query has Exception
-     * <p>
      * dump_log_roll_num:
-     * Maximal FE log files to be kept within a dump_log_roll_interval.
+     * Maximal FE dump log files to be kept within a dump_log_roll_interval.
+     * fe.dump.log is written to sys_log_dir (same directory as fe.log).
      * <p>
      * dump_log_modules:
      * Dump information for an abnormal query.
@@ -238,8 +235,6 @@ public class Config extends ConfigBase {
      * 120s    120 seconds
      */
     @ConfField
-    public static String dump_log_dir = Config.STARROCKS_HOME_DIR + "/log";
-    @ConfField
     public static int dump_log_roll_num = 10;
     @ConfField
     public static String[] dump_log_modules = {"query"};
@@ -247,6 +242,30 @@ public class Config extends ConfigBase {
     public static String dump_log_roll_interval = "DAY";
     @ConfField
     public static String dump_log_delete_age = "7d";
+
+    /**
+     * plan_log_roll_num:
+     * Maximal FE plan log files to be kept within a plan_log_roll_interval.
+     * fe.plan.log is written to sys_log_dir (same directory as fe.log).
+     * <p>
+     * plan_log_roll_interval:
+     * DAY:  log suffix is yyyyMMdd
+     * HOUR: log suffix is yyyyMMddHH
+     * <p>
+     * plan_log_delete_age:
+     * default is 7 days, if log's last modify time is 7 days ago, it will be deleted.
+     * support format:
+     * 7d      7 days
+     * 10h     10 hours
+     * 60m     60 mins
+     * 120s    120 seconds
+     */
+    @ConfField
+    public static int plan_log_roll_num = 10;
+    @ConfField
+    public static String plan_log_roll_interval = "DAY";
+    @ConfField
+    public static String plan_log_delete_age = "7d";
 
     /**
      * big_query_log_dir:
@@ -344,12 +363,58 @@ public class Config extends ConfigBase {
     public static int log_cleaner_check_interval_second = 300;
 
     /**
-     * Log the COSTS plan, if the query is cancelled due to a crash of the backend or RpcException.
-     * It is only effective when enable_collect_query_detail_info is set to false, since the plan will be recorded
-     * in the query detail when enable_collect_query_detail_info is true.
+     * @deprecated Use {@code log_plan_on_query_failure} instead.
+     * Previously controlled whether the COSTS plan was written inline to fe.log on RpcException/BE crash.
+     * Plan logging is now unified under log_plan_on_query_failure and written to fe.plan.log.
      */
     @ConfField(mutable = true)
+    @Deprecated
     public static boolean log_plan_cancelled_by_crash_be = true;
+
+    /**
+     * When enabled, the COSTS plan of failed queries will be written to fe.plan.log.
+     * Which failure types are logged is controlled by {@code plan_log_failure_types}.
+     */
+    @ConfField(mutable = true)
+    public static boolean log_plan_on_query_failure = true;
+
+    /**
+     * When enabled, a full query dump (JSON with table metadata, statistics, plan, etc.)
+     * of failed queries will be written to fe.dump.log for offline replay and diagnosis.
+     * Which failure types trigger the dump is controlled by {@code plan_log_failure_types}.
+     * Note: enabling this causes DumpInfo to be collected for every query, which adds overhead.
+     * Default is false. Enable only when diagnosing persistent query failures.
+     */
+    @ConfField(mutable = true)
+    public static boolean dump_query_on_failure = false;
+
+    /**
+     * Comma-separated list of query failure types that trigger plan logging to fe.plan.log.
+     * Only effective when {@code log_plan_on_query_failure} is true.
+     * Valid values (from QueryState.ErrType):
+     *   ANALYSIS_ERR  - SQL analysis / semantic errors (usually user mistakes, low diagnostic value)
+     *   BLACKLISTED   - query rejected by SQL blacklist
+     *   IGNORE_ERR    - silently ignored errors (e.g. KILL statement)
+     *   INTERNAL_ERR  - internal errors, BE crashes, RPC failures
+     *   IO_ERR        - client connection lost
+     *   EXEC_TIME_OUT - query execution timeout
+     *   UNKNOWN       - unclassified errors
+     * Default logs only execution-side failures that are worth investigating.
+     */
+    @ConfField(mutable = true)
+    public static String[] plan_log_failure_types = {"INTERNAL_ERR", "UNKNOWN"};
+
+    /**
+     * Error message keywords that trigger plan/dump logging regardless of {@code plan_log_failure_types}.
+     * When the error message of a failed query contains any of the listed substrings (case-insensitive),
+     * the query plan is written to fe.plan.log and (if enabled) a dump is written to fe.dump.log.
+     * This is useful for catching specific known-bad patterns (e.g. "OOM", "deadlock", "tablet not found")
+     * without broadening the failure-type filter.
+     * Empty by default (keyword matching disabled).
+     * Example: plan_log_error_keywords = OOM, tablet not found, deadlock
+     */
+    @ConfField(mutable = true)
+    public static String[] plan_log_error_keywords = {};
 
     /**
      * In high-concurrency scenarios, the logging of register and unregister query ID can become a bottleneck.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -175,6 +175,20 @@ public class Log4jConfig extends XmlConfiguration {
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
+
+            "    <RollingFile name=\"PlanFile\" fileName=\"${plan_log_dir}/fe.plan.log\" filePattern=\"${plan_log_dir}/fe.plan.log.${plan_file_pattern}-%i\">\n" +
+            "      ${syslog_dump_layout}\n" +
+            "      <Policies>\n" +
+            "        <TimeBasedTriggeringPolicy/>\n" +
+            "        <SizeBasedTriggeringPolicy size=\"${plan_roll_maxsize}MB\"/>\n" +
+            "      </Policies>\n" +
+            "      <DefaultRolloverStrategy max=\"${plan_roll_num}\" fileIndex=\"min\">\n" +
+            "        <Delete basePath=\"${plan_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
+            "          <IfFileName glob=\"fe.plan.log.*\" />\n" +
+            "          <IfLastModified age=\"${plan_log_delete_age}\" />\n" +
+            "        </Delete>\n" +
+            "      </DefaultRolloverStrategy>\n" +
+            "    </RollingFile>\n" +
             "  </Appenders>\n";
 
     // Predefined loggers to write log to file
@@ -197,6 +211,9 @@ public class Log4jConfig extends XmlConfiguration {
             "    </Logger>\n" +
             "    <Logger name=\"features\" level=\"INFO\" additivity=\"false\">\n" +
             "      <AppenderRef ref=\"FeaturesFile\"/>\n" +
+            "    </Logger>\n" +
+            "    <Logger name=\"plan\" level=\"INFO\" additivity=\"false\">\n" +
+            "      <AppenderRef ref=\"PlanFile\"/>\n" +
             "    </Logger>\n" +
             "<!--REPLACED BY AUDIT AND VERBOSE MODULE NAMES-->" +
             "  </Loggers>\n" +
@@ -251,8 +268,8 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("audit_file_pattern",
                 getIntervalPattern("audit_log_roll_interval", Config.audit_log_roll_interval));
 
-        // dump log config
-        properties.put("dump_log_dir", Config.dump_log_dir);
+        // dump log config — always co-located with fe.log (sys_log_dir)
+        properties.put("dump_log_dir", Config.sys_log_dir);
         properties.put("dump_roll_maxsize", String.valueOf(Config.log_roll_size_mb));
         properties.put("dump_roll_num", String.valueOf(Config.dump_log_roll_num));
         properties.put("dump_log_delete_age", String.valueOf(Config.dump_log_delete_age));
@@ -290,6 +307,14 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("internal_log_delete_age", String.valueOf(Config.internal_log_delete_age));
         properties.put("internal_file_pattern",
                 getIntervalPattern("big_query_log_roll_interval", Config.internal_log_roll_interval));
+
+        // plan log config — always co-located with fe.log (sys_log_dir)
+        properties.put("plan_log_dir", Config.sys_log_dir);
+        properties.put("plan_roll_maxsize", String.valueOf(Config.log_roll_size_mb));
+        properties.put("plan_roll_num", String.valueOf(Config.plan_log_roll_num));
+        properties.put("plan_log_delete_age", String.valueOf(Config.plan_log_delete_age));
+        properties.put("plan_file_pattern",
+                getIntervalPattern("plan_log_roll_interval", Config.plan_log_roll_interval));
 
         // appender layout
         final String jsonLoggingConfValue = "json";

--- a/fe/fe-core/src/main/java/com/starrocks/common/LogCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/LogCleaner.java
@@ -53,7 +53,8 @@ public class LogCleaner extends FrontendDaemon {
             "fe.big_query.log",
             "fe.profile.log",
             "fe.features.log",
-            "fe.gc.log"
+            "fe.gc.log",
+            "fe.plan.log"
     };
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/LogCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/LogCleaner.java
@@ -78,7 +78,6 @@ public class LogCleaner extends FrontendDaemon {
         uniquePaths.add(Config.sys_log_dir);
         uniquePaths.add(Config.audit_log_dir);
         uniquePaths.add(Config.internal_log_dir);
-        uniquePaths.add(Config.dump_log_dir);
         uniquePaths.add(Config.big_query_log_dir);
         uniquePaths.add(Config.profile_log_dir);
         uniquePaths.add(Config.feature_log_dir);

--- a/fe/fe-core/src/main/java/com/starrocks/common/QueryPlanLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/QueryPlanLog.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class QueryPlanLog {
+    public static final QueryPlanLog QUERY_PLAN = new QueryPlanLog("plan.query");
+    private final Logger logger;
+
+    public QueryPlanLog(String loggerName) {
+        logger = LogManager.getLogger(loggerName);
+    }
+
+    public static QueryPlanLog getQueryPlan() {
+        return QUERY_PLAN;
+    }
+
+    public void log(String message) {
+        logger.info(message);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -19,9 +19,12 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.Pair;
+import com.starrocks.common.QueryDumpLog;
+import com.starrocks.common.QueryPlanLog;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.GlobalDictNotMatchException;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
@@ -33,9 +36,14 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.dump.DumpInfo;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.sql.optimizer.dump.QueryDumper;
 import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TStatusCode;
@@ -43,6 +51,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -65,6 +74,129 @@ public class ExecuteExceptionHandler {
         } else {
             throw e;
         }
+    }
+
+    /**
+     * Writes the COSTS plan to fe.plan.log when {@code log_plan_on_query_failure} is enabled
+     * and the error type is listed in {@code plan_log_failure_types}.
+     * Called from the finally block of {@code StmtExecutor.execute()} after error state is set.
+     * Safe to call when {@code execPlan} is null (e.g. planning itself failed).
+     */
+    public static void logFailedQueryPlan(ExecPlan execPlan, ConnectContext connectContext,
+                                          OriginStatement originStmt) {
+        QueryState state = connectContext.getState();
+        logFailedQueryPlan(execPlan, connectContext, originStmt,
+                state.getErrorMessage(), state.getErrType());
+    }
+
+    /**
+     * Same as above, but accepts explicit {@code errorMsg} and {@code errType}.
+     * Used during retry handling (e.g. RpcException), where the context error state is not yet set.
+     */
+    public static void logFailedQueryPlan(ExecPlan execPlan, ConnectContext connectContext,
+                                          OriginStatement originStmt, String errorMsg,
+                                          QueryState.ErrType errType) {
+        if (!shouldLog(errType, errorMsg)) {
+            return;
+        }
+        // Write COSTS plan to fe.plan.log.
+        // When enable_collect_query_detail_info is set to true, the plan will be recorded in the query
+        // detail, and hence there is no need to log it here.
+        if (Config.log_plan_on_query_failure && execPlan != null && connectContext.getQueryDetail() == null) {
+            try {
+                String sql = originStmt != null ? originStmt.originStmt : "";
+                String queryId = DebugUtil.printId(connectContext.getQueryId());
+                String plan = execPlan.getExplainString(TExplainLevel.COSTS);
+                QueryPlanLog.getQueryPlan().log(String.format(
+                        "Query failed. queryId=%s, errType=%s, error=%s, sql=%s\n%s",
+                        queryId, errType, errorMsg, SqlCredentialRedactor.redact(sql), plan));
+            } catch (Exception e) {
+                LOG.warn("Failed to write plan to fe.plan.log", e);
+            }
+        }
+        // Write query dump to fe.dump.log.
+        // Two cases:
+        //   1. DumpInfo already exists (session var enable_query_dump was set): write the full dump.
+        //   2. DumpInfo is absent: re-plan the SQL with dump mode enabled to generate a full dump
+        //      (FE-side planning only, no BE execution) with zero upfront overhead on normal queries.
+        if (Config.dump_query_on_failure) {
+            try {
+                DumpInfo dumpInfo = connectContext.getDumpInfo();
+                if (dumpInfo == null) {
+                    dumpInfo = buildVirtualDump(connectContext, originStmt, errorMsg, execPlan != null);
+                }
+                if (dumpInfo instanceof QueryDumpInfo) {
+                    String queryId = DebugUtil.printId(connectContext.getQueryId());
+                    QueryDumpLog.getQueryDump().log(QueryDumper.toJson((QueryDumpInfo) dumpInfo, queryId));
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to write query dump to fe.dump.log", e);
+            }
+        }
+    }
+
+    /**
+     * Regenerates a full {@link QueryDumpInfo} by re-planning the failed query with dump mode enabled.
+     * This re-runs only FE-side planning (no BE execution), so table schemas, column statistics,
+     * and optimizer decisions are captured exactly as during the original query.
+     *
+     * <p>Re-planning is only attempted when {@code execPlanSucceeded} is true — i.e. the original
+     * planning succeeded but execution failed. If planning itself failed, re-planning would hit the
+     * same error again, so we skip it and return a minimal dump (SQL + error message only).
+     */
+    private static QueryDumpInfo buildVirtualDump(ConnectContext connectContext,
+                                                  OriginStatement originStmt, String errorMsg,
+                                                  boolean execPlanSucceeded) {
+        String sql = originStmt != null ? originStmt.originStmt : "";
+        QueryDumpInfo dump = new QueryDumpInfo(connectContext);
+        dump.setOriginStmt(sql);
+        dump.addException(errorMsg);
+        if (sql.isEmpty() || !execPlanSucceeded) {
+            // Planning failed originally; skip re-plan to avoid repeating the same error.
+            return dump;
+        }
+        DumpInfo prevDumpInfo = connectContext.getDumpInfo();
+        connectContext.setDumpInfo(dump);
+        try {
+            List<StatementBase> stmts = SqlParser.parse(sql, connectContext.getSessionVariable());
+            int idx = originStmt.idx < stmts.size() ? originStmt.idx : 0;
+            StatementPlanner.plan(stmts.get(idx), connectContext);
+        } catch (Exception e) {
+            LOG.debug("Re-plan for dump failed, dump will be partial", e);
+        } finally {
+            connectContext.setDumpInfo(prevDumpInfo);
+        }
+        return dump;
+    }
+
+    /**
+     * Returns true if the failed query should be logged to fe.plan.log / fe.dump.log.
+     * Triggers when either condition is met (OR logic):
+     * 1. The error type is listed in {@code plan_log_failure_types}.
+     * 2. The error message contains any keyword in {@code plan_log_error_keywords}
+     * (case-insensitive substring match; ignored when the keyword list is empty).
+     *
+     * <p>ANALYSIS_ERR is always excluded — SQL syntax/semantic mistakes are user errors
+     * and should never produce a plan dump, even if a keyword accidentally matches.
+     */
+    private static boolean shouldLog(QueryState.ErrType errType, String errorMsg) {
+        // Hard-exclude user SQL mistakes regardless of any other config.
+        if (errType == QueryState.ErrType.ANALYSIS_ERR) {
+            return false;
+        }
+        if (Arrays.asList(Config.plan_log_failure_types).contains(errType.name())) {
+            return true;
+        }
+        String[] keywords = Config.plan_log_error_keywords;
+        if (keywords.length > 0 && errorMsg != null) {
+            String lower = errorMsg.toLowerCase();
+            for (String kw : keywords) {
+                if (!kw.isEmpty() && lower.contains(kw.toLowerCase())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public static boolean isRetryableStatus(TStatusCode statusCode) {
@@ -134,17 +266,18 @@ public class ExecuteExceptionHandler {
     }
 
     private static void handleRpcException(RpcException e, RetryContext context) throws Exception {
-        // When enable_collect_query_detail_info is set to true, the plan will be recorded in the query detail,
-        // and hence there is no need to log it here.
         ConnectContext connectContext = context.connectContext;
-        if (context.retryTime == 0 && connectContext.getQueryDetail() == null &&
-                Config.log_plan_cancelled_by_crash_be) {
-            LOG.warn(
-                    "Query cancelled by crash of backends or RpcException, [QueryId={}] [SQL={}] [Plan={}]",
+        // Log only on the first attempt to avoid duplicate entries during retries.
+        // The plan is written to fe.plan.log; the inline plan is no longer written to fe.log
+        // to keep it readable. If the query ultimately fails, the finally block in
+        // StmtExecutor will log again with the latest rebuilt plan.
+        if (context.retryTime == 0) {
+            LOG.warn("Query cancelled by crash of backends or RpcException, [QueryId={}] [SQL={}]",
                     DebugUtil.printId(connectContext.getExecutionId()),
                     context.parsedStmt.getOrigStmt() == null ? "" : context.parsedStmt.getOrigStmt().originStmt,
-                    context.execPlan == null ? "" : context.execPlan.getExplainString(TExplainLevel.COSTS),
                     e);
+            logFailedQueryPlan(context.execPlan, connectContext,
+                    context.parsedStmt.getOrigStmt(), e.getMessage(), QueryState.ErrType.INTERNAL_ERR);
         }
         // rebuild the exec plan in case the node is not available any more.
         rebuildExecPlan(e, context);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -344,7 +344,9 @@ public class StmtExecutor {
     private HttpResultSender httpResultSender;
     private PrepareStmtContext prepareStmtContext = null;
     private boolean isInternalStmt = false;
-    
+    // Stores the last generated exec plan, used to dump the plan to fe.plan.log on query failure.
+    private ExecPlan lastExecPlan = null;
+
     // Store table query timeout info for error message
     private String tableQueryTimeoutTableName = null;
     private int tableQueryTimeoutValue = -1;
@@ -774,6 +776,7 @@ public class StmtExecutor {
             logOptimizerTraceOnGenerateExecPlanFailure(e);
             throw e;
         }
+        lastExecPlan = execPlan;
         return execPlan;
     }
 
@@ -985,6 +988,8 @@ public class StmtExecutor {
                             throw e;
                         }
                         ExecuteExceptionHandler.handle(e, retryContext);
+                        // sync lastExecPlan in case rebuildExecPlan produced a new plan
+                        lastExecPlan = retryContext.getExecPlan();
                         if (!context.getMysqlChannel().isSend()) {
                             String originStmt;
                             if (parsedStmt.getOrigStmt() != null) {
@@ -1148,6 +1153,7 @@ public class StmtExecutor {
             // the exception happens when interact with client
             // this exception shows the connection is gone
             context.getState().setError(e.getMessage());
+            context.getState().setErrType(QueryState.ErrType.IO_ERR);
         } catch (LargeInPredicateException e) {
             // Re-throw LargeInPredicateException to trigger a full retry from parser stage
             // The query will be re-parsed and re-executed with enable_large_in_predicate=false
@@ -1172,9 +1178,14 @@ public class StmtExecutor {
             } else if (e instanceof NoAliveBackendException) {
                 context.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
             } else {
-                // TODO: some StarRocksException doesn't belong to analysis error
-                // we should set such error type to internal error
-                context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+                // If planning completed (lastExecPlan != null) the exception is from execution
+                // (e.g. BE CORRUPTION/CANCELLED), not from analysis — classify as INTERNAL_ERR.
+                // Only fall back to ANALYSIS_ERR when planning itself failed (no plan was produced).
+                if (lastExecPlan != null) {
+                    context.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
+                } else {
+                    context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+                }
             }
         } catch (Throwable e) {
             String sql = originStmt != null ? originStmt.originStmt : "";
@@ -1183,8 +1194,11 @@ public class StmtExecutor {
             context.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
         } finally {
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
-            if (context.getState().isError() && coord != null) {
-                coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
+            if (context.getState().isError()) {
+                ExecuteExceptionHandler.logFailedQueryPlan(lastExecPlan, context, originStmt);
+                if (coord != null) {
+                    coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
+                }
             }
 
             if (coord != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumper.java
@@ -41,6 +41,16 @@ public class QueryDumper {
             .registerTypeAdapter(QueryDumpInfo.class, new QueryDumpDeserializer())
             .create();
 
+    /**
+     * Serializes {@code dumpInfo} to JSON using the proper dump serializer and injects {@code queryId}
+     * as a top-level field so log entries can be correlated with other logs.
+     */
+    public static String toJson(QueryDumpInfo dumpInfo, String queryId) {
+        com.google.gson.JsonObject obj = GSON.toJsonTree(dumpInfo, QueryDumpInfo.class).getAsJsonObject();
+        obj.addProperty("query_id", queryId);
+        return obj.toString();
+    }
+
     public static Pair<HttpResponseStatus, String> dumpQuery(String catalogName, String dbName, String query,
                                                              boolean enableMock) {
         ConnectContext context = ConnectContext.get();

--- a/fe/fe-core/src/test/java/com/starrocks/common/LogCleanerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/LogCleanerTest.java
@@ -50,7 +50,6 @@ public class LogCleanerTest {
         Config.sys_log_dir = testLogDir.getAbsolutePath();
         Config.audit_log_dir = testLogDir.getAbsolutePath();
         Config.internal_log_dir = testLogDir.getAbsolutePath();
-        Config.dump_log_dir = testLogDir.getAbsolutePath();
         Config.big_query_log_dir = testLogDir.getAbsolutePath();
         Config.profile_log_dir = testLogDir.getAbsolutePath();
         Config.feature_log_dir = testLogDir.getAbsolutePath();


### PR DESCRIPTION
## Why I'm doing:

When a query fails with an exception, it can be very difficult for users and developers to diagnose why the failure occurred—especially when only a generic error message is returned. Being able to capture the query execution plan at the point of failure helps in:

* Quickly understanding how the query was planned and executed.
* Identifying optimization or semantic issues in the query logic.
* Providing richer debug information for triaging errors in CI, staging or production.
* Reducing turnaround time when reporting issues to maintainers or support.

StarRocks already provides facilities such as query_dump to capture query details (including plan, stack traces, etc.) for debugging purposes.
However, without explicit support for dumping the execution plan when an exception occurs, valuable diagnostic information is lost.

This enhancement aims to address that gap by introducing support to automatically dump the query plan upon query exceptions.

## What I'm doing:

This PR adds the following behaviors:

* Automatically generate a query plan dump when a query hits an exception at runtime.
* Include enough context (plan structure, statistics, error stack) to allow effective post‑mortem analysis.
* Enable easier troubleshooting for complex queries that may fail due to optimizer or execution engine issues.

In concrete terms, this change ensures that instead of only returning a generic exception or error code, the system will also persist the execution plan associated with that query, so users and developers can inspect and diagnose the failure more effectively.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
