### PR TITLE
[BugFix] Fix equality of InformationFunction and add regression tests

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -90,6 +90,22 @@ public class SelectConstTest extends PlanTestBase {
     }
 
     @Test
+    public void testMultipleInformationFunctions() throws Exception {
+        // Before the fix, different InformationFunction instances were considered equal
+        // due to missing equalsWithoutChild()/hashCode() overrides, causing them to be
+        // deduplicated into the same output slot.
+        assertPlanContains("select current_user, current_group",
+                "<slot 2> : '\\'root\\'@\\'%\\''",
+                "<slot 3> : 'NONE'");
+        assertPlanContains("select current_user, current_role",
+                "<slot 2> : '\\'root\\'@\\'%\\''",
+                "<slot 3> : 'root'");
+        assertPlanContains("select database(), catalog()",
+                "<slot 2> : 'test'",
+                "<slot 3> : 'default_catalog'");
+    }
+
+    @Test
     public void testFromUnixtime() throws Exception {
         assertPlanContains("select from_unixtime(10)", "'1970-01-01 08:00:10'");
         assertPlanContains("select from_unixtime(1024)", "'1970-01-01 08:17:04'");

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/InformationFunction.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/InformationFunction.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.parser.NodePosition;
 
+import java.util.Objects;
+
 public class InformationFunction extends Expr {
     private final String funcType;
     private long intValue;
@@ -76,6 +78,22 @@ public class InformationFunction extends Expr {
         return strValue;
     }
 
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), funcType, intValue, strValue);
+    }
+
+    @Override
+    public boolean equalsWithoutChild(Object o) {
+        if (!super.equalsWithoutChild(o)) {
+            return false;
+        }
+        InformationFunction that = (InformationFunction) o;
+        return intValue == that.intValue
+                && Objects.equals(funcType, that.funcType)
+                && Objects.equals(strValue, that.strValue);
+    }
 
     /**
      * Below function is added by new analyzer


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request addresses a bug where different instances of the `InformationFunction` class were incorrectly considered equal, leading to issues with deduplication in query planning. The main changes involve implementing proper equality and hash code logic for `InformationFunction`, and adding tests to ensure correct behavior when multiple information functions are used in a query.

**Bug fix for equality and deduplication in `InformationFunction`:**

* Added `hashCode()` and `equalsWithoutChild()` overrides to the `InformationFunction` class to ensure that different instances are correctly distinguished based on their contents, preventing them from being deduplicated into the same output slot.
* Imported `java.util.Objects` to support the new equality and hash code logic in `InformationFunction.java`.

**Testing improvements:**

* Added a new test `testMultipleInformationFunctions` in `SelectConstTest.java` to verify that queries with multiple information functions (such as `current_user`, `current_group`, `current_role`, `database()`, and `catalog()`) produce distinct output slots as expected.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
