### PR TITLE
[BugFix] Fix BE crash when child iterator is exhausted in MaskMergeIterator

### DIFF
--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -497,6 +497,10 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
         RowSourceMask mask = _mask_buffer->current();
         uint16_t child = mask.get_source_num();
         auto& min_chunk = _chunks[child];
+        if (min_chunk._chunk == nullptr) {
+            return Status::InternalError(strings::Substitute(
+                    "Mask buffer expects more rows from child $0, but child iterator is exhausted", child));
+        }
         DCHECK_GT(min_chunk.remaining_rows(), 0);
 
         size_t offset = min_chunk.compared_row();
@@ -584,8 +588,10 @@ inline Status MaskMergeIterator::fill(size_t child) {
     } else if (st.is_end_of_file()) {
         // ignore Status::EndOfFile.
         close_child(child);
+        _chunks[child]._chunk = nullptr;
     } else {
         close_child(child);
+        _chunks[child]._chunk = nullptr;
         return st;
     }
     return Status::OK();

--- a/be/test/storage/merge_iterator_test.cpp
+++ b/be/test/storage/merge_iterator_test.cpp
@@ -367,4 +367,41 @@ TEST_F(MergeIteratorTest, mask_merge_boundary_test) {
     }
 }
 
+TEST_F(MergeIteratorTest, mask_merge_exhausted_iterator) {
+    std::vector<int32_t> v1{1, 2}; // Only 2 elements
+    std::vector<int32_t> v2{10, 11};
+    auto sub1 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v1));
+    auto sub2 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(v2));
+
+    std::vector<RowSourceMask> source_masks;
+    // Request 3 elements from source 0, but it only has 2 elements.
+    // This matches the exhausted iterator scenario that caused nullptr dereference.
+    std::vector<uint16_t> expected_sources{0, 0, 0, 1, 1};
+    for (unsigned short expected_source : expected_sources) {
+        source_masks.emplace_back(RowSourceMask(expected_source, false));
+    }
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    mask_buffer.write(source_masks);
+    mask_buffer.flush();
+    mask_buffer.flip_to_read();
+    source_masks.clear();
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub1, sub2}, &mask_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+
+    ChunkPtr chunk = ChunkHelper::new_chunk(iter->schema(), config::vector_chunk_size);
+    Status st;
+    while (true) {
+        chunk->reset();
+        st = iter->get_next(chunk.get(), &source_masks);
+        if (!st.ok()) {
+            break;
+        }
+    }
+    // Should return InternalError instead of crashing
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_internal_error());
+    ASSERT_TRUE(st.message().find("child iterator is exhausted") != std::string::npos);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

In vertical compaction, the key columns and non-key columns might have mismatched row counts due to some bugs. 
When this happens, `MaskMergeIterator` reads according to the `mask_buffer` generated from the key columns' horizontal merge. 
If a non-key segment iterator is exhausted earlier than expected, `MaskMergeIterator::fill` would close the child iterator but leave a dangling or null pointer in `_chunks[child]._chunk`. The main loop in `do_get_next` would then blindly dereference this pointer, leading to a BE crash (Dereference null pointer).

## What I'm doing:

1. In `MaskMergeIterator::fill`, explicitly set `_chunks[child]._chunk = nullptr` when the child iterator reaches EOF or an error occurs.
2. In `MaskMergeIterator::do_get_next`, add a safeguard check for `min_chunk._chunk == nullptr`. If the mask buffer expects more rows but the child iterator is already exhausted, it will return `Status::InternalError` instead of crashing. This allows the compaction task to fail gracefully and surface the underlying data mismatch issue.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
