### PR TITLE
[Refactor] fix remaining clang-tidy errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,7 +28,7 @@ Checks: >
     performance-for-range-copy,
     performance-implicit-conversion-in-loop,
     performance-inefficient-algorithm,
-    performance-inefficient-vector-operation
+    performance-inefficient-vector-operation,
     performance-move-const-arg,
     performance-no-automatic-move,
     performance-no-int-to-ptr,

--- a/be/src/base/concurrency/bthread_shared_mutex.h
+++ b/be/src/base/concurrency/bthread_shared_mutex.h
@@ -30,7 +30,7 @@ private:
     typedef bthread::ConditionVariable _cv_type;
 
 public:
-    BThreadSharedMutex() {}
+    BThreadSharedMutex() = default;
     ~BThreadSharedMutex() { assert(_state == 0); }
 
     BThreadSharedMutex(const BThreadSharedMutex&) = delete;

--- a/be/src/base/concurrency/moodycamel/.clang-tidy
+++ b/be/src/base/concurrency/moodycamel/.clang-tidy
@@ -1,2 +1,0 @@
-# moodycamel concurrentqueue (third-party): keep only naming checks.
-Checks: '-*,readability-identifier-naming'

--- a/be/src/base/concurrency/moodycamel/concurrentqueue.h
+++ b/be/src/base/concurrency/moodycamel/concurrentqueue.h
@@ -1,4 +1,5 @@
 // clang-format off
+// NOLINTBEGIN
 // Provides a C++11 implementation of a multi-producer, multi-consumer lock-free queue.
 // An overview, including benchmark results, is provided here:
 //     http://moodycamel.com/blog/2014/a-fast-general-purpose-lock-free-queue-for-c++
@@ -3740,4 +3741,5 @@ inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a, ty
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND
 // clang-format on

--- a/be/src/base/concurrency/spinlock.h
+++ b/be/src/base/concurrency/spinlock.h
@@ -23,9 +23,7 @@ namespace starrocks {
 // Lightweight spinlock.
 class SpinLock {
 public:
-    SpinLock() {
-        // do nothing
-    }
+    SpinLock() = default;
 
     // Acquires the lock, spins until the lock becomes available
     void lock() {

--- a/be/src/base/orlp/pdqsort.h
+++ b/be/src/base/orlp/pdqsort.h
@@ -1,3 +1,4 @@
+// NOLINTBEGIN
 /*
 pdqsort.h - Pattern-defeating quicksort.
 
@@ -596,3 +597,4 @@ inline void pdqsort_branchless(Iter begin, Iter end) {
 }
 
 #undef PDQSORT_PREFER_MOVE
+// NOLINTEND

--- a/be/src/base/phmap/.clang-tidy
+++ b/be/src/base/phmap/.clang-tidy
@@ -1,2 +1,0 @@
-# phmap (third-party): keep only naming checks.
-Checks: '-*,readability-identifier-naming'

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -117,7 +117,7 @@ StatusOr<ColumnAccessPathPtr> ColumnAccessPath::convert_by_index(const Field* fi
         return path;
     }
 
-    auto all_field = field->sub_fields();
+    const auto& all_field = field->sub_fields();
 
     if (field->type()->type() == LogicalType::TYPE_ARRAY) {
         // _type must be ALL/INDEX/OFFSET

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -171,8 +171,7 @@ void Schema::append(const FieldPtr& field) {
         _name_to_index->emplace(field->name(), _fields.size() - 1);
     } else {
         if (_name_to_index_append_buffer == nullptr) {
-            _name_to_index_append_buffer =
-                    std::make_shared<std::unordered_map<std::string_view, size_t>>();
+            _name_to_index_append_buffer = std::make_shared<std::unordered_map<std::string_view, size_t>>();
         }
         _name_to_index_append_buffer->emplace(field->name(), _fields.size() - 1);
     }

--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -166,12 +166,13 @@ void Schema::append(const FieldPtr& field) {
     _num_keys += field->is_key();
     if (!_share_name_to_index) {
         if (_name_to_index == nullptr) {
-            _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
+            _name_to_index = std::make_shared<std::unordered_map<std::string_view, size_t>>();
         }
         _name_to_index->emplace(field->name(), _fields.size() - 1);
     } else {
         if (_name_to_index_append_buffer == nullptr) {
-            _name_to_index_append_buffer.reset(new std::unordered_map<std::string_view, size_t>());
+            _name_to_index_append_buffer =
+                    std::make_shared<std::unordered_map<std::string_view, size_t>>();
         }
         _name_to_index_append_buffer->emplace(field->name(), _fields.size() - 1);
     }
@@ -278,7 +279,7 @@ void Schema::set_field_by_name(FieldPtr field, const std::string& name) {
 }
 
 void Schema::_build_index_map(const Fields& fields) {
-    _name_to_index.reset(new std::unordered_map<std::string_view, size_t>());
+    _name_to_index = std::make_shared<std::unordered_map<std::string_view, size_t>>();
     for (size_t i = 0; i < fields.size(); i++) {
         _name_to_index->emplace(fields[i]->name(), i);
     }

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -71,7 +71,7 @@ public:
 
     operator std::string() const { return value(); }
 
-    MutableString& operator=(std::string s);
+    MutableString& operator=(const std::string& s);
 
 private:
     static bool update_value(std::string& bg, std::string new_value) {
@@ -88,7 +88,7 @@ inline std::string MutableString::value() const {
     return *ptr;
 }
 
-inline MutableString& MutableString::operator=(std::string s) {
+inline MutableString& MutableString::operator=(const std::string& s) {
     _str.Modify(update_value, s);
     return *this;
 }

--- a/be/src/common/thread/thread.cpp
+++ b/be/src/common/thread/thread.cpp
@@ -435,7 +435,7 @@ void Thread::finish_thread(void* arg) {
 }
 
 void Thread::init_threadmgr() {
-    thread_manager.reset(new ThreadMgr());
+    thread_manager = std::make_shared<ThreadMgr>();
 }
 
 ThreadJoiner::ThreadJoiner(Thread* thr) : _thread(CHECK_NOTNULL(thr)) {}

--- a/be/src/common/util/stack_trace_mutex.h
+++ b/be/src/common/util/stack_trace_mutex.h
@@ -29,7 +29,7 @@
 #include "common/compiler_util.h"
 #include "common/logging.h"
 #include "common/stack_util.h"
-#include "gutil//macros.h"
+#include "gutil/macros.h"
 
 namespace starrocks {
 
@@ -57,7 +57,10 @@ class StackTraceMutex {
 public:
     StackTraceMutex() : _mutex() {}
 
-    DISALLOW_COPY_AND_MOVE(StackTraceMutex);
+    StackTraceMutex(const StackTraceMutex&) = delete;
+    StackTraceMutex& operator=(const StackTraceMutex&) = delete;
+    StackTraceMutex(StackTraceMutex&&) = delete;
+    StackTraceMutex& operator=(StackTraceMutex&&) = delete;
 
     void lock() {
         while (!try_lock_for(std::chrono::minutes(5))) {
@@ -93,6 +96,11 @@ template <>
 class StackTraceMutex<bthread::Mutex> {
 public:
     StackTraceMutex() : _mutex() {}
+
+    StackTraceMutex(const StackTraceMutex&) = delete;
+    StackTraceMutex& operator=(const StackTraceMutex&) = delete;
+    StackTraceMutex(StackTraceMutex&&) = delete;
+    StackTraceMutex& operator=(StackTraceMutex&&) = delete;
 
     void lock() {
         while (!try_lock_for(std::chrono::minutes(5))) {

--- a/be/src/common/util/thrift_server.cpp
+++ b/be/src/common/util/thrift_server.cpp
@@ -242,7 +242,7 @@ void* ThriftServer::ThriftServerEventProcessor::createContext(
     {
         std::lock_guard<std::mutex> _l(_thrift_server->_session_keys_lock);
 
-        std::shared_ptr<SessionKey> key_ptr(new std::string(ss.str()));
+        auto key_ptr = std::make_shared<std::string>(ss.str());
 
         _session_key = key_ptr.get();
         _thrift_server->_session_keys[key_ptr.get()] = key_ptr;
@@ -327,22 +327,21 @@ Status ThriftServer::start() {
     switch (_server_type) {
     case NON_BLOCKING: {
         if (transport_factory == nullptr) {
-            transport_factory.reset(new apache::thrift::transport::TTransportFactory());
+            transport_factory = std::make_shared<apache::thrift::transport::TTransportFactory>();
         }
 
-        std::shared_ptr<apache::thrift::transport::TNonblockingServerSocket> port(
-                new apache::thrift::transport::TNonblockingServerSocket(_port));
+        auto port = std::make_shared<apache::thrift::transport::TNonblockingServerSocket>(_port);
         _server = std::make_unique<apache::thrift::server::TNonblockingServer>(
                 _processor, transport_factory, transport_factory, protocol_factory, protocol_factory, port, thread_mgr);
         break;
     }
 
     case THREAD_POOL:
-        fe_server_transport.reset(new apache::thrift::transport::TServerSocket(
-                BackendOptions::get_service_bind_address_without_bracket(), _port));
+        fe_server_transport = std::make_shared<apache::thrift::transport::TServerSocket>(
+                BackendOptions::get_service_bind_address_without_bracket(), _port);
 
         if (transport_factory == nullptr) {
-            transport_factory.reset(new apache::thrift::transport::TBufferedTransportFactory());
+            transport_factory = std::make_shared<apache::thrift::transport::TBufferedTransportFactory>();
         }
 
         _server = std::make_unique<apache::thrift::server::TThreadPoolServer>(
@@ -357,7 +356,7 @@ Status ThriftServer::start() {
         server_socket->setKeepAlive(true);
 
         if (transport_factory == nullptr) {
-            transport_factory.reset(new apache::thrift::transport::TBufferedTransportFactory());
+            transport_factory = std::make_shared<apache::thrift::transport::TBufferedTransportFactory>();
         }
 
         // Use non-detached thread mode, so the ThreadedServer can correctly wait for all client threads done and exits cleanly.
@@ -374,8 +373,7 @@ Status ThriftServer::start() {
         return Status::InternalError(error_msg.str());
     }
 
-    std::shared_ptr<ThriftServer::ThriftServerEventProcessor> event_processor(
-            new ThriftServer::ThriftServerEventProcessor(this));
+    auto event_processor = std::make_shared<ThriftServer::ThriftServerEventProcessor>(this);
     _server->setServerEventHandler(event_processor);
 
     RETURN_IF_ERROR(event_processor->start_and_wait_for_server());

--- a/be/src/common/vlog_cntl.h
+++ b/be/src/common/vlog_cntl.h
@@ -18,8 +18,6 @@
 
 #include <string>
 
-#include "gutil/macros.h"
-
 namespace starrocks {
 class VLogCntl {
 public:
@@ -28,7 +26,10 @@ public:
         return log_module;
     }
 
-    DISALLOW_COPY_AND_MOVE(VLogCntl);
+    VLogCntl(const VLogCntl&) = delete;
+    VLogCntl& operator=(const VLogCntl&) = delete;
+    VLogCntl(VLogCntl&&) = delete;
+    VLogCntl& operator=(VLogCntl&&) = delete;
 
     void setLogLevel(const std::string& module, int level) { google::SetVLOGLevel(module.c_str(), level); }
 

--- a/be/src/connector/utils.h
+++ b/be/src/connector/utils.h
@@ -66,14 +66,14 @@ class PathUtils {
 public:
     // requires: path contains "/"
     static std::string get_parent_path(const std::string& path) {
-        std::size_t i = path.find_last_of("/");
+        std::size_t i = path.find_last_of('/');
         CHECK_NE(i, std::string::npos);
         return path.substr(0, i);
     }
 
     // requires: path contains "/"
     static std::string get_filename(const std::string& path) {
-        std::size_t i = path.find_last_of("/");
+        std::size_t i = path.find_last_of('/');
         CHECK_NE(i, std::string::npos);
         return path.substr(i + 1);
     }

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -80,7 +80,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     // TODO: figure out appropriate buffer size
     DCHECK_GT(_num_senders, 0);
-    _sub_plan_query_statistics_recvr.reset(new QueryStatisticsRecvr());
+    _sub_plan_query_statistics_recvr = std::make_shared<QueryStatisticsRecvr>();
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _is_merging, _sub_plan_query_statistics_recvr, false, 1, false);

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -179,8 +179,8 @@ Status ExecNode::prepare(RuntimeState* state) {
                 return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
-    _mem_tracker.reset(new MemTracker(_runtime_profile.get(), std::make_tuple(true, false, false), "", -1,
-                                      _runtime_profile->name(), nullptr));
+    _mem_tracker = std::make_shared<MemTracker>(_runtime_profile.get(), std::make_tuple(true, false, false), "", -1,
+                                                _runtime_profile->name(), nullptr);
     RETURN_IF_ERROR(ExprExecutor::prepare(_conjunct_ctxs, state));
     RETURN_IF_ERROR(_runtime_filter_collector.prepare(state, _runtime_profile.get()));
 
@@ -374,7 +374,7 @@ void ExecNode::collect_scan_nodes(vector<ExecNode*>* nodes) {
 void ExecNode::init_runtime_profile(const std::string& name) {
     std::stringstream ss;
     ss << name << " (id=" << _id << ")";
-    _runtime_profile.reset(new RuntimeProfile(ss.str()));
+    _runtime_profile = std::make_shared<RuntimeProfile>(ss.str());
     _runtime_profile->set_metadata(_id);
 }
 

--- a/be/src/exec/file_scanner/avro_scanner.h
+++ b/be/src/exec/file_scanner/avro_scanner.h
@@ -60,7 +60,7 @@ public:
     static std::string preprocess_jsonpaths(std::string jsonpath);
 
     struct SlotInfo {
-        SlotInfo() {}
+        SlotInfo() = default;
         SlotId id{-2};
         TypeDescriptor type;
         std::string key;

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <bit>
+#include <cstdint>
+
 #include "column/chunk.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -111,10 +114,12 @@ private:
     int _chunk_meta_index;
 
     void reset_chunk_meta(long chunk_meta) {
-        _chunk_meta_ptr = static_cast<long*>(reinterpret_cast<void*>(chunk_meta));
+        _chunk_meta_ptr = std::bit_cast<long*>(static_cast<std::uintptr_t>(chunk_meta));
         _chunk_meta_index = 0;
     }
-    void* next_chunk_meta_as_ptr() { return reinterpret_cast<void*>(_chunk_meta_ptr[_chunk_meta_index++]); }
+    void* next_chunk_meta_as_ptr() {
+        return std::bit_cast<void*>(static_cast<std::uintptr_t>(_chunk_meta_ptr[_chunk_meta_index++]));
+    }
     long next_chunk_meta_as_long() { return _chunk_meta_ptr[_chunk_meta_index++]; }
 };
 

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -14,9 +14,6 @@
 
 #pragma once
 
-#include <bit>
-#include <cstdint>
-
 #include "column/chunk.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -114,12 +111,10 @@ private:
     int _chunk_meta_index;
 
     void reset_chunk_meta(long chunk_meta) {
-        _chunk_meta_ptr = std::bit_cast<long*>(static_cast<std::uintptr_t>(chunk_meta));
+        _chunk_meta_ptr = static_cast<long*>(reinterpret_cast<void*>(chunk_meta));
         _chunk_meta_index = 0;
     }
-    void* next_chunk_meta_as_ptr() {
-        return std::bit_cast<void*>(static_cast<std::uintptr_t>(_chunk_meta_ptr[_chunk_meta_index++]));
-    }
+    void* next_chunk_meta_as_ptr() { return reinterpret_cast<void*>(_chunk_meta_ptr[_chunk_meta_index++]); }
     long next_chunk_meta_as_long() { return _chunk_meta_ptr[_chunk_meta_index++]; }
 };
 

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -30,7 +30,8 @@ namespace starrocks {
 
 struct PartitionChunks {
     explicit PartitionChunks(size_t partition_idx) : partition_idx(partition_idx) {}
-    DISALLOW_COPY_AND_ASSIGN(PartitionChunks);
+    PartitionChunks(const PartitionChunks&) = delete;
+    PartitionChunks& operator=(const PartitionChunks&) = delete;
 
     Chunks chunks;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -20,8 +20,7 @@
 #include "exec/pipeline/operator.h"
 #include "runtime/runtime_state_fwd.h"
 
-namespace starrocks {
-namespace pipeline {
+namespace starrocks::pipeline {
 
 class AggregateStreamingSinkOperatorFactory;
 class AggregateStreamingSinkOperator : public Operator {
@@ -117,5 +116,4 @@ private:
     std::once_flag _set_collector_flag;
     const std::vector<RuntimeFilterBuildDescriptor*>& _build_runtime_filters;
 };
-} // namespace pipeline
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.h
@@ -52,7 +52,7 @@ public:
                                                   AggregateBlockingSourceOperatorPtr non_pw_agg,
                                                   ConjugateOperatorPtr pw_agg)
             : SourceOperator(factory, id, "spillable_partitionwise_agg_source", plan_node_id, false, driver_sequence),
-              _non_pw_agg(non_pw_agg),
+              _non_pw_agg(std::move(non_pw_agg)),
               _pw_agg(std::move(pw_agg)) {}
 
     ~SpillablePartitionWiseAggregateSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.h
@@ -53,7 +53,7 @@ public:
                                                  ConjugateOperatorPtr pw_agg)
             : SourceOperator(factory, id, "spillable_partitionwise_distinct_source", plan_node_id, false,
                              driver_sequence),
-              _non_pw_distinct(non_pw_agg),
+              _non_pw_distinct(std::move(non_pw_agg)),
               _pw_distinct(std::move(pw_agg)) {}
 
     ~SpillablePartitionWiseDistinctSourceOperator() override = default;

--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -35,7 +35,8 @@ public:
     ContextWithDependency() = default;
     virtual ~ContextWithDependency() = default;
 
-    DISALLOW_COPY_AND_ASSIGN(ContextWithDependency);
+    ContextWithDependency(const ContextWithDependency&) = delete;
+    ContextWithDependency& operator=(const ContextWithDependency&) = delete;
 
     // For pipeline, it is called by unref() when the last operator is unreffed.
     // For non-pipeline, it is called by close() of the exec node directly

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -56,7 +56,7 @@ private:
     // TODO: use c++20 barrier after upgrading gcc
     class Barrier {
     public:
-        explicit Barrier() {}
+        explicit Barrier() = default;
 
         void arrive() {
             std::unique_lock<std::mutex> lock(_mutex);

--- a/be/src/exec/pipeline/sink/dictionary_cache_sink_operator.h
+++ b/be/src/exec/pipeline/sink/dictionary_cache_sink_operator.h
@@ -20,9 +20,7 @@
 #include "gen_cpp/DataSinks_types.h"
 #include "gen_cpp/InternalService_types.h"
 
-namespace starrocks {
-
-namespace pipeline {
+namespace starrocks::pipeline {
 
 class DictionaryCacheSinkOperator final : public Operator {
 public:
@@ -85,5 +83,4 @@ private:
     FragmentContext* _fragment_ctx = nullptr;
 };
 
-} // namespace pipeline
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -51,7 +51,7 @@ StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
 
     auto chunk_st = _channel->current_task()();
     if (chunk_st.status().ok() && !state->is_cancelled()) {
-        auto chunk = chunk_st.value();
+        const auto& chunk = chunk_st.value();
         if (chunk != nullptr && !chunk->is_empty()) {
             auto& spiller = _channel->spiller();
             RETURN_IF_ERROR(spiller->spill(state, chunk_st.value(), TRACKER_WITH_SPILLER_GUARD(state, spiller)));

--- a/be/src/exec/pipeline/stream_pipeline_driver.cpp
+++ b/be/src/exec/pipeline/stream_pipeline_driver.cpp
@@ -99,7 +99,7 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
                 }
 
                 if (return_status.ok() && maybe_chunk.value()) {
-                    auto chunk_value = maybe_chunk.value();
+                    const auto& chunk_value = maybe_chunk.value();
                     if (chunk_value->num_rows() > 0) {
                         size_t row_num = chunk_value->num_rows();
                         total_rows_moved += row_num;
@@ -238,7 +238,7 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
             }
 
             if (return_status.ok() && maybe_chunk.value()) {
-                auto chunk_value = maybe_chunk.value();
+                const auto& chunk_value = maybe_chunk.value();
                 if (chunk_value->num_rows() > 0) {
                     size_t row_num = chunk_value->num_rows();
                     total_rows_moved += row_num;

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -101,7 +101,7 @@ struct SortedRuns {
     SortedRuns() = default;
     ~SortedRuns() = default;
     SortedRuns(const SortedRuns& run) = default;
-    SortedRuns(SortedRuns&& run) = default;
+    SortedRuns(SortedRuns&& run) noexcept = default;
     SortedRuns(const SortedRun& run) : chunks{run} {}
     SortedRuns& operator=(SortedRuns&& run) = default;
 

--- a/be/src/exec/sorting/sort_helper.h
+++ b/be/src/exec/sorting/sort_helper.h
@@ -179,7 +179,7 @@ static inline Status sort_and_tie_helper(const std::atomic<bool>& cancel, const 
             }
 
             // Find if any element equal with the nth element, take it into account of this run
-            auto nth = permutation[limit - 1];
+            const auto& nth = permutation[limit - 1];
             size_t equal_count = 0;
             for (auto iter = begin + n; iter < end; iter++) {
                 if (cmp(*iter, nth) == 0) {

--- a/be/src/exprs/agg/combinator/state_combinator.h
+++ b/be/src/exprs/agg/combinator/state_combinator.h
@@ -43,7 +43,7 @@ public:
         VLOG_ROW << "StateCombinator constructor:" << _agg_state_desc.debug_string();
     }
 
-    ~StateCombinator() = default;
+    virtual ~StateCombinator() = default;
 
     // prepare the state combinator
     virtual Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) { return Status::OK(); }

--- a/be/src/exprs/agg/combinator/state_merge_function.h
+++ b/be/src/exprs/agg/combinator/state_merge_function.h
@@ -44,7 +44,7 @@ public:
         DCHECK(_function != nullptr);
     }
 
-    ~StateMergeFunction() {
+    ~StateMergeFunction() override {
         if (_nested_ctx != nullptr) {
             delete _nested_ctx;
         }

--- a/be/src/exprs/agg/combinator/state_union_function.h
+++ b/be/src/exprs/agg/combinator/state_union_function.h
@@ -42,7 +42,7 @@ public:
         DCHECK(_function != nullptr);
     }
 
-    ~StateUnionFunction() {
+    ~StateUnionFunction() override {
         if (_nested_ctx != nullptr) {
             delete _nested_ctx;
         }

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -35,7 +35,7 @@ public:
     // This is used when the state is already constructed (e.g., as part of NullableAggregateFunctionState)
     // but we need to apply a different compression factor from FunctionContext
     void reinit_with_compression(double compression) {
-        percentile.reset(new PercentileValue(compression));
+        percentile = std::make_unique<PercentileValue>(compression);
         compression_initialized = true;
     }
 

--- a/be/src/exprs/geo_functions.cpp
+++ b/be/src/exprs/geo_functions.cpp
@@ -300,7 +300,7 @@ StatusOr<ColumnPtr> GeoFunctions::st_as_wkt(FunctionContext* context, const Colu
 }
 
 struct StContainsState {
-    StContainsState() {}
+    StContainsState() = default;
     ~StContainsState() {
         delete shapes[0];
         delete shapes[1];

--- a/be/src/exprs/jit/jit_engine.h
+++ b/be/src/exprs/jit/jit_engine.h
@@ -54,11 +54,11 @@ public:
 
     JITCallable(const JITCallable&) = delete;
 
-    JITCallable(JITCallable&& that) : _mem_mgr(std::move(that._mem_mgr)), _func(that._func) {
+    JITCallable(JITCallable&& that) noexcept : _mem_mgr(std::move(that._mem_mgr)), _func(that._func) {
         that._func = nullptr; // Prevent double free
     }
 
-    JITCallable& operator=(JITCallable&& that) {
+    JITCallable& operator=(JITCallable&& that) noexcept {
         if (this != &that) {
             _mem_mgr = std::move(that._mem_mgr);
             _func = that._func;

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -1867,7 +1867,7 @@ StatusOr<ColumnPtr> JsonFunctions::json_set(FunctionContext* context, const Colu
                 null_arg = true;
                 break;
             }
-            JsonPath json_path = res.value();
+            const JsonPath& json_path = res.value();
 
             JsonValue* new_val = val_viewers[i].value(row);
 

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -360,8 +360,8 @@ public:
      */
     template <LogicalType Type>
     DEFINE_VECTORIZED_FN(pmod) {
-        auto l = VECTORIZED_FN_ARGS(0);
-        auto r = VECTORIZED_FN_ARGS(1);
+        const auto& l = VECTORIZED_FN_ARGS(0);
+        const auto& r = VECTORIZED_FN_ARGS(1);
 
         if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
             return VectorizedUnstrictBinaryFunction<RValueCheckZeroImpl, pmodFloatImpl>::evaluate<Type>(l, r);
@@ -377,8 +377,8 @@ public:
      */
     template <LogicalType Type>
     DEFINE_VECTORIZED_FN(fmod) {
-        auto l = VECTORIZED_FN_ARGS(0);
-        auto r = VECTORIZED_FN_ARGS(1);
+        const auto& l = VECTORIZED_FN_ARGS(0);
+        const auto& r = VECTORIZED_FN_ARGS(1);
 
         return VectorizedUnstrictBinaryFunction<RValueCheckZeroImpl, fmodImpl>::evaluate<Type>(l, r);
     }
@@ -392,8 +392,8 @@ public:
      */
     template <LogicalType Type>
     DEFINE_VECTORIZED_FN(mod) {
-        auto l = VECTORIZED_FN_ARGS(0);
-        auto r = VECTORIZED_FN_ARGS(1);
+        const auto& l = VECTORIZED_FN_ARGS(0);
+        const auto& r = VECTORIZED_FN_ARGS(1);
 
         if constexpr (lt_is_decimalv2<Type>) {
             return VectorizedUnstrictBinaryFunction<RValueCheckZeroDecimalv2Impl, modDecimalv2Impl>::evaluate<Type>(l,

--- a/be/src/fs/azure/fs_azblob.cpp
+++ b/be/src/fs/azure/fs_azblob.cpp
@@ -371,7 +371,7 @@ BlobContainerClientPtr AzBlobClientFactory::create_blob_container_client(
 
 class AzBlobFileSystem : public FileSystem {
 public:
-    explicit AzBlobFileSystem(const FSOptions& options);
+    explicit AzBlobFileSystem(FSOptions options);
     ~AzBlobFileSystem() override = default;
 
     AzBlobFileSystem(const AzBlobFileSystem&) = delete;
@@ -476,7 +476,7 @@ private:
     AzBlobClientFactory* _factory;
 };
 
-AzBlobFileSystem::AzBlobFileSystem(const FSOptions& options) : _options(options), _factory(blob_client_factory()) {}
+AzBlobFileSystem::AzBlobFileSystem(FSOptions options) : _options(std::move(options)), _factory(blob_client_factory()) {}
 
 StatusOr<BlobContainerClientPtr> AzBlobFileSystem::new_blob_container_client(const AzBlobURI& uri) {
     // Create azure cloud credential from TCloudConfiguration.cloud_properties
@@ -539,8 +539,8 @@ StatusOr<std::unique_ptr<WritableFile>> AzBlobFileSystem::new_writable_file(cons
     return wrap_encrypted(std::make_unique<OutputStreamAdapter>(std::move(output_stream), fname), opts.encryption_info);
 }
 
-std::unique_ptr<FileSystem> new_fs_azblob(const FSOptions& options) {
-    return std::make_unique<AzBlobFileSystem>(options);
+std::unique_ptr<FileSystem> new_fs_azblob(FSOptions options) {
+    return std::make_unique<AzBlobFileSystem>(std::move(options));
 }
 
 } // namespace starrocks

--- a/be/src/fs/azure/fs_azblob.h
+++ b/be/src/fs/azure/fs_azblob.h
@@ -18,6 +18,6 @@
 
 namespace starrocks {
 
-std::unique_ptr<FileSystem> new_fs_azblob(const FSOptions& options);
+std::unique_ptr<FileSystem> new_fs_azblob(FSOptions options);
 
 } // namespace starrocks

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -359,7 +359,7 @@ static std::shared_ptr<Aws::S3::S3Client> new_s3client(
 
 class S3FileSystem : public FileSystem {
 public:
-    S3FileSystem(const FSOptions& options) : _options(options) {}
+    S3FileSystem(FSOptions options) : _options(std::move(options)) {}
     ~S3FileSystem() override = default;
 
     S3FileSystem(const S3FileSystem&) = delete;
@@ -572,9 +572,9 @@ Status S3FileSystem::rename_file(const std::string& src, const std::string& targ
 
 StatusOr<SpaceInfo> S3FileSystem::space(const std::string& path) {
     // call `is_directory()` to check if 'path' is an valid path
-    const Status status = S3FileSystem::is_directory(path).status();
+    Status status = S3FileSystem::is_directory(path).status();
     if (!status.ok()) {
-        return status;
+        return std::move(status);
     }
     return SpaceInfo{.capacity = std::numeric_limits<int64_t>::max(),
                      .free = std::numeric_limits<int64_t>::max(),

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -525,7 +525,7 @@ public:
     }
 
     StatusOr<SpaceInfo> space(const std::string& path) override {
-        const Status status = is_directory(path).status();
+        Status status = is_directory(path).status();
         if (!status.ok()) {
             return status;
         }

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -39,8 +39,8 @@ namespace starrocks {
 
 class GetHdfsFileReadOnlyHandle {
 public:
-    GetHdfsFileReadOnlyHandle(const FSOptions& options, std::string path, int buffer_size)
-            : _options(options), _path(std::move(path)), _buffer_size(buffer_size) {}
+    GetHdfsFileReadOnlyHandle(FSOptions options, std::string path, int buffer_size)
+            : _options(std::move(options)), _path(std::move(path)), _buffer_size(buffer_size) {}
 
     StatusOr<hdfsFS> getOrCreateFS() {
         if (_hdfs_client == nullptr) {
@@ -161,7 +161,7 @@ public:
     }
 
 private:
-    const FSOptions _options;
+    FSOptions _options;
     std::string _path;
     int _buffer_size;
     std::shared_ptr<HdfsFsClient> _hdfs_client = nullptr;
@@ -386,7 +386,7 @@ Status HDFSWritableFile::close() {
 
 class HdfsFileSystem : public FileSystem {
 public:
-    HdfsFileSystem(const FSOptions& options) : _options(options) {}
+    HdfsFileSystem(FSOptions options) : _options(std::move(options)) {}
     ~HdfsFileSystem() override = default;
 
     HdfsFileSystem(const HdfsFileSystem&) = delete;

--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -105,6 +105,7 @@ set(SRC_FILES
 # each other
 ADD_BE_LIB(StarRocksGen ${SRC_FILES})
 add_dependencies(StarRocksGen be_proto_codegen be_thrift_codegen)
+set_target_properties(StarRocksGen PROPERTIES CXX_CLANG_TIDY "")
 
 # Setting these files as code-generated lets make clean and incremental builds work
 # correctly

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -82,7 +82,7 @@ public:
     public:
         Scope() = delete;
         Scope(const Scope&) = delete;
-        Scope(Scope&& other) {
+        Scope(Scope&& other) noexcept {
             _old = other._old;
             _tls_io_snapshot = other._tls_io_snapshot;
             other._old = nullptr;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -441,7 +441,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, co
         }
     }
     exec_state = std::make_shared<FragmentExecState>(params.params.query_id, fragment_instance_id, params.backend_num,
-                                                      _exec_env, params.coord);
+                                                     _exec_env, params.coord);
     RETURN_IF_ERROR_WITH_WARN(exec_state->prepare(params), "Fail to prepare Fragment");
 
     {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -440,8 +440,8 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, co
             return Status::OK();
         }
     }
-    exec_state.reset(new FragmentExecState(params.params.query_id, fragment_instance_id, params.backend_num, _exec_env,
-                                           params.coord));
+    exec_state = std::make_shared<FragmentExecState>(params.params.query_id, fragment_instance_id, params.backend_num,
+                                                      _exec_env, params.coord);
     RETURN_IF_ERROR_WITH_WARN(exec_state->prepare(params), "Fail to prepare Fragment");
 
     {

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -138,7 +138,7 @@ void LoadChannel::open(const LoadChannelOpenContext& open_context) {
         std::shared_ptr<TabletsChannel> channel;
         std::lock_guard l(_lock);
         if (_schema == nullptr) {
-            _schema.reset(new OlapTableSchemaParam());
+            _schema = std::make_shared<OlapTableSchemaParam>();
             RETURN_RESPONSE_IF_ERROR(_schema->init(request.schema()), response);
         }
         if (_row_desc == nullptr) {

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -213,8 +213,9 @@ void LoadChannelMgr::_open(LoadChannelOpenContext open_context) {
             int64_t job_timeout_s = calc_job_timeout_s(timeout_in_req_s);
             auto job_mem_tracker = std::make_unique<MemTracker>(job_max_memory, load_id.to_string(), _mem_tracker);
 
-            channel.reset(new LoadChannel(this, ExecEnv::GetInstance()->lake_tablet_manager(), load_id, txn_id,
-                                          request.txn_trace_parent(), job_timeout_s, std::move(job_mem_tracker)));
+            channel = std::make_shared<LoadChannel>(this, ExecEnv::GetInstance()->lake_tablet_manager(), load_id,
+                                                    txn_id, request.txn_trace_parent(), job_timeout_s,
+                                                    std::move(job_mem_tracker));
             if (request.has_load_channel_profile_config()) {
                 channel->set_profile_config(request.load_channel_profile_config());
             }

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -101,7 +101,7 @@ class MemTracker;
 ///    delete p;
 class MemPool {
 public:
-    MemPool() {}
+    MemPool() = default;
 
     /// Frees all chunks of memory and subtracts the total allocated bytes
     /// from the registered limits.

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -154,7 +154,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
 
     _runtime_state->set_per_fragment_instance_idx(params.sender_id);
     _runtime_state->set_num_per_fragment_instances(params.num_senders);
-    _query_statistics.reset(new QueryStatistics());
+    _query_statistics = std::make_shared<QueryStatistics>();
 
     // set up sink, if required
     if (request.fragment.__isset.output_sink) {

--- a/be/src/runtime/small_file_mgr.cpp
+++ b/be/src/runtime/small_file_mgr.cpp
@@ -94,7 +94,7 @@ Status SmallFileMgr::_load_single_file(const std::string& path, const std::strin
         return Status::InternalError(strings::Substitute("Not a valid file name: $0", file_name));
     }
     int64_t file_id = std::stol(parts[0]);
-    std::string md5 = parts[1];
+    const std::string& md5 = parts[1];
 
     if (_file_cache.find(file_id) != _file_cache.end()) {
         return Status::InternalError(strings::Substitute("File with same id is already been loaded: $0", file_id));

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -174,7 +174,7 @@ Status TransactionMgr::list_transactions(const HttpRequest* req, std::string* re
 }
 
 Status TransactionMgr::begin_transaction(const HttpRequest* req, std::string* resp) {
-    auto label = req->header(HTTP_LABEL_KEY);
+    const auto& label = req->header(HTTP_LABEL_KEY);
     Status st;
     auto ctx = _exec_env->stream_context_mgr()->get(label);
     if (ctx == nullptr) {
@@ -205,7 +205,7 @@ Status TransactionMgr::begin_transaction(const HttpRequest* req, std::string* re
 }
 
 Status TransactionMgr::rollback_transaction(const HttpRequest* req, std::string* resp) {
-    auto label = req->header(HTTP_LABEL_KEY);
+    const auto& label = req->header(HTTP_LABEL_KEY);
     Status st;
     auto ctx = _exec_env->stream_context_mgr()->get(label);
     if (ctx == nullptr) {

--- a/be/src/service/service_be/arrow_flight_auth_server_middleware.h
+++ b/be/src/service/service_be/arrow_flight_auth_server_middleware.h
@@ -66,7 +66,7 @@ private:
 // No actual authentication.
 class NoOpBearerAuthServerMiddlewareFactory : public arrow::flight::ServerMiddlewareFactory {
 public:
-    NoOpBearerAuthServerMiddlewareFactory() {}
+    NoOpBearerAuthServerMiddlewareFactory() = default;
 
     arrow::Status StartCall(const arrow::flight::CallInfo& info, const arrow::flight::ServerCallContext& context,
                             std::shared_ptr<arrow::flight::ServerMiddleware>* middleware) override;

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -159,7 +159,7 @@ Status BinlogManager::_recover_version(int64_t version, BinlogLsn& min_lsn, std:
             useless_file_ids->push_back(file_id);
             continue;
         }
-        BinlogFileMetaPBPtr file_meta = status_or.value();
+        const BinlogFileMetaPBPtr& file_meta = status_or.value();
         recovered_file_metas.push_back(file_meta);
         BinlogLsn lsn(file_meta->start_version(), file_meta->start_seq_id());
         last_file_meta = file_meta;
@@ -364,7 +364,7 @@ void BinlogManager::_check_wait_reader_binlog_files() {
         if (binlog_file->reader_count() > 0) {
             break;
         }
-        auto file_meta = binlog_file->file_meta();
+        const auto& file_meta = binlog_file->file_meta();
         _total_wait_reader_binlog_file_size -= file_meta->file_size();
         for (int64_t rowset_id : file_meta->rowsets()) {
             int32_t count = --_wait_reader_rowset_count_map[rowset_id];
@@ -470,7 +470,7 @@ void BinlogManager::delete_unused_binlog() {
         LOG(ERROR) << "Failed to delete unused binlog, tablet: " << _tablet_id << ", " << status_or.status();
         return;
     }
-    std::shared_ptr<FileSystem> fs = status_or.value();
+    const std::shared_ptr<FileSystem>& fs = status_or.value();
     int64_t file_id;
     int32_t total_num = 0;
     int32_t fail_num = 0;

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -34,8 +34,6 @@ struct CompactionCandidate {
     CompactionCandidate(TabletSharedPtr t, CompactionType compaction_type)
             : tablet(std::move(t)), type(compaction_type) {}
 
-    CompactionCandidate(const TabletSharedPtr& t, CompactionType compaction_type) : tablet(t), type(compaction_type) {}
-
     CompactionCandidate(const CompactionCandidate& other) {
         tablet = other.tablet;
         type = other.type;
@@ -44,18 +42,9 @@ struct CompactionCandidate {
 
     CompactionCandidate& operator=(const CompactionCandidate& rhs) = default;
 
-    CompactionCandidate(CompactionCandidate&& other) {
-        tablet = std::move(other.tablet);
-        type = other.type;
-        score = other.score;
-    }
+    CompactionCandidate(CompactionCandidate&& other) noexcept = default;
 
-    CompactionCandidate& operator=(CompactionCandidate&& rhs) {
-        tablet = std::move(rhs.tablet);
-        type = rhs.type;
-        score = rhs.score;
-        return *this;
-    }
+    CompactionCandidate& operator=(CompactionCandidate&& rhs) noexcept = default;
 
     std::string to_string() const {
         std::stringstream ss;

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -113,7 +113,7 @@ Status TypeConverter::convert_column(TypeInfo* src_type, const Column& src, Type
 class DatetimeToDateTypeConverter : public TypeConverter {
 public:
     DatetimeToDateTypeConverter() = default;
-    virtual ~DatetimeToDateTypeConverter() = default;
+    ~DatetimeToDateTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -139,7 +139,7 @@ public:
 class TimestampToDateTypeConverter : public TypeConverter {
 public:
     TimestampToDateTypeConverter() = default;
-    virtual ~TimestampToDateTypeConverter() = default;
+    ~TimestampToDateTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -162,7 +162,7 @@ public:
 class IntToDateTypeConverter : public TypeConverter {
 public:
     IntToDateTypeConverter() = default;
-    virtual ~IntToDateTypeConverter() = default;
+    ~IntToDateTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -190,7 +190,7 @@ public:
 class DateV2ToDateTypeConverter : public TypeConverter {
 public:
     DateV2ToDateTypeConverter() = default;
-    virtual ~DateV2ToDateTypeConverter() = default;
+    ~DateV2ToDateTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -211,7 +211,7 @@ public:
 class TimestampToDateV2TypeConverter : public TypeConverter {
 public:
     TimestampToDateV2TypeConverter() = default;
-    virtual ~TimestampToDateV2TypeConverter() = default;
+    ~TimestampToDateV2TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         unaligned_store<DateValue>(dst, unaligned_load<TimestampValue>(src));
@@ -237,7 +237,7 @@ public:
 class DatetimeToDateV2TypeConverter : public TypeConverter {
 public:
     DatetimeToDateV2TypeConverter() = default;
-    virtual ~DatetimeToDateV2TypeConverter() = default;
+    ~DatetimeToDateV2TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         TimestampValue timestamp{0};
@@ -267,7 +267,7 @@ public:
 class DateToDateV2TypeConverter : public TypeConverter {
 public:
     DateToDateV2TypeConverter() = default;
-    virtual ~DateToDateV2TypeConverter() = default;
+    ~DateToDateV2TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -289,7 +289,7 @@ public:
 class DateToDatetimeFieldConveter : public TypeConverter {
 public:
     DateToDatetimeFieldConveter() = default;
-    virtual ~DateToDatetimeFieldConveter() = default;
+    ~DateToDatetimeFieldConveter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -313,7 +313,7 @@ public:
 class DateV2ToDatetimeFieldConveter : public TypeConverter {
 public:
     DateV2ToDatetimeFieldConveter() = default;
-    virtual ~DateV2ToDatetimeFieldConveter() = default;
+    ~DateV2ToDatetimeFieldConveter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -336,7 +336,7 @@ public:
 class TimestampToDatetimeTypeConverter : public TypeConverter {
 public:
     TimestampToDatetimeTypeConverter() = default;
-    virtual ~TimestampToDatetimeTypeConverter() = default;
+    ~TimestampToDatetimeTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -356,7 +356,7 @@ public:
 class DateToTimestampTypeConverter : public TypeConverter {
 public:
     DateToTimestampTypeConverter() = default;
-    virtual ~DateToTimestampTypeConverter() = default;
+    ~DateToTimestampTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         uint32_t src_value = unaligned_load<uint24_t>(src);
@@ -385,7 +385,7 @@ public:
 class DateV2ToTimestampTypeConverter : public TypeConverter {
 public:
     DateV2ToTimestampTypeConverter() = default;
-    virtual ~DateV2ToTimestampTypeConverter() = default;
+    ~DateV2ToTimestampTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         auto src_value = unaligned_load<DateValue>(src);
@@ -416,7 +416,7 @@ public:
 class DatetimeToTimestampTypeConverter : public TypeConverter {
 public:
     DatetimeToTimestampTypeConverter() = default;
-    virtual ~DatetimeToTimestampTypeConverter() = default;
+    ~DatetimeToTimestampTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -438,7 +438,7 @@ public:
 class FloatToDoubleTypeConverter : public TypeConverter {
 public:
     FloatToDoubleTypeConverter() = default;
-    virtual ~FloatToDoubleTypeConverter() = default;
+    ~FloatToDoubleTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -461,7 +461,7 @@ public:
 class DecimalToDecimal12TypeConverter : public TypeConverter {
 public:
     DecimalToDecimal12TypeConverter() = default;
-    virtual ~DecimalToDecimal12TypeConverter() = default;
+    ~DecimalToDecimal12TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -482,7 +482,7 @@ public:
 class Decimal12ToDecimalTypeConverter : public TypeConverter {
 public:
     Decimal12ToDecimalTypeConverter() = default;
-    virtual ~Decimal12ToDecimalTypeConverter() = default;
+    ~Decimal12ToDecimalTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -507,7 +507,7 @@ public:
     using CppType = typename CppTypeTraits<int_type>::CppType;
 
     IntegerToDateV2TypeConverter() = default;
-    virtual ~IntegerToDateV2TypeConverter() = default;
+    ~IntegerToDateV2TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         auto src_value = unaligned_load<CppType>(src);
@@ -543,7 +543,7 @@ public:
     using DstCppType = typename CppTypeTraits<DstType>::CppType;
 
     DecimalTypeConverter() = default;
-    virtual ~DecimalTypeConverter() = default;
+    ~DecimalTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -570,7 +570,7 @@ public:
     using DstCppType = typename CppTypeTraits<DstType>::CppType;
 
     DecimalV3TypeConverter() = default;
-    virtual ~DecimalV3TypeConverter() = default;
+    ~DecimalV3TypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -598,7 +598,7 @@ public:
     using CppType = typename CppTypeTraits<Type>::CppType;
 
     StringToOtherTypeConverter() = default;
-    virtual ~StringToOtherTypeConverter() = default;
+    ~StringToOtherTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -627,7 +627,7 @@ public:
     using CppType = typename CppTypeTraits<TYPE_JSON>::CppType;
 
     StringToOtherTypeConverter() = default;
-    virtual ~StringToOtherTypeConverter() = default;
+    ~StringToOtherTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("not supported");
@@ -662,7 +662,7 @@ public:
     using CppType = typename CppTypeTraits<Type>::CppType;
 
     OtherToStringTypeConverter() = default;
-    virtual ~OtherToStringTypeConverter() = default;
+    ~OtherToStringTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("missing implementation");
@@ -699,7 +699,7 @@ public:
     using CppType = typename CppTypeTraits<TYPE_JSON>::CppType;
 
     OtherToStringTypeConverter() = default;
-    virtual ~OtherToStringTypeConverter() = default;
+    ~OtherToStringTypeConverter() override = default;
 
     Status convert(void* dst, const void* src, MemPool* memPool) const override {
         return Status::InternalError("not supported");
@@ -992,7 +992,7 @@ template <typename SrcType>
 class BitMapTypeConverter : public MaterializeTypeConverter {
 public:
     BitMapTypeConverter() = default;
-    virtual ~BitMapTypeConverter() = default;
+    ~BitMapTypeConverter() override = default;
 
     Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
@@ -1023,7 +1023,7 @@ template <typename SrcType>
 class HLLTypeConverter : public MaterializeTypeConverter {
 public:
     HLLTypeConverter() = default;
-    virtual ~HLLTypeConverter() = default;
+    ~HLLTypeConverter() override = default;
 
     Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
@@ -1051,7 +1051,7 @@ template <typename SrcType>
 class PercentileTypeConverter : public MaterializeTypeConverter {
 public:
     PercentileTypeConverter() = default;
-    virtual ~PercentileTypeConverter() = default;
+    ~PercentileTypeConverter() override = default;
 
     Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
@@ -1077,7 +1077,7 @@ class DecimalToPercentileTypeConverter : public MaterializeTypeConverter {
 public:
     using CppType = typename CppTypeTraits<SrcType>::CppType;
     DecimalToPercentileTypeConverter() = default;
-    virtual ~DecimalToPercentileTypeConverter() = default;
+    ~DecimalToPercentileTypeConverter() override = default;
 
     Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {
@@ -1104,7 +1104,7 @@ public:
 class CountTypeConverter : public MaterializeTypeConverter {
 public:
     CountTypeConverter() = default;
-    virtual ~CountTypeConverter() = default;
+    ~CountTypeConverter() override = default;
 
     Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const override {
         for (size_t row_index = 0; row_index < src_col->size(); ++row_index) {

--- a/be/src/storage/convert_helper.h
+++ b/be/src/storage/convert_helper.h
@@ -34,7 +34,7 @@ class Schema;
 class TypeConverter {
 public:
     TypeConverter() = default;
-    ~TypeConverter() = default;
+    virtual ~TypeConverter() = default;
 
     virtual Status convert(void* dest, const void* src, MemPool* memPool) const = 0;
 
@@ -53,7 +53,7 @@ const TypeConverter* get_type_converter(LogicalType from_type, LogicalType to_ty
 class MaterializeTypeConverter {
 public:
     MaterializeTypeConverter() = default;
-    ~MaterializeTypeConverter() = default;
+    virtual ~MaterializeTypeConverter() = default;
 
     virtual Status convert_materialized(ColumnPtr src_col, Column* dst_col, TypeInfo* src_type) const = 0;
 };

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
@@ -43,9 +43,9 @@ class CLuceneInvertedWriterImpl : public CLuceneInvertedWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
 
-    explicit CLuceneInvertedWriterImpl(const std::string& field_name, const std::string& directory,
+    explicit CLuceneInvertedWriterImpl(const std::string& field_name, std::string directory,
                                        const TabletIndex* inverted_index)
-            : _directory(directory), _inverted_index(inverted_index) {
+            : _directory(std::move(directory)), _inverted_index(inverted_index) {
         _parser_type = get_inverted_index_parser_type_from_string(
                 get_parser_string_from_properties(_inverted_index->index_properties()));
         _field_name = std::wstring(field_name.begin(), field_name.end());

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -187,7 +187,7 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
         if (async_writer->closed()) {
             st.update(Status::InternalError("AsyncDeltaWriter has been closed"));
         }
-        auto task_ptr = *iter;
+        const auto& task_ptr = *iter;
         num_tasks += 1;
         pending_time_ns += MonotonicNanos() - task_ptr->create_time_ns;
         switch (task_ptr->type) {

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -36,12 +36,12 @@ Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelV
 
 Status LakeDelvecLoader::load_from_meta(const TabletMetadataPtr& metadata, const DelvecPagePB& delvec_page,
                                         DelVectorPtr* pdelvec) {
-    (*pdelvec).reset(new DelVector());
+    *pdelvec = std::make_shared<DelVector>();
     return lake::get_del_vec(_tablet_manager, *metadata, delvec_page, _fill_cache, _lake_io_opts, pdelvec->get());
 }
 
 Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) {
-    (*pdelvec).reset(new DelVector());
+    *pdelvec = std::make_shared<DelVector>();
     // 2. find in delvec file
     TabletMetadataPtr metadata;
     if (_lake_io_opts.location_provider) {

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -33,9 +33,9 @@ class TabletManager;
 
 class KeyValueMerger {
 public:
-    explicit KeyValueMerger(const std::string& key, uint64_t max_rss_rowid, bool merge_base_level,
+    explicit KeyValueMerger(std::string key, uint64_t max_rss_rowid, bool merge_base_level,
                             TabletManager* tablet_mgr, int64_t tablet_id, bool enable_multiple_output_files)
-            : _key(key),
+            : _key(std::move(key)),
               _max_rss_rowid(max_rss_rowid),
               _merge_base_level(merge_base_level),
               _tablet_mgr(tablet_mgr),

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.h
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.h
@@ -33,8 +33,8 @@ class TabletManager;
 
 class KeyValueMerger {
 public:
-    explicit KeyValueMerger(std::string key, uint64_t max_rss_rowid, bool merge_base_level,
-                            TabletManager* tablet_mgr, int64_t tablet_id, bool enable_multiple_output_files)
+    explicit KeyValueMerger(std::string key, uint64_t max_rss_rowid, bool merge_base_level, TabletManager* tablet_mgr,
+                            int64_t tablet_id, bool enable_multiple_output_files)
             : _key(std::move(key)),
               _max_rss_rowid(max_rss_rowid),
               _merge_base_level(merge_base_level),

--- a/be/src/storage/lake/lake_primary_key_recover.h
+++ b/be/src/storage/lake/lake_primary_key_recover.h
@@ -38,7 +38,7 @@ class LakePrimaryKeyRecover : public PrimaryKeyRecover {
 public:
     explicit LakePrimaryKeyRecover(MetaFileBuilder* builder, Tablet* tablet, MutableTabletMetadataPtr metadata)
             : _builder(builder), _tablet(tablet), _metadata(std::move(metadata)) {}
-    ~LakePrimaryKeyRecover() = default;
+    ~LakePrimaryKeyRecover() override = default;
 
     // clean old state, include pk index and delvec
     Status pre_cleanup() override;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1351,7 +1351,7 @@ StatusOr<TabletBasicInfo> TabletManager::get_tablet_basic_info(
                                                  shard_info_or.status().message()));
     }
 
-    auto shard_info = shard_info_or.value();
+    const auto& shard_info = shard_info_or.value();
     auto id_pair = get_table_partition_id(shard_info);
     auto shard_table_id = id_pair.first;
     auto shard_partition_id = id_pair.second;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1327,7 +1327,7 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
         return;
     }
 
-    auto compaction_task = compaction_task_or.value();
+    const auto& compaction_task = compaction_task_or.value();
 
     // Increment runs counter to track that this subtask has actually started execution.
     // This is important for list_tasks() to correctly display the profile for completed subtasks,
@@ -1393,7 +1393,7 @@ Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
         return Status::OK(); // Don't fail the entire compaction for SST compaction failure
     }
 
-    auto tablet = tablet_or.value();
+    const auto& tablet = tablet_or.value();
     const auto& metadata = tablet.metadata();
 
     // Check if this is a primary key table with cloud native persistent index
@@ -2060,7 +2060,7 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
         return;
     }
 
-    auto compaction_task = compaction_task_or.value();
+    const auto& compaction_task = compaction_task_or.value();
     context->runs.fetch_add(1, std::memory_order_relaxed);
 
     // Execute compaction

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -22,9 +22,7 @@
 #include "storage/olap_common.h"
 #include "storage/tablet_schema.h"
 
-namespace starrocks {
-
-namespace lake {
+namespace starrocks::lake {
 class Rowset;
 class UpdateManager;
 
@@ -63,6 +61,4 @@ inline std::ostream& operator<<(std::ostream& os, const CompactionState& o) {
     return os;
 }
 
-} // namespace lake
-
-} // namespace starrocks
+} // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1211,7 +1211,7 @@ static StatusOr<std::shared_ptr<Segment>> get_lake_dcg_segment(GetDeltaColumnCon
             return Status::InternalError(
                     fmt::format("DCG file not found for column {}: {}", ucid, column_file_result.status().to_string()));
         }
-        std::string column_file = column_file_result.value();
+        const auto& column_file = column_file_result.value();
 
         if (ctx.dcg_segments.count(column_file) == 0) {
             auto dcg_segment_result = ctx.segment->new_dcg_segment(*dcg, idx.first, read_tablet_schema);
@@ -1240,7 +1240,7 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_lake_dcg_column_iterator(
         return dcg_segment_result.status();
     }
 
-    auto dcg_segment = dcg_segment_result.value();
+    const auto& dcg_segment = dcg_segment_result.value();
     if (ctx.dcg_read_files.count(dcg_segment->file_name()) == 0) {
         RandomAccessFileOptions ropts;
         if (!dcg_segment->file_info().encryption_meta.empty()) {
@@ -1445,7 +1445,7 @@ Status UpdateManager::get_del_vec(const TabletSegmentId& tsid, int64_t version, 
             return Status::OK();
         }
     }
-    (*pdelvec).reset(new DelVector());
+    *pdelvec = std::make_shared<DelVector>();
     // 2. find in delvec file
     return get_del_vec_in_meta(tsid, version, fill_cache, pdelvec->get());
 }

--- a/be/src/storage/local_primary_key_recover.h
+++ b/be/src/storage/local_primary_key_recover.h
@@ -21,7 +21,7 @@ namespace starrocks {
 class LocalPrimaryKeyRecover : public PrimaryKeyRecover {
 public:
     LocalPrimaryKeyRecover(Tablet* tablet, UpdateManager* update_mgr) : _tablet(tablet), _update_mgr(update_mgr) {}
-    ~LocalPrimaryKeyRecover() = default;
+    ~LocalPrimaryKeyRecover() override = default;
 
     Status pre_cleanup() override;
 

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -61,7 +61,7 @@ Status SegmentMetaCollecter::parse_field_and_colname(const std::string& item, st
 
 MetaReaderParams::MetaReaderParams() : chunk_size(config::vector_chunk_size) {}
 
-MetaReader::MetaReader() {}
+MetaReader::MetaReader() = default;
 
 Status MetaReader::open() {
     return Status::OK();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -34,8 +34,8 @@ struct CompactConflictResolveParams {
     uint32_t rowset_id = 0;
     int64_t base_version = 0;
     int64_t new_version = 0;
-    DelvecLoader* delvec_loader = 0;
-    PrimaryIndex* index = 0;
+    DelvecLoader* delvec_loader = nullptr;
+    PrimaryIndex* index = nullptr;
 };
 
 class PrimaryKeyCompactionConflictResolver {

--- a/be/src/storage/primary_key_recover.h
+++ b/be/src/storage/primary_key_recover.h
@@ -39,6 +39,8 @@ class OlapReaderStatistics;
 */
 class PrimaryKeyRecover {
 public:
+    virtual ~PrimaryKeyRecover() = default;
+
     // Follow the steps below:
     // 1. reset_state
     // 2. recover

--- a/be/src/storage/rowset/bitmap_index_evaluator.cpp
+++ b/be/src/storage/rowset/bitmap_index_evaluator.cpp
@@ -302,7 +302,7 @@ struct BitmapIndexSeeker {
         auto& col_ctx = parent_node_ctx.col_contexts.find(cid)->second;
 
         SparseRange<> r;
-        const Status st = col_pred->seek_bitmap_dictionary(bitmap_iter, &r);
+        Status st = col_pred->seek_bitmap_dictionary(bitmap_iter, &r);
         if (st.ok()) {
             if constexpr (Type == CompoundNodeType::AND) {
                 col_ctx.bitmap_ranges &= r;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -330,11 +330,11 @@ Status LinkedSchemaChange::generate_delta_column_group_and_cols(const Tablet* ne
         return res.status();
     }
 
-    auto seg_iterators = res.value();
+    const auto& seg_iterators = res.value();
 
     // Fetch the new columns value into the new_chunk
     for (int idx = 0; idx < seg_iterators.size(); ++idx) {
-        auto seg_iterator = seg_iterators[idx];
+        const auto& seg_iterator = seg_iterators[idx];
         if (seg_iterator.get() == nullptr) {
             std::stringstream ss;
             ss << "Failed to get segment iterator, segment id: " << idx;
@@ -366,7 +366,7 @@ Status LinkedSchemaChange::generate_delta_column_group_and_cols(const Tablet* ne
         }
 
         // Write cols file with current new_chunk
-        ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(new_tablet->schema_hash_path()));
+        ASSIGN_OR_RETURN(const auto& fs, FileSystemFactory::CreateSharedFromString(new_tablet->schema_hash_path()));
         const std::string path = Rowset::delta_column_group_path(new_tablet->schema_hash_path(), rid, idx, version,
                                                                  last_dcg_counts[idx]);
         // must record unique column id in delta column group
@@ -598,7 +598,7 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
             LOG(WARNING) << msg;
             return res.status();
         }
-        auto full = res.value();
+        const auto& full = res.value();
         if (full) {
             RETURN_IF_ERROR_WITH_WARN(mem_table->finalize(), alter_msg_header() + "failed to finalize mem table");
             RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), alter_msg_header() + "failed to flush mem table");

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -33,9 +33,9 @@ ChunkChanger::ChunkChanger(const TabletSchemaCSPtr& new_schema) {
     _schema_mapping.resize(new_schema->num_columns());
 }
 
-ChunkChanger::ChunkChanger(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
+ChunkChanger::ChunkChanger(TabletSchemaCSPtr base_schema, const TabletSchemaCSPtr& new_schema,
                            std::vector<std::string>& base_table_column_names, TAlterJobType::type alter_job_type)
-        : _base_schema(base_schema),
+        : _base_schema(std::move(base_schema)),
           _base_table_column_names(base_table_column_names),
           _alter_job_type(alter_job_type) {
     size_t num_columns = new_schema->num_columns();

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -60,7 +60,7 @@ struct SchemaChangeParams {
 
 class ChunkChanger {
 public:
-    ChunkChanger(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
+    ChunkChanger(TabletSchemaCSPtr base_schema, const TabletSchemaCSPtr& new_schema,
                  std::vector<std::string>& base_table_column_names, TAlterJobType::type alter_job_type);
     ChunkChanger(const TabletSchemaCSPtr& new_schema);
     ~ChunkChanger();

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -668,7 +668,7 @@ bool TabletManager::get_next_batch_tablets(size_t batch_size, std::vector<Tablet
     size_t size = 0;
     const auto& tablets_shard = _tablets_shards[_cur_shard];
     std::shared_lock rlock(tablets_shard.lock);
-    for (auto [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+    for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
         if (_shard_visited_tablet_ids.find(tablet_id) == _shard_visited_tablet_ids.end()) {
             tablets->push_back(tablet_ptr);
             _shard_visited_tablet_ids.insert(tablet_id);
@@ -701,7 +701,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType com
     TabletSharedPtr best_tablet;
     for (int32_t i = tablet_shards_range.first; i < tablet_shards_range.second; i++) {
         std::shared_lock rlock(_tablets_shards[i].lock);
-        for (auto [tablet_id, tablet_ptr] : _tablets_shards[i].tablet_map) {
+        for (const auto& [tablet_id, tablet_ptr] : _tablets_shards[i].tablet_map) {
             if (tablet_ptr->keys_type() == PRIMARY_KEYS) {
                 continue;
             }

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -385,7 +385,7 @@ inline size_t TabletMeta::version_count() const {
 
 inline size_t TabletMeta::segment_count() const {
     size_t num_segments = 0;
-    for (auto rowset_meta : _rs_metas) {
+    for (const auto& rowset_meta : _rs_metas) {
         num_segments += rowset_meta->num_segments();
     }
     return num_segments;

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -216,7 +216,7 @@ Status UpdateManager::get_del_vec(KVStore* meta, const TabletSegmentId& tsid, in
             }
         }
     }
-    (*pdelvec).reset(new DelVector());
+    *pdelvec = std::make_shared<DelVector>();
     int64_t latest_version = 0;
     RETURN_IF_ERROR(get_del_vec_in_meta(meta, tsid, version, pdelvec->get(), &latest_version));
     if ((*pdelvec)->version() == latest_version) {
@@ -533,7 +533,7 @@ Status UpdateManager::get_latest_del_vec(KVStore* meta, const TabletSegmentId& t
         return Status::OK();
     } else {
         // TODO(cbl): move get_del_vec_in_meta out of lock
-        (*pdelvec).reset(new DelVector());
+        *pdelvec = std::make_shared<DelVector>();
         int64_t latest_version = 0;
         RETURN_IF_ERROR(get_del_vec_in_meta(meta, tsid, INT64_MAX, pdelvec->get(), &latest_version));
         _del_vec_cache.emplace(tsid, *pdelvec);

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -334,7 +334,7 @@ Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::strin
         msg << "create BufferOutputStream failure, reason: " << sink_res.status().ToString();
         return Status::InternalError(msg.str());
     }
-    std::shared_ptr<arrow::io::BufferOutputStream> sink = sink_res.ValueOrDie();
+    const auto& sink = sink_res.ValueOrDie();
     // create RecordBatch Writer
     auto writer_res = arrow::ipc::MakeStreamWriter(sink.get(), record_batch.schema());
     if (!writer_res.ok()) {
@@ -342,7 +342,7 @@ Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::strin
         msg << "open RecordBatchStreamWriter failure, reason: " << writer_res.status().ToString();
         return Status::InternalError(msg.str());
     }
-    std::shared_ptr<arrow::ipc::RecordBatchWriter> record_batch_writer = writer_res.ValueOrDie();
+    const auto& record_batch_writer = writer_res.ValueOrDie();
     // write RecordBatch to memory buffer outputstream
     a_st = record_batch_writer->WriteRecordBatch(record_batch);
     if (!a_st.ok()) {
@@ -357,7 +357,7 @@ Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::strin
         msg << "allocate result buffer failure, reason: " << finish_res.status().ToString();
         return Status::InternalError(msg.str());
     }
-    std::shared_ptr<arrow::Buffer> buffer = finish_res.ValueOrDie();
+    const auto& buffer = finish_res.ValueOrDie();
     *result = buffer->ToString();
     // close the sink
     [[maybe_unused]] auto sk_close_st = sink->Close();
@@ -370,7 +370,7 @@ Status serialize_arrow_schema(std::shared_ptr<arrow::Schema>* schema, std::strin
         return Status::InternalError("serialize_arrow_schema failed");
     }
 
-    const auto record_batch = empty_arrow_record_batch.ValueOrDie();
+    const auto& record_batch = empty_arrow_record_batch.ValueOrDie();
     return serialize_record_batch(*record_batch, result);
 }
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

after this patch, we can enable clang-tidy checks with clang 21

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
