### PR TITLE
[Enhancement] Support multi-column functional dependency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -26,9 +26,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.statistic.StatisticUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
@@ -36,6 +38,8 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static java.lang.Double.isInfinite;
 
 public class StatisticsEstimateUtils {
+    private static final double FD_NDV_TOLERANCE = 0.01;
+
     public static ColumnStatistic unionColumnStatistic(ColumnStatistic left, double leftRowCount, ColumnStatistic right,
                                                        double rightRowCount) {
         if (left.isUnknown() || right.isUnknown()) {
@@ -112,6 +116,50 @@ public class StatisticsEstimateUtils {
     }
 
     /**
+     * Detects functional dependency via NDV ratio: if multi_column_ndv ≈ single_column_ndv for some
+     * column in the set, that column functionally determines the others. Returns the selectivity
+     * of the most selective determinant column, or null if no FD is detected.
+     * Prefers MCV-based selectivity when histogram is available for more accurate estimation.
+     */
+    private static Double trySelectivityFromFunctionalDependency(
+            Set<ColumnRefOperator> correlatedColumns,
+            double multiNdv,
+            Statistics statistics,
+            Map<ColumnRefOperator, Double> columnToSelectivityMap,
+            Map<ColumnRefOperator, ConstantOperator> equalityPredicates) {
+        List<Double> determinantSelectivities = new ArrayList<>();
+        for (ColumnRefOperator col : correlatedColumns) {
+            ColumnStatistic colStat = statistics.getColumnStatistic(col);
+            if (colStat == null || colStat.isUnknown()) {
+                continue;
+            }
+            double singleNdv = colStat.getDistinctValuesCount();
+            // FD: multi_ndv <= single_ndv * (1 + tolerance) => this column determines the rest. Otherwise, continue
+            if (singleNdv < 1.0 || multiNdv > singleNdv * (1.0 + FD_NDV_TOLERANCE)) {
+                continue;
+            }
+            Double sel = null;
+            if (colStat.getHistogram() != null) {
+                Optional<Histogram> hist = BinaryPredicateStatisticCalculator
+                        .updateHistWithEqual(colStat, Optional.ofNullable(equalityPredicates.get(col)));
+                if (hist.isPresent()) {
+                    double total = colStat.getHistogram().getTotalRows();
+                    if (total > 0) {
+                        sel = (hist.get().getTotalRows() / total) * (1.0 - colStat.getNullsFraction());
+                    }
+                }
+            }
+            if (sel == null) {
+                sel = columnToSelectivityMap.get(col);
+            }
+            if (sel != null) {
+                determinantSelectivities.add(sel);
+            }
+        }
+        return determinantSelectivities.isEmpty() ? null : Collections.min(determinantSelectivities);
+    }
+
+    /**
      * Estimates selectivity for conjunctive equality predicates across multiple columns.
      *
      * This method implements a hybrid approach that:
@@ -172,18 +220,27 @@ public class StatisticsEstimateUtils {
                 multiColumnStatsPair.second.getNdv() > 0) {
 
             Set<ColumnRefOperator> correlatedColumns = multiColumnStatsPair.first;
-            double distinctValueCount = Math.max(1.0, multiColumnStatsPair.second.getNdv());
+            double multiNdv = Math.max(1.0, multiColumnStatsPair.second.getNdv());
 
-            // Formula: S_corr = 1/NDV
-            // NDV-based selectivity estimation for correlated columns
-            double correlationBasedSelectivity = 1.0 / distinctValueCount;
+            // Functional dependency detection: if ndv(col1, col2, ...) ≈ ndv(col_i), then col_i
+            // functionally determines the others. Use that column's selectivity instead of 1/multi_ndv
+            // to avoid severe underestimation (e.g. province -> city).
+            Double fdBasedSelectivity = trySelectivityFromFunctionalDependency(
+                    correlatedColumns, multiNdv, statistics, columnToSelectivityMap, equalityPredicates);
 
-            double maxNullFraction = correlatedColumns.stream()
-                    .map(statistics::getColumnStatistic)
-                    .mapToDouble(ColumnStatistic::getNullsFraction)
-                    .max()
-                    .orElse(0.0);
-            correlationBasedSelectivity = correlationBasedSelectivity * (1.0 - maxNullFraction);
+            double correlationBasedSelectivity;
+            if (fdBasedSelectivity != null) {
+                correlationBasedSelectivity = fdBasedSelectivity;
+            } else {
+                // Formula: S_corr = 1/NDV
+                correlationBasedSelectivity = 1.0 / multiNdv;
+                double maxNullFraction = correlatedColumns.stream()
+                        .map(statistics::getColumnStatistic)
+                        .mapToDouble(ColumnStatistic::getNullsFraction)
+                        .max()
+                        .orElse(0.0);
+                correlationBasedSelectivity = correlationBasedSelectivity * (1.0 - maxNullFraction);
+            }
 
             // Formula: S_ind = ∏(S_i) for all i in correlatedColumns
             // Calculate independence-assumption selectivity product as lower bound

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class PredicateStatisticsCalculatorTest {
     @Test
@@ -586,5 +587,177 @@ public class PredicateStatisticsCalculatorTest {
 
         result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
         Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
+    }
+
+    /**
+     * Functional dependency (FD) case: multi-column NDV ≈ single-column NDV for one column (e.g. province -> city).
+     * Expect combined selectivity to follow the determinant column's selectivity, not 1/multi_ndv.
+     */
+    @Test
+    public void testCompoundEqualityWithFunctionalDependency() {
+        ColumnRefOperator province = new ColumnRefOperator(1, IntegerType.INT, "province", true);
+        ColumnRefOperator city = new ColumnRefOperator(2, IntegerType.INT, "city", true);
+
+        double rowCount = 10000;
+        // Province NDV=30, city NDV=30; multi-column (province, city) NDV=30 -> province determines city (FD).
+        // Note: city NDV must be <= multi_ndv when FD holds (at most 30 distinct cities in 30 pairs).
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(province,
+                        ColumnStatistic.builder().setDistinctValuesCount(30).setNullsFraction(0).build())
+                .addColumnStatistic(city,
+                        ColumnStatistic.builder().setDistinctValuesCount(30).setNullsFraction(0).build())
+                .addMultiColumnStatistics(Set.of(province, city), new MultiColumnCombinedStats(30))
+                .build();
+
+        CompoundPredicateOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                new BinaryPredicateOperator(BinaryType.EQ, province, ConstantOperator.createInt(1)),
+                new BinaryPredicateOperator(BinaryType.EQ, city, ConstantOperator.createInt(10)));
+
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics);
+
+        // With FD: selectivity ~ 1/30 (province), so rows ~ 10000/30 ≈ 333. Without FD (wrong): would be ~ 1/9000.
+        double expectedApprox = rowCount / 30;
+        Assertions.assertTrue(result.getOutputRowCount() >= expectedApprox * 0.5
+                        && result.getOutputRowCount() <= expectedApprox * 2.0,
+                "FD path should give ~" + expectedApprox + ", got " + result.getOutputRowCount());
+    }
+
+    /**
+     * FD with histogram + MCV: when province has histogram with MCV containing the constant,
+     * use MCV-based selectivity for more accurate estimation.
+     */
+    @Test
+    public void testCompoundEqualityWithFunctionalDependencyAndHistogramMcv() {
+        ColumnRefOperator province = new ColumnRefOperator(1, IntegerType.INT, "province", true);
+        ColumnRefOperator city = new ColumnRefOperator(2, IntegerType.INT, "city", true);
+
+        double rowCount = 10000;
+        // Province has histogram with MCV: "1" -> 400 rows. Total histogram rows = 10000.
+        // MCV selectivity for province=1: 400/10000 = 0.04
+        // City has histogram with MCV: "10" -> 400 rows (FD: province=1 implies city=10).
+        // min(0.04, 0.04) = 0.04, so rows ~ 400
+        Map<String, Long> provinceMcv = new java.util.HashMap<>();
+        provinceMcv.put("1", 400L);
+        List<Bucket> provinceBuckets = List.of(new Bucket(1, 100, 9600L, 0L));
+        Histogram provinceHistogram = new Histogram(provinceBuckets, provinceMcv);
+
+        Map<String, Long> cityMcv = new java.util.HashMap<>();
+        cityMcv.put("10", 400L);
+        List<Bucket> cityBuckets = List.of(new Bucket(1, 100, 9600L, 0L));
+        Histogram cityHistogram = new Histogram(cityBuckets, cityMcv);
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(province,
+                        ColumnStatistic.builder()
+                                .setDistinctValuesCount(30)
+                                .setNullsFraction(0)
+                                .setHistogram(provinceHistogram)
+                                .build())
+                .addColumnStatistic(city,
+                        ColumnStatistic.builder()
+                                .setDistinctValuesCount(30)
+                                .setNullsFraction(0)
+                                .setHistogram(cityHistogram)
+                                .build())
+                .addMultiColumnStatistics(Set.of(province, city), new MultiColumnCombinedStats(30))
+                .build();
+
+        CompoundPredicateOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                new BinaryPredicateOperator(BinaryType.EQ, province, ConstantOperator.createInt(1)),
+                new BinaryPredicateOperator(BinaryType.EQ, city, ConstantOperator.createInt(10)));
+
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics);
+
+        // FD + MCV: both use MCV selectivity 400/10000 = 0.04, min = 0.04, rows ~ 400
+        double expectedApprox = 400;
+        Assertions.assertTrue(result.getOutputRowCount() >= expectedApprox * 0.5
+                        && result.getOutputRowCount() <= expectedApprox * 2.0,
+                "FD with MCV should give ~" + expectedApprox + ", got " + result.getOutputRowCount());
+    }
+
+    /**
+     * No FD: multi-column NDV is large (300), so no single column "determines" the combination.
+     */
+    @Test
+    public void testCompoundEqualityWithoutFunctionalDependency() {
+        ColumnRefOperator province = new ColumnRefOperator(1, IntegerType.INT, "province", true);
+        ColumnRefOperator city = new ColumnRefOperator(2, IntegerType.INT, "city", true);
+
+        double rowCount = 10000;
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(province,
+                        ColumnStatistic.builder().setDistinctValuesCount(30).setNullsFraction(0).build())
+                .addColumnStatistic(city,
+                        ColumnStatistic.builder().setDistinctValuesCount(300).setNullsFraction(0).build())
+                .addMultiColumnStatistics(Set.of(province, city), new MultiColumnCombinedStats(300))
+                .build();
+
+        CompoundPredicateOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                new BinaryPredicateOperator(BinaryType.EQ, province, ConstantOperator.createInt(1)),
+                new BinaryPredicateOperator(BinaryType.EQ, city, ConstantOperator.createInt(10)));
+
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics);
+
+        // No FD: selectivity ~ 1/300 (multi_ndv), so rows ~ 10000/300 ≈ 33.
+        double expectedApprox = rowCount / 300;
+        Assertions.assertTrue(result.getOutputRowCount() >= expectedApprox * 0.3
+                        && result.getOutputRowCount() <= expectedApprox * 3.0,
+                "No-FD path should give ~" + expectedApprox + ", got " + result.getOutputRowCount());
+    }
+
+    @Test
+    public void testCompoundEqualityFdCoverage() {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+        try {
+            double rowCount = 10000;
+
+            // Scenario 1: FD with unknown column -> line 131 (skip c), a and b are determinants
+            ColumnRefOperator a1 = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+            ColumnRefOperator b1 = new ColumnRefOperator(2, IntegerType.INT, "b", true);
+            ColumnRefOperator c1 = new ColumnRefOperator(3, IntegerType.INT, "c", true);
+            Statistics stats1 = Statistics.builder()
+                    .setOutputRowCount(rowCount)
+                    .addColumnStatistic(a1, ColumnStatistic.builder().setDistinctValuesCount(100).setNullsFraction(0).build())
+                    .addColumnStatistic(b1, ColumnStatistic.builder().setDistinctValuesCount(100).setNullsFraction(0).build())
+                    .addColumnStatistic(c1, ColumnStatistic.unknown())
+                    .addMultiColumnStatistics(Set.of(a1, b1, c1), new MultiColumnCombinedStats(100))
+                    .build();
+            CompoundPredicateOperator pred1 = new CompoundPredicateOperator(
+                    CompoundPredicateOperator.CompoundType.AND,
+                    new BinaryPredicateOperator(BinaryType.EQ, a1, ConstantOperator.createInt(1)),
+                    new BinaryPredicateOperator(BinaryType.EQ, b1, ConstantOperator.createInt(2)),
+                    new BinaryPredicateOperator(BinaryType.EQ, c1, ConstantOperator.createInt(3)));
+            Statistics result1 = PredicateStatisticsCalculator.statisticsCalculate(pred1, stats1);
+            // FD path: selectivity ~ 1/100, rows ~ 100
+            Assertions.assertTrue(result1.getOutputRowCount() >= 10 && result1.getOutputRowCount() <= 500,
+                    "Scenario 1: expected ~100, got " + result1.getOutputRowCount());
+
+            // Scenario 2: No FD (all fail, line 144) + nullsFraction (lines 223-229)
+            ColumnRefOperator a2 = new ColumnRefOperator(4, IntegerType.INT, "a", true);
+            ColumnRefOperator b2 = new ColumnRefOperator(5, IntegerType.INT, "b", true);
+            Statistics stats2 = Statistics.builder()
+                    .setOutputRowCount(rowCount)
+                    .addColumnStatistic(a2, ColumnStatistic.builder().setDistinctValuesCount(100).setNullsFraction(0.1).build())
+                    .addColumnStatistic(b2, ColumnStatistic.builder().setDistinctValuesCount(100).setNullsFraction(0).build())
+                    .addMultiColumnStatistics(Set.of(a2, b2), new MultiColumnCombinedStats(1000))
+                    .build();
+            CompoundPredicateOperator pred2 = new CompoundPredicateOperator(
+                    CompoundPredicateOperator.CompoundType.AND,
+                    new BinaryPredicateOperator(BinaryType.EQ, a2, ConstantOperator.createInt(1)),
+                    new BinaryPredicateOperator(BinaryType.EQ, b2, ConstantOperator.createInt(2)));
+            Statistics result2 = PredicateStatisticsCalculator.statisticsCalculate(pred2, stats2);
+            // No FD path: selectivity ~ 0.9/1000, rows ~ 9
+            Assertions.assertTrue(result2.getOutputRowCount() >= 1 && result2.getOutputRowCount() <= 50,
+                    "Scenario 2: expected ~9, got " + result2.getOutputRowCount());
+        } finally {
+            ConnectContext.remove();
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Leveraging multi-column functional dependencies can improve the accuracy of cardinality estimation for conjunctive equality predicates.

### What's the multi-column functional dependency
 For example，a table with 3 columns，c1，c2，c3.
- ditinct(c1)=[c1v1,c1v2,c1v3,c1v4,c1v5], NDV(c1)=5
- ditinct(c2)=[c2v1,c2v2,c2v3], NDV(c2)=3
- ditinct(c3)=[c3v1,c3v2,c3v3,c3v4], NDV(c3)=4
- NDV(c1,c2,c3)=NDV(c1)=5
- total n rows

we can deduce that each value of c1 corresponds to a unique combination {c2, c3}. This functional dependency is denoted as:  
**{c1} —> {c2, c3}**

That is, given the premise that distinct_count(c1, c2, c3) = 5 = distinct_count(c1), once the value of c1 is determined, the values of {c2,c3} are also determined. Consequently, the entire combination {c1, c2, c3} is determined, so:
**{c1} —> {c1, c2, c3}**


Cardinality Estimation for Combined Predicates c1=c1v1 and c2=c2v1 and c3=c3v1

Type | Combination Count Estimation | Multi-Column Functional Dependency
-- | -- | --
Estimated Rows | n / NDV(c1,c2,c3) | COUNT(c1 = c1v1)

In this case, the row count estimated by Multi-Column Functional Dependency is more accurate.

## What I'm doing:
Support multi-column functional dependency for selectivity estimation in StatisticsEstimateUtils.

- When FD is detected, use fdBasedSelectivity (determinant column's histogram MCV) instead of 1/multi_ndv as correlationBasedSelectivity.
- When FD is not detected, keep the original logic.

### SQL TEST
**show create table test_fd_demo;**

CREATE TABLE `test_fd_demo` (
  `c1` varchar(20) NULL COMMENT "",
  `c2` varchar(20) NULL COMMENT "",
  `c3` varchar(20) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);

**select * from test_fd_demo;**  
total 41 rows
c1=c1v1, 1 row
c1=c1v2, 10 rows 
c1=c1v3, 10 rows 
c1=c1v4, 10 rows
c1=c1v5, 10 rows

+------+------+------+
| c1   | c2   | c3   |
+------+------+------+
| c1v1 | c2v1 | c3v1 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v2 | c2v2 | c3v2 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v3 | c2v3 | c3v3 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v4 | c2v1 | c3v4 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
| c1v5 | c2v2 | c3v1 |
+------+------+------+

Test estimatedSelectivity for sql:
1.select * from test_fd_demo where c1='c1v1' and c2='c2v1' and c3='c3v2';  return empty
2.select * from test_fd_demo where c1='c1v1' and c2='c2v1' and c3='c3v1';  return one row
3.select * from test_fd_demo where c1='c1v2' and c2='c2v1' and c3='c3v1'; return empty

I have both pre-collected the multi_ndv for columns c1, c2, c3 and pre-built the histograms for columns c1, c2, and c3. 
<img width="1141" height="274" alt="WechatIMG266" src="https://github.com/user-attachments/assets/29e99fbf-4dba-49d0-9072-659887618657" />


I have added some log in the class StatisticsEstimateUtils.
Original version
<img width="1290" height="103" alt="WechatIMG261" src="https://github.com/user-attachments/assets/12fcb7fa-3438-43f3-acd5-4d78326a34f9" />
estimatedSelectivity = 1/mutil_ndv= 1/5 = 0.2


Current version
<img width="1402" height="104" alt="WechatIMG263" src="https://github.com/user-attachments/assets/4659846b-f498-49c9-94ba-3d9306d633f2" />
sql1 and sql2 estimatedSelectivity = count(c1=c1v1)/41 = 1/41 = 0.024390243902439025 
sql3 estimatedSelectivity = count = count(c1=c1v2)/41 = 10/41 = 0.24390243902439024



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
