### PR TITLE
[Enhancement] Compressing RuntimeProfile Keys Using a Dictionary

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
@@ -1,0 +1,492 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Global static dictionary for profile string keys (counter names and info-string keys).
+ *
+ * <p>Pre-assigns a fixed set of universally-common names to integer IDs
+ * 0..{@link #STATIC_SIZE}-1.  {@link ProfileSerializer} resolves these names
+ * with a single lock-free lookup and never writes them into any per-tree binary
+ * header, shrinking every stored {@code ProfileElement.profileContent}.
+ *
+ * <p>Profile data is kept purely in memory and never persisted; IDs therefore
+ * carry no cross-process or cross-version meaning.
+ */
+public final class ProfileKeyDictionary {
+    // --- top-level profile node names ---
+    public static final String SUMMARY = "Summary";
+    public static final String PLANNER = "Planner";
+
+    // --- Summary info-string keys ---
+    public static final String QUERY_ID = "Query ID";
+    public static final String START_TIME = "Start Time";
+    public static final String END_TIME = "End Time";
+    public static final String TOTAL_TIME = "Total";
+    public static final String RETRY_TIMES = "Retry Times";
+    public static final String QUERY_TYPE = "Query Type";
+    public static final String QUERY_STATE = "Query State";
+    public static final String SQL_STATEMENT = "Sql Statement";
+    public static final String SQL_DIALECT = "Sql Dialect";
+    public static final String USER = "User";
+    public static final String DEFAULT_DB = "Default Db";
+    public static final String VARIABLES = "Variables";
+    public static final String PROFILE_COLLECT_TIME = "Collect Profile Time";
+    public static final String LOAD_TYPE = "Load Type";
+    public static final String WAREHOUSE_CNGROUP = "Warehouse";
+    public static final String STARROCKS_VERSION = "StarRocks Version";
+    public static final String NON_DEFAULT_SESSION_VARIABLES = "NonDefaultSessionVariables";
+    public static final String IS_PROFILE_ASYNC = "IsProfileAsync";
+    public static final String HIT_MATERIALIZED_VIEWS = "HitMaterializedViews";
+
+    // --- Execution info-string keys ---
+    public static final String TOPOLOGY = "Topology";
+
+    // --- FE-added query-level counters ---
+    public static final String BACKEND_NUM = "BackendNum";
+    public static final String INSTANCE_NUM = "InstanceNum";
+    public static final String OPERATOR_TOTAL_TIME = "OperatorTotalTime";
+    public static final String SCAN_TIME = "ScanTime";
+    public static final String NETWORK_TIME = "NetworkTime";
+    public static final String RESULT_DELIVER_TIME = "ResultDeliverTime";
+    public static final String QUERY_ALLOCATED_MEMORY_USAGE = "QueryAllocatedMemoryUsage";
+    public static final String QUERY_DEALLOCATED_MEMORY_USAGE = "QueryDeallocatedMemoryUsage";
+    public static final String QUERY_CUMULATIVE_OPERATOR_TIME = "QueryCumulativeOperatorTime";
+    public static final String QUERY_CUMULATIVE_SCAN_TIME = "QueryCumulativeScanTime";
+    public static final String QUERY_CUMULATIVE_NETWORK_TIME = "QueryCumulativeNetworkTime";
+    public static final String QUERY_PEAK_SCHEDULE_TIME = "QueryPeakScheduleTime";
+    public static final String QUERY_CUMULATIVE_CPU_TIME = "QueryCumulativeCpuTime";
+    public static final String QUERY_PEAK_MEMORY_USAGE_PER_NODE = "QueryPeakMemoryUsagePerNode";
+    public static final String QUERY_SUM_MEMORY_USAGE = "QuerySumMemoryUsage";
+    public static final String QUERY_EXECUTION_WALL_TIME = "QueryExecutionWallTime";
+    public static final String QUERY_SPILL_BYTES = "QuerySpillBytes";
+    public static final String FRONTEND_PROFILE_MERGE_TIME = "FrontendProfileMergeTime";
+
+    // --- common pipeline / scheduler counters (from BE Thrift) ---
+    public static final String SCHEDULE_TIME = "ScheduleTime";
+    public static final String OUTPUT_FULL_TIME = "OutputFullTime";
+    public static final String PENDING_FINISH_TIME = "PendingFinishTime";
+    public static final String CHANNEL_NUM = "ChannelNum";
+
+    // --- CommonMetrics (present in every pipeline operator) ---
+    public static final String OUTPUT_CHUNK_BYTES = "OutputChunkBytes";
+    public static final String PULL_CHUNK_NUM = "PullChunkNum";
+    public static final String PULL_ROW_NUM = "PullRowNum";
+    public static final String PULL_TOTAL_TIME = "PullTotalTime";
+    public static final String PUSH_CHUNK_NUM = "PushChunkNum";
+    public static final String PUSH_ROW_NUM = "PushRowNum";
+    public static final String PUSH_TOTAL_TIME = "PushTotalTime";
+    public static final String RUNTIME_FILTER_NUM = "RuntimeFilterNum";
+    public static final String RUNTIME_IN_FILTER_NUM = "RuntimeInFilterNum";
+    public static final String IS_SUBORDINATE = "IsSubordinate";
+    public static final String IS_FINAL_SINK = "IsFinalSink";
+    public static final String RUNTIME_FILTER_DESC = "RuntimeFilterDesc";
+    public static final String ACTIVE_TIME = "ActiveTime";
+    public static final String BLOCK_BY_INPUT_EMPTY = "BlockByInputEmpty";
+    public static final String BLOCK_BY_OUTPUT_FULL = "BlockByOutputFull";
+    public static final String BLOCK_BY_PRECONDITION = "BlockByPrecondition";
+    public static final String DEGREE_OF_PARALLELISM = "DegreeOfParallelism";
+    public static final String TOTAL_DEGREE_OF_PARALLELISM = "TotalDegreeOfParallelism";
+    public static final String DRIVER_TOTAL_TIME = "DriverTotalTime";
+    public static final String IS_GROUP_EXECUTION = "IsGroupExecution";
+    public static final String PEAK_DRIVER_QUEUE_SIZE = "PeakDriverQueueSize";
+    public static final String SCHEDULE_COUNT = "ScheduleCount";
+    public static final String YIELD_BY_LOCAL_WAIT = "YieldByLocalWait";
+    public static final String YIELD_BY_PREEMPT = "YieldByPreempt";
+    public static final String YIELD_BY_TIME_LIMIT = "YieldByTimeLimit";
+    public static final String PENDING_TIME = "PendingTime";
+    public static final String INPUT_EMPTY_TIME = "InputEmptyTime";
+    public static final String FIRST_INPUT_EMPTY_TIME = "FirstInputEmptyTime";
+    public static final String FOLLOWUP_INPUT_EMPTY_TIME = "FollowupInputEmptyTime";
+    public static final String PRECONDITION_BLOCK_TIME = "PreconditionBlockTime";
+    public static final String WAIT_TIME = "WaitTime";
+
+    // --- join operator metrics ---
+    public static final String JOIN_RUNTIME_FILTER_TIME = "JoinRuntimeFilterTime";
+    public static final String JOIN_RUNTIME_FILTER_OUTPUT_ROWS = "JoinRuntimeFilterOutputRows";
+    public static final String JOIN_RUNTIME_FILTER_INPUT_ROWS = "JoinRuntimeFilterInputRows";
+    public static final String JOIN_RUNTIME_FILTER_HASH_TIME = "JoinRuntimeFilterHashTime";
+    public static final String JOIN_RUNTIME_FILTER_EVALUATE = "JoinRuntimeFilterEvaluate";
+    public static final String RUNTIME_FILTER_EVAL_TIME = "RuntimeFilterEvalTime";
+    public static final String RUNTIME_FILTER_INPUT_ROWS = "RuntimeFilterInputRows";
+    public static final String RUNTIME_FILTER_OUTPUT_ROWS = "RuntimeFilterOutputRows";
+    public static final String JOIN_TYPE = "JoinType";
+    public static final String DISTRIBUTION_MODE = "DistributionMode";
+
+    // --- exchange operator metrics ---
+    public static final String BYTES_PASS_THROUGH = "BytesPassThrough";
+    public static final String SERIALIZED_BYTES = "SerializedBytes";
+    public static final String SERIALIZE_CHUNK_TIME = "SerializeChunkTime";
+    public static final String DESERIALIZE_CHUNK_TIME = "DeserializeChunkTime";
+    public static final String NETWORK_BANDWIDTH = "NetworkBandwidth";
+    public static final String RPC_COUNT = "RpcCount";
+    public static final String RPC_AVG_TIME = "RpcAvgTime";
+    public static final String REQUEST_SENT = "RequestSent";
+    public static final String REQUEST_RECEIVED = "RequestReceived";
+    public static final String REQUEST_UNSENT = "RequestUnsent";
+    public static final String RECEIVER_PROCESS_TOTAL_TIME = "ReceiverProcessTotalTime";
+    public static final String SHUFFLE_NUM = "ShuffleNum";
+    public static final String SHUFFLE_HASH_TIME = "ShuffleHashTime";
+    public static final String SHUFFLE_CHUNK_APPEND_TIME = "ShuffleChunkAppendTime";
+    public static final String SHUFFLE_CHUNK_APPEND_COUNTER = "ShuffleChunkAppendCounter";
+    public static final String OVERALL_TIME = "OverallTime";
+    public static final String OVERALL_THROUGHPUT = "OverallThroughput";
+    public static final String WAIT_LOCK_TIME = "WaitLockTime";
+    public static final String PART_TYPE = "PartType";
+    public static final String DEST_ID = "DestID";
+    public static final String DEST_FRAGMENTS = "DestFragments";
+    public static final String PEAK_BUFFER_MEMORY_BYTES = "PeakBufferMemoryBytes";
+    public static final String PASS_THROUGH_BUFFER_PEAK_MEMORY_USAGE = "PassThroughBufferPeakMemoryUsage";
+    public static final String LOCAL_EXCHANGE_PEAK_MEMORY_USAGE = "LocalExchangePeakMemoryUsage";
+
+    // --- scan operator metrics ---
+    public static final String RAW_ROWS_READ = "RawRowsRead";
+    public static final String ROWS_READ = "RowsRead";
+    public static final String READ_PAGES_NUM = "ReadPagesNum";
+    public static final String UNCOMPRESSED_BYTES_READ = "UncompressedBytesRead";
+    public static final String BLOCK_FETCH = "BlockFetch";
+    public static final String BLOCK_FETCH_COUNT = "BlockFetchCount";
+    public static final String BLOCK_SEEK = "BlockSeek";
+    public static final String BLOCK_SEEK_COUNT = "BlockSeekCount";
+    public static final String SEGMENT_READ = "SegmentRead";
+    public static final String DECOMPRESS_T = "DecompressT";
+    public static final String CHUNK_COPY = "ChunkCopy";
+    public static final String PRED_FILTER = "PredFilter";
+    public static final String PRED_FILTER_ROWS = "PredFilterRows";
+    public static final String ZONE_MAP_INDEX_FILTER_ROWS = "ZoneMapIndexFilterRows";
+    public static final String ZONE_MAP_INDEX_FITER = "ZoneMapIndexFiter";
+    public static final String SHORT_KEY_FILTER_ROWS = "ShortKeyFilterRows";
+    public static final String SHORT_KEY_RANGE_NUMBER = "ShortKeyRangeNumber";
+    public static final String BITMAP_INDEX_FILTER_ROWS = "BitmapIndexFilterRows";
+    public static final String BLOOM_FILTER_ROWS = "BloomFilterRows";
+    public static final String VECTOR_INDEX_FILTER_ROWS = "VectorIndexFilterRows";
+    public static final String VECTOR_SEARCH_TIME = "VectorSearchTime";
+    public static final String ROWSETS_READ_COUNT = "RowsetsReadCount";
+    public static final String SEGMENTS_READ_COUNT = "SegmentsReadCount";
+    public static final String TOTAL_COLUMNS_DATA_PAGE_COUNT = "TotalColumnsDataPageCount";
+    public static final String TABLET_COUNT = "TabletCount";
+    public static final String MORSELS_COUNT = "MorselsCount";
+    public static final String PUSHDOWN_PREDICATES = "PushdownPredicates";
+    public static final String NON_PUSHDOWN_PREDICATES = "NonPushdownPredicates";
+    public static final String PUSHDOWN_ACCESS_PATHS = "PushdownAccessPaths";
+    public static final String PREPARE_CHUNK_SOURCE_TIME = "PrepareChunkSourceTime";
+    public static final String SUBMIT_TASK_COUNT = "SubmitTaskCount";
+    public static final String SUBMIT_TASK_TIME = "SubmitTaskTime";
+    public static final String IO_TASK_WAIT_TIME = "IOTaskWaitTime";
+    public static final String PEAK_IO_TASKS = "PeakIOTasks";
+    public static final String PEAK_SCAN_TASK_QUEUE_SIZE = "PeakScanTaskQueueSize";
+    public static final String PEAK_CHUNK_BUFFER_MEMORY_USAGE = "PeakChunkBufferMemoryUsage";
+    public static final String PEAK_CHUNK_BUFFER_SIZE = "PeakChunkBufferSize";
+    public static final String DEL_VEC_FILTER_ROWS = "DelVecFilterRows";
+    public static final String CAPTURE_TABLET_ROWSETS_TIME = "CaptureTabletRowsetsTime";
+
+    // --- aggregation / computation metrics ---
+    public static final String HASH_TABLE_MEMORY_USAGE = "HashTableMemoryUsage";
+    public static final String EXPR_COMPUTE_TIME = "ExprComputeTime";
+    public static final String COMMON_SUB_EXPR_COMPUTE_TIME = "CommonSubExprComputeTime";
+
+    // --- operator type info strings ---
+    public static final String TYPE = "Type";
+
+    // --- fragment-level metrics ---
+    public static final String BACKEND_ADDRESSES = "BackendAddresses";
+    public static final String BACKEND_PROFILE_MERGE_TIME = "BackendProfileMergeTime";
+    public static final String INITIAL_PROCESS_DRIVER_COUNT = "InitialProcessDriverCount";
+    public static final String INITIAL_PROCESS_MEM = "InitialProcessMem";
+    public static final String INSTANCE_ALLOCATED_MEMORY_USAGE = "InstanceAllocatedMemoryUsage";
+    public static final String INSTANCE_DEALLOCATED_MEMORY_USAGE = "InstanceDeallocatedMemoryUsage";
+    public static final String INSTANCE_IDS = "InstanceIds";
+    public static final String INSTANCE_PEAK_MEMORY_USAGE = "InstancePeakMemoryUsage";
+    public static final String JIT_COUNTER = "JITCounter";
+    public static final String JIT_TOTAL_COST_TIME = "JITTotalCostTime";
+    public static final String QUERY_MEMORY_LIMIT = "QueryMemoryLimit";
+
+    /**
+     * All globally-known string keys. Index in this array == static ID used by {@link ProfileSerializer}.
+     */
+    static final String[] STATIC_NAMES = {
+            // --- universally present in every profile node ---
+            RuntimeProfile.ROOT_COUNTER,
+            RuntimeProfile.TOTAL_TIME_COUNTER,
+
+            // --- FE-added query-level counters ---
+            BACKEND_NUM,
+            INSTANCE_NUM,
+            OPERATOR_TOTAL_TIME,
+            SCAN_TIME,
+            NETWORK_TIME,
+            RESULT_DELIVER_TIME,
+            QUERY_ALLOCATED_MEMORY_USAGE,
+            QUERY_DEALLOCATED_MEMORY_USAGE,
+            QUERY_CUMULATIVE_OPERATOR_TIME,
+            QUERY_CUMULATIVE_SCAN_TIME,
+            QUERY_CUMULATIVE_NETWORK_TIME,
+            QUERY_PEAK_SCHEDULE_TIME,
+            QUERY_CUMULATIVE_CPU_TIME,
+            QUERY_PEAK_MEMORY_USAGE_PER_NODE,
+            QUERY_SUM_MEMORY_USAGE,
+            QUERY_EXECUTION_WALL_TIME,
+            QUERY_SPILL_BYTES,
+            FRONTEND_PROFILE_MERGE_TIME,
+
+            // --- common pipeline / scheduler counters ---
+            SCHEDULE_TIME,
+            OUTPUT_FULL_TIME,
+            PENDING_FINISH_TIME,
+            CHANNEL_NUM,
+
+            // --- Summary info-string keys ---
+            QUERY_ID,
+            START_TIME,
+            END_TIME,
+            TOTAL_TIME,
+            RETRY_TIMES,
+            QUERY_TYPE,
+            QUERY_STATE,
+            SQL_STATEMENT,
+            SQL_DIALECT,
+            USER,
+            DEFAULT_DB,
+            VARIABLES,
+            PROFILE_COLLECT_TIME,
+            LOAD_TYPE,
+            WAREHOUSE_CNGROUP,
+            STARROCKS_VERSION,
+            NON_DEFAULT_SESSION_VARIABLES,
+            IS_PROFILE_ASYNC,
+            HIT_MATERIALIZED_VIEWS,
+
+            // --- Execution info-string keys ---
+            TOPOLOGY,
+
+            // --- CommonMetrics (pipeline operator) ---
+            OUTPUT_CHUNK_BYTES,
+            PULL_CHUNK_NUM,
+            PULL_ROW_NUM,
+            PULL_TOTAL_TIME,
+            PUSH_CHUNK_NUM,
+            PUSH_ROW_NUM,
+            PUSH_TOTAL_TIME,
+            RUNTIME_FILTER_NUM,
+            RUNTIME_IN_FILTER_NUM,
+            IS_SUBORDINATE,
+            IS_FINAL_SINK,
+            RUNTIME_FILTER_DESC,
+            ACTIVE_TIME,
+            BLOCK_BY_INPUT_EMPTY,
+            BLOCK_BY_OUTPUT_FULL,
+            BLOCK_BY_PRECONDITION,
+            DEGREE_OF_PARALLELISM,
+            TOTAL_DEGREE_OF_PARALLELISM,
+            DRIVER_TOTAL_TIME,
+            IS_GROUP_EXECUTION,
+            PEAK_DRIVER_QUEUE_SIZE,
+            SCHEDULE_COUNT,
+            YIELD_BY_LOCAL_WAIT,
+            YIELD_BY_PREEMPT,
+            YIELD_BY_TIME_LIMIT,
+            PENDING_TIME,
+            INPUT_EMPTY_TIME,
+            FIRST_INPUT_EMPTY_TIME,
+            FOLLOWUP_INPUT_EMPTY_TIME,
+            PRECONDITION_BLOCK_TIME,
+            WAIT_TIME,
+
+            // --- join operator ---
+            JOIN_RUNTIME_FILTER_TIME,
+            JOIN_RUNTIME_FILTER_OUTPUT_ROWS,
+            JOIN_RUNTIME_FILTER_INPUT_ROWS,
+            JOIN_RUNTIME_FILTER_HASH_TIME,
+            JOIN_RUNTIME_FILTER_EVALUATE,
+            RUNTIME_FILTER_EVAL_TIME,
+            RUNTIME_FILTER_INPUT_ROWS,
+            RUNTIME_FILTER_OUTPUT_ROWS,
+            JOIN_TYPE,
+            DISTRIBUTION_MODE,
+
+            // --- exchange operator ---
+            BYTES_PASS_THROUGH,
+            SERIALIZED_BYTES,
+            SERIALIZE_CHUNK_TIME,
+            DESERIALIZE_CHUNK_TIME,
+            NETWORK_BANDWIDTH,
+            RPC_COUNT,
+            RPC_AVG_TIME,
+            REQUEST_SENT,
+            REQUEST_RECEIVED,
+            REQUEST_UNSENT,
+            RECEIVER_PROCESS_TOTAL_TIME,
+            SHUFFLE_NUM,
+            SHUFFLE_HASH_TIME,
+            SHUFFLE_CHUNK_APPEND_TIME,
+            SHUFFLE_CHUNK_APPEND_COUNTER,
+            OVERALL_TIME,
+            OVERALL_THROUGHPUT,
+            WAIT_LOCK_TIME,
+            PART_TYPE,
+            DEST_ID,
+            DEST_FRAGMENTS,
+            PEAK_BUFFER_MEMORY_BYTES,
+            PASS_THROUGH_BUFFER_PEAK_MEMORY_USAGE,
+            LOCAL_EXCHANGE_PEAK_MEMORY_USAGE,
+
+            // --- scan operator ---
+            RAW_ROWS_READ,
+            ROWS_READ,
+            READ_PAGES_NUM,
+            UNCOMPRESSED_BYTES_READ,
+            BLOCK_FETCH,
+            BLOCK_FETCH_COUNT,
+            BLOCK_SEEK,
+            BLOCK_SEEK_COUNT,
+            SEGMENT_READ,
+            DECOMPRESS_T,
+            CHUNK_COPY,
+            PRED_FILTER,
+            PRED_FILTER_ROWS,
+            ZONE_MAP_INDEX_FILTER_ROWS,
+            ZONE_MAP_INDEX_FITER,
+            SHORT_KEY_FILTER_ROWS,
+            SHORT_KEY_RANGE_NUMBER,
+            BITMAP_INDEX_FILTER_ROWS,
+            BLOOM_FILTER_ROWS,
+            VECTOR_INDEX_FILTER_ROWS,
+            VECTOR_SEARCH_TIME,
+            ROWSETS_READ_COUNT,
+            SEGMENTS_READ_COUNT,
+            TOTAL_COLUMNS_DATA_PAGE_COUNT,
+            TABLET_COUNT,
+            MORSELS_COUNT,
+            PUSHDOWN_PREDICATES,
+            NON_PUSHDOWN_PREDICATES,
+            PUSHDOWN_ACCESS_PATHS,
+            PREPARE_CHUNK_SOURCE_TIME,
+            SUBMIT_TASK_COUNT,
+            SUBMIT_TASK_TIME,
+            IO_TASK_WAIT_TIME,
+            PEAK_IO_TASKS,
+            PEAK_SCAN_TASK_QUEUE_SIZE,
+            PEAK_CHUNK_BUFFER_MEMORY_USAGE,
+            PEAK_CHUNK_BUFFER_SIZE,
+            DEL_VEC_FILTER_ROWS,
+            CAPTURE_TABLET_ROWSETS_TIME,
+
+            // --- aggregation / computation ---
+            HASH_TABLE_MEMORY_USAGE,
+            EXPR_COMPUTE_TIME,
+            COMMON_SUB_EXPR_COMPUTE_TIME,
+
+            // --- operator type info string ---
+            TYPE,
+
+            // --- fragment-level ---
+            BACKEND_ADDRESSES,
+            BACKEND_PROFILE_MERGE_TIME,
+            INITIAL_PROCESS_DRIVER_COUNT,
+            INITIAL_PROCESS_MEM,
+            INSTANCE_ALLOCATED_MEMORY_USAGE,
+            INSTANCE_DEALLOCATED_MEMORY_USAGE,
+            INSTANCE_IDS,
+            INSTANCE_PEAK_MEMORY_USAGE,
+            JIT_COUNTER,
+            JIT_TOTAL_COST_TIME,
+            QUERY_MEMORY_LIMIT,
+    };
+
+    /**
+     * Number of entries in the static dictionary.
+     */
+    static final int STATIC_SIZE = STATIC_NAMES.length;
+
+    /**
+     * Forward lookup for all three static zones (size = 3 × {@link #STATIC_SIZE}):
+     * <pre>
+     *   [0 .. S-1]   base names   (zone 0)
+     *   [S .. 2S-1]  __MIN_OF_... (zone 1)
+     *   [2S .. 3S-1] __MAX_OF_... (zone 2)
+     * </pre>
+     * Use {@code STATIC_ALL.get(id)} to resolve any static-zone nameId to its string.
+     */
+    static final List<String> STATIC_ALL;
+
+    /**
+     * Sentinel returned when a name is not found.
+     * Matches the {@link Object2IntOpenHashMap} default return value.
+     */
+    static final int ABSENT = -1;
+
+    /**
+     * Lock-free reverse map: name → static ID (covers all three zones).
+     * Initialised once at class-load; never mutated afterwards.
+     */
+    private static final Object2IntOpenHashMap<String> STATIC_MAP;
+
+    static {
+        ArrayList<String> all = new ArrayList<>(STATIC_SIZE * 3);
+        Object2IntOpenHashMap<String> map = new Object2IntOpenHashMap<>(STATIC_SIZE * 6);
+        map.defaultReturnValue(ABSENT);
+        // Zone 0: base names
+        for (int i = 0; i < STATIC_SIZE; i++) {
+            all.add(STATIC_NAMES[i]);
+            map.put(STATIC_NAMES[i], i);
+        }
+        // Zone 1: __MIN_OF_ prefixed
+        for (int i = 0; i < STATIC_SIZE; i++) {
+            String minName = RuntimeProfile.MERGED_INFO_PREFIX_MIN + STATIC_NAMES[i];
+            all.add(minName);
+            map.put(minName, STATIC_SIZE + i);
+        }
+        // Zone 2: __MAX_OF_ prefixed
+        for (int i = 0; i < STATIC_SIZE; i++) {
+            String maxName = RuntimeProfile.MERGED_INFO_PREFIX_MAX + STATIC_NAMES[i];
+            all.add(maxName);
+            map.put(maxName, 2 * STATIC_SIZE + i);
+        }
+        STATIC_ALL = Collections.unmodifiableList(all);
+        STATIC_MAP = map;
+    }
+
+    // -- public API -----------------------------------------------------------
+
+    /**
+     * Returns the static ID for {@code name}, or {@link #ABSENT} if the name
+     * is not in the dictionary.
+     *
+     * <p>Lock-free; safe on any hot path.</p>
+     */
+    static int staticId(String name) {
+        return STATIC_MAP.getInt(name);
+    }
+
+    /**
+     * Returns the name for static {@code id} (0..{@link #STATIC_SIZE}-1),
+     * or {@code null} if {@code id} is out of range.
+     */
+    static String nameOf(int id) {
+        if (id >= 0 && id < STATIC_SIZE) {
+            return STATIC_NAMES[id];
+        }
+        return null;
+    }
+
+    private ProfileKeyDictionary() {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -55,32 +55,32 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 /*
- * if you want to visit the atrribute(such as queryID,defaultDb)
+ * if you want to visit the attribute(such as queryID,defaultDb)
  * you can use profile.getInfoStrings("queryId")
  * All attributes can be seen from the above.
  *
- * why the element in the finished profile arary is not RuntimeProfile,
+ * why the element in the finished profile is not RuntimeProfile,
  * the purpose is let coordinator can destruct earlier(the fragment profile is in Coordinator)
  *
  */
 public class ProfileManager implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(ProfileManager.class);
     private static ProfileManager INSTANCE = null;
-    public static final String QUERY_ID = "Query ID";
-    public static final String START_TIME = "Start Time";
-    public static final String END_TIME = "End Time";
-    public static final String TOTAL_TIME = "Total";
-    public static final String RETRY_TIMES = "Retry Times";
-    public static final String QUERY_TYPE = "Query Type";
-    public static final String QUERY_STATE = "Query State";
-    public static final String SQL_STATEMENT = "Sql Statement";
-    public static final String SQL_DIALECT = "Sql Dialect";
-    public static final String USER = "User";
-    public static final String DEFAULT_DB = "Default Db";
-    public static final String VARIABLES = "Variables";
-    public static final String PROFILE_COLLECT_TIME = "Collect Profile Time";
-    public static final String LOAD_TYPE = "Load Type";
-    public static final String WAREHOUSE_CNGROUP = "Warehouse";
+    public static final String QUERY_ID             = ProfileKeyDictionary.QUERY_ID;
+    public static final String START_TIME           = ProfileKeyDictionary.START_TIME;
+    public static final String END_TIME             = ProfileKeyDictionary.END_TIME;
+    public static final String TOTAL_TIME           = ProfileKeyDictionary.TOTAL_TIME;
+    public static final String RETRY_TIMES          = ProfileKeyDictionary.RETRY_TIMES;
+    public static final String QUERY_TYPE           = ProfileKeyDictionary.QUERY_TYPE;
+    public static final String QUERY_STATE          = ProfileKeyDictionary.QUERY_STATE;
+    public static final String SQL_STATEMENT        = ProfileKeyDictionary.SQL_STATEMENT;
+    public static final String SQL_DIALECT          = ProfileKeyDictionary.SQL_DIALECT;
+    public static final String USER                 = ProfileKeyDictionary.USER;
+    public static final String DEFAULT_DB           = ProfileKeyDictionary.DEFAULT_DB;
+    public static final String VARIABLES            = ProfileKeyDictionary.VARIABLES;
+    public static final String PROFILE_COLLECT_TIME = ProfileKeyDictionary.PROFILE_COLLECT_TIME;
+    public static final String LOAD_TYPE            = ProfileKeyDictionary.LOAD_TYPE;
+    public static final String WAREHOUSE_CNGROUP    = ProfileKeyDictionary.WAREHOUSE_CNGROUP;
 
     public static final String LOAD_TYPE_STREAM_LOAD = "STREAM_LOAD";
     public static final String LOAD_TYPE_ROUTINE_LOAD = "ROUTINE_LOAD";
@@ -91,8 +91,47 @@ public class ProfileManager implements MemoryTrackable {
 
     public static class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();
-        public byte[] profileContent;
+        private byte[] profileContent;
         public ProfilingExecPlan plan;
+
+        void setProfileContent(byte[] content) {
+            this.profileContent = content;
+        }
+
+        /**
+         * Deserialises the stored binary and returns a {@link RuntimeProfile}
+         * for programmatic analysis (e.g. via {@code ExplainAnalyzer}).
+         */
+        public RuntimeProfile getRuntimeProfile() {
+            if (profileContent == null) {
+                return null;
+            }
+            try {
+                return ProfileSerializer.deserialize(profileContent);
+            } catch (IOException e) {
+                LOG.warn("Failed to deserialize profile: {}", e.getMessage());
+                return null;
+            }
+        }
+
+        /**
+         * Returns the profile formatted as a string according to
+         * {@link Config#profile_info_format}.
+         */
+        public String getProfileString() {
+            RuntimeProfile profile = getRuntimeProfile();
+            return profile != null ? format(profile) : null;
+        }
+
+        /** Formats {@code profile} per the current {@link Config#profile_info_format}. */
+        static String format(RuntimeProfile profile) {
+            switch (Config.profile_info_format) {
+                case "json":
+                    return new RuntimeProfile.JsonProfileFormatter().format(profile, "");
+                default:
+                    return profile.toString();
+            }
+        }
 
         public List<String> toRow() {
             List<String> res = Lists.newArrayList();
@@ -100,7 +139,7 @@ public class ProfileManager implements MemoryTrackable {
             res.add(infoStrings.get(START_TIME));
             res.add(infoStrings.get(TOTAL_TIME));
             res.add(infoStrings.get(QUERY_STATE));
-            String statement = infoStrings.get(SQL_STATEMENT);
+            String statement = infoStrings.getOrDefault(SQL_STATEMENT, "");
             if (statement.length() > 128) {
                 statement = statement.substring(0, 124) + " ...";
             }
@@ -129,48 +168,36 @@ public class ProfileManager implements MemoryTrackable {
         profileMap = new LinkedHashMap<>();
     }
 
-    public ProfileElement createElement(RuntimeProfile summaryProfile, String profileString) {
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@link ProfileElement} by serialising {@code fullProfile} to the
+     * compact binary format (see {@link ProfileSerializer}).
+     * Summary metadata is extracted from {@code summaryProfile}.
+     */
+    public ProfileElement createElement(RuntimeProfile summaryProfile,
+                                        RuntimeProfile fullProfile) {
         ProfileElement element = new ProfileElement();
         for (String header : PROFILE_HEADERS) {
             element.infoStrings.put(header, summaryProfile.getInfoString(header));
         }
         try {
-            element.profileContent = CompressionUtils.gzipCompressString(profileString);
+            element.setProfileContent(ProfileSerializer.serialize(fullProfile));
         } catch (IOException e) {
-            LOG.warn("Compress profile string failed, length: {}, reason: {}",
-                    profileString.length(), e.getMessage());
+            LOG.warn("Failed to serialize profile, reason: {}", e.getMessage());
         }
         return element;
     }
 
-    private String generateProfileString(RuntimeProfile profile) {
-        if (profile == null) {
-            return "";
-        }
-
-        String profileString;
-        switch (Config.profile_info_format) {
-            case "default":
-                profileString = profile.toString();
-                break;
-            case "json":
-                RuntimeProfile.ProfileFormatter formatter = new RuntimeProfile.JsonProfileFormatter();
-                profileString = formatter.format(profile, "");
-                break;
-            default:
-                profileString = profile.toString();
-                LOG.warn("unknown profile format '{}',  use default format instead.", Config.profile_info_format);
-        }
-        return profileString;
-    }
-
     public String pushProfile(ProfilingExecPlan plan, RuntimeProfile profile) {
-        String profileString = generateProfileString(profile);
-        ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
+        // Format eagerly: the caller (e.g. StmtExecutor) needs the string immediately.
+        // The element stores compact binary so in-memory size is proportional to data.
+        String profileString = ProfileElement.format(profile);
+        ProfileElement element = createElement(profile.getChildList().get(0).first, profile);
         element.plan = plan;
         String queryId = element.infoStrings.get(ProfileManager.QUERY_ID);
-        // check when push in, which can ensure every element in the list has QUERY_ID column,
-        // so there is no need to check when remove element from list.
         if (Strings.isNullOrEmpty(queryId)) {
             LOG.warn("the key or value of Map is null, "
                     + "may be forget to insert 'QUERY_ID' column into infoStrings");
@@ -238,23 +265,21 @@ public class ProfileManager implements MemoryTrackable {
         }
     }
 
+    /**
+     * Returns the formatted profile string for {@code queryId}.
+     *
+     * <p>Deserialisation and formatting are performed outside the read lock so
+     * the lock is held only for the map lookup.</p>
+     */
     public String getProfile(String queryId) {
-        ProfileElement element = new ProfileElement();
+        ProfileElement element;
         readLock.lock();
         try {
             element = profileMap.get(queryId);
-            if (element == null) {
-                return null;
-            }
-
-            return CompressionUtils.gzipDecompressString(element.profileContent);
-        } catch (IOException e) {
-            LOG.warn("Decompress profile content failed, length: {}, reason: {}",
-                    element.profileContent.length, e.getMessage());
-            return null;
         } finally {
             readLock.unlock();
         }
+        return element != null ? element.getProfileString() : null;
     }
 
     public ProfileElement getProfileElement(String queryId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileRawCounter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileRawCounter.java
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+/**
+ * Display-only snapshot of a single {@link Counter} entry within a serialised
+ * profile tree.
+ *
+ * <p>Both profile formatters ({@code DefaultProfileFormatter} and
+ * {@code JsonProfileFormatter}) consult exactly two Counter fields:
+ * {@link Counter#getValue()} and {@link Counter#getType()}.  Merge-time fields
+ * (strategy, min/max, display_threshold) are never read during formatting and
+ * are therefore intentionally absent from this record.</p>
+ *
+ * <p>{@code nameId} and {@code parentId} are local dictionary indices assigned
+ * by {@link ProfileSerializer} — they map to counter name strings via the
+ * per-tree dictionary stored in the binary header.</p>
+ *
+ * @param nameId   local dictionary index of this counter's name
+ * @param parentId local dictionary index of the parent counter's name
+ * @param value    counter value ({@link Counter#getValue()})
+ * @param typeVal  TUnit ordinal ({@link com.starrocks.thrift.TUnit#getValue()})
+ */
+record ProfileRawCounter(int nameId, int parentId, long value, int typeVal) {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileRawNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileRawNode.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Raw intermediate representation of a single {@link RuntimeProfile} node
+ * and its subtree, used by {@link ProfileSerializer} during serialisation and
+ * deserialisation.
+ *
+ * <p>Carries exactly what the formatters need to produce a profile string —
+ * no merge-time fields (strategy, min/max, display_threshold) are included.</p>
+ *
+ * <p>Counters are stored in BFS order (parent before child) so that
+ * {@link RuntimeProfile#addCounter} can be called unconditionally during
+ * deserialisation — every parent counter is guaranteed to exist before its
+ * children are inserted.</p>
+ *
+ * @param name        profile node name ({@link RuntimeProfile#getName()})
+ * @param counters    display-only counter snapshots, BFS order
+ * @param infoStrings key-value metadata strings ({@link RuntimeProfile#getInfoStrings()})
+ * @param children    child node snapshots, preserving original order
+ */
+record ProfileRawNode(
+        String name,
+        List<ProfileRawCounter> counters,
+        Map<String, String> infoStrings,
+        List<ProfileRawNode> children) {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileSerializer.java
@@ -1,0 +1,460 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.common.Pair;
+import com.starrocks.thrift.TUnit;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Compact binary serialisation for {@link RuntimeProfile} trees.
+ *
+ * <h3>Why a custom format?</h3>
+ * Profiles are stored purely to produce a formatted display string on demand.
+ * Both formatters ({@code DefaultProfileFormatter}, {@code JsonProfileFormatter})
+ * consult exactly two {@link Counter} fields per counter entry:
+ * <ul>
+ *   <li>{@link Counter#getValue()} — the numeric value</li>
+ *   <li>{@link Counter#getType()} — TUnit, controls how the value is printed</li>
+ * </ul>
+ * Merge-time fields (strategy, min/max, display_threshold) are never read during
+ * formatting and are therefore intentionally omitted from the stored bytes.
+ *
+ * <h3>Dictionary compression</h3>
+ * A six-zone nameId space eliminates repeated string encoding for both base names
+ * and their {@code __MIN_OF_} / {@code __MAX_OF_} prefixed variants:
+ * <pre>
+ *   Zone 0  [0 .. S-1]         static base names
+ *   Zone 1  [S .. 2S-1]        __MIN_OF_ + static base[id - S]
+ *   Zone 2  [2S .. 3S-1]       __MAX_OF_ + static base[id - 2S]
+ *   Zone 3  [3S .. 3S+L-1]     local base names
+ *   Zone 4  [3S+L .. 3S+2L-1]  __MIN_OF_ + local base[id - (3S+L)]
+ *   Zone 5  [3S+2L .. 3S+3L-1] __MAX_OF_ + local base[id - (3S+2L)]
+ * </pre>
+ * where S = {@code GLOBAL_COUNT} and L = {@code LOCAL_COUNT}.
+ * Profile data is never persisted; IDs carry no cross-process meaning.
+ *
+ * <h3>Binary layout</h3>
+ * <pre>
+ * gzip(
+ *   MAGIC        : 4 bytes  — 0x50524F46 ('P','R','O','F')
+ *   VERSION      : 1 byte   — {@link #VERSION}
+ *   GLOBAL_COUNT : 2 bytes  — ProfileKeyDictionary.STATIC_SIZE at write time (= S)
+ *   LOCAL_COUNT  : 4 bytes  — number of local BASE names (= L; MIN/MAX not counted)
+ *   LOCAL_NAMES  : L × string(baseName)
+ *   NODES        : pre-order DFS, each NODE:
+ *                    nodeName    : string
+ *                    counters    : count:4 | COUNTER...
+ *                    infoStrings : count:4 | (nameId:4, string value)...
+ * where string = int(byteLen) + utf8Bytes  (no 65 535-byte limit)
+ *                    children    : count:4 | NODE...
+ *   COUNTER      : 17 bytes fixed
+ *                    nameId   : 4 bytes  (zone as above)
+ *                    parentId : 4 bytes
+ *                    value    : 8 bytes
+ *                    typeVal  : 1 byte   (TUnit ordinal)
+ * )
+ *
+ * <p>All variable-length strings (node names, local base names, info-string values)
+ * are encoded as {@code writeInt(byteLen) + write(utf8Bytes)} rather than
+ * {@link java.io.DataOutputStream#writeUTF writeUTF}, which is limited to 65 535
+ * bytes and throws {@link java.io.UTFDataFormatException} for long SQL text or
+ * serialised session-variable blobs.</p>
+ * </pre>
+ */
+final class ProfileSerializer {
+
+    private static final int MAGIC = 0x50524F46;  // 'P','R','O','F'
+    static final byte VERSION = 6;
+
+    // -- public API -----------------------------------------------------------
+
+    /**
+     * Serialises {@code profile} to the compact binary format.
+     *
+     * <p>A two-pass approach is used: the first pass collects all local base
+     * names (prefixes stripped); the second pass encodes each name to its
+     * six-zone nameId.</p>
+     */
+    static byte[] serialize(RuntimeProfile profile) throws IOException {
+        // Pass 1: collect local base names in encounter order.
+        LinkedHashSet<String> localBaseSet = new LinkedHashSet<>();
+        collectLocalBaseNames(profile, localBaseSet);
+
+        // Build index: baseName → position (0-based within local base zone).
+        LinkedHashMap<String, Integer> localBaseIdx = new LinkedHashMap<>(localBaseSet.size() * 2);
+        for (String name : localBaseSet) {
+            localBaseIdx.put(name, localBaseIdx.size());
+        }
+        int localCount = localBaseIdx.size();
+
+        // Pass 2: build node tree with fully-resolved nameIds.
+        ProfileRawNode root = buildNode(profile, localBaseIdx, localCount);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
+        try (DataOutputStream dos = new DataOutputStream(new GZIPOutputStream(baos))) {
+            dos.writeInt(MAGIC);
+            dos.writeByte(VERSION);
+            dos.writeShort(ProfileKeyDictionary.STATIC_SIZE); // GLOBAL_COUNT = S
+            dos.writeInt(localCount);                          // LOCAL_COUNT
+            for (String baseName : localBaseSet) {
+                writeString(dos, baseName);
+            }
+            writeNode(dos, root, localBaseIdx, localCount);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Deserialises bytes produced by {@link #serialize} back into a
+     * display-ready {@link RuntimeProfile}.
+     *
+     * <p>{@link RuntimeProfile#computeTimeInProfile()} is called on the root
+     * after reconstruction so that {@code localTimePercent} values are correct.</p>
+     */
+    static RuntimeProfile deserialize(byte[] data) throws IOException {
+        try (DataInputStream dis = new DataInputStream(
+                new GZIPInputStream(new ByteArrayInputStream(data)))) {
+            int magic = dis.readInt();
+            if (magic != MAGIC) {
+                throw new IOException("Invalid profile magic: 0x" + Integer.toHexString(magic));
+            }
+            int version = dis.readByte() & 0xFF;
+            if (version != VERSION) {
+                throw new IOException("Unsupported profile version: " + version);
+            }
+
+            int staticCount = dis.readShort() & 0xFFFF;
+            if (staticCount > ProfileKeyDictionary.STATIC_SIZE) {
+                throw new IOException(
+                        "Profile was written with a newer global dictionary (globalCount=" + staticCount
+                                + ", known=" + ProfileKeyDictionary.STATIC_SIZE + ")");
+            }
+
+            int localCount = dis.readInt();
+
+            String[] localBaseNames = new String[localCount];
+            for (int i = 0; i < localCount; i++) {
+                localBaseNames[i] = readString(dis);
+            }
+
+            RuntimeProfile root = toProfile(
+                    readNode(dis, staticCount, localCount, localBaseNames),
+                    staticCount, localCount, localBaseNames);
+            root.computeTimeInProfile();
+            return root;
+        }
+    }
+
+    // -- write path -----------------------------------------------------------
+
+    /**
+     * Pass 1 — collects every local base name reachable from {@code profile}.
+     *
+     * <p>If a name has a {@code __MIN_OF_} or {@code __MAX_OF_} prefix whose
+     * base is not in the static dictionary, the base (not the prefixed form) is
+     * added.  This ensures MIN/MAX variants share the same base slot in the local
+     * zone and do not consume extra {@code LOCAL_NAMES} entries.</p>
+     */
+    private static void collectLocalBaseNames(RuntimeProfile profile,
+                                              LinkedHashSet<String> out) {
+        for (String name : profile.getCounterMap().keySet()) {
+            collectLocalBaseName(name, out);
+        }
+        Map<String, String> infoStrings = profile.getInfoStrings();
+        synchronized (infoStrings) {
+            for (String key : infoStrings.keySet()) {
+                collectLocalBaseName(key, out);
+            }
+        }
+        for (Pair<RuntimeProfile, Boolean> child : profile.getChildList()) {
+            collectLocalBaseNames(child.first, out);
+        }
+    }
+
+    private static void collectLocalBaseName(String name, LinkedHashSet<String> out) {
+        if (ProfileKeyDictionary.staticId(name) != ProfileKeyDictionary.ABSENT) {
+            return;  // static — no local entry needed
+        }
+        String base = stripPrefix(name);
+        if (ProfileKeyDictionary.staticId(base) != ProfileKeyDictionary.ABSENT) {
+            return;  // prefixed-static — handled by zones 1/2
+        }
+        out.add(base);
+    }
+
+    /**
+     * Strips a single {@code __MIN_OF_} or {@code __MAX_OF_} prefix if present;
+     * returns the name unchanged otherwise.
+     */
+    private static String stripPrefix(String name) {
+        if (name.startsWith(RuntimeProfile.MERGED_INFO_PREFIX_MIN)) {
+            return name.substring(RuntimeProfile.MERGED_INFO_PREFIX_MIN.length());
+        }
+        if (name.startsWith(RuntimeProfile.MERGED_INFO_PREFIX_MAX)) {
+            return name.substring(RuntimeProfile.MERGED_INFO_PREFIX_MAX.length());
+        }
+        return name;
+    }
+
+    /**
+     * Pass 2 — resolves a string key to its six-zone nameId.
+     *
+     * <p>Zones 0–2 (static base, MIN, MAX) are resolved with a single lookup
+     * into {@link ProfileKeyDictionary#STATIC_MAP} which was pre-populated with
+     * all three variants at class-load time.  Only local keys require prefix
+     * stripping.</p>
+     *
+     * @param localBaseIdx position of each local base name (0-based within zone 3)
+     * @param localCount   total number of local base names
+     */
+    private static int nameId(String name,
+                              LinkedHashMap<String, Integer> localBaseIdx,
+                              int localCount) {
+        final int staticCount = ProfileKeyDictionary.STATIC_SIZE;
+
+        // Zones 0, 1, 2: base and prefixed static names (all in STATIC_MAP).
+        int id = ProfileKeyDictionary.staticId(name);
+        if (id != ProfileKeyDictionary.ABSENT) {
+            return id;
+        }
+
+        // Zones 4, 5: prefixed local names — strip prefix to find base slot.
+        if (name.startsWith(RuntimeProfile.MERGED_INFO_PREFIX_MIN)) {
+            Integer localPos = localBaseIdx.get(
+                    name.substring(RuntimeProfile.MERGED_INFO_PREFIX_MIN.length()));
+            if (localPos != null) {
+                return 3 * staticCount + localCount + localPos;  // zone 4
+            }
+        } else if (name.startsWith(RuntimeProfile.MERGED_INFO_PREFIX_MAX)) {
+            Integer localPos = localBaseIdx.get(
+                    name.substring(RuntimeProfile.MERGED_INFO_PREFIX_MAX.length()));
+            if (localPos != null) {
+                return 3 * staticCount + 2 * localCount + localPos;  // zone 5
+            }
+        }
+
+        // Zone 3: local base name.
+        Integer localPos = localBaseIdx.get(name);
+        if (localPos != null) {
+            return 3 * staticCount + localPos;
+        }
+
+        // Should not happen if pass 1 was complete; fall back to zone 3.
+        int pos = localBaseIdx.size();
+        localBaseIdx.put(name, pos);
+        return 3 * staticCount + pos;
+    }
+
+    /**
+     * Resolves a nameId back to its string, using the six-zone layout.
+     * Zones 0–2 reference the pre-built static arrays; zones 3–5 use
+     * {@code localBaseNames} with arithmetic.
+     */
+    private static String resolveId(int id, int staticCount, int localCount, String[] localBaseNames) {
+        if (id < 3 * staticCount) {
+            return ProfileKeyDictionary.STATIC_ALL.get(id);
+        }
+        int local = id - 3 * staticCount;
+        if (local < localCount) {
+            return localBaseNames[local];
+        }
+        if (local < 2 * localCount) {
+            return RuntimeProfile.MERGED_INFO_PREFIX_MIN + localBaseNames[local - localCount];
+        }
+        return RuntimeProfile.MERGED_INFO_PREFIX_MAX + localBaseNames[local - 2 * localCount];
+    }
+
+    /**
+     * Pass 2 — builds a {@link ProfileRawNode} tree with nameIds fully resolved.
+     *
+     * <p>Counters are emitted in BFS order (parent before child) so that
+     * {@link RuntimeProfile#addCounter} can be called unconditionally on the
+     * read path.</p>
+     */
+    private static ProfileRawNode buildNode(RuntimeProfile profile,
+                                            LinkedHashMap<String, Integer> localBaseIdx,
+                                            int localCount) {
+        List<ProfileRawCounter> counters = new ArrayList<>(profile.getCounterMap().size());
+        Map<String, Set<String>> childCounterMap = profile.getChildCounterMap();
+
+        Queue<String> queue = new ArrayDeque<>();
+        queue.add(RuntimeProfile.ROOT_COUNTER);
+
+        Counter totalTime = profile.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER);
+        if (totalTime != null) {
+            int ttId = nameId(RuntimeProfile.TOTAL_TIME_COUNTER, localBaseIdx, localCount);
+            counters.add(new ProfileRawCounter(ttId,
+                    nameId(RuntimeProfile.ROOT_COUNTER, localBaseIdx, localCount),
+                    totalTime.getValue(), totalTime.getType().getValue()));
+            queue.add(RuntimeProfile.TOTAL_TIME_COUNTER);
+        }
+
+        while (!queue.isEmpty()) {
+            String parentName = queue.poll();
+            Set<String> childNames = childCounterMap.get(parentName);
+            if (childNames == null) {
+                continue;
+            }
+            int parentId = nameId(parentName, localBaseIdx, localCount);
+            for (String childName : childNames) {
+                Pair<Counter, String> pair = profile.getCounterPair(childName);
+                if (pair == null) {
+                    continue;
+                }
+                int childId = nameId(childName, localBaseIdx, localCount);
+                counters.add(new ProfileRawCounter(childId, parentId,
+                        pair.first.getValue(), pair.first.getType().getValue()));
+                queue.add(childName);
+            }
+        }
+
+        Map<String, String> info = new LinkedHashMap<>();
+        Map<String, String> src = profile.getInfoStrings();
+        synchronized (src) {
+            info.putAll(src);
+        }
+
+        List<ProfileRawNode> children = new ArrayList<>(profile.getChildList().size());
+        for (Pair<RuntimeProfile, Boolean> child : profile.getChildList()) {
+            children.add(buildNode(child.first, localBaseIdx, localCount));
+        }
+        return new ProfileRawNode(profile.getName(), counters, info, children);
+    }
+
+    private static void writeNode(DataOutputStream dos, ProfileRawNode node,
+                                  LinkedHashMap<String, Integer> localBaseIdx,
+                                  int localCount) throws IOException {
+        writeString(dos, node.name() != null ? node.name() : "");
+
+        dos.writeInt(node.counters().size());
+        for (ProfileRawCounter c : node.counters()) {
+            dos.writeInt(c.nameId());
+            dos.writeInt(c.parentId());
+            dos.writeLong(c.value());
+            dos.writeByte(c.typeVal());
+        }
+
+        dos.writeInt(node.infoStrings().size());
+        for (Map.Entry<String, String> e : node.infoStrings().entrySet()) {
+            dos.writeInt(nameId(e.getKey(), localBaseIdx, localCount));
+            writeString(dos, e.getValue());
+        }
+
+        dos.writeInt(node.children().size());
+        for (ProfileRawNode child : node.children()) {
+            writeNode(dos, child, localBaseIdx, localCount);
+        }
+    }
+
+    // -- read path ------------------------------------------------------------
+
+    private static ProfileRawNode readNode(DataInputStream dis,
+                                           int staticCount, int localCount,
+                                           String[] localBaseNames) throws IOException {
+        String name = readString(dis);
+
+        int counterCount = dis.readInt();
+        List<ProfileRawCounter> counters = new ArrayList<>(counterCount);
+        for (int i = 0; i < counterCount; i++) {
+            counters.add(new ProfileRawCounter(
+                    dis.readInt(), dis.readInt(), dis.readLong(), dis.readByte() & 0xFF));
+        }
+
+        int infoCount = dis.readInt();
+        Map<String, String> info = new LinkedHashMap<>(infoCount * 2);
+        for (int i = 0; i < infoCount; i++) {
+            info.put(resolveId(dis.readInt(), staticCount, localCount, localBaseNames), readString(dis));
+        }
+
+        int childCount = dis.readInt();
+        List<ProfileRawNode> children = new ArrayList<>(childCount);
+        for (int i = 0; i < childCount; i++) {
+            children.add(readNode(dis, staticCount, localCount, localBaseNames));
+        }
+        return new ProfileRawNode(name, counters, info, children);
+    }
+
+    /**
+     * Reconstructs a {@link RuntimeProfile} from a {@link ProfileRawNode}.
+     *
+     * <p>Counters are added in BFS order, so every parent exists before its
+     * children are inserted — satisfying {@link RuntimeProfile#addCounter}'s
+     * precondition without any extra check.</p>
+     */
+    private static RuntimeProfile toProfile(ProfileRawNode node,
+                                            int staticCount, int localCount,
+                                            String[] localBaseNames) {
+        RuntimeProfile profile = new RuntimeProfile(node.name());
+        for (ProfileRawCounter c : node.counters()) {
+            String name = resolveId(c.nameId(), staticCount, localCount, localBaseNames);
+            String parentName = resolveId(c.parentId(), staticCount, localCount, localBaseNames);
+            TUnit type = TUnit.findByValue(c.typeVal());
+            Counter counter = profile.addCounter(name, type, null, parentName);
+            counter.setValue(c.value());
+        }
+        for (Map.Entry<String, String> e : node.infoStrings().entrySet()) {
+            profile.addInfoString(e.getKey(), e.getValue());
+        }
+        for (ProfileRawNode child : node.children()) {
+            profile.addChild(toProfile(child, staticCount, localCount, localBaseNames));
+        }
+        return profile;
+    }
+
+    // -- string I/O helpers ---------------------------------------------------
+
+    /**
+     * Writes a UTF-8 string as {@code int byteLen + raw bytes}.
+     *
+     * <p>Unlike {@link DataOutputStream#writeUTF}, this encoding has no
+     * 65 535-byte limit and is therefore safe for long SQL text or serialised
+     * session-variable blobs.</p>
+     */
+    private static void writeString(DataOutputStream dos, String s) throws IOException {
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(bytes.length);
+        dos.write(bytes);
+    }
+
+    /**
+     * Reads a string previously written by {@link #writeString}.
+     */
+    private static String readString(DataInputStream dis) throws IOException {
+        int len = dis.readInt();
+        byte[] bytes = new byte[len];
+        dis.readFully(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private ProfileSerializer() {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
@@ -36,9 +36,7 @@ package com.starrocks.http.action;
 
 import com.github.vertical_blank.sqlformatter.SqlFormatter;
 import com.google.common.base.Strings;
-import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ProfileManager;
-import com.starrocks.common.util.RuntimeProfileParser;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -129,8 +127,8 @@ public class QueryProfileAction extends WebBaseAction {
     private String getAnalyzeProfileResult(ProfileManager.ProfileElement queryProfile) {
         String analysis;
         try {
-            analysis = ExplainAnalyzer.analyze(queryProfile.plan, RuntimeProfileParser.parseFrom(
-                    CompressionUtils.gzipDecompressString(queryProfile.profileContent)), Collections.emptyList(), false);
+            analysis = ExplainAnalyzer.analyze(queryProfile.plan,
+                    queryProfile.getRuntimeProfile(), Collections.emptyList(), false);
             analysis = analysis.replaceAll(ANSI_REGEX, "");
         } catch (Exception e) {
             String queryId = queryProfile.infoStrings.getOrDefault(ProfileManager.QUERY_ID, "unknown");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
@@ -34,9 +34,7 @@
 
 package com.starrocks.http.rest;
 
-import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ProfileManager;
-import com.starrocks.common.util.RuntimeProfileParser;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -84,8 +82,7 @@ public class QueryProgressAction extends RestBaseAction {
             } else {
                 try {
                     result = ExplainAnalyzer.analyze(profileElement.plan,
-                            RuntimeProfileParser.parseFrom(
-                                    CompressionUtils.gzipDecompressString(profileElement.profileContent)));
+                            profileElement.getRuntimeProfile());
                 } catch (Exception e) {
                     result = "Failed to get query progress, query_id:" + queryId;
                     LOG.warn(result, e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -38,6 +38,7 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.LoadPriority;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
@@ -639,7 +640,7 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
             summaryProfile.addInfoString(ProfileManager.QUERY_STATE, taskState.name());
             summaryProfile.addInfoString("State Message", taskStateMessage);
             summaryProfile.addInfoString(ProfileManager.LOAD_TYPE, LOAD_TYPE_NAME);
-            summaryProfile.addInfoString("StarRocks Version",
+            summaryProfile.addInfoString(ProfileKeyDictionary.STARROCKS_VERSION,
                     String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
             summaryProfile.addInfoString("Default Db", tableRef.getDbName());
             summaryProfile.addInfoString("Table", tableRef.getTableName());
@@ -647,7 +648,7 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
             summaryProfile.addInfoString(ProfileManager.WAREHOUSE_CNGROUP, warehouseName);
             summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
                     DebugUtil.getPrettyStringMs(collectProfileCostMs.get()));
-            summaryProfile.addInfoString("IsProfileAsync", String.valueOf(true));
+            summaryProfile.addInfoString(ProfileKeyDictionary.IS_PROFILE_ASYNC, String.valueOf(true));
             summaryProfile.addInfoString("Pending Time",
                     DebugUtil.getPrettyStringMs(loadTimeTrace.pendingCostMs.get()));
             summaryProfile.addInfoString("Label", label);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -44,6 +44,7 @@ import com.starrocks.common.Version;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
@@ -191,7 +192,7 @@ public class LoadLoadingTask extends LoadTask {
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, isFinished ? "Finished" : "Running");
-        summaryProfile.addInfoString("StarRocks Version",
+        summaryProfile.addInfoString(ProfileKeyDictionary.STARROCKS_VERSION,
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
@@ -227,7 +228,8 @@ public class LoadLoadingTask extends LoadTask {
             sb.deleteCharAt(sb.length() - 1);
             summaryProfile.addInfoString(ProfileManager.VARIABLES, sb.toString());
 
-            summaryProfile.addInfoString("NonDefaultSessionVariables", variables.getNonDefaultVariablesJson());
+            summaryProfile.addInfoString(ProfileKeyDictionary.NON_DEFAULT_SESSION_VARIABLES,
+                    variables.getNonDefaultVariablesJson());
         }
 
         profile.addChild(summaryProfile);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -32,6 +32,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.LoadPriority;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
@@ -1223,7 +1224,7 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
         summaryProfile.addInfoString(ProfileManager.LOAD_TYPE, getStringByType());
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, isAborted ? "Aborted" : "Finished");
-        summaryProfile.addInfoString("StarRocks Version",
+        summaryProfile.addInfoString(ProfileKeyDictionary.STARROCKS_VERSION,
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, getStmt());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -76,12 +76,11 @@ import com.starrocks.common.Version;
 import com.starrocks.common.profile.RawScopedTimer;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
-import com.starrocks.common.util.RuntimeProfileParser;
 import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.common.util.SqlUtils;
 import com.starrocks.common.util.TimeUtils;
@@ -405,7 +404,7 @@ public class StmtExecutor {
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, context.getState().toProfileString());
-        summaryProfile.addInfoString("StarRocks Version",
+        summaryProfile.addInfoString(ProfileKeyDictionary.STARROCKS_VERSION,
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
@@ -449,10 +448,11 @@ public class StmtExecutor {
             sb.deleteCharAt(sb.length() - 1);
             summaryProfile.addInfoString(ProfileManager.VARIABLES, sb.toString());
 
-            summaryProfile.addInfoString("NonDefaultSessionVariables", variables.getNonDefaultVariablesJson());
+            summaryProfile.addInfoString(ProfileKeyDictionary.NON_DEFAULT_SESSION_VARIABLES,
+                    variables.getNonDefaultVariablesJson());
             String hitMvs = context.getAuditEventBuilder().getHitMvs();
             if (StringUtils.isNotEmpty(hitMvs)) {
-                summaryProfile.addInfoString("HitMaterializedViews", hitMvs);
+                summaryProfile.addInfoString(ProfileKeyDictionary.HIT_MATERIALIZED_VIEWS, hitMvs);
             }
         }
 
@@ -1460,7 +1460,7 @@ public class StmtExecutor {
             RuntimeProfile summaryProfile = profile.getChild("Summary");
             summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
                     DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
-            summaryProfile.addInfoString("IsProfileAsync", String.valueOf(isAsync));
+            summaryProfile.addInfoString(ProfileKeyDictionary.IS_PROFILE_ASYNC, String.valueOf(isAsync));
             profile.addChild(coord.buildQueryProfile(needMerge));
 
             // Update TotalTime to include the Profile Collect Time and the time to build the profile.
@@ -2027,7 +2027,7 @@ public class StmtExecutor {
                             "you can set it off by using  set enable_short_circuit=false");
         }
         handleExplainStmt(ExplainAnalyzer.analyze(profileElement.plan,
-                RuntimeProfileParser.parseFrom(CompressionUtils.gzipDecompressString(profileElement.profileContent)),
+                profileElement.getRuntimeProfile(),
                 planNodeIds, context.getSessionVariable().getColorExplainOutput()));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -24,6 +24,7 @@ import com.starrocks.common.Status;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.Counter;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
@@ -446,11 +447,11 @@ public class QueryRuntimeProfile {
                 }
 
                 // Get query level peak memory usage, cpu cost, wall time
-                Counter toBeRemove = instanceProfile.getCounter("QueryCumulativeCpuTime");
+                Counter toBeRemove = instanceProfile.getCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_CPU_TIME);
                 if (toBeRemove != null) {
                     sumQueryCumulativeCpuTime += toBeRemove.getValue();
                 }
-                instanceProfile.removeCounter("QueryCumulativeCpuTime");
+                instanceProfile.removeCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_CPU_TIME);
 
                 toBeRemove = instanceProfile.getCounter("QueryPeakMemoryUsage");
                 if (toBeRemove != null) {
@@ -460,28 +461,28 @@ public class QueryRuntimeProfile {
                 }
                 instanceProfile.removeCounter("QueryPeakMemoryUsage");
 
-                toBeRemove = instanceProfile.getCounter("QueryExecutionWallTime");
+                toBeRemove = instanceProfile.getCounter(ProfileKeyDictionary.QUERY_EXECUTION_WALL_TIME);
                 if (toBeRemove != null) {
                     maxQueryExecutionWallTime = Math.max(maxQueryExecutionWallTime, toBeRemove.getValue());
                 }
-                instanceProfile.removeCounter("QueryExecutionWallTime");
+                instanceProfile.removeCounter(ProfileKeyDictionary.QUERY_EXECUTION_WALL_TIME);
 
-                toBeRemove = instanceProfile.getCounter("QuerySpillBytes");
+                toBeRemove = instanceProfile.getCounter(ProfileKeyDictionary.QUERY_SPILL_BYTES);
                 if (toBeRemove != null) {
                     sumQuerySpillBytes += toBeRemove.getValue();
                 }
-                instanceProfile.removeCounter("QuerySpillBytes");
+                instanceProfile.removeCounter(ProfileKeyDictionary.QUERY_SPILL_BYTES);
             }
             newFragmentProfile.addInfoString("BackendAddresses", String.join(",", backendAddresses));
             newFragmentProfile.addInfoString("InstanceIds", String.join(",", instanceIds));
             if (!missingInstanceIds.isEmpty()) {
                 newFragmentProfile.addInfoString("MissingInstanceIds", String.join(",", missingInstanceIds));
             }
-            Counter backendNum = newFragmentProfile.addCounter("BackendNum", TUnit.UNIT, null);
+            Counter backendNum = newFragmentProfile.addCounter(ProfileKeyDictionary.BACKEND_NUM, TUnit.UNIT, null);
             backendNum.setValue(backendAddresses.size());
 
             // Setup number of instance
-            Counter counter = newFragmentProfile.addCounter("InstanceNum", TUnit.UNIT, null);
+            Counter counter = newFragmentProfile.addCounter(ProfileKeyDictionary.INSTANCE_NUM, TUnit.UNIT, null);
             counter.setValue(instanceProfiles.size());
 
             RuntimeProfile mergedInstanceProfile =
@@ -527,7 +528,7 @@ public class QueryRuntimeProfile {
 
             for (Pair<RuntimeProfile, Boolean> pipelineProfilePair : fragmentProfile.getChildList()) {
                 RuntimeProfile pipelineProfile = pipelineProfilePair.first;
-                Counter scheduleTime = pipelineProfile.getMaxCounter("ScheduleTime");
+                Counter scheduleTime = pipelineProfile.getMaxCounter(ProfileKeyDictionary.SCHEDULE_TIME);
                 if (scheduleTime != null) {
                     maxScheduleTime = Math.max(maxScheduleTime, scheduleTime.getValue());
                 }
@@ -541,30 +542,32 @@ public class QueryRuntimeProfile {
 
                     if (commonMetrics.containsInfoString("IsFinalSink")) {
                         long resultDeliverTime = 0;
-                        Counter outputFullTime = pipelineProfile.getMaxCounter("OutputFullTime");
+                        Counter outputFullTime = pipelineProfile.getMaxCounter(ProfileKeyDictionary.OUTPUT_FULL_TIME);
                         if (outputFullTime != null) {
                             resultDeliverTime += outputFullTime.getValue();
                         }
-                        Counter pendingFinishTime = pipelineProfile.getMaxCounter("PendingFinishTime");
+                        Counter pendingFinishTime =
+                                pipelineProfile.getMaxCounter(ProfileKeyDictionary.PENDING_FINISH_TIME);
                         if (pendingFinishTime != null) {
                             resultDeliverTime += pendingFinishTime.getValue();
                         }
                         Counter resultDeliverTimer =
-                                newQueryProfile.addCounter("ResultDeliverTime", TUnit.TIME_NS, null);
+                                newQueryProfile.addCounter(ProfileKeyDictionary.RESULT_DELIVER_TIME, TUnit.TIME_NS,
+                                        null);
                         resultDeliverTimer.setValue(resultDeliverTime);
                     }
 
-                    Counter operatorTotalTime = commonMetrics.getMaxCounter("OperatorTotalTime");
+                    Counter operatorTotalTime = commonMetrics.getMaxCounter(ProfileKeyDictionary.OPERATOR_TOTAL_TIME);
                     Preconditions.checkNotNull(operatorTotalTime);
                     queryCumulativeOperatorTime += operatorTotalTime.getValue();
 
-                    Counter scanTime = uniqueMetrics.getMaxCounter("ScanTime");
+                    Counter scanTime = uniqueMetrics.getMaxCounter(ProfileKeyDictionary.SCAN_TIME);
                     if (scanTime != null) {
                         queryCumulativeScanTime += scanTime.getValue();
                         queryCumulativeOperatorTime += scanTime.getValue();
                     }
 
-                    Counter networkTime = uniqueMetrics.getMaxCounter("NetworkTime");
+                    Counter networkTime = uniqueMetrics.getMaxCounter(ProfileKeyDictionary.NETWORK_TIME);
                     if (networkTime != null) {
                         queryCumulativeNetworkTime += networkTime.getValue();
                         queryCumulativeOperatorTime += networkTime.getValue();
@@ -573,40 +576,45 @@ public class QueryRuntimeProfile {
             }
         }
         Counter queryAllocatedMemoryUsageCounter =
-                newQueryProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_ALLOCATED_MEMORY_USAGE, TUnit.BYTES, null);
         queryAllocatedMemoryUsageCounter.setValue(queryAllocatedMemoryUsage);
         Counter queryDeallocatedMemoryUsageCounter =
-                newQueryProfile.addCounter("QueryDeallocatedMemoryUsage", TUnit.BYTES, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_DEALLOCATED_MEMORY_USAGE, TUnit.BYTES, null);
         queryDeallocatedMemoryUsageCounter.setValue(queryDeallocatedMemoryUsage);
         Counter queryCumulativeOperatorTimer =
-                newQueryProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_OPERATOR_TIME, TUnit.TIME_NS, null);
         queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);
         Counter queryCumulativeScanTimer =
-                newQueryProfile.addCounter("QueryCumulativeScanTime", TUnit.TIME_NS, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_SCAN_TIME, TUnit.TIME_NS, null);
         queryCumulativeScanTimer.setValue(queryCumulativeScanTime);
         Counter queryCumulativeNetworkTimer =
-                newQueryProfile.addCounter("QueryCumulativeNetworkTime", TUnit.TIME_NS, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_NETWORK_TIME, TUnit.TIME_NS, null);
         queryCumulativeNetworkTimer.setValue(queryCumulativeNetworkTime);
-        Counter queryPeakScheduleTime = newQueryProfile.addCounter("QueryPeakScheduleTime", TUnit.TIME_NS, null);
+        Counter queryPeakScheduleTime =
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_PEAK_SCHEDULE_TIME, TUnit.TIME_NS, null);
         queryPeakScheduleTime.setValue(maxScheduleTime);
         newQueryProfile.getCounterTotalTime().setValue(0);
 
-        Counter queryCumulativeCpuTime = newQueryProfile.addCounter("QueryCumulativeCpuTime", TUnit.TIME_NS, null);
+        Counter queryCumulativeCpuTime =
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_CPU_TIME, TUnit.TIME_NS, null);
         queryCumulativeCpuTime.setValue(sumQueryCumulativeCpuTime);
-        Counter queryPeakMemoryUsage = newQueryProfile.addCounter("QueryPeakMemoryUsagePerNode", TUnit.BYTES, null);
+        Counter queryPeakMemoryUsage =
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_PEAK_MEMORY_USAGE_PER_NODE, TUnit.BYTES, null);
         queryPeakMemoryUsage.setValue(maxQueryPeakMemoryUsage);
-        Counter sumQueryPeakMemoryUsage = newQueryProfile.addCounter("QuerySumMemoryUsage", TUnit.BYTES, null);
+        Counter sumQueryPeakMemoryUsage =
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_SUM_MEMORY_USAGE, TUnit.BYTES, null);
         sumQueryPeakMemoryUsage.setValue(peakMemoryEachBE.values().stream().reduce(0L, Long::sum));
-        Counter queryExecutionWallTime = newQueryProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
+        Counter queryExecutionWallTime =
+                newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_EXECUTION_WALL_TIME, TUnit.TIME_NS, null);
         queryExecutionWallTime.setValue(maxQueryExecutionWallTime);
-        Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
+        Counter querySpillBytes = newQueryProfile.addCounter(ProfileKeyDictionary.QUERY_SPILL_BYTES, TUnit.BYTES, null);
         querySpillBytes.setValue(sumQuerySpillBytes);
 
         if (execPlan != null) {
-            newQueryProfile.addInfoString("Topology", execPlan.getProfilingPlan().toTopologyJson());
+            newQueryProfile.addInfoString(ProfileKeyDictionary.TOPOLOGY, execPlan.getProfilingPlan().toTopologyJson());
         }
         Counter processTimer =
-                newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);
+                newQueryProfile.addCounter(ProfileKeyDictionary.FRONTEND_PROFILE_MERGE_TIME, TUnit.TIME_NS, null);
         processTimer.setValue(System.nanoTime() - start);
 
         Optional<RuntimeProfile> mergedLoadChannelProfile = mergeLoadChannelProfile();
@@ -645,7 +653,7 @@ public class QueryRuntimeProfile {
                 .map(pair -> pair.first)
                 .collect(Collectors.toList());
 
-        Counter counter = mergedProfile.addCounter("ChannelNum", TUnit.UNIT, null);
+        Counter counter = mergedProfile.addCounter(ProfileKeyDictionary.CHANNEL_NUM, TUnit.UNIT, null);
         counter.setValue(channelProfiles.size());
 
         String hosts = channelProfiles.stream()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.Counter;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
@@ -82,7 +83,7 @@ public class ExplainAnalyzer {
 
     private static final Set<String> EXCLUDE_DETAIL_METRIC_NAMES = Sets.newHashSet(
             RuntimeProfile.ROOT_COUNTER, RuntimeProfile.TOTAL_TIME_COUNTER,
-            "NetworkTime", "ScanTime");
+            ProfileKeyDictionary.NETWORK_TIME, ProfileKeyDictionary.SCAN_TIME);
     private static final Set<String> INCLUDE_DETAIL_METRIC_NAMES = Sets.newHashSet(
             "IOTaskWaitTime", "IOTaskExecTime"
     );
@@ -322,7 +323,7 @@ public class ExplainAnalyzer {
                         null, "UniqueMetrics", "PartType");
                 if (TPartitionType.UNPARTITIONED.name().equalsIgnoreCase(partType) &&
                         nodeInfo.fragmentProfile != null) {
-                    Counter instanceNum = nodeInfo.fragmentProfile.getCounter("InstanceNum");
+                    Counter instanceNum = nodeInfo.fragmentProfile.getCounter(ProfileKeyDictionary.INSTANCE_NUM);
                     if (instanceNum != null && instanceNum.getValue() > 0) {
                         nodeInfo.outputRowNums.setValue(nodeInfo.outputRowNums.getValue() / instanceNum.getValue());
                     }
@@ -331,7 +332,7 @@ public class ExplainAnalyzer {
         });
 
         // Setup mv hits
-        String mvContent = summaryProfile.getInfoString("HitMaterializedViews");
+        String mvContent = summaryProfile.getInfoString(ProfileKeyDictionary.HIT_MATERIALIZED_VIEWS);
         if (StringUtils.isNotBlank(mvContent)) {
             HashSet<String> mvs = Sets.newHashSet(mvContent.split(","));
             allNodeInfos.values().forEach(nodeInfo -> {
@@ -345,10 +346,11 @@ public class ExplainAnalyzer {
             });
         }
 
-        cumulativeOperatorTime = executionProfile.getCounter("QueryCumulativeOperatorTime").getValue();
-        cumulativeScanTime = executionProfile.getCounter("QueryCumulativeScanTime");
-        cumulativeNetworkTime = executionProfile.getCounter("QueryCumulativeNetworkTime");
-        scheduleTime = executionProfile.getCounter("QueryPeakScheduleTime");
+        cumulativeOperatorTime =
+                executionProfile.getCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_OPERATOR_TIME).getValue();
+        cumulativeScanTime = executionProfile.getCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_SCAN_TIME);
+        cumulativeNetworkTime = executionProfile.getCounter(ProfileKeyDictionary.QUERY_CUMULATIVE_NETWORK_TIME);
+        scheduleTime = executionProfile.getCounter(ProfileKeyDictionary.QUERY_PEAK_SCHEDULE_TIME);
     }
 
     private void checkIdentical() {
@@ -388,7 +390,7 @@ public class ExplainAnalyzer {
                     "Profile is not identical!!!", getAnsiColor(ANSI_RESET));
         }
         appendSummaryLine("QueryId: ", summaryProfile.getInfoString(ProfileManager.QUERY_ID));
-        appendSummaryLine("Version: ", summaryProfile.getInfoString("StarRocks Version"));
+        appendSummaryLine("Version: ", summaryProfile.getInfoString(ProfileKeyDictionary.STARROCKS_VERSION));
         appendSummaryLine("State: ", summaryProfile.getInfoString(ProfileManager.QUERY_STATE));
         if (isRuntimeProfile) {
             appendSummaryLine("Legend: ", NodeState.INIT.symbol, " for blocked; ", NodeState.RUNNING.symbol,
@@ -400,11 +402,11 @@ public class ExplainAnalyzer {
                 summaryProfile.getInfoString(ProfileManager.TOTAL_TIME) :
                 summaryProfile.getCounter(ProfileManager.TOTAL_TIME));
         pushIndent(GraphElement.LEAF_METRIC_INDENT);
-        Counter executionWallTime = executionProfile.getCounter("QueryExecutionWallTime");
+        Counter executionWallTime = executionProfile.getCounter(ProfileKeyDictionary.QUERY_EXECUTION_WALL_TIME);
         if (executionWallTime == null) {
             executionWallTime = getMaximumPipelineDriverTime();
         }
-        Counter resultDeliverTime = executionProfile.getCounter("ResultDeliverTime");
+        Counter resultDeliverTime = executionProfile.getCounter(ProfileKeyDictionary.RESULT_DELIVER_TIME);
         if (resultDeliverTime == null) {
             resultDeliverTime = new Counter(TUnit.TIME_NS, null, 0);
         }
@@ -426,12 +428,15 @@ public class ExplainAnalyzer {
                             summaryProfile.getInfoString(ProfileManager.PROFILE_COLLECT_TIME) :
                             summaryProfile.getCounter(ProfileManager.PROFILE_COLLECT_TIME));
         }
-        appendSummaryLine("FrontendProfileMergeTime: ", executionProfile.getCounter("FrontendProfileMergeTime"));
+        appendSummaryLine("FrontendProfileMergeTime: ",
+                executionProfile.getCounter(ProfileKeyDictionary.FRONTEND_PROFILE_MERGE_TIME));
         popIndent(); // metric indent
 
         // 3. Memory Usage
-        appendSummaryLine("QueryPeakMemoryUsage: ", executionProfile.getCounter("QueryPeakMemoryUsagePerNode"),
-                ", QueryAllocatedMemoryUsage: ", executionProfile.getCounter("QueryAllocatedMemoryUsage"));
+        appendSummaryLine("QueryPeakMemoryUsage: ",
+                executionProfile.getCounter(ProfileKeyDictionary.QUERY_PEAK_MEMORY_USAGE_PER_NODE),
+                ", QueryAllocatedMemoryUsage: ",
+                executionProfile.getCounter(ProfileKeyDictionary.QUERY_ALLOCATED_MEMORY_USAGE));
 
         // 4. Top Cpu Nodes
         appendCpuTopNodes();
@@ -451,7 +456,7 @@ public class ExplainAnalyzer {
         }
 
         // 7. Non default Variables
-        String sessionVariables = summaryProfile.getInfoString("NonDefaultSessionVariables");
+        String sessionVariables = summaryProfile.getInfoString(ProfileKeyDictionary.NON_DEFAULT_SESSION_VARIABLES);
         Map<String, SessionVariable.NonDefaultValue> variables = Maps.newTreeMap();
         var map = SessionVariable.NonDefaultValue.parseFrom(sessionVariables);
         if (map != null) {
@@ -534,7 +539,7 @@ public class ExplainAnalyzer {
     private void appendFragment(ProfilingExecPlan.ProfilingFragment fragment, RuntimeProfile fragmentProfile) {
         appendDetailLine(fragmentProfile.getName());
         pushIndent(GraphElement.NON_LEAF_METRIC_INDENT);
-        appendDetailLine("BackendNum: ", fragmentProfile.getCounter("BackendNum"));
+        appendDetailLine("BackendNum: ", fragmentProfile.getCounter(ProfileKeyDictionary.BACKEND_NUM));
         appendDetailLine("InstancePeakMemoryUsage: ",
                 fragmentProfile.getCounter("InstancePeakMemoryUsage"),
                 ", InstanceAllocatedMemoryUsage: ", fragmentProfile.getCounter("InstanceAllocatedMemoryUsage"));
@@ -768,9 +773,9 @@ public class ExplainAnalyzer {
     private void appendOperatorUniqueInfo(NodeInfo nodeInfo) {
         if (nodeInfo.element.instanceOf(JoinNode.class)) {
             Counter buildTime = searchMetric(nodeInfo, SearchMode.NATIVE_ONLY, "_JOIN_BUILD (", true,
-                    "CommonMetrics", "OperatorTotalTime");
+                    "CommonMetrics", ProfileKeyDictionary.OPERATOR_TOTAL_TIME);
             Counter probeTime = searchMetric(nodeInfo, SearchMode.NATIVE_ONLY, "_JOIN_PROBE (", true,
-                    "CommonMetrics", "OperatorTotalTime");
+                    "CommonMetrics", ProfileKeyDictionary.OPERATOR_TOTAL_TIME);
             appendDetailLine("BuildTime: ", buildTime);
             appendDetailLine("ProbeTime: ", probeTime);
         } else if (nodeInfo.element.instanceOf(AggregationNode.class)) {
@@ -1528,17 +1533,20 @@ public class ExplainAnalyzer {
 
         public void computeTimeUsage(long cumulativeOperatorTime) {
             totalTime = new Counter(TUnit.TIME_NS, null, 0);
-            cpuTime = sumUpMetric(this, SearchMode.BOTH, true, "CommonMetrics", "OperatorTotalTime");
+            cpuTime =
+                    sumUpMetric(this, SearchMode.BOTH, true, "CommonMetrics", ProfileKeyDictionary.OPERATOR_TOTAL_TIME);
             if (cpuTime != null) {
                 totalTime.update(cpuTime.getValue());
             }
             if (element.instanceOf(ExchangeNode.class)) {
-                networkTime = searchMetric(this, SearchMode.NATIVE_ONLY, null, true, "UniqueMetrics", "NetworkTime");
+                networkTime = searchMetric(this, SearchMode.NATIVE_ONLY, null, true, "UniqueMetrics",
+                        ProfileKeyDictionary.NETWORK_TIME);
                 if (networkTime != null) {
                     totalTime.update(networkTime.getValue());
                 }
             } else if (element.instanceOf(ScanNode.class)) {
-                scanTime = searchMetric(this, SearchMode.NATIVE_ONLY, null, true, "UniqueMetrics", "ScanTime");
+                scanTime = searchMetric(this, SearchMode.NATIVE_ONLY, null, true, "UniqueMetrics",
+                        ProfileKeyDictionary.SCAN_TIME);
                 if (scanTime != null) {
                     totalTime.update(scanTime.getValue());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -41,6 +41,7 @@ import com.starrocks.common.Status;
 import com.starrocks.common.Version;
 import com.starrocks.common.util.BrokerUtil;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
@@ -202,7 +203,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, job.getState().toString());
-        summaryProfile.addInfoString("StarRocks Version",
+        summaryProfile.addInfoString(ProfileKeyDictionary.STARROCKS_VERSION,
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, "xxx");
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, String.valueOf(job.getDbId()));

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileKeyDictionaryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileKeyDictionaryTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ProfileKeyDictionaryTest {
+
+    @Test
+    public void rootAndTotalTimeHaveExpectedIds() {
+        assertEquals(0, ProfileKeyDictionary.staticId(RuntimeProfile.ROOT_COUNTER));
+        assertEquals(1, ProfileKeyDictionary.staticId(RuntimeProfile.TOTAL_TIME_COUNTER));
+    }
+
+    @Test
+    public void unknownNameReturnsAbsent() {
+        assertEquals(ProfileKeyDictionary.ABSENT,
+                ProfileKeyDictionary.staticId("NoSuchCounter_xyz"));
+    }
+
+    @Test
+    public void nameOfRoundTrips() {
+        for (int i = 0; i < ProfileKeyDictionary.STATIC_SIZE; i++) {
+            String name = ProfileKeyDictionary.STATIC_NAMES[i];
+            assertEquals(i, ProfileKeyDictionary.staticId(name),
+                    "staticId mismatch at index " + i);
+            assertEquals(name, ProfileKeyDictionary.nameOf(i),
+                    "nameOf mismatch at index " + i);
+        }
+    }
+
+    @Test
+    public void allStaticIdsAreUnique() {
+        Set<Integer> ids = new HashSet<>();
+        for (String name : ProfileKeyDictionary.STATIC_NAMES) {
+            int id = ProfileKeyDictionary.staticId(name);
+            assertNotEquals(ProfileKeyDictionary.ABSENT, id);
+            ids.add(id);
+        }
+        assertEquals(ProfileKeyDictionary.STATIC_SIZE, ids.size(),
+                "Every static name must have a distinct ID");
+    }
+
+    @Test
+    public void nameOfOutOfRangeReturnsNull() {
+        assertNull(ProfileKeyDictionary.nameOf(-1));
+        assertNull(ProfileKeyDictionary.nameOf(ProfileKeyDictionary.STATIC_SIZE));
+        assertNull(ProfileKeyDictionary.nameOf(Integer.MAX_VALUE));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileSerializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileSerializerTest.java
@@ -1,0 +1,227 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.thrift.TUnit;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link ProfileSerializer}.
+ *
+ * <p>Includes a size-comparison test that measures the serialized footprint of a
+ * representative query profile under two encodings:
+ * <ol>
+ *   <li><b>ProfileSerializer (new)</b> — custom binary format with a global
+ *       static dictionary ({@link ProfileKeyDictionary}) and a per-tree local
+ *       dictionary, wrapped in gzip.</li>
+ *   <li><b>Gzipped text (baseline)</b> — {@link RuntimeProfile#toString()} fed
+ *       through a {@link GZIPOutputStream}; the simplest possible storage
+ *       approach.</li>
+ * </ol>
+ */
+public class ProfileSerializerTest {
+
+    // -------------------------------------------------------------------------
+    // Roundtrip correctness
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void roundTripRestoresProfileNameAndCounterValues() throws IOException {
+        RuntimeProfile root = buildRepresentativeProfile();
+        byte[] bytes = ProfileSerializer.serialize(root);
+
+        RuntimeProfile restored = ProfileSerializer.deserialize(bytes);
+
+        assertNotNull(restored);
+        assertEquals(root.getName(), restored.getName());
+
+        // Root TotalTime counter must survive roundtrip.
+        Counter originalTt = root.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER);
+        Counter restoredTt = restored.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER);
+        assertNotNull(restoredTt, "TotalTime counter must be present after deserialization");
+        assertEquals(originalTt.getValue(), restoredTt.getValue());
+        assertEquals(originalTt.getType(), restoredTt.getType());
+    }
+
+    @Test
+    public void roundTripRestoresInfoStrings() throws IOException {
+        RuntimeProfile root = buildRepresentativeProfile();
+        byte[] bytes = ProfileSerializer.serialize(root);
+
+        RuntimeProfile restored = ProfileSerializer.deserialize(bytes);
+        // Summary child carries the query metadata info strings.
+        RuntimeProfile summary = restored.getChildList().get(0).first;
+
+        assertEquals("query-roundtrip-001", summary.getInfoString(ProfileManager.QUERY_ID));
+        assertEquals("SELECT 1", summary.getInfoString(ProfileManager.SQL_STATEMENT));
+    }
+
+    @Test
+    public void roundTripRestoresAllChildNodes() throws IOException {
+        RuntimeProfile root = buildRepresentativeProfile();
+        int originalDepth = countNodes(root);
+        byte[] bytes = ProfileSerializer.serialize(root);
+
+        RuntimeProfile restored = ProfileSerializer.deserialize(bytes);
+        int restoredDepth = countNodes(restored);
+
+        assertEquals(originalDepth, restoredDepth,
+                "Deserialized tree must have the same number of nodes");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a profile tree that resembles a real two-fragment query, with
+     * repeated counter names across many nodes — the scenario that most benefits
+     * from dictionary compression.
+     *
+     * <p>Tree structure (abbreviated):
+     * <pre>
+     * "" (query root)
+     *   Summary
+     *   Fragment 0
+     *     Instance 0-0
+     *       Pipeline 0  (ExchangeSinkOperator → AggregateBlockingOperator)
+     *       Pipeline 1  (AggregateStreamingOperator → ProjectOperator)
+     *   Fragment 1
+     *     Instance 1-0
+     *       Pipeline 0  (OlapScanOperator → ProjectOperator)
+     *     Instance 1-1
+     *       Pipeline 0  (OlapScanOperator → ProjectOperator)
+     * </pre>
+     */
+    private static RuntimeProfile buildRepresentativeProfile() {
+        RuntimeProfile root = new RuntimeProfile("");
+        root.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER).setValue(1_500_000_000L);
+
+        // --- Summary ---
+        RuntimeProfile summary = new RuntimeProfile("Summary");
+        summary.addInfoString(ProfileManager.QUERY_ID, "query-roundtrip-001");
+        summary.addInfoString(ProfileManager.SQL_STATEMENT, "SELECT 1");
+        summary.addInfoString(ProfileManager.QUERY_STATE, "EOF");
+        summary.addInfoString(ProfileManager.START_TIME, "2024-01-01 00:00:00");
+        summary.addInfoString(ProfileManager.END_TIME, "2024-01-01 00:00:01");
+        summary.addInfoString(ProfileManager.TOTAL_TIME, "1s500ms");
+        summary.addInfoString(ProfileManager.USER, "root");
+        summary.addInfoString(ProfileManager.DEFAULT_DB, "tpch");
+        root.addChild(summary);
+
+        // --- Fragment 0 (aggregation) ---
+        root.addChild(buildFragmentProfile("Fragment 0", 0, new String[] {
+                "ExchangeSinkOperator",
+                "AggregateBlockingOperator",
+                "AggregateStreamingOperator",
+                "ProjectOperator",
+        }, 1));
+
+        // --- Fragment 1 (scan, 2 instances) ---
+        root.addChild(buildFragmentProfile("Fragment 1", 1, new String[] {
+                "OlapScanOperator",
+                "ProjectOperator",
+        }, 2));
+
+        return root;
+    }
+
+    /**
+     * Builds a fragment profile with {@code instanceCount} instances, each
+     * containing one pipeline with {@code operatorNames.length} operators.
+     * Every operator gets the same set of counters, which exercises the
+     * dictionary's ability to deduplicate repeated counter names.
+     */
+    private static RuntimeProfile buildFragmentProfile(
+            String fragmentName, int fragmentIdx,
+            String[] operatorNames, int instanceCount) {
+
+        RuntimeProfile fragment = new RuntimeProfile(fragmentName);
+        fragment.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER).setValue(1_000_000_000L);
+        fragment.addCounter("BackendNum", TUnit.UNIT, null).setValue(instanceCount);
+        fragment.addCounter("InstanceNum", TUnit.UNIT, null).setValue(instanceCount);
+
+        for (int inst = 0; inst < instanceCount; inst++) {
+            RuntimeProfile instance = new RuntimeProfile(
+                    "Instance " + fragmentIdx + "-" + inst);
+            instance.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER)
+                    .setValue(900_000_000L + inst * 10_000_000L);
+            instance.addInfoString("Address", "127.0.0." + (inst + 1) + ":9060");
+            instance.addInfoString("ActiveTime", "900ms");
+
+            RuntimeProfile pipeline = new RuntimeProfile("Pipeline 0");
+            pipeline.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER).setValue(880_000_000L);
+            pipeline.addCounter("ScheduleTime", TUnit.TIME_NS, null).setValue(5_000_000L);
+            pipeline.addCounter("OutputFullTime", TUnit.TIME_NS, null).setValue(1_000_000L);
+            pipeline.addCounter("PendingFinishTime", TUnit.TIME_NS, null).setValue(500_000L);
+
+            for (int opIdx = 0; opIdx < operatorNames.length; opIdx++) {
+                pipeline.addChild(buildOperatorProfile(
+                        operatorNames[opIdx] + " (id=" + (fragmentIdx * 10 + opIdx) + ")",
+                        800_000_000L - opIdx * 50_000_000L));
+            }
+            instance.addChild(pipeline);
+            fragment.addChild(instance);
+        }
+        return fragment;
+    }
+
+    /**
+     * Builds an operator-level profile with a realistic set of counters.
+     * These counter names are identical across all operators, making them
+     * the primary beneficiaries of dictionary compression.
+     */
+    private static RuntimeProfile buildOperatorProfile(String name, long totalTimeNs) {
+        RuntimeProfile op = new RuntimeProfile(name);
+        op.getCounter(RuntimeProfile.TOTAL_TIME_COUNTER).setValue(totalTimeNs);
+
+        op.addCounter("OperatorTotalTime", TUnit.TIME_NS, null).setValue(totalTimeNs - 1_000_000L);
+        op.addCounter("NetworkTime", TUnit.TIME_NS, null).setValue(2_000_000L);
+        op.addCounter("ScanTime", TUnit.TIME_NS, null).setValue(3_000_000L);
+
+        // Child counters under OperatorTotalTime
+        op.addCounter("WaitTime", TUnit.TIME_NS, null, "OperatorTotalTime")
+                .setValue(500_000L);
+        op.addCounter("OutputTime", TUnit.TIME_NS, null, "OperatorTotalTime")
+                .setValue(1_500_000L);
+
+        op.addCounter("RowsProduced", TUnit.UNIT, null).setValue(100_000L);
+        op.addCounter("RowsConsumed", TUnit.UNIT, null).setValue(200_000L);
+        op.addCounter("PeakMemoryBytes", TUnit.BYTES, null).setValue(4 * 1024 * 1024L);
+
+        op.addInfoString("DegreeOfParallelism", "4");
+        op.addInfoString("ColocatedNumber", "1");
+
+        return op;
+    }
+
+    /**
+     * Returns the total number of nodes in the profile tree (inclusive).
+     */
+    private static int countNodes(RuntimeProfile profile) {
+        int count = 1;
+        for (com.starrocks.common.Pair<RuntimeProfile, Boolean> child : profile.getChildList()) {
+            count += countNodes(child.first);
+        }
+        return count;
+    }
+
+}


### PR DESCRIPTION
## Why I'm doing:

To improve both efficiency and consistency of runtime profiling, this PR introduces a mechanism to compress repetitive profile keys using a dictionary encoding scheme, reducing overhead while preserving full profile semantics.

## What I'm doing:

Introducing a dictionary compression layer for profile keys — common key strings are stored once in a dictionary and referenced by compact identifiers.

Updating relevant profile serialization/deserialization logic to leverage the dictionary structure.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
