### PR TITLE
[Enhancement] Add log for update compaction suspension

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -390,6 +390,20 @@ void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data
             continue;
         }
 
+        if (!status.ok()) {
+            if (!status.is_not_found()) {
+                LOG_EVERY_N(INFO, 10) << "Update compaction suspended because of status: " << status
+                                      << ", data_dir: " << data_dir->path();
+            }
+        } else {
+            LOG_EVERY_N(INFO, 10) << "Update compaction suspended because memory limit exceeded. "
+                                  << "Compaction mem tracker limit exceeded: "
+                                  << _options.compaction_mem_tracker->any_limit_exceeded()
+                                  << ", Update mem tracker limit exceeded: "
+                                  << _options.update_mem_tracker->any_limit_exceeded()
+                                  << ", data_dir: " << data_dir->path();
+        }
+
         int32_t interval = config::update_compaction_check_interval_seconds;
         if (interval <= 0) {
             LOG(WARNING) << "update compaction check interval config is illegal: " << interval << ", force set to 1";
@@ -401,6 +415,12 @@ void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data
                 !_options.update_mem_tracker->any_limit_exceeded()) {
                 break;
             }
+            LOG_EVERY_N(INFO, 10) << "Update compaction still suspended due to memory limit"
+                                  << ", Compaction mem tracker limit exceeded: "
+                                  << _options.compaction_mem_tracker->any_limit_exceeded()
+                                  << ", Update mem tracker limit exceeded: "
+                                  << _options.update_mem_tracker->any_limit_exceeded()
+                                  << ", data_dir: " << data_dir->path();
         } while (true);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Currently, when the `_update_compaction_thread_callback` thread suspends update compaction due to disk capacity limits or memory limits, it happens silently. This makes it difficult to troubleshoot why update compaction is not executing for Primary Key tables.

## What I'm doing:

Add `LOG_EVERY_N` in `StorageEngine::_update_compaction_thread_callback` to print:
1. The detailed status message when compaction is stopped (e.g. data dir out of capacity).
2. The specific memory tracker (`compaction_mem_tracker` or `update_mem_tracker`) that caused the memory limit exceeded suspension.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
