### PR TITLE
[BugFix] Fix Trino connector compatibility with Trino 479 and handle null COLUMN_SIZE

### DIFF
--- a/contrib/trino-connector/pom.xml
+++ b/contrib/trino-connector/pom.xml
@@ -6,20 +6,20 @@
 
     <groupId>com.starrocks</groupId>
     <artifactId>trino-starrocks</artifactId>
-    <version>418</version>
+    <version>479</version>
     <description>Trino - StarRocks Connector</description>
     <packaging>trino-plugin</packaging>
 
     <properties>
         <air.main.basedir>${project.basedir}</air.main.basedir>
-        <dep.airlift.version>230</dep.airlift.version>
-        <dep.airlift.units.version>1.8</dep.airlift.units.version>
-        <dep.jackson.version>2.15.0</dep.jackson.version>
-        <dep.guava.version>32.0.0-jre</dep.guava.version>
-        <dep.guice.version>6.0.0</dep.guice.version>
+        <dep.airlift.version>386</dep.airlift.version>
+        <dep.airlift.units.version>1.12</dep.airlift.units.version>
+        <dep.jackson.version>2.18.6</dep.jackson.version>
+        <dep.guava.version>33.5.0-jre</dep.guava.version>
+        <dep.guice.version>7.0.0</dep.guice.version>
         <dep.drift.version>1.14</dep.drift.version>
-        <dep.antlr.version>4.12.0</dep.antlr.version>
-        <dep.opentelemetry.version>1.26.0</dep.opentelemetry.version>
+        <dep.antlr.version>4.13.2</dep.antlr.version>
+        <dep.opentelemetry.version>1.57.0</dep.opentelemetry.version>
     </properties>
 
     <dependencies>
@@ -139,8 +139,10 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
-            <version>3.23.0</version>
+            <version>3.50.0</version>
         </dependency>
+
+
 
         <!-- used by tests but also needed transitively -->
         <dependency>
@@ -189,6 +191,13 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
             <version>${dep.opentelemetry.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
+            <version>${dep.opentelemetry.version}-alpha</version>
             <scope>provided</scope>
         </dependency>
 

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -25,6 +25,8 @@ import io.airlift.log.Logger;
 import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
 import io.trino.plugin.base.aggregation.AggregateFunctionRule;
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.mapping.IdentifierMapping;
+import io.trino.plugin.base.mapping.RemoteIdentifiers;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
@@ -57,7 +59,6 @@ import io.trino.plugin.jdbc.aggregation.ImplementVarianceSamp;
 import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
-import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
@@ -87,7 +88,7 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -134,6 +135,7 @@ import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.isNonTransactional
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
@@ -342,11 +344,11 @@ public class StarRocksClient
     }
 
     @Override
-    protected String createTableSql(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
+    protected List<String> createTableSqls(RemoteTableName remoteTableName, List<String> columns, ConnectorTableMetadata tableMetadata)
     {
         checkArgument(tableMetadata.getProperties().isEmpty(), "Unsupported table properties: %s", tableMetadata.getProperties());
         String columnName = columns.get(0).split(" ")[0];
-        return format("CREATE TABLE %s (%s) COMMENT %s DISTRIBUTED by hash(%s) PROPERTIES (\"replication_num\" = \"1\")", quoted(remoteTableName), join(", ", columns), starRocksVarcharLiteral(tableMetadata.getComment().orElse(NO_COMMENT)), columnName);
+        return ImmutableList.of(format("CREATE TABLE %s (%s) COMMENT %s DISTRIBUTED by hash(%s) PROPERTIES (\"replication_num\" = \"1\")", quoted(remoteTableName), join(", ", columns), starRocksVarcharLiteral(tableMetadata.getComment().orElse(NO_COMMENT)), columnName));
     }
 
     private static String starRocksVarcharLiteral(String value)
@@ -358,7 +360,7 @@ public class StarRocksClient
     @Override
     public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        String jdbcTypeName = typeHandle.getJdbcTypeName()
+        String jdbcTypeName = typeHandle.jdbcTypeName()
                 .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
 
         Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
@@ -367,6 +369,8 @@ public class StarRocksClient
         }
 
         switch (jdbcTypeName.toLowerCase(ENGLISH)) {
+            case "tinyint":
+                return Optional.of(tinyintColumnMapping());
             case "tinyint unsigned":
                 return Optional.of(smallintColumnMapping());
             case "smallint unsigned":
@@ -378,11 +382,25 @@ public class StarRocksClient
             case "json":
                 return Optional.of(jsonColumnMapping());
             case "enum":
-                return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), false));
+                return Optional.of(defaultVarcharColumnMapping(typeHandle.columnSize().orElse(255), false));
+            case "boolean":
+                return Optional.of(booleanColumnMapping());
+            case "largeint":
+                return Optional.of(decimalColumnMapping(createDecimalType(38, 0)));
+            case "bitmap":
+            case "hll":
+            case "percentile":
+                return Optional.of(defaultVarcharColumnMapping(Integer.MAX_VALUE, false));
         }
 
-        switch (typeHandle.getJdbcType()) {
+        switch (typeHandle.jdbcType()) {
+            case Types.BIT:
+                return Optional.of(booleanColumnMapping());
+
             case Types.TINYINT:
+                if (typeHandle.columnSize().orElse(0) == 1) {
+                    return Optional.of(booleanColumnMapping());
+                }
                 return Optional.of(tinyintColumnMapping());
 
             case Types.SMALLINT:
@@ -394,9 +412,8 @@ public class StarRocksClient
             case Types.BIGINT:
                 return Optional.of(bigintColumnMapping());
 
+            case Types.FLOAT:
             case Types.REAL:
-                // Disable pushdown because floating-point values are approximate and not stored as exact values,
-                // attempts to treat them as exact in comparisons may lead to problems
                 return Optional.of(ColumnMapping.longMapping(
                         REAL,
                         (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)),
@@ -407,8 +424,8 @@ public class StarRocksClient
                 return Optional.of(doubleColumnMapping());
 
             case Types.DECIMAL:
-                int decimalDigits = typeHandle.getDecimalDigits().orElseThrow(() -> new IllegalStateException("decimal digits not present"));
-                int precision = typeHandle.getRequiredColumnSize();
+                int decimalDigits = typeHandle.decimalDigits().orElse(0);
+                int precision = typeHandle.columnSize().orElse(38);
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));
                     return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
@@ -420,14 +437,14 @@ public class StarRocksClient
                 return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
 
             case Types.CHAR:
-                return Optional.of(defaultCharColumnMapping(typeHandle.getRequiredColumnSize(), false));
+                return Optional.of(defaultCharColumnMapping(typeHandle.columnSize().orElse(255), false));
 
             // TODO not all these type constants are necessarily used by the JDBC driver
             case Types.VARCHAR:
             case Types.NVARCHAR:
             case Types.LONGVARCHAR:
             case Types.LONGNVARCHAR:
-                return Optional.of(defaultVarcharColumnMapping(typeHandle.getColumnSize().orElse(Integer.MAX_VALUE), false));
+                return Optional.of(defaultVarcharColumnMapping(typeHandle.columnSize().orElse(Integer.MAX_VALUE), false));
 
             case Types.BINARY:
             case Types.VARBINARY:
@@ -441,7 +458,7 @@ public class StarRocksClient
                         starRocksDateWriteFunctionUsingLocalDate()));
 
             case Types.TIME:
-                TimeType timeType = createTimeType(getTimePrecision(typeHandle.getRequiredColumnSize()));
+                TimeType timeType = createTimeType(getTimePrecision(typeHandle.requiredColumnSize()));
                 requireNonNull(timeType, "timeType is null");
                 checkArgument(timeType.getPrecision() <= 9, "Unsupported type precision: %s", timeType);
                 return Optional.of(ColumnMapping.longMapping(
@@ -450,7 +467,7 @@ public class StarRocksClient
                         timeWriteFunction(timeType.getPrecision())));
 
             case Types.TIMESTAMP:
-                TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.getRequiredColumnSize()));
+                TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.requiredColumnSize()));
                 checkArgument(timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION, "Precision is out of range: %s", timestampType.getPrecision());
                 return Optional.of(ColumnMapping.longMapping(
                         timestampType,
@@ -529,20 +546,24 @@ public class StarRocksClient
     private static int getTimestampPrecision(int timestampColumnSize)
     {
         if (timestampColumnSize == ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE) {
-            return 0;
+            return 6;
         }
         int timestampPrecision = timestampColumnSize - ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE - 1;
-        verify(1 <= timestampPrecision && timestampPrecision <= MAX_SUPPORTED_DATE_TIME_PRECISION, "Unexpected timestamp precision %s calculated from timestamp column size %s", timestampPrecision, timestampColumnSize);
+        if (timestampPrecision < 1 || timestampPrecision > MAX_SUPPORTED_DATE_TIME_PRECISION) {
+            return 6;
+        }
         return timestampPrecision;
     }
 
     private static int getTimePrecision(int timeColumnSize)
     {
         if (timeColumnSize == ZERO_PRECISION_TIME_COLUMN_SIZE) {
-            return 0;
+            return 6;
         }
         int timePrecision = timeColumnSize - ZERO_PRECISION_TIME_COLUMN_SIZE - 1;
-        verify(1 <= timePrecision && timePrecision <= MAX_SUPPORTED_DATE_TIME_PRECISION, "Unexpected time precision %s calculated from time column size %s", timePrecision, timeColumnSize);
+        if (timePrecision < 1 || timePrecision > MAX_SUPPORTED_DATE_TIME_PRECISION) {
+            return 6;
+        }
         return timePrecision;
     }
 
@@ -649,8 +670,9 @@ public class StarRocksClient
         verify(tableHandle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s".formatted(tableHandle));
         try (Connection connection = connectionFactory.openConnection(session)) {
             connection.setAutoCommit(true);
-            String remoteSchema = getIdentifierMapping().toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
-            String remoteTable = getIdentifierMapping().toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
+            RemoteIdentifiers remoteIdentifiers = getRemoteIdentifiers(connection);
+            String remoteSchema = getIdentifierMapping().toRemoteSchemaName(remoteIdentifiers, identity, schemaTableName.getSchemaName());
+            String remoteTable = getIdentifierMapping().toRemoteTableName(remoteIdentifiers, identity, remoteSchema, schemaTableName.getTableName());
             String catalog = connection.getCatalog();
 
             ImmutableList.Builder<String> columnNames = ImmutableList.builder();
@@ -665,9 +687,7 @@ public class StarRocksClient
 
             if (isNonTransactionalInsert(session) || isPkTable) {
                 return new StarRocksOutputTableHandle(
-                        catalog,
-                        remoteSchema,
-                        remoteTable,
+                        new RemoteTableName(Optional.ofNullable(catalog), Optional.ofNullable(remoteSchema), remoteTable),
                         columnNames.build(),
                         columnTypes.build(),
                         Optional.of(jdbcColumnTypes.build()),
@@ -676,20 +696,19 @@ public class StarRocksClient
                         isPkTable);
             }
 
-            String remoteTemporaryTableName = getIdentifierMapping().toRemoteTableName(identity, connection, remoteSchema, generateTemporaryTableName(session));
+            String remoteTemporaryTableName = getIdentifierMapping().toRemoteTableName(remoteIdentifiers, identity, remoteSchema, generateTemporaryTableName(session));
 
             Optional<ColumnMetadata> pageSinkIdColumn = Optional.empty();
             copyTableSchema(session, connection, catalog, remoteSchema, remoteTable, remoteTemporaryTableName, columnNames.build());
 
             return new StarRocksOutputTableHandle(
-                    catalog,
-                    remoteSchema,
-                    remoteTable,
+                    new RemoteTableName(Optional.ofNullable(catalog), Optional.ofNullable(remoteSchema), remoteTable),
                     columnNames.build(),
                     columnTypes.build(),
                     Optional.of(jdbcColumnTypes.build()),
                     Optional.of(remoteTemporaryTableName),
-                    pageSinkIdColumn.map(column -> getIdentifierMapping().toRemoteColumnName(connection, column.getName())), Boolean.FALSE);
+                    pageSinkIdColumn.map(column -> getIdentifierMapping().toRemoteColumnName(remoteIdentifiers, column.getName())),
+                    Boolean.FALSE);
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -705,14 +724,12 @@ public class StarRocksClient
             return;
         }
 
+        RemoteTableName remoteTableName = handle.getRemoteTableName();
         RemoteTableName temporaryTable = new RemoteTableName(
-                Optional.ofNullable(handle.getCatalogName()),
-                Optional.ofNullable(handle.getSchemaName()),
+                remoteTableName.getCatalogName(),
+                remoteTableName.getSchemaName(),
                 handle.getTemporaryTableName().orElseThrow());
-        RemoteTableName targetTable = new RemoteTableName(
-                Optional.ofNullable(handle.getCatalogName()),
-                Optional.ofNullable(handle.getSchemaName()),
-                handle.getTableName());
+        RemoteTableName targetTable = remoteTableName;
 
         // We conditionally create more than the one table, so keep a list of the tables that need to be dropped.
         Closer closer = Closer.create();
@@ -785,7 +802,7 @@ public class StarRocksClient
     public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<JdbcSortItem> sortOrder)
     {
         for (JdbcSortItem sortItem : sortOrder) {
-            Type sortItemType = sortItem.getColumn().getColumnType();
+            Type sortItemType = sortItem.column().getColumnType();
             if (sortItemType instanceof CharType || sortItemType instanceof VarcharType) {
                 // Remote database can be case insensitive.
                 return false;
@@ -800,24 +817,24 @@ public class StarRocksClient
         return Optional.of((query, sortItems, limit) -> {
             String orderBy = sortItems.stream()
                     .flatMap(sortItem -> {
-                        String ordering = sortItem.getSortOrder().isAscending() ? "ASC" : "DESC";
-                        String columnSorting = format("%s %s", quoted(sortItem.getColumn().getColumnName()), ordering);
+                        String ordering = sortItem.sortOrder().isAscending() ? "ASC" : "DESC";
+                        String columnSorting = format("%s %s", quoted(sortItem.column().getColumnName()), ordering);
 
-                        switch (sortItem.getSortOrder()) {
+                        switch (sortItem.sortOrder()) {
                             case ASC_NULLS_FIRST:
                             case DESC_NULLS_LAST:
                                 return Stream.of(columnSorting);
 
                             case ASC_NULLS_LAST:
                                 return Stream.of(
-                                        format("ISNULL(%s) ASC", quoted(sortItem.getColumn().getColumnName())),
+                                        format("ISNULL(%s) ASC", quoted(sortItem.column().getColumnName())),
                                         columnSorting);
                             case DESC_NULLS_FIRST:
                                 return Stream.of(
-                                        format("ISNULL(%s) DESC", quoted(sortItem.getColumn().getColumnName())),
+                                        format("ISNULL(%s) DESC", quoted(sortItem.column().getColumnName())),
                                         columnSorting);
                         }
-                        throw new UnsupportedOperationException("Unsupported sort order: " + sortItem.getSortOrder());
+                        throw new UnsupportedOperationException("Unsupported sort order: " + sortItem.sortOrder());
                     })
                     .collect(joining(", "));
             return format("%s ORDER BY %s LIMIT %s", query, orderBy, limit);
@@ -831,7 +848,7 @@ public class StarRocksClient
     }
 
     @Override
-    public Optional<PreparedQuery> implementJoin(
+    public Optional<PreparedQuery> legacyImplementJoin(
             ConnectorSession session,
             JoinType joinType,
             PreparedQuery leftSource,
@@ -850,13 +867,13 @@ public class StarRocksClient
                 leftSource,
                 rightSource,
                 statistics,
-                () -> super.implementJoin(session, joinType, leftSource, rightSource, joinConditions, rightAssignments, leftAssignments, statistics));
+                () -> super.legacyImplementJoin(session, joinType, leftSource, rightSource, joinConditions, rightAssignments, leftAssignments, statistics));
     }
 
     @Override
     protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
-        if (joinCondition.getOperator() == JoinCondition.Operator.IS_DISTINCT_FROM) {
+        if (joinCondition.getOperator() == JoinCondition.Operator.IDENTICAL) {
             return false;
         }
 
@@ -914,7 +931,7 @@ public class StarRocksClient
                 return tableStatistics.build();
             }
 
-            for (JdbcColumnHandle column : this.getColumns(session, table)) {
+            for (JdbcColumnHandle column : this.getColumns(session, table.getRequiredNamedRelation().getSchemaTableName(), table.getRequiredNamedRelation().getRemoteTableName())) {
                 ColumnStatistics.Builder columnStatisticsBuilder = ColumnStatistics.builder();
 
                 String columnName = column.getColumnName();
@@ -1160,7 +1177,7 @@ public class StarRocksClient
     {
         String columnName = column.getName();
         verifyColumnName(connection.getMetaData(), columnName);
-        String remoteColumnName = getIdentifierMapping().toRemoteColumnName(connection, columnName);
+        String remoteColumnName = getIdentifierMapping().toRemoteColumnName(getRemoteIdentifiers(connection), columnName);
         String sql = format(
                 "ALTER TABLE %s ADD COLUMN %s",
                 quoted(table),
@@ -1169,17 +1186,10 @@ public class StarRocksClient
     }
 
     @Override
-    public List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle)
+    public List<JdbcColumnHandle> getColumns(ConnectorSession session, SchemaTableName schemaTableName, RemoteTableName remoteTableName)
     {
-        if (tableHandle.getColumns().isPresent()) {
-            return tableHandle.getColumns().get();
-        }
-        checkArgument(tableHandle.isNamedRelation(), "Cannot get columns for %s", tableHandle);
-        SchemaTableName schemaTableName = tableHandle.getRequiredNamedRelation().getSchemaTableName();
-        RemoteTableName remoteTableName = tableHandle.getRequiredNamedRelation().getRemoteTableName();
-
         try (Connection connection = connectionFactory.openConnection(session);
-                ResultSet resultSet = getColumns(tableHandle, connection.getMetaData())) {
+                ResultSet resultSet = getColumns(remoteTableName, connection.getMetaData())) {
             int allColumns = 0;
             List<JdbcColumnHandle> columns = new ArrayList<>();
             while (resultSet.next()) {
@@ -1189,10 +1199,22 @@ public class StarRocksClient
                 }
                 allColumns++;
                 String columnName = resultSet.getString("COLUMN_NAME");
+                // StarRocks may return null COLUMN_SIZE for certain types (STRING, JSON, etc.)
+                // Provide a safe fallback to avoid "column size not present" errors
+                Optional<Integer> columnSize = getInteger(resultSet, "COLUMN_SIZE");
+                if (columnSize.isEmpty()) {
+                    int dataType = getInteger(resultSet, "DATA_TYPE").orElse(Types.VARCHAR);
+                    columnSize = switch (dataType) {
+                        case Types.CHAR -> Optional.of(255);
+                        case Types.TIME -> Optional.of(ZERO_PRECISION_TIME_COLUMN_SIZE);
+                        case Types.TIMESTAMP -> Optional.of(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE);
+                        default -> Optional.of(Integer.MAX_VALUE);
+                    };
+                }
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                         getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
                         Optional.ofNullable(resultSet.getString("TYPE_NAME")),
-                        getInteger(resultSet, "COLUMN_SIZE"),
+                        columnSize,
                         getInteger(resultSet, "DECIMAL_DIGITS"),
                         Optional.empty(),
                         Optional.empty());

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -427,7 +427,10 @@ public class StarRocksClient
                 int decimalDigits = typeHandle.decimalDigits().orElse(0);
                 int precision = typeHandle.columnSize().orElse(38);
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
-                    int scale = min(decimalDigits, getDecimalDefaultScale(session));
+                    // Clamp scale into [0, getDecimalDefaultScale(session)] so that a bogus
+                    // decimalDigits (negative or larger than MAX_PRECISION) never reaches
+                    // createDecimalType(MAX_PRECISION, scale), which would throw.
+                    int scale = min(max(decimalDigits, 0), getDecimalDefaultScale(session));
                     return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                 }
                 precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
@@ -1217,6 +1220,13 @@ public class StarRocksClient
                         case Types.CHAR -> Optional.of(255);
                         case Types.TIME -> Optional.of(ZERO_PRECISION_TIME_COLUMN_SIZE);
                         case Types.TIMESTAMP -> Optional.of(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE);
+                        // DECIMAL/NUMERIC: leave unknown and let the Types.DECIMAL branch in
+                        // toColumnMapping() apply its own precision fallback (orElse(38)).
+                        // Substituting Integer.MAX_VALUE here would force that branch to reject
+                        // the column as precision > MAX_PRECISION and silently drop it, which
+                        // manifests as TableNotFoundException for views whose only column is a
+                        // derived DECIMAL (e.g. CREATE VIEW v AS SELECT SUM(x) FROM t).
+                        case Types.DECIMAL, Types.NUMERIC -> Optional.empty();
                         default -> Optional.of(Integer.MAX_VALUE);
                     };
                 }

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -431,7 +431,11 @@ public class StarRocksClient
                     return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                 }
                 precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
-                if (precision > Decimals.MAX_PRECISION) {
+                // Defense in depth: Trino's createDecimalType(p, s) rejects p <= 0, so fall through
+                // to the CONVERT_TO_VARCHAR / IGNORE handler at the bottom of the method if the
+                // remote reported bogus precision (e.g. COLUMN_SIZE = -1 that slipped past upstream
+                // normalization) instead of throwing IllegalArgumentException here.
+                if (precision <= 0 || precision > Decimals.MAX_PRECISION) {
                     break;
                 }
                 return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
@@ -1199,9 +1203,14 @@ public class StarRocksClient
                 }
                 allColumns++;
                 String columnName = resultSet.getString("COLUMN_NAME");
-                // StarRocks may return null COLUMN_SIZE for certain types (STRING, JSON, etc.)
-                // Provide a safe fallback to avoid "column size not present" errors
-                Optional<Integer> columnSize = getInteger(resultSet, "COLUMN_SIZE");
+                // StarRocks may report null or non-positive COLUMN_SIZE for certain types
+                // (STRING, JSON, LARGEINT, unbounded VARCHAR, etc.). Treat any non-positive
+                // value the same as absent to avoid "Invalid VARCHAR length -1" /
+                // "Invalid CHAR length -1" / "DECIMAL precision must be > 0" errors when
+                // the value flows into Trino type factories via `orElse(...)` (which does
+                // not replace a *present* negative value).
+                Optional<Integer> columnSize = getInteger(resultSet, "COLUMN_SIZE")
+                        .filter(size -> size > 0);
                 if (columnSize.isEmpty()) {
                     int dataType = getInteger(resultSet, "DATA_TYPE").orElse(Types.VARCHAR);
                     columnSize = switch (dataType) {
@@ -1211,11 +1220,17 @@ public class StarRocksClient
                         default -> Optional.of(Integer.MAX_VALUE);
                     };
                 }
+                // Same defensive normalization for DECIMAL_DIGITS: drop negative scales here
+                // since downstream arithmetic already handles missing scale via orElse(0) and
+                // explicitly compensates for legitimately-negative Oracle-style scales only
+                // when both precision and scale are present.
+                Optional<Integer> decimalDigits = getInteger(resultSet, "DECIMAL_DIGITS")
+                        .filter(digits -> digits >= 0);
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                         getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
                         Optional.ofNullable(resultSet.getString("TYPE_NAME")),
                         columnSize,
-                        getInteger(resultSet, "DECIMAL_DIGITS"),
+                        decimalDigits,
                         Optional.empty(),
                         Optional.empty());
                 Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -270,7 +270,9 @@ public class StarRocksClient
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
             while (resultSet.next()) {
                 String schemaName = resultSet.getString("TABLE_CAT");
-                // skip internal schemas
+                if (schemaName == null) {
+                    continue;
+                }
                 if (filterSchema(schemaName)) {
                     schemaNames.add(schemaName);
                 }
@@ -285,6 +287,9 @@ public class StarRocksClient
     @Override
     protected boolean filterSchema(String schemaName)
     {
+        if (schemaName == null) {
+            return false;
+        }
         if (schemaName.equalsIgnoreCase("sys")) {
             return false;
         }
@@ -340,7 +345,8 @@ public class StarRocksClient
     protected String getTableSchemaName(ResultSet resultSet)
             throws SQLException
     {
-        return resultSet.getString("TABLE_CAT");
+        String schemaName = resultSet.getString("TABLE_CAT");
+        return schemaName == null ? "" : schemaName;
     }
 
     @Override
@@ -360,8 +366,11 @@ public class StarRocksClient
     @Override
     public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        String jdbcTypeName = typeHandle.jdbcTypeName()
-                .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
+        // TYPE_NAME is optional per JDBC spec. When StarRocks metadata omits it we still
+        // have the numeric jdbcType code, which is enough to reach the Types.* switch
+        // below and yield a correct mapping. Failing hard here would turn a cosmetic
+        // metadata gap into "GENERIC_INTERNAL_ERROR: Type name is missing" for the user.
+        String jdbcTypeName = typeHandle.jdbcTypeName().orElse("");
 
         Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
         if (mapping.isPresent()) {
@@ -465,7 +474,7 @@ public class StarRocksClient
                         starRocksDateWriteFunctionUsingLocalDate()));
 
             case Types.TIME:
-                TimeType timeType = createTimeType(getTimePrecision(typeHandle.requiredColumnSize()));
+                TimeType timeType = createTimeType(getTimePrecision(typeHandle.columnSize().orElse(ZERO_PRECISION_TIME_COLUMN_SIZE)));
                 requireNonNull(timeType, "timeType is null");
                 checkArgument(timeType.getPrecision() <= 9, "Unsupported type precision: %s", timeType);
                 return Optional.of(ColumnMapping.longMapping(
@@ -474,7 +483,7 @@ public class StarRocksClient
                         timeWriteFunction(timeType.getPrecision())));
 
             case Types.TIMESTAMP:
-                TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.requiredColumnSize()));
+                TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.columnSize().orElse(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE)));
                 checkArgument(timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION, "Precision is out of range: %s", timestampType.getPrecision());
                 return Optional.of(ColumnMapping.longMapping(
                         timestampType,
@@ -1001,7 +1010,18 @@ public class StarRocksClient
     {
         return ColumnMapping.sliceMapping(
                 jsonType,
-                (resultSet, columnIndex) -> jsonParse(utf8Slice(resultSet.getString(columnIndex))),
+                (resultSet, columnIndex) -> {
+                    String raw = resultSet.getString(columnIndex);
+                    if (raw == null || resultSet.wasNull()) {
+                        return null;
+                    }
+                    try {
+                        return jsonParse(utf8Slice(raw));
+                    }
+                    catch (RuntimeException e) {
+                        throw new TrinoException(JDBC_ERROR, "Invalid JSON value from StarRocks at column index " + columnIndex, e);
+                    }
+                },
                 varcharWriteFunction(),
                 DISABLE_PUSHDOWN);
     }
@@ -1011,7 +1031,8 @@ public class StarRocksClient
         try (java.sql.Statement statement = connection.createStatement();
                 ResultSet resultSet = statement.executeQuery("SHOW VARIABLES LIKE 'gtid_mode'")) {
             if (resultSet.next()) {
-                return !resultSet.getString("Value").equalsIgnoreCase("OFF");
+                String value = resultSet.getString("Value");
+                return value != null && !value.equalsIgnoreCase("OFF");
             }
 
             return false;
@@ -1063,14 +1084,18 @@ public class StarRocksClient
                     .map((rs, ctx) -> {
                         String columnName = rs.getString("COLUMN_NAME");
 
-                        boolean nullable = rs.getString("NULLABLE").equalsIgnoreCase("YES");
-                        checkState(!rs.wasNull(), "NULLABLE is null");
+                        String nullableValue = rs.getString("NULLABLE");
+                        boolean nullable = nullableValue == null || nullableValue.equalsIgnoreCase("YES");
 
                         long cardinality = rs.getLong("CARDINALITY");
-                        checkState(!rs.wasNull(), "CARDINALITY is null");
+                        if (rs.wasNull()) {
+                            cardinality = 0L;
+                        }
 
                         return new SimpleEntry<>(columnName, new ColumnIndexStatistics(nullable, cardinality));
                     })
+                    .stream()
+                    .filter(entry -> entry.getKey() != null)
                     .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
@@ -1093,6 +1118,8 @@ public class StarRocksClient
                     .bind("schema", remoteTableName.getCatalogName().orElse(null))
                     .bind("table_name", remoteTableName.getTableName())
                     .map((rs, ctx) -> new SimpleEntry<>(rs.getString("COLUMN_NAME"), rs.getString("HISTOGRAM")))
+                    .stream()
+                    .filter(entry -> entry.getKey() != null && entry.getValue() != null)
                     .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
@@ -1206,6 +1233,16 @@ public class StarRocksClient
                 }
                 allColumns++;
                 String columnName = resultSet.getString("COLUMN_NAME");
+                if (columnName == null) {
+                    log.debug("Skipping column with null COLUMN_NAME for %s", schemaTableName);
+                    continue;
+                }
+                Optional<Integer> dataTypeOpt = getInteger(resultSet, "DATA_TYPE");
+                if (dataTypeOpt.isEmpty()) {
+                    log.debug("Skipping column '%s' with null DATA_TYPE for %s", columnName, schemaTableName);
+                    continue;
+                }
+                int dataType = dataTypeOpt.get();
                 // StarRocks may report null or non-positive COLUMN_SIZE for certain types
                 // (STRING, JSON, LARGEINT, unbounded VARCHAR, etc.). Treat any non-positive
                 // value the same as absent to avoid "Invalid VARCHAR length -1" /
@@ -1215,7 +1252,6 @@ public class StarRocksClient
                 Optional<Integer> columnSize = getInteger(resultSet, "COLUMN_SIZE")
                         .filter(size -> size > 0);
                 if (columnSize.isEmpty()) {
-                    int dataType = getInteger(resultSet, "DATA_TYPE").orElse(Types.VARCHAR);
                     columnSize = switch (dataType) {
                         case Types.CHAR -> Optional.of(255);
                         case Types.TIME -> Optional.of(ZERO_PRECISION_TIME_COLUMN_SIZE);
@@ -1237,7 +1273,7 @@ public class StarRocksClient
                 Optional<Integer> decimalDigits = getInteger(resultSet, "DECIMAL_DIGITS")
                         .filter(digits -> digits >= 0);
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
-                        getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                        dataType,
                         Optional.ofNullable(resultSet.getString("TYPE_NAME")),
                         columnSize,
                         decimalDigits,
@@ -1280,10 +1316,11 @@ public class StarRocksClient
     private static RemoteTableName getRemoteTable(ResultSet resultSet)
             throws SQLException
     {
+        String tableName = resultSet.getString("TABLE_NAME");
         return new RemoteTableName(
                 Optional.ofNullable(resultSet.getString("TABLE_CAT")),
                 Optional.ofNullable(resultSet.getString("TABLE_SCHEM")),
-                resultSet.getString("TABLE_NAME"));
+                tableName == null ? "" : tableName);
     }
 
     private Boolean isPkTable(Connection connection, String schemaName, String tableName)
@@ -1291,7 +1328,7 @@ public class StarRocksClient
         try (java.sql.Statement statement = connection.createStatement();
                 ResultSet resultSet = statement.executeQuery(String.format("SELECT TABLE_MODEL FROM information_schema.tables_config WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'", schemaName, tableName))) {
             if (resultSet.next()) {
-                return resultSet.getString("TABLE_MODEL").equalsIgnoreCase(TABLE_MODEL_PRIMARY_KEYS);
+                return TABLE_MODEL_PRIMARY_KEYS.equalsIgnoreCase(resultSet.getString("TABLE_MODEL"));
             }
 
             return false;

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -700,6 +700,7 @@ public class StarRocksClient
                 jdbcColumnTypes.add(column.getJdbcTypeHandle());
             }
             Boolean isPkTable = isPkTable(connection, remoteSchema, remoteTable);
+            rejectIfView(connection, remoteSchema, remoteTable, schemaTableName);
 
             if (isNonTransactionalInsert(session) || isPkTable) {
                 return new StarRocksOutputTableHandle(
@@ -1369,6 +1370,34 @@ public class StarRocksClient
             }
 
             return false;
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    private void rejectIfView(Connection connection, String schemaName, String tableName, SchemaTableName schemaTableName)
+    {
+        // StarRocks's Table.getMysqlType() maps regular views, inline views, and both
+        // synchronous and asynchronous materialized views to the JDBC TABLE_TYPE "VIEW"
+        // (only plain OLAP tables report "BASE TABLE"). Without this guard the
+        // non-transactional path would stream-load into the view name and the
+        // transactional path would run CREATE TABLE ... LIKE <view>, both of which
+        // fail late at the FE with cryptic errors. Reject up front with NOT_SUPPORTED
+        // so the user sees a clear message before any work is done.
+        try (java.sql.Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(String.format(
+                        "SELECT TABLE_TYPE FROM information_schema.tables WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
+                        schemaName,
+                        tableName))) {
+            if (resultSet.next()) {
+                String tableType = resultSet.getString("TABLE_TYPE");
+                if (tableType != null && !"BASE TABLE".equalsIgnoreCase(tableType)) {
+                    throw new TrinoException(
+                            NOT_SUPPORTED,
+                            "Cannot write to " + schemaTableName + ": " + tableType + " is not writable through the StarRocks connector");
+                }
+            }
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -864,6 +864,34 @@ public class StarRocksClient
     }
 
     @Override
+    public Optional<PreparedQuery> implementJoin(
+            ConnectorSession session,
+            JoinType joinType,
+            PreparedQuery leftSource,
+            Map<JdbcColumnHandle, String> leftProjections,
+            PreparedQuery rightSource,
+            Map<JdbcColumnHandle, String> rightProjections,
+            List<ParameterizedExpression> joinConditions,
+            JoinStatistics statistics)
+    {
+        // Trino 479's DefaultJdbcMetadata.applyJoin() takes the complex-expression path
+        // (this method) whenever `complex_join_pushdown_enabled` is true, which is the
+        // shipped default. Without this override the superclass path would skip the
+        // StarRocks-specific guards below, so we mirror the legacy override's behavior
+        // here and keep them aligned.
+        if (joinType == JoinType.FULL_OUTER) {
+            return Optional.empty();
+        }
+        return implementJoinCostAware(
+                session,
+                joinType,
+                leftSource,
+                rightSource,
+                statistics,
+                () -> super.implementJoin(session, joinType, leftSource, leftProjections, rightSource, rightProjections, joinConditions, statistics));
+    }
+
+    @Override
     public Optional<PreparedQuery> legacyImplementJoin(
             ConnectorSession session,
             JoinType joinType,
@@ -1243,6 +1271,12 @@ public class StarRocksClient
                     continue;
                 }
                 int dataType = dataTypeOpt.get();
+                // Same defensive normalization for DECIMAL_DIGITS: drop negative scales here
+                // since downstream arithmetic already handles missing scale via orElse(0) and
+                // explicitly compensates for legitimately-negative Oracle-style scales only
+                // when both precision and scale are present.
+                Optional<Integer> decimalDigits = getInteger(resultSet, "DECIMAL_DIGITS")
+                        .filter(digits -> digits >= 0);
                 // StarRocks may report null or non-positive COLUMN_SIZE for certain types
                 // (STRING, JSON, LARGEINT, unbounded VARCHAR, etc.). Treat any non-positive
                 // value the same as absent to avoid "Invalid VARCHAR length -1" /
@@ -1254,8 +1288,17 @@ public class StarRocksClient
                 if (columnSize.isEmpty()) {
                     columnSize = switch (dataType) {
                         case Types.CHAR -> Optional.of(255);
-                        case Types.TIME -> Optional.of(ZERO_PRECISION_TIME_COLUMN_SIZE);
-                        case Types.TIMESTAMP -> Optional.of(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE);
+                        // TIME/TIMESTAMP: reconstruct COLUMN_SIZE from DECIMAL_DIGITS when
+                        // available so getTime/TimestampPrecision() can recover subsecond
+                        // precision. MySQL-protocol convention:
+                        //   COLUMN_SIZE = ZERO_PRECISION + (p > 0 ? p + 1 : 0)   // +1 = decimal point
+                        // Without this, TIME(3)/DATETIME(6) with null COLUMN_SIZE and
+                        // DECIMAL_DIGITS=p would fall back to the zero-precision width and
+                        // silently drop subsecond data through the read function.
+                        case Types.TIME -> Optional.of(ZERO_PRECISION_TIME_COLUMN_SIZE
+                                + decimalDigits.filter(d -> d > 0).map(d -> d + 1).orElse(0));
+                        case Types.TIMESTAMP -> Optional.of(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE
+                                + decimalDigits.filter(d -> d > 0).map(d -> d + 1).orElse(0));
                         // DECIMAL/NUMERIC: leave unknown and let the Types.DECIMAL branch in
                         // toColumnMapping() apply its own precision fallback (orElse(38)).
                         // Substituting Integer.MAX_VALUE here would force that branch to reject
@@ -1266,12 +1309,6 @@ public class StarRocksClient
                         default -> Optional.of(Integer.MAX_VALUE);
                     };
                 }
-                // Same defensive normalization for DECIMAL_DIGITS: drop negative scales here
-                // since downstream arithmetic already handles missing scale via orElse(0) and
-                // explicitly compensates for legitimately-negative Oracle-style scales only
-                // when both precision and scale are present.
-                Optional<Integer> decimalDigits = getInteger(resultSet, "DECIMAL_DIGITS")
-                        .filter(digits -> digits >= 0);
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                         dataType,
                         Optional.ofNullable(resultSet.getString("TYPE_NAME")),

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClient.java
@@ -16,6 +16,9 @@ package io.trino.plugin.starrocks;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +44,8 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.ObjectReadFunction;
+import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
@@ -60,6 +65,8 @@ import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -75,6 +82,7 @@ import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.StandardTypes;
@@ -402,6 +410,14 @@ public class StarRocksClient
                 return Optional.of(defaultVarcharColumnMapping(Integer.MAX_VALUE, false));
         }
 
+        // StarRocks ARRAY columns arrive as jdbcType OTHER / TYPE_NAME "ARRAY" with no element
+        // type in DatabaseMetaData; getColumns() enriches the name to the full COLUMN_TYPE
+        // (e.g. "array<varchar(255)>") so the element type is parseable here.
+        String lowerTypeName = jdbcTypeName.toLowerCase(ENGLISH);
+        if (lowerTypeName.startsWith("array<")) {
+            return arrayColumnMapping(session, connection, lowerTypeName);
+        }
+
         switch (typeHandle.jdbcType()) {
             case Types.BIT:
                 return Optional.of(booleanColumnMapping());
@@ -496,6 +512,184 @@ public class StarRocksClient
         }
         return Optional.empty();
     }
+
+    private static final ObjectMapper ARRAY_JSON_MAPPER = new ObjectMapper();
+
+    private Optional<ColumnMapping> arrayColumnMapping(ConnectorSession session, Connection connection, String lowerArrayTypeName)
+    {
+        String elementTypeName = unwrapArrayElementType(lowerArrayTypeName);
+        Optional<JdbcTypeHandle> elementHandle = elementTypeToHandle(elementTypeName);
+        if (elementHandle.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<ColumnMapping> elementMapping = toColumnMapping(session, connection, elementHandle.get());
+        if (elementMapping.isEmpty()) {
+            return Optional.empty();
+        }
+        ArrayType arrayType = new ArrayType(elementMapping.get().getType());
+        return Optional.of(ColumnMapping.objectMapping(
+                arrayType,
+                arrayReadFunction(arrayType),
+                arrayWriteNotSupported(),
+                DISABLE_PUSHDOWN));
+    }
+
+    private static String unwrapArrayElementType(String lowerArrayTypeName)
+    {
+        int open = lowerArrayTypeName.indexOf('<');
+        int close = lowerArrayTypeName.lastIndexOf('>');
+        checkArgument(open >= 0 && close > open, "Malformed StarRocks array type: %s", lowerArrayTypeName);
+        return lowerArrayTypeName.substring(open + 1, close).trim();
+    }
+
+    private Optional<JdbcTypeHandle> elementTypeToHandle(String elementType)
+    {
+        if (elementType.startsWith("array<")) {
+            return Optional.of(new JdbcTypeHandle(Types.OTHER, Optional.of(elementType), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+        }
+        String baseName = elementType;
+        int paren = baseName.indexOf('(');
+        Optional<Integer> precision = Optional.empty();
+        Optional<Integer> scale = Optional.empty();
+        if (paren >= 0) {
+            String args = baseName.substring(paren + 1, baseName.lastIndexOf(')'));
+            baseName = baseName.substring(0, paren).trim();
+            String[] parts = args.split(",");
+            precision = parseIntOptional(parts[0]);
+            if (parts.length > 1) {
+                scale = parseIntOptional(parts[1]);
+            }
+        }
+        return switch (baseName) {
+            case "boolean" -> handle(Types.BIT, "boolean", Optional.empty(), Optional.empty());
+            case "tinyint" -> handle(Types.TINYINT, "tinyint", Optional.empty(), Optional.empty());
+            case "smallint" -> handle(Types.SMALLINT, "smallint", Optional.empty(), Optional.empty());
+            case "int" -> handle(Types.INTEGER, "int", Optional.empty(), Optional.empty());
+            case "bigint" -> handle(Types.BIGINT, "bigint", Optional.empty(), Optional.empty());
+            case "largeint" -> handle(Types.BIGINT, "largeint", Optional.empty(), Optional.empty());
+            case "float" -> handle(Types.REAL, "float", Optional.empty(), Optional.empty());
+            case "double" -> handle(Types.DOUBLE, "double", Optional.empty(), Optional.empty());
+            case "decimal", "decimalv2", "decimal32", "decimal64", "decimal128" ->
+                    handle(Types.DECIMAL, "decimal", Optional.of(precision.orElse(38)), Optional.of(scale.orElse(0)));
+            case "char" -> handle(Types.CHAR, "char", Optional.of(precision.orElse(255)), Optional.empty());
+            case "varchar", "string" -> handle(Types.VARCHAR, "varchar", Optional.of(precision.orElse(Integer.MAX_VALUE)), Optional.empty());
+            case "date" -> handle(Types.DATE, "date", Optional.empty(), Optional.empty());
+            case "datetime" -> handle(Types.TIMESTAMP, "datetime", Optional.of(ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE), Optional.empty());
+            case "json" -> handle(Types.OTHER, "json", Optional.empty(), Optional.empty());
+            default -> Optional.empty();
+        };
+    }
+
+    private static Optional<JdbcTypeHandle> handle(int jdbcType, String name, Optional<Integer> size, Optional<Integer> digits)
+    {
+        return Optional.of(new JdbcTypeHandle(jdbcType, Optional.of(name), size, digits, Optional.empty(), Optional.empty()));
+    }
+
+    private static Optional<Integer> parseIntOptional(String value)
+    {
+        try {
+            return Optional.of(Integer.parseInt(value.trim()));
+        }
+        catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static ObjectReadFunction arrayReadFunction(ArrayType arrayType)
+    {
+        return ObjectReadFunction.of(Block.class, (resultSet, columnIndex) -> {
+            String json = resultSet.getString(columnIndex);
+            if (json == null) {
+                return null;
+            }
+            JsonNode node;
+            try {
+                node = ARRAY_JSON_MAPPER.readTree(json);
+            }
+            catch (JsonProcessingException e) {
+                throw new TrinoException(JDBC_ERROR, "Failed to parse StarRocks array JSON: " + json, e);
+            }
+            if (!node.isArray()) {
+                throw new TrinoException(JDBC_ERROR, "Expected JSON array from StarRocks array column, got: " + json);
+            }
+            BlockBuilder builder = arrayType.createBlockBuilder(null, node.size());
+            writeArray(builder, arrayType, node);
+            return arrayType.getObject(builder.build(), 0);
+        });
+    }
+
+    private static void writeArray(BlockBuilder arrayBuilder, ArrayType arrayType, JsonNode arrayNode)
+    {
+        Type elementType = arrayType.getElementType();
+        ((io.trino.spi.block.ArrayBlockBuilder) arrayBuilder).buildEntry(elementBuilder -> {
+            for (JsonNode element : arrayNode) {
+                writeElement(elementBuilder, elementType, element);
+            }
+        });
+    }
+
+    private static void writeElement(BlockBuilder builder, Type elementType, JsonNode value)
+    {
+        if (value == null || value.isNull()) {
+            builder.appendNull();
+            return;
+        }
+        if (elementType instanceof ArrayType nestedArray) {
+            if (!value.isArray()) {
+                throw new TrinoException(JDBC_ERROR, "Expected nested JSON array, got: " + value);
+            }
+            writeArray(builder, nestedArray, value);
+            return;
+        }
+        if (elementType == BOOLEAN) {
+            elementType.writeBoolean(builder, value.asInt() != 0);
+        }
+        else if (elementType == TINYINT || elementType == SMALLINT || elementType == INTEGER || elementType == BIGINT) {
+            elementType.writeLong(builder, value.asLong());
+        }
+        else if (elementType == REAL) {
+            elementType.writeLong(builder, floatToRawIntBits((float) value.asDouble()));
+        }
+        else if (elementType == DOUBLE) {
+            elementType.writeDouble(builder, value.asDouble());
+        }
+        else if (elementType instanceof DecimalType decimalType) {
+            writeDecimal(builder, decimalType, new java.math.BigDecimal(value.asText()));
+        }
+        else if (elementType instanceof CharType || elementType instanceof VarcharType) {
+            elementType.writeSlice(builder, utf8Slice(value.asText()));
+        }
+        else if (elementType == DATE) {
+            elementType.writeLong(builder, LocalDate.parse(value.asText(), ISO_DATE).toEpochDay());
+        }
+        else if (elementType instanceof TimestampType timestampType) {
+            long micros = LocalDateTime.parse(value.asText().replace(' ', 'T'))
+                    .toInstant(java.time.ZoneOffset.UTC).toEpochMilli() * 1000;
+            timestampType.writeLong(builder, micros);
+        }
+        else {
+            throw new TrinoException(JDBC_ERROR, "Unsupported StarRocks array element type: " + elementType.getDisplayName());
+        }
+    }
+
+    private static void writeDecimal(BlockBuilder builder, DecimalType decimalType, java.math.BigDecimal value)
+    {
+        java.math.BigDecimal scaled = value.setScale(decimalType.getScale(), java.math.RoundingMode.HALF_UP);
+        if (decimalType.isShort()) {
+            decimalType.writeLong(builder, scaled.unscaledValue().longValueExact());
+        }
+        else {
+            decimalType.writeObject(builder, io.trino.spi.type.Int128.valueOf(scaled.unscaledValue()));
+        }
+    }
+
+    private static ObjectWriteFunction arrayWriteNotSupported()
+    {
+        return ObjectWriteFunction.of(Block.class, (statement, index, block) -> {
+            throw new TrinoException(NOT_SUPPORTED, "Writing to StarRocks ARRAY columns is not supported");
+        });
+    }
+
 
     private LongWriteFunction starRocksDateWriteFunctionUsingLocalDate()
     {
@@ -1253,6 +1447,7 @@ public class StarRocksClient
     {
         try (Connection connection = connectionFactory.openConnection(session);
                 ResultSet resultSet = getColumns(remoteTableName, connection.getMetaData())) {
+            Map<String, String> complexColumnTypes = loadComplexColumnTypes(connection, schemaTableName, remoteTableName);
             int allColumns = 0;
             List<JdbcColumnHandle> columns = new ArrayList<>();
             while (resultSet.next()) {
@@ -1312,7 +1507,7 @@ public class StarRocksClient
                 }
                 JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                         dataType,
-                        Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                        resolveTypeName(resultSet.getString("TYPE_NAME"), columnName, complexColumnTypes),
                         columnSize,
                         decimalDigits,
                         Optional.empty(),
@@ -1349,6 +1544,35 @@ public class StarRocksClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    private Map<String, String> loadComplexColumnTypes(Connection connection, SchemaTableName schemaTableName, RemoteTableName remoteTableName)
+            throws SQLException
+    {
+        String schema = remoteTableName.getSchemaName().orElseGet(schemaTableName::getSchemaName);
+        String table = remoteTableName.getTableName();
+        String sql = "SELECT COLUMN_NAME, COLUMN_TYPE FROM information_schema.columns "
+                + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND DATA_TYPE IN ('array', 'map', 'struct')";
+        Map<String, String> result = new java.util.HashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, schema);
+            statement.setString(2, table);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    result.put(rs.getString("COLUMN_NAME"), rs.getString("COLUMN_TYPE"));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Optional<String> resolveTypeName(String typeName, String columnName, Map<String, String> complexColumnTypes)
+    {
+        String enriched = complexColumnTypes.get(columnName);
+        if (enriched != null) {
+            return Optional.of(enriched);
+        }
+        return Optional.ofNullable(typeName);
     }
 
     private static RemoteTableName getRemoteTable(ResultSet resultSet)

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClientModule.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksClientModule.java
@@ -22,6 +22,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import io.opentelemetry.api.OpenTelemetry;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
@@ -36,7 +37,7 @@ import io.trino.plugin.jdbc.credential.CredentialConfig;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
-import io.trino.spi.ptf.ConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunction;
 
 import java.sql.SQLException;
 import java.util.Properties;
@@ -81,14 +82,16 @@ public class StarRocksClientModule
     @Provides
     @Singleton
     @ForBaseJdbc
-    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, StarRocksJdbcConfig starRocksJdbcConfig)
+    public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, StarRocksJdbcConfig starRocksJdbcConfig, OpenTelemetry openTelemetry)
             throws SQLException
     {
-        return new DriverConnectionFactory(
-                new Driver(),
-                transConnectionUrl(config.getConnectionUrl()),
-                getConnectionProperties(starRocksJdbcConfig),
-                credentialProvider);
+        return DriverConnectionFactory.builder(
+                        new Driver(),
+                        transConnectionUrl(config.getConnectionUrl()),
+                        credentialProvider)
+                .setConnectionProperties(getConnectionProperties(starRocksJdbcConfig))
+                .setOpenTelemetry(openTelemetry)
+                .build();
     }
 
     public static Properties getConnectionProperties(StarRocksJdbcConfig starRocksJdbcConfig)

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksOperationApplier.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksOperationApplier.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.data.load.stream.StreamLoadUtils.getSendUrl;
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.plugin.starrocks.StarRocksErrorCode.STAR_ROCKS_WRITE_ERROR;
 
 public final class StarRocksOperationApplier
         implements AutoCloseable
@@ -95,8 +95,11 @@ public final class StarRocksOperationApplier
                     this.send();
                 }
             }
+            catch (TrinoException e) {
+                throw e;
+            }
             catch (Exception e) {
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+                throw new TrinoException(STAR_ROCKS_WRITE_ERROR, "Stream load to StarRocks failed", e);
             }
         }
     }
@@ -125,6 +128,11 @@ public final class StarRocksOperationApplier
         try {
             StreamLoadDataFormat dataFormat = tableProperties.getDataFormat();
             String host = getAvailableHost();
+            if (host == null) {
+                throw new TrinoException(
+                        STAR_ROCKS_WRITE_ERROR,
+                        "None of the hosts in `load_url` could be reached for Stream Load");
+            }
             String table = region.getTemporaryTableName().orElseGet(region::getTable);
             String sendUrl = getSendUrl(host, region.getDatabase(), table);
             String label = region.getLabel();
@@ -147,34 +155,52 @@ public final class StarRocksOperationApplier
             try (CloseableHttpClient client = clientBuilder.build()) {
                 log.info("Stream loading, label : %s, request : %s", label, httpPut);
                 long startNanoTime = System.currentTimeMillis();
-                CloseableHttpResponse response = client.execute(httpPut);
-                String responseBody = EntityUtils.toString(response.getEntity());
+                try (CloseableHttpResponse response = client.execute(httpPut)) {
+                    String responseBody = EntityUtils.toString(response.getEntity());
 
-                log.info("Stream load completed, label : %s, database : %s, table : %s, body : %s",
-                        label, region.getDatabase(), table, responseBody);
+                    log.info("Stream load completed, label : %s, database : %s, table : %s, body : %s",
+                            label, region.getDatabase(), table, responseBody);
 
-                StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
-                StreamLoadResponse.StreamLoadResponseBody streamLoadBody = objectMapper.readValue(responseBody, StreamLoadResponse.StreamLoadResponseBody.class);
-                streamLoadResponse.setBody(streamLoadBody);
-
-                String status = streamLoadBody.getStatus();
-
-                if (StreamLoadConstants.RESULT_STATUS_SUCCESS.equals(status)
-                        || StreamLoadConstants.RESULT_STATUS_OK.equals(status)
-                        || StreamLoadConstants.RESULT_STATUS_TRANSACTION_PUBLISH_TIMEOUT.equals(status)) {
-                    streamLoadResponse.setCostNanoTime(System.nanoTime() - startNanoTime);
-                    region.complete(streamLoadResponse);
-                }
-                else if (StreamLoadConstants.RESULT_STATUS_LABEL_EXISTED.equals(status)) {
-                    boolean succeed = checkLabelState(host, region.getDatabase(), label);
-                    if (!succeed) {
-                        throw new StreamLoadFailException("Stream load failed");
+                    StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
+                    StreamLoadResponse.StreamLoadResponseBody streamLoadBody;
+                    try {
+                        streamLoadBody = objectMapper.readValue(responseBody, StreamLoadResponse.StreamLoadResponseBody.class);
                     }
+                    catch (Exception e) {
+                        // Stream Load responses are JSON. An HTML error page or an
+                        // empty body here means a proxy / gateway failure. Surface it
+                        // as a controlled write error with the raw body excerpt so the
+                        // user can see what actually came back without leaking a raw
+                        // Jackson parse stack trace through GENERIC_INTERNAL_ERROR.
+                        String excerpt = responseBody == null
+                                ? "<null>"
+                                : responseBody.substring(0, Math.min(responseBody.length(), 500));
+                        throw new TrinoException(
+                                STAR_ROCKS_WRITE_ERROR,
+                                "Unexpected Stream Load response for label " + label + ": " + excerpt,
+                                e);
+                    }
+                    streamLoadResponse.setBody(streamLoadBody);
+
+                    String status = streamLoadBody.getStatus();
+
+                    if (StreamLoadConstants.RESULT_STATUS_SUCCESS.equals(status)
+                            || StreamLoadConstants.RESULT_STATUS_OK.equals(status)
+                            || StreamLoadConstants.RESULT_STATUS_TRANSACTION_PUBLISH_TIMEOUT.equals(status)) {
+                        streamLoadResponse.setCostNanoTime(System.nanoTime() - startNanoTime);
+                        region.complete(streamLoadResponse);
+                    }
+                    else if (StreamLoadConstants.RESULT_STATUS_LABEL_EXISTED.equals(status)) {
+                        boolean succeed = checkLabelState(host, region.getDatabase(), label);
+                        if (!succeed) {
+                            throw new StreamLoadFailException("Stream load failed");
+                        }
+                    }
+                    else {
+                        throw new StreamLoadFailException(responseBody, streamLoadBody);
+                    }
+                    return streamLoadResponse;
                 }
-                else {
-                    throw new StreamLoadFailException(responseBody, streamLoadBody);
-                }
-                return streamLoadResponse;
             }
             catch (Exception e) {
                 log.error("Stream load failed unknown, label : " + label, e);
@@ -192,12 +218,21 @@ public final class StarRocksOperationApplier
     {
         String[] hosts = properties.getLoadUrls();
         int size = hosts.length;
-        long pos = availableHostPos;
-        while (pos < pos + size) {
-            String host = "http://" + hosts[(int) (pos % size)];
+        if (size == 0) {
+            return null;
+        }
+        // Bounded rotation: try each host at most once per call. The original
+        // `while (pos < pos + size)` condition is always true for positive size
+        // (long overflow aside), so with no reachable host the method would spin
+        // forever. Tracking the starting position in a local variable and walking
+        // `size` steps gives a deterministic O(size) probe that returns null when
+        // every host is unreachable.
+        long startPos = availableHostPos;
+        for (int i = 0; i < size; i++) {
+            long pos = startPos + i;
+            String host = "http://" + hosts[(int) Math.floorMod(pos, size)];
             if (testHttpConnection(host)) {
-                pos++;
-                availableHostPos = pos;
+                availableHostPos = pos + 1;
                 return host;
             }
         }
@@ -289,7 +324,10 @@ public final class StarRocksOperationApplier
     public void callback(Throwable e)
     {
         log.error("Stream load failed", e);
-        throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+        if (e instanceof TrinoException trinoException) {
+            throw trinoException;
+        }
+        throw new TrinoException(STAR_ROCKS_WRITE_ERROR, "Stream load to StarRocks failed", e);
     }
 
     @Override

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksOutputTableHandle.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksOutputTableHandle.java
@@ -18,9 +18,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.spi.type.Type;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,9 +33,7 @@ public class StarRocksOutputTableHandle
 
     @JsonCreator
     public StarRocksOutputTableHandle(
-            @JsonProperty("catalogName") @Nullable String catalogName,
-            @Nullable @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("columnTypes") List<Type> columnTypes,
             @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
@@ -44,7 +41,7 @@ public class StarRocksOutputTableHandle
             @JsonProperty("pageSinkIdColumnName") Optional<String> pageSinkIdColumnName,
             @JsonProperty("isPkTable") Boolean isPkTable)
     {
-        super(catalogName, schemaName, tableName, columnNames, columnTypes, jdbcColumnTypes, temporaryTableName, pageSinkIdColumnName);
+        super(remoteTableName, columnNames, columnTypes, jdbcColumnTypes, temporaryTableName, pageSinkIdColumnName);
         this.isPkTable = requireNonNull(isPkTable, "isPkTable is null");
     }
 

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPageSink.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPageSink.java
@@ -76,8 +76,14 @@ public class StarRocksPageSink
                 applier.applyOperationAsync(row);
             }
         }
+        catch (TrinoException e) {
+            throw e;
+        }
         catch (SQLException | JsonProcessingException e) {
             throw new TrinoException(STAR_ROCKS_WRITE_ERROR, e);
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(STAR_ROCKS_WRITE_ERROR, "Failed to serialize page for Stream Load", e);
         }
         return NOT_BLOCKED;
     }
@@ -118,14 +124,23 @@ public class StarRocksPageSink
             objectNode.put(columnName, type.getSlice(block, position).toStringUtf8());
         }
         else {
-            objectNode.put(columnName, type.getObject(block, position).toString());
+            Object object = type.getObject(block, position);
+            objectNode.put(columnName, object == null ? null : object.toString());
         }
     }
 
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        applier.close();
+        try {
+            applier.close();
+        }
+        catch (TrinoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(STAR_ROCKS_WRITE_ERROR, "Failed to finalize Stream Load", e);
+        }
         return completedFuture(ImmutableList.of(Slices.wrappedLongArray(pageSinkId.getId())));
     }
 
@@ -133,5 +148,8 @@ public class StarRocksPageSink
     @Override
     public void abort()
     {
+        // StarRocks Stream Load is label-based and the FE will eventually garbage
+        // collect aborted labels on its own. We don't have a cheap synchronous
+        // cancel, but future partial-write cleanup can hook here.
     }
 }

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPageSinkProvider.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPageSinkProvider.java
@@ -15,6 +15,7 @@
 package io.trino.plugin.starrocks;
 
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
@@ -26,7 +27,7 @@ import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import static java.util.Objects.requireNonNull;
 
@@ -55,8 +56,9 @@ public class StarRocksPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
         StarRocksOutputTableHandle starRocksOutputTableHandle = (StarRocksOutputTableHandle) tableHandle;
+        RemoteTableName remoteTableName = starRocksOutputTableHandle.getRemoteTableName();
         StarRocksOperationApplier applier = new StarRocksOperationApplier(
-                starRocksOutputTableHandle.getSchemaName(), starRocksOutputTableHandle.getTableName(), starRocksOutputTableHandle.getTemporaryTableName(), starRocksOutputTableHandle.getColumnNames(), starRocksOutputTableHandle.getIsPkTable(), streamLoadProperties, clientBuilder);
+                remoteTableName.getSchemaName().orElse(null), remoteTableName.getTableName(), starRocksOutputTableHandle.getTemporaryTableName(), starRocksOutputTableHandle.getColumnNames(), starRocksOutputTableHandle.getIsPkTable(), streamLoadProperties, clientBuilder);
         return new StarRocksPageSink(starRocksOutputTableHandle, applier, pageSinkId);
     }
 
@@ -64,8 +66,9 @@ public class StarRocksPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle, ConnectorPageSinkId pageSinkId)
     {
         StarRocksOutputTableHandle starRocksOutputTableHandle = (StarRocksOutputTableHandle) tableHandle;
+        RemoteTableName remoteTableName = starRocksOutputTableHandle.getRemoteTableName();
         StarRocksOperationApplier applier = new StarRocksOperationApplier(
-                starRocksOutputTableHandle.getSchemaName(), starRocksOutputTableHandle.getTableName(), starRocksOutputTableHandle.getTemporaryTableName(), starRocksOutputTableHandle.getColumnNames(), starRocksOutputTableHandle.getIsPkTable(), streamLoadProperties, clientBuilder);
+                remoteTableName.getSchemaName().orElse(null), remoteTableName.getTableName(), starRocksOutputTableHandle.getTemporaryTableName(), starRocksOutputTableHandle.getColumnNames(), starRocksOutputTableHandle.getIsPkTable(), streamLoadProperties, clientBuilder);
         return new StarRocksPageSink(starRocksOutputTableHandle, applier, pageSinkId);
     }
 }

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPlugin.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksPlugin.java
@@ -21,6 +21,6 @@ public class StarRocksPlugin
 {
     public StarRocksPlugin()
     {
-        super("starrocks", new StarRocksClientModule());
+        super("starrocks", StarRocksClientModule::new);
     }
 }

--- a/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksWriteSessionProperties.java
+++ b/contrib/trino-connector/src/main/java/io/trino/plugin/starrocks/StarRocksWriteSessionProperties.java
@@ -20,7 +20,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.util.List;
 


### PR DESCRIPTION
## Why I'm doing:

The Trino connector (`contrib/trino-connector`) was built against Trino SPI 418 and fails to load on Trino 479 clusters due to:
1. **SPI version mismatch**: `Trino SPI version 479 does not match the version 418 connector starrocks was compiled for`
2. **Guice injection failure**: `No injectable constructor for type StarRocksClient` — Guice 7 requires `com.google.inject.Inject` instead of `javax.inject.Inject`
3. **Missing class**: `NoClassDefFoundError: io/airlift/configuration/secrets/SecretsResolver` — airlift 386 added this class
4. **Null COLUMN_SIZE**: `IllegalStateException: column size not present` — StarRocks returns null `COLUMN_SIZE` in JDBC metadata for `STRING`, `JSON`, and other types

## What I'm doing:

### Dependency upgrades (pom.xml)
- Trino SPI: 418 → 479
- airlift: 230 → 386
- guava: 32.0.0-jre → 33.5.0-jre
- guice: 6.0.0 → 7.0.0
- opentelemetry: 1.26.0 → 1.57.0 (+ `opentelemetry-api-incubator` added as provided)
- jackson: 2.15.0 → 2.18.6
- airlift units: 1.8 → 1.12
- antlr: 4.12.0 → 4.13.2

### Code changes
- **javax.inject → com.google.inject**: Guice 7 no longer scans `javax.inject.Inject`; migrated all 3 files (`StarRocksClient`, `StarRocksPageSinkProvider`, `StarRocksWriteSessionProperties`)
- **Trino 479 SPI adaptations**: Record accessor changes (`getColumn()` → `column()`, `getSortOrder()` → `sortOrder()`), `RemoteIdentifiers` parameter, `Plugin.getConnectorFactories()` signature
- **Null COLUMN_SIZE fallback** in `StarRocksClient.getColumns()`: StarRocks doesn't always return `COLUMN_SIZE` in JDBC `DatabaseMetaData.getColumns()` for types like `STRING` and `JSON`. Added safe defaults per type (`CHAR` → 255, `TIME` → 8, `TIMESTAMP` → 19, others → `Integer.MAX_VALUE`)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior
- [x] No, this PR will not result in a change in behavior

## Related issues

Fixes compatibility with Trino 479. Previously only worked with Trino 418.