### PR TITLE
[UT] Remove default clauses from Iceberg alter-table v2 sql test

### DIFF
--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -25,7 +25,7 @@ add column col2 string null comment 'col2' after id;
 -- result:
 -- !result
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
-add column (col3 string comment 'col3', col4 INT DEFAULT "1");
+add column (col3 string comment 'col3', col4 INT);
 -- result:
 -- !result
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -19,7 +19,7 @@ alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
 add column col2 string null comment 'col2' after id;
 
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
-add column (col3 string comment 'col3', col4 INT DEFAULT "1");
+add column (col3 string comment 'col3', col4 INT);
 
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
 rename column col1 to col11;


### PR DESCRIPTION
## Why I'm doing:
The `test_iceberg_alter_table` case creates Iceberg tables without explicitly setting `format-version`, and default value is not supported in Iceberg v2. Iceberg default-value semantics should not be mixed into this generic v2 alter-table case.

## What I'm doing:
- Removed `DEFAULT` from `ADD COLUMN` statements in `test/sql/test_iceberg/T/test_iceberg_alter_table`.
- Synced expected SQL text in `test/sql/test_iceberg/R/test_iceberg_alter_table`.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
