### PR TITLE
[Enhancement] adding a config to limit the buffer size to dop * local_exchange_buffer_mem_limit_per_driver

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1621,7 +1621,7 @@ CONF_Int64(rocksdb_max_write_buffer_memory_bytes, "1073741824");
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 // limit local exchange buffer size by dop * local_exchange_buffer_mem_limit_per_driver for union operators.
-CONF_mBool(local_exchange_buffer_mem_limit_by_consumer_dop, "false");
+CONF_mBool(local_exchange_buffer_mem_limit_by_consumer_dop, "true");
 // only used for test. default: 128M
 CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
 // mem limit for partition hash join probe side buffer

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1620,6 +1620,8 @@ CONF_Int64(rocksdb_max_write_buffer_memory_bytes, "1073741824");
 
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
+// limit local exchange buffer size by dop * local_exchange_buffer_mem_limit_per_driver for union operators.
+CONF_mBool(local_exchange_buffer_mem_limit_by_consumer_dop, "false");
 // only used for test. default: 128M
 CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
 // mem limit for partition hash join probe side buffer

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -178,6 +178,9 @@ CONF_mInt32(query_cache_num_lanes_per_driver, "4");
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 
+// limit local exchange buffer size by dop * local_exchange_buffer_mem_limit_per_driver for union operators.
+CONF_mBool(local_exchange_buffer_mem_limit_by_consumer_dop, "true");
+
 // only used for test. default: 128M
 CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -176,6 +176,7 @@
         "report_exec_rpc_request_retry_num",
         "query_cache_num_lanes_per_driver",
         "local_exchange_buffer_mem_limit_per_driver",
+        "local_exchange_buffer_mem_limit_by_consumer_dop",
         "streaming_agg_limited_memory_size",
         "partition_hash_join_probe_limit_size",
         "streaming_agg_chunk_buffer_size",

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -376,6 +376,10 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
         max_input_dop += source_op->degree_of_parallelism();
     }
 
+    if (config::local_exchange_buffer_mem_limit_by_consumer_dop) {
+        max_input_dop = std::min(max_input_dop, degree_of_parallelism());
+    }
+
     auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(max_input_dop,
                                                               config::local_exchange_buffer_mem_limit_per_driver);
     auto local_exchange_source =

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -352,9 +352,9 @@ private:
 //   cast STRUCT<tinyint, tinyint> to STRUCT<int, int>
 class CastStructExpr final : public Expr {
 public:
-    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts,
-                   std::vector<int> source_field_indices)
-            : Expr(node), _field_casts(std::move(field_casts)),
+    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts, std::vector<int> source_field_indices)
+            : Expr(node),
+              _field_casts(std::move(field_casts)),
               _source_field_indices(std::move(source_field_indices)) {}
 
     ~CastStructExpr() override = default;


### PR DESCRIPTION
## Why I'm doing:
Currently the buffer size in a local exchange for union operators is computed as 
`sum(source_op->degree_of_parallelism() *  config::local_exchange_buffer_mem_limit_per_driver)`.
This value increases linearly with the number of inputs to the union operator and can result in huge peak memory due to an oversized buffer. 

## What I'm doing:
Adding a config to limit the buffer size to 
`degree_of_parallelism() * config::local_exchange_buffer_mem_limit_per_driver)`.

Note to reviewer: In my opinion the current behavior is a bug and we may want to merge this code without being behind a flag.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
