### PR TITLE
[Enhancement] enable information_schema show comments for external catalogs (backport #70197)

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3939,6 +3939,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to enable Backup and Restore for Colocate Tables. `true` indicates enabling Backup and Restore for Colocate Tables and `false` indicates disabling it.
 - Introduced in: v3.2.10, v3.3.3
 
+##### `enable_external_catalog_information_schema_tables_access_full_metadata`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether `information_schema.tables` is allowed to access external metadata services when resolving tables in external catalogs (such as Hive, Iceberg, JDBC). When set to `false` (default), columns like `TABLE_COMMENT` may be empty for external tables but the query is fast and avoids remote calls. When set to `true`, the FE contacts the corresponding external metadata service and can populate fields like `TABLE_COMMENT` at the cost of additional latency and remote calls per table.
+- Introduced in: -
+
 ##### `enable_materialized_view_concurrent_prepare`
 
 - Default: true

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -3939,6 +3939,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: コロケーションテーブルのバックアップと復元を有効にするかどうか。`true` はコロケーションテーブルのバックアップと復元を有効にすることを示し、`false` は無効にすることを示します。
 - Introduced in: v3.2.10, v3.3.3
 
+##### `enable_external_catalog_information_schema_tables_access_full_metadata`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 外部カタログ（Hive、Iceberg、JDBC など）内のテーブルを解決する際に、`information_schema.tables` が外部メタデータサービスにアクセスすることを許可するかどうかを制御します。`false`（デフォルト）に設定すると、外部テーブルの `TABLE_COMMENT` などの列は空になる場合がありますが、クエリは高速でリモート呼び出しを回避します。`true` に設定すると、FE は対応する外部メタデータサービスに問い合わせ、`TABLE_COMMENT` などのフィールドを埋めることができますが、テーブルごとに追加のレイテンシとリモート呼び出しが発生します。
+- Introduced in: -
+
 ##### `enable_materialized_view_concurrent_prepare`
 
 - Default: true

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -3940,6 +3940,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否为 Colocate 表启用备份和恢复。`true` 表示为 Colocate 表启用备份和恢复，`false` 表示禁用。
 - 引入版本: v3.2.10, v3.3.3
 
+##### `enable_external_catalog_information_schema_tables_access_full_metadata`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 控制在构建 `information_schema.tables` 时，是否为外部 Catalog（如 Hive、Iceberg、JDBC）中的表加载完整元数据。当该项为 `false`（默认）时不会访问远端 metastore，因此外部表在 `information_schema.tables` 中的 `TABLE_COMMENT` 等字段可能为空，但查询开销较小且不会对外部服务产生额外请求。当该项为 `true` 时，FE 会访问对应的外部元数据服务，填充 `TABLE_COMMENT` 等字段，但代价是每张外部表都会产生额外的远端调用和一定延迟。
+- 引入版本: -
+
 ##### `enable_materialized_view_concurrent_prepare`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3645,6 +3645,13 @@ public class Config extends ConfigBase {
     public static boolean enable_show_external_catalog_privilege = true;
 
     /**
+     * Whether information_schema.tables for external catalogs is allowed to
+     * access external metadata service to get full metadata.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_external_catalog_information_schema_tables_access_full_metadata = false;
+
+    /**
      * Loading or compaction must be stopped for primary_key_disk_schedule_time
      * seconds before it can be scheduled
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -255,8 +255,12 @@ public class JDBCMetadata implements ConnectorMetadata {
 
                         Integer tableId = tableIdCache.getPersistentCache(jdbcTable,
                                 j -> ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt());
-                        return schemaResolver.getTable(tableId, tblName, fullSchema,
+                        Table table = schemaResolver.getTable(tableId, tblName, fullSchema,
                                 partitionColumns, dbName, catalogName, properties);
+                        if (table != null) {
+                            table.setComment(schemaResolver.getTableComment(connection, dbName, tblName));
+                        }
+                        return table;
                     } catch (SQLException | DdlException e) {
                         LOG.warn("get table for JDBC catalog fail!", e);
                         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -36,6 +36,7 @@ import java.util.Map;
 public abstract class JDBCSchemaResolver {
 
     boolean supportPartitionInformation = false;
+    protected String[] defaultTableTypes = new String[] {"TABLE", "VIEW"};
 
     /**
      * Get the query timeout in seconds for JDBC statement execution.
@@ -102,8 +103,11 @@ public abstract class JDBCSchemaResolver {
     }
 
     public ResultSet getTables(Connection connection, String dbName) throws SQLException {
-        return connection.getMetaData().getTables(dbName, null, null,
-                new String[] {"TABLE", "VIEW"});
+        return connection.getMetaData().getTables(dbName, null, null, defaultTableTypes);
+    }
+
+    public ResultSet getTables(Connection connection, String dbName, String tblName) throws SQLException {
+        return connection.getMetaData().getTables(dbName, null, tblName, defaultTableTypes);
     }
 
     public ResultSet getColumns(Connection connection, String dbName, String tblName) throws SQLException {
@@ -118,6 +122,30 @@ public abstract class JDBCSchemaResolver {
     public Table getTable(long id, String name, List<Column> schema, List<Column> partitionColumns, String dbName,
                           String catalogName, Map<String, String> properties) throws DdlException {
         return new JDBCTable(id, name, schema, partitionColumns, dbName, catalogName, properties);
+    }
+
+    /**
+     * Get table comment from JDBC metadata, typically from the "REMARKS" column of DatabaseMetaData#getTables().
+     *
+     * <p>Notes:
+     * - Some JDBC drivers don't support REMARKS or may throw SQLException when accessing it.
+     * - Some drivers return empty REMARKS unless certain connection properties are enabled.
+     */
+    public String getTableComment(Connection connection, String dbName, String tblName) {
+        try (ResultSet resultSet = getTables(connection, dbName, tblName)) {
+            if (!resultSet.next()) {
+                return "";
+            }
+            try {
+                String remarks = resultSet.getString("REMARKS");
+                return remarks != null ? remarks : "";
+            } catch (SQLException ignored) {
+                // ignore
+            }
+        } catch (SQLException ignored) {
+            // ignore
+        }
+        return "";
     }
 
     public List<String> listPartitionNames(Connection connection, String databaseName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/OracleSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/OracleSchemaResolver.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.SchemaConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 
@@ -40,30 +39,23 @@ import static java.lang.Math.max;
 
 public class OracleSchemaResolver extends JDBCSchemaResolver {
 
+    public OracleSchemaResolver() {
+        this.defaultTableTypes = new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"};
+    }
+
     @Override
     public ResultSet getTables(Connection connection, String dbName) throws SQLException {
-        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null,
-                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null, defaultTableTypes);
+    }
+
+    @Override
+    public ResultSet getTables(Connection connection, String dbName, String tblName) throws SQLException {
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, tblName, defaultTableTypes);
     }
 
     @Override
     public ResultSet getColumns(Connection connection, String dbName, String tblName) throws SQLException {
         return connection.getMetaData().getColumns(connection.getCatalog(), dbName, tblName, "%");
-    }
-
-    @Override
-    public List<Column> convertToSRTable(ResultSet columnSet) throws SQLException {
-        List<Column> fullSchema = Lists.newArrayList();
-        while (columnSet.next()) {
-            Type type = convertColumnType(columnSet.getInt("DATA_TYPE"),
-                    columnSet.getString("TYPE_NAME"),
-                    columnSet.getInt("COLUMN_SIZE"),
-                    columnSet.getInt("DECIMAL_DIGITS"));
-            String columnName = columnSet.getString("COLUMN_NAME");
-            fullSchema.add(new Column(columnName, type,
-                    columnSet.getString("IS_NULLABLE").equals(SchemaConstants.YES)));
-        }
-        return fullSchema;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -38,10 +38,18 @@ import static java.lang.Math.max;
 
 public class PostgresSchemaResolver extends JDBCSchemaResolver {
 
+    public PostgresSchemaResolver() {
+        this.defaultTableTypes = new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"};
+    }
+
     @Override
     public ResultSet getTables(Connection connection, String dbName) throws SQLException {
-        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null,
-                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null, defaultTableTypes);
+    }
+
+    @Override
+    public ResultSet getTables(Connection connection, String dbName, String tblName) throws SQLException {
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, tblName, defaultTableTypes);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
@@ -34,10 +34,18 @@ import static java.lang.Math.max;
 
 public class SqlServerSchemaResolver extends JDBCSchemaResolver {
 
+    public SqlServerSchemaResolver() {
+        this.defaultTableTypes = new String[] {"TABLE", "VIEW"};
+    }
+
     @Override
     public ResultSet getTables(Connection connection, String dbName) throws SQLException {
-        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null,
-                new String[] {"TABLE", "VIEW"});
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, null, defaultTableTypes);
+    }
+
+    @Override
+    public ResultSet getTables(Connection connection, String dbName, String tblName) throws SQLException {
+        return connection.getMetaData().getTables(connection.getCatalog(), dbName, tblName, defaultTableTypes);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -597,6 +597,11 @@ public class MetadataMgr {
      * Use this method if you are absolutely sure, otherwise use MetadataMgr#getTable.
      */
     public BasicTable getBasicTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+        return getBasicTable(context, catalogName, dbName, tblName, false);
+    }
+
+    public BasicTable getBasicTable(ConnectContext context, String catalogName, String dbName, String tblName,
+                                    boolean fetchExternalMetadata) {
         if (catalogName == null) {
             return getTable(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName, tblName);
         }
@@ -605,7 +610,11 @@ public class MetadataMgr {
             return getTable(context, catalogName, dbName, tblName);
         }
 
-        // for external catalog, do not reach external metadata service
+        // for external catalog, optionally reach external metadata service
+        if (fetchExternalMetadata) {
+            return getTable(context, catalogName, dbName, tblName);
+        }
+
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         return connectorMetadata.map(
                         metadata -> new ExternalCatalogTableBasicInfo(catalogName, dbName, tblName, metadata.getTableType()))

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -551,7 +551,8 @@ public class InformationSchemaDataSource {
 
                 BasicTable table = null;
                 try {
-                    table = metadataMgr.getBasicTable(context, catalogName, dbName, tableName);
+                    table = metadataMgr.getBasicTable(context, catalogName, dbName, tableName,
+                        Config.enable_external_catalog_information_schema_tables_access_full_metadata);
                 } catch (Exception e) {
                     LOG.warn(e.getMessage(), e);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -359,6 +359,28 @@ public class JDBCMetadataTest {
     }
 
     @Test
+    public void testGetTableSetsCommentFromMetadata() throws SQLException {
+        // Prepare a TABLES result set with REMARKS for tbl1
+        MockResultSet tablesWithRemarks = new MockResultSet("tables_with_remarks");
+        tablesWithRemarks.addColumn("TABLE_NAME", Arrays.asList("tbl1"));
+        tablesWithRemarks.addColumn("REMARKS", Arrays.asList("jdbc table comment"));
+
+        new Expectations() {
+            {
+                // getColumns is already mocked in setUp; here we only need to mock getTables for a single table
+                connection.getMetaData().getTables("test", null, "tbl1", new String[] {"TABLE", "VIEW"});
+                result = tablesWithRemarks;
+                minTimes = 0;
+            }
+        };
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
+        Assertions.assertNotNull(table);
+        Assertions.assertEquals("jdbc table comment", table.getComment());
+    }
+
+    @Test
     public void testCreateHikariDataSource() {
         properties = new HashMap<>();
         properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -19,11 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.starrocks.catalog.MaterializedView;
-<<<<<<< HEAD
-=======
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
->>>>>>> 2b213f9f98 ([Enhancement] enable information_schema show comments for external catalogs (#70197))
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.catalog.system.information.TablesSystemTable;
 import com.starrocks.catalog.system.information.ViewsSystemTable;
@@ -46,11 +42,8 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.WarehouseManager;
-<<<<<<< HEAD
 import com.starrocks.sql.ast.UserIdentity;
-=======
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
->>>>>>> 2b213f9f98 ([Enhancement] enable information_schema show comments for external catalogs (#70197))
 import com.starrocks.thrift.TApplicableRolesInfo;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TGetApplicableRolesRequest;

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -19,11 +19,18 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.starrocks.catalog.MaterializedView;
+<<<<<<< HEAD
+=======
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.UserIdentity;
+>>>>>>> 2b213f9f98 ([Enhancement] enable information_schema show comments for external catalogs (#70197))
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.catalog.system.information.TablesSystemTable;
 import com.starrocks.catalog.system.information.ViewsSystemTable;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.BaseSlotTracker;
@@ -37,8 +44,13 @@ import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.WarehouseManager;
+<<<<<<< HEAD
 import com.starrocks.sql.ast.UserIdentity;
+=======
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+>>>>>>> 2b213f9f98 ([Enhancement] enable information_schema show comments for external catalogs (#70197))
 import com.starrocks.thrift.TApplicableRolesInfo;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TGetApplicableRolesRequest;
@@ -921,6 +933,50 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
             TListTableStatusResult result = ViewsSystemTable.query(params, connectContext);
             Assertions.assertEquals(0, result.getTables().size(),
                     "Should return empty result for non-existing db");
+        }
+    }
+
+    @Test
+    public void testExternalJdbcTableCommentVisibleInInformationSchemaTables() throws Exception {
+        boolean originFlag = Config.enable_external_catalog_information_schema_tables_access_full_metadata;
+        try {
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = true;
+
+            // Prepare mocked JDBC catalog and metadata
+            ConnectorPlanTestBase.mockCatalog(connectContext, MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME);
+            MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+            MockedJDBCMetadata mockedJDBCMetadata =
+                    (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(
+                            MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+
+            Table extTable = mockedJDBCMetadata.getTable(connectContext,
+                    MockedJDBCMetadata.MOCKED_PARTITIONED_DB_NAME,
+                    MockedJDBCMetadata.MOCKED_PARTITIONED_TABLE_NAME0);
+            extTable.setComment("external jdbc table comment");
+
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TGetTablesInfoRequest request = new TGetTablesInfoRequest();
+            TAuthInfo authInfo = new TAuthInfo();
+            TUserIdentity userIdentity = new TUserIdentity();
+            userIdentity.setUsername("root");
+            userIdentity.setHost("%");
+            userIdentity.setIs_domain(false);
+            authInfo.setCurrent_user_ident(userIdentity);
+            authInfo.setCatalog_name(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME);
+            authInfo.setPattern(MockedJDBCMetadata.MOCKED_PARTITIONED_DB_NAME);
+            request.setAuth_info(authInfo);
+
+            TGetTablesInfoResponse response = impl.getTablesInfo(request);
+            TTableInfo tableInfo = response.getTables_infos().stream()
+                    .filter(t -> t.getTable_schema().equals(MockedJDBCMetadata.MOCKED_PARTITIONED_DB_NAME)
+                            && t.getTable_name().equals(MockedJDBCMetadata.MOCKED_PARTITIONED_TABLE_NAME0))
+                    .findFirst()
+                    .orElse(null);
+
+            Assertions.assertNotNull(tableInfo);
+            Assertions.assertEquals("external jdbc table comment", tableInfo.getTable_comment());
+        } finally {
+            Config.enable_external_catalog_information_schema_tables_access_full_metadata = originFlag;
         }
     }
 }

--- a/test/sql/test_information_schema/R/test_external_catalog_information_schema_comments
+++ b/test/sql/test_information_schema/R/test_external_catalog_information_schema_comments
@@ -1,0 +1,97 @@
+-- name: test_external_catalog_information_schema_comments
+admin set frontend config ("enable_external_catalog_information_schema_tables_access_full_metadata" = "true");
+-- result:
+-- !result
+create external catalog ice_hive_${uuid0}
+properties (
+    "type"="iceberg", 
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "enable_iceberg_metadata_cache"="true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database ice_hive_${uuid0}.db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/ice_hive_${uuid0}/db_${uuid0}"
+);
+-- result:
+-- !result
+create table ice_hive_${uuid0}.db_${uuid0}.t_ice_comment (
+    c0 int comment 'c0 comment',
+    c1 string comment 'c1 comment'
+)
+comment 'iceberg table comment';
+-- result:
+-- !result
+select TABLE_NAME, TABLE_COMMENT
+from ice_hive_${uuid0}.information_schema.tables
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 't_ice_comment';
+-- result:
+t_ice_comment	iceberg table comment
+-- !result
+select TABLE_NAME, COLUMN_NAME, COLUMN_COMMENT
+from ice_hive_${uuid0}.information_schema.columns
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 't_ice_comment';
+-- result:
+t_ice_comment	c0	c0 comment
+t_ice_comment	c1	c1 comment
+-- !result
+drop table ice_hive_${uuid0}.db_${uuid0}.t_ice_comment force;
+-- result:
+-- !result
+drop database ice_hive_${uuid0}.db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_hive_${uuid0};
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_comment_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e "use db_comment_${uuid0}; CREATE TABLE t_mysql_comment (c0 int comment 'c0 comment', c1 int comment 'c1 comment') comment = 'mysql table comment';"
+-- result:
+0
+
+-- !result
+create external catalog jdbc_mysql_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${jdbc_url}",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+select TABLE_NAME, TABLE_COMMENT
+from jdbc_mysql_${uuid0}.information_schema.tables
+where TABLE_SCHEMA = 'db_comment_${uuid0}'
+  and TABLE_NAME = 't_mysql_comment';
+-- result:
+t_mysql_comment	mysql table comment
+-- !result
+select TABLE_NAME, COLUMN_NAME, COLUMN_COMMENT
+from jdbc_mysql_${uuid0}.information_schema.columns
+where TABLE_SCHEMA = 'db_comment_${uuid0}' and TABLE_NAME = 't_mysql_comment';
+-- result:
+t_mysql_comment	c0	c0 comment
+t_mysql_comment	c1	c1 comment
+-- !result
+drop catalog jdbc_mysql_${uuid0};
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_comment_${uuid0};'
+-- result:
+0
+
+-- !result
+admin set frontend config ("enable_external_catalog_information_schema_tables_access_full_metadata" = "false");
+-- result:
+-- !result

--- a/test/sql/test_information_schema/T/test_external_catalog_information_schema_comments
+++ b/test/sql/test_information_schema/T/test_external_catalog_information_schema_comments
@@ -1,0 +1,73 @@
+-- name: test_external_catalog_information_schema_comments
+
+admin set frontend config ("enable_external_catalog_information_schema_tables_access_full_metadata" = "true");
+
+-- Iceberg catalog (hive metastore) table comments in information_schema.tables
+create external catalog ice_hive_${uuid0}
+properties (
+    "type"="iceberg", 
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "enable_iceberg_metadata_cache"="true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database ice_hive_${uuid0}.db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/ice_hive_${uuid0}/db_${uuid0}"
+);
+
+create table ice_hive_${uuid0}.db_${uuid0}.t_ice_comment (
+    c0 int comment 'c0 comment',
+    c1 string comment 'c1 comment'
+)
+comment 'iceberg table comment';
+
+select TABLE_NAME, TABLE_COMMENT
+from ice_hive_${uuid0}.information_schema.tables
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 't_ice_comment';
+
+select TABLE_NAME, COLUMN_NAME, COLUMN_COMMENT
+from ice_hive_${uuid0}.information_schema.columns
+where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 't_ice_comment';
+
+drop table ice_hive_${uuid0}.db_${uuid0}.t_ice_comment force;
+drop database ice_hive_${uuid0}.db_${uuid0};
+
+drop catalog ice_hive_${uuid0};
+
+-- JDBC catalog (MySQL) table comments in information_schema.tables
+
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_comment_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e "use db_comment_${uuid0}; CREATE TABLE t_mysql_comment (c0 int comment 'c0 comment', c1 int comment 'c1 comment') comment = 'mysql table comment';"
+
+-- create catalog
+create external catalog jdbc_mysql_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${jdbc_url}",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+select TABLE_NAME, TABLE_COMMENT
+from jdbc_mysql_${uuid0}.information_schema.tables
+where TABLE_SCHEMA = 'db_comment_${uuid0}'
+  and TABLE_NAME = 't_mysql_comment';
+
+select TABLE_NAME, COLUMN_NAME, COLUMN_COMMENT
+from jdbc_mysql_${uuid0}.information_schema.columns
+where TABLE_SCHEMA = 'db_comment_${uuid0}' and TABLE_NAME = 't_mysql_comment';
+
+drop catalog jdbc_mysql_${uuid0};
+
+-- drop mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_comment_${uuid0};'
+
+
+admin set frontend config ("enable_external_catalog_information_schema_tables_access_full_metadata" = "false");


### PR DESCRIPTION
## Why I'm doing

In current versions, `information_schema.tables` and related system views only expose very limited local information for tables in external catalogs (such as Hive, Iceberg, JDBC).  
This leads to several issues:
- Users cannot see table comments for external tables via the unified `information_schema` interface, which is inconsistent with internal tables.
- To inspect comments, users have to query each external system or use different commands, which increases operational and troubleshooting overhead.
We want to provide a configurable way to let `information_schema` show comments for external catalog tables, while keeping the default behavior lightweight and performance‑friendly.

## What I'm doing

- Add a new FE configuration item `enable_external_catalog_information_schema_tables_access_full_metadata` (default `false`) to control whether `information_schema.tables` may load full metadata for tables in external catalogs.
- When this config is set to `true`:
  - `information_schema.tables` is allowed to contact external metadata services (Hive / Iceberg / JDBC, etc.) when resolving external tables, so fields such as `TABLE_COMMENT` can be populated from real external metadata.
- When this config is `false` (default):
  - StarRocks still relies only on lightweight local basic information for external catalogs, does not contact external metadata services, and the behavior/performance remain unchanged (external table comments in `information_schema.tables` may be empty).
- Update the English and Chinese `FE_configuration` docs to document this new configuration, its default value, and when to enable it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4