### PR TITLE
[BugFix] Fix the columnt type mismatch of __iceberg_transform_bucket

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -330,7 +330,6 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* con
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
@@ -352,15 +351,8 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* con
 
     // result column is mutable, use non-const raw pointer
     RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
-    if (c0_is_const) {
-        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-        }
+    for (auto i = 0; i < size; i++) {
+        raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
     }
 #define ABS(x) ((x) < 0 ? -(x) : (x))
     for (int i = 0; i < size; i++) {
@@ -389,28 +381,20 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int(FunctionContext* context
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
 
-    uint8_t* raw_null_flags = null_flags->get_data().data();
+    const auto& raw_null_flags = null_flags->immutable_data();
     auto int_col = ColumnHelper::cast_to_raw<Type>(c0);
-    const RunTimeCppType<Type>* raw_c0 = int_col->get_data().data();
+    const auto& raw_c0 = int_col->immutable_data();
     MutableColumnPtr res = RunTimeColumnType<Type>::create();
     res->resize_uninitialized(size);
 
     // result column is mutable, use non-const raw pointer
-    RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
-    if (c0_is_const) {
-        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-        }
+    auto& raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data();
+    for (auto i = 0; i < size; i++) {
+        raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
     }
 #define haveDifferentSigns(x, y) (((x) ^ (y)) < 0)
     for (int i = 0; i < size; i++) {
@@ -436,32 +420,20 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int(FunctionContext* context, 
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<Type>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
+    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
     res->resize_uninitialized(size);
-    const RunTimeCppType<Type>* raw_c0 = col->get_data().data();
+    const auto& raw_c0 = col->immutable_data();
     // result column is mutable, use non-const raw pointer
-    RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
-            ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
-
-    if (c0_is_const) {
-        int64_t val = raw_c0[0];
-        murmur_hash3_x86_32(&val, sizeof(val), 0, (void*)&raw_res[0]);
-        raw_res[0] = (raw_res[0] & INT_MAX) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            int64_t val = raw_c0[i];
-            murmur_hash3_x86_32(&val, sizeof(val), 0, (void*)&raw_res[i]);
-            raw_res[i] = (raw_res[i] & INT_MAX) % width;
-        }
+    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
+    for (auto i = 0; i < size; i++) {
+        int64_t val = raw_c0[i];
+        murmur_hash3_x86_32(&val, sizeof(val), 0, (void*)&raw_res[i]);
+        raw_res[i] = (raw_res[i] & INT_MAX) % width;
     }
 
     if (has_null) {
@@ -478,30 +450,19 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_string(FunctionContext* contex
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
+    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
     res->resize_uninitialized(size);
     auto raw_c0 = col->immutable_data();
-    // result column is mutable, use non-const raw pointer
-    RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
-            ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
+    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
 
-    if (c0_is_const) {
-        murmur_hash3_x86_32(raw_c0[0].data, raw_c0[0].size, 0, (void*)&raw_res[0]);
-        raw_res[0] = (raw_res[0] & INT_MAX) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            murmur_hash3_x86_32(raw_c0[i].data, raw_c0[i].size, 0, (void*)&raw_res[i]);
-            raw_res[i] = (raw_res[i] & INT_MAX) % width;
-        }
+    for (auto i = 0; i < size; i++) {
+        murmur_hash3_x86_32(raw_c0[i].data, raw_c0[i].size, 0, &raw_res[i]);
+        raw_res[i] = (raw_res[i] & INT_MAX) % width;
     }
 
     if (has_null) {
@@ -515,32 +476,21 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_date(FunctionContext* context,
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_DATE>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
+    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
     res->resize_uninitialized(size);
-    const RunTimeCppType<TYPE_DATE>* raw_c0 = col->get_data().data();
+    const auto& raw_c0 = col->immutable_data();
     // result column is mutable, use non-const raw pointer
-    RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
-            ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
+    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
 
-    if (c0_is_const) {
-        int64_t val = raw_c0[0].julian() - date::UNIX_EPOCH_JULIAN;
-        murmur_hash3_x86_32(&val, sizeof(int64_t), 0, (void*)&raw_res[0]);
-        raw_res[0] = (raw_res[0] & INT_MAX) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            int64_t val = raw_c0[i].julian() - date::UNIX_EPOCH_JULIAN;
-            murmur_hash3_x86_32(&val, sizeof(int64_t), 0, (void*)&raw_res[i]);
-            raw_res[i] = (raw_res[i] & INT_MAX) % width;
-        }
+    for (auto i = 0; i < size; i++) {
+        int64_t val = raw_c0[i].julian() - date::UNIX_EPOCH_JULIAN;
+        murmur_hash3_x86_32(&val, sizeof(int64_t), 0, (void*)&raw_res[i]);
+        raw_res[i] = (raw_res[i] & INT_MAX) % width;
     }
 
     if (has_null) {
@@ -554,40 +504,24 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* cont
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_DATETIME>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
+    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
     res->resize_uninitialized(size);
-    const RunTimeCppType<TYPE_DATETIME>* raw_c0 = col->get_data().data();
-    // result column is mutable, use non-const raw pointer
-    RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
-            ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
+    const auto& raw_c0 = col->immutable_data();
+    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
 
-    if (c0_is_const) {
-        int64_t result = timestamp::to_julian(raw_c0[0].timestamp());
+    for (auto i = 0; i < size; i++) {
+        int64_t result = timestamp::to_julian(raw_c0[i].timestamp());
         result *= SECS_PER_DAY;
         result -= timestamp::UNIX_EPOCH_SECONDS;
         result *= 1000000L;
-        result += timestamp::to_time(raw_c0[0].timestamp());
-        murmur_hash3_x86_32(&result, sizeof(int64_t), 0, (void*)&raw_res[0]);
-        raw_res[0] = (raw_res[0] & INT_MAX) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            int64_t result = timestamp::to_julian(raw_c0[i].timestamp());
-            result *= SECS_PER_DAY;
-            result -= timestamp::UNIX_EPOCH_SECONDS;
-            result *= 1000000L;
-            result += timestamp::to_time(raw_c0[i].timestamp());
-            murmur_hash3_x86_32(&result, sizeof(int64_t), 0, (void*)&raw_res[i]);
-            raw_res[i] = (raw_res[i] & INT_MAX) % width;
-        }
+        result += timestamp::to_time(raw_c0[i].timestamp());
+        murmur_hash3_x86_32(&result, sizeof(int64_t), 0, (void*)&raw_res[i]);
+        raw_res[i] = (raw_res[i] & INT_MAX) % width;
     }
 
     if (has_null) {
@@ -624,33 +558,20 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_decimal(FunctionContext* conte
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
-    bool c0_is_const = false;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     const int size = c0->size();
     int64_t width = c1->get(0).get_int32();
     auto decimalv3_col = ColumnHelper::cast_to_raw<Type>(c0);
 
-    MutableColumnPtr res = RunTimeColumnType<TYPE_UNSIGNED_INT>::create();
+    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
     res->resize_uninitialized(size);
-    const RunTimeCppType<Type>* raw_c0 = decimalv3_col->get_data().data();
-    // result column is mutable, use non-const raw pointer
-    RunTimeCppType<TYPE_UNSIGNED_INT>* raw_res =
-            ColumnHelper::cast_to_raw<TYPE_UNSIGNED_INT>(res.get())->get_data().data();
-    // If c2 is not const, than we need to keep the originl scale
-    if (c0_is_const) {
-        auto result = raw_c0[0];
+    const auto& raw_c0 = decimalv3_col->immutable_data();
+    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
+    for (auto i = 0; i < size; i++) {
+        auto result = raw_c0[i];
         auto byte_array = int_to_byte_array(result);
-        murmur_hash3_x86_32(byte_array.data(), byte_array.size(), 0, (void*)&raw_res[0]);
-        raw_res[0] = (raw_res[0] & INT_MAX) % width;
-        res->resize(1);
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        for (auto i = 0; i < size; i++) {
-            auto result = raw_c0[i];
-            auto byte_array = int_to_byte_array(result);
-            murmur_hash3_x86_32(byte_array.data(), byte_array.size(), 0, (void*)&raw_res[i]);
-            raw_res[i] = (raw_res[i] & INT_MAX) % width;
-        }
+        murmur_hash3_x86_32(byte_array.data(), byte_array.size(), 0, (void*)&raw_res[i]);
+        raw_res[i] = (raw_res[i] & INT_MAX) % width;
     }
 
     if (has_null) {
@@ -893,7 +814,7 @@ StatusOr<ColumnPtr> MathFunctions::decimal_round(FunctionContext* context, const
     auto& null_data = null_flags->get_data();
     uint8_t* raw_null_flags = null_data.data();
 
-    // If c2 is not const, than we need to keep the originl scale
+    // If c2 is not const, than we need to keep the original scale
     // TODO(hcf) For truncate(v, d), we also to keep the scale if d is constant
     if (c0_is_const && c1_is_const) {
         bool is_over_flow;

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -1649,7 +1649,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ColumnPtr result = MathFunctions::iceberg_bucket_int<TYPE_INT>(ctx.get(), columns).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
-        auto v = ColumnHelper::as_column<UInt32Column>(result);
+        auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(4, v->get_data()[0]);
     }
 
@@ -1668,7 +1668,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ColumnPtr result = MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL64>(ctx.get(), columns_const).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
-        auto v = ColumnHelper::as_column<UInt32Column>(result);
+        auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(9, v->get_data()[0]);
     }
 
@@ -1751,7 +1751,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ColumnPtr result = MathFunctions::iceberg_bucket_string(ctx.get(), columns_const).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
-        auto v = ColumnHelper::as_column<UInt32Column>(result);
+        auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(8, v->get_data()[0]);
     }
 
@@ -1768,7 +1768,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ColumnPtr result = MathFunctions::iceberg_bucket_date(ctx.get(), columns_const).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
-        auto v = ColumnHelper::as_column<UInt32Column>(result);
+        auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(3, v->get_data()[0]);
     }
 
@@ -1785,7 +1785,7 @@ TEST_F(VecMathFunctionsTest, IcbergTransTest) {
         ColumnPtr result = MathFunctions::iceberg_bucket_datetime(ctx.get(), columns_const).value();
         ASSERT_TRUE(result->is_numeric());
         ASSERT_FALSE(result->is_nullable());
-        auto v = ColumnHelper::as_column<UInt32Column>(result);
+        auto v = ColumnHelper::as_column<Int32Column>(result);
         ASSERT_EQ(0, v->get_data()[0]);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Fix: https://github.com/StarRocks/StarRocksTest/issues/11100

As defined, the function should return TYPE_INT, but in the implementation, it returns a UInt32Column, causing a type mismatch that leads to a crash in ASAN mode

```
    [10340, '__iceberg_transform_truncate', True, False, 'INT', ['INT', 'INT'], 'MathFunctions::iceberg_truncate_int<TYPE_INT>'],
```

```
F20260318 15:41:11.188693 22597011940928 column_helper.h:339] Check failed: raw_column_ptr Cast failed for column:  (expected type: 5, actual type: in
tegral-4)
*** Aborted at 1773819671 (unix time) try "date -d @1773819671" if you are using GNU date ***
F00000000 00:00:00.000000 22596929193536 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1
] == '\n' failed:
PC: @     0x148e0b12c9fc pthread_kill
*** SIGABRT (@0x3e8000123f4) received by PID 74740 (TID 0x148d4394e640) LWP(75136) from PID 74740; stack trace: ***
    @         0x3a8b0547 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x148e0b12fee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x3a8afd46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x148e0b0d8520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x148e0b12c9fc pthread_kill
    @     0x148e0b0d8476 raise
    @     0x148e0b0be7f3 abort
    @         0x32dc8959 starrocks::failure_function()
    @         0x3a8a3d9d google::LogMessage::Fail()
    @         0x3a8a4e84 google::LogMessageFatal::~LogMessageFatal()
    @         0x2024f2f6 starrocks::RunTimeTypeTraits<(starrocks::LogicalType)5>::ColumnType const* starrocks::ColumnHelper::cast_to_raw<(starrocks::L
ogicalType)5>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x33db0578 starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::BaseBinaryFunction<starrocks::BinaryPredFunc<std::e
qual_to<int> > >::vector_const<(starrocks::LogicalType)5, (starrocks::LogicalType)5, (starrocks::LogicalType)24>(starrocks::Cow<sta@
    @         0x33d2fd8c starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnBinaryFunction<starrocks::BinaryPr
edFunc<std::equal_to<int> > >::evaluate<(starrocks::LogicalType)5, (starrocks::LogicalType)5, (starrocks::LogicalType)24>(starrocks@
    @         0x33cf71bc starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnionNullableColumnBinaryFunction<starrocks::Unpack
ConstColumnBinaryFunction<starrocks::BinaryPredFunc<std::equal_to<int> > > >::evaluate<(starrocks::LogicalType)5, (starrocks::Logic@
    @         0x33cbebe4 starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnionNullableColumnBinaryFunction<starrocks::Unpack
ConstColumnBinaryFunction<starrocks::BinaryPredFunc<std::equal_to<int> > > >::evaluate<(starrocks::LogicalType)5, (starrocks::Logic@
    @         0x33c812e1 starrocks::VectorizedBinaryPredicate<(starrocks::LogicalType)5, starrocks::BinaryPredFunc<std::equal_to<int> > >::evaluate_ch
ecked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x33afba49 starrocks::Expr::evaluate_with_filter(starrocks::ExprContext*, starrocks::Chunk*, unsigned char*)
    @         0x33af4877 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x33af3ee6 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x3573829c starrocks::ChunkPredicateEvaluator::eval_conjuncts_into_filter(std::vector<starrocks::ExprContext*, std::allocator<starrocks:
:ExprContext*> > const&, starrocks::Chunk*, std::vector<unsigned char, starrocks::ColumnAllocator<unsigned char> >*)
    @         0x28a7664b starrocks::parquet::GroupReader::_read_range_round_by_round(starrocks::Range<unsigned long> const&, std::vector<unsigned char
, starrocks::ColumnAllocator<unsigned char> >*, std::shared_ptr<starrocks::Chunk>*)
    @         0x28a72781 starrocks::parquet::GroupReader::get_next(std::shared_ptr<starrocks::Chunk>*, unsigned long*)
    @         0x289b01c8 starrocks::parquet::FileReader::get_next(std::shared_ptr<starrocks::Chunk>*)
```

## What I'm doing:

* Fix the columnt type mismatch of __iceberg_transform_bucket
* c0_is_const is useless, to remove
* Use immutable_data interface to get the immutable data of column

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
