### PR TITLE
[Enhancement] Auto warmup SST files for cloud-native PK index during CACHE SELECT

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -16,9 +16,8 @@
 
 #include <vector>
 
-#include "base/testutil/sync_point.h"
-
 #include "base/string/string_parser.hpp"
+#include "base/testutil/sync_point.h"
 #include "column/column_access_path.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_scan_io_fwd.h"
@@ -755,8 +754,7 @@ Status LakeDataSource::prune_schema_by_access_paths(Schema* schema) {
     return Status::OK();
 }
 
-bool has_all_pk_columns_selected(const TabletSchema* tablet_schema,
-                                 const std::vector<SlotDescriptor*>& slots) {
+bool has_all_pk_columns_selected(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>& slots) {
     if (tablet_schema == nullptr) {
         return false;
     }
@@ -802,14 +800,12 @@ Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletM
     }
 
     const auto& sstable_meta = metadata->sstable_meta();
-    VLOG(2) << "Warmup PK index SST files: tablet_id=" << tablet_id
-            << " sst_count=" << sstable_meta.sstables_size();
+    VLOG(2) << "Warmup PK index SST files: tablet_id=" << tablet_id << " sst_count=" << sstable_meta.sstables_size();
     for (const auto& sstable_pb : sstable_meta.sstables()) {
         std::string sst_path = tablet_mgr->sst_location(tablet_id, sstable_pb.filename());
         RandomAccessFileOptions opts;
         if (!sstable_pb.encryption_meta().empty()) {
-            ASSIGN_OR_RETURN(auto info,
-                             KeyCache::instance().unwrap_encryption_meta(sstable_pb.encryption_meta()));
+            ASSIGN_OR_RETURN(auto info, KeyCache::instance().unwrap_encryption_meta(sstable_pb.encryption_meta()));
             opts.encryption_info = std::move(info);
         }
         ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(opts, sst_path));
@@ -826,7 +822,6 @@ Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletM
 
     return Status::OK();
 }
-
 
 Status LakeDataSource::build_scan_range(RuntimeState* state) {
     // Get key_ranges and not_push_down_conjuncts from _conjuncts_manager.

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -16,10 +16,13 @@
 
 #include <vector>
 
+#include "base/testutil/sync_point.h"
+
 #include "base/string/string_parser.hpp"
 #include "column/column_access_path.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_scan_io_fwd.h"
+#include "common/config_starlet_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "exec/connector_scan_node.h"
 #include "exec/olap_scan_prepare.h"
@@ -28,6 +31,8 @@
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr_factory.h"
 #include "exprs/jsonpath.h"
+#include "fs/fs.h"
+#include "fs/key_cache.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/global_dict/fragment_dict_state.h"
@@ -421,6 +426,18 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(init_global_dicts(&_params));
     RETURN_IF_ERROR(init_unused_output_columns(thrift_lake_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(init_reader_params(_scanner_ranges));
+
+    // Setup SST warmup callback for CACHE SELECT on PK tables
+    if (_params.lake_io_opts.cache_file_only && _slots != nullptr &&
+        has_all_pk_columns_selected(_tablet_schema.get(), *_slots)) {
+        auto metadata = _tablet.metadata();
+        auto* tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+        _params.lake_io_opts.sst_warmup_done = std::make_shared<std::atomic<bool>>(false);
+        _params.lake_io_opts.sst_warmup_fn = [metadata, tablet_mgr]() -> Status {
+            return warmup_pk_index_sst_files(metadata.get(), tablet_mgr);
+        };
+    }
+
     RETURN_IF_ERROR(init_scanner_columns(scanner_columns, reader_columns));
 
     if (_split_context != nullptr) {
@@ -737,6 +754,79 @@ Status LakeDataSource::prune_schema_by_access_paths(Schema* schema) {
 
     return Status::OK();
 }
+
+bool has_all_pk_columns_selected(const TabletSchema* tablet_schema,
+                                 const std::vector<SlotDescriptor*>& slots) {
+    if (tablet_schema == nullptr) {
+        return false;
+    }
+    if (tablet_schema->keys_type() != KeysType::PRIMARY_KEYS) {
+        return false;
+    }
+    size_t num_key_columns = tablet_schema->num_key_columns();
+    if (num_key_columns == 0) {
+        return false;
+    }
+    std::unordered_set<std::string_view> slot_names;
+    slot_names.reserve(slots.size());
+    for (const auto* slot : slots) {
+        slot_names.emplace(slot->col_name());
+    }
+    for (size_t i = 0; i < num_key_columns; i++) {
+        if (!slot_names.contains(tablet_schema->column(i).name())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletManager* tablet_mgr) {
+    if (metadata == nullptr) {
+        return Status::OK();
+    }
+
+    // Check if the table is a PK table with cloud-native persistent index
+    if (!metadata->enable_persistent_index() ||
+        metadata->persistent_index_type() != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return Status::OK();
+    }
+
+    if (!metadata->has_sstable_meta() || metadata->sstable_meta().sstables_size() == 0) {
+        return Status::OK();
+    }
+
+    int64_t tablet_id = metadata->id();
+    size_t buf_size = config::starlet_fs_stream_buffer_size_bytes;
+    if (buf_size <= 0) {
+        buf_size = 1048576; // 1MB
+    }
+
+    const auto& sstable_meta = metadata->sstable_meta();
+    VLOG(2) << "Warmup PK index SST files: tablet_id=" << tablet_id
+            << " sst_count=" << sstable_meta.sstables_size();
+    for (const auto& sstable_pb : sstable_meta.sstables()) {
+        std::string sst_path = tablet_mgr->sst_location(tablet_id, sstable_pb.filename());
+        RandomAccessFileOptions opts;
+        if (!sstable_pb.encryption_meta().empty()) {
+            ASSIGN_OR_RETURN(auto info,
+                             KeyCache::instance().unwrap_encryption_meta(sstable_pb.encryption_meta()));
+            opts.encryption_info = std::move(info);
+        }
+        ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(opts, sst_path));
+        int64_t file_size = sstable_pb.filesize();
+        if (file_size <= 0) {
+            ASSIGN_OR_RETURN(file_size, rf->get_size());
+        }
+        for (int64_t offset = 0; offset < file_size;) {
+            int64_t cur_size = std::min(static_cast<int64_t>(buf_size), file_size - offset);
+            RETURN_IF_ERROR(rf->touch_cache(offset, cur_size));
+            offset += cur_size;
+        }
+    }
+
+    return Status::OK();
+}
+
 
 Status LakeDataSource::build_scan_range(RuntimeState* state) {
     // Get key_ranges and not_push_down_conjuncts from _conjuncts_manager.

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -22,7 +22,24 @@
 #include "storage/lake/versioned_tablet.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
 
+namespace starrocks {
+class TabletSchema;
+class TabletMetadataPB;
+class SlotDescriptor;
+namespace lake {
+class TabletManager;
+}
+} // namespace starrocks
+
 namespace starrocks::connector {
+
+// Check if all PK columns are in the selected slots. Used by CACHE SELECT to
+// decide whether to warm up persistent index SST files.
+bool has_all_pk_columns_selected(const TabletSchema* tablet_schema,
+                                 const std::vector<SlotDescriptor*>& slots);
+
+// Warm up persistent index SST files for cloud-native PK tables.
+Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletManager* tablet_mgr);
 
 class LakeConnector final : public Connector {
 public:

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -35,8 +35,7 @@ namespace starrocks::connector {
 
 // Check if all PK columns are in the selected slots. Used by CACHE SELECT to
 // decide whether to warm up persistent index SST files.
-bool has_all_pk_columns_selected(const TabletSchema* tablet_schema,
-                                 const std::vector<SlotDescriptor*>& slots);
+bool has_all_pk_columns_selected(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>& slots);
 
 // Warm up persistent index SST files for cloud-native PK tables.
 Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletManager* tablet_mgr);

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -34,6 +34,9 @@
 
 #pragma once
 
+#include <atomic>
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -77,6 +80,10 @@ struct LakeIOOptions {
     bool fill_metadata_cache = false;
     bool use_page_cache = false;
     bool cache_file_only = false; // only used for CACHE SELECT
+    // Callback to warmup SST files, invoked at most once per tablet during CACHE SELECT.
+    // Protected by sst_warmup_done (CAS guard) to ensure single execution across segments.
+    std::function<Status()> sst_warmup_fn;
+    std::shared_ptr<std::atomic<bool>> sst_warmup_done;
     std::shared_ptr<FileSystem> fs;
     std::shared_ptr<starrocks::lake::LocationProvider> location_provider;
 };

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2077,6 +2077,14 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
             }
         }
 
+        // Warmup SST files for cloud-native PK index, executed once per tablet
+        if (_opts.lake_io_opts.sst_warmup_fn && _opts.lake_io_opts.sst_warmup_done) {
+            bool expected = false;
+            if (_opts.lake_io_opts.sst_warmup_done->compare_exchange_strong(expected, true)) {
+                RETURN_IF_ERROR(_opts.lake_io_opts.sst_warmup_fn());
+            }
+        }
+
         _opts.stats->block_load_ns += sw.elapsed_time();
 
         return Status::EndOfFile("no more data in segment");

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -487,14 +487,10 @@ TEST_F(LakeDataSourceTest, test_has_all_pk_columns_selected) {
 
 TEST_F(LakeDataSourceTest, test_warmup_pk_index_sst_files) {
     // Case 1: Non-PK table → skip warmup
-    {
-        ASSERT_OK(connector::warmup_pk_index_sst_files(_tablet_metadata.get(), _tablet_mgr));
-    }
+    { ASSERT_OK(connector::warmup_pk_index_sst_files(_tablet_metadata.get(), _tablet_mgr)); }
 
     // Case 2: nullptr metadata → skip warmup
-    {
-        ASSERT_OK(connector::warmup_pk_index_sst_files(nullptr, _tablet_mgr));
-    }
+    { ASSERT_OK(connector::warmup_pk_index_sst_files(nullptr, _tablet_mgr)); }
 
     // Case 3: PK table with cloud-native persistent index but no SST files → skip
     {

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -376,4 +376,229 @@ TEST_F(LakeDataSourceTest, get_tablet_schema) {
     ASSERT_EQ(schema_id, tablet_schema->id());
 }
 
+TEST_F(LakeDataSourceTest, test_has_all_pk_columns_selected) {
+    // Build a PK tablet schema: c0 (key), c1 (key), c2 (value)
+    TabletSchemaPB pk_schema_pb;
+    pk_schema_pb.set_id(next_id());
+    pk_schema_pb.set_num_short_key_columns(2);
+    pk_schema_pb.set_keys_type(PRIMARY_KEYS);
+    pk_schema_pb.set_num_rows_per_row_block(65535);
+    {
+        auto* c = pk_schema_pb.add_column();
+        c->set_unique_id(next_id());
+        c->set_name("c0");
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(false);
+    }
+    {
+        auto* c = pk_schema_pb.add_column();
+        c->set_unique_id(next_id());
+        c->set_name("c1");
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(false);
+    }
+    {
+        auto* c = pk_schema_pb.add_column();
+        c->set_unique_id(next_id());
+        c->set_name("c2");
+        c->set_type("INT");
+        c->set_is_key(false);
+        c->set_is_nullable(false);
+    }
+    auto pk_tablet_schema = TabletSchema::create(pk_schema_pb);
+
+    auto runtime_state = create_runtime_state();
+    TSlotDescriptorBuilder slot_desc_builder;
+
+    // Case 1: Select all PK columns (c0, c1) → true
+    {
+        TDescriptorTableBuilder builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(false).build());
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(false).build());
+        tuple_builder.build(&builder);
+        DescriptorTbl* desc_tbl = nullptr;
+        CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), builder.desc_tbl(), &desc_tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+        ASSERT_TRUE(connector::has_all_pk_columns_selected(pk_tablet_schema.get(), tuple_desc->slots()));
+    }
+
+    // Case 2: Select only one PK column (c0) → false (c1 missing)
+    {
+        TDescriptorTableBuilder builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(false).build());
+        tuple_builder.build(&builder);
+        DescriptorTbl* desc_tbl = nullptr;
+        CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), builder.desc_tbl(), &desc_tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+        ASSERT_FALSE(connector::has_all_pk_columns_selected(pk_tablet_schema.get(), tuple_desc->slots()));
+    }
+
+    // Case 3: Select only value column (c2) → false
+    {
+        TDescriptorTableBuilder builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c2").column_pos(2).nullable(false).build());
+        tuple_builder.build(&builder);
+        DescriptorTbl* desc_tbl = nullptr;
+        CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), builder.desc_tbl(), &desc_tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+        ASSERT_FALSE(connector::has_all_pk_columns_selected(pk_tablet_schema.get(), tuple_desc->slots()));
+    }
+
+    // Case 4: Select all columns (c0, c1, c2) → true (superset of PK)
+    {
+        TDescriptorTableBuilder builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(false).build());
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(false).build());
+        tuple_builder.add_slot(
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c2").column_pos(2).nullable(false).build());
+        tuple_builder.build(&builder);
+        DescriptorTbl* desc_tbl = nullptr;
+        CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), builder.desc_tbl(), &desc_tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+        ASSERT_TRUE(connector::has_all_pk_columns_selected(pk_tablet_schema.get(), tuple_desc->slots()));
+    }
+
+    // Case 5: DUP_KEYS table → false
+    ASSERT_FALSE(connector::has_all_pk_columns_selected(_tablet_schema.get(), {}));
+
+    // Case 6: nullptr schema → false
+    ASSERT_FALSE(connector::has_all_pk_columns_selected(nullptr, {}));
+}
+
+TEST_F(LakeDataSourceTest, test_warmup_pk_index_sst_files) {
+    // Case 1: Non-PK table → skip warmup
+    {
+        ASSERT_OK(connector::warmup_pk_index_sst_files(_tablet_metadata.get(), _tablet_mgr));
+    }
+
+    // Case 2: nullptr metadata → skip warmup
+    {
+        ASSERT_OK(connector::warmup_pk_index_sst_files(nullptr, _tablet_mgr));
+    }
+
+    // Case 3: PK table with cloud-native persistent index but no SST files → skip
+    {
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        ASSERT_OK(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr));
+    }
+
+    // Case 4: PK table with LOCAL persistent index → skip
+    {
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::LOCAL);
+        auto* sst_meta = pk_metadata.mutable_sstable_meta();
+        auto* sst = sst_meta->add_sstables();
+        sst->set_filename("dummy.sst");
+        sst->set_filesize(100);
+        ASSERT_OK(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr));
+    }
+
+    // Case 5: PK table with cloud-native persistent index and SST file that exists
+    {
+        // Create a fake SST file on disk
+        std::string sst_filename = "test_warmup.sst";
+        std::string sst_path = _tablet_mgr->sst_location(_tablet_metadata->id(), sst_filename);
+        {
+            ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(sst_path));
+            std::string sst_content(4096, 'x');
+            ASSERT_OK(wf->append(sst_content));
+            ASSERT_OK(wf->close());
+        }
+
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        auto* sst_meta = pk_metadata.mutable_sstable_meta();
+        auto* sst = sst_meta->add_sstables();
+        sst->set_filename(sst_filename);
+        sst->set_filesize(4096);
+
+        ASSERT_OK(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr));
+    }
+
+    // Case 6: SST file exists but filesize not set in pb → fallback to get_size()
+    {
+        std::string sst_filename = "test_warmup_nosize.sst";
+        std::string sst_path = _tablet_mgr->sst_location(_tablet_metadata->id(), sst_filename);
+        {
+            ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(sst_path));
+            std::string sst_content(2048, 'y');
+            ASSERT_OK(wf->append(sst_content));
+            ASSERT_OK(wf->close());
+        }
+
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        auto* sst_meta = pk_metadata.mutable_sstable_meta();
+        auto* sst = sst_meta->add_sstables();
+        sst->set_filename(sst_filename);
+        // filesize not set (defaults to 0), should fallback to get_size()
+
+        ASSERT_OK(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr));
+    }
+
+    // Case 7: SST file does not exist → should return error
+    {
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        auto* sst_meta = pk_metadata.mutable_sstable_meta();
+        auto* sst = sst_meta->add_sstables();
+        sst->set_filename("nonexistent.sst");
+        sst->set_filesize(100);
+
+        ASSERT_FALSE(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr).ok());
+    }
+
+    // Case 8: SST with invalid encryption_meta → should return error
+    {
+        TabletMetadata pk_metadata;
+        pk_metadata.set_id(_tablet_metadata->id());
+        pk_metadata.set_version(1);
+        pk_metadata.set_enable_persistent_index(true);
+        pk_metadata.set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        auto* sst_meta = pk_metadata.mutable_sstable_meta();
+        auto* sst = sst_meta->add_sstables();
+        sst->set_filename("dummy_enc.sst");
+        sst->set_filesize(1024);
+        sst->set_encryption_meta("invalid_encryption_meta");
+
+        ASSERT_FALSE(connector::warmup_pk_index_sst_files(&pk_metadata, _tablet_mgr).ok());
+    }
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
During CACHE SELECT for cloud-native primary key tables, only segment data files are warmed up into local DataCache. However, PK ingestion workloads also heavily depend on persistent index SST files. Without pre-caching SST files, the first ingestion after warmup still suffers from cold-start latency when reading SST files from remote storage.

## What I'm doing:
Automatically warm up persistent index SST files when CACHE SELECT includes PK columns on a cloud-native PK table. No additional PROPERTIES needed — SST warmup is triggered transparently when PK columns are detected in the selected columns.

**How it works:**
- `_has_pk_columns_selected()` checks if the tablet schema is PRIMARY_KEYS and any selected slot maps to a key column
- If true (and `cache_file_only` mode is active), `_warmup_pk_index_sst_files()` iterates over SST files from tablet metadata and warms each via `touch_cache()`

**SST warmup conditions (all must be met):**
- CACHE SELECT in physical mode (`cache_file_only = true`)
- Primary key table with selected PK columns
- Cloud-native persistent index (`persistent_index_type = CLOUD_NATIVE`)
- Tablet metadata contains SST files (`sstable_meta` is non-empty)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)