### PR TITLE
[BugFix] fix starlet config can not be set

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -434,14 +434,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
 
 #ifdef USE_STAROS
-#define UPDATE_STARLET_CONFIG(BE_CONFIG, STARLET_CONFIG)                                                        \
-    _config_callback.emplace(#BE_CONFIG, [&]() {                                                                \
-        auto val = std::to_string(config::BE_CONFIG);                                                           \
-        if (staros::starlet::common::GFlagsUtils::UpdateFlagValue(#STARLET_CONFIG, val).empty()) {              \
-            LOG(WARNING) << "Failed to update " << #STARLET_CONFIG;                                             \
-            return Status::InvalidArgument("Failed to update " + std::string(#BE_CONFIG) + ".");                \
-        }                                                                                                       \
-        return Status::OK();                                                                                    \
+#define UPDATE_STARLET_CONFIG(BE_CONFIG, STARLET_CONFIG)                                           \
+    _config_callback.emplace(#BE_CONFIG, [&]() {                                                   \
+        auto val = std::to_string(config::BE_CONFIG);                                              \
+        if (staros::starlet::common::GFlagsUtils::UpdateFlagValue(#STARLET_CONFIG, val).empty()) { \
+            LOG(WARNING) << "Failed to update " << #STARLET_CONFIG;                                \
+            return Status::InvalidArgument("Failed to update " + std::string(#BE_CONFIG) + ".");   \
+        }                                                                                          \
+        return Status::OK();                                                                       \
     });
 
         UPDATE_STARLET_CONFIG(starlet_cache_thread_num, cachemgr_threadpool_size);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -434,13 +434,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
 
 #ifdef USE_STAROS
-#define UPDATE_STARLET_CONFIG(BE_CONFIG, STARLET_CONFIG)                                             \
-    _config_callback.emplace(#BE_CONFIG, [value]() {                                                 \
-        if (staros::starlet::common::GFlagsUtils::UpdateFlagValue(#STARLET_CONFIG, value).empty()) { \
-            LOG(WARNING) << "Failed to update " << #STARLET_CONFIG;                                  \
-            return Status::InvalidArgument("Failed to update " + std::string(#BE_CONFIG) + ".");     \
-        }                                                                                            \
-        return Status::OK();                                                                         \
+#define UPDATE_STARLET_CONFIG(BE_CONFIG, STARLET_CONFIG)                                                        \
+    _config_callback.emplace(#BE_CONFIG, [&]() {                                                                \
+        auto val = std::to_string(config::BE_CONFIG);                                                           \
+        if (staros::starlet::common::GFlagsUtils::UpdateFlagValue(#STARLET_CONFIG, val).empty()) {              \
+            LOG(WARNING) << "Failed to update " << #STARLET_CONFIG;                                             \
+            return Status::InvalidArgument("Failed to update " + std::string(#BE_CONFIG) + ".");                \
+        }                                                                                                       \
+        return Status::OK();                                                                                    \
     });
 
         UPDATE_STARLET_CONFIG(starlet_cache_thread_num, cachemgr_threadpool_size);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
fix https://github.com/StarRocks/StarRocksTest/issues/11131

value will be captured only once for starlet config in `std::call_once`, so the first value `true` will be captured, when we execute the second update, `4096` will be overridden by `true`
```
update information_schema.be_configs set value = "true" where name = "starlet_fs_read_prefetch_enable";
Query OK, 0 rows affected (0.00 sec)

update information_schema.be_configs set value = "4096" where name = "starlet_fs_stream_buffer_size_bytes";
ERROR 5609 (22000): Failed to update starlet_fs_stream_buffer_size_bytes.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
