### PR TITLE
[BugFix] Fix NOT NULL constraint incorrectly pushed down to FILES() schema

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -513,6 +513,10 @@ public class InsertAnalyzer {
                     // file table function table should use original column name because BE is case-sensitive when reading columns.
                     String origColumnName = oldCol.getName();
                     newCol.setName(origColumnName);
+                    // FileScanNode will set all slot nullable, it checks null in OlapTableSink if dest table column is not null.
+                    // Currently, the nullable property in files() table is always true.
+                    // So we keep the old column nullable property.
+                    newCol.setIsAllowNull(oldCol.isAllowNull());
                     newFileTableColumns.put(origColumnName, newCol);
                 }
 

--- a/test/sql/test_files/R/test_insert_push_down_column_type_nullable
+++ b/test/sql/test_files/R/test_insert_push_down_column_type_nullable
@@ -1,0 +1,42 @@
+-- name: test_insert_push_down_column_type_nullable
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as k1, 1 as k2
+union all
+select 1 as k1, 2 as k2;
+-- result:
+-- !result
+
+
+create table t1 (k1 int not null, v int);
+-- result:
+-- !result
+
+insert into t1 select k1, sum(k2) as v from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+group by k1;
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	3
+-- !result
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_insert_push_down_column_type_nullable
+++ b/test/sql/test_files/T/test_insert_push_down_column_type_nullable
@@ -1,0 +1,33 @@
+-- name: test_insert_push_down_column_type_nullable
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select 1 as k1, 1 as k2
+union all
+select 1 as k1, 2 as k2;
+
+-- should not push down k1 not null
+create table t1 (k1 int not null, v int);
+
+insert into t1 select k1, sum(k2) as v from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+group by k1;
+
+select * from t1;
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

  When INSERT INTO ... SELECT FROM FILES() triggers the schema push-down
  optimization, the target table column is deep-copied to replace the file
  column's type. However, the NOT NULL constraint was also carried over,
  causing a nullable mismatch because `FileScanNode` will set all slot nullable.

## What I'm doing:

Preserve the nullable property from the original `files()` column
when constructing the pushed-down schema, so only the data type is
pushed down, not the nullability constraint.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11135

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
