### PR TITLE
[BugFix] Remove duplicate closure ref from _tablet_multi_get_rpc

### DIFF
--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -271,7 +271,6 @@ Status TableReader::_tablet_multi_get_rpc(const std::shared_ptr<PInternalService
     if (_params->timeout_ms > 0) {
         closure->cntl.set_timeout_ms(_params->timeout_ms);
     }
-    closure->ref();
     stub->local_tablet_reader_multi_get(&closure->cntl, &request, &closure->result, closure);
     closure->join();
     if (closure->cntl.Failed()) {


### PR DESCRIPTION
## What's I'm doing:
pr #42005 and pr#19235 is duplicated and add closure ref for twice in current branch. Should remove one of them

Fixes https://github.com/StarRocks/StarRocksTest/issues/11137

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
