### PR TITLE
[BugFix] fix truncate bug

### DIFF
--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -122,24 +122,25 @@ inline void FunctionHelper::get_data_of_column<BinaryColumn, Slice>(const Column
         }                                    \
     } while (false)
 
-#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)     \
-    do {                                                                \
-        if (c0->only_null() || c1->only_null()) {                       \
-            return ColumnHelper::create_const_null_column(c0->size());  \
-        }                                                               \
-        if (c0->has_null() || c1->has_null()) {                         \
-            has_null = true;                                            \
-            null_flags = FunctionHelper::union_nullable_column(c0, c1); \
-        } else {                                                        \
-            auto null_flags_mut = NullColumn::create();                 \
-            null_flags_mut->reserve(c0->size());                        \
-            null_flags_mut->append_default(c0->size());                 \
-            null_flags = std::move(null_flags_mut);                     \
-        }                                                               \
-        c0 = FunctionHelper::get_data_column_of_const(c0);              \
-        c1 = FunctionHelper::get_data_column_of_const(c1);              \
-        c0 = FunctionHelper::get_data_column_of_nullable(c0);           \
-        c1 = FunctionHelper::get_data_column_of_nullable(c1);           \
+#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)           \
+    do {                                                                      \
+        const int __num_rows = c0->size();                                    \
+        if (c0->only_null() || c1->only_null()) {                             \
+            return ColumnHelper::create_const_null_column(__num_rows);        \
+        }                                                                     \
+        if (c0->has_null() || c1->has_null()) {                               \
+            has_null = true;                                                  \
+            null_flags = FunctionHelper::union_nullable_column(c0, c1);       \
+        } else {                                                              \
+            auto null_flags_mut = NullColumn::create();                       \
+            null_flags_mut->reserve(__num_rows);                              \
+            null_flags_mut->append_default(__num_rows);                       \
+            null_flags = std::move(null_flags_mut);                           \
+        }                                                                     \
+        c0 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c0); \
+        c1 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c1); \
+        c0 = FunctionHelper::get_data_column_of_nullable(c0);                 \
+        c1 = FunctionHelper::get_data_column_of_nullable(c1);                 \
     } while (0)
 
 } // namespace starrocks

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -122,25 +122,29 @@ inline void FunctionHelper::get_data_of_column<BinaryColumn, Slice>(const Column
         }                                    \
     } while (false)
 
-#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)           \
-    do {                                                                      \
-        const int __num_rows = c0->size();                                    \
-        if (c0->only_null() || c1->only_null()) {                             \
-            return ColumnHelper::create_const_null_column(__num_rows);        \
-        }                                                                     \
-        if (c0->has_null() || c1->has_null()) {                               \
-            has_null = true;                                                  \
-            null_flags = FunctionHelper::union_nullable_column(c0, c1);       \
-        } else {                                                              \
-            auto null_flags_mut = NullColumn::create();                       \
-            null_flags_mut->reserve(__num_rows);                              \
-            null_flags_mut->append_default(__num_rows);                       \
-            null_flags = std::move(null_flags_mut);                           \
-        }                                                                     \
-        c0 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c0); \
-        c1 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c1); \
-        c0 = FunctionHelper::get_data_column_of_nullable(c0);                 \
-        c1 = FunctionHelper::get_data_column_of_nullable(c1);                 \
+#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)                    \
+    do {                                                                                \
+        const int __num_rows = c0->size();                                              \
+        if (c0->only_null() || c1->only_null()) {                                       \
+            return ColumnHelper::create_const_null_column(__num_rows);                  \
+        }                                                                               \
+        if (c0->has_null() || c1->has_null()) {                                         \
+            has_null = true;                                                            \
+            null_flags = FunctionHelper::union_nullable_column(c0, c1);                 \
+        } else {                                                                        \
+            auto null_flags_mut = NullColumn::create();                                 \
+            null_flags_mut->reserve(__num_rows);                                        \
+            null_flags_mut->append_default(__num_rows);                                 \
+            null_flags = std::move(null_flags_mut);                                     \
+        }                                                                               \
+        c0 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c0);           \
+        if (UNLIKELY(__num_rows == 0 && c1->is_constant())) {                           \
+            c1 = FunctionHelper::get_data_column_of_const(c1);                          \
+        } else {                                                                        \
+            c1 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c1);       \
+        }                                                                               \
+        c0 = FunctionHelper::get_data_column_of_nullable(c0);                           \
+        c1 = FunctionHelper::get_data_column_of_nullable(c1);                           \
     } while (0)
 
 } // namespace starrocks

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -122,29 +122,29 @@ inline void FunctionHelper::get_data_of_column<BinaryColumn, Slice>(const Column
         }                                    \
     } while (false)
 
-#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)                    \
-    do {                                                                                \
-        const int __num_rows = c0->size();                                              \
-        if (c0->only_null() || c1->only_null()) {                                       \
-            return ColumnHelper::create_const_null_column(__num_rows);                  \
-        }                                                                               \
-        if (c0->has_null() || c1->has_null()) {                                         \
-            has_null = true;                                                            \
-            null_flags = FunctionHelper::union_nullable_column(c0, c1);                 \
-        } else {                                                                        \
-            auto null_flags_mut = NullColumn::create();                                 \
-            null_flags_mut->reserve(__num_rows);                                        \
-            null_flags_mut->append_default(__num_rows);                                 \
-            null_flags = std::move(null_flags_mut);                                     \
-        }                                                                               \
-        c0 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c0);           \
-        if (UNLIKELY(__num_rows == 0 && c1->is_constant())) {                           \
-            c1 = FunctionHelper::get_data_column_of_const(c1);                          \
-        } else {                                                                        \
-            c1 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c1);       \
-        }                                                                               \
-        c0 = FunctionHelper::get_data_column_of_nullable(c0);                           \
-        c1 = FunctionHelper::get_data_column_of_nullable(c1);                           \
+#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)               \
+    do {                                                                          \
+        const int __num_rows = c0->size();                                        \
+        if (c0->only_null() || c1->only_null()) {                                 \
+            return ColumnHelper::create_const_null_column(__num_rows);            \
+        }                                                                         \
+        if (c0->has_null() || c1->has_null()) {                                   \
+            has_null = true;                                                      \
+            null_flags = FunctionHelper::union_nullable_column(c0, c1);           \
+        } else {                                                                  \
+            auto null_flags_mut = NullColumn::create();                           \
+            null_flags_mut->reserve(__num_rows);                                  \
+            null_flags_mut->append_default(__num_rows);                           \
+            null_flags = std::move(null_flags_mut);                               \
+        }                                                                         \
+        c0 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c0);     \
+        if (c1->is_constant()) {                                                  \
+            c1 = FunctionHelper::get_data_column_of_const(c1);                    \
+        } else {                                                                  \
+            c1 = ColumnHelper::unpack_and_duplicate_const_column(__num_rows, c1); \
+        }                                                                         \
+        c0 = FunctionHelper::get_data_column_of_nullable(c0);                     \
+        c1 = FunctionHelper::get_data_column_of_nullable(c1);                     \
     } while (0)
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC unwraps ConstColumn Via
get_data_column_of_const , So cO->size（） becomes 1 when the caller passes a const
column （typical for literals/constant-folded exprs）. Using const int size = c0->size（）；
after this macro can therefore produce a 1-row result and/or a size mismatch with
null_flags （which was sized using the original co->size（））， potentially leading to
incorrect results or crashes when const inputs occur. Consider capturing the original input
row count before unwrapping const, and if columns ［e］ is const, either broadcast the
computed value to that row count or return a ConstColumn with the original size （and
ensure the indexing uses row O for const inputs）
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
