### PR TITLE
[BugFix] Fix schema push-down using positional mapping for INSERT INTO BY NAME from FILES()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -497,7 +497,12 @@ public class InsertAnalyzer {
                         continue;
                     }
 
-                    String targetColumnName = targetColumnNames.get(i);
+                    String targetColumnName;
+                    if (insertStmt.isColumnMatchByName()) {
+                        targetColumnName = selectColumnName;
+                    } else {
+                        targetColumnName = targetColumnNames.get(i);
+                    }
                     if (!targetTableColumns.containsKey(targetColumnName)) {
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -462,23 +462,33 @@ public class InsertAnalyzer {
                             .map(Column::getName).collect(Collectors.toList());
                 }
 
-                // get select column names, null if it is not slot ref column
+                // get select column names, null if it is not slot ref column.
+                // selectColumnNames: source column names used to locate the file column to rewrite.
+                // selectOutputNames: output names (alias if present, else source name) used to look up the
+                //                    target table column type in BY NAME mode.
                 List<String> selectColumnNames = Lists.newArrayList();
+                List<String> selectOutputNames = Lists.newArrayList();
                 List<SelectListItem> listItems = selectRelation.getSelectList().getItems();
                 for (SelectListItem item : listItems) {
                     if (item.isStar()) {
-                        selectColumnNames.addAll(fileTable.getFullSchema().stream().map(Column::getName)
-                                .collect(Collectors.toList()));
+                        List<String> fileColNames = fileTable.getFullSchema().stream().map(Column::getName)
+                                .collect(Collectors.toList());
+                        selectColumnNames.addAll(fileColNames);
+                        selectOutputNames.addAll(fileColNames);
                         continue;
                     }
 
                     Expr expr = item.getExpr();
                     if (expr instanceof SlotRef) {
-                        selectColumnNames.add(((SlotRef) expr).getColumnName());
+                        String srcName = ((SlotRef) expr).getColumnName();
+                        selectColumnNames.add(srcName);
+                        String alias = item.getAlias();
+                        selectOutputNames.add(alias != null ? alias : srcName);
                         continue;
                     }
 
                     selectColumnNames.add(null);
+                    selectOutputNames.add(null);
                 }
 
                 if (targetColumnNames.size() != selectColumnNames.size()) {
@@ -497,9 +507,11 @@ public class InsertAnalyzer {
                         continue;
                     }
 
+                    // In BY NAME mode the output name (alias) is what gets matched to the target column,
+                    // so use selectOutputNames to find the right target column type.
                     String targetColumnName;
                     if (insertStmt.isColumnMatchByName()) {
-                        targetColumnName = selectColumnName;
+                        targetColumnName = selectOutputNames.get(i);
                     } else {
                         targetColumnName = targetColumnNames.get(i);
                     }

--- a/test/sql/test_files/R/test_insert_by_name_from_files
+++ b/test/sql/test_files/R/test_insert_by_name_from_files
@@ -1,0 +1,50 @@
+-- name: test_insert_by_name_from_files
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select "a" as k2, 1 as k1;
+-- result:
+-- !result
+
+desc files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+k2	varchar(1048576)	YES
+k1	int	YES
+-- !result
+
+
+create table t1 (k1 int, k2 varchar(10));
+-- result:
+-- !result
+
+insert into t1 by name select * from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	a
+-- !result
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/R/test_insert_by_name_from_files
+++ b/test/sql/test_files/R/test_insert_by_name_from_files
@@ -47,4 +47,23 @@ select * from t1;
 -- !result
 
 
+create table t2 (k1 varchar(10), k2 int);
+-- result:
+-- !result
+
+insert into t2 by name select k2 as k1, k1 as k2 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+
+select * from t2;
+-- result:
+a	1
+-- !result
+
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_insert_by_name_from_files
+++ b/test/sql/test_files/T/test_insert_by_name_from_files
@@ -33,4 +33,22 @@ insert into t1 by name select * from files(
 select * from t1;
 
 
+-- Test BY NAME with cross-column aliases: SELECT k2 AS k1, k1 AS k2 FROM files(...)
+-- The parquet file has k2(varchar='a') and k1(int=1).
+-- With cross-aliases the schema push-down must use the output name (alias) to resolve the
+-- target column type, not the raw source column name.  If it used the source name it would
+-- push INT onto file column k2 and reject 'a', or push VARCHAR onto file column k1 and
+-- then fail to cast '1' to the INT target, depending on strict mode.
+create table t2 (k1 varchar(10), k2 int);
+
+insert into t2 by name select k2 as k1, k1 as k2 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+select * from t2;
+
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_insert_by_name_from_files
+++ b/test/sql/test_files/T/test_insert_by_name_from_files
@@ -1,0 +1,36 @@
+-- name: test_insert_by_name_from_files
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}")
+select "a" as k2, 1 as k1;
+
+desc files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+
+create table t1 (k1 int, k2 varchar(10));
+
+insert into t1 by name select * from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
+select * from t1;
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

  When using `INSERT INTO t BY NAME SELECT * FROM FILES(...)`, the schema
  push-down to FILES() was incorrectly matching file columns to target table
  columns by position instead of by name. This caused wrong types to be
  applied to file columns, leading to spurious data filtering errors.

## What I'm doing:

  Fix by using the select column name or alias (instead of the positional target column
  name) as the lookup key into the target table schema when BY NAME mode is
  active.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
