### PR TITLE
[BugFix] Add missing visitDictionaryGetOperator to BaseScalarOperatorShuttle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -130,8 +130,25 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
                 .put(DictionaryGetOperator.class, (op, childOps) -> {
                     DictionaryGetOperator dictGet = (DictionaryGetOperator) op;
                     return new DictionaryGetOperator(childOps, dictGet.getType(), dictGet.getDictionaryId(),
-                            dictGet.getDictionaryTxnId(), dictGet.getKeySize(), dictGet.getNullIfNotExist()); })
+                            dictGet.getDictionaryTxnId(), dictGet.getKeySize(),
+                            getNullIfNotExistForClone(dictGet, childOps)); })
                 .build();
+    }
+
+    private static boolean getNullIfNotExistForClone(DictionaryGetOperator dictGet, List<ScalarOperator> childOps) {
+        // dictionary_get(dict_name, key1, ..., keyN [, null_if_not_exist])
+        // If null_if_not_exist child exists and is a non-null bool literal, keep field in sync with rewritten child.
+        int expectedArgsWithFlag = dictGet.getKeySize() + 2;
+        if (childOps.size() == expectedArgsWithFlag) {
+            ScalarOperator nullIfNotExist = childOps.get(childOps.size() - 1);
+            if (nullIfNotExist instanceof ConstantOperator) {
+                ConstantOperator constant = (ConstantOperator) nullIfNotExist;
+                if (constant.getType().isBoolean() && !constant.isNull()) {
+                    return constant.getBoolean();
+                }
+            }
+        }
+        return dictGet.getNullIfNotExist();
     }
 
     public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -126,6 +127,10 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
                     LambdaFunctionOperator lambda = (LambdaFunctionOperator) op;
                     return new LambdaFunctionOperator(lambda.getRefColumns(), childOps.get(0), lambda.getType()); })
                 .put(CloneOperator.class, (op, childOps) -> new CloneOperator(childOps.get(0)))
+                .put(DictionaryGetOperator.class, (op, childOps) -> {
+                    DictionaryGetOperator dictGet = (DictionaryGetOperator) op;
+                    return new DictionaryGetOperator(childOps, dictGet.getType(), dictGet.getDictionaryId(),
+                            dictGet.getDictionaryTxnId(), dictGet.getKeySize(), dictGet.getNullIfNotExist()); })
                 .build();
     }
 
@@ -267,6 +272,11 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
 
     @Override
     public ScalarOperator visitDictQueryOperator(DictQueryOperator operator, Void context) {
+        return shuttleIfUpdate(operator);
+    }
+
+    @Override
+    public ScalarOperator visitDictionaryGetOperator(DictionaryGetOperator operator, Void context) {
         return shuttleIfUpdate(operator);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -452,6 +453,52 @@ class BaseScalarOperatorShuttleTest {
         argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2, cast(a as int(11))) " +
                 "OR 1: id IN (1, 2, cast(a as int(11))) IS NULL"));
         return argumentsList.stream();
+    }
+
+
+    @Test
+    void testDictionaryGetOperator() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, INT, "col1", true);
+        DictionaryGetOperator operator = new DictionaryGetOperator(
+                Lists.newArrayList(col1, ConstantOperator.createInt(0)),
+                INT, 100L, 200L, 1, true);
+        {
+            ScalarOperator newOperator = shuttle.visitDictionaryGetOperator(operator, null);
+            assertEquals(operator, newOperator);
+        }
+        {
+            ScalarOperator newOperator = shuttle2.visitDictionaryGetOperator(operator, null);
+            assertEquals(operator, newOperator);
+        }
+    }
+
+    @Test
+    void testDictionaryGetOperatorChildUpdate() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, INT, "col1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, INT, "col2", true);
+        DictionaryGetOperator dictGet = new DictionaryGetOperator(
+                Lists.newArrayList(col1, ConstantOperator.createInt(0)),
+                INT, 100L, 200L, 1, true);
+        SubfieldOperator subfield = new SubfieldOperator(dictGet, INT, Lists.newArrayList("mapping_id"));
+
+        BaseScalarOperatorShuttle replaceShuttle = new BaseScalarOperatorShuttle() {
+            @Override
+            public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+                if (variable.getId() == 1) {
+                    return col2;
+                }
+                return variable;
+            }
+        };
+
+        ScalarOperator result = replaceShuttle.visitSubfield(subfield, null);
+        assertNotEquals(subfield, result);
+        assert result instanceof SubfieldOperator;
+        SubfieldOperator newSubfield = (SubfieldOperator) result;
+        assert newSubfield.getChild(0) instanceof DictionaryGetOperator;
+        DictionaryGetOperator newDictGet = (DictionaryGetOperator) newSubfield.getChild(0);
+        assertEquals(col2, newDictGet.getChild(0));
+        assertEquals(100L, newDictGet.getDictionaryId());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -501,4 +501,32 @@ class BaseScalarOperatorShuttleTest {
         assertEquals(100L, newDictGet.getDictionaryId());
     }
 
+
+    @Test
+    void testDictionaryGetOperatorRewriteNullIfNotExist() {
+        ColumnRefOperator key = new ColumnRefOperator(1, INT, "key", true);
+        DictionaryGetOperator dictGet = new DictionaryGetOperator(
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar("test_db.user_mapping_dict"),
+                        key,
+                        ConstantOperator.createBoolean(true)),
+                INT, 100L, 200L, 1, true);
+
+        BaseScalarOperatorShuttle toggleBool = new BaseScalarOperatorShuttle() {
+            @Override
+            public ScalarOperator visitConstant(ConstantOperator literal, Void context) {
+                if (literal.getType().isBoolean() && !literal.isNull()) {
+                    return ConstantOperator.createBoolean(!literal.getBoolean());
+                }
+                return literal;
+            }
+        };
+
+        ScalarOperator result = toggleBool.visitDictionaryGetOperator(dictGet, null);
+        assert result instanceof DictionaryGetOperator;
+        DictionaryGetOperator rewritten = (DictionaryGetOperator) result;
+        assertEquals(ConstantOperator.FALSE, rewritten.getChild(2));
+        assertEquals(false, rewritten.getNullIfNotExist());
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

`BaseScalarOperatorShuttle` is missing the `visitDictionaryGetOperator` override method. When the shuttle encounters a `DictionaryGetOperator`, it falls through to the base `visit(ScalarOperator)` method which simply returns the operator **without traversing its children**.

This causes the low-cardinality dictionary optimization (`DecodeRewriter`'s `ExprReplacer`) to fail: when a dict-optimized (low-cardinality) string column is referenced **inside** `dictionary_get()` arguments, the `ExprReplacer` cannot traverse into `DictionaryGetOperator`'s children to rewrite the column reference from the original string column to its dict-encoded column. This leaves a stale column ID in the projection while `colRefToColumnMetaMap` has already been updated, triggering `InputDependenciesChecker` validation failure: 

```
Input dependency cols check failed. The required cols {19} cannot obtain from input cols {1,3,4,5,30,311}.
```

```
Invalid plan:
PhysicalOlapScanOperator {table=156685386, selectedPartitionId=[1414597220, 1420791847, 1427291819], selectedIndexId=156685387, outputColumns=[1: pt, 3: dt, 4: user_id, 5: short_play_id, 30: is_user_member], projection=[1: pt, Subfield([DICTIONARY_GET], "mapping_id"), 3: dt, Subfield([DICTIONARY_GET], "mapping_id"), 4: user_id, Subfield([DICTIONARY_GET], "mapping_id"), 5: short_play_id, Subfield([DICTIONARY_GET], "mapping_id"), 30: is_user_member], predicate=null, prunedPartitionPredicates=[1: pt >= 2026-03-10, 1: pt <= 2026-03-12], limit=-1}Input dependency cols check failed. The required cols {19} cannot obtain from input cols {1,3,4,5,30,311}.
```

Note: The `CLONE_FUNCTIONS` entry for `DictionaryGetOperator` was already correctly added by #40074, but the corresponding visitor method was missed.

### How to Reproduce

Given a table with a low-cardinality VARCHAR column (e.g., `unlock_type`) and a dictionary:

```sql
CREATE TABLE test_db.t_event (
    pt DATE NOT NULL,
    user_id BIGINT NOT NULL,
    short_play_id BIGINT NOT NULL,
    unlock_type VARCHAR(32) NOT NULL
) DUPLICATE KEY(pt, user_id)
PARTITION BY date_trunc('day', pt)
DISTRIBUTED BY HASH(user_id) BUCKETS 3;

CREATE TABLE test_db.t_user_mapping (
    user_id BIGINT NOT NULL,
    mapping_id BIGINT NOT NULL
) PRIMARY KEY(user_id)
DISTRIBUTED BY HASH(user_id) BUCKETS 3;

USE test_db;
CREATE DICTIONARY user_mapping_dict USING t_user_mapping
(user_id KEY, mapping_id VALUE);
```

**Query A (works)** — low-cardinality column referenced **outside** `dictionary_get`:
```sql
SELECT pt, short_play_id,
  bitmap_union(to_bitmap(
    if(length(unlock_type) > 0,
       dictionary_get('test_db.user_mapping_dict', user_id, true).mapping_id,
       null)
  )) AS unlock_uv
FROM test_db.t_event GROUP BY pt, short_play_id;
```

**Query B (fails)** — same column referenced **inside** `dictionary_get` arguments:
```sql
SELECT pt, short_play_id,
  bitmap_union(to_bitmap(
    dictionary_get('test_db.user_mapping_dict',
      if(length(unlock_type) > 0, user_id, 0),
      true).mapping_id
  )) AS unlock_uv
FROM test_db.t_event GROUP BY pt, short_play_id;
```

Query B fails because `unlock_type`'s column ref inside `DictionaryGetOperator` is never rewritten to the dict-encoded column.

**Workaround**: set `cbo_enable_low_cardinality_optimize = false`, or rewrite SQL to move the low-cardinality column outside of `dictionary_get()` arguments (Query A pattern).

## What I'm doing:

Add the missing `visitDictionaryGetOperator` method to `BaseScalarOperatorShuttle` that delegates to `shuttleIfUpdate(operator)`, consistent with the pattern used by `visitDictMappingOperator`, `visitDictQueryOperator`, and `visitCloneOperator`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4