### PR TITLE
[BugFix] [MV] Fix precise external MV refresh fallback for Iceberg-like connectors

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -337,7 +337,7 @@ public abstract class BaseMVRefreshProcessor {
         if (!Config.enable_materialized_view_external_table_precise_refresh) {
             return false;
         }
-        // if any base table is external table, enable precise refresh
+        // only enable precise refresh for external connectors that can actually consume partition names
         final List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
             final Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
@@ -345,7 +345,37 @@ public abstract class BaseMVRefreshProcessor {
                 continue;
             }
             final Table table = optTable.get();
-            if (!table.isCloudNativeTableOrMaterializedView()) {
+            if (isRefreshableExternalBaseTable(table) && supportsPreciseExternalTableRefresh(table)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isRefreshableExternalBaseTable(Table table) {
+        return !(table.isNativeTableOrMaterializedView() || table.isView()
+                || MaterializedViewAnalyzer.isExternalTableFromResource(table));
+    }
+
+    private boolean supportsPreciseExternalTableRefresh(Table table) {
+        // Only connectors that really consume partition names can safely keep the fast path.
+        return table.isHiveTable() || table.isHudiTable();
+    }
+
+    private boolean shouldSyncPartitionsAfterExternalRefresh(int retryNum) {
+        if (!isEnableExternalTablePreciseRefresh || retryNum > 1) {
+            return true;
+        }
+
+        for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
+            final Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
+            if (optTable.isEmpty()) {
+                continue;
+            }
+            final Table table = optTable.get();
+            // Iceberg/Paimon/Delta/JDBC/ODPS still refresh table-level metadata. If we skip syncPartitions here,
+            // later PCT phases may keep using snapshotBaseTables collected before refreshExternalTable().
+            if (isRefreshableExternalBaseTable(table) && !supportsPreciseExternalTableRefresh(table)) {
                 return true;
             }
         }
@@ -549,14 +579,15 @@ public abstract class BaseMVRefreshProcessor {
             // refresh old table
             final Table table = optTable.get();
             // if table is native table or materialized view or connector view or external table, no need to refresh
-            if (table.isNativeTableOrMaterializedView() || table.isView()
-                    || MaterializedViewAnalyzer.isExternalTableFromResource(table)) {
+            if (!isRefreshableExternalBaseTable(table)) {
                 logger.debug("No need to refresh table:{} because it is native table or mv or connector view",
                         baseTableInfo.getTableInfoStr());
                 continue;
             }
             final BaseTableSnapshotInfo snapshotInfo = buildBaseTableSnapshotInfo(baseTableInfo, table);
-            final PCellSortedSet basePartitions = baseTableCandidatePartitions.get(snapshotInfo);
+            // Connectors without partition-level refresh support should never consume candidate partitions here.
+            final PCellSortedSet basePartitions = supportsPreciseExternalTableRefresh(table)
+                    ? baseTableCandidatePartitions.get(snapshotInfo) : null;
             if (PCellUtils.isNotEmpty(basePartitions)) {
                 // only refresh referenced partitions, to reduce metadata overhead
                 final List<String> realPartitionNames = basePartitions.stream()
@@ -768,7 +799,7 @@ public abstract class BaseMVRefreshProcessor {
                 refreshExternalTable(baseTableCandidatePartitions);
             }
 
-            if (!isEnableExternalTablePreciseRefresh || retryNum > 1) {
+            if (shouldSyncPartitionsAfterExternalRefresh(retryNum)) {
                 try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
                     // sync partitions between mv and base tables out of lock
                     // do it outside lock because it is a time-cost operation

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -597,8 +597,11 @@ public abstract class BaseMVRefreshProcessor {
                         baseTableInfo.getDbName(), table, realPartitionNames, false);
             } else {
                 // refresh the whole table, which may be costly in extreme case
+                // Hive/Hudi can refresh table-level cache incrementally. Other external connectors may still need a
+                // full table metadata invalidation so the next syncPartitions() can rebuild snapshotBaseTables correctly.
+                boolean onlyCachedPartitions = supportsPreciseExternalTableRefresh(table);
                 connectContext.getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
-                        baseTableInfo.getDbName(), table, Lists.newArrayList(), true);
+                        baseTableInfo.getDbName(), table, Lists.newArrayList(), onlyCachedPartitions);
             }
             // should clear query cache
             connectContext.getGlobalStateMgr().getMetadataMgr().removeQueryMetadata();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -17,15 +17,19 @@ package com.starrocks.scheduler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
 import com.starrocks.clone.DynamicPartitionScheduler;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
@@ -33,6 +37,8 @@ import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -60,6 +66,47 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
+    }
+
+    @Test
+    public void testRefreshExternalTablePreciseFallsBackToWholeTable() throws Exception {
+        String mvName = "iceberg_precise_mv";
+        boolean originalConfig = Config.enable_materialized_view_external_table_precise_refresh;
+        List<List<String>> calls = Lists.newArrayList();
+        List<Boolean> onlyCachedPartitions = Lists.newArrayList();
+        Config.enable_materialized_view_external_table_precise_refresh = true;
+        try {
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName + "`\n" +
+                            "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"partition_refresh_number\" = \"1\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+
+            new MockUp<MetadataMgr>() {
+                @Mock
+                public void refreshTable(String catalogName, String srDbName, Table table,
+                                         List<String> partitionNames, boolean onlyCached) {
+                    if (table.isIcebergTable()) {
+                        calls.add(Lists.newArrayList(partitionNames));
+                        onlyCachedPartitions.add(onlyCached);
+                    }
+                }
+            };
+
+            starRocksAssert.refreshMvPartition("refresh materialized view " + mvName + " partition " +
+                    "start('2020-01-01') end('2020-01-03')");
+            Assertions.assertFalse(calls.isEmpty());
+            Assertions.assertTrue(calls.stream().allMatch(List::isEmpty));
+            Assertions.assertTrue(onlyCachedPartitions.stream().allMatch(Boolean::booleanValue));
+        } finally {
+            Config.enable_materialized_view_external_table_precise_refresh = originalConfig;
+            starRocksAssert.dropMaterializedView(mvName);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -102,7 +102,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
                     "start('2020-01-01') end('2020-01-03')");
             Assertions.assertFalse(calls.isEmpty());
             Assertions.assertTrue(calls.stream().allMatch(List::isEmpty));
-            Assertions.assertTrue(onlyCachedPartitions.stream().allMatch(Boolean::booleanValue));
+            Assertions.assertTrue(onlyCachedPartitions.stream().allMatch(value -> !value));
         } finally {
             Config.enable_materialized_view_external_table_precise_refresh = originalConfig;
             starRocksAssert.dropMaterializedView(mvName);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -15,18 +15,24 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import mockit.Mock;
+import mockit.MockUp;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -145,6 +151,35 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
         refreshMVRange(materializedView.getName(), "20230801", "20230805", false);
         Collection<Partition> incrementalPartitions = materializedView.getPartitions();
         Assertions.assertEquals(4, incrementalPartitions.size());
+    }
+
+    @Test
+    public void testRefreshExternalTablePreciseFallsBackToInvalidateJdbcTableCache() throws Exception {
+        String mvName = "jdbc_parttbl_mv6";
+        boolean originalConfig = Config.enable_materialized_view_external_table_precise_refresh;
+        List<List<String>> calls = Lists.newArrayList();
+        List<Boolean> onlyCachedPartitions = Lists.newArrayList();
+        Config.enable_materialized_view_external_table_precise_refresh = true;
+        try {
+            new MockUp<MetadataMgr>() {
+                @Mock
+                public void refreshTable(String catalogName, String srDbName, Table table,
+                                         List<String> partitionNames, boolean onlyCached) {
+                    if (table.isJDBCTable()) {
+                        calls.add(Lists.newArrayList(partitionNames));
+                        onlyCachedPartitions.add(onlyCached);
+                    }
+                }
+            };
+
+            starRocksAssert.refreshMvPartition("refresh materialized view " + mvName + " partition " +
+                    "start('20230801') end('20230803')");
+            Assertions.assertFalse(calls.isEmpty());
+            Assertions.assertTrue(calls.stream().allMatch(List::isEmpty));
+            Assertions.assertTrue(onlyCachedPartitions.stream().allMatch(value -> !value));
+        } finally {
+            Config.enable_materialized_view_external_table_precise_refresh = originalConfig;
+        }
     }
 
     @NotNull


### PR DESCRIPTION
## Why I'm doing:
`enable_materialized_view_external_table_precise_refresh` was originally applied to all external-table based MV refresh paths, but some connectors do not actually support` partition-granular `metadata refresh. For Iceberg-like connectors, the processor could still enter the precise-refresh fast path, refresh table-level metadata, and then skip the first post-refresh syncPartitions(). That left later PCT phases using snapshotBaseTables collected before external refresh, which could cause stale snapshot comparisons and incorrect MV refresh bookkeeping.

## What I'm doing:
I restricted the precise external-table refresh fast path to connectors that really consume partition names during refresh, currently Hive and Hudi. For other external connectors such as Iceberg, the refresh path now always falls back to whole-table refresh and forces a post-refresh syncPartitions() on the first round so later PCT stages rebuild snapshot state from fresh metadata. I also added an Iceberg MV regression test to verify that enable_materialized_view_external_table_precise_refresh=true no longer pushes candidate partition names into Iceberg refresh.

Enhancements to external table refresh logic:

* Refined `isEnableExternalTablePreciseRefresh` to only enable precise refresh for external connectors that can consume partition names (Hive and Hudi), and introduced helper methods `isRefreshableExternalBaseTable` and `supportsPreciseExternalTableRefresh` for clearer logic separation.
* Updated `refreshExternalTable` to prevent unsupported connectors from consuming candidate partitions, ensuring partition-level refresh is only attempted for connectors with precise support.
* Added `shouldSyncPartitionsAfterExternalRefresh` to decide when to sync partitions after external refresh, improving reliability for connectors without partition-level support. 

Test coverage improvements:

* Added a new test, `testRefreshExternalTablePreciseFallsBackToWholeTable`, to verify that unsupported connectors fall back to whole-table refresh when precise partition refresh is not possible.
* Imported necessary classes and utilities in the test file to support new test scenarios.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
