### PR TITLE
[BugFix] Fix partial manifest cache writes in Iceberg ManifestReader

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.starrocks.connector.iceberg.DataFileWrapper;
 import com.starrocks.connector.iceberg.DeleteFileWrapper;
 import org.apache.iceberg.avro.AvroIterable;
@@ -48,6 +47,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
@@ -282,20 +282,23 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
     // when the identifier field ids is null, it will copy all metrics.
     private CloseableIterable<ManifestEntry<F>> fillCacheIfNeeded(CloseableIterable<ManifestEntry<F>> entries) {
+        boolean shouldCacheDataFiles =
+                dataFileCache != null && content == FileType.DATA_FILES && dataFileCache.getIfPresent(file.location()) != null;
+        boolean shouldCacheDeleteFiles =
+                deleteFileCache != null && content == FileType.DELETE_FILES &&
+                        deleteFileCache.getIfPresent(file.location()) != null;
+        if (!shouldCacheDataFiles && !shouldCacheDeleteFiles) {
+            return entries;
+        }
+
         Set<DataFile> tmpDataFiles = Sets.newHashSet();
         Set<DeleteFile> tmpDeleteFiles = Sets.newHashSet();
-        if (dataFileCache != null && content == FileType.DATA_FILES) {
+        if (shouldCacheDataFiles) {
+            final Set<Integer> requestedColumnIds =
+                    identifierFieldIds != null && !identifierFieldIds.isEmpty() ? identifierFieldIds : null;
             entries = CloseableIterable.transform(entries,
                     entry -> {
-                        // Could not use the getIfpresent result Set to add items, because here is thread-unsafe.
-                        // Be careful to not corrupt the cache.
-                        Set<DataFile> keyExisted = dataFileCache.getIfPresent(file.location());
-                        if (keyExisted != null && entry.isLive()) {
-                            Set<Integer> requestedColumnIds = null;
-                            if (identifierFieldIds != null && !identifierFieldIds.isEmpty()) {
-                                requestedColumnIds = identifierFieldIds;
-                            }
-
+                        if (entry.isLive()) {
                             DataFile dataFile = (DataFile) entry.file();
                             DataFile copiedDataFile = dataFileCacheWithMetrics ?
                                     dataFile.copyWithStats(requestedColumnIds) :
@@ -304,13 +307,12 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                         }
                         return entry;
                     });
-                }
-                
-        if (content == FileType.DELETE_FILES && deleteFileCache != null) {
+        }
+
+        if (shouldCacheDeleteFiles) {
             entries = CloseableIterable.transform(entries,
                     entry -> {
-                        Set<DeleteFile> keyExisted = deleteFileCache.getIfPresent(file.location());
-                        if (keyExisted != null && entry.isLive()) {
+                        if (entry.isLive()) {
                             tmpDeleteFiles.add(DeleteFileWrapper.wrap((DeleteFile) entry.file().copy()));
                         }
                         return entry;
@@ -318,21 +320,47 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
         }
 
         final CloseableIterable<ManifestEntry<F>> transformedEntries = entries;
+        final AtomicBoolean fullyConsumed = new AtomicBoolean(false);
         return new CloseableIterable<ManifestEntry<F>>() {
             @Override
             public CloseableIterator<ManifestEntry<F>> iterator() {
-                return transformedEntries.iterator();
+                CloseableIterator<ManifestEntry<F>> iterator = transformedEntries.iterator();
+                return new CloseableIterator<ManifestEntry<F>>() {
+                    @Override
+                    public boolean hasNext() {
+                        boolean hasNext = iterator.hasNext();
+                        if (!hasNext) {
+                            fullyConsumed.set(true);
+                        }
+                        return hasNext;
+                    }
+
+                    @Override
+                    public ManifestEntry<F> next() {
+                        return iterator.next();
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        iterator.close();
+                    }
+                };
             }
-        
+
             @Override
             public void close() throws IOException {
-                if (!tmpDataFiles.isEmpty()) {
-                    dataFileCache.put(file.location(), tmpDataFiles); // to recalculate the weight
+                try {
+                    if (fullyConsumed.get()) {
+                        if (!tmpDataFiles.isEmpty()) {
+                            dataFileCache.put(file.location(), tmpDataFiles); // to recalculate the weight
+                        }
+                        if (!tmpDeleteFiles.isEmpty()) {
+                            deleteFileCache.put(file.location(), tmpDeleteFiles); // to recalculate the weight
+                        }
+                    }
+                } finally {
+                    transformedEntries.close();
                 }
-                if (!tmpDeleteFiles.isEmpty()) {
-                    deleteFileCache.put(file.location(), tmpDeleteFiles); // to recalculate the weight
-                }
-                transformedEntries.close();
             }
         };
     }

--- a/fe/fe-core/src/test/java/org/apache/iceberg/ManifestReaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/iceberg/ManifestReaderTest.java
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class ManifestReaderTest {
+    private static final Schema TEST_SCHEMA =
+            new Schema(required(1, "id", Types.IntegerType.get()), required(2, "data", Types.StringType.get()));
+    private static final PartitionSpec TEST_SPEC = PartitionSpec.unpartitioned();
+    private static final FileIO FILE_IO = new LocalFileIO();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testFillCacheIfNeededWritesCompleteFilesWhenCacheEntryDisappearsMidIteration() throws IOException {
+        DataFile file1 = newDataFile("data-file-1.parquet", 10L);
+        DataFile file2 = newDataFile("data-file-2.parquet", 20L);
+        ManifestFile manifest = writeManifest("complete-cache.avro", file1, file2);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> dataFileCache = Mockito.mock(Cache.class);
+        Set<DataFile> placeholder = ConcurrentHashMap.newKeySet();
+        AtomicInteger getCount = new AtomicInteger(0);
+        Mockito.when(dataFileCache.getIfPresent(manifest.path()))
+                .thenAnswer(invocation -> getCount.getAndIncrement() == 0 ? placeholder : null);
+
+        AtomicReference<Set<DataFile>> cachedFilesRef = new AtomicReference<>();
+        Mockito.doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Set<DataFile> cachedFiles = invocation.getArgument(1);
+            cachedFilesRef.set(cachedFiles);
+            return null;
+        }).when(dataFileCache).put(Mockito.eq(manifest.path()), Mockito.anySet());
+
+        ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, Map.of(TEST_SPEC.specId(), TEST_SPEC))
+                .select(ManifestReader.ALL_COLUMNS)
+                .dataFileCache(dataFileCache)
+                .cacheWithMetrics(false);
+
+        try (CloseableIterable<ManifestEntry<DataFile>> entries = reader.liveEntries();
+                CloseableIterator<ManifestEntry<DataFile>> iterator = entries.iterator()) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        }
+
+        Mockito.verify(dataFileCache, Mockito.times(1)).getIfPresent(manifest.path());
+        Mockito.verify(dataFileCache, Mockito.times(1)).put(Mockito.eq(manifest.path()), Mockito.anySet());
+        Assertions.assertTrue(placeholder.isEmpty(), "placeholder should stay empty until the full manifest is ready");
+        Assertions.assertNotNull(cachedFilesRef.get(), "a fully materialized cache entry should be published on close");
+        Assertions.assertEquals(Set.of(file1.location(), file2.location()),
+                cachedFilesRef.get().stream().map(DataFile::location).collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void testFillCacheIfNeededSkipsPublishingPartialDataOnEarlyClose() throws IOException {
+        DataFile file1 = newDataFile("partial-file-1.parquet", 10L);
+        DataFile file2 = newDataFile("partial-file-2.parquet", 20L);
+        ManifestFile manifest = writeManifest("partial-close.avro", file1, file2);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> dataFileCache = Mockito.mock(Cache.class);
+        Set<DataFile> placeholder = ConcurrentHashMap.newKeySet();
+        Mockito.when(dataFileCache.getIfPresent(manifest.path())).thenReturn(placeholder);
+
+        ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, Map.of(TEST_SPEC.specId(), TEST_SPEC))
+                .select(ManifestReader.ALL_COLUMNS)
+                .dataFileCache(dataFileCache)
+                .cacheWithMetrics(false);
+
+        try (CloseableIterable<ManifestEntry<DataFile>> entries = reader.liveEntries();
+                CloseableIterator<ManifestEntry<DataFile>> iterator = entries.iterator()) {
+            Assertions.assertTrue(iterator.hasNext());
+            iterator.next();
+        }
+
+        Mockito.verify(dataFileCache, Mockito.times(1)).getIfPresent(manifest.path());
+        Mockito.verify(dataFileCache, Mockito.never()).put(Mockito.eq(manifest.path()), Mockito.anySet());
+        Assertions.assertTrue(placeholder.isEmpty(), "partial iteration must not leak partially cached files");
+    }
+
+    private ManifestFile writeManifest(String manifestFileName, DataFile... dataFiles) throws IOException {
+        File manifestFile = tempDir.resolve(manifestFileName).toFile();
+        OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
+        ManifestWriter<DataFile> writer = ManifestFiles.write(1, TEST_SPEC, outputFile, 1L);
+        try {
+            for (DataFile dataFile : dataFiles) {
+                writer.add(dataFile);
+            }
+        } finally {
+            writer.close();
+        }
+        return writer.toManifestFile();
+    }
+
+    private DataFile newDataFile(String fileName, long recordCount) {
+        return DataFiles.builder(TEST_SPEC)
+                .withPath(tempDir.resolve(fileName).toString())
+                .withFileSizeInBytes(64L)
+                .withRecordCount(recordCount)
+                .build();
+    }
+
+    private static final class LocalFileIO implements FileIO {
+        @Override
+        public InputFile newInputFile(String path) {
+            return Files.localInput(path);
+        }
+
+        @Override
+        public OutputFile newOutputFile(String path) {
+            return Files.localOutput(path);
+        }
+
+        @Override
+        public void deleteFile(String path) {
+            if (!new File(path).delete()) {
+                throw new RuntimeIOException("Failed to delete file: " + path);
+            }
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return Maps.newHashMap();
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Fix #70522

ManifestReader checked cache presence for every manifest entry while filling data/delete file cache. If the placeholder cache entry was evicted during iteration, only a prefix of files would be collected andthen published back to cache as a seemingly valid non-empty entry.
## What I'm doing:

This pull request enhances the caching logic in `ManifestReader` to ensure that cache entries are only published when the manifest has been fully read, preventing partial or inconsistent data from being cached. It also introduces comprehensive unit tests to verify this behavior.

**Caching improvements in `ManifestReader`:**

* Refactored the `fillCacheIfNeeded` method to only write to the cache if the manifest is fully consumed, using an `AtomicBoolean` to track completion and wrapping the iterator to detect full consumption. This prevents publishing partial cache data if iteration is stopped early. 
* Simplified logic for determining when to cache data or delete files by introducing `shouldCacheDataFiles` and `shouldCacheDeleteFiles` flags, improving code clarity and correctness.

**Testing improvements:**

* Added a new test class `ManifestReaderTest` to verify that the cache is only updated when iteration completes, and that no partial data is cached if iteration is stopped early. The tests use mocks to simulate cache behavior and validate correct interactions.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
