### PR TITLE
[Enhancement] Add per-target-BE MIN/MAX for RPC metrics in load profile

### DIFF
--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/tablet_sink_colocate_sender.h"
 
+#include <limits>
 #include <utility>
 
 #include "column/chunk.h"
@@ -307,6 +308,13 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
 
     int64_t total_server_rpc_time_us = 0;
     int64_t total_server_wait_memtable_flush_time_us = 0;
+    int64_t total_client_rpc_time_ns = 0;
+    int64_t min_server_rpc_time_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_rpc_time_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_server_wait_flush_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_wait_flush_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_client_rpc_time_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_client_rpc_time_ns = std::numeric_limits<int64_t>::min();
     // print log of add batch time of all node, for tracing load performance easily
     std::stringstream ss;
     ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
@@ -314,11 +322,33 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
     for (auto const& pair : node_add_batch_counter_map) {
         total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
         total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
+        total_client_rpc_time_ns += pair.second.client_rpc_time_ns;
+
+        int64_t server_rpc_ns = pair.second.add_batch_execution_time_us * 1000;
+        min_server_rpc_time_ns = std::min(min_server_rpc_time_ns, server_rpc_ns);
+        max_server_rpc_time_ns = std::max(max_server_rpc_time_ns, server_rpc_ns);
+
+        int64_t server_wait_flush_ns = pair.second.add_batch_wait_memtable_flush_time_us * 1000;
+        min_server_wait_flush_ns = std::min(min_server_wait_flush_ns, server_wait_flush_ns);
+        max_server_wait_flush_ns = std::max(max_server_wait_flush_ns, server_wait_flush_ns);
+
+        min_client_rpc_time_ns = std::min(min_client_rpc_time_ns, pair.second.client_rpc_time_ns);
+        max_client_rpc_time_ns = std::max(max_client_rpc_time_ns, pair.second.client_rpc_time_ns);
+
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
     COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
     COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
+
+    if (!node_add_batch_counter_map.empty()) {
+        ts_profile->server_rpc_timer->set_min(min_server_rpc_time_ns);
+        ts_profile->server_rpc_timer->set_max(max_server_rpc_time_ns);
+        ts_profile->server_wait_flush_timer->set_min(min_server_wait_flush_ns);
+        ts_profile->server_wait_flush_timer->set_max(max_server_wait_flush_ns);
+        ts_profile->client_rpc_timer->set_min(min_client_rpc_time_ns);
+        ts_profile->client_rpc_timer->set_max(max_client_rpc_time_ns);
+    }
     LOG(INFO) << ss.str();
 
     ExprExecutor::close(_output_expr_ctxs, state);

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -14,7 +14,6 @@
 
 #include "exec/tablet_sink_colocate_sender.h"
 
-#include <limits>
 #include <utility>
 
 #include "column/chunk.h"
@@ -309,12 +308,6 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
     int64_t total_server_rpc_time_us = 0;
     int64_t total_server_wait_memtable_flush_time_us = 0;
     int64_t total_client_rpc_time_ns = 0;
-    int64_t min_server_rpc_time_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_server_rpc_time_ns = std::numeric_limits<int64_t>::min();
-    int64_t min_server_wait_flush_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_server_wait_flush_ns = std::numeric_limits<int64_t>::min();
-    int64_t min_client_rpc_time_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_client_rpc_time_ns = std::numeric_limits<int64_t>::min();
     // print log of add batch time of all node, for tracing load performance easily
     std::stringstream ss;
     ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
@@ -324,31 +317,13 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
         total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
         total_client_rpc_time_ns += pair.second.client_rpc_time_ns;
 
-        int64_t server_rpc_ns = pair.second.add_batch_execution_time_us * 1000;
-        min_server_rpc_time_ns = std::min(min_server_rpc_time_ns, server_rpc_ns);
-        max_server_rpc_time_ns = std::max(max_server_rpc_time_ns, server_rpc_ns);
-
-        int64_t server_wait_flush_ns = pair.second.add_batch_wait_memtable_flush_time_us * 1000;
-        min_server_wait_flush_ns = std::min(min_server_wait_flush_ns, server_wait_flush_ns);
-        max_server_wait_flush_ns = std::max(max_server_wait_flush_ns, server_wait_flush_ns);
-
-        min_client_rpc_time_ns = std::min(min_client_rpc_time_ns, pair.second.client_rpc_time_ns);
-        max_client_rpc_time_ns = std::max(max_client_rpc_time_ns, pair.second.client_rpc_time_ns);
-
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
     COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
     COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
 
-    if (!node_add_batch_counter_map.empty()) {
-        ts_profile->server_rpc_timer->set_min(min_server_rpc_time_ns);
-        ts_profile->server_rpc_timer->set_max(max_server_rpc_time_ns);
-        ts_profile->server_wait_flush_timer->set_min(min_server_wait_flush_ns);
-        ts_profile->server_wait_flush_timer->set_max(max_server_wait_flush_ns);
-        ts_profile->client_rpc_timer->set_min(min_client_rpc_time_ns);
-        ts_profile->client_rpc_timer->set_max(max_client_rpc_time_ns);
-    }
+    update_rpc_min_max_profile(node_add_batch_counter_map, ts_profile);
     LOG(INFO) << ss.str();
 
     ExprExecutor::close(_output_expr_ctxs, state);

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -821,6 +821,7 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
     _mem_tracker->release(closure->request_size);
 
     COUNTER_UPDATE(_ts_profile->client_rpc_timer, closure->latency());
+    _add_batch_counter.client_rpc_time_ns += closure->latency();
 
     if (closure->cntl.Failed()) {
         _cancelled = true;

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -58,8 +58,8 @@ struct AddBatchCounter {
     int64_t add_batch_wait_lock_time_us = 0;
     // number of add_batch call
     int64_t add_batch_num = 0;
-    // total time of client rpc
-    int64_t client_prc_time_us = 0;
+    // total time of client rpc (in nanoseconds)
+    int64_t client_rpc_time_ns = 0;
     // total time of wait memtable flush
     int64_t add_batch_wait_memtable_flush_time_us = 0;
 
@@ -68,6 +68,7 @@ struct AddBatchCounter {
         add_batch_wait_lock_time_us += rhs.add_batch_wait_lock_time_us;
         add_batch_num += rhs.add_batch_num;
         add_batch_wait_memtable_flush_time_us += rhs.add_batch_wait_memtable_flush_time_us;
+        client_rpc_time_ns += rhs.client_rpc_time_ns;
         return *this;
     }
     friend AddBatchCounter operator+(const AddBatchCounter& lhs, const AddBatchCounter& rhs) {

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <queue>
 #include <set>
@@ -100,6 +101,47 @@ struct TabletSinkProfile {
     RuntimeProfile::Counter* server_wait_flush_timer = nullptr;
     RuntimeProfile::Counter* update_load_channel_profile_timer = nullptr;
 };
+
+// Update per-target-BE MIN/MAX for RPC metrics in load profile.
+// Only considers nodes that actually participated (add_batch_num > 0).
+inline void update_rpc_min_max_profile(const std::unordered_map<int64_t, AddBatchCounter>& counter_map,
+                                       TabletSinkProfile* ts_profile) {
+    int64_t min_server_rpc_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_rpc_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_server_wait_flush_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_wait_flush_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_client_rpc_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_client_rpc_ns = std::numeric_limits<int64_t>::min();
+    bool has_participating_node = false;
+
+    for (const auto& pair : counter_map) {
+        if (pair.second.add_batch_num == 0) {
+            continue;
+        }
+        has_participating_node = true;
+
+        // add_batch_execution_time_us is in microseconds, convert to nanoseconds
+        int64_t server_rpc_ns = pair.second.add_batch_execution_time_us * 1000;
+        min_server_rpc_ns = std::min(min_server_rpc_ns, server_rpc_ns);
+        max_server_rpc_ns = std::max(max_server_rpc_ns, server_rpc_ns);
+
+        int64_t server_wait_flush_ns = pair.second.add_batch_wait_memtable_flush_time_us * 1000;
+        min_server_wait_flush_ns = std::min(min_server_wait_flush_ns, server_wait_flush_ns);
+        max_server_wait_flush_ns = std::max(max_server_wait_flush_ns, server_wait_flush_ns);
+
+        min_client_rpc_ns = std::min(min_client_rpc_ns, pair.second.client_rpc_time_ns);
+        max_client_rpc_ns = std::max(max_client_rpc_ns, pair.second.client_rpc_time_ns);
+    }
+
+    if (has_participating_node) {
+        ts_profile->server_rpc_timer->set_min(min_server_rpc_ns);
+        ts_profile->server_rpc_timer->set_max(max_server_rpc_ns);
+        ts_profile->server_wait_flush_timer->set_min(min_server_wait_flush_ns);
+        ts_profile->server_wait_flush_timer->set_max(max_server_wait_flush_ns);
+        ts_profile->client_rpc_timer->set_min(min_client_rpc_ns);
+        ts_profile->client_rpc_timer->set_max(max_client_rpc_ns);
+    }
+}
 
 // map index_id to TabletBEMap(map tablet_id to backend id)
 using IndexIdToTabletBEMap = std::unordered_map<int64_t, std::unordered_map<int64_t, std::vector<int64_t>>>;

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/tablet_sink_sender.h"
 
+#include <limits>
 #include <utility>
 
 #include "column/chunk.h"
@@ -347,6 +348,13 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
 
     int64_t total_server_rpc_time_us = 0;
     int64_t total_server_wait_memtable_flush_time_us = 0;
+    int64_t total_client_rpc_time_ns = 0;
+    int64_t min_server_rpc_time_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_rpc_time_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_server_wait_flush_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_server_wait_flush_ns = std::numeric_limits<int64_t>::min();
+    int64_t min_client_rpc_time_ns = std::numeric_limits<int64_t>::max();
+    int64_t max_client_rpc_time_ns = std::numeric_limits<int64_t>::min();
     // print log of add batch time of all node, for tracing load performance easily
     std::stringstream ss;
     ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
@@ -354,11 +362,33 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
     for (auto const& pair : node_add_batch_counter_map) {
         total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
         total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
+        total_client_rpc_time_ns += pair.second.client_rpc_time_ns;
+
+        int64_t server_rpc_ns = pair.second.add_batch_execution_time_us * 1000;
+        min_server_rpc_time_ns = std::min(min_server_rpc_time_ns, server_rpc_ns);
+        max_server_rpc_time_ns = std::max(max_server_rpc_time_ns, server_rpc_ns);
+
+        int64_t server_wait_flush_ns = pair.second.add_batch_wait_memtable_flush_time_us * 1000;
+        min_server_wait_flush_ns = std::min(min_server_wait_flush_ns, server_wait_flush_ns);
+        max_server_wait_flush_ns = std::max(max_server_wait_flush_ns, server_wait_flush_ns);
+
+        min_client_rpc_time_ns = std::min(min_client_rpc_time_ns, pair.second.client_rpc_time_ns);
+        max_client_rpc_time_ns = std::max(max_client_rpc_time_ns, pair.second.client_rpc_time_ns);
+
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
     COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
     COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
+
+    if (!node_add_batch_counter_map.empty()) {
+        ts_profile->server_rpc_timer->set_min(min_server_rpc_time_ns);
+        ts_profile->server_rpc_timer->set_max(max_server_rpc_time_ns);
+        ts_profile->server_wait_flush_timer->set_min(min_server_wait_flush_ns);
+        ts_profile->server_wait_flush_timer->set_max(max_server_wait_flush_ns);
+        ts_profile->client_rpc_timer->set_min(min_client_rpc_time_ns);
+        ts_profile->client_rpc_timer->set_max(max_client_rpc_time_ns);
+    }
     LOG(INFO) << ss.str();
 
     ExprExecutor::close(_output_expr_ctxs, state);

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -14,7 +14,6 @@
 
 #include "exec/tablet_sink_sender.h"
 
-#include <limits>
 #include <utility>
 
 #include "column/chunk.h"
@@ -349,12 +348,6 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
     int64_t total_server_rpc_time_us = 0;
     int64_t total_server_wait_memtable_flush_time_us = 0;
     int64_t total_client_rpc_time_ns = 0;
-    int64_t min_server_rpc_time_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_server_rpc_time_ns = std::numeric_limits<int64_t>::min();
-    int64_t min_server_wait_flush_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_server_wait_flush_ns = std::numeric_limits<int64_t>::min();
-    int64_t min_client_rpc_time_ns = std::numeric_limits<int64_t>::max();
-    int64_t max_client_rpc_time_ns = std::numeric_limits<int64_t>::min();
     // print log of add batch time of all node, for tracing load performance easily
     std::stringstream ss;
     ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
@@ -364,31 +357,13 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
         total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
         total_client_rpc_time_ns += pair.second.client_rpc_time_ns;
 
-        int64_t server_rpc_ns = pair.second.add_batch_execution_time_us * 1000;
-        min_server_rpc_time_ns = std::min(min_server_rpc_time_ns, server_rpc_ns);
-        max_server_rpc_time_ns = std::max(max_server_rpc_time_ns, server_rpc_ns);
-
-        int64_t server_wait_flush_ns = pair.second.add_batch_wait_memtable_flush_time_us * 1000;
-        min_server_wait_flush_ns = std::min(min_server_wait_flush_ns, server_wait_flush_ns);
-        max_server_wait_flush_ns = std::max(max_server_wait_flush_ns, server_wait_flush_ns);
-
-        min_client_rpc_time_ns = std::min(min_client_rpc_time_ns, pair.second.client_rpc_time_ns);
-        max_client_rpc_time_ns = std::max(max_client_rpc_time_ns, pair.second.client_rpc_time_ns);
-
         ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
            << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
     }
     COUNTER_UPDATE(ts_profile->server_rpc_timer, total_server_rpc_time_us * 1000);
     COUNTER_UPDATE(ts_profile->server_wait_flush_timer, total_server_wait_memtable_flush_time_us * 1000);
 
-    if (!node_add_batch_counter_map.empty()) {
-        ts_profile->server_rpc_timer->set_min(min_server_rpc_time_ns);
-        ts_profile->server_rpc_timer->set_max(max_server_rpc_time_ns);
-        ts_profile->server_wait_flush_timer->set_min(min_server_wait_flush_ns);
-        ts_profile->server_wait_flush_timer->set_max(max_server_wait_flush_ns);
-        ts_profile->client_rpc_timer->set_min(min_client_rpc_time_ns);
-        ts_profile->client_rpc_timer->set_max(max_client_rpc_time_ns);
-    }
+    update_rpc_min_max_profile(node_add_batch_counter_map, ts_profile);
     LOG(INFO) << ss.str();
 
     ExprExecutor::close(_output_expr_ctxs, state);


### PR DESCRIPTION
## Why I'm doing:

In the load profile, `RpcClientSideTime`, `RpcServerSideTime`, and `RpcServerWaitFlushTime` are accumulated across all target BEs via `update()`/`fetch_add` for each RPC call. In multi-machine scenarios, the total can far exceed the wall clock time (e.g., 26 target BEs accumulate to 51s while the actual `SendDataTime` is only 8.5s), making it impossible to identify which receiver BE is the bottleneck.

## What I'm doing:

During the close phase of `TabletSinkSender` and `TabletSinkColocateSender`, iterate over each target BE's `AddBatchCounter` to compute per-target-BE MIN/MAX, and set them on the corresponding profile counters via `set_min()`/`set_max()`. The FE-side profile merge framework automatically displays these as `__MIN_OF_` / `__MAX_OF_` child counters.

**Changed files:**
- `tablet_sink_index_channel.h`: Fix `AddBatchCounter` client RPC time field naming (`client_prc_time_us` → `client_rpc_time_ns`) and accumulate it in `operator+=`
- `tablet_sink_index_channel.cpp`: Record each RPC latency into `AddBatchCounter` in `NodeChannel::_wait_request`
- `tablet_sink_sender.cpp`: Compute per-target-BE MIN/MAX for all three metrics during close phase
- `tablet_sink_colocate_sender.cpp`: Same changes for the colocate sender path

**Expected profile output after this change:**
```
- RpcClientSideTime: 51s434ms
  - __MIN_OF_RpcClientSideTime: 1s200ms
  - __MAX_OF_RpcClientSideTime: 3s800ms
- RpcServerSideTime: 48s17ms
  - __MIN_OF_RpcServerSideTime: 800ms
  - __MAX_OF_RpcServerSideTime: 3s500ms
```

**Risks:**
- MIN/MAX reflects the accumulated value per target BE (sum of all batches), not single RPC latency

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4