### PR TITLE
[Tool] Fallback to main clang-format helper for old branches

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -57,19 +57,16 @@ jobs:
           CLANG_FORMAT_BINARY: /usr/local/bin/clang-format-10
           FORMAT_BASE_REF: upstream/${{ github.base_ref }}
         run: |
-          if [[ -f build-support/clang-format-changed.sh ]]; then
-            bash build-support/clang-format-changed.sh
-            exit 0
-          fi
-
-          echo "build-support/clang-format-changed.sh not found on this branch; using upstream/main helpers."
-
           fetched_files=(
             "build-support/clang-format-changed.sh"
             "build-support/format_changed_files.py"
           )
           cleanup_files=()
           trap 'rm -f "${cleanup_files[@]}"' EXIT
+
+          if [[ ! -f build-support/clang-format-changed.sh || ! -f build-support/format_changed_files.py ]]; then
+            echo "clang-format helpers missing on this branch; fetching missing files from upstream/main."
+          fi
 
           for path in "${fetched_files[@]}"; do
             if [[ -f "${path}" ]]; then

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -166,6 +166,6 @@ jobs:
             else
               echo "::error::Same-repo push failed unexpectedly. Check repository permissions."
             fi
-            echo "::error::To fix locally: if [ -f build-support/clang-format-changed.sh ] && [ -f build-support/format_changed_files.py ]; then CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format-changed.sh; else CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format.sh; fi"
+            echo "::error::To fix locally: CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format.sh"
             exit 1
           fi

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -56,32 +56,70 @@ jobs:
         env:
           CLANG_FORMAT_BINARY: /usr/local/bin/clang-format-10
           FORMAT_BASE_REF: upstream/${{ github.base_ref }}
-          FALLBACK_HELPER_REF: e8fb00c3b4346229d0916c9d6243b94a63d8237e
         run: |
           fetched_files=(
-            "build-support/clang-format-changed.sh"
             "build-support/format_changed_files.py"
             "build-support/run_clang_format.py"
             "build-support/lintutils.py"
             "build-support/excludes"
           )
-          helper_root=$(mktemp -d)
+          helper_dir=$(mktemp -d)
           cleanup() {
-            rm -rf "${helper_root}"
+            rm -rf "${helper_dir}"
           }
           trap cleanup EXIT
 
-          ln -s "${GITHUB_WORKSPACE}/.git" "${helper_root}/.git"
-          ln -s "${GITHUB_WORKSPACE}/be" "${helper_root}/be"
-          ln -s "${GITHUB_WORKSPACE}/.clang-format" "${helper_root}/.clang-format"
-
           for path in "${fetched_files[@]}"; do
-            mkdir -p "$(dirname "${helper_root}/${path}")"
-            git show "${FALLBACK_HELPER_REF}:${path}" > "${helper_root}/${path}"
+            mkdir -p "$(dirname "${helper_dir}/${path}")"
+            git show "upstream/main:${path}" > "${helper_dir}/${path}"
           done
 
-          chmod +x "${helper_root}/build-support/clang-format-changed.sh"
-          "${helper_root}/build-support/clang-format-changed.sh"
+          excludes_file="${helper_dir}/build-support/excludes"
+          source_dirs="${GITHUB_WORKSPACE}/be/src,${GITHUB_WORKSPACE}/be/test"
+
+          if ! git rev-parse --verify "${FORMAT_BASE_REF}" >/dev/null 2>&1; then
+            echo "${FORMAT_BASE_REF} not found; formatting all C++ files."
+            python3 "${helper_dir}/build-support/run_clang_format.py" \
+              --clang_format_binary="${CLANG_FORMAT_BINARY}" \
+              --fix \
+              --source_dirs="${source_dirs}" \
+              --exclude_globs="${excludes_file}"
+            exit 0
+          fi
+
+          changed_files=$(
+            {
+              git diff --name-only --diff-filter=ACMR "${FORMAT_BASE_REF}...HEAD"
+              git diff --name-only --diff-filter=ACMR --cached -- be
+              git diff --name-only --diff-filter=ACMR -- be
+            } | sort -u
+          )
+
+          if [[ -z "${changed_files}" ]]; then
+            echo "No files changed since ${FORMAT_BASE_REF}."
+            exit 0
+          fi
+
+          tmpfile=$(mktemp)
+          trap 'rm -f "${tmpfile}"; rm -rf "${helper_dir}"' EXIT
+
+          python3 "${helper_dir}/build-support/format_changed_files.py" \
+            --repo_root "${GITHUB_WORKSPACE}" \
+            --exclude_globs "${excludes_file}" \
+            --source_dirs "${source_dirs}" \
+            --null < <(printf '%s\n' "${changed_files}") > "${tmpfile}"
+
+          if [[ ! -s "${tmpfile}" ]]; then
+            echo "No changed C++ files to format since ${FORMAT_BASE_REF}."
+            exit 0
+          fi
+
+          echo "C++ files to format:"
+          while IFS= read -r -d '' filename; do
+            echo "${filename}"
+          done < "${tmpfile}"
+
+          xargs -0 -n 16 "${CLANG_FORMAT_BINARY}" -style=file -i < "${tmpfile}"
 
       - name: Commit and push formatting fixes
         env:

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -61,20 +61,29 @@ jobs:
             "build-support/clang-format-changed.sh"
             "build-support/format_changed_files.py"
           )
-          cleanup_files=()
-          trap 'rm -f "${cleanup_files[@]}"' EXIT
-
-          if [[ ! -f build-support/clang-format-changed.sh || ! -f build-support/format_changed_files.py ]]; then
-            echo "clang-format helpers missing on this branch; fetching missing files from upstream/main."
-          fi
+          backup_dir=$(mktemp -d)
+          cleanup() {
+            for path in "${fetched_files[@]}"; do
+              backup_path="${backup_dir}/${path}"
+              if [[ -f "${backup_path}" ]]; then
+                mkdir -p "$(dirname "${path}")"
+                cp "${backup_path}" "${path}"
+              else
+                rm -f "${path}"
+              fi
+            done
+            rm -rf "${backup_dir}"
+          }
+          trap cleanup EXIT
 
           for path in "${fetched_files[@]}"; do
+            backup_path="${backup_dir}/${path}"
+            mkdir -p "$(dirname "${backup_path}")"
             if [[ -f "${path}" ]]; then
-              continue
+              cp "${path}" "${backup_path}"
             fi
             mkdir -p "$(dirname "${path}")"
             git show "upstream/main:${path}" > "${path}"
-            cleanup_files+=("${path}")
           done
 
           chmod +x build-support/clang-format-changed.sh

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -56,38 +56,32 @@ jobs:
         env:
           CLANG_FORMAT_BINARY: /usr/local/bin/clang-format-10
           FORMAT_BASE_REF: upstream/${{ github.base_ref }}
+          FALLBACK_HELPER_REF: e8fb00c3b4346229d0916c9d6243b94a63d8237e
         run: |
           fetched_files=(
             "build-support/clang-format-changed.sh"
             "build-support/format_changed_files.py"
+            "build-support/run_clang_format.py"
+            "build-support/lintutils.py"
+            "build-support/excludes"
           )
-          backup_dir=$(mktemp -d)
+          helper_root=$(mktemp -d)
           cleanup() {
-            for path in "${fetched_files[@]}"; do
-              backup_path="${backup_dir}/${path}"
-              if [[ -f "${backup_path}" ]]; then
-                mkdir -p "$(dirname "${path}")"
-                cp "${backup_path}" "${path}"
-              else
-                rm -f "${path}"
-              fi
-            done
-            rm -rf "${backup_dir}"
+            rm -rf "${helper_root}"
           }
           trap cleanup EXIT
 
+          ln -s "${GITHUB_WORKSPACE}/.git" "${helper_root}/.git"
+          ln -s "${GITHUB_WORKSPACE}/be" "${helper_root}/be"
+          ln -s "${GITHUB_WORKSPACE}/.clang-format" "${helper_root}/.clang-format"
+
           for path in "${fetched_files[@]}"; do
-            backup_path="${backup_dir}/${path}"
-            mkdir -p "$(dirname "${backup_path}")"
-            if [[ -f "${path}" ]]; then
-              cp "${path}" "${backup_path}"
-            fi
-            mkdir -p "$(dirname "${path}")"
-            git show "upstream/main:${path}" > "${path}"
+            mkdir -p "$(dirname "${helper_root}/${path}")"
+            git show "${FALLBACK_HELPER_REF}:${path}" > "${helper_root}/${path}"
           done
 
-          chmod +x build-support/clang-format-changed.sh
-          bash build-support/clang-format-changed.sh
+          chmod +x "${helper_root}/build-support/clang-format-changed.sh"
+          "${helper_root}/build-support/clang-format-changed.sh"
 
       - name: Commit and push formatting fixes
         env:
@@ -116,6 +110,6 @@ jobs:
             else
               echo "::error::Same-repo push failed unexpectedly. Check repository permissions."
             fi
-            echo "::error::To fix locally: CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format-changed.sh"
+            echo "::error::To fix locally: if [ -f build-support/clang-format-changed.sh ] && [ -f build-support/format_changed_files.py ]; then CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format-changed.sh; else CLANG_FORMAT_BINARY=clang-format-10 bash build-support/clang-format.sh; fi"
             exit 1
           fi

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -56,6 +56,8 @@ jobs:
         env:
           CLANG_FORMAT_BINARY: /usr/local/bin/clang-format-10
           FORMAT_BASE_REF: upstream/${{ github.base_ref }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           fetched_files=(
             "build-support/format_changed_files.py"
@@ -69,9 +71,25 @@ jobs:
           }
           trap cleanup EXIT
 
+          pr_changed_paths=$(
+            git diff --name-only --diff-filter=ACMR "${FORMAT_BASE_REF}...HEAD" | sort -u
+          )
+
           for path in "${fetched_files[@]}"; do
             mkdir -p "$(dirname "${helper_dir}/${path}")"
-            git show "upstream/main:${path}" > "${helper_dir}/${path}"
+            if [[ "${HEAD_REPO}" == "${BASE_REPO}" ]] && printf '%s\n' "${pr_changed_paths}" | grep -Fxq "${path}"; then
+              if [[ -L "${path}" ]]; then
+                echo "::error::Refusing to load helper from symlinked path ${path}"
+                exit 1
+              fi
+              if [[ ! -f "${path}" ]]; then
+                echo "::error::Expected helper file ${path} to exist in the PR workspace"
+                exit 1
+              fi
+              cp "${path}" "${helper_dir}/${path}"
+            else
+              git show "upstream/main:${path}" > "${helper_dir}/${path}"
+            fi
           done
 
           excludes_file="${helper_dir}/build-support/excludes"

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -45,7 +45,7 @@ jobs:
           BASE_REPO: ${{ github.repository }}
         run: |
           git remote add upstream "https://github.com/${BASE_REPO}.git"
-          git fetch upstream "${BASE_REF}"
+          git fetch upstream "${BASE_REF}" main
 
       - name: Install clang-format-10
         run: |
@@ -56,7 +56,32 @@ jobs:
         env:
           CLANG_FORMAT_BINARY: /usr/local/bin/clang-format-10
           FORMAT_BASE_REF: upstream/${{ github.base_ref }}
-        run: bash build-support/clang-format-changed.sh
+        run: |
+          if [[ -f build-support/clang-format-changed.sh ]]; then
+            bash build-support/clang-format-changed.sh
+            exit 0
+          fi
+
+          echo "build-support/clang-format-changed.sh not found on this branch; using upstream/main helpers."
+
+          fetched_files=(
+            "build-support/clang-format-changed.sh"
+            "build-support/format_changed_files.py"
+          )
+          cleanup_files=()
+          trap 'rm -f "${cleanup_files[@]}"' EXIT
+
+          for path in "${fetched_files[@]}"; do
+            if [[ -f "${path}" ]]; then
+              continue
+            fi
+            mkdir -p "$(dirname "${path}")"
+            git show "upstream/main:${path}" > "${path}"
+            cleanup_files+=("${path}")
+          done
+
+          chmod +x build-support/clang-format-changed.sh
+          bash build-support/clang-format-changed.sh
 
       - name: Commit and push formatting fixes
         env:

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,9 +71,17 @@ jobs:
           }
           trap cleanup EXIT
 
-          pr_changed_paths=$(
-            git diff --name-only --diff-filter=ACMR "${FORMAT_BASE_REF}...HEAD" | sort -u
-          )
+          base_ref_exists=true
+          if ! git rev-parse --verify "${FORMAT_BASE_REF}" >/dev/null 2>&1; then
+            base_ref_exists=false
+          fi
+
+          pr_changed_paths=""
+          if [[ "${base_ref_exists}" == "true" ]]; then
+            pr_changed_paths=$(
+              git diff --name-only --diff-filter=ACMR "${FORMAT_BASE_REF}...HEAD" | sort -u
+            )
+          fi
 
           for path in "${fetched_files[@]}"; do
             mkdir -p "$(dirname "${helper_dir}/${path}")"
@@ -95,7 +103,7 @@ jobs:
           excludes_file="${helper_dir}/build-support/excludes"
           source_dirs="${GITHUB_WORKSPACE}/be/src,${GITHUB_WORKSPACE}/be/test"
 
-          if ! git rev-parse --verify "${FORMAT_BASE_REF}" >/dev/null 2>&1; then
+          if [[ "${base_ref_exists}" != "true" ]]; then
             echo "${FORMAT_BASE_REF} not found; formatting all C++ files."
             python3 "${helper_dir}/build-support/run_clang_format.py" \
               --clang_format_binary="${CLANG_FORMAT_BINARY}" \


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
