### PR TITLE
[BugFix] Track Arrow memory pool allocations in Parquet reader via MemTracker

### DIFF
--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -472,7 +472,8 @@ Status ParquetScanner::open_next_reader() {
         _conv_ctx.current_file = file->filename();
         auto parquet_file = std::make_shared<ParquetChunkFile>(file, 0, _counter);
         auto parquet_reader = std::make_shared<ParquetReaderWrap>(std::move(parquet_file), _num_of_columns_from_file,
-                                                                  range_desc.start_offset, range_desc.size);
+                                                                  range_desc.start_offset, range_desc.size,
+                                                                  ExecEnv::GetInstance()->query_pool_mem_tracker());
         if (_scan_range.params.__isset.flexible_column_mapping && _scan_range.params.flexible_column_mapping) {
             parquet_reader->set_invalid_as_null(true);
         }
@@ -510,7 +511,8 @@ Status ParquetScanner::get_schema(std::vector<SlotDescriptor>* schema) {
     _conv_ctx.current_file = file->filename();
     auto parquet_file = std::make_shared<ParquetChunkFile>(file, 0, _counter);
     auto parquet_reader = std::make_shared<ParquetReaderWrap>(std::move(parquet_file), _num_of_columns_from_file,
-                                                              range_desc.start_offset, range_desc.size);
+                                                              range_desc.start_offset, range_desc.size,
+                                                              ExecEnv::GetInstance()->query_pool_mem_tracker());
     return parquet_reader->get_schema(schema);
 }
 

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -29,7 +29,6 @@
 #include "parquet/schema.h"
 #include "parquet_schema_builder.h"
 #include "runtime/descriptors.h"
-#include "util/byte_buffer.h"
 
 namespace starrocks {
 // ====================================================================================================================
@@ -39,15 +38,19 @@ ParquetReaderWrap::~ParquetReaderWrap() {
 }
 
 ParquetReaderWrap::ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile>&& parquet_file,
-                                     int32_t num_of_columns_from_file, int64_t read_offset, int64_t read_size)
+                                     int32_t num_of_columns_from_file, int64_t read_offset, int64_t read_size,
+                                     MemTracker* mem_tracker)
 
         : _num_of_columns_from_file(num_of_columns_from_file),
 
+          _arrow_pool(std::make_shared<ArrowMemoryPool>(mem_tracker)),
           _read_offset(read_offset),
           _read_size(read_size) {
     _parquet = std::move(parquet_file);
     _properties = ::parquet::ReaderProperties();
-    _filename = (reinterpret_cast<ParquetChunkFile*>(_parquet.get()))->filename();
+    auto* chunk_file = reinterpret_cast<ParquetChunkFile*>(_parquet.get());
+    _filename = chunk_file->filename();
+    chunk_file->set_memory_pool(_arrow_pool);
 }
 
 Status ParquetReaderWrap::next_selected_row_group() {
@@ -107,7 +110,7 @@ Status ParquetReaderWrap::_init_parquet_reader() {
         arrow_reader_properties.set_cache_options(cache_options);
 
         // new file reader for parquet file
-        auto st = ::parquet::arrow::FileReader::Make(arrow::default_memory_pool(),
+        auto st = ::parquet::arrow::FileReader::Make(_arrow_pool.get(),
                                                      ::parquet::ParquetFileReader::Open(_parquet, _properties),
                                                      arrow_reader_properties, &_reader);
         if (!st.ok()) {
@@ -375,7 +378,7 @@ using ArrowStatus = ::arrow::Status;
 
 ParquetChunkFile::ParquetChunkFile(std::shared_ptr<starrocks::RandomAccessFile> file, uint64_t pos,
                                    ScannerCounter* counter)
-        : _file(std::move(file)), _pos(pos), _counter(counter) {}
+        : _file(std::move(file)), _pos(pos), _counter(counter), _pool(std::make_shared<ArrowMemoryPool>()) {}
 
 ParquetChunkFile::~ParquetChunkFile() {
     [[maybe_unused]] auto st = Close();
@@ -421,22 +424,23 @@ arrow::Result<int64_t> ParquetChunkFile::Tell() const {
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> ParquetChunkFile::Read(int64_t nbytes) {
-    auto tracker = CurrentThread::mem_tracker();
-    if (tracker == nullptr) {
-        return arrow::Status::ExecutionError("current thread memory tracker Not Found when allocate arrow Buffer");
-    }
-    std::unique_ptr<arrow::Buffer> buffer_res;
-    ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(nbytes, arrow::default_memory_pool()).Value(&buffer_res));
-    std::shared_ptr<arrow::Buffer> read_buf(buffer_res.release(), MemTrackerDeleter(tracker));
+    ARROW_ASSIGN_OR_RAISE(auto read_buf, arrow::AllocateBuffer(nbytes, _pool.get()));
     int64_t bytes_read_res = 0;
     ARROW_RETURN_NOT_OK(ReadAt(_pos, nbytes, read_buf->mutable_data()).Value(&bytes_read_res));
-    // If bytes_read is equal with read_buf's capacity, we just assign
+    // Custom deleter captures shared_ptr<ArrowMemoryPool>, keeping pool alive
+    // until the buffer is freed (even from Arrow IO threads after
+    // ParquetReaderWrap is destroyed).
+    auto deleter = read_buf.get_deleter();
+    auto shared_buf = std::shared_ptr<arrow::Buffer>(
+            read_buf.release(), [pool = _pool, deleter = std::move(deleter)](arrow::Buffer* buf) mutable {
+                (void)pool; // prevent pool from being released before buffer is freed
+                deleter(buf);
+            });
+    // If bytes_read is equal with read_buf's capacity, we just assign.
     if (bytes_read_res == nbytes) {
-        return std::move(read_buf);
+        return shared_buf;
     } else {
-        std::shared_ptr<arrow::Buffer> slice_buf(new arrow::Buffer(read_buf, 0, bytes_read_res),
-                                                 MemTrackerDeleter(tracker));
-        return slice_buf;
+        return arrow::SliceBuffer(shared_buf, 0, bytes_read_res);
     }
 }
 

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -32,12 +32,14 @@
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exprs/expr.h"
+#include "formats/parquet/arrow_memory_pool.h"
 #include "fs/fs.h"
 #include "runtime/descriptors.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks {
 
+class MemTracker;
 class ScannerCounter;
 using RecordBatch = ::arrow::RecordBatch;
 using RecordBatchPtr = std::shared_ptr<RecordBatch>;
@@ -54,17 +56,19 @@ public:
     arrow::Status Close() override;
     bool closed() const override;
     const std::string& filename() const;
+    void set_memory_pool(std::shared_ptr<ArrowMemoryPool> pool) { _pool = std::move(pool); }
 
 private:
     std::shared_ptr<starrocks::RandomAccessFile> _file;
     uint64_t _pos = 0;
     ScannerCounter* _counter = nullptr;
+    std::shared_ptr<ArrowMemoryPool> _pool;
 };
 
 class ParquetReaderWrap {
 public:
     ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile>&& parquet_file, int32_t num_of_columns_from_file,
-                      int64_t read_offset, int64_t read_size);
+                      int64_t read_offset, int64_t read_size, MemTracker* mem_tracker = nullptr);
     virtual ~ParquetReaderWrap();
 
     void close();
@@ -88,6 +92,15 @@ private:
     int64_t _num_rows = 0;
     ::parquet::ReaderProperties _properties;
     std::shared_ptr<arrow::io::RandomAccessFile> _parquet;
+
+    // Declared before Arrow-owned members (_rb_batch, _batch, _reader) so that
+    // _arrow_pool outlives them during destruction (C++ destroys members in
+    // reverse declaration order). Arrow objects may call pool->Free() in their
+    // destructors.
+    // shared_ptr so that buffers returned by ParquetChunkFile::Read(nbytes) can
+    // prevent the pool from being destroyed while Arrow IO threads still hold
+    // references to those buffers.
+    std::shared_ptr<ArrowMemoryPool> _arrow_pool;
 
     // parquet file reader object
     std::shared_ptr<::arrow::RecordBatchReader> _rb_batch;

--- a/be/src/formats/parquet/arrow_memory_pool.cpp
+++ b/be/src/formats/parquet/arrow_memory_pool.cpp
@@ -14,6 +14,9 @@
 
 #include "arrow_memory_pool.h"
 
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
+
 namespace starrocks {
 
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
@@ -26,11 +29,24 @@ ArrowMemoryPool::Status ArrowMemoryPool::Allocate(int64_t size, int64_t alignmen
     if (size == 0) {
         *out = kZeroSizeArea;
     }
+#ifndef BE_TEST
+    // In production, jemalloc hooks intercept posix_memalign and attribute
+    // the allocation to the current TLS tracker.  Redirect TLS to
+    // _mem_tracker so the hook tracks to the right place.
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+#endif
     // On Linux (and other systems), posix_memalign() does not modify memptr on failure.
     if (posix_memalign(reinterpret_cast<void**>(out), alignment, size)) {
         return Status::OutOfMemory("malloc of size ", size, " failed");
     }
     _stats.DidAllocateBytes(size);
+#ifdef BE_TEST
+    // In test builds (ASAN), jemalloc hooks are not active.
+    // Explicitly track the allocation.
+    if (_mem_tracker != nullptr) {
+        _mem_tracker->consume(size);
+    }
+#endif
     return Status::OK();
 }
 
@@ -63,8 +79,16 @@ void ArrowMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t /*alignment*/)
         DCHECK_EQ(size, 0);
         return;
     }
+#ifndef BE_TEST
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+#endif
     std::free(buffer);
     _stats.DidFreeBytes(size);
+#ifdef BE_TEST
+    if (_mem_tracker != nullptr) {
+        _mem_tracker->release(size);
+    }
+#endif
 }
 
 } // namespace starrocks

--- a/be/src/formats/parquet/arrow_memory_pool.h
+++ b/be/src/formats/parquet/arrow_memory_pool.h
@@ -20,9 +20,14 @@
 
 namespace starrocks {
 
+class MemTracker;
+
 class ArrowMemoryPool final : public arrow::MemoryPool {
 public:
     using Status = arrow::Status;
+
+    ArrowMemoryPool() = default;
+    explicit ArrowMemoryPool(MemTracker* mem_tracker) : _mem_tracker(mem_tracker) {}
 
     ~ArrowMemoryPool() override = default;
 
@@ -43,6 +48,7 @@ public:
     std::string backend_name() const override { return "starrocks"; }
 
 private:
+    MemTracker* _mem_tracker = nullptr;
     arrow::internal::MemoryPoolStats _stats;
 };
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -108,6 +108,7 @@ set(EXEC_FILES
         ./exec/cache_stats_scanner_test.cpp
         ./exec/lake_meta_scanner_test.cpp
         ./exec/multi_olap_table_sink_test.cpp
+        ./exec/parquet_reader_test.cpp
         ./exec/parquet_schema_builder_test.cpp
         ./exec/repeat_node_test.cpp
         ./exec/sorting_test.cpp
@@ -219,6 +220,7 @@ set(EXEC_FILES
         ./formats/orc/orc_file_writer_test.cpp
         ./formats/orc/orc_lazy_load_test.cpp
         ./formats/orc/utils_test.cpp
+        ./formats/parquet/arrow_memory_pool_test.cpp
         ./formats/parquet/arrow_parquet_writer_test.cpp
         ./formats/parquet/parquet_schema_test.cpp
         ./formats/parquet/encoding_test.cpp

--- a/be/test/exec/parquet_reader_test.cpp
+++ b/be/test/exec/parquet_reader_test.cpp
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/parquet_reader.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "common/status.h"
+#include "common/statusor.h"
+#include "exec/file_scanner/file_scanner.h"
+#include "fs/fs.h"
+#include "io/core/seekable_input_stream.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+
+namespace starrocks {
+namespace {
+
+class TestSeekableInputStream final : public io::SeekableInputStream {
+public:
+    explicit TestSeekableInputStream(std::string data) : _data(std::move(data)) {}
+
+    StatusOr<int64_t> read(void* out, int64_t count) override {
+        if (count < 0) {
+            return Status::InvalidArgument("count must be non-negative");
+        }
+        const int64_t available = static_cast<int64_t>(_data.size()) - _position;
+        const int64_t to_read = std::min(count, std::max<int64_t>(available, 0));
+        if (to_read > 0) {
+            memcpy(out, _data.data() + _position, to_read);
+            _position += to_read;
+        }
+        return to_read;
+    }
+
+    Status read_fully(void* out, int64_t count) override {
+        ASSIGN_OR_RETURN(auto bytes_read, read(out, count));
+        if (bytes_read != count) {
+            return Status::IOError("unexpected eof");
+        }
+        return Status::OK();
+    }
+
+    Status skip(int64_t count) override {
+        if (count < 0) {
+            return Status::InvalidArgument("count must be non-negative");
+        }
+        _position = std::min<int64_t>(_position + count, _data.size());
+        return Status::OK();
+    }
+
+    Status seek(int64_t position) override {
+        if (position < 0) {
+            return Status::InvalidArgument("position must be non-negative");
+        }
+        _position = std::min<int64_t>(position, _data.size());
+        return Status::OK();
+    }
+
+    StatusOr<int64_t> position() override { return _position; }
+
+    StatusOr<int64_t> read_at(int64_t offset, void* out, int64_t count) override {
+        if (offset < 0 || count < 0) {
+            return Status::InvalidArgument("offset and count must be non-negative");
+        }
+        const int64_t available = static_cast<int64_t>(_data.size()) - offset;
+        const int64_t to_read = std::min(count, std::max<int64_t>(available, 0));
+        if (to_read > 0) {
+            memcpy(out, _data.data() + offset, to_read);
+        }
+        return to_read;
+    }
+
+    Status read_at_fully(int64_t offset, void* out, int64_t count) override {
+        ASSIGN_OR_RETURN(auto bytes_read, read_at(offset, out, count));
+        if (bytes_read != count) {
+            return Status::IOError("unexpected eof");
+        }
+        return Status::OK();
+    }
+
+    StatusOr<int64_t> get_size() override { return static_cast<int64_t>(_data.size()); }
+
+private:
+    std::string _data;
+    int64_t _position = 0;
+};
+
+std::shared_ptr<RandomAccessFile> create_random_access_file(std::string content) {
+    return std::make_shared<RandomAccessFile>(std::make_shared<TestSeekableInputStream>(std::move(content)),
+                                              "test.parquet");
+}
+
+TEST(ParquetReaderTest, LateBufferFreeAfterReaderClose) {
+    MemTracker* mem_tracker = ExecEnv::GetInstance()->query_pool_mem_tracker();
+    ASSERT_NE(mem_tracker, nullptr);
+
+    const int64_t initial_consumption = mem_tracker->consumption();
+    auto file = create_random_access_file("hello");
+    ScannerCounter counter;
+    auto parquet_file = std::make_shared<ParquetChunkFile>(file, 0, &counter);
+    auto arrow_file = std::static_pointer_cast<arrow::io::RandomAccessFile>(parquet_file);
+    auto reader = std::make_unique<ParquetReaderWrap>(std::move(arrow_file), 1, 0, 0, mem_tracker);
+
+    auto buffer_result = parquet_file->Read(5);
+    ASSERT_TRUE(buffer_result.ok()) << buffer_result.status().ToString();
+    auto buffer = std::move(buffer_result).MoveValueUnsafe();
+    const int64_t allocated_bytes = mem_tracker->consumption() - initial_consumption;
+
+    EXPECT_GT(allocated_bytes, 0);
+    EXPECT_GE(allocated_bytes, buffer->size());
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buffer->data()), buffer->size()), "hello");
+
+    reader->close();
+    reader.reset();
+    parquet_file.reset();
+
+    EXPECT_EQ(mem_tracker->consumption(), initial_consumption + allocated_bytes);
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(buffer->data()), buffer->size()), "hello");
+
+    buffer.reset();
+    EXPECT_EQ(mem_tracker->consumption(), initial_consumption);
+}
+
+} // namespace
+} // namespace starrocks

--- a/be/test/formats/parquet/arrow_memory_pool_test.cpp
+++ b/be/test/formats/parquet/arrow_memory_pool_test.cpp
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/arrow_memory_pool.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
+
+namespace starrocks {
+namespace {
+
+// Verify allocation is tracked on pool tracker AND propagates to parent,
+// with exactly single-counting (no double-count, no miss).
+TEST(ArrowMemoryPoolTest, TrackerHierarchyAllocateAndFree) {
+    auto process_tracker = std::make_unique<MemTracker>(-1, "process");
+    auto query_pool_tracker = std::make_unique<MemTracker>(-1, "query_pool", process_tracker.get());
+    ArrowMemoryPool pool(query_pool_tracker.get());
+
+    uint8_t* buf = nullptr;
+    constexpr int64_t alloc_size = 4096;
+    ASSERT_TRUE(pool.Allocate(alloc_size, 64, &buf).ok());
+    ASSERT_NE(buf, nullptr);
+
+    // Both query_pool and process see exactly alloc_size (single-counting).
+    EXPECT_EQ(query_pool_tracker->consumption(), alloc_size);
+    EXPECT_EQ(process_tracker->consumption(), alloc_size);
+
+    pool.Free(buf, alloc_size, 64);
+
+    // Both return to zero after free.
+    EXPECT_EQ(query_pool_tracker->consumption(), 0);
+    EXPECT_EQ(process_tracker->consumption(), 0);
+}
+
+// Verify that the outer TLS tracker is NOT affected by pool operations
+// (hook is redirected to a sink tracker, preventing double-counting).
+TEST(ArrowMemoryPoolTest, NoDoubleCountingWithOuterTracker) {
+    auto pool_tracker = std::make_unique<MemTracker>(-1, "pool_tracker");
+    auto outer_tracker = std::make_unique<MemTracker>(-1, "outer_tracker");
+    ArrowMemoryPool pool(pool_tracker.get());
+
+    // Simulate a scanner thread that already has a TLS tracker.
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(outer_tracker.get());
+
+    uint8_t* buf = nullptr;
+    constexpr int64_t alloc_size = 4096;
+    ASSERT_TRUE(pool.Allocate(alloc_size, 64, &buf).ok());
+    ASSERT_NE(buf, nullptr);
+
+    // Pool tracker sees the allocation.
+    EXPECT_EQ(pool_tracker->consumption(), alloc_size);
+    // Outer tracker is unchanged — hook was redirected to the sink tracker.
+    EXPECT_EQ(outer_tracker->consumption(), 0);
+
+    pool.Free(buf, alloc_size, 64);
+
+    // Pool tracker back to zero.
+    EXPECT_EQ(pool_tracker->consumption(), 0);
+    // Outer tracker still unchanged.
+    EXPECT_EQ(outer_tracker->consumption(), 0);
+}
+
+// Verify Reallocate tracks correctly: old freed, new allocated, net = new_size.
+TEST(ArrowMemoryPoolTest, ReallocateTracking) {
+    auto tracker = std::make_unique<MemTracker>(-1, "realloc_tracker");
+    ArrowMemoryPool pool(tracker.get());
+
+    uint8_t* buf = nullptr;
+    ASSERT_TRUE(pool.Allocate(1024, 64, &buf).ok());
+    ASSERT_NE(buf, nullptr);
+    EXPECT_EQ(tracker->consumption(), 1024);
+
+    memset(buf, 0xAB, 1024);
+
+    ASSERT_TRUE(pool.Reallocate(1024, 4096, 64, &buf).ok());
+    ASSERT_NE(buf, nullptr);
+
+    // Data preserved.
+    for (int i = 0; i < 1024; i++) {
+        ASSERT_EQ(buf[i], 0xAB) << "index " << i;
+    }
+
+    // Net consumption = new_size (old allocation was freed internally).
+    EXPECT_EQ(tracker->consumption(), 4096);
+    EXPECT_EQ(pool.bytes_allocated(), 4096);
+
+    pool.Free(buf, 4096, 64);
+    EXPECT_EQ(tracker->consumption(), 0);
+}
+
+// Verify pool works without a tracker (nullptr).
+TEST(ArrowMemoryPoolTest, WithoutTracker) {
+    ArrowMemoryPool pool;
+
+    uint8_t* buf = nullptr;
+    ASSERT_TRUE(pool.Allocate(1024, 64, &buf).ok());
+    ASSERT_NE(buf, nullptr);
+    EXPECT_EQ(pool.bytes_allocated(), 1024);
+
+    pool.Free(buf, 1024, 64);
+    EXPECT_EQ(pool.bytes_allocated(), 0);
+}
+
+// Verify zero-size allocation does not affect tracker.
+TEST(ArrowMemoryPoolTest, ZeroSizeAllocation) {
+    auto tracker = std::make_unique<MemTracker>(-1, "zero_tracker");
+    ArrowMemoryPool pool(tracker.get());
+
+    uint8_t* buf = nullptr;
+    ASSERT_TRUE(pool.Allocate(0, 64, &buf).ok());
+    EXPECT_EQ(tracker->consumption(), 0);
+
+    pool.Free(buf, 0, 64);
+    EXPECT_EQ(tracker->consumption(), 0);
+}
+
+} // namespace
+} // namespace starrocks


### PR DESCRIPTION
##  Why I'm doing:
                                                                                                                                                                                                                                                                             
  Arrow IO prebuffering in the legacy Parquet reader (ParquetReaderWrap) accounts for a significant
  portion of memory consumption, but is completely invisible to StarRocks' MemTracker system. The root                                                                                                                                                                       
  cause is that ParquetReaderWrap uses arrow::default_memory_pool(), and Arrow's internal IO threads                                                                                                                                                                         
  allocate memory via posix_memalign without any MemTracker integration.

  Additionally, replacing the global arrow::default_memory_pool() with a per-instance pool introduces
  a lifetime concern: Arrow's future.Cancel() is cooperative — already-running IO tasks won't stop
  immediately. If ParquetReaderWrap is destroyed while an IO thread still holds buffers allocated from
  the pool, those buffers would call Free() on a destroyed pool (UAF).

##  What I'm doing:

  Introduce ArrowMemoryPool with MemTracker integration, safe pool lifetime management, and correct
  interaction with the jemalloc allocator hooks.

  1. ArrowMemoryPool with MemTracker tracking

  ArrowMemoryPool gains an optional MemTracker* constructor. In production builds, memory tracking
  is done via SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker) which temporarily redirects the
  jemalloc allocator hook to attribute posix_memalign/std::free to the target tracker — this is the
  single tracking path, avoiding double-counting between the hook and explicit consume()/release().
  In test builds (BE_TEST, ASAN) where jemalloc hooks are not active, explicit consume()/release()
  is used instead.

  2. Pool lifetime via shared_ptr + custom buffer deleter

  Arrow's PoolBuffer stores a raw MemoryPool* pointer internally. Buffers returned by
  ParquetChunkFile::Read(nbytes) use a custom deleter that captures shared_ptr<ArrowMemoryPool>,
  keeping the pool alive until all buffers are freed — even those held by Arrow IO threads after
  ParquetReaderWrap is destroyed.

  3. Global query_pool_mem_tracker — no UAF risk

  The pool is initialized with ExecEnv::GetInstance()->query_pool_mem_tracker(), a global singleton
  that is never destroyed. This eliminates the parent-chain UAF problem entirely: no need for
  shared_ptr<MemTracker>, no need for detach_mem_tracker(), no need for atomic.

  4. Member declaration order

  _arrow_pool is declared before _rb_batch, _batch, _reader in ParquetReaderWrap, so C++
  destruction order guarantees the pool outlives internal Arrow objects.

  5. Defensive initialization

  ParquetChunkFile initializes _pool with a default ArrowMemoryPool (no tracker) in its
  constructor, preventing null dereference if set_memory_pool() is not called.

  6. Write path unaffected

  ParquetFileWriter continues using the default no-arg ArrowMemoryPool.



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
