### PR TITLE
[BugFix] fix jdbc mysql push down unsupported cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -122,6 +122,20 @@ public class JDBCTable extends Table {
         return connectInfo.get(connectInfoKey);
     }
 
+    public String getJdbcUri() {
+        if (!Strings.isNullOrEmpty(resourceName)) {
+            JDBCResource resource = (JDBCResource) GlobalStateMgr.getCurrentState().getResourceMgr()
+                    .getResource(resourceName);
+            return resource != null ? resource.getProperty(JDBCResource.URI) : null;
+        }
+        return connectInfo != null ? connectInfo.get(JDBCResource.URI) : null;
+    }
+
+    public boolean isMySQLCompatible() {
+        String uri = getJdbcUri();
+        return uri != null && (uri.startsWith("jdbc:mysql") || uri.startsWith("jdbc:mariadb"));
+    }
+
     private void validate(Map<String, String> properties) throws DdlException {
         if (properties == null) {
             throw new DdlException("Please set properties of jdbc table, they are: table and resource");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateToExternalTableScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateToExternalTableScanRule.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -23,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJDBCScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.MultiOpPattern;
@@ -62,7 +64,7 @@ public class PushDownPredicateToExternalTableScanRule extends TransformationRule
         ScalarOperator scanPredicate = operator.getPredicate();
         ScalarOperator filterPredicate = lfo.getPredicate();
         ExternalTablePredicateExtractor extractor = new ExternalTablePredicateExtractor(
-                operator.getOpType() == OperatorType.LOGICAL_MYSQL_SCAN);
+                        operator.getOpType() == OperatorType.LOGICAL_MYSQL_SCAN || isMySQLCompatibleJDBC(operator));
         extractor.extract(predicate);
         ScalarOperator pushedPredicate = extractor.getPushPredicate();
         ScalarOperator reservedPredicate = extractor.getReservePredicate();
@@ -120,5 +122,13 @@ public class PushDownPredicateToExternalTableScanRule extends TransformationRule
 
             return Lists.newArrayList(project);
         }
+    }
+
+    private boolean isMySQLCompatibleJDBC(Operator operator) {
+        if (operator.getOpType() != OperatorType.LOGICAL_JDBC_SCAN) {
+            return false;
+        }
+        JDBCTable table = (JDBCTable) ((LogicalJDBCScanOperator) operator).getTable();
+        return table.isMySQLCompatible();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.starrocks.catalog.JDBCResource;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
@@ -26,6 +28,8 @@ import com.starrocks.sql.parser.NodePosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class JDBCTableTest {
@@ -56,6 +60,26 @@ public class JDBCTableTest {
             System.out.println(e.getMessage());
             Assertions.fail();
         }
+    }
+
+    private JDBCTable buildJDBCTable(String uri) throws Exception {
+        Map<String, String> props = new HashMap<>();
+        props.put(JDBCResource.URI, uri);
+        props.put(JDBCResource.USER, "root");
+        props.put(JDBCResource.PASSWORD, "");
+        props.put(JDBCResource.DRIVER_URL, "https://example.com/driver.jar");
+        props.put(JDBCResource.CHECK_SUM, "abc");
+        props.put(JDBCResource.DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
+        return new JDBCTable(1L, "test", null, props);
+    }
+
+    @Test
+    public void testIsMySQLCompatible() throws Exception {
+        Assertions.assertTrue(buildJDBCTable("jdbc:mysql://host:3306/db").isMySQLCompatible());
+        Assertions.assertTrue(buildJDBCTable("jdbc:mariadb://host:3306/db").isMySQLCompatible());
+        Assertions.assertFalse(buildJDBCTable("jdbc:postgresql://host:5432/db").isMySQLCompatible());
+        Assertions.assertFalse(buildJDBCTable("jdbc:oracle:thin:@host:1521:db").isMySQLCompatible());
+        Assertions.assertFalse(buildJDBCTable("jdbc:sqlserver://host:1433").isMySQLCompatible());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
select * from mysql.t1 where cast(c1 as bigint) is not null will be pushed down incorrectly.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
