### PR TITLE
[BugFix] Add warehouse info to information_schema.task_runs and adjust scanner tests

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -30,6 +30,7 @@ SchemaScanner::ColumnDesc SchemaTaskRunsScanner::_s_tbls_columns[] = {
         {"FINISH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"STATE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"CATALOG", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"WAREHOUSE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"DATABASE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"DEFINITION", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"EXPIRE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(Slice), true},
@@ -172,9 +173,22 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             break;
         }
         case 7: {
-            // DATABASE
+            // WAREHOUSE
             {
                 auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(7);
+                std::string warehouse_name = "default_warehouse";
+                if (task_run_info.__isset.warehouse) {
+                    warehouse_name = task_run_info.warehouse;
+                }
+                Slice value(warehouse_name.c_str(), warehouse_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            }
+            break;
+        }
+        case 8: {
+            // DATABASE
+            {
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(8);
                 if (task_run_info.__isset.database) {
                     const std::string* str = &task_run_info.database;
                     Slice value(str->c_str(), str->length());
@@ -185,10 +199,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 8: {
+        case 9: {
             // DEFINITION
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(8);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(9);
                 if (task_run_info.__isset.definition) {
                     const std::string* str = &task_run_info.definition;
                     Slice value(str->c_str(), str->length());
@@ -199,10 +213,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 9: {
+        case 10: {
             // EXPIRE_TIME
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(9);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(10);
                 auto* nullable_column = down_cast<NullableColumn*>(column);
                 if (task_run_info.__isset.expire_time) {
                     int64_t expire_time = task_run_info.expire_time;
@@ -219,10 +233,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 10: {
+        case 11: {
             // ERROR_CODE
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(10);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(11);
                 if (task_run_info.__isset.error_code) {
                     int64_t value = task_run_info.error_code;
                     fill_column_with_slot<TYPE_BIGINT>(column, (void*)&value);
@@ -232,10 +246,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 11: {
+        case 12: {
             // ERROR_MESSAGE
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(11);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(12);
                 if (task_run_info.__isset.error_message) {
                     const std::string* str = &task_run_info.error_message;
                     Slice value(str->c_str(), str->length());
@@ -246,10 +260,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 12: {
-            // progress
+        case 13: {
+            // PROGRESS
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(12);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(13);
                 if (task_run_info.__isset.progress) {
                     const std::string* str = &task_run_info.progress;
                     Slice value(str->c_str(), str->length());
@@ -260,10 +274,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 13: {
-            // extra_message
+        case 14: {
+            // EXTRA_MESSAGE
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(13);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(14);
                 if (task_run_info.__isset.extra_message) {
                     const std::string* str = &task_run_info.extra_message;
                     Slice value(str->c_str(), str->length());
@@ -274,10 +288,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 14: {
-            // properties
+        case 15: {
+            // PROPERTIES
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(14);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(15);
                 if (task_run_info.__isset.properties) {
                     const std::string* str = &task_run_info.properties;
                     Slice value(str->c_str(), str->length());
@@ -288,10 +302,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 15: {
-            // job_id
+        case 16: {
+            // JOB_ID
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(15);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(16);
                 if (task_run_info.__isset.job_id) {
                     const std::string* str = &task_run_info.job_id;
                     Slice value(str->c_str(), str->length());
@@ -302,10 +316,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 16: {
-            // process_time
+        case 17: {
+            // PROCESS_TIME
             {
-                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(16);
+                auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(17);
                 auto* nullable_column = down_cast<NullableColumn*>(column);
                 if (task_run_info.__isset.process_time) {
                     int64_t complete_time = task_run_info.process_time;

--- a/be/test/exec/schema_task_runs_scanner_test.cpp
+++ b/be/test/exec/schema_task_runs_scanner_test.cpp
@@ -57,7 +57,7 @@ TEST_F(SchemaTaskRunsScannerTest, test_scanner_initialization) {
 
     // Test that scanner has the correct number of columns
     auto slot_descs = scanner.get_slot_descs();
-    EXPECT_EQ(16, slot_descs.size());
+    EXPECT_EQ(17, slot_descs.size());
 
     // Test column names and types
     EXPECT_EQ("QUERY_ID", slot_descs[0]->col_name());
@@ -66,16 +66,17 @@ TEST_F(SchemaTaskRunsScannerTest, test_scanner_initialization) {
     EXPECT_EQ("FINISH_TIME", slot_descs[3]->col_name());
     EXPECT_EQ("STATE", slot_descs[4]->col_name());
     EXPECT_EQ("CATALOG", slot_descs[5]->col_name());
-    EXPECT_EQ("DATABASE", slot_descs[6]->col_name());
-    EXPECT_EQ("DEFINITION", slot_descs[7]->col_name());
-    EXPECT_EQ("EXPIRE_TIME", slot_descs[8]->col_name());
-    EXPECT_EQ("ERROR_CODE", slot_descs[9]->col_name());
-    EXPECT_EQ("ERROR_MESSAGE", slot_descs[10]->col_name());
-    EXPECT_EQ("PROGRESS", slot_descs[11]->col_name());
-    EXPECT_EQ("EXTRA_MESSAGE", slot_descs[12]->col_name());
-    EXPECT_EQ("PROPERTIES", slot_descs[13]->col_name());
-    EXPECT_EQ("JOB_ID", slot_descs[14]->col_name());
-    EXPECT_EQ("PROCESS_TIME", slot_descs[15]->col_name());
+    EXPECT_EQ("WAREHOUSE", slot_descs[6]->col_name());
+    EXPECT_EQ("DATABASE", slot_descs[7]->col_name());
+    EXPECT_EQ("DEFINITION", slot_descs[8]->col_name());
+    EXPECT_EQ("EXPIRE_TIME", slot_descs[9]->col_name());
+    EXPECT_EQ("ERROR_CODE", slot_descs[10]->col_name());
+    EXPECT_EQ("ERROR_MESSAGE", slot_descs[11]->col_name());
+    EXPECT_EQ("PROGRESS", slot_descs[12]->col_name());
+    EXPECT_EQ("EXTRA_MESSAGE", slot_descs[13]->col_name());
+    EXPECT_EQ("PROPERTIES", slot_descs[14]->col_name());
+    EXPECT_EQ("JOB_ID", slot_descs[15]->col_name());
+    EXPECT_EQ("PROCESS_TIME", slot_descs[16]->col_name());
 }
 
 TEST_F(SchemaTaskRunsScannerTest, test_uninitialized_scanner) {


### PR DESCRIPTION
## Why I'm doing:
fix #https://github.com/StarRocks/StarRocksTest/issues/11134
## What I'm doing:
This pull request adds a new column, `WAREHOUSE`, to the schema for task runs and updates the implementation and tests to support this change. The addition requires shifting the positions of subsequent columns in the code, ensuring that both data population and testing reflect the new schema layout.

Schema changes:

* Added the `WAREHOUSE` column to the `SchemaTaskRunsScanner::_s_tbls_columns` array, updating the schema definition for task runs.

Implementation updates:

* Modified the `SchemaTaskRunsScanner::fill_chunk` method to populate the new `WAREHOUSE` column, including logic to use a default value if not set, and updated all following column slot IDs to accommodate the new column. [[1]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL175-R191) [[2]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL188-R205) [[3]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL202-R219) [[4]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL222-R239) [[5]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL235-R252) [[6]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL249-R266) [[7]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL263-R280) [[8]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL277-R294) [[9]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL291-R308) [[10]](diffhunk://#diff-281848b64fe43498ac174f5cb12bea0df92c682a4dda6932eff4cc3fea50f64aL305-R322)

Testing updates:

* Updated the `SchemaTaskRunsScannerTest` to expect 17 columns instead of 16 and to verify the correct order and names of columns, including the new `WAREHOUSE` column. [[1]](diffhunk://#diff-ba836a26e8955d39770be7ad3b7f8a3063f7f4b1fded5c9d432d295df3e1ab79L60-R60) [[2]](diffhunk://#diff-ba836a26e8955d39770be7ad3b7f8a3063f7f4b1fded5c9d432d295df3e1ab79L69-R79)
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
