### PR TITLE
[Tool] Upgrade Ubuntu Docker runtime images to 24.04 LTS

### DIFF
--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -13,32 +13,32 @@ ARG ARTIFACT_SOURCE=image
 ARG WITH_DEBUG_INFO=false
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
-FROM ${ARTIFACTIMAGE} as artifacts-from-image
+FROM ${ARTIFACTIMAGE} AS artifacts-from-image
 
 # create a docker build stage that copy locally build artifacts
-FROM busybox:latest as artifacts-from-local
+FROM busybox:latest AS artifacts-from-local
 ARG LOCAL_REPO_PATH
 
 COPY ${LOCAL_REPO_PATH}/output/fe /release/fe_artifacts/fe
 COPY ${LOCAL_REPO_PATH}/output/be /release/be_artifacts/be
 
 
-FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
+FROM artifacts-from-${ARTIFACT_SOURCE} AS artifacts
 ARG WITH_DEBUG_INFO
 
 RUN if [ "$WITH_DEBUG_INFO" = "false" ]; then rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo; fi
 
-FROM ubuntu:22.04 as dependencies-installed
+FROM ubuntu:24.04 AS dependencies-installed
 ARG DEPLOYDIR=/data/deploy
 ENV SR_HOME=${DEPLOYDIR}/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales tini && \
+        openjdk-17-jdk python3 python-is-python3 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat-traditional locales tini && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN echo "export PATH=/usr/lib/linux-tools/5.15.0-60-generic:$PATH" >> /etc/bash.bashrc ; ARCH=`uname -m` && cd /lib/jvm && \
+RUN echo "export PATH=/usr/lib/linux-tools/linux-tools-6.8.0-106:$PATH" >> /etc/bash.bashrc ; ARCH=`uname -m` && cd /lib/jvm && \
     if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
 ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 

--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -44,7 +44,7 @@ COPY . ${BUILD_ROOT}
 WORKDIR ${BUILD_ROOT}
 RUN --mount=type=cache,target=/root/.m2/ STARROCKS_VERSION=${RELEASE_VERSION} BUILD_TYPE=${BUILD_TYPE} MAVEN_OPTS=${MAVEN_OPTS} ./build.sh --be --enable-shared-data --clean -j `nproc`
 
-FROM ubuntu:22.04 as downloader
+FROM ubuntu:24.04 as downloader
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends wget tar xz-utils
 

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -24,19 +24,19 @@ ARG MINIMAL=false
 
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
-FROM ${ARTIFACTIMAGE} as artifacts-from-image
+FROM ${ARTIFACTIMAGE} AS artifacts-from-image
 
 # create a docker build stage that copy locally build artifacts
-FROM busybox:latest as artifacts-from-local
+FROM busybox:latest AS artifacts-from-local
 ARG LOCAL_REPO_PATH
 COPY ${LOCAL_REPO_PATH}/output/be /release/be_artifacts/be
 
 
-FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
+FROM artifacts-from-${ARTIFACT_SOURCE} AS artifacts
 RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
 
 
-FROM ubuntu:22.04 AS base_image
+FROM ubuntu:24.04 AS base_image
 ARG STARROCKS_ROOT=/opt/starrocks
 ARG USER
 ARG RUN_AS_USER
@@ -57,11 +57,30 @@ ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 
 WORKDIR $STARROCKS_ROOT
 
-RUN groupadd --gid 1000 $GROUP && \
-    if [ "$USER" != "root" ]; then \
-        useradd --no-create-home --uid 1000 --gid 1000 --shell /usr/sbin/nologin $USER; \
+# Ubuntu 24.04 has a builtin id ubuntu (uid=1000,gid=1000), need to rename to $USER:$GROUP
+# Why can't create a fresh new account with a new id?
+# A: compatibility reason, previous versions run with uid=1000, if running with a different uid in a later docker image,
+#    local files on PVC may not be able to access any more after upgrade.
+RUN if getent group 1000 >/dev/null 2>&1; then \
+        gname=`getent group 1000 | cut -d: -f1` && \
+        if [ "$gname" != "$GROUP" ]; then \
+            groupmod -n "$GROUP" "$gname"; \
+        fi ; \
+    else \
+        groupadd --gid 1000 "$GROUP"; \
     fi && \
-    chown -R $USER:$GROUP $STARROCKS_ROOT
+    if [ "$USER" != "root" ]; then \
+        if id 1000 >/dev/null 2>&1; then \
+            username=`id -un 1000` && \
+            if [ "$username" != "$USER" ]; then \
+                usermod -l "$USER" "$username"; \
+            fi && \
+            usermod -g "$GROUP" "$USER"; \
+        else \
+            useradd --no-create-home --uid 1000 --gid "$GROUP" --shell /usr/sbin/nologin "$USER"; \
+        fi ; \
+    fi && \
+    chown -R "$USER":"$GROUP" "$STARROCKS_ROOT"
 
 USER $USER
 

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -23,18 +23,18 @@ ARG MINIMAL=false
 
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
-FROM ${ARTIFACTIMAGE} as artifacts-from-image
+FROM ${ARTIFACTIMAGE} AS artifacts-from-image
 
 # create a docker build stage that copy locally build artifacts
-FROM busybox:latest as artifacts-from-local
+FROM busybox:latest AS artifacts-from-local
 ARG LOCAL_REPO_PATH
 COPY ${LOCAL_REPO_PATH}/output/fe /release/fe_artifacts/fe
 
 
-FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
+FROM artifacts-from-${ARTIFACT_SOURCE} AS artifacts
 
 
-FROM ubuntu:22.04 AS base_image
+FROM ubuntu:24.04 AS base_image
 ARG STARROCKS_ROOT=/opt/starrocks
 ARG USER
 ARG RUN_AS_USER
@@ -44,7 +44,7 @@ ARG MINIMAL
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
 RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-17-jdk curl vim tree net-tools less pigz rclone" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk mysql-client tzdata locales netcat tini $OPTIONAL_PKGS && \
+        openjdk-17-jdk mysql-client tzdata locales netcat-traditional tini $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
@@ -55,11 +55,30 @@ ENV JAVA_HOME=/lib/jvm/java-17-openjdk
 
 WORKDIR $STARROCKS_ROOT
 
-RUN groupadd --gid 1000 $GROUP && \
-    if [ "$USER" != "root" ]; then \
-        useradd --no-create-home --uid 1000 --gid 1000 --shell /usr/sbin/nologin $USER; \
+# Ubuntu 24.04 has a builtin id ubuntu (uid=1000,gid=1000), need to rename to $USER:$GROUP
+# Why can't create a fresh new account with a new id?
+# A: compatibility reason, previous versions run with uid=1000, if running with a different uid in a later docker image,
+#    local files on PVC may not be able to access any more after upgrade.
+RUN if getent group 1000 >/dev/null 2>&1; then \
+        gname=`getent group 1000 | cut -d: -f1` && \
+        if [ "$gname" != "$GROUP" ]; then \
+            groupmod -n "$GROUP" "$gname"; \
+        fi ; \
+    else \
+        groupadd --gid 1000 "$GROUP"; \
     fi && \
-    chown -R $USER:$GROUP $STARROCKS_ROOT
+    if [ "$USER" != "root" ]; then \
+        if id 1000 >/dev/null 2>&1; then \
+            username=`id -un 1000` && \
+            if [ "$username" != "$USER" ]; then \
+                usermod -l "$USER" "$username"; \
+            fi && \
+            usermod -g "$GROUP" "$USER"; \
+        else \
+            useradd --no-create-home --uid 1000 --gid "$GROUP" --shell /usr/sbin/nologin "$USER"; \
+        fi ; \
+    fi && \
+    chown -R "$USER":"$GROUP" "$STARROCKS_ROOT"
 
 USER $USER
 


### PR DESCRIPTION
Upgrade StarRocks Docker runtime images to Ubuntu 24.04 LTS.

- Switch runtime bases in allin1/BE/FE Dockerfiles to ubuntu:24.04
- Replace netcat with netcat-traditional for package compatibility
- Update FE/BE user bootstrap logic for UID 1000 compatibility on Ubuntu 24.04

## Why I'm doing:

## What I'm doing:

Refs #67716

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
