### PR TITLE
[Enhancement] Support Iceberg ALTER TABLE REPLACE PARTITION COLUMN

### DIFF
--- a/docs/en/data_source/catalog/iceberg/DDL.md
+++ b/docs/en/data_source/catalog/iceberg/DDL.md
@@ -227,6 +227,9 @@ ADD PARTITION COLUMN partition_expr [, partition_expr ...];
 
 ALTER TABLE [catalog.][database.]table_name
 DROP PARTITION COLUMN partition_expr [, partition_expr ...];
+
+ALTER TABLE [catalog.][database.]table_name
+REPLACE PARTITION COLUMN old_partition_expr WITH new_partition_expr;
 ```
 
 Supported `partition_expr` formats:
@@ -247,6 +250,13 @@ ADD PARTITION COLUMN month(sale_date), bucket(customer_id, 10);
 ```SQL
 ALTER TABLE sales_data
 DROP PARTITION COLUMN day(sale_date);
+```
+
+- **Replace partition column:**
+
+```SQL
+ALTER TABLE sales_data
+REPLACE PARTITION COLUMN day(sale_date) WITH month(sale_date);
 ```
 
 ## DROP TABLE

--- a/docs/ja/data_source/catalog/iceberg/DDL.md
+++ b/docs/ja/data_source/catalog/iceberg/DDL.md
@@ -1,20 +1,17 @@
 ---
 displayed_sidebar: docs
-toc_max_heading_level: 5
 keywords: ['iceberg', 'ddl', 'create table', 'alter table', 'create database', 'drop table', 'create view', 'alter view']
 ---
 
 # Iceberg DDL 操作
 
-このドキュメントでは、StarRocksにおけるIcebergカタログのデータ定義言語（DDL）操作について説明します。これには、データベース、テーブル、およびビューの作成と管理が含まれます。
+StarRocks Iceberg Catalog は、データベース、テーブル、ビューの作成と管理を含む、さまざまなデータ定義言語 (DDL) 操作をサポートしています。
 
-DDL操作を実行するには、適切な権限が必要です。権限の詳細については、[権限](../../../administration/user_privs/authorization/privilege_item.md)を参照してください。
+DDL 操作を実行するには、適切な権限が必要です。権限の詳細については、以下を参照してください。[権限](../../../administration/user_privs/authorization/privilege_item.md)。
 
----
+## CREATE DATABASE
 
-## データベースの作成
-
-Icebergカタログにデータベースを作成します。この機能はv3.1以降でサポートされています。
+Iceberg カタログにデータベースを作成します。この機能は v3.1 以降でサポートされています。
 
 ### 構文
 
@@ -25,9 +22,10 @@ CREATE DATABASE [IF NOT EXISTS] <database_name>
 
 ### パラメータ
 
-- `location`: データベースが作成されるファイルパスを指定します。HDFSとクラウドストレージの両方がサポートされています。指定しない場合、データベースはIcebergカタログのデフォルトファイルパスに作成されます。
+`location`: データベースが作成されるファイルパスを指定します。HDFS とクラウドストレージの両方がサポートされています。指定しない場合、データベースは Iceberg カタログのデフォルトのファイルパスに作成されます。
 
-`prefix`は使用するストレージシステムに基づいて異なります：
+`prefix` はストレージシステムによって異なります。
+
 - HDFS: `hdfs`
 - Google GCS: `gs`
 - Azure Blob Storage (HTTP): `wasb`
@@ -35,7 +33,7 @@ CREATE DATABASE [IF NOT EXISTS] <database_name>
 - Azure Data Lake Storage Gen1: `adl`
 - Azure Data Lake Storage Gen2 (HTTP): `abfs`
 - Azure Data Lake Storage Gen2 (HTTPS): `abfss`
-- AWS S3またはS3互換ストレージ: `s3`
+- AWS S3 または S3 互換ストレージ: `s3`
 
 ### 例
 
@@ -44,14 +42,12 @@ CREATE DATABASE iceberg_db
 PROPERTIES ("location" = "s3://my_bucket/iceberg_db/");
 ```
 
----
+## DROP DATABASE
 
-## データベースの削除
-
-Icebergカタログから空のデータベースを削除します。この機能はv3.1以降でサポートされています。
+Iceberg カタログから空のデータベースを削除します。この機能は v3.1 以降でサポートされています。
 
 :::note
-空のデータベースのみを削除できます。データベースを削除しても、ストレージ上のファイルパスは削除されません。
+空のデータベースのみを削除できます。データベースを削除しても、リモートストレージ内のファイルパスは削除されません。
 :::
 
 ### 構文
@@ -66,11 +62,9 @@ DROP DATABASE [IF EXISTS] <database_name>
 DROP DATABASE iceberg_db;
 ```
 
----
+## CREATE TABLE
 
-## テーブルの作成
-
-Icebergデータベースにテーブルを作成します。この機能はv3.1以降でサポートされています。
+Iceberg データベースにテーブルを作成します。この機能は v3.1 以降でサポートされています。
 
 ### 構文
 
@@ -88,24 +82,24 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
 
 ### パラメータ
 
-#### column_definition
+#### `column_definition`
 
 ```SQL
 col_name col_type [COMMENT 'comment'] [DEFAULT default_value]
 ```
 
 :::note
-非パーティション列にはすべて `NULL` をデフォルト値として使用する必要があります。パーティション列は非パーティション列の後に定義する必要があり、`NULL` をデフォルト値として使用することはできません。
+すべての非パーティション列は、デフォルト値として `NULL` を使用する必要があります。パーティション列は非パーティション列の後に定義する必要があり、デフォルト値として `NULL` を使用することはできません。
 :::
 
 ##### デフォルト値
 
-v4.1以降、StarRocksはIcebergテーブルの列にデフォルト値を設定することをサポートしています。この機能には、Icebergフォーマットバージョン3（`"format-version" = "3"`）が必要です。
+v4.1 以降、StarRocks は Iceberg テーブルの列にデフォルト値を設定することをサポートしています。この機能には Iceberg フォーマットバージョン 3 (`"format-version" = "3"`) が必要です。
 
-**用途：**
+**使用法:**
 
-- **書き込み時の補完**: INSERT文を実行する際、列に値が指定されていない場合、システムは自動的にその列のデフォルト値を使用します。
-- **スキーマ進化時の補完**: 既存のテーブルに新しい列を追加した後、古いデータファイル（新しい列を含まない）を読み取る際、システムは新しい列のデフォルト値を使用します。
+- **書き込み時の埋め込み**: INSERT ステートメントを実行する際、列に値が指定されていない場合、システムは自動的にその列のデフォルト値を使用します。
+- **スキーマ進化時の埋め込み**: 既存のテーブルに新しい列が追加された場合、古いデータファイル（新しい列を含まない）を読み取ると、新しい列のデフォルト値が使用されます。
 
 **構文:**
 
@@ -115,9 +109,8 @@ col_name col_type DEFAULT default_value
 
 **要件:**
 
-- テーブルはIcebergフォーマットバージョン3（`"format-version" = "3"`）を使用する必要があります。
-- 数値型（INT、BIGINT、FLOAT、DOUBLE）、BOOLEAN、DATE/TIMESTAMP型のデフォルト値は二重引用符で囲む必要があります。例：`DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
-- 数値型（INT、BIGINT、FLOAT、DOUBLE）、BOOLEAN、STRING、DATE/TIMESTAMP型のデフォルト値は引用符で囲む必要があります。例：`DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
+- テーブルは Iceberg フォーマットバージョン 3 (`"format-version" = "3"`) を使用する必要があります。
+- 数値型 (INT, BIGINT, FLOAT, DOUBLE)、BOOLEAN、STRING、および DATE/TIMESTAMP 型のデフォルト値は引用符で囲む必要があります。例: `DEFAULT "18"`、`DEFAULT "100.0"`、`DEFAULT "true"`。
 
 **例:**
 
@@ -146,42 +139,43 @@ ALTER TABLE user_info ADD COLUMN bonus DOUBLE DEFAULT "50.5";
 ALTER TABLE user_info MODIFY COLUMN status STRING DEFAULT "inactive";
 ```
 
-#### partition_desc
+#### `partition_desc`
 
 ```SQL
 PARTITION BY (partition_expr[, partition_expr...])
 ```
 
-各 `partition_expr` は以下のいずれかです：
-- `column_name`（識別変換）
+各 `partition_expr` は次のいずれかです:
+
+- `column_name` (同一性変換)
 - `transform_expr(column_name)`
 - `transform_expr(column_name, parameter)`
 
-StarRocksは、Apache Iceberg仕様で定義されたパーティション変換式をサポートしています。
+StarRocks は、Apache Iceberg 仕様で定義されているパーティション変換式をサポートしています。
 
 :::note
-パーティション列は、FLOAT、DOUBLE、DECIMAL、およびDATETIMEを除くすべてのデータ型をサポートしています。
+パーティション列は、FLOAT、DOUBLE、DECIMAL、DATETIME を除くすべてのデータ型をサポートしています。
 :::
 
-#### ORDER BY (v4.0+)
+#### `ORDER BY`
 
-Icebergテーブルのソートキーを指定します：
+Iceberg テーブルのソートキーを指定します。この機能は v4.0 以降でサポートされています。
 
 ```SQL
 ORDER BY (column_name [ASC | DESC] [NULLS FIRST | NULLS LAST], ...)
 ```
 
-#### PROPERTIES
+#### `PROPERTIES`
 
-主要なテーブルプロパティ：
+主要なテーブルプロパティ:
 
-- `location`: テーブルのファイルパス。データベースレベルの場所を指定せずにAWS Glueを使用する場合に必要です。
-- `file_format`: ファイル形式。`parquet` のみがサポートされています（デフォルト）。
-- `compression_codec`: 圧縮アルゴリズム。オプション：SNAPPY、GZIP、ZSTD、LZ4（デフォルト：`zstd`）。
+- `location`: テーブルのファイルパス。データベースレベルのロケーションなしで AWS Glue を使用する場合に必須です。
+- `file_format`: ファイル形式。`parquet` (デフォルト) のみがサポートされています。
+- `compression_codec`: 圧縮アルゴリズム。オプション: SNAPPY, GZIP, ZSTD, LZ4 (デフォルト: `zstd`)。
 
 ### 例
 
-**非パーティションテーブルを作成する：**
+- **非パーティションテーブルを作成する:**
 
 ```SQL
 CREATE TABLE unpartition_tbl
@@ -191,7 +185,7 @@ CREATE TABLE unpartition_tbl
 );
 ```
 
-**パーティションテーブルを作成する：**
+- **パーティションテーブルを作成する:**
 
 ```SQL
 CREATE TABLE partition_tbl
@@ -203,7 +197,7 @@ CREATE TABLE partition_tbl
 PARTITION BY (id, dt);
 ```
 
-**隠しパーティションを持つテーブルを作成する：**
+- **隠しパーティションを持つテーブルを作成する:**
 
 ```SQL
 CREATE TABLE hidden_partition_tbl
@@ -215,7 +209,7 @@ CREATE TABLE hidden_partition_tbl
 PARTITION BY bucket(id, 10), year(dt);
 ```
 
-**SELECTを使用してテーブルを作成する：**
+- **CREATE TABLE AS SELECT:**
 
 ```SQL
 CREATE TABLE new_tbl
@@ -223,11 +217,9 @@ PARTITION BY (id, dt)
 AS SELECT * FROM existing_tbl;
 ```
 
----
+## パーティション仕様を進化させるための ALTER TABLE
 
-## テーブルの変更（パーティション仕様の変更）
-
-パーティション列を追加または削除して、Icebergテーブルのパーティション仕様を変更します。
+パーティション列を追加または削除して、Iceberg テーブルのパーティション仕様を変更します。
 
 ### 構文
 
@@ -237,35 +229,44 @@ ADD PARTITION COLUMN partition_expr [, partition_expr ...];
 
 ALTER TABLE [catalog.][database.]table_name
 DROP PARTITION COLUMN partition_expr [, partition_expr ...];
+
+ALTER TABLE [catalog.][database.]table_name
+REPLACE PARTITION COLUMN old_partition_expr WITH new_partition_expr;
 ```
 
-サポートされている `partition_expr` 形式：
-- 列名（識別変換）
-- 変換式：`year()`、`month()`、`day()`、`hour()`、`truncate()`、`bucket()`
+サポートされている `partition_expr` 形式:
+
+- 列名 (同一性変換)
+- 変換式: `year()`、`month()`、`day()`、`hour()`、`truncate()`、`bucket()`
 
 ### 例
 
-**パーティション列を追加する：**
+- **パーティション列を追加する:**
 
 ```SQL
 ALTER TABLE sales_data
 ADD PARTITION COLUMN month(sale_date), bucket(customer_id, 10);
 ```
 
-**パーティション列を削除する：**
+- **パーティション列を削除する:**
 
 ```SQL
 ALTER TABLE sales_data
 DROP PARTITION COLUMN day(sale_date);
 ```
 
----
+- **パーティション列を置き換える:**
 
-## テーブルの削除
+```SQL
+ALTER TABLE sales_data
+REPLACE PARTITION COLUMN day(sale_date) WITH month(sale_date);
+```
 
-Icebergテーブルを削除します。この機能はv3.1以降でサポートされています。
+## DROP TABLE
 
-テーブルを削除しても、デフォルトではストレージ上のファイルパスとデータは削除されません。
+Iceberg テーブルを削除します。この機能は v3.1 以降でサポートされています。
+
+テーブルを削除しても、リモートストレージ内のファイルパスとデータはデフォルトでは削除されません。
 
 ### 構文
 
@@ -275,22 +276,20 @@ DROP TABLE [IF EXISTS] <table_name> [FORCE]
 
 ### パラメータ
 
-- `FORCE`: 指定すると、ファイルパスを保持したまま、ストレージ上のテーブルのデータを削除します。
+- `FORCE`: 指定すると、リモートストレージ内のテーブルデータは削除されますが、ファイルパスは保持されます。
 
 ### 例
 
 ```SQL
 DROP TABLE iceberg_db.sales_data;
 
--- データ削除を伴う強制削除
+-- テーブルとそのデータを強制的に削除
 DROP TABLE iceberg_db.temp_data FORCE;
 ```
 
----
+## CREATE VIEW
 
-## ビューの作成
-
-Icebergビューを作成します。この機能はv3.5以降でサポートされています。
+Iceberg ビューを作成します。この機能は v3.5 以降でサポートされています。PROPERTIES を使用した Iceberg ビューの作成は v4.0.3 以降でサポートされています。
 
 ### 構文
 
@@ -308,6 +307,8 @@ AS <query_statement>
 
 ### 例
 
+- **通常のIcebergビューを作成します:**
+
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg_db.sales_summary AS
 SELECT region, SUM(amount) as total_sales
@@ -315,7 +316,7 @@ FROM iceberg_db.sales
 GROUP BY region;
 ```
 
-**プロパティを使用する場合（v4.0.3以降）：**
+- **プロパティを持つIcebergビューを作成します:**
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg_db.sales_summary
@@ -328,14 +329,12 @@ FROM iceberg_db.sales
 GROUP BY region;
 ```
 
----
-
-## ビューの変更
+## ALTER VIEWでStarRocks方言を更新
 
 既存のIcebergビューにStarRocks方言を追加または変更します。この機能はv3.5以降でサポートされています。
 
 :::note
-各Icebergビューに対して1つのStarRocks方言のみを定義できます。
+各Icebergビューに対して定義できるStarRocks方言は1つだけです。
 :::
 
 ### 構文
@@ -351,14 +350,14 @@ ALTER VIEW [<catalog>.<database>.]<view_name>
 
 ### 例
 
-**StarRocks方言を追加する：**
+- **StarRocks方言を追加:**
 
 ```SQL
 ALTER VIEW iceberg_db.spark_view ADD DIALECT
 SELECT k1, k2 FROM iceberg_db.source_table;
 ```
 
-**StarRocks方言を変更する：**
+- **StarRocks方言を変更:**
 
 ```SQL
 ALTER VIEW iceberg_db.spark_view MODIFY DIALECT

--- a/docs/zh/data_source/catalog/iceberg/DDL.md
+++ b/docs/zh/data_source/catalog/iceberg/DDL.md
@@ -236,6 +236,9 @@ ADD PARTITION COLUMN partition_expr [, partition_expr ...];
 
 ALTER TABLE [catalog.][database.]table_name
 DROP PARTITION COLUMN partition_expr [, partition_expr ...];
+
+ALTER TABLE [catalog.][database.]table_name
+REPLACE PARTITION COLUMN old_partition_expr WITH new_partition_expr;
 ```
 
 支持的 `partition_expr` 格式：
@@ -256,6 +259,13 @@ ADD PARTITION COLUMN month(sale_date), bucket(customer_id, 10);
 ```SQL
 ALTER TABLE sales_data
 DROP PARTITION COLUMN day(sale_date);
+```
+
+**替换分区列：**
+
+```SQL
+ALTER TABLE sales_data
+REPLACE PARTITION COLUMN day(sale_date) WITH month(sale_date);
 ```
 
 ---

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -23,7 +23,6 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.procedure.IcebergTableProcedure;
 import com.starrocks.connector.iceberg.procedure.IcebergTableProcedureContext;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddFieldClause;
@@ -45,13 +44,13 @@ import com.starrocks.sql.ast.DropPartitionColumnClause;
 import com.starrocks.sql.ast.DropTagClause;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.sql.ast.ReplacePartitionColumnClause;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TagOptions;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.FunctionCallExpr;
-import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Snapshot;
@@ -62,7 +61,6 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
-import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -73,6 +71,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.IcebergApiConverter.toIcebergColumnType;
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
@@ -463,47 +463,6 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         return null;
     }
 
-    private Term transformExprToIcebergTerm(Expr expr) {
-        if (expr instanceof SlotRef) {
-            SlotRef slotRef = (SlotRef) expr;
-            return Expressions.ref(slotRef.getColumnName());
-        } else if (expr instanceof FunctionCallExpr) {
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
-            String fn = functionCallExpr.getFunctionName();
-            Expr child = functionCallExpr.getChild(0);
-            if (child instanceof SlotRef) {
-                String colName = ((SlotRef) child).getColumnName();
-                switch (fn.toLowerCase()) {
-                    case "year":
-                        return Expressions.year(colName);
-                    case "month":
-                        return Expressions.month(colName);
-                    case "day":
-                        return Expressions.day(colName);
-                    case "hour":
-                        return Expressions.hour(colName);
-                    case "identity":
-                        return Expressions.ref(colName);
-                    case "truncate":
-                        IntLiteral width = (IntLiteral) functionCallExpr.getChild(1);
-                        return Expressions.truncate(colName, (int) width.getValue());
-                    case "bucket":
-                        IntLiteral numBuckets = (IntLiteral) functionCallExpr.getChild(1);
-                        return Expressions.bucket(colName, (int) numBuckets.getValue());
-                    case "void":
-                        // not supported yet.
-                    default:
-                        throw new SemanticException(
-                                "Unsupported partition transform %s for column %s", fn, colName);
-                }
-            } else {
-                throw new SemanticException("Unsupported partition transform %s for arguments", fn);
-            }
-        } else {
-            throw new SemanticException("Does not support partition clause: " + expr);
-        }
-    }
-
     private Literal<?> buildIcebergDefaultLiteral(ColumnDef columnDef, org.apache.iceberg.types.Type icebergType) {
         if (!columnDef.getDefaultValueDef().isSet) {
             return null;
@@ -517,7 +476,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         actions.add(() -> {
             UpdatePartitionSpec spec = this.transaction.updateSpec();
             List<Term> terms = clause.getPartitionExprList().stream()
-                    .map(this::transformExprToIcebergTerm).toList();
+                    .map(IcebergPartitionUtils::convertPartitionExprToTerm).toList();
             try {
                 for (Term term : terms) {
                     spec.addField(term);
@@ -535,7 +494,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         actions.add(() -> {
             UpdatePartitionSpec spec = this.transaction.updateSpec();
             List<Term> terms = clause.getPartitionExprList().stream()
-                    .map(this::transformExprToIcebergTerm).toList();
+                    .map(IcebergPartitionUtils::convertPartitionExprToTerm).toList();
             try {
                 for (Term term : terms) {
                     spec.removeField(term);
@@ -546,5 +505,87 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
             }
         });
         return null;
+    }
+
+    @Override
+    public Void visitReplacePartitionColumnClause(ReplacePartitionColumnClause clause, ConnectContext context) {
+        actions.add(() -> {
+            if (table instanceof BaseTable baseTable) {
+                int formatVersion = baseTable.operations().current().formatVersion();
+                if (formatVersion < 2) {
+                    throw new StarRocksConnectorException(
+                            "REPLACE PARTITION COLUMN is only supported for Iceberg v2 tables, " +
+                                    "but table is v%d format", formatVersion);
+                }
+            }
+
+            UpdatePartitionSpec spec = this.transaction.updateSpec();
+            Expr oldPartitionExpr = clause.getOldPartitionExpr();
+            Expr newPartitionExpr = clause.getNewPartitionExpr();
+
+            // Resolve old partition: by field name (e.g. "dt_day") or by transform expression (e.g. "day(dt)")
+            String oldFieldName = resolvePartitionFieldName(oldPartitionExpr);
+
+            String newExprStr = IcebergPartitionUtils.normalizePartitionExpr(newPartitionExpr);
+            Set<String> currentPartitionExprs = table.spec().fields().stream()
+                    .map(field -> IcebergApiConverter.toPartitionField(table.spec(), field, false)
+                            .toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toSet());
+
+            if (oldFieldName == null) {
+                String oldExprStr = IcebergPartitionUtils.normalizePartitionExpr(oldPartitionExpr);
+                if (oldExprStr.equalsIgnoreCase(newExprStr)) {
+                    throw new StarRocksConnectorException(
+                            "Failed to replace partition column: old and new partition column are the same: "
+                                    + oldExprStr);
+                }
+                if (!currentPartitionExprs.contains(oldExprStr.toLowerCase(Locale.ROOT))) {
+                    throw new StarRocksConnectorException(
+                            "Failed to replace partition column: old partition column does not exist: " + oldExprStr);
+                }
+            }
+
+            if (currentPartitionExprs.contains(newExprStr.toLowerCase(Locale.ROOT))) {
+                throw new StarRocksConnectorException(
+                        "Failed to replace partition column: new partition column already exists: " + newExprStr);
+            }
+
+            Term newTerm = IcebergPartitionUtils.convertPartitionExprToTerm(newPartitionExpr);
+            try {
+                if (oldFieldName != null) {
+                    spec.removeField(oldFieldName);
+                } else {
+                    Term oldTerm = IcebergPartitionUtils.convertPartitionExprToTerm(oldPartitionExpr);
+                    spec.removeField(oldTerm);
+                }
+                spec.addField(newTerm);
+                spec.commit();
+            } catch (Exception e) {
+                throw new StarRocksConnectorException("Failed to replace partition column: " + e.getMessage(), e);
+            }
+        });
+        return null;
+    }
+
+    /**
+     * Check if the old partition expression is a partition field name reference (e.g., "dt_day")
+     * rather than a transform expression (e.g., "day(dt)").
+     * Returns the field name if resolved by name, null otherwise.
+     */
+    private String resolvePartitionFieldName(Expr expr) {
+        if (!(expr instanceof SlotRef slotRef)) {
+            return null;
+        }
+        String name = slotRef.getColumnName();
+        // If the name matches a schema column, treat as identity transform, not a field name
+        if (table.schema().findField(name) != null) {
+            return null;
+        }
+        // Check if it matches a partition field name
+        return table.spec().fields().stream()
+                .filter(f -> f.name().equalsIgnoreCase(name))
+                .map(f -> f.name())
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -26,10 +26,13 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
@@ -38,6 +41,8 @@ import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.type.Type;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,6 +54,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 
 import static com.starrocks.connector.iceberg.IcebergPartitionTransform.YEAR;
 
@@ -124,6 +130,95 @@ public class IcebergPartitionUtils {
 
     public static LocalDateTime convertTimezone(LocalDateTime time, ZoneId from, ZoneId to) {
         return time.atZone(from).withZoneSameInstant(to).toLocalDateTime();
+    }
+
+    public static Term convertPartitionExprToTerm(Expr expr) {
+        if (expr instanceof SlotRef slotRef) {
+            return Expressions.ref(slotRef.getColumnName());
+        } else if (expr instanceof FunctionCallExpr functionCallExpr) {
+            String fn = functionCallExpr.getFunctionName();
+            Expr child = functionCallExpr.getChild(0);
+            if (child instanceof SlotRef) {
+                String colName = ((SlotRef) child).getColumnName();
+                switch (fn.toLowerCase(Locale.ROOT)) {
+                    case "year":
+                        return Expressions.year(colName);
+                    case "month":
+                        return Expressions.month(colName);
+                    case "day":
+                        return Expressions.day(colName);
+                    case "hour":
+                        return Expressions.hour(colName);
+                    case "identity":
+                        return Expressions.ref(colName);
+                    case "truncate":
+                        IntLiteral width = (IntLiteral) functionCallExpr.getChild(1);
+                        return Expressions.truncate(colName, (int) width.getValue());
+                    case "bucket":
+                        IntLiteral numBuckets = (IntLiteral) functionCallExpr.getChild(1);
+                        return Expressions.bucket(colName, (int) numBuckets.getValue());
+                    case "void":
+                        // not supported yet.
+                    default:
+                        throw new SemanticException(
+                                "Unsupported partition transform %s for column %s", fn, colName);
+                }
+            } else {
+                throw new SemanticException("Unsupported partition transform %s for arguments", fn);
+            }
+        } else {
+            throw new SemanticException("Does not support partition clause: " + expr);
+        }
+    }
+
+    public static String normalizePartitionExpr(Expr expr) {
+        if (expr instanceof SlotRef slotRef) {
+            return "`" + slotRef.getColumnName() + "`";
+        } else if (expr instanceof FunctionCallExpr functionCallExpr) {
+            String fn = functionCallExpr.getFunctionName().toLowerCase(Locale.ROOT);
+            Expr child = functionCallExpr.getChild(0);
+            if (!(child instanceof SlotRef slotRef)) {
+                throw new SemanticException("Unsupported partition transform %s for arguments",
+                        functionCallExpr.getFunctionName());
+            }
+
+            String quotedColumn = "`" + slotRef.getColumnName() + "`";
+            switch (fn) {
+                case "year":
+                case "month":
+                case "day":
+                case "hour":
+                    return String.format("%s(%s)", fn, quotedColumn);
+                case "identity":
+                    return quotedColumn;
+                case "truncate":
+                case "bucket":
+                    IntLiteral number = (IntLiteral) functionCallExpr.getChild(1);
+                    return String.format("%s(%s, %s)", fn, quotedColumn, number.getValue());
+                case "void":
+                    // not supported yet.
+                default:
+                    throw new SemanticException("Unsupported partition transform %s for column %s",
+                            functionCallExpr.getFunctionName(), slotRef.getColumnName());
+            }
+        } else {
+            throw new SemanticException("Does not support partition clause: " + expr);
+        }
+    }
+
+    public static String getPartitionExprSourceColumn(Expr expr) {
+        if (expr instanceof SlotRef slotRef) {
+            return slotRef.getColumnName();
+        } else if (expr instanceof FunctionCallExpr functionCallExpr) {
+            Expr child = functionCallExpr.getChild(0);
+            if (child instanceof SlotRef slotRef) {
+                return slotRef.getColumnName();
+            }
+            throw new SemanticException("Unsupported partition transform %s for arguments",
+                    functionCallExpr.getFunctionName());
+        } else {
+            throw new SemanticException("Does not support partition clause: " + expr);
+        }
     }
 
     // Get the date interval from iceberg partition transform

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -47,6 +47,7 @@ import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.WriteQuorum;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.connector.iceberg.procedure.IcebergTableProcedure;
 import com.starrocks.connector.iceberg.procedure.NamedArgument;
@@ -59,6 +60,7 @@ import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddFieldClause;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.AddPartitionColumnClause;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterClause;
@@ -77,6 +79,7 @@ import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropFieldClause;
 import com.starrocks.sql.ast.DropPartitionClause;
+import com.starrocks.sql.ast.DropPartitionColumnClause;
 import com.starrocks.sql.ast.DropRollupClause;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
@@ -103,6 +106,7 @@ import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.ReorderColumnsClause;
 import com.starrocks.sql.ast.ReplacePartitionClause;
+import com.starrocks.sql.ast.ReplacePartitionColumnClause;
 import com.starrocks.sql.ast.RollupRenameClause;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.SinglePartitionDesc;
@@ -136,6 +140,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1676,6 +1681,67 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
     }
 
     @Override
+    public Void visitAddPartitionColumnClause(AddPartitionColumnClause clause, ConnectContext context) {
+        analyzeIcebergPartitionColumnClause(clause.getPartitionExprList(), false, true);
+        return null;
+    }
+
+    @Override
+    public Void visitDropPartitionColumnClause(DropPartitionColumnClause clause, ConnectContext context) {
+        analyzeIcebergPartitionColumnClause(clause.getPartitionExprList(), true, false);
+        return null;
+    }
+
+    @Override
+    public Void visitReplacePartitionColumnClause(ReplacePartitionColumnClause clause, ConnectContext context) {
+        IcebergTable icebergTable = getIcebergTable();
+        if (!icebergTable.isV2Format()) {
+            throw new SemanticException("REPLACE PARTITION COLUMN is only supported for Iceberg v2 tables, " +
+                    "but table %s is v%d format", icebergTable.getName(), icebergTable.getFormatVersion());
+        }
+
+        Expr oldPartitionExpr = clause.getOldPartitionExpr();
+        boolean oldResolvedByName = false;
+
+        // Old partition: support both transform expression (e.g. day(dt)) and field name (e.g. dt_day)
+        if (oldPartitionExpr instanceof SlotRef slotRef
+                && icebergTable.getColumn(slotRef.getColumnName()) == null) {
+            // Not a table column - check if it's a partition field name
+            String fieldName = slotRef.getColumnName();
+            boolean isFieldName = icebergTable.getNativeTable().spec().fields().stream()
+                    .anyMatch(f -> f.name().equalsIgnoreCase(fieldName));
+            if (!isFieldName) {
+                throw new SemanticException("Partition column or field name does not exist: %s", fieldName);
+            }
+            oldResolvedByName = true;
+        } else {
+            analyzeIcebergPartitionColumnExpr(oldPartitionExpr);
+        }
+
+        // New partition: always a transform expression
+        analyzeIcebergPartitionColumnExpr(clause.getNewPartitionExpr());
+
+        String newExpr = IcebergPartitionUtils.normalizePartitionExpr(clause.getNewPartitionExpr());
+
+        if (!oldResolvedByName) {
+            String oldExpr = IcebergPartitionUtils.normalizePartitionExpr(oldPartitionExpr);
+            if (oldExpr.equalsIgnoreCase(newExpr)) {
+                throw new SemanticException("Old partition column and new partition column are the same: %s", oldExpr);
+            }
+            Set<String> currentPartitionExprs = getCurrentIcebergPartitionExprs();
+            if (!currentPartitionExprs.contains(oldExpr.toLowerCase(Locale.ROOT))) {
+                throw new SemanticException("Partition column does not exist: %s", oldExpr);
+            }
+        }
+
+        Set<String> currentPartitionExprs = getCurrentIcebergPartitionExprs();
+        if (currentPartitionExprs.contains(newExpr.toLowerCase(Locale.ROOT))) {
+            throw new SemanticException("Partition column already exists: %s", newExpr);
+        }
+        return null;
+    }
+
+    @Override
     public Void visitAlterTableOperationClause(AlterTableOperationClause clause, ConnectContext context) {
         String tableOperationName = clause.getTableOperationName();
         if (tableOperationName == null) {
@@ -1794,6 +1860,46 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             }
         }
         return null;
+    }
+
+    private void analyzeIcebergPartitionColumnClause(List<Expr> partitionExprs,
+                                                     boolean shouldExist,
+                                                     boolean shouldNotExist) {
+        partitionExprs.forEach(this::analyzeIcebergPartitionColumnExpr);
+        Set<String> currentPartitionExprs = getCurrentIcebergPartitionExprs();
+        for (Expr partitionExpr : partitionExprs) {
+            String normalizedExpr = IcebergPartitionUtils.normalizePartitionExpr(partitionExpr);
+            boolean exists = currentPartitionExprs.contains(normalizedExpr.toLowerCase(Locale.ROOT));
+            if (shouldExist && !exists) {
+                throw new SemanticException("Partition column does not exist: %s", normalizedExpr);
+            }
+            if (shouldNotExist && exists) {
+                throw new SemanticException("Partition column already exists: %s", normalizedExpr);
+            }
+        }
+    }
+
+    private void analyzeIcebergPartitionColumnExpr(Expr partitionExpr) {
+        IcebergTable icebergTable = getIcebergTable();
+        IcebergPartitionUtils.convertPartitionExprToTerm(partitionExpr);
+
+        String columnName = IcebergPartitionUtils.getPartitionExprSourceColumn(partitionExpr);
+        if (icebergTable.getColumn(columnName) == null) {
+            throw new SemanticException("Column %s not found in table %s", columnName, icebergTable.getName());
+        }
+    }
+
+    private IcebergTable getIcebergTable() {
+        if (!(table instanceof IcebergTable icebergTable)) {
+            throw new SemanticException("Alter table operation is only supported for Iceberg tables");
+        }
+        return icebergTable;
+    }
+
+    private Set<String> getCurrentIcebergPartitionExprs() {
+        return getIcebergTable().getPartitionColumnNamesWithTransform().stream()
+                .map(expr -> expr.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -297,6 +297,7 @@ import com.starrocks.sql.ast.RefreshTableStmt;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.ReorderColumnsClause;
 import com.starrocks.sql.ast.ReplacePartitionClause;
+import com.starrocks.sql.ast.ReplacePartitionColumnClause;
 import com.starrocks.sql.ast.ResourceDesc;
 import com.starrocks.sql.ast.RestoreStmt;
 import com.starrocks.sql.ast.ResumeRoutineLoadStmt;
@@ -5289,6 +5290,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             com.starrocks.sql.parser.StarRocksParser.DropPartitionColumnClauseContext context) {
         List<Expr> partitionExprList = visit(context.expressionList().expression(), Expr.class);
         return new DropPartitionColumnClause(partitionExprList, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitReplacePartitionColumnClause(
+            com.starrocks.sql.parser.StarRocksParser.ReplacePartitionColumnClauseContext context) {
+        Expr oldPartitionExpr = (Expr) visit(context.oldPartitionExpr);
+        Expr newPartitionExpr = (Expr) visit(context.newPartitionExpr);
+        return new ReplacePartitionColumnClause(oldPartitionExpr, newPartitionExpr, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AlterTableTest.java
@@ -24,6 +24,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateOrReplaceBranchClause;
 import com.starrocks.sql.ast.CreateOrReplaceTagClause;
+import com.starrocks.sql.ast.ReplacePartitionColumnClause;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -282,6 +285,35 @@ public class AlterTableTest extends TableTestBase {
     }
 
     @Test
+    public void testReplacePartitionColumn() throws Exception {
+        String sql = "alter table iceberg_catalog.db.srTableName replace partition column day(dt) with month(dt)";
+        AlterTableStmt stmt =
+                (AlterTableStmt) UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, starRocksAssert.getCtx());
+        Assertions.assertEquals(1, stmt.getAlterClauseList().size());
+        Assertions.assertTrue(stmt.getAlterClauseList().get(0) instanceof ReplacePartitionColumnClause);
+        ReplacePartitionColumnClause clause = (ReplacePartitionColumnClause) stmt.getAlterClauseList().get(0);
+        Assertions.assertTrue(clause.getOldPartitionExpr() instanceof FunctionCallExpr);
+        Assertions.assertTrue(clause.getNewPartitionExpr() instanceof FunctionCallExpr);
+        Assertions.assertEquals("day", ((FunctionCallExpr) clause.getOldPartitionExpr()).getFunctionName());
+        Assertions.assertEquals("month", ((FunctionCallExpr) clause.getNewPartitionExpr()).getFunctionName());
+    }
+
+    @Test
+    public void testReplacePartitionColumnByFieldName() throws Exception {
+        String sql = "alter table iceberg_catalog.db.srTableName replace partition column dt_day with month(dt)";
+        AlterTableStmt stmt =
+                (AlterTableStmt) UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, starRocksAssert.getCtx());
+        Assertions.assertEquals(1, stmt.getAlterClauseList().size());
+        Assertions.assertTrue(stmt.getAlterClauseList().get(0) instanceof ReplacePartitionColumnClause);
+        ReplacePartitionColumnClause clause = (ReplacePartitionColumnClause) stmt.getAlterClauseList().get(0);
+        // field name "dt_day" is parsed as a SlotRef
+        Assertions.assertTrue(clause.getOldPartitionExpr() instanceof SlotRef);
+        Assertions.assertEquals("dt_day", ((SlotRef) clause.getOldPartitionExpr()).getColumnName());
+        Assertions.assertTrue(clause.getNewPartitionExpr() instanceof FunctionCallExpr);
+        Assertions.assertEquals("month", ((FunctionCallExpr) clause.getNewPartitionExpr()).getFunctionName());
+    }
+
+    @Test
     public void testAlterView() throws Exception {
         new MockUp<IcebergHiveCatalog>() {
             @Mock
@@ -312,5 +344,92 @@ public class AlterTableTest extends TableTestBase {
                 "Unknown database 'db'",
                 () -> UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx()));
 
+    }
+
+    @Test
+    public void testReplacePartitionColumnAnalyzerFullPath() throws Exception {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, "db");
+            }
+
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableFV2;
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        // Use a unique table name to avoid metadata cache conflicts with other tests
+        String tbl = "iceberg_catalog.db.partTestTable";
+
+        // --- Error cases (no mutation, test these first) ---
+
+        // Same old and new should be rejected
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " replace partition column day(dt) with day(dt)",
+                        starRocksAssert.getCtx()));
+
+        // Non-existent old partition column (table has day(dt) not month(dt))
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " replace partition column month(dt) with year(dt)",
+                        starRocksAssert.getCtx()));
+
+        // Non-existent field name should be rejected
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " replace partition column no_such_field with month(dt)",
+                        starRocksAssert.getCtx()));
+
+        // Column "nonexistent" doesn't exist in table schema
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " replace partition column day(dt) with day(nonexistent)",
+                        starRocksAssert.getCtx()));
+
+        // Drop non-existent partition column should fail (table has day(dt), not month(dt))
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " drop partition column month(dt)",
+                        starRocksAssert.getCtx()));
+
+        // Add partition column that already exists should fail (table already has day(dt))
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " add partition column day(dt)",
+                        starRocksAssert.getCtx()));
+
+        // --- Success cases (mutate table) ---
+
+        // 1. Successful replace day(dt) with month(dt) through full analyzer + executor path
+        String sql = "alter table " + tbl + " replace partition column day(dt) with month(dt)";
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
+        mockedNativeTableFV2.refresh();
+
+        // 2. Now table has month(dt). Replace by field name "dt_month" with year(dt)
+        sql = "alter table " + tbl + " replace partition column dt_month with year(dt)";
+        stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
+        mockedNativeTableFV2.refresh();
+
+        // 3. Now add month(dt) back so table has both year(dt) and month(dt)
+        sql = "alter table " + tbl + " add partition column month(dt)";
+        stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        connectContext.getGlobalStateMgr().getMetadataMgr().alterTable(connectContext, stmt);
+        mockedNativeTableFV2.refresh();
+
+        // 4. Replace year(dt) with month(dt) should fail because month(dt) already exists
+        Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(
+                        "alter table " + tbl + " replace partition column year(dt) with month(dt)",
+                        starRocksAssert.getCtx()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -87,6 +87,7 @@ import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.ReplacePartitionColumnClause;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.expression.BinaryType;
@@ -1923,6 +1924,207 @@ public class IcebergMetadataTest extends TableTestBase {
                 }
             }
         }
+    }
+
+    @Test
+    public void testReplacePartitionColumnV1Rejected() throws StarRocksException {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableF;
+            }
+
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, dbName);
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef partitionSlot = new SlotRef(tableName, "dt");
+        FunctionCallExpr dayExpr = new FunctionCallExpr("day", Lists.newArrayList(partitionSlot));
+        FunctionCallExpr monthExpr = new FunctionCallExpr("month", Lists.newArrayList(partitionSlot));
+
+        // REPLACE PARTITION COLUMN should be rejected for v1 tables
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(dayExpr, monthExpr, NodePosition.ZERO)))));
+    }
+
+    @Test
+    public void testReplacePartitionColumn() throws StarRocksException {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableFV2;
+            }
+
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, dbName);
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef partitionSlot = new SlotRef(tableName, "dt");
+        FunctionCallExpr dayExpr = new FunctionCallExpr("day", Lists.newArrayList(partitionSlot));
+        FunctionCallExpr monthExpr = new FunctionCallExpr("month", Lists.newArrayList(partitionSlot));
+
+        // replace day(dt) with month(dt) on v2 table should succeed
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(createTableRef(tableName),
+                List.of(new ReplacePartitionColumnClause(dayExpr, monthExpr, NodePosition.ZERO))));
+        mockedNativeTableFV2.refresh();
+        List<String> partitionFields = IcebergApiConverter.toPartitionFields(mockedNativeTableFV2.spec(), false);
+        Assertions.assertTrue(partitionFields.contains("month(`dt`)"));
+        Assertions.assertFalse(partitionFields.contains("day(`dt`)"));
+
+        // replace with non-existent old partition column should fail
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(dayExpr, monthExpr, NodePosition.ZERO)))));
+
+        // replace with same old and new partition column should fail
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(monthExpr, monthExpr, NodePosition.ZERO)))));
+    }
+
+    @Test
+    public void testReplacePartitionColumnByFieldName() throws StarRocksException {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableFV2;
+            }
+
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, dbName);
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef partitionSlot = new SlotRef(tableName, "dt");
+        FunctionCallExpr monthExpr = new FunctionCallExpr("month", Lists.newArrayList(partitionSlot));
+
+        // replace by field name: "dt_day" is the default name for day(dt)
+        SlotRef fieldNameRef = new SlotRef(tableName, "dt_day");
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(createTableRef(tableName),
+                List.of(new ReplacePartitionColumnClause(fieldNameRef, monthExpr, NodePosition.ZERO))));
+        mockedNativeTableFV2.refresh();
+        List<String> partitionFields = IcebergApiConverter.toPartitionFields(mockedNativeTableFV2.spec(), false);
+        Assertions.assertTrue(partitionFields.contains("month(`dt`)"));
+        Assertions.assertFalse(partitionFields.contains("day(`dt`)"));
+
+        // non-existent field name should fail
+        SlotRef badFieldName = new SlotRef(tableName, "no_such_field");
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(badFieldName, monthExpr, NodePosition.ZERO)))));
+    }
+
+    @Test
+    public void testReplacePartitionColumnNewAlreadyExists() throws StarRocksException {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableFV2;
+            }
+
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, dbName);
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef partitionSlot = new SlotRef(tableName, "dt");
+        FunctionCallExpr dayExpr = new FunctionCallExpr("day", Lists.newArrayList(partitionSlot));
+        FunctionCallExpr monthExpr = new FunctionCallExpr("month", Lists.newArrayList(partitionSlot));
+
+        // First add month(dt) so table has both day(dt) and month(dt)
+        metadata.alterTable(new ConnectContext(), new AlterTableStmt(createTableRef(tableName),
+                List.of(new AddPartitionColumnClause(List.of(monthExpr), NodePosition.ZERO))));
+        mockedNativeTableFV2.refresh();
+
+        // Try to replace day(dt) with month(dt) - should fail because month(dt) already exists
+        FunctionCallExpr dayExpr2 = new FunctionCallExpr("day", Lists.newArrayList(new SlotRef(tableName, "dt")));
+        FunctionCallExpr monthExpr2 = new FunctionCallExpr("month", Lists.newArrayList(new SlotRef(tableName, "dt")));
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(dayExpr2, monthExpr2, NodePosition.ZERO)))));
+    }
+
+    @Test
+    public void testReplacePartitionColumnSchemaColumnAsFieldName() throws StarRocksException {
+        new MockUp<IcebergHiveCatalog>() {
+            @Mock
+            org.apache.iceberg.Table getTable(ConnectContext context, String dbName, String tblName) {
+                return mockedNativeTableFV2;
+            }
+
+            @Mock
+            Database getDB(ConnectContext context, String dbName) {
+                return new Database(1, dbName);
+            }
+
+            @Mock
+            boolean tableExists(ConnectContext context, String dbName, String tblName) {
+                return true;
+            }
+        };
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef partitionSlot = new SlotRef(tableName, "dt");
+        FunctionCallExpr monthExpr = new FunctionCallExpr("month", Lists.newArrayList(partitionSlot));
+
+        // Using "dt" as old partition - "dt" is a schema column name, so resolvePartitionFieldName
+        // returns null (treats it as identity transform, not a field name reference)
+        // This should fail because identity(dt) is not an existing partition (day(dt) is)
+        SlotRef schemaColRef = new SlotRef(tableName, "dt");
+        Assertions.assertThrows(DdlException.class, () -> metadata.alterTable(new ConnectContext(),
+                new AlterTableStmt(createTableRef(tableName),
+                        List.of(new ReplacePartitionColumnClause(schemaColRef, monthExpr, NodePosition.ZERO)))));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -14,14 +14,21 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.TableName;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.DateType;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.expressions.Term;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -33,14 +40,14 @@ import java.util.TimeZone;
 
 public class IcebergPartitionUtilsTest extends TableTestBase {
     @TempDir
-    public static File temp;
+    public static File staticTemp;
     private static ConnectContext connectContext;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         connectContext = UtFrameUtils.createDefaultCtx();
-        ConnectorPlanTestBase.mockAllCatalogs(connectContext, newFolder(temp, "junit").toURI().toString());
+        ConnectorPlanTestBase.mockAllCatalogs(connectContext, newFolder(staticTemp, "junit").toURI().toString());
     }
 
     @Test
@@ -113,6 +120,72 @@ public class IcebergPartitionUtilsTest extends TableTestBase {
         result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_E,
                 DateType.DATETIME);
         Assertions.assertEquals("2020-01-02 12:00:00", result);
+    }
+
+    @Test
+    public void testConvertPartitionExprToTerm() {
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef slotRef = new SlotRef(tableName, "ts");
+
+        // hour transform
+        FunctionCallExpr hourExpr = new FunctionCallExpr("hour", Lists.newArrayList(slotRef));
+        Term hourTerm = IcebergPartitionUtils.convertPartitionExprToTerm(hourExpr);
+        Assertions.assertNotNull(hourTerm);
+
+        // non-SlotRef child in FunctionCallExpr
+        FunctionCallExpr badChildExpr = new FunctionCallExpr("day", Lists.newArrayList(new IntLiteral(1)));
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.convertPartitionExprToTerm(badChildExpr));
+
+        // unsupported expr type (IntLiteral)
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.convertPartitionExprToTerm(new IntLiteral(1)));
+    }
+
+    @Test
+    public void testNormalizePartitionExpr() {
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef slotRef = new SlotRef(tableName, "ts");
+
+        // identity transform returns quoted column name
+        FunctionCallExpr identityExpr = new FunctionCallExpr("identity", Lists.newArrayList(slotRef));
+        Assertions.assertEquals("`ts`", IcebergPartitionUtils.normalizePartitionExpr(identityExpr));
+
+        // non-SlotRef child in FunctionCallExpr
+        FunctionCallExpr badChildExpr = new FunctionCallExpr("day", Lists.newArrayList(new IntLiteral(1)));
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.normalizePartitionExpr(badChildExpr));
+
+        // unsupported transform (void)
+        FunctionCallExpr voidExpr = new FunctionCallExpr("void", Lists.newArrayList(slotRef));
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.normalizePartitionExpr(voidExpr));
+
+        // unsupported expr type
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.normalizePartitionExpr(new IntLiteral(1)));
+    }
+
+    @Test
+    public void testGetPartitionExprSourceColumn() {
+        TableName tableName = new TableName("db", "tbl");
+        SlotRef slotRef = new SlotRef(tableName, "ts");
+
+        // SlotRef returns column name directly
+        Assertions.assertEquals("ts", IcebergPartitionUtils.getPartitionExprSourceColumn(slotRef));
+
+        // FunctionCallExpr with SlotRef child
+        FunctionCallExpr dayExpr = new FunctionCallExpr("day", Lists.newArrayList(slotRef));
+        Assertions.assertEquals("ts", IcebergPartitionUtils.getPartitionExprSourceColumn(dayExpr));
+
+        // non-SlotRef child in FunctionCallExpr
+        FunctionCallExpr badChildExpr = new FunctionCallExpr("day", Lists.newArrayList(new IntLiteral(1)));
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.getPartitionExprSourceColumn(badChildExpr));
+
+        // unsupported expr type
+        Assertions.assertThrows(SemanticException.class,
+                () -> IcebergPartitionUtils.getPartitionExprSourceColumn(new IntLiteral(1)));
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -264,6 +264,7 @@ public class TableTestBase {
     public TestTables.TestTable mockedNativeTableD = null;
     public TestTables.TestTable mockedNativeTableE = null;
     public TestTables.TestTable mockedNativeTableF = null;
+    public TestTables.TestTable mockedNativeTableFV2 = null;
     public TestTables.TestTable mockedNativeTableG = null;
     public TestTables.TestTable mockedNativeTableH = null;
     public TestTables.TestTable mockedNativeTableI = null;
@@ -286,6 +287,7 @@ public class TableTestBase {
         this.mockedNativeTableD = create(SCHEMA_D, SPEC_D_5, "td", 1);
         this.mockedNativeTableE = create(SCHEMA_D, SPEC_D_1, "te", 1);
         this.mockedNativeTableF = create(SCHEMA_F, SPEC_F, "tf", 1);
+        this.mockedNativeTableFV2 = create(SCHEMA_F, SPEC_F, "tfv2", 2);
         this.mockedNativeTableG = create(SCHEMA_B, SPEC_B_1, "tg", 1);
         this.mockedNativeTableH = create(SCHEMA_H, PartitionSpec.unpartitioned(), "th", 1);
         this.mockedNativeTableI = create(SCHEMA_F, SPEC_F_1, "ti", 1);

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -994,6 +994,7 @@ alterClause
     | dropColumnClause
     | addPartitionColumnClause
     | dropPartitionColumnClause
+    | replacePartitionColumnClause
     | modifyColumnCommentClause
     | modifyColumnClause
     | columnRenameClause
@@ -1155,6 +1156,10 @@ dropColumnClause
 
 dropPartitionColumnClause
     : DROP PARTITION COLUMN expressionList
+    ;
+
+replacePartitionColumnClause
+    : REPLACE PARTITION COLUMN oldPartitionExpr=expression WITH newPartitionExpr=expression
     ;
 
 modifyColumnClause

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -763,6 +763,10 @@ public interface AstVisitor<R, C> {
         return visitNode(clause, context);
     }
 
+    default R visitReplacePartitionColumnClause(ReplacePartitionColumnClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
     default R visitAddRollupClause(AddRollupClause clause, C context) {
         return visitNode(clause, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ReplacePartitionColumnClause.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ReplacePartitionColumnClause.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+public class ReplacePartitionColumnClause extends AlterTableClause {
+    private final Expr oldPartitionExpr;
+    private final Expr newPartitionExpr;
+
+    public ReplacePartitionColumnClause(Expr oldPartitionExpr, Expr newPartitionExpr, NodePosition pos) {
+        super(pos);
+        this.oldPartitionExpr = oldPartitionExpr;
+        this.newPartitionExpr = newPartitionExpr;
+    }
+
+    public Expr getOldPartitionExpr() {
+        return oldPartitionExpr;
+    }
+
+    public Expr getNewPartitionExpr() {
+        return newPartitionExpr;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitReplacePartitionColumnClause(this, context);
+    }
+}

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -103,6 +103,13 @@ function: assert_query_contains("show create table test_part_evo", "PARTITION BY
 -- result:
 None
 -- !result
+alter table test_part_evo replace partition column month(dt) with dt;
+-- result:
+-- !result
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY truncate(`value`, 10), bucket(`id`, 10), `dt`")
+-- result:
+None
+-- !result
 select * from test_part_evo order by id;
 -- result:
 1	data1	2023-01-01	100
@@ -114,7 +121,7 @@ select * from test_part_evo order by id;
 alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 -- result:
 -- !result
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY month(`dt`)")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY `dt`")
 -- result:
 None
 -- !result
@@ -130,11 +137,19 @@ function: assert_query_error_contains("alter table test_part_evo add partition c
 -- result:
 None
 -- !result
-function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to add partition column")
+function: assert_query_error_contains("alter table test_part_evo add partition column dt", "Partition column already exists")
 -- result:
 None
 -- !result
-function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to drop partition column")
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Partition column does not exist")
+-- result:
+None
+-- !result
+function: assert_query_error_contains("alter table test_part_evo replace partition column day(dt) with month(dt)", "Partition column does not exist")
+-- result:
+None
+-- !result
+function: assert_query_error_contains("alter table test_part_evo replace partition column dt with dt", "Old partition column and new partition column are the same")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -70,19 +70,27 @@ insert into test_part_evo values (5, 'data5', '2023-01-05', 500);
 
 function: assert_query_contains("show create table test_part_evo", "PARTITION BY truncate(`value`, 10), bucket(`id`, 10), month(`dt`)")
 
+alter table test_part_evo replace partition column month(dt) with dt;
+
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY truncate(`value`, 10), bucket(`id`, 10), `dt`")
+
 select * from test_part_evo order by id;
 
 alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY month(`dt`)")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY `dt`")
 
 select * from test_part_evo order by id;
 
 function: assert_query_error_contains("alter table test_part_evo add partition column fn(dt)", "Unsupported partition transform")
 
-function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to add partition column")
+function: assert_query_error_contains("alter table test_part_evo add partition column dt", "Partition column already exists")
 
-function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to drop partition column")
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Partition column does not exist")
+
+function: assert_query_error_contains("alter table test_part_evo replace partition column day(dt) with month(dt)", "Partition column does not exist")
+
+function: assert_query_error_contains("alter table test_part_evo replace partition column dt with dt", "Old partition column and new partition column are the same")
 
 drop table test_part_evo force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request adds support for replacing partition columns in Iceberg tables via a new `ALTER TABLE ... REPLACE PARTITION COLUMN ... WITH ...` SQL statement. The implementation includes changes to both the backend logic and documentation, introducing new utility methods and validation checks to ensure correct usage.

New feature: Replace partition column in Iceberg tables

* Added `visitReplacePartitionColumnClause` method in `IcebergAlterTableExecutor.java` to handle replacing partition columns, including validation to prevent duplicate or missing columns and committing the changes to Iceberg.
* Introduced `convertPartitionExprToTerm`, `normalizePartitionExpr`, and `getPartitionExprSourceColumn` utility methods in `IcebergPartitionUtils.java` to support partition expression conversion and normalization for the new feature.

Integration and refactoring

* Updated `visitAddPartitionColumnClause` and `visitDropPartitionColumnClause` in `IcebergAlterTableExecutor.java` to use the new `IcebergPartitionUtils.convertPartitionExprToTerm` method for partition expression conversion. [[1]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L520-R477) [[2]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L538-R495)
* Added necessary imports for new clause types and utility methods in `AlterTableClauseAnalyzer.java` and other affected files to support the new replace partition column feature. [[1]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR50) [[2]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR63) [[3]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR82) [[4]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR109) [[5]](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR143)

Documentation updates

* Updated both English and Chinese Iceberg DDL documentation to describe and provide examples for the new `REPLACE PARTITION COLUMN` syntax. [[1]](diffhunk://#diff-c21157f7aa260e61a04d0db50a73c40defc4f55e5208dcdf4540720781421437R230-R232) [[2]](diffhunk://#diff-c21157f7aa260e61a04d0db50a73c40defc4f55e5208dcdf4540720781421437R255-R261) [[3]](diffhunk://#diff-14e4aa85c496610035079e87a2ee4ac0c6caffefb0ac24c627c05f5699e79d95R239-R241) [[4]](diffhunk://#diff-14e4aa85c496610035079e87a2ee4ac0c6caffefb0ac24c627c05f5699e79d95R264-R270)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4