### PR TITLE
[BugFix] Fix range continuity check for range distribution table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -422,21 +422,9 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
             Tuple prevUpperBound = prevRange.getUpperBound();
             Tuple currLowerBound = currRange.getLowerBound();
 
-            // Validate that bounds are not null
-            if (prevUpperBound == null || currLowerBound == null) {
-                throw new IllegalStateException(
-                        "Range bound is null: tablet " + prevTablet.getId() + " upper bound is "
-                                + (prevUpperBound == null ? "null" : prevUpperBound)
-                                + ", tablet " + currTablet.getId() + " lower bound is "
-                                + (currLowerBound == null ? "null" : currLowerBound));
-            }
-
             // Validate range continuity
-            if (!prevUpperBound.equals(currLowerBound)) {
-                throw new IllegalStateException(
-                        "Adjacent tablet ranges are not continuous: tablet " + prevTablet.getId()
-                                + " upper bound " + prevUpperBound + " != tablet " + currTablet.getId()
-                                + " lower bound " + currLowerBound);
+            if (prevUpperBound == null || currLowerBound == null || !prevUpperBound.equals(currLowerBound)) {
+                continue;
             }
 
             // Share the same Tuple object: use prevUpperBound as the shared bound

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -198,7 +198,7 @@ public class MaterializedIndexTest {
     }
 
     @Test
-    public void testShareAdjacentTabletRangeBoundsThrowsOnDiscontinuity() throws Exception {
+    public void testShareAdjacentTabletRangeBoundsOnDiscontinuity() throws Exception {
         // Test that non-continuous ranges throw exception
         MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
 
@@ -213,19 +213,11 @@ public class MaterializedIndexTest {
         index.addTablet(tablet1, null, false);
         index.addTablet(tablet2, null, false);
 
-        // Should throw exception due to discontinuous ranges
-        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            index.shareAdjacentTabletRangeBounds();
-        });
-
-        // Verify error message contains relevant information
-        Assertions.assertTrue(exception.getMessage().contains("not continuous"));
-        Assertions.assertTrue(exception.getMessage().contains("1001"));
-        Assertions.assertTrue(exception.getMessage().contains("1002"));
+        index.shareAdjacentTabletRangeBounds();
     }
 
     @Test
-    public void testShareAdjacentTabletRangeBoundsThrowsOnNullBounds() throws Exception {
+    public void testShareAdjacentTabletRangeBoundsOnNullBounds() throws Exception {
         // Test that null bounds throw exception
         MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
 
@@ -243,13 +235,7 @@ public class MaterializedIndexTest {
         index.addTablet(tablet1, null, false);
         index.addTablet(tablet2, null, false);
 
-        // Should throw exception due to null bound
-        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            index.shareAdjacentTabletRangeBounds();
-        });
-
-        // Verify error message contains relevant information
-        Assertions.assertTrue(exception.getMessage().contains("null"));
+        index.shareAdjacentTabletRangeBounds();
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
SplitTabletjob creates a new tablet and adds it to the MaterializedIndex in `runPendingJob()`, but the range bounds of the new tablet are only set after `BE publish` returns in `runRunningJob()`. When a journal entry in the PENDING/PREPARING/RUNNING state is written, the SplitTabletJob is serialized as a whole, including the MaterializedIndex with null range bounds. During deserialization, Gson calls `MaterializedIndex.gsonPostProcess()` → `shareAdjacentTabletRangeBounds()`, and throws an `IllegalStateException` if it encounters null bounds.

## What I'm doing:
Fix range continuity check for range distribution table.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
