### PR TITLE
[BugFix] Fix Invalid Plan error when MV transparent rewrite creates Union with GROUP BY function expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRule.java
@@ -19,14 +19,18 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class PruneUnionColumnsRule extends TransformationRule {
@@ -47,6 +51,11 @@ public class PruneUnionColumnsRule extends TransformationRule {
                         .map(Lists::newArrayList)
                         .collect(Collectors.toList()))
                 .build();
+
+        // If the Union has an embedded projection, propagate required columns from
+        // projection expressions into the base output required set, and prune the
+        // projection entries that are no longer needed.
+        pruneProjectionAndPropagateRequired(luo, requiredOutputColumns);
 
         List<ColumnRefOperator> outputs = luo.getOutputColumnRefOp();
 
@@ -95,5 +104,43 @@ public class PruneUnionColumnsRule extends TransformationRule {
         }
 
         return Collections.singletonList(OptExpression.create(luo, input.getInputs()));
+    }
+
+    /**
+     * When a Union has an embedded projection (e.g. from MV rewrite + MergeProjectWithChildRule),
+     * the projection's expressions reference the Union's base output columns. If we prune those
+     * base columns without considering the projection, a later SeparateProjectRule will create a
+     * Project that references columns no longer in the Union's output, causing an "Invalid plan" error.
+     *
+     * This method:
+     * 1. Keeps projection entries whose output column is required
+     * 2. Adds the base columns used by kept entries to requiredOutputColumns
+     * 3. Removes projection entries that are no longer needed
+     */
+    void pruneProjectionAndPropagateRequired(LogicalUnionOperator luo,
+                                                      ColumnRefSet requiredOutputColumns) {
+        Projection projection = luo.getProjection();
+        if (projection == null) {
+            return;
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap = projection.getColumnRefMap();
+        Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = new HashMap<>();
+        ColumnRefSet baseColumnsNeededByProjection = new ColumnRefSet();
+
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : columnRefMap.entrySet()) {
+            if (requiredOutputColumns.contains(entry.getKey())) {
+                newColumnRefMap.put(entry.getKey(), entry.getValue());
+                baseColumnsNeededByProjection.union(entry.getValue().getUsedColumns());
+            }
+        }
+
+        requiredOutputColumns.union(baseColumnsNeededByProjection);
+
+        if (newColumnRefMap.isEmpty()) {
+            luo.setProjection(null);
+        } else if (newColumnRefMap.size() != columnRefMap.size()) {
+            luo.setProjection(new Projection(newColumnRefMap));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRule.java
@@ -15,11 +15,18 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.tree.TreeRewriteRule;
 import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 // SeparateProjectRule is used to separate the projection from Operator and construct
 // a LogicalProjectOperator which resides above the Operator from the projection.
@@ -43,9 +50,39 @@ public class SeparateProjectRule implements TreeRewriteRule {
             // Clear statistics to recompute statistics when calculating statistics later,
             // because some operators only recompute statistics when statistics is null.
             root.setStatistics(null);
-            return OptExpression.create(new LogicalProjectOperator(projection.getColumnRefMap()), root);
+
+            Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                    filterProjectionByAvailableColumns(operator, projection);
+            if (columnRefMap.isEmpty()) {
+                return root;
+            }
+            return OptExpression.create(new LogicalProjectOperator(columnRefMap), root);
         } else {
             return root;
         }
+    }
+
+    /**
+     * After column pruning removes columns from an operator's base output (e.g. Union's
+     * outputColumnRefOp), the embedded projection may still reference those pruned columns.
+     * Filter out such stale entries to prevent creating a Project that references
+     * columns unavailable from its child.
+     */
+    private Map<ColumnRefOperator, ScalarOperator> filterProjectionByAvailableColumns(
+            Operator operator, Projection projection) {
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap = projection.getColumnRefMap();
+        if (!(operator instanceof LogicalSetOperator)) {
+            return columnRefMap;
+        }
+        ColumnRefSet availableColumns =
+                new ColumnRefSet(((LogicalSetOperator) operator).getOutputColumnRefOp());
+        Map<ColumnRefOperator, ScalarOperator> filtered = new LinkedHashMap<>();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : columnRefMap.entrySet()) {
+            ColumnRefSet usedCols = entry.getValue().getUsedColumns();
+            if (availableColumns.containsAll(usedCols)) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -16,11 +16,11 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +32,8 @@ import java.util.Set;
 import static java.lang.Double.NaN;
 
 public class Statistics {
+    private static final Logger LOG = LogManager.getLogger(Statistics.class);
+
     private final double outputRowCount;
     private final Map<ColumnRefOperator, ColumnStatistic> columnStatistics;
     // This flag set true if get table row count from GlobalStateMgr LE 1
@@ -128,13 +130,13 @@ public class Statistics {
     }
 
     public ColumnStatistic getColumnStatistic(ColumnRefOperator column) {
-        if (columnStatistics.get(column) == null) {
-            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
-                    "only found column statistics: %s, but missing statistic of col: %s.",
-                    ColumnRefOperator.toString(columnStatistics.keySet()), column);
-        } else {
-            return columnStatistics.get(column);
+        ColumnStatistic result = columnStatistics.get(column);
+        if (result == null) {
+            LOG.warn("Missing column statistic for col: {}, available: {}",
+                    column, ColumnRefOperator.toString(columnStatistics.keySet()));
+            return ColumnStatistic.unknown();
         }
+        return result;
     }
 
     public Map<ColumnRefOperator, ColumnStatistic> getColumnStatistics() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionColumnsRuleTest.java
@@ -1,0 +1,171 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PruneUnionColumnsRuleTest {
+
+    /**
+     * Test that pruneProjectionAndPropagateRequired correctly preserves base
+     * output columns that are used by the Union's embedded projection.
+     */
+    @Test
+    public void testPruneUnionWithEmbeddedProjectionPreservesUsedColumns() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, VarcharType.VARCHAR, "k2", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, DateType.DATETIME, "v2", true);
+
+        ColumnRefOperator dateResult = new ColumnRefOperator(3, DateType.DATE, "date_result", true);
+        CallOperator dateCall = new CallOperator("date", DateType.DATE, ImmutableList.of(col2));
+
+        ColumnRefOperator child1Col1 = new ColumnRefOperator(4, VarcharType.VARCHAR, "c1_k2", true);
+        ColumnRefOperator child1Col2 = new ColumnRefOperator(5, DateType.DATETIME, "c1_v2", true);
+        ColumnRefOperator child2Col1 = new ColumnRefOperator(6, VarcharType.VARCHAR, "c2_k2", true);
+        ColumnRefOperator child2Col2 = new ColumnRefOperator(7, DateType.DATETIME, "c2_v2", true);
+
+        List<ColumnRefOperator> outputs = Lists.newArrayList(col1, col2);
+        List<List<ColumnRefOperator>> childOutputs = Lists.newArrayList(
+                Lists.newArrayList(child1Col1, child1Col2),
+                Lists.newArrayList(child2Col1, child2Col2)
+        );
+
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        projectionMap.put(dateResult, dateCall);
+        projectionMap.put(col1, col1);
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator.Builder()
+                .setOutputColumnRefOp(outputs)
+                .setChildOutputColumns(childOutputs)
+                .isUnionAll(true)
+                .setProjection(new Projection(projectionMap))
+                .build();
+
+        // Required: dateResult and col1; col2 is NOT directly required but IS used by date(col2)
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+        requiredColumns.union(dateResult);
+        requiredColumns.union(col1);
+
+        PruneUnionColumnsRule rule = new PruneUnionColumnsRule();
+        rule.pruneProjectionAndPropagateRequired(unionOp, requiredColumns);
+
+        // col2 must now be in requiredColumns because the projection uses date(col2)
+        Assertions.assertTrue(requiredColumns.contains(col2),
+                "col2 should be added to required columns because projection uses date(col2)");
+        Assertions.assertTrue(requiredColumns.contains(col1),
+                "col1 should remain in required columns");
+
+        // Projection should still contain both entries
+        Projection resultProjection = unionOp.getProjection();
+        Assertions.assertNotNull(resultProjection);
+        Assertions.assertTrue(resultProjection.getColumnRefMap().containsKey(dateResult));
+        Assertions.assertTrue(resultProjection.getColumnRefMap().containsKey(col1));
+    }
+
+    /**
+     * Test that unrequired projection entries are properly pruned from the
+     * Union's embedded projection.
+     */
+    @Test
+    public void testPruneUnionRemovesUnrequiredProjectionEntries() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "k1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, DateType.DATETIME, "v1", true);
+
+        ColumnRefOperator projOut1 = new ColumnRefOperator(3, DateType.DATE, "proj1", true);
+        ColumnRefOperator projOut2 = new ColumnRefOperator(4, IntegerType.INT, "proj2", true);
+        CallOperator dateCall = new CallOperator("date", DateType.DATE, ImmutableList.of(col2));
+
+        List<ColumnRefOperator> outputs = Lists.newArrayList(col1, col2);
+        List<List<ColumnRefOperator>> childOutputs = Lists.newArrayList();
+        childOutputs.add(Lists.newArrayList(
+                new ColumnRefOperator(5, IntegerType.INT, "c1_k1", true),
+                new ColumnRefOperator(6, DateType.DATETIME, "c1_v1", true)
+        ));
+
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        projectionMap.put(projOut1, dateCall);
+        projectionMap.put(projOut2, col1);
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator.Builder()
+                .setOutputColumnRefOp(outputs)
+                .setChildOutputColumns(childOutputs)
+                .isUnionAll(true)
+                .setProjection(new Projection(projectionMap))
+                .build();
+
+        // Only projOut2 is required (not projOut1)
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+        requiredColumns.union(projOut2);
+
+        PruneUnionColumnsRule rule = new PruneUnionColumnsRule();
+        rule.pruneProjectionAndPropagateRequired(unionOp, requiredColumns);
+
+        // col1 should be in required (used by projOut2), col2 should NOT (only used by unrequired projOut1)
+        Assertions.assertTrue(requiredColumns.contains(col1),
+                "col1 should be required (used by kept projOut2)");
+        Assertions.assertFalse(requiredColumns.contains(col2),
+                "col2 should NOT be required (only used by pruned projOut1)");
+
+        // Projection should only contain projOut2
+        Projection resultProjection = unionOp.getProjection();
+        Assertions.assertNotNull(resultProjection);
+        Assertions.assertFalse(resultProjection.getColumnRefMap().containsKey(projOut1),
+                "projOut1 should be removed from projection");
+        Assertions.assertTrue(resultProjection.getColumnRefMap().containsKey(projOut2),
+                "projOut2 should be kept in projection");
+    }
+
+    /**
+     * Test that pruneProjectionAndPropagateRequired is a no-op when Union
+     * has no embedded projection.
+     */
+    @Test
+    public void testPruneUnionWithoutProjectionUnchanged() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "k1", true);
+
+        List<ColumnRefOperator> outputs = Lists.newArrayList(col1);
+        List<List<ColumnRefOperator>> childOutputs = Lists.newArrayList();
+        childOutputs.add(Lists.newArrayList(
+                new ColumnRefOperator(2, IntegerType.INT, "c1_k1", true)
+        ));
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator(outputs, childOutputs, true);
+
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+        requiredColumns.union(col1);
+
+        PruneUnionColumnsRule rule = new PruneUnionColumnsRule();
+        rule.pruneProjectionAndPropagateRequired(unionOp, requiredColumns);
+
+        // No projection means no change
+        Assertions.assertNull(unionOp.getProjection());
+        Assertions.assertTrue(requiredColumns.contains(col1));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/SeparateProjectRuleTest.java
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SeparateProjectRuleTest {
+
+    /**
+     * Test that SeparateProjectRule filters out projection entries whose used
+     * columns are not available in the Union's base output after column pruning.
+     */
+    @Test
+    public void testSeparateProjectFiltersInvalidProjectionEntries() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, VarcharType.VARCHAR, "k2", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, DateType.DATETIME, "v2", true);
+        ColumnRefOperator dateResult = new ColumnRefOperator(3, DateType.DATE, "date_result", true);
+        CallOperator dateCall = new CallOperator("date", DateType.DATE, ImmutableList.of(col2));
+
+        ColumnRefOperator child1Col1 = new ColumnRefOperator(4, VarcharType.VARCHAR, "c1_k2", true);
+        ColumnRefOperator child2Col1 = new ColumnRefOperator(5, VarcharType.VARCHAR, "c2_k2", true);
+
+        // Union's base output only has col1 (col2 was pruned)
+        List<ColumnRefOperator> outputs = Lists.newArrayList(col1);
+        List<List<ColumnRefOperator>> childOutputs = Lists.newArrayList(
+                Lists.newArrayList(child1Col1),
+                Lists.newArrayList(child2Col1)
+        );
+
+        // Embedded projection still references col2 via date(col2)
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        projectionMap.put(dateResult, dateCall);
+        projectionMap.put(col1, col1);
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator.Builder()
+                .setOutputColumnRefOp(outputs)
+                .setChildOutputColumns(childOutputs)
+                .isUnionAll(true)
+                .setProjection(new Projection(projectionMap))
+                .build();
+
+        OptExpression child1 = new OptExpression(
+                new LogicalValuesOperator(ImmutableList.of(child1Col1)));
+        OptExpression child2 = new OptExpression(
+                new LogicalValuesOperator(ImmutableList.of(child2Col1)));
+        OptExpression unionExpr = OptExpression.create(unionOp, child1, child2);
+
+        SeparateProjectRule rule = new SeparateProjectRule();
+        OptExpression result = rule.rewriteImpl(unionExpr);
+
+        Assertions.assertEquals(OperatorType.LOGICAL_PROJECT, result.getOp().getOpType());
+        LogicalProjectOperator projectOp = (LogicalProjectOperator) result.getOp();
+
+        Assertions.assertFalse(projectOp.getColumnRefMap().containsKey(dateResult),
+                "date(col2) should be filtered out because col2 is not in Union output");
+        Assertions.assertTrue(projectOp.getColumnRefMap().containsKey(col1),
+                "col1 pass-through should be preserved");
+
+        LogicalUnionOperator childUnion = (LogicalUnionOperator) result.inputAt(0).getOp();
+        Assertions.assertNull(childUnion.getProjection(),
+                "Union should have no embedded projection after separation");
+    }
+
+    /**
+     * Test that when ALL projection entries reference unavailable columns,
+     * SeparateProjectRule returns the original operator without creating
+     * an empty Project.
+     */
+    @Test
+    public void testSeparateProjectAllEntriesInvalid() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, VarcharType.VARCHAR, "k2", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, DateType.DATETIME, "v2", true);
+        ColumnRefOperator dateResult = new ColumnRefOperator(3, DateType.DATE, "date_result", true);
+        CallOperator dateCall = new CallOperator("date", DateType.DATE, ImmutableList.of(col2));
+
+        ColumnRefOperator child1Col1 = new ColumnRefOperator(4, VarcharType.VARCHAR, "c1_k2", true);
+
+        List<ColumnRefOperator> outputs = Lists.newArrayList(col1);
+        List<List<ColumnRefOperator>> childOutputs = Lists.newArrayList();
+        childOutputs.add(Lists.newArrayList(child1Col1));
+
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        projectionMap.put(dateResult, dateCall);
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator.Builder()
+                .setOutputColumnRefOp(outputs)
+                .setChildOutputColumns(childOutputs)
+                .isUnionAll(true)
+                .setProjection(new Projection(projectionMap))
+                .build();
+
+        OptExpression child = new OptExpression(
+                new LogicalValuesOperator(ImmutableList.of(child1Col1)));
+        OptExpression unionExpr = OptExpression.create(unionOp, child);
+
+        SeparateProjectRule rule = new SeparateProjectRule();
+        OptExpression result = rule.rewriteImpl(unionExpr);
+
+        Assertions.assertEquals(OperatorType.LOGICAL_UNION, result.getOp().getOpType());
+    }
+
+    /**
+     * Test that SeparateProjectRule works correctly for non-SetOperator types
+     * (original behavior unchanged).
+     */
+    @Test
+    public void testSeparateProjectNonSetOperator() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "k1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v1", true);
+
+        Map<ColumnRefOperator, ScalarOperator> projectionMap = new HashMap<>();
+        projectionMap.put(col1, col1);
+        projectionMap.put(col2, new CallOperator("abs", IntegerType.INT, ImmutableList.of(col2)));
+
+        LogicalValuesOperator valuesOp = new LogicalValuesOperator(ImmutableList.of(col1, col2));
+        valuesOp.setProjection(new Projection(projectionMap));
+
+        OptExpression valuesExpr = new OptExpression(valuesOp);
+
+        SeparateProjectRule rule = new SeparateProjectRule();
+        OptExpression result = rule.rewriteImpl(valuesExpr);
+
+        Assertions.assertEquals(OperatorType.LOGICAL_PROJECT, result.getOp().getOpType());
+        LogicalProjectOperator projectOp = (LogicalProjectOperator) result.getOp();
+        Assertions.assertEquals(2, projectOp.getColumnRefMap().size());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When a transparent materialized view (MV) only partially covers queried partitions, the optimizer creates a Union plan (MV scan + base table scan). If the query includes `GROUP BY` with function expressions like `DATE(column)`, the interaction between `MergeProjectWithChildRule`, `PruneUnionColumnsRule`, and `SeparateProjectRule` causes an "Invalid plan" error.

**Root Cause:**

1. `MergeProjectWithChildRule` embeds a projection (containing `date(column)`) into the Union operator
2. `PruneUnionColumnsRule` prunes the base column from the Union's output but does NOT update the embedded projection
3. `SeparateProjectRule` extracts the embedded projection, creating a `LogicalProjectOperator` that references columns no longer in the Union's output
4. The plan validator detects the inconsistency and throws `StarRocksPlannerException: Invalid plan`

The bug is intermittent because it depends on:
- MV partition refresh state (determines whether a Union plan is created)
- Statistics cache timing (influences CBO plan choices)

## What I'm doing:

This fix addresses the issue at three levels:

1. **PruneUnionColumnsRule**: When pruning Union output columns, also prune the embedded projection and propagate columns used by kept projection entries into the required output set.

2. **SeparateProjectRule**: Add defensive filtering when extracting embedded projections from `SetOperator`s — discard entries referencing columns not available in the operator's output.

3. **Statistics.getColumnStatistic()**: Return `ColumnStatistic.unknown()` with a warning log instead of throwing `StarRocksPlannerException` when a column statistic is missing, preventing intermittent query failures caused by statistics cache timing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4