### PR TITLE
[BugFix] Fix lock-free MV rewrite fallback to live metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -347,7 +347,14 @@ public class MvRewritePreprocessor {
         }
     }
 
-    private static MaterializedView copyOnlyMaterializedView(MaterializedView mv, long timeoutMs) {
+    public enum MvCopyFailurePolicy {
+        SKIP_ON_COPY_FAILURE,
+        FALLBACK_TO_LIVE_MV
+    }
+
+    private static MaterializedView copyOnlyMaterializedView(MaterializedView mv,
+                                                             long timeoutMs,
+                                                             MvCopyFailurePolicy copyFailurePolicy) {
         // Query will not lock dbs in the optimizer stage, so use a shallow copy of mv to avoid
         // metadata race for different operations.
         // Ensure to re-optimize if the mv's version has changed after the optimization.
@@ -356,8 +363,14 @@ public class MvRewritePreprocessor {
         // Add a timeout to avoid waiting too long for the lock in some cases to avoid affecting query latency.
         if (!locker.tryLockTableWithIntensiveDbLock(mv.getDbId(), mv.getId(), LockType.READ,
                 timeoutMsPerTry, TimeUnit.MILLISECONDS)) {
-            logMVPrepare("Failed to lock mv {} for copying, use mv directly", mv.getName());
-            return mv;
+            if (copyFailurePolicy == MvCopyFailurePolicy.FALLBACK_TO_LIVE_MV) {
+                logMVPrepare("Failed to lock mv {} for copying, use live mv to preserve transparent rewrite semantics",
+                        mv.getName());
+                return mv;
+            }
+            logMVPrepare("Failed to lock mv {} for copying under lock-free planning, skip this mv candidate",
+                    mv.getName());
+            return null;
         }
         try {
             MaterializedView copiedMV = new MaterializedView();
@@ -798,7 +811,8 @@ public class MvRewritePreprocessor {
         }
 
         MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
-                mvUpdateInfo, queryTables, mvWithPlanContext.getLevel(), timeoutMs);
+                mvUpdateInfo, queryTables, mvWithPlanContext.getLevel(), timeoutMs,
+                MvCopyFailurePolicy.SKIP_ON_COPY_FAILURE);
         if (materializationContext == null) {
             logMVPrepare(connectContext, "Prepare MV {} failed to build materialization context", mv.getName());
             return;
@@ -980,7 +994,20 @@ public class MvRewritePreprocessor {
                                                                      Set<Table> queryTables,
                                                                      int level) {
         long timeoutMs = getPrepareTimeoutMsPerMV(context.getConnectContext(), 1);
-        return buildMaterializationContext(context, mv, mvPlanContext, mvUpdateInfo, queryTables, level, timeoutMs);
+        return buildMaterializationContext(context, mv, mvPlanContext, mvUpdateInfo, queryTables, level, timeoutMs,
+                MvCopyFailurePolicy.SKIP_ON_COPY_FAILURE);
+    }
+
+    public static MaterializationContext buildMaterializationContext(OptimizerContext context,
+                                                                     MaterializedView mv,
+                                                                     MvPlanContext mvPlanContext,
+                                                                     MvUpdateInfo mvUpdateInfo,
+                                                                     Set<Table> queryTables,
+                                                                     int level,
+                                                                     MvCopyFailurePolicy copyFailurePolicy) {
+        long timeoutMs = getPrepareTimeoutMsPerMV(context.getConnectContext(), 1);
+        return buildMaterializationContext(context, mv, mvPlanContext, mvUpdateInfo, queryTables, level, timeoutMs,
+                copyFailurePolicy);
     }
 
     private static MaterializationContext buildMaterializationContext(OptimizerContext context,
@@ -989,7 +1016,8 @@ public class MvRewritePreprocessor {
                                                                       MvUpdateInfo mvUpdateInfo,
                                                                       Set<Table> queryTables,
                                                                       int level,
-                                                                      long timeoutMs) {
+                                                                      long timeoutMs,
+                                                                      MvCopyFailurePolicy copyFailurePolicy) {
         if (mvPlanContext == null) {
             logMVPrepare(context.getConnectContext(), "MV {} plan context is null", mv.getName());
             return null;
@@ -1013,7 +1041,14 @@ public class MvRewritePreprocessor {
 
         // If query tables are set which means use related mv for non lock optimization,
         // copy mv's metadata into a ready-only object.
-        MaterializedView copiedMV = (context.getQueryTables() != null) ? copyOnlyMaterializedView(mv, timeoutMs) : mv;
+        MaterializedView copiedMV = (context.getQueryTables() != null)
+                ? copyOnlyMaterializedView(mv, timeoutMs, copyFailurePolicy)
+                : mv;
+        if (copiedMV == null) {
+            logMVPrepare(context.getConnectContext(),
+                    "MV {} cannot build materialization context because its metadata copy is unavailable", mv.getName());
+            return null;
+        }
         return buildMaterializationContext(context, copiedMV, mvPlanContext, mvUpdateInfo,
                 baseTables, intersectingTables, mvPlan, level);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -29,6 +29,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor.MvCopyFailurePolicy;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
@@ -184,7 +185,13 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         logMVRewrite(context, this, "MV to refresh partition info: {}", mvUpdateInfo);
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, mvUpdateInfo, queryTables, 0);
+                mv, mvPlanContext, mvUpdateInfo, queryTables, 0, MvCopyFailurePolicy.FALLBACK_TO_LIVE_MV);
+        if (mvContext == null) {
+            logMVRewrite(context, this,
+                    "Failed to build transparent rewrite context for {}, redirect to default transparent behavior",
+                    mv.getName());
+            return getOptExpressionByDefault(context, mv, mvPlanContext, olapScanOperator, queryTables);
+        }
 
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         // use ordered output columns to ensure the order of output columns if the mv contains order-by clause.
@@ -231,7 +238,12 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         mvUpdateInfo.addMVToRefreshPartitionNames(mv.getPartitionCells(Optional.empty()));
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, mvUpdateInfo, queryTables, 0);
+                mv, mvPlanContext, mvUpdateInfo, queryTables, 0, MvCopyFailurePolicy.FALLBACK_TO_LIVE_MV);
+        if (mvContext == null) {
+            logMVRewrite(context, this,
+                    "Failed to build defined-query redirect context for {}", mv.getName());
+            throw new RuntimeException("Failed to build defined-query redirect context for mv: " + mv.getName());
+        }
         logMVRewrite(mvContext, "Get mv transparent plan failed, and redirect to mv's defined query");
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         List<Column> mvColumns = mv.getOrderedOutputColumns();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -258,6 +258,11 @@ public class TextMatchBasedRewriteRule extends Rule {
                 final Set<Table> queryTables = MvUtils.getAllTables(mvPlan).stream().collect(Collectors.toSet());
                 final MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
                         mv, mvPlanContext, mvUpdateInfo, queryTables, 0);
+                if (mvContext == null) {
+                    logMVRewrite(context, this,
+                            "Skip text-based rewrite for {} because its metadata copy is unavailable", mv.getName());
+                    continue;
+                }
                 final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
                 final List<ColumnRefOperator>  mvScanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -22,8 +22,11 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
@@ -57,6 +60,9 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.parquet.Strings;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.Assertions;
@@ -181,6 +187,54 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 new ColumnRefSet(logicalPlan.getOutputColumn()));
         Assertions.assertNotNull(expr);
         Assertions.assertEquals(2, optimizer.getContext().getCandidateMvs().size());
+
+        starRocksAssert.dropMaterializedView("mv_1");
+        starRocksAssert.dropMaterializedView("mv_2");
+    }
+
+    @Test
+    public void testPreprocessMvSkipsOnlyMvWhoseCopyLockFails() throws Exception {
+        executeInsertSql(connectContext, "insert into t0 values(10, 20, 30)");
+        starRocksAssert.withMaterializedView("create materialized view mv_1 distributed by hash(`v1`) " +
+                "as select v1, v2, sum(v3) as total from t0 group by v1, v2");
+        starRocksAssert.withMaterializedView("create materialized view mv_2 distributed by hash(`v1`) " +
+                "as select v1, sum(total) as total from mv_1 group by v1");
+        refreshMaterializedView("test", "mv_1");
+        refreshMaterializedView("test", "mv_2");
+
+        MaterializedView mv1 = getMv("test", "mv_1");
+        long mv1DbId = mv1.getDbId();
+        long mv1TableId = mv1.getId();
+        new MockUp<Locker>() {
+            @Mock
+            public boolean tryLockTableWithIntensiveDbLock(Invocation invocation, Long dbId, Long tableId,
+                                                           LockType lockType, long timeout, java.util.concurrent.TimeUnit unit) {
+                if (lockType == LockType.READ && mv1DbId == dbId && mv1TableId == tableId) {
+                    return false;
+                }
+                return invocation.proceed(dbId, tableId, lockType, timeout, unit);
+            }
+        };
+
+        String sql = "select v1, sum(v3) from t0 group by v1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        QueryStatement query = (QueryStatement) stmt;
+
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
+                .transformWithSelectLimit(query.getQueryRelation());
+        OptimizerContext optimizerContext = OptimizerFactory.mockContext(connectContext, columnRefFactory);
+        Set<OlapTable> queryTables = MvUtils.getAllTables(logicalPlan.getRoot()).stream()
+                .filter(OlapTable.class::isInstance)
+                .map(OlapTable.class::cast)
+                .collect(Collectors.toSet());
+        optimizerContext.setQueryTables(queryTables);
+        Optimizer optimizer = OptimizerFactory.create(optimizerContext);
+        OptExpression expr = optimizer.optimize(logicalPlan.getRoot(), new PhysicalPropertySet(),
+                new ColumnRefSet(logicalPlan.getOutputColumn()));
+        Assertions.assertNotNull(expr);
+        Assertions.assertEquals(1, optimizer.getContext().getCandidateMvs().size());
+        Assertions.assertEquals("mv_2", optimizer.getContext().getCandidateMvs().iterator().next().getMv().getName());
 
         starRocksAssert.dropMaterializedView("mv_1");
         starRocksAssert.dropMaterializedView("mv_2");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -18,12 +18,23 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.schema.MTable;
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor.MvCopyFailurePolicy;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -31,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
     private static MTable m1;
@@ -256,6 +268,52 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
                 }
             }
+        });
+    }
+
+    @Test
+    public void testTransparentRewritePreservesSemanticsWhenMvCopyLockFails() {
+        withPartialScanMv(() -> {
+            MaterializedView mv = getMv("test", "mv0");
+            long mvDbId = mv.getDbId();
+            long mvTableId = mv.getId();
+            new MockUp<Locker>() {
+                @Mock
+                public boolean tryLockTableWithIntensiveDbLock(Invocation invocation, Long dbId, Long tableId,
+                                                               LockType lockType, long timeout, TimeUnit unit) {
+                    if (lockType == LockType.READ && mvDbId == dbId && mvTableId == tableId) {
+                        return false;
+                    }
+                    return invocation.proceed(dbId, tableId, lockType, timeout, unit);
+                }
+            };
+
+            String plan = getFragmentPlan("SELECT * from mv0 where k1<6 and k2 like 'a%'");
+            PlanTestBase.assertContains(plan, ":UNION");
+            PlanTestBase.assertContains(plan, "mv0");
+            PlanTestBase.assertContains(plan, "m1");
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteBuildContextFailureFallsBackToOriginalScan() {
+        withPartialScanMv(() -> {
+            new MockUp<MvRewritePreprocessor>() {
+                @Mock
+                public MaterializationContext buildMaterializationContext(OptimizerContext context,
+                                                                         MaterializedView mv,
+                                                                         MvPlanContext mvPlanContext,
+                                                                         MvUpdateInfo mvUpdateInfo,
+                                                                         Set<Table> queryTables,
+                                                                         int level,
+                                                                         MvCopyFailurePolicy copyFailurePolicy) {
+                    return null;
+                }
+            };
+
+            String plan = getFragmentPlan("SELECT * from mv0 where k1<6 and k2 like 'a%'");
+            PlanTestBase.assertNotContains(plan, ":UNION");
+            PlanTestBase.assertContains(plan, "mv0");
         });
     }
 


### PR DESCRIPTION
## Why I'm doing:
During query planning, StarRocks is designed to work on copied table metadata instead of directly using live catalog objects. The purpose of this design is to isolate the optimizer from concurrent metadata changes, such as schema updates, partition changes, or materialized view state changes happening in background threads. This copied-metadata model is an important protection because the optimizer and statistics derivation may iterate table structures like partitions and indexes without holding long-lived catalog locks.

However, the MV rewrite path breaks this assumption in one corner case. When the optimizer prepares a materialized view candidate for query rewrite, it tries to build a copied MV object first. If the MV lock cannot be acquired, the previous implementation may fall back to using the live MV object from the catalog directly. Once that happens, the planner is no longer operating on fully isolated metadata. As a result, if the live MV metadata is modified concurrently while the optimizer is reading it, query planning may fail with runtime errors such as `ConcurrentModificationException`, for example when statistics calculation iterates partition-related metadata.

In other words, the original table-copy design intends to make planning lock-light but still safe, while the fallback-to-live-MV behavior reintroduces concurrency risk into the normal MV rewrite path.

## What I'm doing:
This change keeps the copied-metadata design consistent for normal MV candidate rewrite. Instead of falling back to the live MV object when MV metadata copy cannot be built, the optimizer now skips only that specific MV candidate and continues processing other eligible MVs.

At the same time, this change does not alter the existing semantics of transparent MV rewrite. For direct queries on materialized views, the transparent rewrite path still preserves its original fallback behavior according to `transparent_mv_rewrite_mode`, rather than degrading into a raw MV scan because of this fix.

This preserves the intended behavior of query planning:
1. normal MV rewrite should avoid reintroducing live MV metadata into the optimizer;
2. failure to copy one MV should not poison the whole rewrite process;
3. other valid MVs can still participate in rewrite normally;
4. transparent MV rewrite semantics remain unchanged.

With this change, query planning stays aligned with the metadata-isolation design in the normal MV rewrite path, while preserving the existing behavior of transparent MV rewrite.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/11126

```
java.util.ConcurrentModificationException: null
        at java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1784) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:258) ~[?:?]
        at java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:248) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.count(ReferencePipeline.java:709) ~[?:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.adjustPartitionColsStatistic(StatisticsCalculator.java:952) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeOlapScanNode(StatisticsCalculator.java:404) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:341) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:186) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator.accept(LogicalOlapScanOperator.java:194) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:240) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.task.DeriveStatsTask.execute(DeriveStatsTask.java:63) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.task.TaskScheduler.executeTasks(TaskScheduler.java:43) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.memoOptimize(QueryOptimizer.java:1012) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:274) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:213) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:404) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:154) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:108) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:712) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:822) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:545) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:432) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:369) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:756) ~[starrocks-fe.jar:?]
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
