### PR TITLE
[Enhancement] Support get LVM disk info

### DIFF
--- a/be/src/common/system/disk_info.cpp
+++ b/be/src/common/system/disk_info.cpp
@@ -31,12 +31,24 @@
 #endif
 
 #include <boost/algorithm/string.hpp>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "gutil/strings/split.h"
 
 namespace starrocks {
+
+#ifdef BE_TEST
+const char* k_ut_partitions_path = nullptr; // NOLINT
+const char* k_ut_mounts_path = nullptr;     // NOLINT
+#endif
 
 bool DiskInfo::_s_initialized;
 std::vector<DiskInfo::Disk> DiskInfo::_s_disks;
@@ -50,7 +62,12 @@ int DiskInfo::_s_num_datanode_dirs;
 void DiskInfo::get_device_names() {
     // Format of this file is:
     //    major, minor, #blocks, name
-    std::ifstream partitions("/proc/partitions", std::ios::in);
+#ifdef BE_TEST
+    const char* partitions_path = (k_ut_partitions_path != nullptr) ? k_ut_partitions_path : "/proc/partitions";
+#else
+    const char* partitions_path = "/proc/partitions";
+#endif
+    std::ifstream partitions(partitions_path, std::ios::in);
 
     while (partitions.good() && !partitions.eof()) {
         std::string line;
@@ -128,7 +145,9 @@ void DiskInfo::init() {
 
 int DiskInfo::disk_id(const char* path) {
     struct stat s;
-    stat(path, &s);
+    if (stat(path, &s) != 0) {
+        return -1;
+    }
     auto it = _s_device_id_to_disk_id.find(s.st_dev);
 
     if (it == _s_device_id_to_disk_id.end()) {
@@ -154,6 +173,109 @@ std::string DiskInfo::debug_string() {
 
     stream << std::endl;
     return stream.str();
+}
+
+bool DiskInfo::is_known_disk_device_name(const std::string& dev) {
+    for (int i = 0; i < num_disks(); ++i) {
+        if (device_name(i) == dev) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths, std::set<std::string>* devices) {
+    std::vector<std::string> real_paths;
+    real_paths.reserve(paths.size());
+    for (const auto& path : paths) {
+        char real_path[PATH_MAX];
+        if (realpath(path.c_str(), real_path) == nullptr) {
+            PLOG(WARNING) << "canonicalize path " << path << " failed, skip disk monitoring of this path";
+            continue;
+        }
+        real_paths.emplace_back(real_path);
+    }
+
+#ifdef BE_TEST
+    FILE* fp = fopen(k_ut_mounts_path ? k_ut_mounts_path : "/proc/mounts", "r");
+#else
+    FILE* fp = fopen("/proc/mounts", "r");
+#endif
+    if (fp == nullptr) {
+        std::stringstream ss;
+        char buf[64];
+        ss << "open /proc/mounts failed, errno:" << errno << ", message:" << strerror_r(errno, buf, 64);
+        LOG(WARNING) << ss.str();
+        return Status::InternalError(ss.str());
+    }
+
+    Status status;
+    char* line_ptr = nullptr;
+    size_t line_buf_size = 0;
+    for (const auto& path : real_paths) {
+        size_t max_mount_size = 0;
+        std::string match_dev;
+        rewind(fp);
+        while (getline(&line_ptr, &line_buf_size, fp) > 0) {
+            char dev_path[4096];
+            char mount_path[4096];
+            int num = sscanf(line_ptr, "%4095s %4095s", dev_path, mount_path);
+            if (num < 2) {
+                continue;
+            }
+            size_t mount_size = strlen(mount_path);
+            if (mount_size < max_mount_size || path.size() < mount_size ||
+                strncmp(path.c_str(), mount_path, mount_size) != 0) {
+                continue;
+            }
+            // Longest-prefix match: pick the most specific mount point for the
+            // storage path. However, a pure prefix match can produce a false
+            // positive when the storage path shares a string prefix with a mount
+            // point but is not actually under it. For example, given:
+            //   /proc/mounts:  "/" -> sda
+            //                  "/data" -> sdb
+            //   storage path:  "/data2/starrocks"
+            // strncmp would match "/data" (len=5) and select sdb, even though
+            // "/data2" is not a child of "/data" — the correct mount is "/" (sda).
+            // Guard against this by requiring that the character immediately after
+            // the mount prefix in the storage path is either '/' or '\0'.
+            if (path.size() > mount_size && path[mount_size] != '/') {
+                continue;
+            }
+            std::string dev = std::filesystem::path(dev_path).filename().string();
+            if (is_known_disk_device_name(dev)) {
+                max_mount_size = mount_size;
+                match_dev = std::move(dev);
+            } else {
+                // Fallback for LVM and other device-mapper setups where basename of the
+                // device path (e.g. "/dev/mapper/localssd-localssd--lv") does not appear in _s_disk_name_to_disk_id.
+                // stat() the mount point to obtain the kernel device number (major:minor),
+                // then look it up in _s_device_id_to_disk_id which is keyed by dev_t
+                // and covers dm-* entries from /proc/partitions.
+                int id = disk_id(mount_path);
+                if (id >= 0) {
+                    max_mount_size = mount_size;
+                    match_dev = device_name(id);
+                }
+            }
+        }
+        if (ferror(fp) != 0) {
+            std::stringstream ss;
+            char buf[64];
+            ss << "open /proc/mounts failed, errno:" << errno << ", message:" << strerror_r(errno, buf, 64);
+            LOG(WARNING) << ss.str();
+            status = Status::InternalError(ss.str());
+            break;
+        }
+        if (max_mount_size > 0) {
+            devices->emplace(match_dev);
+        }
+    }
+    if (line_ptr != nullptr) {
+        free(line_ptr);
+    }
+    fclose(fp);
+    return status;
 }
 
 } // namespace starrocks

--- a/be/src/common/system/disk_info.h
+++ b/be/src/common/system/disk_info.h
@@ -36,11 +36,13 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "common/logging.h"
+#include "common/status.h"
 
 namespace starrocks {
 
@@ -95,6 +97,9 @@ public:
 
     static std::string debug_string();
 
+    // get disk devices of given path
+    static Status get_disk_devices(const std::vector<std::string>& paths, std::set<std::string>* devices);
+
 private:
     static bool _s_initialized;
 
@@ -127,6 +132,7 @@ private:
     static int _s_num_datanode_dirs;
 
     static void get_device_names();
+    static bool is_known_disk_device_name(const std::string& dev);
 };
 
 } // namespace starrocks

--- a/be/src/service/backend_metrics_initializer.cpp
+++ b/be/src/service/backend_metrics_initializer.cpp
@@ -16,12 +16,10 @@
 
 #include <unistd.h>
 
-#include <cerrno>
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -32,7 +30,6 @@
 #include "cache/datacache_metrics.h"
 #include "common/config_metrics_fwd.h"
 #include "common/metrics/process_metrics_registry.h"
-#include "common/status.h"
 #include "common/system/backend_options.h"
 #include "common/system/disk_info.h"
 #include "compute_env/load/stream_load_metrics.h"
@@ -40,6 +37,8 @@
 #include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
+#include "fs/key_cache.h"
+#include "http/http_metrics.h"
 #include "io/io_profiler_metrics.h"
 #include "platform/http/http_metrics.h"
 #include "platform/key_cache.h"
@@ -65,84 +64,9 @@ namespace {
 
 const char* const kRuntimeMetricsHookName = "runtime_metrics";
 
-bool is_known_disk_device_name(const std::string& dev) {
-    for (int i = 0; i < DiskInfo::num_disks(); ++i) {
-        if (DiskInfo::device_name(i) == dev) {
-            return true;
-        }
-    }
-    return false;
-}
-
-Status get_disk_devices(const std::vector<std::string>& paths, std::set<std::string>* devices) {
-    std::vector<std::string> real_paths;
-    real_paths.reserve(paths.size());
-    for (const auto& path : paths) {
-        std::string real_path;
-        Status st = fs::canonicalize(path, &real_path);
-        if (!st.ok()) {
-            WARN_IF_ERROR(st, "canonicalize path " + path + " failed, skip disk monitoring of this path");
-            continue;
-        }
-        real_paths.emplace_back(std::move(real_path));
-    }
-
-    FILE* fp = fopen("/proc/mounts", "r");
-    if (fp == nullptr) {
-        std::stringstream ss;
-        char buf[64];
-        ss << "open /proc/mounts failed, errno:" << errno << ", message:" << strerror_r(errno, buf, 64);
-        LOG(WARNING) << ss.str();
-        return Status::InternalError(ss.str());
-    }
-
-    Status status;
-    char* line_ptr = nullptr;
-    size_t line_buf_size = 0;
-    for (const auto& path : real_paths) {
-        size_t max_mount_size = 0;
-        std::string match_dev;
-        rewind(fp);
-        while (getline(&line_ptr, &line_buf_size, fp) > 0) {
-            char dev_path[4096];
-            char mount_path[4096];
-            int num = sscanf(line_ptr, "%4095s %4095s", dev_path, mount_path);
-            if (num < 2) {
-                continue;
-            }
-            size_t mount_size = strlen(mount_path);
-            if (mount_size < max_mount_size || path.size() < mount_size ||
-                strncmp(path.c_str(), mount_path, mount_size) != 0) {
-                continue;
-            }
-            std::string dev = std::filesystem::path(dev_path).filename().string();
-            if (is_known_disk_device_name(dev)) {
-                max_mount_size = mount_size;
-                match_dev = std::move(dev);
-            }
-        }
-        if (ferror(fp) != 0) {
-            std::stringstream ss;
-            char buf[64];
-            ss << "open /proc/mounts failed, errno:" << errno << ", message:" << strerror_r(errno, buf, 64);
-            LOG(WARNING) << ss.str();
-            status = Status::InternalError(ss.str());
-            break;
-        }
-        if (max_mount_size > 0) {
-            devices->emplace(match_dev);
-        }
-    }
-    if (line_ptr != nullptr) {
-        free(line_ptr);
-    }
-    fclose(fp);
-    return status;
-}
-
 bool prepare_system_metrics_inputs(const BackendMetricsInitOptions& options, std::set<std::string>* disk_devices,
                                    std::vector<std::string>* network_interfaces) {
-    auto st = get_disk_devices(options.storage_paths, disk_devices);
+    auto st = DiskInfo::get_disk_devices(options.storage_paths, disk_devices);
     if (!st.ok()) {
         LOG(WARNING) << "get disk devices failed, status=" << st.message();
         return false;

--- a/be/src/service/backend_metrics_initializer.cpp
+++ b/be/src/service/backend_metrics_initializer.cpp
@@ -37,8 +37,6 @@
 #include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
-#include "fs/key_cache.h"
-#include "http/http_metrics.h"
 #include "io/io_profiler_metrics.h"
 #include "platform/http/http_metrics.h"
 #include "platform/key_cache.h"

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -583,5 +583,8 @@ ADD_BE_TEST(storage/lake/compaction_task_test)
 # Standalone executable for builtin_functions_fuzzy_test
 ADD_BE_TEST(fuzzy/builtin_functions_fuzzy_test)
 
-add_dependencies(starrocks_dw_test engine_storage_migration_task_test compaction_task_test builtin_functions_fuzzy_test)
-add_dependencies(starrocks_dw_test engine_storage_migration_task_test compaction_task_test builtin_functions_fuzzy_test)
+# Standalone executable for disk_info_test (needs to control DiskInfo::init() before gtest runs)
+ADD_BE_TEST(common/system/disk_info_test)
+
+add_dependencies(starrocks_dw_test engine_storage_migration_task_test compaction_task_test builtin_functions_fuzzy_test disk_info_test)
+add_dependencies(starrocks_dw_test engine_storage_migration_task_test compaction_task_test builtin_functions_fuzzy_test disk_info_test)

--- a/be/test/common/system/disk_info_test.cpp
+++ b/be/test/common/system/disk_info_test.cpp
@@ -1,0 +1,157 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#ifdef __linux__
+#include <sys/sysmacros.h>
+#endif
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <fstream>
+#include <set>
+#include <vector>
+
+#include "common/logging.h"
+#include "common/system/disk_info.h"
+
+namespace starrocks {
+
+extern const char* k_ut_partitions_path;
+extern const char* k_ut_mounts_path;
+
+// Paths to the per-test-suite temporary mock files.
+static std::string s_tmp_partitions_path;
+static std::string s_tmp_mounts_path;
+
+// Writes a /proc/partitions-format file that registers "dev_abcd" with the
+// major:minor matching stat("/tmp").  Returns false on failure.
+static bool write_mock_partitions(const std::string& path) {
+    struct stat st {};
+    if (::stat("/tmp", &st) != 0) {
+        return false;
+    }
+#ifdef __linux__
+    unsigned int maj = gnu_dev_major(st.st_dev);
+    unsigned int min = gnu_dev_minor(st.st_dev);
+#else
+    // macOS: high 12 bits = major, low 20 bits = minor (same as the macro above)
+    unsigned int maj = static_cast<unsigned int>(st.st_dev >> 20) & 0xFFFU;
+    unsigned int min = static_cast<unsigned int>(st.st_dev) & 0xFFFFFU;
+#endif
+    std::ofstream f(path);
+    if (!f.is_open()) {
+        return false;
+    }
+    // header line expected by get_device_names (skipped because "name" != 4 fields)
+    f << "major minor  #blocks  name\n\n";
+    f << maj << " " << min << " 1048576 dev_abcd\n";
+    return true;
+}
+
+class DiskInfoTest : public testing::Test {
+public:
+    static void SetUpTestSuite() {
+        s_tmp_partitions_path = "/tmp/ut_partitions_" + std::to_string(::getpid());
+        s_tmp_mounts_path = "/tmp/ut_mounts_" + std::to_string(::getpid());
+
+        ASSERT_TRUE(write_mock_partitions(s_tmp_partitions_path)) << "Failed to write mock partitions file";
+
+        // Re-initialise DiskInfo using the mock partitions so that _s_disks
+        // contains "dev_abcd" mapped to the real dev_t of /tmp.
+        k_ut_partitions_path = s_tmp_partitions_path.c_str();
+        DiskInfo::init();
+    }
+
+    static void TearDownTestSuite() {
+        ::remove(s_tmp_mounts_path.c_str());
+        ::remove(s_tmp_partitions_path.c_str());
+        k_ut_partitions_path = nullptr;
+    }
+
+    void TearDown() override { k_ut_mounts_path = nullptr; }
+};
+
+// ── Test 1 ────────────────────────────────────────────────────────────────
+// Empty input: no paths given; devices should remain empty and status OK.
+TEST_F(DiskInfoTest, GetDiskDevices_EmptyPaths) {
+    std::vector<std::string> paths;
+    std::set<std::string> devices;
+
+    auto st = DiskInfo::get_disk_devices(paths, &devices);
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(devices.empty());
+}
+
+// ── Test 2 ────────────────────────────────────────────────────────────────
+// Verify a path that is covered by the mock mounts resolves to a non-empty device set.
+TEST_F(DiskInfoTest, GetDiskDevices_MockedPath) {
+    std::ofstream f(s_tmp_mounts_path);
+    ASSERT_TRUE(f.is_open());
+    f << "/dev/dev_abcd /tmp ext4 rw,relatime 0 0\n";
+    f.close();
+    k_ut_mounts_path = s_tmp_mounts_path.c_str();
+    std::vector<std::string> paths = {"/tmp"};
+    std::set<std::string> devices;
+
+    auto st = DiskInfo::get_disk_devices(paths, &devices);
+
+    ASSERT_TRUE(st.ok()) << st.message();
+    ASSERT_FALSE(devices.empty()) << "/tmp should map to 'dev_abcd' as normal device";
+    ASSERT_EQ("dev_abcd", *devices.begin());
+}
+
+// ── Test 3 ────────────────────────────────────────────────────────────────
+// LVM fallback path: the mock mounts file maps /dev/mapper/fake-vg-fake-lv
+// to /tmp.  dev "fake-vg-fake-lv" is not in _s_disk_name_to_disk_id,
+// so the else-fallback fires: stat("/tmp") returns the real `dev_t` whose major and minor were
+// pre-registered as "dev_abcd" in the mock partitions file.
+TEST_F(DiskInfoTest, GetDiskDevices_LvmFallback) {
+    // Writes a /proc/mounts-format file that maps /dev/mapper/fake-vg-fake-lv to
+    // /tmp (LVM-style, that is not in _s_disk_name_to_disk_id)
+    std::ofstream f(s_tmp_mounts_path);
+    ASSERT_TRUE(f.is_open());
+    f << "/dev/mapper/fake-vg-fake-lv /tmp ext4 rw,relatime 0 0\n";
+    f.close();
+    k_ut_mounts_path = s_tmp_mounts_path.c_str();
+
+    std::vector<std::string> paths = {"/tmp"};
+    std::set<std::string> devices;
+
+    auto st = DiskInfo::get_disk_devices(paths, &devices);
+
+    ASSERT_TRUE(st.ok()) << st.message();
+    ASSERT_FALSE(devices.empty()) << "LVM fallback should resolve /tmp to 'dev_abcd'";
+    ASSERT_EQ("dev_abcd", *devices.begin());
+}
+
+// ── Test 4 ────────────────────────────────────────────────────────────────
+// fopen failure to open mount path, get_disk_devices must return InternalError.
+TEST_F(DiskInfoTest, GetDiskDevices_MountsOpenFailed) {
+    k_ut_mounts_path = "/tmp/this_file_does_not_exist_ut_disk_info";
+
+    std::vector<std::string> paths = {"/tmp"};
+    std::set<std::string> devices;
+
+    auto st = DiskInfo::get_disk_devices(paths, &devices);
+
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_internal_error()) << "expected InternalError, got: " << st.message();
+    ASSERT_TRUE(devices.empty());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Currently, disk related metrics can't be collected if the `storage` path is on logic volume (LVM) 
## What I'm doing:

`DiskInfo::get_disk_devices` is moved out of `Diskinfo` in #68876 due to `common` module dependency restriction.   
I fixed the dependency and move it back to `Diskinfo`.  


And add `else` branch if the device is `LVM`:

```c++
            if (is_known_disk_device_name(dev)) {
                max_mount_size = mount_size;
                match_dev = std::move(dev);
            } else {
                // Fallback for LVM and other device-mapper setups where basename of the
                // device path (e.g. "/dev/mapper/localssd-localssd--lv") does not appear in _s_disk_name_to_disk_id.
                // stat() the mount point to obtain the kernel device number (major:minor),
                // then look it up in _s_device_id_to_disk_id which is keyed by dev_t
                // and covers dm-* entries from /proc/partitions.
                int id = disk_id(mount_path);
                if (id >= 0) {
                    max_mount_size = mount_size;
                    match_dev = device_name(id);
                }
            }
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
