### PR TITLE
[BugFix] fix optimizer timeout 

### DIFF
--- a/fe/AGENTS.md
+++ b/fe/AGENTS.md
@@ -360,6 +360,14 @@ DELETE /api/v2/catalogs/hive/databases/tpch    # Delete database
 - Use appropriate collection types (ArrayList vs LinkedList)
 - Be careful with synchronized blocks
 
+## Optimizer Rule Contract
+
+For optimizer rewrite rules, `transform(...)` must only return a non-empty list when it actually changes the input
+`OptExpression`.
+
+- If this transform don't change the input `OptExpression`, should return the empty list.
+- Do not return a structurally identical plan, or `RewriteTreeTask` may treat it as a change and keep rewriting.
+
 ## Debugging
 
 ### Logging

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -825,6 +825,13 @@ public class Utils {
         if (distinctFuncs.size() <= 1) {
             return false;
         }
+
+        // If all distinct functions are constant-only expressions, do not treat them as
+        // "sharing the same distinct columns".
+        if (distinctFuncs.stream().allMatch(call -> call.getUsedColumns().isEmpty())) {
+            return false;
+        }
+
         Set<ColumnRefOperator> distinctChildren = Sets.newHashSet();
         for (CallOperator callOperator : distinctFuncs) {
             if (distinctChildren.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByMultiFuncRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByMultiFuncRewriter.java
@@ -53,6 +53,7 @@ public class MultiDistinctByMultiFuncRewriter {
     public List<OptExpression> transformImpl(OptExpression input, OptimizerContext context) {
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
 
+        boolean changed = false;
         Map<ColumnRefOperator, CallOperator> newAggMap = new HashMap<>();
         for (Map.Entry<ColumnRefOperator, CallOperator> aggregation : aggregationOperator.getAggregations()
                 .entrySet()) {
@@ -62,12 +63,15 @@ public class MultiDistinctByMultiFuncRewriter {
 
                 if (oldFunctionCall.getFnName().equalsIgnoreCase(FunctionSet.COUNT)) {
                     newAggOperator = buildMultiCountDistinct(oldFunctionCall);
+                    changed = true;
                 } else if (oldFunctionCall.getFnName().equalsIgnoreCase(FunctionSet.SUM)) {
                     newAggOperator = buildMultiSumDistinct(oldFunctionCall);
+                    changed = true;
                 } else if (oldFunctionCall.getFnName().equals(FunctionSet.ARRAY_AGG)) {
                     if (oldFunctionCall.getColumnRefs().size() == 1 &&
                             !oldFunctionCall.getColumnRefs().get(0).getType().isDecimalOfAnyVersion()) {
                         newAggOperator = buildArrayAggDistinct(oldFunctionCall);
+                        changed = true;
                     } else {
                         newAggOperator = oldFunctionCall;
                     }
@@ -92,6 +96,7 @@ public class MultiDistinctByMultiFuncRewriter {
             CallOperator oldFunctionCall = aggMap.getValue();
             if (oldFunctionCall.isDistinct() && oldFunctionCall.getFnName().equals(FunctionSet.AVG)) {
                 hasAvg = true;
+                changed = true;
                 CallOperator count = buildMultiCountDistinct(oldFunctionCall);
                 ColumnRefOperator countColRef = null;
                 for (Map.Entry<ColumnRefOperator, CallOperator> entry : newAggMap.entrySet()) {
@@ -138,6 +143,10 @@ public class MultiDistinctByMultiFuncRewriter {
                 projections.put(aggMap.getKey(), aggMap.getKey());
                 newAggMapWithAvg.put(aggMap.getKey(), aggMap.getValue());
             }
+        }
+
+        if (!changed) {
+            return Lists.newArrayList();
         }
 
         OptExpression result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -103,6 +103,15 @@ public class DistinctAggTest extends PlanTestBase {
                 "  |  offset: 0");
     }
 
+    @Test
+    void testDistinctArrayAggOnConstantSubqueryColumns() throws Exception {
+        String sql = "select array_agg(distinct aaa), array_agg(distinct bbb) as equip_type " +
+                "from (select 'xxxx' as aaa, 'xxx' as bbb) t";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "output: array_agg(DISTINCT 'xxxx'), array_agg(DISTINCT 'xxx')");
+        assertNotContains(plan, "array_agg_distinct");
+    }
+
     private static Stream<Arguments> sqlWithDistinctLimit() {
         List<Arguments> argumentsList = Lists.newArrayList();
         argumentsList.add(Arguments.of("select count(distinct v1, v2) from (select * from t0 limit 2) t",


### PR DESCRIPTION
## Why I'm doing:
for sql like "select array_agg(distinct aaa), array_agg(distinct bbb) as equip_type  from (select 'xxxx' as aaa, 'xxx' as bbb) t", multiple array_agg with const input, MultiDistinctByMultiFuncRewriter wil return the same logical plan, which cause optimizer reapply the same rule until timeout

## What I'm doing:
1. forbidden such case in Rule's check()
2. if MultiDistinctByMultiFuncRewriter doesn't modify plan, return emtpy list


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
