### PR TITLE
[BugFix] Fix COLUMN_UPSERT_MODE checksum error in shared-data (backport #65320)

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -616,7 +616,13 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_lake_dcg_column_iterator(
 
     auto dcg_segment = dcg_segment_result.value();
     if (ctx.dcg_read_files.count(dcg_segment->file_name()) == 0) {
-        ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(dcg_segment->file_info()));
+        RandomAccessFileOptions ropts;
+        if (!dcg_segment->file_info().encryption_meta.empty()) {
+            ASSIGN_OR_RETURN(auto info,
+                             KeyCache::instance().unwrap_encryption_meta(dcg_segment->file_info().encryption_meta));
+            ropts.encryption_info = std::move(info);
+        }
+        ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file_with_bundling(ropts, dcg_segment->file_info()));
         ctx.dcg_read_files[dcg_segment->file_name()] = std::move(read_file);
     }
     iter_opts.read_file = ctx.dcg_read_files[dcg_segment->file_name()].get();

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -2110,3 +2110,1487 @@ INSTANTIATE_TEST_SUITE_P(LakePartialUpdateConcurrentSchemaEvolutionTest,
 // clang-format on
 
 } // namespace starrocks::lake
+
+namespace starrocks::lake {
+
+class LakeColumnUpsertModeTest : public LakePartialUpdateTestBase {
+public:
+    LakeColumnUpsertModeTest() : LakePartialUpdateTestBase(kTestDirectory) {}
+
+    void SetUp() override {
+        LakePartialUpdateTestBase::SetUp();
+        // Seed encryption keys for tests that enable TDE (no FE in UT environment)
+        // Only add keys if they don't already exist to avoid conflicts with other tests
+        if (KeyCache::instance().get_key("0000000000000000") == nullptr) {
+            EncryptionKeyPB pb;
+            pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+            pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+            pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+            pb.set_plain_key("0000000000000000");
+            std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+            auto val_st = root_encryption_key->generate_key();
+            ASSERT_TRUE(val_st.ok());
+            std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+            encryption_key->set_id(2);
+            KeyCache::instance().add_key(root_encryption_key);
+            KeyCache::instance().add_key(encryption_key);
+        }
+    }
+
+    constexpr static const char* const kTestDirectory = "test_lake_column_upsert_mode";
+};
+
+TEST_F(LakeColumnUpsertModeTest, upsert_existing_rows_generates_dcg_only) {
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_partial = generate_data(kChunkSize, 0, true, 5);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto md, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(md->rowsets_size(), 3);
+    EXPECT_GT(md->dcg_meta().dcgs_size(), 0);
+}
+
+TEST_F(LakeColumnUpsertModeTest, partial_update_reads_encrypted_dcg_segments) {
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_partial = generate_data(kChunkSize, 0, true, 7);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    const bool old_enable_tde = config::enable_transparent_data_encryption;
+    config::enable_transparent_data_encryption = true;
+    DeferOp tde_guard([&]() { config::enable_transparent_data_encryption = old_enable_tde; });
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPDATE_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        bool has_encrypted_dcg = false;
+        for (const auto& entry : metadata->dcg_meta().dcgs()) {
+            const auto& dcg_ver = entry.second;
+            if (dcg_ver.encryption_metas_size() > 0) {
+                has_encrypted_dcg = true;
+                break;
+            }
+        }
+        ASSERT_TRUE(has_encrypted_dcg);
+    }
+
+    std::vector<int> keys_only(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) keys_only[i] = i;
+    auto c0_only = Int32Column::create();
+    c0_only->append_numbers(keys_only.data(), keys_only.size() * sizeof(int));
+    Chunk::SlotHashMap slot_only;
+    slot_only[0] = 0;
+    Chunk c0_chunk({std::move(c0_only)}, slot_only);
+
+    std::vector<SlotDescriptor> key_slots;
+    key_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> key_slot_ptrs;
+    key_slot_ptrs.emplace_back(&key_slots[0]);
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&key_slot_ptrs)
+                                                   .set_partial_update_mode(PartialUpdateMode::ROW_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(c0_chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 == c0 * 7) && (c2 == c0 * 4); }));
+}
+
+TEST_F(LakeColumnUpsertModeTest, upsert_with_new_rows_adds_new_segments) {
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSIGN_OR_ABORT(auto md_before, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto prev_rowsets = md_before->rowsets_size();
+
+    auto chunk_insert = generate_data(kChunkSize, 100, true, 7);
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_insert, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSIGN_OR_ABORT(auto md_after, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_GT(md_after->rowsets_size(), prev_rowsets);
+    auto total = check(version, [](int c0, int c1, int c2) { return (c2 == c0 * 4) || (c2 == 10); });
+    EXPECT_EQ(total, kChunkSize * 2);
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_default_values_handling) {
+    // Create a schema with default values
+    auto tablet_metadata = std::make_shared<TabletMetadata>();
+    tablet_metadata->set_id(next_id());
+    tablet_metadata->set_version(1);
+    tablet_metadata->set_next_rowset_id(1);
+
+    // Schema with default values
+    auto schema = tablet_metadata->mutable_schema();
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(1);
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_num_rows_per_row_block(65535);
+
+    auto c0 = schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema->add_column();
+    c1->set_unique_id(next_id());
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(true);
+    c1->set_aggregation("REPLACE");
+    c1->set_default_value("100");
+
+    auto c2 = schema->add_column();
+    c2->set_unique_id(next_id());
+    c2->set_name("c2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(true);
+    c2->set_aggregation("REPLACE");
+    // No default value set
+
+    auto tablet_schema = TabletSchema::create(*schema);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+
+    auto tablet_id = tablet_metadata->id();
+    auto version = 1;
+
+    // Create some initial data
+    std::vector<int> v0 = {1, 2, 3};
+    std::vector<int> v1 = {10, 20, 30};
+    std::vector<int> v2 = {40, 50, 60};
+
+    auto c0_col = Int32Column::create();
+    auto c1_col = Int32Column::create();
+    auto c2_col = Int32Column::create();
+    c0_col->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1_col->append_numbers(v1.data(), v1.size() * sizeof(int));
+    c2_col->append_numbers(v2.data(), v2.size() * sizeof(int));
+
+    Chunk::SlotHashMap slot_map;
+    slot_map[0] = 0;
+    slot_map[1] = 1;
+    slot_map[2] = 2;
+    auto chunk_full = Chunk({std::move(c0_col), std::move(c1_col), std::move(c2_col)}, slot_map);
+
+    auto indexes = std::vector<uint32_t>{0, 1, 2};
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Column upsert with new rows
+    std::vector<int> new_keys = {4, 5};
+    auto c0_partial = Int32Column::create();
+    c0_partial->append_numbers(new_keys.data(), new_keys.size() * sizeof(int));
+
+    Chunk::SlotHashMap partial_slot_map;
+    partial_slot_map[0] = 0;
+    auto chunk_partial = Chunk({std::move(c0_partial)}, partial_slot_map);
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> slot_pointers;
+    slot_pointers.emplace_back(&slots[0]);
+
+    auto indexes_partial = std::vector<uint32_t>{0, 1};
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .set_slot_descriptors(&slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes_partial.data(), indexes_partial.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify that new rows have default values applied
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto reader_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *reader_schema);
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+    auto result_chunk = ChunkHelper::new_chunk(*reader_schema, 128);
+
+    int total_rows = 0;
+    bool found_default_values = false;
+    while (true) {
+        auto st = reader->get_next(result_chunk.get());
+        if (st.is_end_of_file()) break;
+        CHECK_OK(st);
+        total_rows += result_chunk->num_rows();
+
+        auto cols = result_chunk->columns();
+        for (int i = 0; i < result_chunk->num_rows(); i++) {
+            auto c0_val = cols[0]->get(i).get_int32();
+            auto c1_datum = cols[1]->get(i);
+            auto c2_datum = cols[2]->get(i);
+
+            // Check if this is one of the new rows with default values
+            if (c0_val == 4 || c0_val == 5) {
+                if (!c1_datum.is_null()) {
+                    auto c1_val = c1_datum.get_int32();
+                    EXPECT_EQ(100, c1_val); // Should have default value
+                }
+                if (!c2_datum.is_null()) {
+                    auto c2_val = c2_datum.get_int32();
+                    EXPECT_EQ(0, c2_val); // Should have default value (0 for nullable int)
+                }
+                found_default_values = true;
+            }
+        }
+        result_chunk->reset();
+    }
+
+    EXPECT_TRUE(found_default_values);
+    EXPECT_EQ(5, total_rows); // 3 original + 2 new rows
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_bundle_file_handling) {
+    // Test bundle file related logic
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_insert = generate_data(kChunkSize, 100, true, 7);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Create initial data
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Column upsert with new rows
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_insert, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify metadata contains both segments and deletion statistics are updated
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_GT(metadata->rowsets_size(), 1);
+
+    // Check for deletion statistics - should be false since no primary key conflicts occurred
+    bool has_del_stats = false;
+    for (const auto& rowset : metadata->rowsets()) {
+        if (rowset.num_dels() > 0) {
+            has_del_stats = true;
+            break;
+        }
+    }
+    // Since there are no primary key conflicts, there should be no deletion statistics
+    EXPECT_FALSE(has_del_stats) << "No deletion statistics expected when there are no primary key conflicts";
+
+    auto total = check(version, [](int c0, int c1, int c2) { return (c2 == c0 * 4) || (c2 == 10); });
+    EXPECT_EQ(total, kChunkSize * 2);
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_delete_handling_with_upsert) {
+    // Test deletion handling logic
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_update = generate_data(kChunkSize, 0, true, 5);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Create initial data with multiple versions to create potential conflicts
+    for (int v = 0; v < 3; v++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Multiple concurrent column upserts to trigger conflict resolution and deletions
+    std::vector<int64_t> txn_ids;
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        txn_ids.push_back(txn_id);
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_update, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    // Publish them in order to create conflicts
+    for (auto txn_id : txn_ids) {
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify final state and that deletions were properly handled
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+
+    // Check that deletion vectors were created due to primary key conflicts
+    bool has_del_vectors = false;
+    if (metadata->has_delvec_meta()) {
+        for (const auto& delvec : metadata->delvec_meta().delvecs()) {
+            (void)delvec; // Suppress unused variable warning
+            has_del_vectors = true;
+            break;
+        }
+    }
+    // Since we have primary key conflicts from multiple upsert operations,
+    // deletion vectors should be created to handle the conflicts
+    EXPECT_TRUE(has_del_vectors)
+            << "Deletion vectors expected when primary key conflicts occur during upsert operations";
+
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_error_handling_scenarios) {
+    // Test error handling paths
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_insert = generate_data(kChunkSize, 100, true, 7);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Test with memory pressure to trigger error paths during upsert index operations
+    const int64_t old_limit = _update_mgr->update_state_mem_tracker()->limit();
+    _update_mgr->update_state_mem_tracker()->set_limit(1); // Very low limit to trigger memory errors
+
+    DeferOp defer([&]() { _update_mgr->update_state_mem_tracker()->set_limit(old_limit); });
+
+    // This should still succeed but may trigger some error handling paths
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_insert, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify the data is still consistent despite memory pressure
+    auto total = check(version, [](int c0, int c1, int c2) { return (c2 == c0 * 4) || (c2 == 10); });
+    EXPECT_EQ(total, kChunkSize * 2);
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_auto_increment_column_handling) {
+    // Test auto increment column behavior in partial update scenarios:
+    // 1. Update existing rows: auto increment column should remain unchanged
+    // 2. Insert new rows: auto increment column generates values
+    auto tablet_metadata = std::make_shared<TabletMetadata>();
+    tablet_metadata->set_id(next_id());
+    tablet_metadata->set_version(1);
+    tablet_metadata->set_next_rowset_id(1);
+
+    auto schema = tablet_metadata->mutable_schema();
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(1);
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_num_rows_per_row_block(65535);
+
+    auto c0 = schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema->add_column();
+    c1->set_unique_id(next_id());
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(false);
+    c1->set_aggregation("REPLACE");
+
+    // Auto increment column
+    auto c2 = schema->add_column();
+    c2->set_unique_id(next_id());
+    c2->set_name("c2");
+    c2->set_type("BIGINT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(false);
+    c2->set_aggregation("REPLACE");
+    c2->set_is_auto_increment(true);
+
+    auto tablet_schema = TabletSchema::create(*schema);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+
+    auto tablet_id = tablet_metadata->id();
+    auto version = 1;
+
+    // Create initial data with explicit auto increment values
+    std::vector<int> v0 = {1, 2, 3};
+    std::vector<int> v1 = {10, 20, 30};
+    std::vector<int64_t> v2 = {1, 2, 3};
+
+    auto c0_col = Int32Column::create();
+    auto c1_col = Int32Column::create();
+    auto c2_col = Int64Column::create();
+    c0_col->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1_col->append_numbers(v1.data(), v1.size() * sizeof(int));
+    c2_col->append_numbers(v2.data(), v2.size() * sizeof(int64_t));
+
+    Chunk::SlotHashMap slot_map;
+    slot_map[0] = 0;
+    slot_map[1] = 1;
+    slot_map[2] = 2;
+    auto chunk_initial = Chunk({std::move(c0_col), std::move(c1_col), std::move(c2_col)}, slot_map);
+    auto indexes = std::vector<uint32_t>{0, 1, 2};
+
+    // Initial write with full data (including auto increment column)
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_initial, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Test 1: Partial update of existing rows - auto increment column should remain unchanged
+    std::vector<int> update_keys = {1, 2};
+    std::vector<int> update_values = {15, 25};
+
+    auto c0_update = Int32Column::create();
+    auto c1_update = Int32Column::create();
+    c0_update->append_numbers(update_keys.data(), update_keys.size() * sizeof(int));
+    c1_update->append_numbers(update_values.data(), update_values.size() * sizeof(int));
+
+    Chunk::SlotHashMap update_slot_map;
+    update_slot_map[0] = 0;
+    update_slot_map[1] = 1;
+    auto chunk_update = Chunk({std::move(c0_update), std::move(c1_update)}, update_slot_map);
+
+    std::vector<SlotDescriptor> update_slots;
+    update_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    update_slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> update_slot_pointers;
+    update_slot_pointers.emplace_back(&update_slots[0]);
+    update_slot_pointers.emplace_back(&update_slots[1]);
+
+    auto update_indexes = std::vector<uint32_t>{0, 1};
+
+    // Inject auto-increment id interval for unit test environment before update as well
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("StorageEngine::get_next_increment_id_interval.1", [](void* arg) {
+        auto& meta = *(std::shared_ptr<AutoIncrementMeta>*)(arg);
+        meta->min = 1;
+        meta->max = 1000000;
+    });
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .set_slot_descriptors(&update_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .set_miss_auto_increment_column(true)
+                                                   .set_table_id(tablet_id)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_update, update_indexes.data(), update_indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Test 2: Partial update with new rows - include auto increment column as placeholder for ID generation
+    std::vector<int> insert_keys = {4, 5};
+    std::vector<int> insert_values = {40, 50};
+
+    auto c0_insert = Int32Column::create();
+    auto c1_insert = Int32Column::create();
+    auto c2_insert = Int64Column::create(); // placeholder for auto increment column
+    c0_insert->append_numbers(insert_keys.data(), insert_keys.size() * sizeof(int));
+    c1_insert->append_numbers(insert_values.data(), insert_values.size() * sizeof(int));
+    // fill zeros; BE will replace with allocated auto-increment ids
+    int64_t zeros[2] = {0, 0};
+    c2_insert->append_numbers(zeros, sizeof(zeros));
+
+    Chunk::SlotHashMap insert_slot_map;
+    insert_slot_map[0] = 0;
+    insert_slot_map[1] = 1;
+    insert_slot_map[2] = 2; // c2 auto increment column (placeholder)
+    auto chunk_insert = Chunk({std::move(c0_insert), std::move(c1_insert), std::move(c2_insert)}, insert_slot_map);
+
+    std::vector<SlotDescriptor> insert_slots;
+    insert_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    insert_slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+    insert_slots.emplace_back(2, "c2", TypeDescriptor{LogicalType::TYPE_BIGINT});
+    std::vector<SlotDescriptor*> insert_slot_pointers;
+    insert_slot_pointers.emplace_back(&insert_slots[0]);
+    insert_slot_pointers.emplace_back(&insert_slots[1]);
+    insert_slot_pointers.emplace_back(&insert_slots[2]);
+
+    auto insert_indexes = std::vector<uint32_t>{0, 1};
+
+    // Inject auto-increment id interval for unit test environment (no FE service)
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("StorageEngine::get_next_increment_id_interval.1", [](void* arg) {
+        auto& meta = *(std::shared_ptr<AutoIncrementMeta>*)(arg);
+        meta->min = 1;
+        meta->max = 1000000;
+    });
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .set_slot_descriptors(&insert_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .set_miss_auto_increment_column(true)
+                                                   .set_table_id(tablet_id)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_insert, insert_indexes.data(), insert_indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Clear SyncPoint callbacks after use
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    // Verify that data was correctly inserted with auto increment columns handled
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto reader_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *reader_schema);
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+    auto result_chunk = ChunkHelper::new_chunk(*reader_schema, 128);
+
+    int total_rows = 0;
+    bool found_updated_rows = false;
+    bool found_new_rows = false;
+    while (true) {
+        auto st = reader->get_next(result_chunk.get());
+        if (st.is_end_of_file()) break;
+        CHECK_OK(st);
+        total_rows += result_chunk->num_rows();
+
+        auto cols = result_chunk->columns();
+        for (int i = 0; i < result_chunk->num_rows(); i++) {
+            auto c0_val = cols[0]->get(i).get_int32();
+            auto c1_val = cols[1]->get(i).get_int32();
+            auto c2_val = cols[2]->get(i).get_int64();
+
+            // Check updated existing rows (c0=1,2) - auto increment should remain unchanged
+            if (c0_val == 1) {
+                EXPECT_EQ(15, c1_val);
+                EXPECT_EQ(1, c2_val);
+                found_updated_rows = true;
+            } else if (c0_val == 2) {
+                EXPECT_EQ(25, c1_val);
+                EXPECT_EQ(2, c2_val);
+                found_updated_rows = true;
+            }
+            // Check original unchanged row
+            else if (c0_val == 3) {
+                EXPECT_EQ(30, c1_val);
+                EXPECT_EQ(3, c2_val);
+            }
+            // Check new inserted rows (c0=4,5) - auto increment behavior
+            else if (c0_val == 4) {
+                EXPECT_EQ(40, c1_val);
+                EXPECT_GT(c2_val, 0);
+                found_new_rows = true;
+            } else if (c0_val == 5) {
+                EXPECT_EQ(50, c1_val);
+                EXPECT_GT(c2_val, 0);
+                found_new_rows = true;
+            }
+        }
+        result_chunk->reset();
+    }
+
+    EXPECT_TRUE(found_updated_rows);
+    EXPECT_TRUE(found_new_rows);
+    EXPECT_EQ(5, total_rows);
+}
+
+TEST_F(LakeColumnUpsertModeTest, test_handle_delete_files) {
+    const int64_t kChunkSize = 64;
+    auto tablet_id = _tablet_metadata->id();
+    int64_t version = 1;
+
+    // First write base data, no deletes
+    {
+        auto chunk = generate_data(kChunkSize, /*shift*/ 0, /*partial*/ false, /*update_ratio*/ 100);
+        std::vector<uint32_t> indexes(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Build a chunk with DELETE op column (last column is op);
+    // set a small write buffer to trigger multiple flushes (more .del files)
+    const auto old_buf = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    const auto old_tde = config::enable_transparent_data_encryption;
+    config::enable_transparent_data_encryption = true;
+    {
+        // keys: delete the first half [0, kChunkSize/2), keep the second half
+        std::vector<int> v0(kChunkSize);
+        std::vector<int> v1(kChunkSize, 777);
+        std::vector<int> v2(kChunkSize, 888); // third column payload
+        std::vector<uint8_t> ops(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) {
+            v0[i] = i; // same keys as base data
+            ops[i] = (i < kChunkSize / 2) ? TOpType::DELETE : TOpType::UPSERT;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        auto cop = Int8Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+        cop->append_numbers(ops.data(), ops.size() * sizeof(uint8_t));
+
+        // Note: last column is op; create a separate slot map for chunk with ops
+        Chunk::SlotHashMap ops_slot_map;
+        ops_slot_map[0] = 0;
+        ops_slot_map[1] = 1;
+        ops_slot_map[2] = 2;
+        ops_slot_map[3] = 3;
+        Chunk chunk_with_ops({std::move(c0), std::move(c1), std::move(c2), std::move(cop)}, ops_slot_map);
+        std::vector<uint32_t> idx(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) idx[i] = i;
+
+        // Create slot descriptors including operation column
+        std::vector<SlotDescriptor> op_slots;
+        op_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+        op_slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+        op_slots.emplace_back(2, "c2", TypeDescriptor{LogicalType::TYPE_INT});
+        op_slots.emplace_back(3, "__op", TypeDescriptor{LogicalType::TYPE_TINYINT});
+        std::vector<SlotDescriptor*> op_slot_pointers;
+        for (auto& slot : op_slots) {
+            op_slot_pointers.emplace_back(&slot);
+        }
+
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&op_slot_pointers)
+                                         .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk_with_ops, idx.data(), idx.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::write_buffer_size = old_buf;
+    config::enable_transparent_data_encryption = old_tde;
+
+    // Verify: first half rows are deleted; also check del_files/stat updates
+    {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        // Total rows should be less than initial rows + UPSERT rows.
+        // Initial write kChunkSize, then half DELETE and half UPSERT; expected >= kChunkSize + kChunkSize/2.
+        // Precisely verify deletes: keys < kChunkSize/2 should be absent.
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        ASSERT_OK(reader->prepare());
+        ASSERT_OK(reader->open(TabletReaderParams()));
+        auto chk = ChunkHelper::new_chunk(*_schema, 256);
+        std::vector<bool> seen(kChunkSize, false);
+        while (true) {
+            auto st = reader->get_next(chk.get());
+            if (st.is_end_of_file()) break;
+            ASSERT_OK(st);
+            auto cols = chk->columns();
+            for (int i = 0; i < chk->num_rows(); i++) {
+                int key = cols[0]->get(i).get_int32();
+                if (key >= 0 && key < kChunkSize) seen[key] = true;
+            }
+            chk->reset();
+        }
+        for (int i = 0; i < kChunkSize / 2; i++) {
+            // Deleted first-half keys should not appear
+            ASSERT_FALSE(seen[i]);
+        }
+
+        // Check metadata records del files
+        // Latest rowset should record del_files list or have num_dels updated.
+        ASSERT_GE(metadata->rowsets_size(), 1);
+        const auto& last_rs = metadata->rowsets(metadata->rowsets_size() - 1);
+        // del_files_size may be 0 (merged in different paths), but num_dels or delvec_meta should be updated.
+        // Assert num_dels non-negative and version advanced.
+        ASSERT_GE(last_rs.num_dels(), 0);
+        ASSERT_EQ(version, metadata->version());
+    }
+}
+
+// Test bundle file offsets and encryption handling in column mode partial update
+TEST_F(LakeColumnUpsertModeTest, test_bundle_files_and_encryption_handling) {
+    // Enable TDE for this test
+    const bool old_enable_tde = config::enable_transparent_data_encryption;
+    config::enable_transparent_data_encryption = true;
+    DeferOp tde_defer([&]() { config::enable_transparent_data_encryption = old_enable_tde; });
+
+    auto tablet_metadata = std::make_shared<TabletMetadataPB>();
+    tablet_metadata->set_id(next_id());
+    tablet_metadata->set_version(1);
+    tablet_metadata->set_next_rowset_id(1);
+
+    // Schema with default values
+    auto schema = tablet_metadata->mutable_schema();
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(1);
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_num_rows_per_row_block(65535);
+
+    auto c0 = schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema->add_column();
+    c1->set_unique_id(next_id());
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(true);
+    c1->set_aggregation("REPLACE");
+    c1->set_default_value("100");
+
+    auto c2 = schema->add_column();
+    c2->set_unique_id(next_id());
+    c2->set_name("c2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(true);
+    c2->set_aggregation("REPLACE");
+
+    auto tablet_schema = TabletSchema::create(*schema);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+
+    auto tablet_id = tablet_metadata->id();
+    auto version = 1;
+
+    // Create some initial data
+    std::vector<int> v0 = {1, 2, 3};
+    std::vector<int> v1 = {10, 20, 30};
+    std::vector<int> v2 = {40, 50, 60};
+
+    auto c0_col = Int32Column::create();
+    auto c1_col = Int32Column::create();
+    auto c2_col = Int32Column::create();
+    c0_col->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c1_col->append_numbers(v1.data(), v1.size() * sizeof(int));
+    c2_col->append_numbers(v2.data(), v2.size() * sizeof(int));
+
+    Chunk::SlotHashMap slot_map;
+    slot_map[0] = 0;
+    slot_map[1] = 1;
+    slot_map[2] = 2;
+    auto chunk_full = Chunk({std::move(c0_col), std::move(c1_col), std::move(c2_col)}, slot_map);
+
+    auto indexes = std::vector<uint32_t>{0, 1, 2};
+
+    // Initial full write
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Column mode partial update - adding new rows with expression override
+    std::vector<int> new_keys = {4, 5};
+    auto c0_partial = Int32Column::create();
+    c0_partial->append_numbers(new_keys.data(), new_keys.size() * sizeof(int));
+
+    Chunk::SlotHashMap partial_slot_map;
+    partial_slot_map[0] = 0;
+    auto chunk_partial = Chunk({std::move(c0_partial)}, partial_slot_map);
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> slot_pointers;
+    slot_pointers.emplace_back(&slots[0]);
+
+    auto indexes_partial = std::vector<uint32_t>{0, 1};
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes_partial.data(), indexes_partial.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+
+        // Manually modify the txn log to add bundle file offsets and encryption metas
+        ASSIGN_OR_ABORT(auto original_txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto new_txn_log = std::make_shared<TxnLogPB>(*original_txn_log);
+
+        // Add column-to-expr-value override for c2
+        auto* column_to_expr_value =
+                new_txn_log->mutable_op_write()->mutable_txn_meta()->mutable_column_to_expr_value();
+        (*column_to_expr_value)["c2"] = "200";
+
+        ASSERT_OK(_tablet_mgr->put_txn_log(new_txn_log));
+
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify results - new rows should have default value for c1 but expression value for c2
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto reader_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *reader_schema);
+    ASSERT_OK(reader->prepare());
+    ASSERT_OK(reader->open(TabletReaderParams()));
+    auto result_chunk = ChunkHelper::new_chunk(*reader_schema, 128);
+
+    int total_rows = 0;
+    bool found_new_rows = false;
+
+    while (true) {
+        auto st = reader->get_next(result_chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        CHECK_OK(st);
+        total_rows += result_chunk->num_rows();
+
+        auto cols = result_chunk->columns();
+        for (int i = 0; i < result_chunk->num_rows(); i++) {
+            auto c0_val = cols[0]->get(i).get_int32();
+            auto c1_datum = cols[1]->get(i);
+            auto c2_datum = cols[2]->get(i);
+
+            // Check if this is one of the new rows
+            if (c0_val == 4 || c0_val == 5) {
+                if (!c1_datum.is_null()) {
+                    auto c1_val = c1_datum.get_int32();
+                    EXPECT_EQ(100, c1_val); // Should have default value
+                }
+                if (!c2_datum.is_null()) {
+                    auto c2_val = c2_datum.get_int32();
+                    EXPECT_EQ(200, c2_val); // Should have expression override value
+                }
+                found_new_rows = true;
+            }
+        }
+        result_chunk->reset();
+    }
+
+    EXPECT_TRUE(found_new_rows);
+    EXPECT_EQ(5, total_rows);
+}
+
+// Test default value handling and null column filling
+TEST_F(LakeColumnUpsertModeTest, test_default_value_and_null_handling) {
+    auto tablet_metadata = std::make_shared<TabletMetadataPB>();
+    tablet_metadata->set_id(next_id());
+    tablet_metadata->set_version(1);
+    tablet_metadata->set_next_rowset_id(1);
+
+    // Schema with various default scenarios
+    auto schema = tablet_metadata->mutable_schema();
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(1);
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_num_rows_per_row_block(65535);
+
+    auto c0 = schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    // Column with default value
+    auto c1 = schema->add_column();
+    c1->set_unique_id(next_id());
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(true);
+    c1->set_aggregation("REPLACE");
+    c1->set_default_value("100");
+
+    // Nullable column without default (should get null)
+    auto c2 = schema->add_column();
+    c2->set_unique_id(next_id());
+    c2->set_name("c2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(true);
+    c2->set_aggregation("REPLACE");
+
+    // Non-nullable column without default (should get type default)
+    auto c3 = schema->add_column();
+    c3->set_unique_id(next_id());
+    c3->set_name("c3");
+    c3->set_type("INT");
+    c3->set_is_key(false);
+    c3->set_is_nullable(false);
+    c3->set_aggregation("REPLACE");
+
+    auto tablet_schema = TabletSchema::create(*schema);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+
+    auto tablet_id = tablet_metadata->id();
+    auto version = 1;
+
+    // Column upsert with only primary key - should trigger all default handling paths
+    std::vector<int> new_keys = {1, 2};
+    auto c0_partial = Int32Column::create();
+    c0_partial->append_numbers(new_keys.data(), new_keys.size() * sizeof(int));
+
+    Chunk::SlotHashMap partial_slot_map;
+    partial_slot_map[0] = 0;
+    auto chunk_partial = Chunk({std::move(c0_partial)}, partial_slot_map);
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> slot_pointers;
+    slot_pointers.emplace_back(&slots[0]);
+
+    auto indexes_partial = std::vector<uint32_t>{0, 1};
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes_partial.data(), indexes_partial.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify default value handling
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto reader_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *reader_schema);
+    ASSERT_OK(reader->prepare());
+    ASSERT_OK(reader->open(TabletReaderParams()));
+    auto result_chunk = ChunkHelper::new_chunk(*reader_schema, 128);
+
+    int total_rows = 0;
+    bool found_correct_defaults = false;
+
+    while (true) {
+        auto st = reader->get_next(result_chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        CHECK_OK(st);
+        total_rows += result_chunk->num_rows();
+
+        auto cols = result_chunk->columns();
+        for (int i = 0; i < result_chunk->num_rows(); i++) {
+            auto c0_val = cols[0]->get(i).get_int32();
+            auto c1_datum = cols[1]->get(i);
+            auto c2_datum = cols[2]->get(i);
+            auto c3_datum = cols[3]->get(i);
+
+            if (c0_val == 1 || c0_val == 2) {
+                // c1 has default value
+                if (!c1_datum.is_null()) {
+                    EXPECT_EQ(100, c1_datum.get_int32());
+                }
+                // c2 is nullable without default - should be null
+                EXPECT_TRUE(c2_datum.is_null());
+                // c3 is non-nullable without default - should get type default (0)
+                EXPECT_FALSE(c3_datum.is_null());
+                EXPECT_EQ(0, c3_datum.get_int32());
+                found_correct_defaults = true;
+            }
+        }
+        result_chunk->reset();
+    }
+
+    EXPECT_TRUE(found_correct_defaults);
+    EXPECT_EQ(2, total_rows);
+}
+
+// Test functional correctness: COLUMN_UPSERT_MODE handles new row insertion correctly
+//
+// Background:
+// - COLUMN_UPSERT_MODE needs RowsetUpdateState::_prepare_partial_update_states to handle new rows
+//   - Before optimization: Incorrectly read all unmodified columns for each new row → OOM for large inserts
+//   - After optimization: Skip reading unmodified columns (new rows don't exist in storage yet)
+//
+// This test verifies:
+// 1. New rows can be inserted with partial columns (c0+c1 only)
+// 2. Unmodified columns (c2) are correctly filled with default values
+// 3. Existing rows can be updated normally
+// 4. All data remains correct after mixed operations
+TEST_F(LakeColumnUpsertModeTest, memory_optimization_skip_column_reading) {
+    auto tablet_id = _tablet_metadata->id();
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+    auto version = 1;
+
+    // Step 1: Write initial full data with all 3 columns (pk 0-11)
+    {
+        auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        LOG(INFO) << "[BASE DATA] Inserted base rows with full columns";
+    }
+
+    // Step 2: Insert NEW rows with COLUMN_UPSERT_MODE (pk 12-23, only update c0+c1)
+    // This tests the optimization for NEW row inserts (src_rss_rowids == UINT64_MAX)
+    // These rows should NOT read c2 from storage since they don't exist yet
+    // c2 should be filled with default value "10"
+    {
+        auto chunk_partial = generate_data(kChunkSize, 1, true, 5); // shift=1 means pk 12-23
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+
+        LOG(INFO) << "[NEW ROWS] Inserted new rows with COLUMN_UPSERT_MODE (only c0+c1)";
+    }
+
+    // Verify new rows: c2 should have default value 10
+    {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+
+        auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+        int total_rows = 0;
+        int new_rows_found = 0;
+
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            total_rows += chunk->num_rows();
+
+            // Find and verify new rows (pk 12-23)
+            for (int i = 0; i < chunk->num_rows(); i++) {
+                int pk = chunk->get_column_by_index(0)->get(i).get_int32();
+                if (pk >= kChunkSize && pk < kChunkSize * 2) {
+                    int c1 = chunk->get_column_by_index(1)->get(i).get_int32();
+                    int c2 = chunk->get_column_by_index(2)->get(i).get_int32();
+                    EXPECT_EQ(c1, pk * 5) << "New row c1 should be pk * 5";
+                    EXPECT_EQ(c2, 10) << "New row c2 should have default value 10";
+                    new_rows_found++;
+                }
+            }
+            chunk->reset();
+        }
+
+        ASSERT_EQ(total_rows, kChunkSize * 2) << "Should have total 24 rows (12 base + 12 new)";
+        ASSERT_EQ(new_rows_found, kChunkSize) << "Should find 12 new rows with pk 12-23";
+    }
+
+    // Step 3: Update existing rows with COLUMN_UPSERT_MODE
+    {
+        auto chunk_partial = generate_data(kChunkSize, 0, true, 9);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+
+        LOG(INFO) << "[UPDATE] Updated existing rows with COLUMN_UPSERT_MODE";
+    }
+
+    // Step 4: Verify functional correctness
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+
+    auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+    int total_rows = 0;
+    int existing_rows_updated = 0;
+    int new_rows_verified = 0;
+
+    while (true) {
+        auto st = reader->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        CHECK_OK(st);
+        total_rows += chunk->num_rows();
+
+        // Verify existing rows (pk 0-11) were updated to c1 = pk * 9 (from Step 3)
+        // and new rows (pk 12-23) still have c1 = pk * 5 and c2 = 10
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            int pk = chunk->get_column_by_index(0)->get(i).get_int32();
+            int c1 = chunk->get_column_by_index(1)->get(i).get_int32();
+            int c2 = chunk->get_column_by_index(2)->get(i).get_int32();
+
+            if (pk < kChunkSize) {
+                // Existing rows: c1 should be updated to pk * 9
+                EXPECT_EQ(c1, pk * 9) << "Existing row c1 should be updated";
+                existing_rows_updated++;
+            } else {
+                // New rows: c1 = pk * 5, c2 = 10 (default)
+                EXPECT_EQ(c1, pk * 5) << "New row c1 should be pk * 5";
+                EXPECT_EQ(c2, 10) << "New row c2 should still have default value 10";
+                new_rows_verified++;
+            }
+        }
+        chunk->reset();
+    }
+
+    ASSERT_EQ(total_rows, kChunkSize * 2) << "Should have total 24 rows";
+    ASSERT_EQ(existing_rows_updated, kChunkSize) << "Should have 12 updated existing rows";
+    ASSERT_EQ(new_rows_verified, kChunkSize) << "Should have 12 new rows";
+
+    // Verify DCG was generated for COLUMN_UPSERT_MODE
+    ASSIGN_OR_ABORT(auto md, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_GT(md->dcg_meta().dcgs_size(), 0) << "DCG should be generated for existing row updates";
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Summary
- Cherry-pick of #65320 to branch-4.0
- Fix deterministic "Bad page: checksum mismatch" when reading DCG columns during row-mode partial update after column-mode partial update in shared-data mode with TDE enabled
- DCG column files were opened with `new_random_access_file` without encryption info, causing wrong reads and checksum mismatch

## Test plan
- [x] Existing UT: `LakeColumnUpsertModeTest.partial_update_reads_encrypted_dcg_segments`

Fixes https://github.com/StarRocks/StarRocksTest/issues/11138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
