### PR TITLE
[BugFix] Fix num_short_key_columns mismatch in partial tablet schema

### DIFF
--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -402,7 +402,13 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_
         index.to_schema_pb(index_pb);
     }
     partial_tablet_schema_pb.mutable_sort_key_idxes()->Add(sort_key_idxes.begin(), sort_key_idxes.end());
-    return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
+    auto partial_schema = std::make_shared<TabletSchema>(partial_tablet_schema_pb);
+    // _init_from_pb may fallback sort_key_idxes to key columns when the PB's sort_key_idxes is empty,
+    // making it inconsistent with num_short_key_columns copied from the source schema. Fix up here.
+    if (partial_schema->num_short_key_columns() > partial_schema->sort_key_idxes().size()) {
+        partial_schema->set_num_short_key_columns(partial_schema->sort_key_idxes().size());
+    }
+    return partial_schema;
 }
 
 std::shared_ptr<TabletSchema> TabletSchema::create_with_uid(const TabletSchemaCSPtr& tablet_schema,

--- a/be/test/storage/tablet_schema_test.cpp
+++ b/be/test/storage/tablet_schema_test.cpp
@@ -338,4 +338,69 @@ TEST(TabletSchemaTest, test_partial_schema_create_keeps_pk_encoding_type) {
     ASSERT_EQ(partial_pb.primary_key_encoding_type(), PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
 }
 
+// Test that partial schema has consistent num_short_key_columns when sort key columns
+// are not in the referenced columns (e.g. column-mode partial update on table with ORDER BY).
+TEST(TabletSchemaTest, test_partial_schema_short_key_consistency_with_separate_sort_key) {
+    // Build a PK table schema: pk=k0, ORDER BY(k3, k2), num_short_key_columns=2
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_num_short_key_columns(2);
+
+    auto c0 = schema_pb.add_column();
+    c0->set_unique_id(0);
+    c0->set_name("k0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema_pb.add_column();
+    c1->set_unique_id(1);
+    c1->set_name("k1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+
+    auto c2 = schema_pb.add_column();
+    c2->set_unique_id(2);
+    c2->set_name("k2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+
+    auto c3 = schema_pb.add_column();
+    c3->set_unique_id(3);
+    c3->set_name("k3");
+    c3->set_type("INT");
+    c3->set_is_key(false);
+
+    auto c4 = schema_pb.add_column();
+    c4->set_unique_id(4);
+    c4->set_name("k4");
+    c4->set_type("INT");
+    c4->set_is_key(false);
+
+    // Set sort key to (k3, k2) — separate from primary key (k0)
+    schema_pb.add_sort_key_idxes(3);
+    schema_pb.add_sort_key_idxes(2);
+
+    auto src_schema = TabletSchema::create(schema_pb);
+    ASSERT_NE(src_schema, nullptr);
+    ASSERT_EQ(src_schema->num_short_key_columns(), 2);
+    ASSERT_EQ(src_schema->sort_key_idxes().size(), 2);
+
+    // Create partial schema with only [k0, k4] — no sort key columns included
+    auto partial_schema = TabletSchema::create(src_schema, {0, 4});
+    ASSERT_NE(partial_schema, nullptr);
+    // num_short_key_columns must not exceed sort_key_idxes.size()
+    ASSERT_LE(partial_schema->num_short_key_columns(), partial_schema->sort_key_idxes().size());
+
+    // Create partial schema with [k0, k2] — one of two sort key columns included
+    auto partial_schema2 = TabletSchema::create(src_schema, {0, 2});
+    ASSERT_NE(partial_schema2, nullptr);
+    ASSERT_LE(partial_schema2->num_short_key_columns(), partial_schema2->sort_key_idxes().size());
+
+    // Create partial schema with all sort keys [k0, k2, k3] — both sort key columns included
+    auto partial_schema3 = TabletSchema::create(src_schema, {0, 2, 3});
+    ASSERT_NE(partial_schema3, nullptr);
+    ASSERT_LE(partial_schema3->num_short_key_columns(), partial_schema3->sort_key_idxes().size());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Fix BE DCHECK crash `num_short_keys <= sort_key_idxes.size()` in `SeekTuple::short_key_encode` during column-mode partial update on primary key tables with separate sort keys (e.g. `ORDER BY(k3, k2)`).

`TabletSchema::create` copies `num_short_key_columns` from the source schema (e.g. 2), but `sort_key_idxes` in the partial schema may be empty when sort key columns are not in the partial column set. `_init_from_pb` then falls back to using key columns as sort keys (e.g. size=1), creating an inconsistency: `num_short_key_columns(2) > sort_key_idxes.size()(1)`.

## What I'm doing:
After constructing the partial tablet schema, ensure `num_short_key_columns <= sort_key_idxes.size()` to keep them consistent.

Trigger SQL:
```sql
CREATE TABLE tab1 (k0 int NOT NULL, k1 int, k2 int, k3 int, k4 int, k5 int, v1 int, v2 int)
PRIMARY KEY(k0) DISTRIBUTED BY HASH(k0) BUCKETS 1 ORDER BY(k3, k2)
PROPERTIES ("replication_num" = "1");

INSERT INTO tab1 VALUES (1,1,1,1,1,1,1,1);
SET partial_update_mode = 'column';
UPDATE tab1 SET k4 = 1;  -- crashes in ASAN build
```

Fixes https://github.com/StarRocks/StarRocksTest/issues/11136

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4