### PR TITLE
[BugFix] Fix delete tablets misdeleting shared files from txn logs after tablet split

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -714,23 +714,33 @@ static StatusOr<BundleTabletMetaState> check_bundle_tablet_meta_state(
 }
 
 static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLogPB& log, bool contains_alive_tablets,
-                                        bool is_combined_log, AsyncFileDeleter& deleter) {
+                                        bool is_combined_log, AsyncFileDeleter& deleter,
+                                        const std::unordered_set<std::string>& retained_files) {
     if (log.has_op_write()) {
         const auto& op = log.op_write();
         // Shared segments can be deleted only when we know all tablets in a combined log are being deleted.
         for (int i = 0; i < op.rowset().segments_size(); ++i) {
+            if (retained_files.count(op.rowset().segments(i))) {
+                continue;
+            }
             if (!is_shared_segment(op.rowset(), i) || (is_combined_log && !contains_alive_tablets)) {
                 RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, op.rowset().segments(i))));
             }
         }
         // delete del files
         for (const auto& f : op.dels()) {
+            if (retained_files.count(f)) {
+                continue;
+            }
             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f)));
         }
     }
     if (log.has_op_compaction()) {
         const auto& op = log.op_compaction();
         for (int i = 0; i < op.output_rowset().segments_size(); ++i) {
+            if (retained_files.count(op.output_rowset().segments(i))) {
+                continue;
+            }
             if (!is_shared_segment(op.output_rowset(), i) || (is_combined_log && !contains_alive_tablets)) {
                 RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, op.output_rowset().segments(i))));
             }
@@ -740,6 +750,9 @@ static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLo
         const auto& op = log.op_schema_change();
         for (const auto& rowset : op.rowsets()) {
             for (int i = 0; i < rowset.segments_size(); ++i) {
+                if (retained_files.count(rowset.segments(i))) {
+                    continue;
+                }
                 if (!is_shared_segment(rowset, i) || (is_combined_log && !contains_alive_tablets)) {
                     RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, rowset.segments(i))));
                 }
@@ -802,50 +815,12 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     // Used to avoid deleting shared files that are shared by multiple tablets.
     AsyncSharedFileDeleter dummy_shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
 
-    for (const auto& log_name : txn_logs) {
-        auto res = tablet_mgr->get_txn_log(join_path(log_dir, log_name), false);
-        if (res.status().is_not_found()) {
-            continue;
-        } else if (!res.ok()) {
-            return res.status();
-        } else {
-            auto log_ptr = std::move(res).value();
-            // delete files under txnlog
-            RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, *log_ptr, false, false, deleter));
-            // delete txnlog
-            RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
-        }
-    }
-
-    for (const auto& log_name : combine_txn_logs) {
-        auto res = tablet_mgr->get_combined_txn_log(join_path(log_dir, log_name), false);
-        if (res.status().is_not_found()) {
-            continue;
-        } else if (!res.ok()) {
-            return res.status();
-        } else {
-            auto combine_log_ptr = std::move(res).value();
-            // check whether every txn_log is contained in tablet_ids.
-            // If not, it means this combine txn log is also shared by other alive tablets.
-            bool contains_alive_tablets = false;
-            for (const auto& log : combine_log_ptr->txn_logs()) {
-                if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
-                    contains_alive_tablets = true;
-                    break;
-                }
-            }
-            // delete files under txnlog
-            for (const auto& log : combine_log_ptr->txn_logs()) {
-                if (std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
-                    RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter));
-                }
-            }
-            // delete txnlog
-            if (!contains_alive_tablets) {
-                RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
-            }
-        }
-    }
+    // Process metadata BEFORE txn logs to collect retained shared files.
+    // After tablet split, txn logs written before split may not mark files as shared,
+    // while the latest metadata (updated after split) does. Processing metadata first
+    // ensures shared files are collected into retained_files and not accidentally deleted
+    // when processing txn logs.
+    std::unordered_set<std::string> retained_files;
 
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(meta_dir, [&](std::string_view name) {
         if (!is_tablet_metadata(name)) {
@@ -948,6 +923,15 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                     // If the segment file is not shared by other alive tablets, we can delete it directly.
                     if (!is_shared_segment(rowset, i) || allow_delete_shared_files) {
                         RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, rowset.segments(i))));
+                    } else {
+                        retained_files.insert(rowset.segments(i));
+                    }
+                }
+                for (const auto& del_file : rowset.del_files()) {
+                    if (!del_file.shared() || allow_delete_shared_files) {
+                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
+                    } else {
+                        retained_files.insert(del_file.name());
                     }
                 }
             }
@@ -955,6 +939,8 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {
                     if (!f.shared() || allow_delete_shared_files) {
                         RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f.name())));
+                    } else {
+                        retained_files.insert(f.name());
                     }
                 }
             }
@@ -964,6 +950,8 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                         const bool shared_file = i < dcg.shared_files_size() && dcg.shared_files(i);
                         if (!shared_file || allow_delete_shared_files) {
                             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, dcg.column_files(i))));
+                        } else {
+                            retained_files.insert(dcg.column_files(i));
                         }
                     }
                 }
@@ -972,11 +960,66 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 for (const auto& sst : latest_metadata->sstable_meta().sstables()) {
                     if (!sst.shared() || allow_delete_shared_files) {
                         RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, sst.filename())));
+                    } else {
+                        retained_files.insert(sst.filename());
                     }
                 }
             }
         }
 
+    }
+
+    // Process txn logs AFTER metadata processing, so that retained_files collected from
+    // shared files in metadata are used to protect files from being accidentally deleted.
+    for (const auto& log_name : txn_logs) {
+        auto res = tablet_mgr->get_txn_log(join_path(log_dir, log_name), false);
+        if (res.status().is_not_found()) {
+            continue;
+        } else if (!res.ok()) {
+            return res.status();
+        } else {
+            auto log_ptr = std::move(res).value();
+            // delete files under txnlog
+            RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, *log_ptr, false, false, deleter, retained_files));
+            // delete txnlog
+            RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
+        }
+    }
+
+    for (const auto& log_name : combine_txn_logs) {
+        auto res = tablet_mgr->get_combined_txn_log(join_path(log_dir, log_name), false);
+        if (res.status().is_not_found()) {
+            continue;
+        } else if (!res.ok()) {
+            return res.status();
+        } else {
+            auto combine_log_ptr = std::move(res).value();
+            // check whether every txn_log is contained in tablet_ids.
+            // If not, it means this combine txn log is also shared by other alive tablets.
+            bool contains_alive_tablets = false;
+            for (const auto& log : combine_log_ptr->txn_logs()) {
+                if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
+                    contains_alive_tablets = true;
+                    break;
+                }
+            }
+            // delete files under txnlog
+            for (const auto& log : combine_log_ptr->txn_logs()) {
+                if (std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
+                    RETURN_IF_ERROR(
+                            delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter, retained_files));
+                }
+            }
+            // delete txnlog
+            if (!contains_alive_tablets) {
+                RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
+            }
+        }
+    }
+
+    // Delete metadata files last. This ensures that if txn log processing above fails,
+    // metadata files are still available on retry to reconstruct retained_files.
+    for (auto& [tablet_id, versions_and_states] : tablet_versions) {
         for (auto& [version, state] : versions_and_states) {
             if (state == BundleTabletMetaState::NOT_BUNDLE_TABLET_META) {
                 // delete the individual tablet metadata file

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -966,7 +966,6 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 }
             }
         }
-
     }
 
     // Process txn logs AFTER metadata processing, so that retained_files collected from
@@ -1006,8 +1005,8 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             // delete files under txnlog
             for (const auto& log : combine_log_ptr->txn_logs()) {
                 if (std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
-                    RETURN_IF_ERROR(
-                            delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter, retained_files));
+                    RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter,
+                                                              retained_files));
                 }
             }
             // delete txnlog

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4226,4 +4226,120 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
     }
 }
 
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_txnlog_retains_shared_files_from_metadata) {
+    // Simulate a tablet split scenario:
+    // - Txn log was written BEFORE split, so the file is NOT marked as shared in the txn log.
+    // - Metadata was updated AFTER split, so the file IS marked as shared in the metadata.
+    // When deleting the old tablet, the shared file should be retained because it is still
+    // referenced by other tablets via the shared flag in metadata.
+    const std::string shared_segment = "0000000000f659e4_66666666-6666-6666-6666-6666666666f1.dat";
+    const std::string shared_delvec = "0000000000f659e4_66666666-6666-6666-6666-6666666666f2.delvec";
+    const std::string shared_sstable = "0000000000f659e4_66666666-6666-6666-6666-6666666666f3.sst";
+    const std::string shared_del_file = "0000000000f659e4_66666666-6666-6666-6666-6666666666f4.del";
+    const std::string private_segment = "0000000000f759e4_77777777-7777-7777-7777-7777777777g1.dat";
+    const std::string private_del_file = "0000000000f759e4_77777777-7777-7777-7777-7777777777g2.del";
+    create_data_file(shared_segment);
+    create_data_file(shared_delvec);
+    create_data_file(shared_sstable);
+    create_data_file(shared_del_file);
+    create_data_file(private_segment);
+    create_data_file(private_del_file);
+
+    // Txn log: file is NOT marked as shared (written before split).
+    ASSERT_OK(_tablet_mgr->put_txn_log(*json_to_pb<TxnLogPB>(R"DEL(
+        {
+            "tablet_id": 5000,
+            "txn_id": 9900,
+            "partition_id": 111,
+            "op_write": {
+                "rowset": {
+                    "segments": [
+                        "0000000000f659e4_66666666-6666-6666-6666-6666666666f1.dat",
+                        "0000000000f759e4_77777777-7777-7777-7777-7777777777g1.dat"
+                    ]
+                },
+                "dels": [
+                    "0000000000f659e4_66666666-6666-6666-6666-6666666666f4.del",
+                    "0000000000f759e4_77777777-7777-7777-7777-7777777777g2.del"
+                ]
+            }
+        }
+        )DEL")));
+
+    // Metadata v2: file IS marked as shared (updated after split).
+    // Only tablet 5000 is being deleted, while the shared files are also used by other tablets.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 5000,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "0000000000f659e4_66666666-6666-6666-6666-6666666666f1.dat",
+                    "0000000000f759e4_77777777-7777-7777-7777-7777777777g1.dat"
+                ],
+                "data_size": 4096,
+                "shared_segments": [true, false],
+                "del_files": [
+                    {
+                        "name": "0000000000f659e4_66666666-6666-6666-6666-6666666666f4.del",
+                        "shared": true
+                    },
+                    {
+                        "name": "0000000000f759e4_77777777-7777-7777-7777-7777777777g2.del",
+                        "shared": false
+                    }
+                ]
+            }
+        ],
+        "delvec_meta": {
+            "version_to_file": [
+                {
+                    "key": 2,
+                    "value": {
+                        "name": "0000000000f659e4_66666666-6666-6666-6666-6666666666f2.delvec",
+                        "size": 32,
+                        "shared": true
+                    }
+                }
+            ]
+        },
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "0000000000f659e4_66666666-6666-6666-6666-6666666666f3.sst",
+                    "shared": true
+                }
+            ]
+        }
+        }
+        )DEL")));
+
+    {
+        // Delete tablet 5000. Shared files in metadata should be retained
+        // even though they are not marked as shared in the txn log.
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(5000);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        // Shared files should be retained (protected by metadata's shared flag).
+        EXPECT_TRUE(file_exist(shared_segment));
+        EXPECT_TRUE(file_exist(shared_delvec));
+        EXPECT_TRUE(file_exist(shared_sstable));
+        EXPECT_TRUE(file_exist(shared_del_file));
+
+        // Private segment and del file should be deleted.
+        EXPECT_FALSE(file_exist(private_segment));
+        EXPECT_FALSE(file_exist(private_del_file));
+
+        // Txn log and metadata should be deleted.
+        EXPECT_FALSE(file_exist(txn_log_filename(5000, 9900)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
+    }
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

  After tablet split, `delete_tablets_impl()` processes txn logs before metadata. Old txn logs (written before split) do not mark files as shared, while the latest metadata (updated after split) correctly marks them as shared. Because txn logs were processed first, `is_shared_segment()` returned false for these files, causing them to be deleted. By the time metadata was processed, the shared files were already gone.

  Additionally, `rowset.del_files` marked as shared in metadata were never collected into the protection set, so shared PK del files suffered the same mis-deletion.

  There was also a retry-safety issue: since `AsyncFileDeleter` submits batches eagerly (when batch is full, not waiting for `finish()`), if metadata files were deleted before txn log processing and txn log reading subsequently failed, retry would find metadata gone and be unable to reconstruct the shared file protection set.

## What I'm doing:

  1. Reorder `delete_tablets_impl()` execution: process metadata before txn logs to collect `retained_files` (shared files that must not be deleted), then process txn logs with `retained_files` as a protection set.
  2. Add `retained_files` parameter to `delete_files_under_txnlog()` so it skips files that are identified as shared in metadata (segments, del files, delvec, dcg, sstable).
  3. Handle `rowset.del_files()` in metadata processing — both for deletion of non-shared del files and for collecting shared del files into `retained_files`.
  4. Defer metadata file deletion to after txn log processing, ensuring metadata remains available for retry if txn log processing fails.


Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
