### PR TITLE
[Enhancement] Increase tablet_reshard_target_size default to 10GB and add publish resharding logs

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -300,6 +300,12 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                  bool skip_write_tablet_metadata,
                                  std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
                                  std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
+    LOG(INFO) << "Start publish resharding tablet"
+              << ", resharding_tablet=" << resharding_tablet.DebugString()
+              << ", txn_info=" << txn_info.DebugString()
+              << ", base_version=" << base_version
+              << ", new_version=" << new_version;
+
     if (resharding_tablet.has_splitting_tablet_info()) {
         RETURN_IF_ERROR(handle_splitting_tablet(tablet_manager, resharding_tablet.splitting_tablet_info(), base_version,
                                                 new_version, txn_info, tablet_metadatas, tablet_ranges));
@@ -321,6 +327,11 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
         }
     }
 
+    LOG(INFO) << "Finish publish resharding tablet"
+              << ", resharding_tablet=" << resharding_tablet.DebugString()
+              << ", txn_info=" << txn_info.DebugString()
+              << ", base_version=" << base_version
+              << ", new_version=" << new_version;
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -301,10 +301,8 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                  std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
                                  std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
     LOG(INFO) << "Start publish resharding tablet"
-              << ", resharding_tablet=" << resharding_tablet.DebugString()
-              << ", txn_info=" << txn_info.DebugString()
-              << ", base_version=" << base_version
-              << ", new_version=" << new_version;
+              << ", resharding_tablet=" << resharding_tablet.DebugString() << ", txn_info=" << txn_info.DebugString()
+              << ", base_version=" << base_version << ", new_version=" << new_version;
 
     if (resharding_tablet.has_splitting_tablet_info()) {
         RETURN_IF_ERROR(handle_splitting_tablet(tablet_manager, resharding_tablet.splitting_tablet_info(), base_version,
@@ -328,10 +326,8 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
     }
 
     LOG(INFO) << "Finish publish resharding tablet"
-              << ", resharding_tablet=" << resharding_tablet.DebugString()
-              << ", txn_info=" << txn_info.DebugString()
-              << ", base_version=" << base_version
-              << ", new_version=" << new_version;
+              << ", resharding_tablet=" << resharding_tablet.DebugString() << ", txn_info=" << txn_info.DebugString()
+              << ", base_version=" << base_version << ", new_version=" << new_version;
     return Status::OK();
 }
 

--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -537,7 +537,7 @@ This topic introduces the following types of FE configurations:
 
 ### `tablet_reshard_target_size`
 
-- Default: 1073741824 (1 GB)
+- Default: 10737418240 (10 GB)
 - Type: Int
 - Unit: Bytes
 - Is mutable: Yes

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -477,7 +477,7 @@ ALTER TABLE <table_name> MERGE { TABLET | TABLETS }
 
 Parameter:
 
-- `tablet_reshard_target_size`: The target size of the tablets after the SPLIT or MERGE operation. Default: 1 GB. You do not need to specify this parameter if you have explicitly specified tablet IDs.
+- `tablet_reshard_target_size`: The target size of the tablets after the SPLIT or MERGE operation. Default: 10 GB. You do not need to specify this parameter if you have explicitly specified tablet IDs.
 
   - A tablet will be split if both the following conditions are met:
     - The size of the tablet is **larger** than `tablet_reshard_target_size`. 
@@ -1398,7 +1398,7 @@ ALTER TABLE db1.test_tbl DROP PERSISTENT INDEX ON TABLETS (100, 101);
 
 ### SPLIT or MERGE tablets
 
-- Split all tablets that meet the conditions in the table to a target size of 1 GB (Default).
+- Split all tablets that meet the conditions in the table to a target size of 10 GB (Default).
 
 ```SQL
 ALTER TABLE table1 SPLIT TABLETS;

--- a/docs/ja/administration/management/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/FE_parameters/stats_storage.md
@@ -537,7 +537,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `tablet_reshard_target_size`
 
-- デフォルト：1073741824 (1 GB)
+- デフォルト：10737418240 (10 GB)
 - タイプ：Int
 - 単位：Bytes
 - 変更可能：Yes

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -479,7 +479,7 @@ ALTER TABLE <table_name> MERGE { TABLET | TABLETS }
 
 パラメータ：
 
-- `tablet_reshard_target_size`：SPLIT または MERGE 実行後の Tablet の目標サイズ。デフォルト値：1 GB。Tablet ID を明示的に指定している場合は、このパラメータを指定する必要はありません。
+- `tablet_reshard_target_size`：SPLIT または MERGE 実行後の Tablet の目標サイズ。デフォルト値：10 GB。Tablet ID を明示的に指定している場合は、このパラメータを指定する必要はありません。
 
   - SPLIT が実行される条件：
     - Tablet のサイズが `tablet_reshard_target_size` を**上回る**こと。
@@ -1399,7 +1399,7 @@ ALTER TABLE db1.test_tbl DROP PERSISTENT INDEX ON TABLETS (100, 101);
 
 ### Tablet の分割または結合
 
-- 表内にあるすべての条件を満たすタブレットを、1 GB (デフォルト) を目標サイズとして分割する。
+- 表内にあるすべての条件を満たすタブレットを、10 GB (デフォルト) を目標サイズとして分割する。
 
 ```SQL
 ALTER TABLE table1 SPLIT TABLETS;

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -537,7 +537,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `tablet_reshard_target_size`
 
-- 默认值: 1073741824 (1 GB)
+- 默认值: 10737418240 (10 GB)
 - 类型: Int
 - 单位: Bytes
 - 是否可变: Yes

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -478,7 +478,7 @@ ALTER TABLE <table_name> MERGE { TABLET | TABLETS }
 
 参数说明：
 
-- `tablet_reshard_target_size`: 执行 SPLIT 或 MERGE 后的 Tablet 目标大小。默认值：1 GB。如果已明确指定了 Tablet ID，则无需指定此参数。
+- `tablet_reshard_target_size`: 执行 SPLIT 或 MERGE 后的 Tablet 目标大小。默认值：10 GB。如果已明确指定了 Tablet ID，则无需指定此参数。
 
   - 触发拆分（SPLIT）的条件：
     - Tablet 的大小**大于** `tablet_reshard_target_size`。
@@ -1399,7 +1399,7 @@ ALTER TABLE db1.test_tbl DROP PERSISTENT INDEX ON TABLETS (100, 101);
 
 ### 拆分或合并 Tablet
 
-- 将表中所有符合条件的 Tablet 拆分，目标大小为 1 GB（默认值）。
+- 将表中所有符合条件的 Tablet 拆分，目标大小为 10 GB（默认值）。
 
 ```SQL
 ALTER TABLE table1 SPLIT TABLETS;
@@ -1419,7 +1419,7 @@ ALTER TABLE table1 SPLIT TABLETS
 (9588955, 9588956, 9588957);
 ```
 
-- 将表中所有符合条件的 Tablet 合并，目标大小为 1 GB（默认值）。
+- 将表中所有符合条件的 Tablet 合并，目标大小为 10 GB（默认值）。
 
 ```SQL
 ALTER TABLE table1 MERGE TABLETS

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4317,7 +4317,7 @@ public class Config extends ConfigBase {
      * Tablet splitting and merging will make tablet size around this value.
      */
     @ConfField(mutable = true, comment = "Tablet splitting and merging will make tablet size around this value.")
-    public static long tablet_reshard_target_size = 1024L * 1024L * 1024L;
+    public static long tablet_reshard_target_size = 10L * 1024L * 1024L * 1024L;
 
     /**
      * The max number of new tablets that an old tablet can be split into.


### PR DESCRIPTION
## Why I'm doing:

  1. The current default value of `tablet_reshard_target_size` (1GB) is too small for production environments, causing tablets to split/merge too aggressively. Increasing it to 10GB makes the split threshold 20GB and merge threshold 10GB, which is more reasonable.
  2. The BE side lacks logging for successful tablet reshard publish operations (`publish_resharding_tablet`). Only error/warning logs exist, making it difficult to troubleshoot issues in production.

## What I'm doing:

  1. Changed the default value of FE config `tablet_reshard_target_size` from 1GB to 10GB.
  2. Added `LOG(INFO)` at the entry and exit of `publish_resharding_tablet()` in `tablet_reshard.cpp`, printing `ReshardingTabletInfoPB`, `TxnInfoPB`, `base_version`, and `new_version`. This uniformly covers split, merge, and identical operations. Failed operations will not reach the "Finish" log due to `RETURN_IF_ERROR`, making it easy to distinguish success from failure.
  3. Updated en/zh/ja documentation accordingly.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4