### PR TITLE
[BugFix] fix stack overflow for to_base64

### DIFF
--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -15,6 +15,7 @@
 #include "exprs/encryption_functions.h"
 
 #include <optional>
+#include <vector>
 
 #include "base/crypto/aes_util.h"
 #include "base/crypto/md5.h"
@@ -514,6 +515,7 @@ StatusOr<ColumnPtr> EncryptionFunctions::to_base64(FunctionContext* ctx, const C
 
     const int size = columns[0]->size();
     ColumnBuilder<TYPE_VARCHAR> result(size);
+    std::vector<char> encoded_buf;
     for (int row = 0; row < size; ++row) {
         if (src_viewer.is_null(row)) {
             result.append_null();
@@ -525,22 +527,20 @@ StatusOr<ColumnPtr> EncryptionFunctions::to_base64(FunctionContext* ctx, const C
         if (src_value.size == 0) {
             result.append_null();
             continue;
-        } else if (src_value.size > limit) {
+        } else if (limit >= 0 && src_value.size > static_cast<size_t>(limit)) {
             std::stringstream ss;
             ss << "to_base64 not supported length > " << limit;
             throw std::runtime_error(ss.str());
         }
 
-        int cipher_len = (size_t)(4.0 * ceil((double)src_value.size / 3.0)) + 1;
-        char p[cipher_len];
-
-        int len = base64_encode2((unsigned char*)src_value.data, src_value.size, (unsigned char*)p);
-        if (len < 0) {
-            result.append_null();
-            continue;
+        size_t encoded_len = (size_t)(4.0 * ceil((double)src_value.size / 3.0)) + 1;
+        if (encoded_buf.size() < encoded_len) {
+            encoded_buf.resize(encoded_len);
         }
 
-        result.append(Slice(p, len));
+        encoded_len = base64_encode2(reinterpret_cast<const unsigned char*>(src_value.data), src_value.size,
+                                     reinterpret_cast<unsigned char*>(encoded_buf.data()));
+        result.append(Slice(encoded_buf.data(), encoded_len));
     }
 
     return result.build(ColumnHelper::is_all_const(columns));

--- a/be/test/exprs/encryption_functions_test.cpp
+++ b/be/test/exprs/encryption_functions_test.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 
 #include "butil/time.h"
+#include "common/config.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "exprs/string_functions.h"
 #include "types/decimalv3.h"
@@ -29,7 +30,12 @@ namespace starrocks {
 
 class EncryptionFunctionsTest : public ::testing::Test {
 public:
-    void SetUp() override {}
+    void SetUp() override { _max_length_for_to_base64 = config::max_length_for_to_base64; }
+
+    void TearDown() override { config::max_length_for_to_base64 = _max_length_for_to_base64; }
+
+private:
+    int64_t _max_length_for_to_base64 = 0;
 };
 
 // ==================== AES Encrypt/Decrypt with Mode Tests ====================
@@ -1874,6 +1880,28 @@ TEST_F(EncryptionFunctionsTest, to_base64Test) {
     for (int j = 0; j < sizeof(results) / sizeof(results[0]); ++j) {
         ASSERT_EQ(results[j], v->get_data()[j].to_string());
     }
+}
+
+TEST_F(EncryptionFunctionsTest, to_base64LargeInputTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto plain = BinaryColumn::create();
+
+    constexpr size_t kInputSize = 8 * 1024 * 1024;
+    std::string input(kInputSize, 'x');
+    config::max_length_for_to_base64 = kInputSize;
+
+    plain->append(input);
+    columns.emplace_back(std::move(plain));
+
+    ColumnPtr encoded = EncryptionFunctions::to_base64(ctx.get(), columns).value();
+
+    Columns decode_columns;
+    decode_columns.emplace_back(encoded);
+
+    ColumnPtr decoded = EncryptionFunctions::from_base64(ctx.get(), decode_columns).value();
+    auto decoded_data = ColumnHelper::cast_to<TYPE_VARCHAR>(decoded);
+    ASSERT_EQ(input, decoded_data->get_data()[0].to_string());
 }
 
 TEST_F(EncryptionFunctionsTest, to_base64NullTest) {

--- a/be/test/exprs/encryption_functions_test.cpp
+++ b/be/test/exprs/encryption_functions_test.cpp
@@ -1900,8 +1900,7 @@ TEST_F(EncryptionFunctionsTest, to_base64LargeInputTest) {
     decode_columns.emplace_back(encoded);
 
     ColumnPtr decoded = EncryptionFunctions::from_base64(ctx.get(), decode_columns).value();
-    auto decoded_data = ColumnHelper::cast_to<TYPE_VARCHAR>(decoded);
-    ASSERT_EQ(input, decoded_data->get_data()[0].to_string());
+    ASSERT_EQ(input, decoded->get(0).get_slice().to_string());
 }
 
 TEST_F(EncryptionFunctionsTest, to_base64NullTest) {


### PR DESCRIPTION
## Why I'm doing:
```
*** Aborted at 1773123660 (unix time) try "date -d @1773123660" if you are using GNU date ***
PC: @          0x53c7ef0 starrocks::base64_encode2(unsigned char const*, unsigned long, unsigned char*)
*** SIGSEGV (@0x153f08be0000) received by PID 223819 (TID 0x153f08fe1700) from PID 146669568; stack trace: ***
    @     0x153f77ecfe97 __pthread_once_slow
    @          0x7de2720 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x153f78d5835d os::Linux::chained_handler(int, siginfo*, void*)
    @     0x153f78d5df5f JVM_handle_linux_signal
    @     0x153f78d4f968 signalHandler(int, siginfo*, void*)
    @     0x153f77ed2d20 (/usr/lib64/libpthread-2.28.so+0x12d1f)
    @          0x53c7ef0 starrocks::base64_encode2(unsigned char const*, unsigned long, unsigned char*)
    @          0x70b63a0 starrocks::EncryptionFunctions::to_base64(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
    @          0x5f25eac starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x53c8abb starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x53c8f3f starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x445e3bc starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x44f50f4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x47b91a3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x39900d3 starrocks::ThreadPool::dispatch_thread()
    @          0x3987756 starrocks::Thread::supervise_thread(void*)
    @     0x153f77ec81ca start_thread
    @     0x153f7717d8d3 __GI___clone
```

## What I'm doing:

allocate buffer in heap

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
