### PR TITLE
[BugFix][Iceberg] Fix OAuth2 token refresh scheduler never started for REST Catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.iceberg.rest.auth.RefreshingAuthManager;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
@@ -126,6 +127,9 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate = new RESTSessionCatalog();
             configureHadoopConf(delegate, conf);
             delegate.initialize(name, restCatalogProperties);
+            if (delegate.authManager() instanceof RefreshingAuthManager) {
+                ((RefreshingAuthManager) delegate.authManager()).keepRefreshed(true);
+            }
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
             throw new StarRocksConnectorException("Failed to load rest catalog",

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -127,14 +127,22 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate = new RESTSessionCatalog();
             configureHadoopConf(delegate, conf);
             delegate.initialize(name, restCatalogProperties);
-            Object authManager = delegate.authManager();
-            if (authManager instanceof RefreshingAuthManager) {
-                ((RefreshingAuthManager) authManager).keepRefreshed(true);
-            }
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
             throw new StarRocksConnectorException("Failed to load rest catalog",
                     new RuntimeException("Failed to load rest catalog, exception: " + re.getMessage(), re));
+        }
+        try {
+            java.lang.reflect.Field authManagerField =
+                    delegate.getClass().getDeclaredField("authManager");
+            authManagerField.setAccessible(true);
+            Object authMgr = authManagerField.get(delegate);
+            if (authMgr instanceof RefreshingAuthManager) {
+                this.refreshingAuthManager = (RefreshingAuthManager) authMgr;
+                this.refreshingAuthManager.keepRefreshed(true);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            LOG.warn("Failed to start OAuth2 token refresh scheduler", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -127,8 +127,9 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate = new RESTSessionCatalog();
             configureHadoopConf(delegate, conf);
             delegate.initialize(name, restCatalogProperties);
-            if (delegate.authManager() instanceof RefreshingAuthManager) {
-                ((RefreshingAuthManager) delegate.authManager()).keepRefreshed(true);
+            Object authManager = delegate.authManager();
+            if (authManager instanceof RefreshingAuthManager) {
+                ((RefreshingAuthManager) authManager).keepRefreshed(true);
             }
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);


### PR DESCRIPTION


Problem:
When using Iceberg REST Catalog with OAuth2 (e.g. Apache Polaris), queries fail after ~1 hour idle with:
  NotAuthorizedException: Failed to verify the token

Root cause:
RefreshingAuthManager.keepRefreshed(boolean) is never called after delegate.initialize() in IcebergRESTCatalog. The background token refresh ScheduledExecutorService never starts. Token expires after TTL (~3600s for Polaris) with no renewal. Confirmed via bytecode analysis: keepRefreshed does not appear in IcebergRESTCatalog.class constant pool at all. No catalog property can work around this - the scheduler is architecturally never started.

Fix:
After delegate.initialize(), check if authManager is a RefreshingAuthManager and call keepRefreshed(true) to start the background token refresh scheduler. Backward compatible: only activates when auth manager is a RefreshingAuthManager instance (i.e. OAuth2 is in use).

Tested: StarRocks 4.0.6 + Apache Polaris, catalog remains functional after 90+ minutes idle with no token expiry errors.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
