### PR TITLE
[Refactor] Refactor create sync materialized view statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -75,7 +75,7 @@ import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.CancelAlterTableStmt;
 import com.starrocks.sql.ast.CancelStmt;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropRollupClause;
 import com.starrocks.sql.ast.KeysType;
@@ -191,7 +191,7 @@ public class MaterializedViewHandler extends AlterHandler {
      * @param olapTable
      * @throws DdlException
      */
-    public void processCreateMaterializedView(CreateMaterializedViewStmt addMVClause, Database db, OlapTable olapTable)
+    public void processCreateMaterializedView(CreateSyncMVStmt addMVClause, Database db, OlapTable olapTable)
             throws DdlException, AnalysisException {
 
         if (olapTable.existTempPartitions()) {
@@ -397,7 +397,7 @@ public class MaterializedViewHandler extends AlterHandler {
         }
     }
 
-    private List<Column> checkAndPrepareMaterializedView(CreateMaterializedViewStmt addMVClause, Database db,
+    private List<Column> checkAndPrepareMaterializedView(CreateSyncMVStmt addMVClause, Database db,
                                                          OlapTable olapTable)
             throws DdlException {
         String mvName = addMVClause.getMVName();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -76,7 +76,7 @@ import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.expression.CastExpr;
@@ -581,7 +581,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         Expr whereExpr = null;
         if (whereClause != null) {
             Type type = BooleanType.BOOLEAN;
-            whereExpr = analyzeExpr(visitor, type, CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME,
+            whereExpr = analyzeExpr(visitor, type, CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME,
                     whereClause, slotDescByName);
             List<SlotRef> slots = Lists.newArrayList();
             whereExpr.collect(SlotRef.class, slots);
@@ -1069,8 +1069,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
 
         Map<String, Expr> columnNameToDefineExpr = MetaUtils.parseColumnNameToDefineExpr(origStmt);
-        if (columnNameToDefineExpr.containsKey(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME)) {
-            whereClause = columnNameToDefineExpr.get(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME);
+        if (columnNameToDefineExpr.containsKey(CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME)) {
+            whereClause = columnNameToDefineExpr.get(CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME);
         }
         setColumnsDefineExpr(columnNameToDefineExpr);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -41,7 +41,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.common.MetaUtils;
@@ -365,8 +365,8 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
             return;
         }
         Map<String, Expr> columnNameToDefineExpr = MetaUtils.parseColumnNameToDefineExpr(defineStmt);
-        if (columnNameToDefineExpr.containsKey(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME)) {
-            whereClause = columnNameToDefineExpr.get(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME);
+        if (columnNameToDefineExpr.containsKey(CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME)) {
+            whereClause = columnNameToDefineExpr.get(CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME);
         }
         setColumnsDefineExpr(columnNameToDefineExpr);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -43,7 +43,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -346,7 +346,7 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createMaterializedView(CreateMaterializedViewStmt stmt) throws AnalysisException, DdlException {
+    public void createMaterializedView(CreateSyncMVStmt stmt) throws AnalysisException, DdlException {
         normal.createMaterializedView(stmt);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -41,7 +41,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -331,7 +331,7 @@ public interface ConnectorMetadata {
     default void renamePartition(Database db, Table table, PartitionRenameClause renameClause) throws DdlException {
     }
 
-    default void createMaterializedView(CreateMaterializedViewStmt stmt)
+    default void createMaterializedView(CreateSyncMVStmt stmt)
             throws AnalysisException, DdlException {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -94,13 +94,13 @@ import com.starrocks.sql.ast.CreateDictionaryStmt;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceGroupStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableLikeStmt;
@@ -386,7 +386,7 @@ public class DDLStmtExecutor {
         }
 
         @Override
-        public ShowResultSet visitCreateMaterializedViewStmt(CreateMaterializedViewStmt stmt, ConnectContext context) {
+        public ShowResultSet visitCreateSyncMVStmt(CreateSyncMVStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getLocalMetastore().createMaterializedView(stmt);
             });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
@@ -77,13 +77,13 @@ import com.starrocks.sql.ast.CreateDictionaryStmt;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceGroupStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -566,7 +566,7 @@ public class RedirectStatus {
         }
 
         @Override
-        public RedirectStatus visitCreateMaterializedViewStmt(CreateMaterializedViewStmt statement, Void context) {
+        public RedirectStatus visitCreateSyncMVStmt(CreateSyncMVStmt statement, Void context) {
             return visitDDLStatement(statement, context);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -203,7 +203,7 @@ import com.starrocks.sql.ast.CancelAlterTableStmt;
 import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
 import com.starrocks.sql.ast.ColumnRenameClause;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableStmt;
@@ -3042,7 +3042,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
-    public void createMaterializedView(CreateMaterializedViewStmt stmt)
+    public void createMaterializedView(CreateSyncMVStmt stmt)
             throws AnalysisException, DdlException {
         MaterializedViewHandler materializedViewHandler =
                 GlobalStateMgr.getCurrentState().getAlterJobMgr().getMaterializedViewHandler();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -68,13 +68,13 @@ import com.starrocks.sql.ast.CreateDictionaryStmt;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceGroupStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -507,8 +507,8 @@ public class Analyzer {
         }
 
         @Override
-        public Void visitCreateMaterializedViewStmt(CreateMaterializedViewStmt statement, ConnectContext context) {
-            statement.analyze(context);
+        public Void visitCreateSyncMVStmt(CreateSyncMVStmt statement, ConnectContext context) {
+            CreateSyncMVStmtAnalyzer.analyze(statement, context);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateSyncMVStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateSyncMVStmtAnalyzer.java
@@ -12,27 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-package com.starrocks.sql.ast;
+package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -52,25 +32,23 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.sql.analyzer.AggregateTypeAnalyzer;
-import com.starrocks.sql.analyzer.AnalyzeState;
-import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
-import com.starrocks.sql.analyzer.ExpressionAnalyzer;
-import com.starrocks.sql.analyzer.Field;
-import com.starrocks.sql.analyzer.FunctionAnalyzer;
-import com.starrocks.sql.analyzer.RelationFields;
-import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.Scope;
-import com.starrocks.sql.analyzer.SelectAnalyzer;
-import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.analyzer.UnsupportedMVException;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapAggPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapUnionPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnHLLUnionPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnOneChildPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnPercentileUnionPattern;
+import com.starrocks.sql.ast.AggregateType;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.MVColumnItem;
+import com.starrocks.sql.ast.OrderByElement;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectList;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.CaseExpr;
 import com.starrocks.sql.ast.expression.CaseWhenClause;
 import com.starrocks.sql.ast.expression.Expr;
@@ -103,21 +81,12 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.rule.mv.MVUtils.MATERIALIZED_VIEW_NAME_PREFIX;
 
 /**
- * Materialized view is performed to materialize the results of query.
- * This clause is used to create a new materialized view for a specified table
- * through a specified query stmt.
- * <p>
- * Syntax:
- * CREATE MATERIALIZED VIEW [MV name] (
- * SELECT select_expr[, select_expr ...]
- * FROM [Base view name]
- * GROUP BY column_name[, column_name ...]
- * ORDER BY column_name[, column_name ...])
- * [PROPERTIES ("key" = "value")]
+ * Analyzer for {@link CreateSyncMVStmt}.
+ * Follows the same static-method pattern as {@link CreateTableAnalyzer}.
  */
-public class CreateMaterializedViewStmt extends DdlStmt {
+public class CreateSyncMVStmtAnalyzer {
 
-    private static final Logger LOG = LogManager.getLogger(CreateMaterializedViewStmt.class);
+    private static final Logger LOG = LogManager.getLogger(CreateSyncMVStmtAnalyzer.class);
 
     public static final Map<String, MVColumnPattern> FN_NAME_TO_PATTERN;
 
@@ -136,181 +105,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         FN_NAME_TO_PATTERN.put(FunctionSet.PERCENTILE_UNION, new MVColumnPercentileUnionPattern());
     }
 
-    private TableRef mvTableRef;
-    private final Map<String, String> properties;
-
-    private final QueryStatement queryStatement;
-    /**
-     * origin stmt: select k1, k2, v1, sum(v2) from base_table group by k1, k2, v1
-     * mvColumnItemList: [k1: {name: k1, isKey: true, aggType: null, isAggregationTypeImplicit: false},
-     * k2: {name: k2, isKey: true, aggType: null, isAggregationTypeImplicit: false},
-     * v1: {name: v1, isKey: true, aggType: null, isAggregationTypeImplicit: false},
-     * v2: {name: v2, isKey: false, aggType: sum, isAggregationTypeImplicit: false}]
-     * This order of mvColumnItemList is meaningful.
-     */
-    private List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
-
-    private Expr whereClause;
-    private String baseIndexName;
-    private String dbName;
-    private KeysType mvKeysType = KeysType.DUP_KEYS;
-
-    // If the process is replaying log, isReplay is true, otherwise is false,
-    // avoid throwing error during replay process, only in Rollup or MaterializedIndexMeta is true.
-    private boolean isReplay = false;
-
-    public static String WHERE_PREDICATE_COLUMN_NAME = "__WHERE_PREDICATION";
-
-    public CreateMaterializedViewStmt(TableRef mvTableRef, QueryStatement queryStatement, Map<String, String> properties) {
-        super(NodePosition.ZERO);
-        this.mvTableRef = mvTableRef;
-        this.queryStatement = queryStatement;
-        this.properties = properties;
-    }
-
-    public QueryStatement getQueryStatement() {
-        return queryStatement;
-    }
-
-    public void setIsReplay(boolean isReplay) {
-        this.isReplay = isReplay;
-    }
-
-    public boolean isReplay() {
-        return isReplay;
-    }
-
-    public TableRef getMvTableRef() {
-        return mvTableRef;
-    }
-
-    public void setMvTableRef(TableRef mvTableRef) {
-        this.mvTableRef = mvTableRef;
-    }
-
-    public String getMVName() {
-        return mvTableRef == null ? null : mvTableRef.getTableName();
-    }
-
-    public String getCatalogName() {
-        return mvTableRef == null ? null : mvTableRef.getCatalogName();
-    }
-
-    public String getDbName() {
-        return mvTableRef == null ? null : mvTableRef.getDbName();
-    }
-
-    public List<MVColumnItem> getMVColumnItemList() {
-        return mvColumnItemList;
-    }
-
-    public void setMvColumnItemList(List<MVColumnItem> mvColumnItemList) {
-        this.mvColumnItemList = mvColumnItemList;
-    }
-
-    public String getBaseIndexName() {
-        return baseIndexName;
-    }
-
-    public void setBaseIndexName(String baseIndexName) {
-        this.baseIndexName = baseIndexName;
-    }
-
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    public String getDBName() {
-        if (dbName != null) {
-            return dbName;
-        }
-        return mvTableRef == null ? null : mvTableRef.getDbName();
-    }
-
-    public void setDBName(String dbName) {
-        this.dbName = dbName;
-    }
-
-    public KeysType getMVKeysType() {
-        return mvKeysType;
-    }
-
-    public void setMvKeysType(KeysType mvKeysType) {
-        this.mvKeysType = mvKeysType;
-    }
-
-    public Expr getWhereClause() {
-        return whereClause;
-    }
-
-    // NOTE: This method is used to replay persistent MaterializedViewMeta,
-    // so need keep the same with `genColumnAndSetIntoStmt` and keep compatible with old version policy.
-    public Map<String, Expr> parseDefineExprWithoutAnalyze(String originalSql) {
-        Map<String, Expr> result = Maps.newHashMap();
-        SelectList selectList = null;
-        QueryRelation queryRelation = queryStatement.getQueryRelation();
-        if (queryRelation instanceof SelectRelation) {
-            SelectRelation selectRelation = (SelectRelation) queryRelation;
-            selectList = selectRelation.getSelectList();
-            if (selectRelation.hasWhereClause()) {
-                result.put(WHERE_PREDICATE_COLUMN_NAME, selectRelation.getWhereClause());
-            }
-        }
-        if (selectList == null) {
-            LOG.warn("parse defineExpr may not correctly for sql [{}] ", originalSql);
-            return result;
-        }
-        for (SelectListItem selectListItem : selectList.getItems()) {
-            Expr selectListItemExpr = selectListItem.getExpr();
-            List<SlotRef> slots = Lists.newArrayList();
-            selectListItemExpr.collect(SlotRef.class, slots);
-
-            String name;
-            Expr expr;
-            if (selectListItemExpr instanceof FunctionCallExpr) {
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItemExpr;
-                String functionName = functionCallExpr.getFunctionName();
-                switch (functionName.toLowerCase()) {
-                    case "sum":
-                    case "min":
-                    case "max":
-                    case FunctionSet.BITMAP_UNION:
-                    case FunctionSet.HLL_UNION:
-                    case FunctionSet.PERCENTILE_UNION:
-                    case FunctionSet.COUNT: {
-                        MVColumnItem item = buildAggColumnItem(ConnectContext.buildInner(), selectListItem, slots);
-                        expr = item.getDefineExpr();
-                        name = item.getName();
-                        break;
-                    }
-                    default: {
-                        MVColumnItem item = buildNonAggColumnItem(selectListItem, slots);
-                        expr = item.getDefineExpr();
-                        name = item.getName();
-                    }
-                }
-            } else {
-                MVColumnItem item = buildNonAggColumnItem(selectListItem, slots);
-                expr = item.getDefineExpr();
-                name = item.getName();
-            }
-            result.put(name, expr);
-        }
-        return result;
-    }
-
-    @Override
-    public String toSql() {
-        return null;
-    }
-
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitCreateMaterializedViewStmt(this, context);
-    }
-
-    public void analyze(ConnectContext context) {
-        QueryStatement queryStatement = getQueryStatement();
+    public static void analyze(CreateSyncMVStmt stmt, ConnectContext context) {
+        QueryStatement queryStatement = stmt.getQueryStatement();
 
         long originSelectLimit = context.getSessionVariable().getSqlSelectLimit();
         try {
@@ -343,11 +139,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         Table table = entry.getValue();
 
         // SyncMV doesn't support mv's database is different from table's db.
-        if (mvTableRef != null && !Strings.isNullOrEmpty(mvTableRef.getDbName()) &&
-                !mvTableRef.getDbName().equalsIgnoreCase(entry.getKey().getDb())) {
+        if (stmt.getMvTableRef() != null && !Strings.isNullOrEmpty(stmt.getMvTableRef().getDbName()) &&
+                !stmt.getMvTableRef().getDbName().equalsIgnoreCase(entry.getKey().getDb())) {
             throw new UnsupportedMVException(
                     String.format("Creating materialized view does not support: MV's db %s is different " +
-                            "from table's db %s", mvTableRef.getDbName(), entry.getKey().getDb()));
+                            "from table's db %s", stmt.getMvTableRef().getDbName(), entry.getKey().getDb()));
         }
 
         if (table instanceof View) {
@@ -358,32 +154,32 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         }
 
         TableName tableName = entry.getKey();
-        setBaseIndexName(table.getName());
-        setDBName(tableName.getDb());
+        stmt.setBaseIndexName(table.getName());
+        stmt.setDBName(tableName.getDb());
 
         SelectRelation selectRelation = ((SelectRelation) queryStatement.getQueryRelation());
         if (!(selectRelation.getRelation() instanceof TableRelation)) {
             throw new UnsupportedMVException("Materialized view query statement only support direct query from table.");
         }
-        int beginIndexOfAggregation = genColumnAndSetIntoStmt(context, table, selectRelation);
+        int beginIndexOfAggregation = genColumnAndSetIntoStmt(context, stmt, table, selectRelation);
         if (selectRelation.isDistinct() || selectRelation.hasAggregation()) {
-            setMvKeysType(KeysType.AGG_KEYS);
+            stmt.setMvKeysType(KeysType.AGG_KEYS);
         }
         if (selectRelation.hasWhereClause()) {
-            whereClause = selectRelation.getWhereClause();
+            stmt.setWhereClause(selectRelation.getWhereClause());
         }
         if (selectRelation.hasHavingClause()) {
             throw new UnsupportedMVException("The having clause is not supported in add materialized view clause, expr:"
                     + ExprToSql.toSql(selectRelation.getHavingClause()));
         }
-        analyzeOrderByClause(selectRelation, beginIndexOfAggregation);
+        analyzeOrderByClause(stmt, selectRelation, beginIndexOfAggregation);
         if (selectRelation.hasLimit()) {
             throw new UnsupportedMVException("The limit clause is not supported in add materialized view clause, expr:"
                     + " limit " + selectRelation.getLimit());
         }
         final String countPrefix = MATERIALIZED_VIEW_NAME_PREFIX + FunctionSet.COUNT + "_";
-        for (MVColumnItem mvColumnItem : getMVColumnItemList()) {
-            if (!isReplay && mvColumnItem.isKey() && !mvColumnItem.getType().canBeMVKey()) {
+        for (MVColumnItem mvColumnItem : stmt.getMVColumnItemList()) {
+            if (!stmt.isReplay() && mvColumnItem.isKey() && !mvColumnItem.getType().canBeMVKey()) {
                 throw new UnsupportedMVException(
                         String.format("Invalid data type of materialized key column '%s': '%s'",
                                 mvColumnItem.getName(), mvColumnItem.getType()));
@@ -395,13 +191,71 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             }
         }
         // analyze table if it has alias
-        analyzeExprWithTableAlias(context, this.dbName, table, getMVColumnItemList());
+        analyzeExprWithTableAlias(context, stmt.getDBName(), table, stmt.getMVColumnItemList());
     }
 
-    private void analyzeExprWithTableAlias(ConnectContext context,
-                                           String dbName,
-                                           Table table,
-                                           List<MVColumnItem> mvColumnItems) {
+    // NOTE: This method is used to replay persistent MaterializedViewMeta,
+    // so need keep the same with `genColumnAndSetIntoStmt` and keep compatible with old version policy.
+    public static Map<String, Expr> parseDefineExprWithoutAnalyze(CreateSyncMVStmt stmt,
+                                                                   String originalSql) {
+        Map<String, Expr> result = Maps.newHashMap();
+        SelectList selectList = null;
+        QueryRelation queryRelation = stmt.getQueryStatement().getQueryRelation();
+        if (queryRelation instanceof SelectRelation) {
+            SelectRelation selectRelation = (SelectRelation) queryRelation;
+            selectList = selectRelation.getSelectList();
+            if (selectRelation.hasWhereClause()) {
+                result.put(CreateSyncMVStmt.WHERE_PREDICATE_COLUMN_NAME, selectRelation.getWhereClause());
+            }
+        }
+        if (selectList == null) {
+            LOG.warn("parse defineExpr may not correctly for sql [{}] ", originalSql);
+            return result;
+        }
+        for (SelectListItem selectListItem : selectList.getItems()) {
+            Expr selectListItemExpr = selectListItem.getExpr();
+            List<SlotRef> slots = Lists.newArrayList();
+            selectListItemExpr.collect(SlotRef.class, slots);
+
+            String name;
+            Expr expr;
+            if (selectListItemExpr instanceof FunctionCallExpr) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItemExpr;
+                String functionName = functionCallExpr.getFunctionName();
+                switch (functionName.toLowerCase()) {
+                    case "sum":
+                    case "min":
+                    case "max":
+                    case FunctionSet.BITMAP_UNION:
+                    case FunctionSet.HLL_UNION:
+                    case FunctionSet.PERCENTILE_UNION:
+                    case FunctionSet.COUNT: {
+                        MVColumnItem item = buildAggColumnItem(ConnectContext.buildInner(), stmt.isReplay(),
+                                selectListItem, slots);
+                        expr = item.getDefineExpr();
+                        name = item.getName();
+                        break;
+                    }
+                    default: {
+                        MVColumnItem item = buildNonAggColumnItem(selectListItem, slots);
+                        expr = item.getDefineExpr();
+                        name = item.getName();
+                    }
+                }
+            } else {
+                MVColumnItem item = buildNonAggColumnItem(selectListItem, slots);
+                expr = item.getDefineExpr();
+                name = item.getName();
+            }
+            result.put(name, expr);
+        }
+        return result;
+    }
+
+    private static void analyzeExprWithTableAlias(ConnectContext context,
+                                                  String dbName,
+                                                  Table table,
+                                                  List<MVColumnItem> mvColumnItems) {
         // sourceScope must be set null tableName for its Field in RelationFields
         // because we hope slotRef can not be resolved in sourceScope but can be
         // resolved in outputScope to force to replace the node using outputExprs.
@@ -420,11 +274,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         }
     }
 
-    private void analyzeExprWithTableAlias(ConnectContext context,
-                                           SelectAnalyzer.SlotRefTableNameCleaner visitor,
-                                           Table table,
-                                           TableName tableName,
-                                           Expr expr) {
+    private static void analyzeExprWithTableAlias(ConnectContext context,
+                                                  SelectAnalyzer.SlotRefTableNameCleaner visitor,
+                                                  Table table,
+                                                  TableName tableName,
+                                                  Expr expr) {
         if (expr == null) {
             return;
         }
@@ -437,7 +291,10 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                                 .collect(Collectors.toList()))), context);
     }
 
-    private int genColumnAndSetIntoStmt(ConnectContext context, Table table, SelectRelation selectRelation) {
+    private static int genColumnAndSetIntoStmt(ConnectContext context,
+                                               CreateSyncMVStmt stmt,
+                                               Table table,
+                                               SelectRelation selectRelation) {
         List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
 
         boolean meetAggregate = false;
@@ -459,7 +316,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             Expr selectListItemExpr = selectListItem.getExpr();
             List<SlotRef> slots = Lists.newArrayList();
             selectListItemExpr.collect(SlotRef.class, slots);
-            if (!isReplay) {
+            if (!stmt.isReplay()) {
                 if (slots.size() == 0) {
                     throw new UnsupportedMVException(String.format("The materialized view currently does not support " +
                             "const expr in select " + "statement: {}", ExprToSql.toMySql(selectListItemExpr)));
@@ -472,7 +329,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItemExpr;
                 String functionName = functionCallExpr.getFunctionName().toLowerCase();
                 // current version not support count(distinct) function in creating materialized view
-                if (!isReplay && functionCallExpr.isDistinct()) {
+                if (!stmt.isReplay() && functionCallExpr.isDistinct()) {
                     throw new UnsupportedMVException(
                             "Materialized view does not support distinct function " + ExprToSql.toSql(functionCallExpr));
                 }
@@ -481,7 +338,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 } else {
                     MVColumnPattern mvColumnPattern = FN_NAME_TO_PATTERN.get(functionName);
                     if (mvColumnPattern == null) {
-
                         throw new UnsupportedMVException(
                                 "Materialized view does not support function:%s, supported functions are: %s",
                                 ExprToSql.toSql(functionCallExpr), FN_NAME_TO_PATTERN.keySet());
@@ -496,7 +352,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 }
                 meetAggregate = true;
 
-                mvColumnItem = buildAggColumnItem(context, selectListItem, slots);
+                mvColumnItem = buildAggColumnItem(context, stmt.isReplay(), selectListItem, slots);
                 if (!mvColumnNameSet.add(mvColumnItem.getName())) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, mvColumnItem.getName());
                 }
@@ -520,7 +376,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 mvColumnItemList.add(mvColumnItem);
                 joiner.add(ExprToSql.toSql(selectListItemExpr));
             }
-            Set<String> fullSchemaColNames = table.getFullSchema().stream().map(Column::getName).collect(Collectors.toSet());
+            Set<String> fullSchemaColNames = table.getFullSchema().stream().map(Column::getName)
+                    .collect(Collectors.toSet());
             if (fullSchemaColNames.contains(mvColumnItem.getName())) {
                 Expr existedDefinedExpr = table.getColumn(mvColumnItem.getName()).getDefineExpr();
                 if (existedDefinedExpr != null && !ExprToSql.toSqlWithoutTbl(existedDefinedExpr)
@@ -537,13 +394,13 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             throw new UnsupportedMVException("Only %s found in the select list. " +
                     "Please add group by clause and at least one group by column in the select list", joiner);
         }
-        setMvColumnItemList(mvColumnItemList);
+        stmt.setMvColumnItemList(mvColumnItemList);
         return beginIndexOfAggregation;
     }
 
     // Convert non-aggregate function to MVColumn
-    private MVColumnItem buildNonAggColumnItem(SelectListItem selectListItem,
-                                               List<SlotRef> baseSlotRefs) throws SemanticException {
+    private static MVColumnItem buildNonAggColumnItem(SelectListItem selectListItem,
+                                                      List<SlotRef> baseSlotRefs) throws SemanticException {
         Expr defineExpr = selectListItem.getExpr();
         Type type = defineExpr.getType();
         String columnName;
@@ -560,13 +417,14 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName())
                 .collect(Collectors.toSet());
         return new MVColumnItem(columnName, type, null, null, false, defineExpr,
-                defineExpr.isNullable(),  baseColumnNames);
+                defineExpr.isNullable(), baseColumnNames);
     }
 
     // Convert the aggregate function to MVColumn.
-    private MVColumnItem buildAggColumnItem(ConnectContext context,
-                                            SelectListItem selectListItem,
-                                            List<SlotRef> baseSlotRefs) {
+    private static MVColumnItem buildAggColumnItem(ConnectContext context,
+                                                   boolean isReplay,
+                                                   SelectListItem selectListItem,
+                                                   List<SlotRef> baseSlotRefs) {
         FunctionCallExpr node = (FunctionCallExpr) selectListItem.getExpr();
         String functionName = node.getFunctionName();
         Preconditions.checkState(node.getChildren().size() == 1, "Aggregate function only support one child");
@@ -581,8 +439,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             List<Type> argTypes = node.getChildren().stream().map(Expr::getType).collect(Collectors.toList());
             Type arg0Type = argTypes.get(0);
             if (arg0Type.getAggStateDesc() == null) {
-                throw new UnsupportedMVException("Unsupported function:" + functionName + ", cannot find agg state desc from " +
-                        "arg0");
+                throw new UnsupportedMVException("Unsupported function:" + functionName +
+                        ", cannot find agg state desc from arg0");
             }
             FunctionParams params = new FunctionParams(false, Lists.newArrayList());
             Type[] argumentTypes = argTypes.toArray(Type[]::new);
@@ -597,12 +455,12 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             AggStateDesc aggStateDesc = aggFunction.getAggStateDesc();
             Type type = aggFunction.getIntermediateTypeOrReturnType();
             if (type.isWildcardDecimal()) {
-                throw new UnsupportedMVException("Unsupported wildcard decimal type in materialized view:" + type + ", " +
-                        "function:" + node);
+                throw new UnsupportedMVException("Unsupported wildcard decimal type in materialized view:" + type +
+                        ", function:" + node);
             }
             if (aggStateDesc.getArgTypes().stream().anyMatch(t -> t.isWildcardDecimal())) {
-                throw new UnsupportedMVException("Unsupported wildcard decimal type in materialized view:" + type + ", " +
-                        "function:" + node);
+                throw new UnsupportedMVException("Unsupported wildcard decimal type in materialized view:" + type +
+                        ", function:" + node);
             }
             Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName())
                     .collect(Collectors.toSet());
@@ -611,13 +469,14 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             return new MVColumnItem(mvColumnName, finalType, mvAggregateType, aggStateDesc, false,
                     defineExpr, aggStateDesc.getResultNullable(), baseColumnNames);
         } else {
-            return buildAggColumnItemWithPattern(selectListItem, baseSlotRefs);
+            return buildAggColumnItemWithPattern(isReplay, selectListItem, baseSlotRefs);
         }
     }
 
     // Convert the aggregate function to MVColumn.
-    private MVColumnItem buildAggColumnItemWithPattern(SelectListItem selectListItem,
-                                                       List<SlotRef> baseSlotRefs) {
+    private static MVColumnItem buildAggColumnItemWithPattern(boolean isReplay,
+                                                              SelectListItem selectListItem,
+                                                              List<SlotRef> baseSlotRefs) {
         FunctionCallExpr functionCallExpr = (FunctionCallExpr) selectListItem.getExpr();
         String functionName = functionCallExpr.getFunctionName();
         Expr defineExpr = functionCallExpr.getChild(0);
@@ -727,16 +586,17 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 defineExpr, functionCallExpr.isNullable(), baseColumnNames);
     }
 
-    private void analyzeOrderByClause(SelectRelation selectRelation,
-                                      int beginIndexOfAggregation) {
+    private static void analyzeOrderByClause(CreateSyncMVStmt stmt,
+                                             SelectRelation selectRelation,
+                                             int beginIndexOfAggregation) {
         if (!selectRelation.hasOrderByClause() ||
                 selectRelation.getGroupBy().size() != selectRelation.getOrderBy().size()) {
-            supplyOrderColumn();
+            supplyOrderColumn(stmt);
             return;
         }
 
         List<OrderByElement> orderByElements = selectRelation.getOrderBy();
-        List<MVColumnItem> mvColumnItemList = getMVColumnItemList();
+        List<MVColumnItem> mvColumnItemList = stmt.getMVColumnItemList();
 
         if (orderByElements.size() > mvColumnItemList.size()) {
             throw new UnsupportedMVException(
@@ -779,15 +639,15 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     /*
     This function is used to supply order by columns and calculate short key count
     */
-    private void supplyOrderColumn() {
-        List<MVColumnItem> mvColumnItemList = getMVColumnItemList();
+    private static void supplyOrderColumn(CreateSyncMVStmt stmt) {
+        List<MVColumnItem> mvColumnItemList = stmt.getMVColumnItemList();
 
         /*
          * The keys type of Materialized view is aggregation.
          * All of group by columns are keys of materialized view.
          */
-        if (getMVKeysType() == KeysType.AGG_KEYS) {
-            for (MVColumnItem mvColumnItem : getMVColumnItemList()) {
+        if (stmt.getMVKeysType() == KeysType.AGG_KEYS) {
+            for (MVColumnItem mvColumnItem : stmt.getMVColumnItemList()) {
                 if (mvColumnItem.getAggregationType() != null) {
                     break;
                 }
@@ -796,7 +656,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 }
                 mvColumnItem.setIsKey(true);
             }
-        } else if (getMVKeysType() == KeysType.DUP_KEYS) {
+        } else if (stmt.getMVKeysType() == KeysType.DUP_KEYS) {
             /*
              * There is no aggregation function in materialized view.
              * Supplement key of MV columns

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -181,7 +181,7 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
-    default R visitCreateMaterializedViewStmt(CreateMaterializedViewStmt statement, C context) {
+    default R visitCreateSyncMVStmt(CreateSyncMVStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * Materialized view is performed to materialize the results of query.
  * This clause is used to create a new materialized view for specified tables
  * through a specified query stmt.
- * The differences with CreateMaterializedViewStmt:
+ * The differences with CreateSyncMVStmt:
  * 1. Supports querying materialized view directly and try best to keep the result consistent with querying base tables
  * 2. Supports creating mvs on multi tables
  * 3. partition and distribution desc can be specified for each mv independently.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateSyncMVStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateSyncMVStmt.java
@@ -1,0 +1,159 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Materialized view is performed to materialize the results of query.
+ * This clause is used to create a new materialized view for a specified table
+ * through a specified query stmt.
+ * <p>
+ * Syntax:
+ * CREATE MATERIALIZED VIEW [MV name] (
+ * SELECT select_expr[, select_expr ...]
+ * FROM [Base view name]
+ * GROUP BY column_name[, column_name ...]
+ * ORDER BY column_name[, column_name ...])
+ * [PROPERTIES ("key" = "value")]
+ */
+public class CreateSyncMVStmt extends DdlStmt {
+
+    private TableRef mvTableRef;
+    private final Map<String, String> properties;
+
+    private final QueryStatement queryStatement;
+    /**
+     * origin stmt: select k1, k2, v1, sum(v2) from base_table group by k1, k2, v1
+     * mvColumnItemList: [k1: {name: k1, isKey: true, aggType: null, isAggregationTypeImplicit: false},
+     * k2: {name: k2, isKey: true, aggType: null, isAggregationTypeImplicit: false},
+     * v1: {name: v1, isKey: true, aggType: null, isAggregationTypeImplicit: false},
+     * v2: {name: v2, isKey: false, aggType: sum, isAggregationTypeImplicit: false}]
+     * This order of mvColumnItemList is meaningful.
+     */
+    private List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
+
+    private Expr whereClause;
+    private String baseIndexName;
+    private String dbName;
+    private KeysType mvKeysType = KeysType.DUP_KEYS;
+
+    // If the process is replaying log, isReplay is true, otherwise is false,
+    // avoid throwing error during replay process, only in Rollup or MaterializedIndexMeta is true.
+    private boolean isReplay = false;
+
+    public static String WHERE_PREDICATE_COLUMN_NAME = "__WHERE_PREDICATION";
+
+    public CreateSyncMVStmt(TableRef mvTableRef, QueryStatement queryStatement, Map<String, String> properties) {
+        super(NodePosition.ZERO);
+        this.mvTableRef = mvTableRef;
+        this.queryStatement = queryStatement;
+        this.properties = properties;
+    }
+
+    public QueryStatement getQueryStatement() {
+        return queryStatement;
+    }
+
+    public void setIsReplay(boolean isReplay) {
+        this.isReplay = isReplay;
+    }
+
+    public boolean isReplay() {
+        return isReplay;
+    }
+
+    public TableRef getMvTableRef() {
+        return mvTableRef;
+    }
+
+    public void setMvTableRef(TableRef mvTableRef) {
+        this.mvTableRef = mvTableRef;
+    }
+
+    public String getMVName() {
+        return mvTableRef == null ? null : mvTableRef.getTableName();
+    }
+
+    public String getCatalogName() {
+        return mvTableRef == null ? null : mvTableRef.getCatalogName();
+    }
+
+    public String getDbName() {
+        return mvTableRef == null ? null : mvTableRef.getDbName();
+    }
+
+    public List<MVColumnItem> getMVColumnItemList() {
+        return mvColumnItemList;
+    }
+
+    public void setMvColumnItemList(List<MVColumnItem> mvColumnItemList) {
+        this.mvColumnItemList = mvColumnItemList;
+    }
+
+    public String getBaseIndexName() {
+        return baseIndexName;
+    }
+
+    public void setBaseIndexName(String baseIndexName) {
+        this.baseIndexName = baseIndexName;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public String getDBName() {
+        if (dbName != null) {
+            return dbName;
+        }
+        return mvTableRef == null ? null : mvTableRef.getDbName();
+    }
+
+    public void setDBName(String dbName) {
+        this.dbName = dbName;
+    }
+
+    public KeysType getMVKeysType() {
+        return mvKeysType;
+    }
+
+    public void setMvKeysType(KeysType mvKeysType) {
+        this.mvKeysType = mvKeysType;
+    }
+
+    public Expr getWhereClause() {
+        return whereClause;
+    }
+
+    public void setWhereClause(Expr whereClause) {
+        this.whereClause = whereClause;
+    }
+
+    @Override
+    public String toSql() {
+        return null;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitCreateSyncMVStmt(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -40,8 +40,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.CreateSyncMVStmtAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
@@ -150,13 +151,13 @@ public class MetaUtils {
     }
 
     public static Map<String, Expr> parseColumnNameToDefineExpr(OriginStatementInfo originStmt) {
-        CreateMaterializedViewStmt stmt;
+        CreateSyncMVStmt stmt;
 
         try {
             List<StatementBase> stmts = SqlParser.parse(originStmt.originStmt, SqlModeHelper.MODE_DEFAULT);
-            stmt = (CreateMaterializedViewStmt) stmts.get(originStmt.idx);
+            stmt = (CreateSyncMVStmt) stmts.get(originStmt.idx);
             stmt.setIsReplay(true);
-            return stmt.parseDefineExprWithoutAnalyze(originStmt.originStmt);
+            return CreateSyncMVStmtAnalyzer.parseDefineExprWithoutAnalyze(stmt, originStmt.originStmt);
         } catch (Exception e) {
             LOG.warn("error happens when parsing create materialized view stmt [{}] use new parser",
                     originStmt, e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -147,7 +147,6 @@ import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateImageClause;
 import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateOrReplaceBranchClause;
 import com.starrocks.sql.ast.CreateOrReplaceTagClause;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
@@ -156,6 +155,7 @@ import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -2332,7 +2332,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 throw new ParsingException(PARSER_ERROR_MSG.forbidClauseInMV("SYNC refresh type", "DISTRIBUTION BY"),
                         distributionDesc.getPos());
             }
-            return new CreateMaterializedViewStmt(tableRef, queryStatement, properties);
+            return new CreateSyncMVStmt(tableRef, queryStatement, properties);
         }
         if (refreshSchemeDesc instanceof AsyncRefreshSchemeDesc) {
             AsyncRefreshSchemeDesc asyncRefreshSchemeDesc = (AsyncRefreshSchemeDesc) refreshSchemeDesc;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -33,7 +33,7 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AlterReplicaTask;
@@ -159,8 +159,8 @@ public class LakeRollupJobTest {
 
     private static LakeRollupJob createJob(String sql) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        Assertions.assertTrue(stmt instanceof CreateMaterializedViewStmt);
-        CreateMaterializedViewStmt createMaterializedViewStmt = (CreateMaterializedViewStmt) stmt;
+        Assertions.assertTrue(stmt instanceof CreateSyncMVStmt);
+        CreateSyncMVStmt createMaterializedViewStmt = (CreateSyncMVStmt) stmt;
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStmt);
         Map<Long, AlterJobV2> alterJobV2Map = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
         List<AlterJobV2> alterJobV2List = new ArrayList<>(alterJobV2Map.values());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
@@ -27,7 +27,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AggregateType;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ShowMaterializedViewsStmt;
 import com.starrocks.sql.ast.StatementBase;
@@ -210,7 +210,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testMaterializedViews() throws Exception {
         String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -230,7 +230,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     public void testSelectFromSyncMV() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view sync_mv as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -248,7 +248,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateSyncMV1() throws Exception {
         String sql = "create materialized view aggregate_table_with_null as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         try {
             // aggregate_table_with_null already existed in the db
@@ -264,7 +264,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateSyncMV2() throws Exception {
         String sql = "create materialized view sync_mv2 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -284,7 +284,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
 
         // sync_mv2 already existed in the tbl1
         sql = "create materialized view sync_mv2 as select k1, sum(v1) from tbl1 group by k1;";
-        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        createTableStmt = (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
             Assertions.fail();
@@ -299,7 +299,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     @Test
     public void testCreateSyncMV3() throws Exception {
         String sql = "create materialized view sync_mv3 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -309,7 +309,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
         Assertions.assertTrue(tbl1.hasMaterializedIndex("sync_mv3"));
         // sync_mv3 already existed in tbl1
         sql = "create materialized view sync_mv3 as select k1, sum(v1) from tbl3 group by k1;";
-        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        createTableStmt = (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
             Assertions.fail();
@@ -324,7 +324,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     public void testCreateSyncMV_WithUpperColumn() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view UPPER_MV1 as select K1, sum(V1) from TBL1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -360,7 +360,7 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
     public void testCreateSyncMV_WithLowerColumn() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view lower_mv1 as select k1, sum(v1) from tbl1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -716,8 +716,8 @@ public class LakeSyncMaterializedViewTest extends StarRocksTestBase {
                 "   GROUP BY k1;";
 
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        if (stmt instanceof CreateMaterializedViewStmt) {
-            CreateMaterializedViewStmt createMaterializedViewStmt = (CreateMaterializedViewStmt) stmt;
+        if (stmt instanceof CreateSyncMVStmt) {
+            CreateSyncMVStmt createMaterializedViewStmt = (CreateSyncMVStmt) stmt;
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStmt);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerEditLogTest.java
@@ -41,7 +41,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AlterClause;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropRollupClause;
 import com.starrocks.sql.ast.KeysType;
@@ -112,7 +112,7 @@ public class MaterializedViewHandlerEditLogTest {
     @Test
     public void testProcessCreateMaterializedViewEditLog() throws Exception {
         String sql = "create materialized view mv1 as select k1, sum(v1) from " + TABLE_NAME + " group by k1";
-        CreateMaterializedViewStmt stmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt stmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
 
         MaterializedViewHandler handler = new MaterializedViewHandler();
@@ -128,7 +128,7 @@ public class MaterializedViewHandlerEditLogTest {
     @Test
     public void testProcessCreateMaterializedViewEditLogException() throws Exception {
         String sql = "create materialized view mv2 as select k1, sum(v1) from " + TABLE_NAME + " group by k1";
-        CreateMaterializedViewStmt stmt = (CreateMaterializedViewStmt) UtFrameUtils
+        CreateSyncMVStmt stmt = (CreateSyncMVStmt) UtFrameUtils
                 .parseStmtWithNewParser(sql, connectContext);
 
         MaterializedViewHandler handler = new MaterializedViewHandler();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerTest.java
@@ -43,7 +43,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.sql.ast.AggregateType;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.MVColumnItem;
 import com.starrocks.type.IntegerType;
@@ -57,7 +57,7 @@ import java.util.List;
 
 public class MaterializedViewHandlerTest {
     @Test
-    public void testDifferentBaseTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testDifferentBaseTable(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                        @Injectable Database db,
                                        @Injectable OlapTable olapTable) {
         new Expectations() {
@@ -79,7 +79,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testNotNormalTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testNotNormalTable(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                    @Injectable Database db,
                                    @Injectable OlapTable olapTable) {
         final String baseIndexName = "t1";
@@ -104,7 +104,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testErrorBaseIndexName(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testErrorBaseIndexName(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                        @Injectable Database db,
                                        @Injectable OlapTable olapTable) {
         final String baseIndexName = "t1";
@@ -131,7 +131,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testRollupReplica(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testRollupReplica(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                   @Injectable Database db,
                                   @Injectable OlapTable olapTable,
                                   @Injectable PhysicalPartition partition,
@@ -169,7 +169,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateMVName(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testDuplicateMVName(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                     @Injectable OlapTable olapTable, @Injectable Database db) {
         final String mvName = "mv1";
         new Expectations() {
@@ -191,7 +191,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidAggregateType(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testInvalidAggregateType(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                          @Injectable OlapTable olapTable, @Injectable Database db) {
         final String mvName = "mv1";
         final String mvColumName = "mv_sum_k1";
@@ -224,7 +224,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidKeysType(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testInvalidKeysType(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                     @Injectable OlapTable olapTable, @Injectable Database db) {
         new Expectations() {
             {
@@ -246,7 +246,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateTable(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void testDuplicateTable(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                    @Injectable OlapTable olapTable, @Injectable Database db) {
         final String mvName = "mv1";
         final String columnName1 = "k1";
@@ -288,7 +288,7 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void checkInvalidPartitionKeyMV(@Injectable CreateMaterializedViewStmt createMaterializedViewStmt,
+    public void checkInvalidPartitionKeyMV(@Injectable CreateSyncMVStmt createMaterializedViewStmt,
                                            @Injectable OlapTable olapTable, @Injectable Database db) {
         final String mvName = "mv1";
         final String columnName1 = "k1";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMVStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMVStmtTest.java
@@ -20,7 +20,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AggregateType;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.MVColumnItem;
 import com.starrocks.type.FloatType;
@@ -141,8 +141,8 @@ public class CreateMVStmtTest {
     public void testCreateMVWithFirstVarchar() throws Exception {
         String columnName1 = "c_1_10";
         String sql = "create materialized view star_view as select c_1_10 from t1;";
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assertions.assertEquals(KeysType.DUP_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvColumns = stmt.getMVColumnItemList();
         Assertions.assertEquals(1, mvColumns.size());
@@ -167,8 +167,8 @@ public class CreateMVStmtTest {
     @Test
     public void testCreateMVColumns() throws Exception {
         String sql = "create materialized view star_view as select k1, sum(v1), min(v2) from agg_tbl group by k1;";
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
 
         Assertions.assertEquals(KeysType.AGG_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvColumns = stmt.getMVColumnItemList();
@@ -194,8 +194,8 @@ public class CreateMVStmtTest {
     @Test
     public void testDuplicateMV() throws Exception {
         String sql = "create materialized view star_view as select k1, sum(v1) from agg_tbl group by k1;";
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
 
         Assertions.assertEquals(KeysType.AGG_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvSchema = stmt.getMVColumnItemList();
@@ -207,21 +207,21 @@ public class CreateMVStmtTest {
     public void testMVAggregate() throws Exception {
         {
             String sql = "create materialized view star_view as select k1, sum(v1) from agg_tbl group by k1;";
-            CreateMaterializedViewStmt stmt =
-                    (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            CreateSyncMVStmt stmt =
+                    (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
             Assertions.assertEquals(IntegerType.BIGINT, stmt.getMVColumnItemList().get(1).getType());
         }
 
         {
             String sql = "create materialized view star_view as select k1, min(v2) from agg_tbl group by k1;";
-            CreateMaterializedViewStmt stmt =
-                    (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            CreateSyncMVStmt stmt =
+                    (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
             Assertions.assertTrue(stmt.getMVColumnItemList().get(1).getType().isVarchar());
         }
         {
             String sql = "create materialized view star_view as select k1, sum(v3) from agg_tbl group by k1;";
-            CreateMaterializedViewStmt stmt =
-                    (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            CreateSyncMVStmt stmt =
+                    (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
             Assertions.assertEquals(FloatType.DOUBLE, stmt.getMVColumnItemList().get(1).getType());
         }
     }
@@ -263,8 +263,8 @@ public class CreateMVStmtTest {
         String columnName4 = "c_1_4";
         String sql = "create materialized view star_view as select c_1_1, c_1_2, c_1_3, c_1_4 from t1;";
 
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assertions.assertEquals(KeysType.DUP_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvColumns = stmt.getMVColumnItemList();
         Assertions.assertEquals(4, mvColumns.size());
@@ -298,8 +298,8 @@ public class CreateMVStmtTest {
     public void testMVColumnsWithoutOrderbyWithoutAggregationWithFloat() throws Exception {
         String columnName4 = "c_1_4";
         String sql = "create materialized view star_view as select c_1_1, c_1_2, c_1_3, c_1_4 from t1;";
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assertions.assertEquals(KeysType.DUP_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvColumns = stmt.getMVColumnItemList();
         Assertions.assertEquals(4, mvColumns.size());
@@ -315,8 +315,8 @@ public class CreateMVStmtTest {
     public void testMVColumnsWithoutOrderbyWithoutAggregationWithVarchar() throws Exception {
         String columnName3 = "c_1_10";
         String sql = "create materialized view star_view as select c_1_1, c_1_2, c_1_10, c_1_11  from t1;";
-        CreateMaterializedViewStmt stmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        CreateSyncMVStmt stmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
         Assertions.assertEquals(KeysType.DUP_KEYS, stmt.getMVKeysType());
         List<MVColumnItem> mvColumns = stmt.getMVColumnItemList();
         Assertions.assertEquals(4, mvColumns.size());
@@ -337,7 +337,7 @@ public class CreateMVStmtTest {
                 "SELECT t1.c_1_1, t1.c_1_2, t1.c_1_13 " +
                 "FROM t1";
         try {
-            CreateMaterializedViewStmt stmt = (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            CreateSyncMVStmt stmt = (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
             boolean jsonKey = stmt.getMVColumnItemList().stream().anyMatch(col -> col.isKey() && col.getType().isJsonType());
             Assertions.assertFalse(jsonKey);
         } catch (Exception ex) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -67,7 +67,7 @@ import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ManualRefreshSchemeDesc;
@@ -593,7 +593,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
         String sql = "create materialized view mv1\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        Assertions.assertTrue(statementBase instanceof CreateMaterializedViewStmt);
+        Assertions.assertTrue(statementBase instanceof CreateSyncMVStmt);
     }
 
     @Test
@@ -1514,7 +1514,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "as select tbl1.k1 ss, k2 from tbl1 group by k1, k2;";
         try {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            Assertions.assertTrue(statementBase instanceof CreateMaterializedViewStmt);
+            Assertions.assertTrue(statementBase instanceof CreateSyncMVStmt);
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }
@@ -2016,7 +2016,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "as select k1, k2 from colocateTable;";
         try {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+            currentState.getLocalMetastore().createMaterializedView((CreateSyncMVStmt) statementBase);
             waitingRollupJobV2Finish();
             ColocateTableIndex colocateTableIndex = currentState.getColocateTableIndex();
             String fullGroupName = testDb.getId() + "_" + "colocate_group1";
@@ -2064,7 +2064,7 @@ public class CreateMaterializedViewTest extends MVTestBase {
 
         Assertions.assertThrows(AnalysisException.class, () -> {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+            currentState.getLocalMetastore().createMaterializedView((CreateSyncMVStmt) statementBase);
         });
 
         currentState.getColocateTableIndex().clear();
@@ -2115,10 +2115,10 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 "as select k1, k2 from colocateTable3;";
         try {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+            currentState.getLocalMetastore().createMaterializedView((CreateSyncMVStmt) statementBase);
             waitingRollupJobV2Finish();
             statementBase = UtFrameUtils.parseStmtWithNewParser(sql2, connectContext);
-            currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+            currentState.getLocalMetastore().createMaterializedView((CreateSyncMVStmt) statementBase);
             waitingRollupJobV2Finish();
 
             ColocateTableIndex colocateTableIndex = currentState.getColocateTableIndex();
@@ -2978,8 +2978,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
                     .useDatabase("test_mv_different_db");
             String sql = "create materialized view test.test_mv_use_different_tbl " +
                     "as select k1, sum(v1), min(v2) from test.tbl5 group by k1;";
-            CreateMaterializedViewStmt stmt =
-                    (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, newStarRocksAssert.getCtx());
+            CreateSyncMVStmt stmt =
+                    (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql, newStarRocksAssert.getCtx());
             Assertions.assertEquals(stmt.getDBName(), "test");
             Assertions.assertEquals(stmt.getMVName(), "test_mv_use_different_tbl");
             currentState.getLocalMetastore().createMaterializedView(stmt);
@@ -3009,8 +3009,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
             Assertions.assertThrows(AnalysisException.class, () -> {
                 String sql = "create materialized view test_mv_different_db.test_mv_use_different_tbl " +
                         "as select k1, sum(v1), min(v2) from test.tbl5 group by k1;";
-                CreateMaterializedViewStmt stmt =
-                        (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                CreateSyncMVStmt stmt =
+                        (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(sql,
                                 newStarRocksAssert.getCtx());
 
             });

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
@@ -27,7 +27,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AggregateType;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -216,7 +216,7 @@ public class CreateSyncMaterializedViewTest {
     public void testSelectFromSyncMV() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -234,7 +234,7 @@ public class CreateSyncMaterializedViewTest {
     @Test
     public void testCreateSyncMV1() throws Exception {
         String sql = "create materialized view aggregate_table_with_null as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         try {
             // aggregate_table_with_null already existed in the db
@@ -249,7 +249,7 @@ public class CreateSyncMaterializedViewTest {
     @Test
     public void testCreateSyncMV2() throws Exception {
         String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -260,7 +260,7 @@ public class CreateSyncMaterializedViewTest {
 
         // sync_mv1 already existed in the tbl1
         sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
@@ -276,7 +276,7 @@ public class CreateSyncMaterializedViewTest {
     @Test
     public void testCreateSyncMV3() throws Exception {
         String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -286,7 +286,7 @@ public class CreateSyncMaterializedViewTest {
         Assertions.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
         // sync_mv1 already existed in tbl1
         sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl3 group by k1;";
-        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
@@ -302,7 +302,7 @@ public class CreateSyncMaterializedViewTest {
     public void testCreateSyncMV_WithUpperColumn() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view UPPER_MV1 as select K1, sum(V1) from TBL1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -338,7 +338,7 @@ public class CreateSyncMaterializedViewTest {
     public void testCreateSyncMV_WithLowerColumn() throws Exception {
         // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
         String sql = "create materialized view lower_mv1 as select k1, sum(v1) from tbl1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createTableStmt);
 
@@ -373,7 +373,7 @@ public class CreateSyncMaterializedViewTest {
     @Test
     public void testCreateSynchronousMVOnAnotherMV() throws Exception {
         String sql = "create materialized view sync_mv1 as select k1, sum(v1) from mocked_cloud_table group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+        CreateSyncMVStmt createTableStmt = (CreateSyncMVStmt) UtFrameUtils.
                 parseStmtWithNewParser(sql, connectContext);
         Table table = getTable("test", "mocked_cloud_table");
         // Change table type to materialized view

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -25,7 +25,7 @@ import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.connector.metadata.TableMetaMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Test;
@@ -184,7 +184,7 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.dropPartition(null, null, null);
                 connectorMetadata.renamePartition(null, null, null);
                 connectorMetadata.createMaterializedView((CreateMaterializedViewStatement) null);
-                connectorMetadata.createMaterializedView((CreateMaterializedViewStmt) null);
+                connectorMetadata.createMaterializedView((CreateSyncMVStmt) null);
                 connectorMetadata.dropMaterializedView(null);
                 connectorMetadata.alterMaterializedView(null);
                 connectorMetadata.refreshMaterializedView(null);
@@ -221,7 +221,7 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.dropPartition(null, null, null);
         catalogConnectorMetadata.renamePartition(null, null, null);
         catalogConnectorMetadata.createMaterializedView((CreateMaterializedViewStatement) null);
-        catalogConnectorMetadata.createMaterializedView((CreateMaterializedViewStmt) null);
+        catalogConnectorMetadata.createMaterializedView((CreateSyncMVStmt) null);
         catalogConnectorMetadata.dropMaterializedView(null);
         catalogConnectorMetadata.alterMaterializedView(null);
         catalogConnectorMetadata.refreshMaterializedView(null);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -72,13 +72,13 @@ import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateDictionaryStmt;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.sql.ast.CreateFunctionStmt;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceGroupStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -936,13 +936,13 @@ public class RedirectStatusTest {
     }
 
     @Test
-    public void testCreateMaterializedViewStmt() {
-        // CreateMaterializedViewStmt requires: TableName, QueryStatement, Map<String,String>
+    public void testCreateSyncMVStmt() {
+        // CreateSyncMVStmt requires: TableName, QueryStatement, Map<String,String>
         // This test is simplified due to complex constructor
         TableName tableName = new TableName("catalog", "db", "mv");
         SelectRelation selectRelation = new SelectRelation(new SelectList(), null, null, null, null);
         QueryStatement queryStatement = new QueryStatement(selectRelation);
-        CreateMaterializedViewStmt stmt = new CreateMaterializedViewStmt(
+        CreateSyncMVStmt stmt = new CreateSyncMVStmt(
                 new TableRef(QualifiedName.of(Lists.newArrayList(
                         tableName.getCatalog(), tableName.getDb(), tableName.getTbl())),
                         null, NodePosition.ZERO), queryStatement,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -39,7 +39,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.optimizer.statistics.EmptyStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
@@ -1438,8 +1438,8 @@ public class MVRewriteTest extends StarRocksTestBase {
 
         String createMVSQL = "CREATE MATERIALIZED VIEW partial_order_by_mv AS " +
                 "SELECT k6, k7 FROM all_type_table GROUP BY k6, k7 ORDER BY k6";
-        CreateMaterializedViewStmt createMaterializedViewStmt =
-                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(createMVSQL, starRocksAssert.getCtx());
+        CreateSyncMVStmt createMaterializedViewStmt =
+                (CreateSyncMVStmt) UtFrameUtils.parseStmtWithNewParser(createMVSQL, starRocksAssert.getCtx());
         createMaterializedViewStmt.getMVColumnItemList().forEach(k -> Assertions.assertTrue(k.isKey()));
 
         starRocksAssert.withMaterializedView(createMVSQL).query(query).explainContains("rollup: partial_order_by_mv");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
@@ -20,7 +20,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
@@ -64,7 +64,7 @@ public class MVRewriteWithSchemaChangeTest extends MVTestBase {
                 "                );");
         String sql = "CREATE MATERIALIZED VIEW sync_mv1 AS select a, b*10 as col2, c+1 as col3 from sync_tbl_t1;";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView((CreateSyncMVStmt) statementBase);
         waitingRollupJobV2Finish();
         String query = "select a, b*10 as col2, c+1 as col3 from sync_tbl_t1 order by a;";
         String plan = getFragmentPlan(query);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -98,10 +98,10 @@ import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
+import com.starrocks.sql.ast.CreateSyncMVStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableLikeStmt;
 import com.starrocks.sql.ast.CreateTemporaryTableStmt;
@@ -937,8 +937,8 @@ public class StarRocksAssert {
 
     public String getMVName(String sql) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        if (stmt instanceof CreateMaterializedViewStmt) {
-            CreateMaterializedViewStmt createMaterializedViewStmt = (CreateMaterializedViewStmt) stmt;
+        if (stmt instanceof CreateSyncMVStmt) {
+            CreateSyncMVStmt createMaterializedViewStmt = (CreateSyncMVStmt) stmt;
             return createMaterializedViewStmt.getMVName();
         } else {
             Preconditions.checkState(stmt instanceof CreateMaterializedViewStatement);
@@ -955,8 +955,8 @@ public class StarRocksAssert {
                                                 boolean isOnlySingleReplica,
                                                 boolean isRefresh) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        if (stmt instanceof CreateMaterializedViewStmt) {
-            CreateMaterializedViewStmt createMaterializedViewStmt = (CreateMaterializedViewStmt) stmt;
+        if (stmt instanceof CreateSyncMVStmt) {
+            CreateSyncMVStmt createMaterializedViewStmt = (CreateSyncMVStmt) stmt;
             if (isOnlySingleReplica) {
                 createMaterializedViewStmt.getProperties().put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
             }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors the codebase to replace usage of the `CreateMaterializedViewStmt` class with the new `CreateSyncMVStmt` class and its associated analyzer, `CreateSyncMVStmtAnalyzer`. The changes ensure that all relevant components now reference and use the new class and its analyzer, improving consistency and maintainability for materialized view creation.

### Refactoring Materialized View Statement Handling

* Replaced all imports and usages of `CreateMaterializedViewStmt` with `CreateSyncMVStmt` across multiple files, including handlers, metadata, analyzers, and executors. [[1]](diffhunk://#diff-f829a0a304b8551a455f3df0adf7c30c9ad559b9e7b053363fed696e93b6e84fL78-R78) [[2]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L79-R79) [[3]](diffhunk://#diff-d9d326de2a5fd2391412036b9b9b344355faa5e467fda376545956f9c9d87be1L44-R44) [[4]](diffhunk://#diff-94124f39edb8940e4a70ade02c7e3b7ab96ef20346bc989713f506bc6bbafe57L46-R46) [[5]](diffhunk://#diff-fb163407084572dcd46e9cc5a3ba160e79d086110cbeac3087f91b3eda7ece31L44-R44) [[6]](diffhunk://#diff-f39e516b374db1420ceb7e1d23494dafa517c7a95993e391d3fb23b52ec10f5bL97-R103) [[7]](diffhunk://#diff-352707b1a11f6ac83b649dcb4d599d1dec52a2da548212a230d8b3ce20b99c42L80-R86) [[8]](diffhunk://#diff-1b0d077c3f2a45922be5fa50d2221e0e7cb4883e224636656434d449ef37ea9cL206-R206) [[9]](diffhunk://#diff-e4170a5a81358120b8e53ad3739a581a5c866bd97a26beb94d10179ebb9131b6L71-R77)
* Updated method signatures and implementations to accept `CreateSyncMVStmt` instead of `CreateMaterializedViewStmt`, ensuring type consistency throughout the codebase. [[1]](diffhunk://#diff-f829a0a304b8551a455f3df0adf7c30c9ad559b9e7b053363fed696e93b6e84fL194-R194) [[2]](diffhunk://#diff-f829a0a304b8551a455f3df0adf7c30c9ad559b9e7b053363fed696e93b6e84fL400-R400) [[3]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L584-R584) [[4]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L1072-R1073) [[5]](diffhunk://#diff-d9d326de2a5fd2391412036b9b9b344355faa5e467fda376545956f9c9d87be1L368-R369) [[6]](diffhunk://#diff-94124f39edb8940e4a70ade02c7e3b7ab96ef20346bc989713f506bc6bbafe57L349-R349) [[7]](diffhunk://#diff-fb163407084572dcd46e9cc5a3ba160e79d086110cbeac3087f91b3eda7ece31L334-R334) [[8]](diffhunk://#diff-f39e516b374db1420ceb7e1d23494dafa517c7a95993e391d3fb23b52ec10f5bL389-R389) [[9]](diffhunk://#diff-352707b1a11f6ac83b649dcb4d599d1dec52a2da548212a230d8b3ce20b99c42L569-R569) [[10]](diffhunk://#diff-1b0d077c3f2a45922be5fa50d2221e0e7cb4883e224636656434d449ef37ea9cL3045-R3045) [[11]](diffhunk://#diff-e4170a5a81358120b8e53ad3739a581a5c866bd97a26beb94d10179ebb9131b6L510-R511)

### Introduction of New Analyzer

* Renamed and refactored the old `CreateMaterializedViewStmt` class file to `CreateSyncMVStmtAnalyzer.java`, updating its package and documentation to clarify its role as the analyzer for `CreateSyncMVStmt`. [[1]](diffhunk://#diff-c9d11ffa188b0a2ebe75f194ea2dd6497ebd24f010688cb43b0aab32083bb2d7L15-R15) [[2]](diffhunk://#diff-c9d11ffa188b0a2ebe75f194ea2dd6497ebd24f010688cb43b0aab32083bb2d7L55-R51) [[3]](diffhunk://#diff-c9d11ffa188b0a2ebe75f194ea2dd6497ebd24f010688cb43b0aab32083bb2d7L106-R89)

### Internal Logic Adjustments

* Updated internal logic and references, such as constants and field accesses, to use `CreateSyncMVStmt` and its associated members (e.g., `WHERE_PREDICATE_COLUMN_NAME`). [[1]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L584-R584) [[2]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L1072-R1073) [[3]](diffhunk://#diff-d9d326de2a5fd2391412036b9b9b344355faa5e467fda376545956f9c9d87be1L368-R369)

These changes collectively modernize and unify the materialized view creation logic, making future maintenance and feature additions easier.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
