### PR TITLE
[Enhancement] Enhance timezone utils

### DIFF
--- a/be/src/base/time/timezone_utils.cpp
+++ b/be/src/base/time/timezone_utils.cpp
@@ -103,18 +103,26 @@ bool TimezoneUtils::_match_cctz_time_zone(std::string_view timezone, cctz::time_
     re2::StringPiece value;
 
     // RE2 obj is thread safe
-    // +8:00
-    static RE2 reg1(R"(^[+-]{1}\d{2}\:\d{2}$)", re2::RE2::Quiet);
-    // GMT+8:00
-    static RE2 reg2(R"(^GMT[+-]{1}\d{2}\:\d{2}$)", re2::RE2::Quiet);
+    // +8:00 or +08:00
+    static RE2 reg1(R"(^[+-]{1}\d{1,2}\:\d{2}$)", re2::RE2::Quiet);
+    // GMT+8:00 or UTC+8:00
+    static RE2 reg2(R"(^(?:GMT|UTC)[+-]{1}\d{1,2}\:\d{2}$)", re2::RE2::Quiet);
+    // GMT+8, GMT-12, UTC+8, UTC-12 (hour only, no minutes)
+    static RE2 reg3(R"(^(?:GMT|UTC)[+-]{1}\d{1,2}$)", re2::RE2::Quiet);
 
+    bool hour_only = false;
     if (reg1.Match(re2::StringPiece(timezone.data(), timezone.size()), 0, timezone.size(), RE2::UNANCHORED, &value,
                    1)) {
         // Do nothing.
     } else if (reg2.Match(re2::StringPiece(timezone.data(), timezone.size()), 0, timezone.size(), RE2::UNANCHORED,
                           &value, 1)) {
-        // remove GMT header.
+        // remove GMT/UTC header.
         value = value.substr(3);
+    } else if (reg3.Match(re2::StringPiece(timezone.data(), timezone.size()), 0, timezone.size(), RE2::UNANCHORED,
+                          &value, 1)) {
+        // remove GMT/UTC header, hour only with no minutes part.
+        value = value.substr(3);
+        hour_only = true;
     } else {
         // all regular expressions return empty.
         return false;
@@ -123,8 +131,15 @@ bool TimezoneUtils::_match_cctz_time_zone(std::string_view timezone, cctz::time_
     bool positive = (value[0] != '-');
 
     //Regular expression guarantees hour and minute mush be int
-    int hour = std::stoi(std::string(value.substr(1, 2)));
-    int minute = std::stoi(std::string(value.substr(4, 2)));
+    int hour = 0;
+    int minute = 0;
+    if (hour_only) {
+        hour = std::stoi(value.substr(1).as_string());
+    } else {
+        size_t colon_pos = value.find(':');
+        hour = std::stoi(value.substr(1, colon_pos - 1).as_string());
+        minute = std::stoi(value.substr(colon_pos + 1, 2).as_string());
+    }
 
     // timezone offsets around the world extended from -12:00 to +14:00
     if (!positive && hour > 12) {

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -352,9 +352,9 @@ private:
 //   cast STRUCT<tinyint, tinyint> to STRUCT<int, int>
 class CastStructExpr final : public Expr {
 public:
-    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts,
-                   std::vector<int> source_field_indices)
-            : Expr(node), _field_casts(std::move(field_casts)),
+    CastStructExpr(const TExprNode& node, std::vector<Expr*> field_casts, std::vector<int> source_field_indices)
+            : Expr(node),
+              _field_casts(std::move(field_casts)),
               _source_field_indices(std::move(source_field_indices)) {}
 
     ~CastStructExpr() override = default;

--- a/be/test/base/time/timezone_utils_test.cpp
+++ b/be/test/base/time/timezone_utils_test.cpp
@@ -52,8 +52,30 @@ PARALLEL_TEST(TimezoneUtilTest, utc_to_offset) {
 
 PARALLEL_TEST(TimezoneUtilTest, find_time_zone) {
     std::vector<std::pair<std::string, bool>> test_cases{
-            {"Asia/Shanghai", true},   {"-08:00", true}, {"GMT+08:00", true}, {"GMT-08:00", true},
-            {"Asia/Shanghaia", false}, {"-8:00", false}, {"GMT-8:00", false}};
+            {"Asia/Shanghai", true},
+            {"-08:00", true},
+            {"GMT+08:00", true},
+            {"GMT-08:00", true},
+            {"Asia/Shanghaia", false},
+            // single-digit hour with minutes
+            {"+8:00", true},
+            {"-8:00", true},
+            {"GMT+8:00", true},
+            {"GMT-8:00", true},
+            {"UTC+8:00", true},
+            {"UTC-5:30", true},
+            // hour-only formats without minutes
+            {"GMT+7", true},
+            {"GMT-12", true},
+            {"GMT+1", true},
+            {"UTC+7", true},
+            {"UTC-12", true},
+            {"UTC+14", true},
+            // out-of-range should fail
+            {"GMT+15", false},
+            {"GMT-13", false},
+            {"UTC+15", false},
+    };
     cctz::time_zone ctz;
     for (const auto& test_case : test_cases) {
         EXPECT_EQ(TimezoneUtils::find_cctz_time_zone(test_case.first, ctz), test_case.second) << test_case.first;


### PR DESCRIPTION
## Why I'm doing:

We met an issue that when we ran the following sql:

select from_unixtime(timestamp, "GMT+7") from table.

We got NULL result. After checking the timezone handling in BE side, besides IANA timezone expr, BE only support expr like "GMT+07:00". This impacted the result correctness of our senarios.

The above sql is supported by trino and this issue blocked our migration from other components to starrocks.

## What I'm doing:

Enhenced the regex matching to support some common used timezone expressions:

- "+8:00", "-8:00"
- "GMT+8", "GMT-8"
- "UTC+8", "UTC-8"
- "GMT+8:00", "GMT-8:00"
- "GMT+08:00", "GMT-08:00"


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
