### PR TITLE
[Enhancement] Support range distribution colocate group creation in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateGroupSchema.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateGroupSchema.java
@@ -42,6 +42,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.ColocatePropertyInfo;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.Type;
 
@@ -109,8 +110,16 @@ public class ColocateGroupSchema implements Writable {
         return distributionColTypes.size();
     }
 
-    public void checkColocateSchema(OlapTable tbl) throws DdlException {
-        checkDistribution(tbl, tbl.getDefaultDistributionInfo());
+    public void checkColocateSchema(OlapTable tbl, String colocateGroup) throws DdlException {
+        DistributionInfo distributionInfo = tbl.getDefaultDistributionInfo();
+        if (distributionInfo instanceof RangeDistributionInfo) {
+            ColocatePropertyInfo propertyInfo = ColocatePropertyInfo.of(colocateGroup);
+            List<Column> colocateColumns = MetaUtils.getRangeColocateColumns(
+                    tbl, propertyInfo == null ? null : propertyInfo.getColocateColumnNames());
+            checkRangeColocateSchema(colocateColumns);
+        } else {
+            checkDistribution(tbl, distributionInfo);
+        }
         checkReplicationNum(tbl.getPartitionInfo());
     }
 
@@ -146,22 +155,24 @@ public class ColocateGroupSchema implements Writable {
                 }
             }
         } else if (distributionInfo instanceof RangeDistributionInfo) {
-            // For range distribution colocate, the colocate columns are the sort key prefix.
-            List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
-            // colocate column count
-            if (sortKeyColumns.size() < distributionColTypes.size()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_SIZE,
-                        distributionColTypes.size(), groupId.toString(),
-                        "sort key columns: " + sortKeyColumns.size());
-            }
-            // colocate column type
-            for (int i = 0; i < distributionColTypes.size(); i++) {
-                Type expectedType = distributionColTypes.get(i);
-                if (!expectedType.equals(sortKeyColumns.get(i).getType())) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE,
-                            groupId.toString(), sortKeyColumns.get(i).getName(),
-                            expectedType, "sort key prefix");
-                }
+            checkRangeColocateSchema(MetaUtils.getRangeDistributionColumns(table));
+        }
+    }
+
+    public void checkRangeColocateSchema(List<Column> colocateColumns) throws DdlException {
+        if (distributionType != DistributionInfoType.RANGE) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_TYPE,
+                    groupId.toString(), distributionType.name(), DistributionInfoType.RANGE.name());
+        }
+        if (colocateColumns.size() != distributionColTypes.size()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_SIZE,
+                    distributionColTypes.size(), groupId.toString(), "sort key columns: " + colocateColumns.size());
+        }
+        for (int i = 0; i < distributionColTypes.size(); i++) {
+            Type expectedType = distributionColTypes.get(i);
+            if (!expectedType.equals(colocateColumns.get(i).getType())) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE,
+                        groupId.toString(), colocateColumns.get(i).getName(), expectedType, "sort key prefix");
             }
         }
     }
@@ -182,7 +193,4 @@ public class ColocateGroupSchema implements Writable {
                     replicationNum, groupId.toString(), String.valueOf(repNum));
         }
     }
-
-
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -142,6 +142,9 @@ public class ColocateTableIndex implements Writable {
     // the colocate group is unstable
     @SerializedName("ug")
     private Set<GroupId> unstableGroups = Sets.newHashSet();
+    @SerializedName("crm")
+    private ColocateRangeMgr colocateRangeMgr = new ColocateRangeMgr();
+
     // lake group, in memory
     private final Set<GroupId> lakeGroups = Sets.newHashSet();
 
@@ -149,6 +152,14 @@ public class ColocateTableIndex implements Writable {
 
     public ColocateTableIndex() {
 
+    }
+
+    public ColocateRangeMgr getColocateRangeMgr() {
+        return colocateRangeMgr;
+    }
+
+    public static String getFullGroupName(long dbId, String colocateGroup) {
+        return dbId + "_" + ColocatePropertyInfo.getColocateGroupName(colocateGroup);
     }
 
     private void readLock() {
@@ -178,21 +189,12 @@ public class ColocateTableIndex implements Writable {
             return false;
         }
 
-        // For range distribution: parse colocate property and validate colocate columns
-        if (olapTable.getDefaultDistributionInfo() instanceof RangeDistributionInfo) {
-            ColocatePropertyInfo propertyInfo = ColocatePropertyInfo.of(colocateGroup);
-            MetaUtils.getRangeColocateColumns(olapTable, propertyInfo.getColocateColumnNames());
-            // TODO: create range colocate group after colocate_init is merged
-            olapTable.setColocateGroup(colocateGroup);
-            return true;
-        }
-
-        String fullGroupName = db.getId() + "_" + colocateGroup;
+        String fullGroupName = getFullGroupName(db.getId(), colocateGroup);
         ColocateGroupSchema groupSchema = this.getGroupSchema(fullGroupName);
         ColocateTableIndex.GroupId colocateGrpIdInOtherDb = null; /* to use GroupId.grpId */
         if (groupSchema != null) {
             // group already exist, check if this table can be added to this group
-            groupSchema.checkColocateSchema(olapTable);
+            groupSchema.checkColocateSchema(olapTable, colocateGroup);
         } else {
             // we also need to check the schema consistency with colocate group in other database
             colocateGrpIdInOtherDb = this.checkColocateSchemaWithGroupInOtherDb(
@@ -213,18 +215,26 @@ public class ColocateTableIndex implements Writable {
 
     // NOTICE: call 'addTableToGroup()' will not modify 'group2BackendsPerBucketSeq'
     // 'group2BackendsPerBucketSeq' need to be set manually before or after, if necessary.
-    public GroupId addTableToGroup(long dbId, OlapTable tbl, String groupName, GroupId assignedGroupId,
+    public GroupId addTableToGroup(long dbId, OlapTable tbl, String colocateGroup, GroupId assignedGroupId,
                                    boolean isReplay)
             throws DdlException {
         Preconditions.checkArgument(tbl.getDefaultDistributionInfo().supportColocate(),
                 "colocate not supported");
+
+        DistributionInfo distributionInfo = tbl.getDefaultDistributionInfo();
+        if (!isReplay && distributionInfo instanceof RangeDistributionInfo
+                && !tbl.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("Range distribution colocate is only supported in shared-data mode");
+        }
+
         writeLock();
         try {
             GroupId groupId;
-            String fullGroupName = dbId + "_" + groupName;
+            String fullGroupName = getFullGroupName(dbId, colocateGroup);
 
             if (groupName2Id.containsKey(fullGroupName)) {
                 groupId = groupName2Id.get(fullGroupName);
+                group2Schema.get(groupId).checkColocateSchema(tbl, colocateGroup);
             } else {
                 if (assignedGroupId != null) {
                     // use the given group id, eg, in replay process or cross db colocation
@@ -233,24 +243,47 @@ public class ColocateTableIndex implements Writable {
                     // generate a new one
                     groupId = new GroupId(dbId, GlobalStateMgr.getCurrentState().getNextId());
                 }
-                HashDistributionInfo distributionInfo = (HashDistributionInfo) tbl.getDefaultDistributionInfo();
-                if (!(tbl instanceof ExternalOlapTable)) {
-                    // Colocate table should keep the same bucket number across the partitions
-                    if (distributionInfo.getBucketNum() == 0) {
-                        int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
-                        distributionInfo.setBucketNum(bucketNum);
+
+                ColocateGroupSchema groupSchema;
+                if (distributionInfo instanceof RangeDistributionInfo) {
+                    ColocatePropertyInfo propertyInfo = ColocatePropertyInfo.of(colocateGroup);
+                    List<Column> colocateColumns = MetaUtils.getRangeColocateColumns(
+                            tbl, propertyInfo.getColocateColumnNames());
+                    groupSchema = new ColocateGroupSchema(groupId, colocateColumns,
+                            0, tbl.getDefaultReplicationNum(),
+                            distributionInfo.getType());
+
+                    if (!colocateRangeMgr.containsColocateGroup(groupId.grpId)) {
+                        // TODO: create actual PACK shard group via StarOSAgent
+                        colocateRangeMgr.initColocateGroup(groupId.grpId, 0);
                     }
+                } else if (distributionInfo instanceof HashDistributionInfo) {
+                    HashDistributionInfo hashDistInfo = (HashDistributionInfo) distributionInfo;
+                    if (!(tbl instanceof ExternalOlapTable)) {
+                        // Colocate table should keep the same bucket number across the partitions
+                        if (hashDistInfo.getBucketNum() == 0) {
+                            int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                            hashDistInfo.setBucketNum(bucketNum);
+                        }
+                    }
+                    groupSchema = new ColocateGroupSchema(groupId,
+                            MetaUtils.getColumnsByColumnIds(tbl, hashDistInfo.getDistributionColumns()),
+                            hashDistInfo.getBucketNum(),
+                            tbl.getDefaultReplicationNum(),
+                            hashDistInfo.getType());
+                } else {
+                    throw new DdlException("Unsupported distribution type for colocate: "
+                            + distributionInfo.getType());
                 }
-                ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId,
-                        MetaUtils.getColumnsByColumnIds(tbl, distributionInfo.getDistributionColumns()),
-                        distributionInfo.getBucketNum(),
-                        tbl.getDefaultReplicationNum(),
-                        distributionInfo.getType());
+
                 groupName2Id.put(fullGroupName, groupId);
                 group2Schema.put(groupId, groupSchema);
             }
 
-            if (tbl.isCloudNativeTableOrMaterializedView()) {
+            // MetaGroup for hash colocate lake tables only.
+            // Range colocate uses PACK shard groups instead of MetaGroup.
+            if (distributionInfo instanceof HashDistributionInfo
+                    && tbl.isCloudNativeTableOrMaterializedView()) {
                 if (!isReplay) { // leader create or update meta group
                     List<Long> shardGroupIds = tbl.getShardGroupIds();
                     // check the group existence in lakeGroups
@@ -771,6 +804,7 @@ public class ColocateTableIndex implements Writable {
         this.group2Schema = data.group2Schema;
         this.group2BackendsPerBucketSeq = data.group2BackendsPerBucketSeq;
         this.unstableGroups = data.unstableGroups;
+        this.colocateRangeMgr = data.colocateRangeMgr != null ? data.colocateRangeMgr : new ColocateRangeMgr();
 
         cleanupInvalidDbOrTable(GlobalStateMgr.getCurrentState());
         constructLakeGroups(GlobalStateMgr.getCurrentState());
@@ -791,10 +825,11 @@ public class ColocateTableIndex implements Writable {
         return groupIds;
     }
 
-    public GroupId checkColocateSchemaWithGroupInOtherDb(String toCreateGroupName, long dbId,
+    public GroupId checkColocateSchemaWithGroupInOtherDb(String colocateGroup, long dbId,
                                                          OlapTable toCreateTable) throws DdlException {
         try {
             readLock();
+            String toCreateGroupName = ColocatePropertyInfo.getColocateGroupName(colocateGroup);
             List<GroupId> sameOrigNameGroups = getOtherGroupsWithSameOrigNameUnlocked(toCreateGroupName, dbId);
             if (sameOrigNameGroups.isEmpty()) {
                 return null;
@@ -805,7 +840,7 @@ public class ColocateTableIndex implements Writable {
             // which group the new colocate group should colocate with, thus we should throw an error explicitly
             // and let the user handle it.
             for (GroupId gid : sameOrigNameGroups) {
-                getGroupSchema(gid).checkColocateSchema(toCreateTable);
+                getGroupSchema(gid).checkColocateSchema(toCreateTable, colocateGroup);
             }
             // For tables that reside in different databases and colocate with each other, there still exists
             // multi colocate groups, but these colocate groups will have the same original name and their
@@ -875,12 +910,12 @@ public class ColocateTableIndex implements Writable {
             if (Strings.isNullOrEmpty(oldGroup)) {
                 return null;
             }
-            String fullGroupName = db.getId() + "_" + oldGroup;
+            String fullGroupName = getFullGroupName(db.getId(), oldGroup);
             return getGroupSchema(fullGroupName).getGroupId();
         }
 
         GroupId colocateGrpIdInOtherDb;
-        String fullGroupName = db.getId() + "_" + colocateGroup;
+        String fullGroupName = getFullGroupName(db.getId(), colocateGroup);
         ColocateGroupSchema groupSchema = getGroupSchema(fullGroupName);
         if (groupSchema == null) {
             // user set a new colocate group,
@@ -917,7 +952,7 @@ public class ColocateTableIndex implements Writable {
             }
         } else {
             // set to an already exist colocate group, check if this table can be added to this group.
-            groupSchema.checkColocateSchema(table);
+            groupSchema.checkColocateSchema(table, colocateGroup);
         }
 
         return groupSchema == null ? assignedGroupId : groupSchema.getGroupId();
@@ -930,7 +965,7 @@ public class ColocateTableIndex implements Writable {
         String oldGroup = table.getColocateGroup();
         GroupId groupId;
         if (!Strings.isNullOrEmpty(colocateGroup)) {
-            String fullGroupName = db.getId() + "_" + colocateGroup;
+            String fullGroupName = getFullGroupName(db.getId(), colocateGroup);
             ColocateGroupSchema groupSchema = getGroupSchema(fullGroupName);
 
             List<List<Long>> backendsPerBucketSeq = null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangeDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangeDistributionInfo.java
@@ -31,12 +31,9 @@ public class RangeDistributionInfo extends DistributionInfo {
         super(DistributionInfoType.RANGE);
     }
 
-    /*
-     * Will be changed to true later once colocate is supported.
-     */
     @Override
     public boolean supportColocate() {
-        return false;
+        return true;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ColocatePropertyInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ColocatePropertyInfo.java
@@ -72,6 +72,24 @@ public class ColocatePropertyInfo {
     }
 
     /**
+     * Extracts the colocate group name from a colocate property value,
+     * stripping the optional column specification suffix.
+     *
+     * @param colocateGroup the property value, e.g. "group1" or "group1:col1,col2"
+     * @return the group name part, e.g. "group1"
+     */
+    public static String getColocateGroupName(String colocateGroup) {
+        if (colocateGroup == null || colocateGroup.isEmpty()) {
+            return colocateGroup;
+        }
+        int colonIndex = colocateGroup.indexOf(':');
+        if (colonIndex < 0) {
+            return colocateGroup;
+        }
+        return colocateGroup.substring(0, colonIndex).trim();
+    }
+
+    /**
      * Returns the original property string format.
      * Inverse of {@link #of(String)}.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1077,7 +1077,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                                  List<PartitionDesc> partitionDescs)
             throws DdlException {
         if (colocateTableIndex.isColocateTable(olapTable.getId())) {
-            String fullGroupName = db.getId() + "_" + olapTable.getColocateGroup();
+            String fullGroupName = ColocateTableIndex.getFullGroupName(db.getId(), olapTable.getColocateGroup());
             ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(fullGroupName);
             Preconditions.checkNotNull(groupSchema);
             groupSchema.checkDistribution(olapTable, distributionInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -24,8 +26,10 @@ import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropDbStmt;
 import com.starrocks.sql.ast.DropTableStmt;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -423,5 +427,245 @@ public class ColocateTableIndexTest {
         Assertions.assertEquals(colocateTableIndex.getGroup(table.getId()), followerIndex.getGroup(table.getId()));
 
         UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testLoadLegacyImageWithoutColocateRangeMgr(@Mocked SRMetaBlockReader reader) throws Exception {
+        ColocateTableIndex legacyIndex = new ColocateTableIndex();
+        Deencapsulation.setField(legacyIndex, "colocateRangeMgr", null);
+
+        new Expectations() {
+            {
+                reader.readJson(ColocateTableIndex.class);
+                result = legacyIndex;
+            }
+        };
+
+        ColocateTableIndex restoredIndex = new ColocateTableIndex();
+        restoredIndex.loadColocateTableIndexV2(reader);
+        Assertions.assertNotNull(restoredIndex.getColocateRangeMgr());
+    }
+
+    @Test
+    public void testRangeColocateNotSupportedInSharedNothing() throws Exception {
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.getSessionVariable().setEnableRangeDistribution(true);
+
+        String createDbStmtStr = "create database db_range_colocate;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(
+                createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
+
+        // Range distribution colocate is only supported in shared-data mode.
+        // In shared-nothing mode (non-lake table), it should fail.
+        String sql = "CREATE TABLE db_range_colocate.t1 (k1 int, k2 int, k3 varchar(32), v1 int)\n" +
+                "DUPLICATE KEY(k1, k2, k3)\n" +
+                "PROPERTIES(\"colocate_with\"=\"rg1:k1,k2\", \"replication_num\" = \"1\");\n";
+        CreateTableStmt stmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        Assertions.assertThrows(Exception.class, () -> StarRocksAssert.utCreateTableWithRetry(stmt));
+    }
+
+    @Test
+    public void testRangeColocateInSharedData(@Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createMetaGroup(long metaGroupId, List<Long> shardGroupIds) {
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        long dbId = 100;
+        long tableId = 200;
+        // Mock a lake table with range distribution and colocate group
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return tableId;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new RangeDistributionInfo();
+            }
+
+            @Mock
+            public String getColocateGroup() {
+                return "rg1:k1,k2";
+            }
+
+            @Mock
+            public short getDefaultReplicationNum() {
+                return 1;
+            }
+        };
+
+        new MockUp<LakeTable>() {
+            @Mock
+            public List<Long> getShardGroupIds() {
+                return Arrays.asList(5001L);
+            }
+        };
+
+        // Mock MetaUtils.getRangeColocateColumns to return 2 columns
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(
+                        new Column("k1", com.starrocks.type.IntegerType.INT),
+                        new Column("k2", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        // Add lake range colocate table should succeed
+        colocateTableIndex.addTableToGroup(
+                dbId, (OlapTable) lakeTable, "rg1", null, false /* isReplay */);
+
+        // Verify group was created with RANGE type
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
+        Assertions.assertNotNull(groupId);
+        ColocateGroupSchema schema = colocateTableIndex.getGroupSchema(groupId);
+        Assertions.assertNotNull(schema);
+        Assertions.assertTrue(schema.isRangeColocate());
+        Assertions.assertEquals(2, schema.getColocateColumnCount());
+
+        // Verify ColocateRangeMgr is initialized
+        ColocateRangeMgr rangeMgr = colocateTableIndex.getColocateRangeMgr();
+        Assertions.assertTrue(rangeMgr.containsColocateGroup(groupId.grpId));
+        List<ColocateRange> ranges = rangeMgr.getColocateRanges(groupId.grpId);
+        Assertions.assertEquals(1, ranges.size());
+        Assertions.assertTrue(ranges.get(0).getRange().isAll());
+    }
+
+    @Test
+    public void testRangeColocatePropertyMustMatchExistingGroupSchema(
+            @Mocked LakeTable firstTable, @Mocked LakeTable secondTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+        DistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setReplicationNum(1L, (short) 1);
+
+        new Expectations() {
+            {
+                firstTable.getId();
+                result = 200L;
+                minTimes = 0;
+                secondTable.getId();
+                result = 201L;
+                minTimes = 0;
+                firstTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                secondTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                firstTable.getDefaultDistributionInfo();
+                result = rangeDistributionInfo;
+                minTimes = 0;
+                secondTable.getDefaultDistributionInfo();
+                result = rangeDistributionInfo;
+                minTimes = 0;
+                firstTable.getDefaultReplicationNum();
+                result = (short) 1;
+                minTimes = 0;
+                secondTable.getDefaultReplicationNum();
+                result = (short) 1;
+                minTimes = 0;
+                firstTable.getPartitionInfo();
+                result = partitionInfo;
+                minTimes = 0;
+                secondTable.getPartitionInfo();
+                result = partitionInfo;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                if (colocateColumnNames != null && colocateColumnNames.size() == 1) {
+                    return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+                }
+                return Arrays.asList(
+                        new Column("k1", com.starrocks.type.IntegerType.INT),
+                        new Column("k2", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        colocateTableIndex.addTableToGroup(100L, firstTable, "rg1:k1", null, false);
+        Assertions.assertThrows(DdlException.class,
+                () -> colocateTableIndex.addTableToGroup(100L, secondTable, "rg1:k1,k2", null, false));
+    }
+
+    @Test
+    public void testRangeCrossDbSchemaCheckUsesRequestedColocateColumns(
+            @Mocked LakeTable existingTable, @Mocked LakeTable newTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+        DistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setReplicationNum(1L, (short) 1);
+
+        new Expectations() {
+            {
+                existingTable.getId();
+                result = 300L;
+                minTimes = 0;
+                newTable.getId();
+                result = 301L;
+                minTimes = 0;
+                existingTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                newTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                existingTable.getDefaultDistributionInfo();
+                result = rangeDistributionInfo;
+                minTimes = 0;
+                newTable.getDefaultDistributionInfo();
+                result = rangeDistributionInfo;
+                minTimes = 0;
+                existingTable.getDefaultReplicationNum();
+                result = (short) 1;
+                minTimes = 0;
+                newTable.getDefaultReplicationNum();
+                result = (short) 1;
+                minTimes = 0;
+                existingTable.getPartitionInfo();
+                result = partitionInfo;
+                minTimes = 0;
+                newTable.getPartitionInfo();
+                result = partitionInfo;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                if (colocateColumnNames != null && colocateColumnNames.size() == 1) {
+                    return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+                }
+                return Arrays.asList(
+                        new Column("k1", com.starrocks.type.IntegerType.INT),
+                        new Column("k2", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        colocateTableIndex.addTableToGroup(100L, existingTable, "rg1:k1", null, false);
+        Assertions.assertThrows(DdlException.class,
+                () -> colocateTableIndex.checkColocateSchemaWithGroupInOtherDb("rg1:k1,k2", 101L, newTable));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangeDistributionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangeDistributionInfoTest.java
@@ -35,7 +35,7 @@ public class RangeDistributionInfoTest {
     @Test
     public void testSupportColocate() {
         RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
-        Assertions.assertFalse(rangeDistributionInfo.supportColocate());
+        Assertions.assertTrue(rangeDistributionInfo.supportColocate());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ColocatePropertyInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ColocatePropertyInfoTest.java
@@ -109,4 +109,14 @@ public class ColocatePropertyInfoTest {
         ColocatePropertyInfo info2 = ColocatePropertyInfo.of("group1:col1,col2");
         Assertions.assertEquals(info1.hashCode(), info2.hashCode());
     }
+
+    @Test
+    public void testGetColocateGroupName() {
+        Assertions.assertEquals("group1", ColocatePropertyInfo.getColocateGroupName("group1"));
+        Assertions.assertEquals("group1", ColocatePropertyInfo.getColocateGroupName("group1:col1,col2"));
+        Assertions.assertEquals("grp1", ColocatePropertyInfo.getColocateGroupName("grp1:tenant_id"));
+        Assertions.assertEquals("group1", ColocatePropertyInfo.getColocateGroupName(" group1 : col1,col2"));
+        Assertions.assertNull(ColocatePropertyInfo.getColocateGroupName(null));
+        Assertions.assertEquals("", ColocatePropertyInfo.getColocateGroupName(""));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

  Previous PRs added colocate metadata classes (ColocateRange, ColocateRangeMgr, ColocateGroupSchema)
  and DDL parsing (ColocatePropertyInfo, MetaUtils.getRangeColocateColumns). This PR continues to
  implement the actual colocate group creation for range distribution tables in shared-data mode.

## What I'm doing:

   1. Add `ColocateRangeMgr` field to `ColocateTableIndex` with image save/load support.

   2. Extend internal `ColocateTableIndex.addTableToGroup` to support range distribution:
      - Parse `ColocatePropertyInfo` directly from the `colocateGroup` parameter (not from
        `tbl.getColocateGroup()`) to avoid dependency on unset table properties.
      - Create `ColocateGroupSchema` with `RANGE` type and initialize `ColocateRangeMgr`
        for new range colocate groups.
      - Hash and unknown distribution types are handled with explicit `instanceof` checks.
      - Range distribution colocate is restricted to shared-data mode (lake tables only).

   3. Add `ColocatePropertyInfo.getColocateGroupName()` static helper to extract the pure
      group name from a colocate property string (stripping the optional `:col1,col2` suffix).

   4. Add `ColocateTableIndex.getFullGroupName()` public helper to construct `fullGroupName`
      from dbId and colocateGroup string, uniformly handling the column name suffix. All places
      that construct `fullGroupName` now use this helper, including `prepareModifyTableColocate`,
      `applyModifyTableColocate`, and `LocalMetastore.checkColocation`.

   5. MetaGroup creation is skipped for range colocate lake tables (range colocate uses
      PACK shard groups instead, to be implemented in a follow-up PR).

   6. `RangeDistributionInfo.supportColocate()` changed to return `true`.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
