### PR TITLE
[BugFix] Fix StarRocksPlannerException when GROUP BY column statistics are missing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -16,11 +16,11 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +32,8 @@ import java.util.Set;
 import static java.lang.Double.NaN;
 
 public class Statistics {
+    private static final Logger LOG = LogManager.getLogger(Statistics.class);
+
     private final double outputRowCount;
     private final Map<ColumnRefOperator, ColumnStatistic> columnStatistics;
     // This flag set true if get table row count from GlobalStateMgr LE 1
@@ -128,13 +130,13 @@ public class Statistics {
     }
 
     public ColumnStatistic getColumnStatistic(ColumnRefOperator column) {
-        if (columnStatistics.get(column) == null) {
-            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
-                    "only found column statistics: %s, but missing statistic of col: %s.",
-                    ColumnRefOperator.toString(columnStatistics.keySet()), column);
-        } else {
-            return columnStatistics.get(column);
+        ColumnStatistic result = columnStatistics.get(column);
+        if (result == null) {
+            LOG.warn("Missing column statistic for col: {}, available: {}",
+                    column, ColumnRefOperator.toString(columnStatistics.keySet()));
+            return ColumnStatistic.unknown();
         }
+        return result;
     }
 
     public Map<ColumnRefOperator, ColumnStatistic> getColumnStatistics() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -28,7 +28,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.expression.BinaryType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
@@ -690,7 +689,7 @@ public class StatisticsCalculatorTest {
     }
 
     @Test
-    public void testNotFoundColumnStatistics() {
+    public void testNotFoundColumnStatisticsReturnsUnknown() {
         ColumnRefOperator v1 = columnRefFactory.create("v1", IntegerType.INT, true);
         ColumnRefOperator v2 = columnRefFactory.create("v2", IntegerType.INT, true);
 
@@ -700,7 +699,57 @@ public class StatisticsCalculatorTest {
         builder.addColumnStatistics(ImmutableMap.of(v1, new ColumnStatistic(0, 100, 0, 10, 50)));
         builder.addColumnStatistics(ImmutableMap.of(v2, new ColumnStatistic(0, 100, 0, 10, 50)));
         Statistics statistics = builder.build();
-        Assertions.assertThrows(StarRocksPlannerException.class, () -> statistics.getColumnStatistic(v3));
+        ColumnStatistic result = statistics.getColumnStatistic(v3);
+        Assertions.assertTrue(result.isUnknown());
+    }
+
+    @Test
+    public void testComputeGroupByStatisticsWithMissingColumn() {
+        ColumnRefOperator v1 = columnRefFactory.create("v1", IntegerType.INT, true);
+        ColumnRefOperator v2 = columnRefFactory.create("v2", IntegerType.INT, true);
+        ColumnRefOperator v3 = columnRefFactory.create("v3", IntegerType.INT, true);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(10000);
+        builder.addColumnStatistics(ImmutableMap.of(v1, new ColumnStatistic(0, 100, 0, 10, 50)));
+        builder.addColumnStatistics(ImmutableMap.of(v2, new ColumnStatistic(0, 100, 0, 10, 50)));
+        Statistics inputStatistics = builder.build();
+
+        List<ColumnRefOperator> groupBys = Lists.newArrayList(v1, v2, v3);
+        Map<ColumnRefOperator, ColumnStatistic> groupStatisticsMap = new HashMap<>();
+        double rowCount = StatisticsCalculator.computeGroupByStatistics(groupBys, inputStatistics,
+                groupStatisticsMap);
+
+        Assertions.assertEquals(3, groupStatisticsMap.size());
+        Assertions.assertTrue(groupStatisticsMap.get(v3).isUnknown());
+        Assertions.assertTrue(rowCount > 0);
+    }
+
+    @Test
+    public void testAggregationWithMissingGroupByColumnStats() throws Exception {
+        ColumnRefOperator v1 = columnRefFactory.create("v1", IntegerType.INT, true);
+        ColumnRefOperator v2 = columnRefFactory.create("v2", IntegerType.INT, true);
+        ColumnRefOperator v3 = columnRefFactory.create("v3", DateType.DATETIME, true);
+
+        Statistics.Builder childBuilder = Statistics.builder();
+        childBuilder.setOutputRowCount(10000);
+        childBuilder.addColumnStatistics(ImmutableMap.of(v1, new ColumnStatistic(0, 100, 0, 10, 50)));
+        childBuilder.addColumnStatistics(ImmutableMap.of(v2, new ColumnStatistic(0, 100, 0, 10, 50)));
+
+        Group childGroup = new Group(0);
+        childGroup.setStatistics(childBuilder.build());
+
+        List<ColumnRefOperator> groupByColumns = Lists.newArrayList(v1, v2, v3);
+        Map<ColumnRefOperator, CallOperator> aggCall = new HashMap<>();
+
+        LogicalAggregationOperator aggNode = new LogicalAggregationOperator(AggType.GLOBAL, groupByColumns, aggCall);
+        GroupExpression groupExpression = new GroupExpression(aggNode, Lists.newArrayList(childGroup));
+        groupExpression.setGroup(new Group(1));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+        StatisticsCalculator statisticsCalculator = new StatisticsCalculator(expressionContext,
+                columnRefFactory, optimizerContext);
+        statisticsCalculator.estimatorStats();
+        Assertions.assertTrue(expressionContext.getStatistics().getOutputRowCount() > 0);
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3488,4 +3488,17 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: count(*)\n" +
                 "  |  group by: ");
     }
+
+    @Test
+    public void testGroupByFunctionExpressionNoStatisticsError() throws Exception {
+        String sql = "SELECT COUNT(*) FROM (" +
+                "SELECT t1a, t1b, DATE(id_datetime) AS dt, " +
+                "SUM(t1c) AS sum_c, " +
+                "IFNULL(SUM(CASE WHEN t1b > 0 THEN id_decimal ELSE 0 END), 0) AS cond_sum " +
+                "FROM test_all_type " +
+                "WHERE id_datetime BETWEEN '2014-01-01' AND '2014-12-01' " +
+                "GROUP BY t1a, t1b, DATE(id_datetime)) tmp";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "AGGREGATE");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`Statistics.getColumnStatistic()` throws a `StarRocksPlannerException` when a `ColumnRefOperator` is not found in its internal statistics map. This can happen in multiple scenarios, notably when `GROUP BY` uses a function expression like `DATE(col)` and the base column's statistics are not propagated through optimizer plan transformations.

The error manifests as:
```
ERROR 1064 (HY000): only found column statistics: {184: vname, ...}, but missing statistic of col: 187: drama_first_cost_time
```

There are **15+ call sites** across `StatisticsCalculator`, `ExpressionStatisticCalculator`, `PredicateStatisticsCalculator`, and various optimizer rules that all call `getColumnStatistic()`. Fixing them individually is fragile and incomplete.

## What I'm doing:

Fix the root method `Statistics.getColumnStatistic()` to return `ColumnStatistic.unknown()` with a WARN log instead of throwing an exception. This allows the optimizer to gracefully degrade to default estimates rather than failing the query.

### Changes:
- **Statistics.java**: Replace the exception-throwing behavior with graceful fallback to `ColumnStatistic.unknown()` and a WARN-level log message for diagnostics.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor

## Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

When a column's statistics are missing from the optimizer's internal `Statistics` object, the query will now proceed with unknown/default estimates instead of failing with a `StarRocksPlannerException`. This may produce slightly different (but still valid) execution plans in edge cases, while preventing query failures.

## How has this PR been tested?

- **Unit Tests**:
  - `StatisticsCalculatorTest#testNotFoundColumnStatisticsReturnsUnknown`: Verifies `getColumnStatistic()` returns `ColumnStatistic.unknown()` instead of throwing.
  - `StatisticsCalculatorTest#testComputeGroupByStatisticsWithMissingColumn`: Tests `computeGroupByStatistics` with a GROUP BY column missing from input statistics.
  - `StatisticsCalculatorTest#testAggregationWithMissingGroupByColumnStats`: End-to-end test through `estimatorStats()` with missing GROUP BY column statistics.
- **SQL Integration Test**:
  - `AggregateTest#testGroupByFunctionExpressionNoStatisticsError`: Tests `EXPLAIN` of a query with `GROUP BY DATE(id_datetime)`.
- **Reverse Verification**: Confirmed that without the fix, the tests fail with the exact `StarRocksPlannerException`; with the fix, all tests pass.