### PR TITLE
[Enhancement] Support filter push down for CTE consumers

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -46,6 +46,7 @@
 #ifndef __APPLE__
 #include "connector/iceberg_chunk_sink.h"
 #endif
+#include "common/system/backend_options.h"
 #include "exec/exec_node.h"
 #include "exec/file_builder.h"
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
@@ -72,17 +73,16 @@
 #include "exec/tablet_sink.h"
 #include "exprs/expr.h"
 #include "exprs/expr_factory.h"
-#include "runtime/runtime_filter/runtime_filter_probe.h"
 #include "formats/csv/csv_file_writer.h"
-#include "runtime/exec_env.h"
-#include "runtime/runtime_filter_cache.h"
-#include "common/system/backend_options.h"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/blackhole_table_sink.h"
 #include "runtime/data_stream_sender.h"
 #include "runtime/dictionary_cache_sink.h"
+#include "runtime/exec_env.h"
 #include "runtime/export_sink.h"
 #include "runtime/hive_table_sink.h"
+#include "runtime/runtime_filter/runtime_filter_probe.h"
+#include "runtime/runtime_filter_cache.h"
 #ifndef __APPLE__
 #include "runtime/iceberg_table_sink.h"
 #endif

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -51,9 +51,11 @@
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
 #include "exec/multi_olap_table_sink.h"
 #include "exec/pipeline/exchange/exchange_sink_operator.h"
+#include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
+#include "exec/pipeline/exchange/split_local_exchange.h"
 #include "exec/pipeline/fragment_executor.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/noop_sink_operator.h"
@@ -69,12 +71,13 @@
 #include "exec/pipeline/sink/table_function_table_sink_operator.h"
 #include "exec/tablet_sink.h"
 #include "exprs/expr.h"
+#include "exprs/expr_factory.h"
+#include "runtime/runtime_filter/runtime_filter_probe.h"
 #include "formats/csv/csv_file_writer.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_filter_cache.h"
+#include "common/system/backend_options.h"
 #include "gen_cpp/InternalService_types.h"
-#include "pipeline/exchange/multi_cast_local_exchange.h"
-#include "pipeline/exchange/split_local_exchange.h"
-#include "pipeline/sink/olap_table_sink_operator.h"
-#include "pipeline/sink/result_sink_operator.h"
 #include "runtime/blackhole_table_sink.h"
 #include "runtime/data_stream_sender.h"
 #include "runtime/dictionary_cache_sink.h"
@@ -370,12 +373,42 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             const auto& sender = sinks[i];
             OpFactories ops;
             // it's okay to set arbitrary dop.
-            const size_t dop = 1;
+            const size_t dop = context->degree_of_parallelism();
             auto& t_stream_sink = t_multi_case_stream_sink.sinks[i];
 
-            // source op
+            // Deserialize per-consumer conjuncts for filter push-down
+            std::vector<ExprContext*> conjunct_ctxs;
+            if (t_stream_sink.__isset.conjuncts && !t_stream_sink.conjuncts.empty()) {
+                RETURN_IF_ERROR(ExprFactory::create_expr_trees(runtime_state->obj_pool(), t_stream_sink.conjuncts,
+                                                               &conjunct_ctxs, runtime_state));
+            }
+
             auto source_op = std::make_shared<MultiCastLocalExchangeSourceOperatorFactory>(
-                    context->next_operator_id(), upstream_plan_node_id, i, mcast_local_exchanger);
+                    context->next_operator_id(), upstream_plan_node_id, i, mcast_local_exchanger,
+                    std::move(conjunct_ctxs));
+
+            if (t_stream_sink.__isset.runtime_filters && !t_stream_sink.runtime_filters.empty()) {
+                auto* pool = runtime_state->obj_pool();
+                auto* rf_collector = pool->add(new RuntimeFilterProbeCollector());
+                TPlanNodeId dest_node_id = t_stream_sink.dest_node_id;
+                for (const auto& rf_desc : t_stream_sink.runtime_filters) {
+                    auto* probe_desc = pool->add(new RuntimeFilterProbeDescriptor());
+                    RETURN_IF_ERROR(probe_desc->init(pool, rf_desc, dest_node_id, runtime_state));
+                    probe_desc->set_probe_plan_node_id(dest_node_id);
+                    rf_collector->add_descriptor(probe_desc);
+                    ExecEnv::GetInstance()->add_rf_event(
+                            {runtime_state->query_id(), rf_desc.filter_id, BackendOptions::get_localhost(),
+                             "REGISTER_MCAST_SOURCE_GRF(dest_node=" + std::to_string(dest_node_id) + ")"});
+                    runtime_state->runtime_filter_port()->add_listener(probe_desc);
+                }
+                int64_t rf_wait_timeout = 0;
+                if (runtime_state->query_options().__isset.runtime_filter_wait_timeout_ms) {
+                    rf_wait_timeout = runtime_state->query_options().runtime_filter_wait_timeout_ms;
+                }
+                rf_collector->set_wait_timeout_ms(rf_wait_timeout);
+                source_op->set_runtime_filter_collector(rf_collector);
+            }
+
             context->inherit_upstream_source_properties(source_op.get(), upstream_source);
             source_op->set_degree_of_parallelism(dop);
             ops.emplace_back(source_op);
@@ -388,7 +421,8 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             }
 
             // sink op
-            ops.emplace_back(_create_exchange_sink_operator(context, t_stream_sink, sender.get()));
+            auto exchange_sink = _create_exchange_sink_operator(context, t_stream_sink, sender.get());
+            ops.emplace_back(exchange_sink);
 
             context->add_pipeline(ops);
         }

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -164,7 +164,10 @@ StatusOr<ChunkPtr> MemLimitedChunkQueue::pop(int32_t consumer_index) {
         if (_opened_sink_number == 0) {
             return Status::EndOfFile("no more data");
         }
-        return Status::InternalError("unreachable path");
+        // With DOP > 1, can_pop may return true for multiple drivers, but another
+        // driver may consume the chunk before this one calls pop. Return nullptr
+        // to let the driver retry.
+        return nullptr;
     }
     // if the block is flushed forcely between can_pop and pop,
     // we should return null and trigger load io task in next can_pop

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -133,7 +133,7 @@ StatusOr<ChunkPtr> InMemoryMultiCastLocalExchanger::pull_chunk(RuntimeState* sta
     Cell* cell = _progress[mcast_consumer_index];
     if (cell->next == nullptr) {
         if (_opened_sink_number == 0) return Status::EndOfFile("mcast_local_exchanger eof");
-        return Status::InternalError("unreachable in multicast local exchanger");
+        return nullptr;
     }
     cell = cell->next;
     VLOG_FILE << "MultiCastLocalExchanger: return chunk to " << mcast_consumer_index

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
@@ -87,10 +87,8 @@ void MultiCastLocalExchangeSourceOperatorFactory::close(RuntimeState* state) {
     SourceOperatorFactory::close(state);
 }
 
-void MultiCastLocalExchangeSourceOperatorFactory::set_runtime_filter_collector(
-        RuntimeFilterProbeCollector* collector) {
-    auto rc_collector = std::make_shared<RefCountedRuntimeFilterProbeCollector>(
-            1, std::move(*collector));
+void MultiCastLocalExchangeSourceOperatorFactory::set_runtime_filter_collector(RuntimeFilterProbeCollector* collector) {
+    auto rc_collector = std::make_shared<RefCountedRuntimeFilterProbeCollector>(1, std::move(*collector));
     _runtime_filter_collector = std::move(rc_collector);
 }
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h"
 
+#include "exprs/chunk_predicate_evaluator.h"
+
 namespace starrocks::pipeline {
 
 Status MultiCastLocalExchangeSourceOperator::prepare(RuntimeState* state) {
@@ -38,12 +40,58 @@ StatusOr<ChunkPtr> MultiCastLocalExchangeSourceOperator::pull_chunk(RuntimeState
     auto ret = _exchanger->pull_chunk(state, _mcast_consumer_index);
     if (ret.status().is_end_of_file()) {
         (void)set_finishing(state);
+        return ret;
     }
+    RETURN_IF_ERROR(ret.status());
+
+    bool has_conjuncts = !_conjunct_ctxs.empty();
+    auto* bloom_filters = runtime_bloom_filters();
+    bool has_rf = bloom_filters != nullptr && !bloom_filters->descriptors().empty();
+
+    if (has_conjuncts || has_rf) {
+        ChunkPtr& chunk = ret.value();
+        if (chunk == nullptr || chunk->num_rows() == 0) {
+            return ret;
+        }
+        // the chunk is shared across multicast consumers
+        auto owned = chunk->clone_unique();
+        if (has_conjuncts) {
+            RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_conjunct_ctxs, owned.get()));
+        }
+        if (has_rf) {
+            eval_runtime_bloom_filters(owned.get());
+        }
+        return ChunkPtr(owned.release());
+    }
+
     return ret;
 }
 
 bool MultiCastLocalExchangeSourceOperator::has_output() const {
     return _exchanger->can_pull_chunk(_mcast_consumer_index);
+}
+
+Status MultiCastLocalExchangeSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperatorFactory::prepare(state));
+    for (auto* ctx : _conjunct_ctxs) {
+        RETURN_IF_ERROR(ctx->prepare(state));
+        RETURN_IF_ERROR(ctx->open(state));
+    }
+    return Status::OK();
+}
+
+void MultiCastLocalExchangeSourceOperatorFactory::close(RuntimeState* state) {
+    for (auto* ctx : _conjunct_ctxs) {
+        ctx->close(state);
+    }
+    SourceOperatorFactory::close(state);
+}
+
+void MultiCastLocalExchangeSourceOperatorFactory::set_runtime_filter_collector(
+        RuntimeFilterProbeCollector* collector) {
+    auto rc_collector = std::make_shared<RefCountedRuntimeFilterProbeCollector>(
+            1, std::move(*collector));
+    _runtime_filter_collector = std::move(rc_collector);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
@@ -16,6 +16,8 @@
 
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/source_operator.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
 
 namespace starrocks::pipeline {
 
@@ -23,10 +25,12 @@ class MultiCastLocalExchangeSourceOperator final : public SourceOperator {
 public:
     MultiCastLocalExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
                                          int32_t driver_sequence, int32_t mcast_consumer_index,
-                                         std::shared_ptr<MultiCastLocalExchanger> exchanger)
+                                         std::shared_ptr<MultiCastLocalExchanger> exchanger,
+                                         const std::vector<ExprContext*>& conjunct_ctxs)
             : SourceOperator(factory, id, "multi_cast_local_exchange_source", plan_node_id, true, driver_sequence),
               _mcast_consumer_index(mcast_consumer_index),
-              _exchanger(std::move(exchanger)) {}
+              _exchanger(std::move(exchanger)),
+              _conjunct_ctxs(conjunct_ctxs) {}
 
     Status prepare(RuntimeState* state) override;
 
@@ -44,25 +48,35 @@ private:
     bool _is_finished = false;
     int32_t _mcast_consumer_index;
     std::shared_ptr<MultiCastLocalExchanger> _exchanger;
+    const std::vector<ExprContext*>& _conjunct_ctxs;
 };
 
 class MultiCastLocalExchangeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     MultiCastLocalExchangeSourceOperatorFactory(int32_t id, int32_t plan_node_id, int32_t mcast_consumer_index,
-                                                std::shared_ptr<MultiCastLocalExchanger> exchanger)
+                                                std::shared_ptr<MultiCastLocalExchanger> exchanger,
+                                                std::vector<ExprContext*>&& conjunct_ctxs = {})
             : SourceOperatorFactory(id, "multi_cast_local_exchange_source", plan_node_id),
               _mcast_consumer_index(mcast_consumer_index),
-              _exchanger(std::move(exchanger)) {}
+              _exchanger(std::move(exchanger)),
+              _conjunct_ctxs(std::move(conjunct_ctxs)) {}
     ~MultiCastLocalExchangeSourceOperatorFactory() override = default;
     bool support_event_scheduler() const override { return _exchanger->support_event_scheduler(); }
 
+    Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+
+    void set_runtime_filter_collector(RuntimeFilterProbeCollector* collector);
+
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<MultiCastLocalExchangeSourceOperator>(this, _id, _plan_node_id, driver_sequence,
-                                                                      _mcast_consumer_index, _exchanger);
+                                                                      _mcast_consumer_index, _exchanger,
+                                                                      _conjunct_ctxs);
     }
 
 private:
     int32_t _mcast_consumer_index;
     std::shared_ptr<MultiCastLocalExchanger> _exchanger;
+    std::vector<ExprContext*> _conjunct_ctxs;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
@@ -69,9 +69,8 @@ public:
     void set_runtime_filter_collector(RuntimeFilterProbeCollector* collector);
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<MultiCastLocalExchangeSourceOperator>(this, _id, _plan_node_id, driver_sequence,
-                                                                      _mcast_consumer_index, _exchanger,
-                                                                      _conjunct_ctxs);
+        return std::make_shared<MultiCastLocalExchangeSourceOperator>(
+                this, _id, _plan_node_id, driver_sequence, _mcast_consumer_index, _exchanger, _conjunct_ctxs);
     }
 
 private:

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -34,12 +34,16 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.planner.expression.ExprToThrift;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TDataStreamSink;
 import com.starrocks.thrift.TExplainLevel;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Data sink that forwards data to an exchange node.
@@ -57,6 +61,12 @@ public class DataStreamSink extends DataSink {
 
     // Specify the limit on output columns, used on MultiCastSink
     private long limit;
+
+    // Per-consumer conjuncts for MultiCast filter push-down
+    private List<Expr> conjuncts;
+
+    // Per-consumer runtime filters for MultiCast RF push-down
+    private List<RuntimeFilterDescription> runtimeFilters;
 
     public DataStreamSink(PlanNodeId exchNodeId) {
         this.exchNodeId = exchNodeId;
@@ -91,6 +101,18 @@ public class DataStreamSink extends DataSink {
 
     public void setLimit(long limit) { this.limit = limit; }
 
+    public void setConjuncts(List<Expr> conjuncts) {
+        this.conjuncts = conjuncts;
+    }
+
+    public void setRuntimeFilters(List<RuntimeFilterDescription> runtimeFilters) {
+        this.runtimeFilters = runtimeFilters;
+    }
+
+    public List<RuntimeFilterDescription> getRuntimeFilters() {
+        return runtimeFilters;
+    }
+
     @Override
     public String getExplainString(String prefix, TExplainLevel explainLevel) {
         StringBuilder strBuilder = new StringBuilder();
@@ -98,6 +120,15 @@ public class DataStreamSink extends DataSink {
         strBuilder.append(prefix + "  EXCHANGE ID: " + exchNodeId + "\n");
         if (outputPartition != null) {
             strBuilder.append(prefix + "  " + outputPartition.getExplainString(explainLevel));
+        }
+        if (conjuncts != null && !conjuncts.isEmpty()) {
+            strBuilder.append(prefix + "  CONJUNCTS: " +
+                    formatExprs(conjuncts, explainLevel) + "\n");
+        }
+        if (runtimeFilters != null && !runtimeFilters.isEmpty()) {
+            strBuilder.append(prefix + "  RUNTIME FILTERS: " +
+                    runtimeFilters.stream().map(rf -> "RF" + rf.getFilterId())
+                            .collect(Collectors.joining(", ")) + "\n");
         }
         return strBuilder.toString();
     }
@@ -110,7 +141,34 @@ public class DataStreamSink extends DataSink {
                     append(outputPartition.getExplainString(TExplainLevel.VERBOSE));
         }
         strBuilder.append(prefix).append("OutPut Exchange Id: ").append(exchNodeId).append("\n");
+        if (conjuncts != null && !conjuncts.isEmpty()) {
+            strBuilder.append(prefix).append("Conjuncts: ").
+                    append(formatExprs(conjuncts, TExplainLevel.VERBOSE)).append("\n");
+        }
+        if (runtimeFilters != null && !runtimeFilters.isEmpty()) {
+            strBuilder.append(prefix).append("RuntimeFilters: ").
+                    append(runtimeFilters.stream().map(rf -> "RF" + rf.getFilterId())
+                            .collect(Collectors.joining(", "))).append("\n");
+        }
         return strBuilder.toString();
+    }
+
+    private static String formatExprs(List<? extends Expr> exprs, TExplainLevel level) {
+        if (exprs == null) {
+            return "";
+        }
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < exprs.size(); ++i) {
+            if (i > 0) {
+                output.append(", ");
+            }
+            if (level.equals(TExplainLevel.NORMAL)) {
+                output.append(ExprToSql.toSql(exprs.get(i)));
+            } else {
+                output.append(ExprToSql.explain(exprs.get(i)));
+            }
+        }
+        return output.toString();
     }
 
     @Override
@@ -125,6 +183,13 @@ public class DataStreamSink extends DataSink {
         }
         if (limit != -1) {
             tStreamSink.setLimit(limit);
+        }
+        if (conjuncts != null && !conjuncts.isEmpty()) {
+            tStreamSink.setConjuncts(ExprToThrift.treesToThrift(conjuncts));
+        }
+        if (runtimeFilters != null && !runtimeFilters.isEmpty()) {
+            tStreamSink.setRuntime_filters(
+                    runtimeFilters.stream().map(RuntimeFilterDescription::toThrift).collect(Collectors.toList()));
         }
         result.setStream_sink(tStreamSink);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -92,6 +92,8 @@ public class ExchangeNode extends PlanNode {
     private List<Integer> receiveColumns;
 
     private boolean useParallelMerge = true;
+
+    private List<Expr> multiCastConjuncts;
     /**
      * Create ExchangeNode that consumes output of inputNode.
      * An ExchangeNode doesn't have an input node as a child, which is why we
@@ -167,6 +169,14 @@ public class ExchangeNode extends PlanNode {
 
     public boolean isUseParallelMerge() {
         return useParallelMerge;
+    }
+
+    public void setMultiCastConjuncts(List<Expr> conjuncts) {
+        this.multiCastConjuncts = conjuncts;
+    }
+
+    public List<Expr> getMultiCastConjuncts() {
+        return multiCastConjuncts;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -16,6 +16,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultSinkType;
 
@@ -79,8 +80,36 @@ public class MultiCastPlanFragment extends PlanFragment {
             streamSink.setFragment(this);
             streamSink.setOutputColumnIds(f.getReceiveColumns());
             streamSink.setLimit(f.getLimit());
+            if (f.getMultiCastConjuncts() != null) {
+                streamSink.setConjuncts(f.getMultiCastConjuncts());
+            }
             multiCastDataSink.getDataStreamSinks().add(streamSink);
             multiCastDataSink.getDestinations().add(Lists.newArrayList());
+        }
+    }
+
+    public void collectRuntimeFiltersForDataStreamSinks() {
+        if (sink == null) {
+            return;
+        }
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx == null || !ctx.getSessionVariable().isEnableMultiCastFilterPushDown()) {
+            return;
+        }
+        MultiCastDataSink multiCastDataSink = (MultiCastDataSink) sink;
+        List<DataStreamSink> dataStreamSinks = multiCastDataSink.getDataStreamSinks();
+        for (int i = 0; i < destNodeList.size(); i++) {
+            ExchangeNode exchangeNode = destNodeList.get(i);
+            List<RuntimeFilterDescription> rfs = exchangeNode.getProbeRuntimeFilters();
+            if (!rfs.isEmpty()) {
+                dataStreamSinks.get(i).setRuntimeFilters(rfs);
+                for (RuntimeFilterDescription rf : rfs) {
+                    if (!rf.isHasRemoteTargets()) {
+                        rf.setHasRemoteTargets(true);
+                    }
+                    probeRuntimeFilters.put(rf.getFilterId(), rf);
+                }
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1059,6 +1059,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSH_DOWN_DISTINCT = "cbo_push_down_distinct";
 
+    public static final String ENABLE_MULTI_CAST_FILTER_PUSH_DOWN = "enable_multi_cast_filter_push_down";
+
     public static final String ENABLE_DATACACHE_SHARING = "enable_datacache_sharing";
     public static final String DATACACHE_SHARING_WORK_PERIOD = "datacache_sharing_work_period";
     public static final String HISTORICAL_NODES_MIN_UPDATE_INTERVAL = "historical_nodes_min_update_interval";
@@ -2217,6 +2219,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int globalLateMaterializeMaxFetchOps = 4;
     @VarAttr(name = GLOBAL_LATE_MATERIALIZE_MAX_LIMIT)
     private int globalLateMaterializeMaxLimit = 4096;
+
+    @VarAttr(name = ENABLE_MULTI_CAST_FILTER_PUSH_DOWN)
+    private boolean enableMultiCastFilterPushDown = true;
 
     @VarAttr(name = ENABLE_DROP_TABLE_CHECK_MV_DEPENDENCY)
     public boolean enableDropTableCheckMvDependency = false;
@@ -5849,6 +5854,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setBackPressureThrottleTimeUpperBound(long value) {
         this.backPressureThrottleTimeUpperBound = value;
+    }
+
+    public void setEnableMultiCastFilterPushDown(boolean enableMultiCastFilterPushDown) {
+        this.enableMultiCastFilterPushDown = enableMultiCastFilterPushDown;
+    }
+
+    public boolean isEnableMultiCastFilterPushDown() {
+        return enableMultiCastFilterPushDown;
     }
 
     public boolean isEnableDataCacheSharing() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -432,6 +432,14 @@ public class PlanFragmentBuilder {
         fragments.forEach(PlanFragment::collectBuildRuntimeFilters);
         fragments.forEach(PlanFragment::collectProbeRuntimeFilters);
 
+        // Collect per-consumer runtime filters from ExchangeNodes onto MultiCast DataStreamSinks,
+        // so that RFs can be applied at the sender side (ExchangeSink) before network transmission.
+        for (PlanFragment fragment : fragments) {
+            if (fragment instanceof MultiCastPlanFragment) {
+                ((MultiCastPlanFragment) fragment).collectRuntimeFiltersForDataStreamSinks();
+            }
+        }
+
         if (useQueryCache(execPlan)) {
             for (PlanFragment fragment : execPlan.getFragments()) {
                 FragmentNormalizer normalizer = new FragmentNormalizer(execPlan, fragment);
@@ -3802,17 +3810,32 @@ public class PlanFragmentBuilder {
             consumeFragment.setQueryGlobalDictExprs(cteFragment.getQueryGlobalDictExprs());
             consumeFragment.setLoadGlobalDicts(cteFragment.getLoadGlobalDicts());
 
-            // add filter node
+            boolean filterPushedDown = false;
             if (consume.getPredicate() != null) {
-                List<Expr> predicates = Utils.extractConjuncts(consume.getPredicate()).stream()
-                        .map(d -> ScalarOperatorToExpr.buildExecExpression(d,
-                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
-                        .collect(Collectors.toList());
-                SelectNode selectNode =
-                        new SelectNode(context.getNextNodeId(), consumeFragment.getPlanRoot(), predicates);
-                this.currentExecGroup.add(selectNode, true);
-                selectNode.computeStatistics(optExpression.getStatistics());
-                consumeFragment.setPlanRoot(selectNode);
+                if (ConnectContext.get().getSessionVariable().isEnableMultiCastFilterPushDown()) {
+                    ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(
+                            consume.getCteOutputColumnRefMap());
+                    List<ScalarOperator> producePredicates = Utils.extractConjuncts(consume.getPredicate())
+                            .stream().map(rewriter::rewrite).collect(Collectors.toList());
+
+                    List<Expr> conjuncts = producePredicates.stream()
+                            .map(d -> ScalarOperatorToExpr.buildExecExpression(d,
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                            .collect(Collectors.toList());
+
+                    exchangeNode.setMultiCastConjuncts(conjuncts);
+                    filterPushedDown = true;
+                } else {
+                    List<Expr> predicates = Utils.extractConjuncts(consume.getPredicate()).stream()
+                            .map(d -> ScalarOperatorToExpr.buildExecExpression(d,
+                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
+                            .collect(Collectors.toList());
+                    SelectNode selectNode =
+                            new SelectNode(context.getNextNodeId(), consumeFragment.getPlanRoot(), predicates);
+                    this.currentExecGroup.add(selectNode, true);
+                    selectNode.computeStatistics(optExpression.getStatistics());
+                    consumeFragment.setPlanRoot(selectNode);
+                }
             }
 
             // if multi cast limit push down is enabled and there is no predicate, the limit can be added at the source of the
@@ -3820,8 +3843,9 @@ public class PlanFragmentBuilder {
             // fragment. Otherwise, especially if there is a predicate, limit push down can not be performed and the limit will
             // be applied after the predicate.
             if (consume.hasLimit()) {
-                if (ConnectContext.get().getSessionVariable().isEnableMultiCastLimitPushDown()
-                        && consume.getPredicate() == null) {
+                if (filterPushedDown
+                        || (ConnectContext.get().getSessionVariable().isEnableMultiCastLimitPushDown()
+                            && consume.getPredicate() == null)) {
                     exchangeNode.setLimit(consume.getLimit());
                 } else {
                     consumeFragment.getPlanRoot().setLimit(consume.getLimit());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -53,6 +53,7 @@ public class CTEPlanTest extends PlanTestBase {
     @BeforeEach
     public void alwaysCTEReuse() {
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        connectContext.getSessionVariable().setEnableMultiCastFilterPushDown(false);
     }
 
     @AfterEach
@@ -60,6 +61,7 @@ public class CTEPlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
         connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(0);
         connectContext.getSessionVariable().setCboCTEForceReuseLimitWithoutOrderBy(true);
+        connectContext.getSessionVariable().setEnableMultiCastFilterPushDown(true);
     }
 
     @ParameterizedTest
@@ -1187,5 +1189,26 @@ public class CTEPlanTest extends PlanTestBase {
         // Should not force CTE reuse when variable is disabled
         // (CTE reuse decision will be based on other factors like ratio and consume count)
         // Note: The actual behavior depends on CTE reuse ratio and consume count
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testMultiCastRuntimeFilterPushDown(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setEnableMultiCastFilterPushDown(true);
+        connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
+        connectContext.getSessionVariable().setGlobalRuntimeFilterProbeMinSize(0);
+
+        String sql = "with cte as (select * from t0) " +
+                "select * from cte c1 join [broadcast] t1 on c1.v1 = t1.v4 where c1.v2 > 100 " +
+                "union all " +
+                "select * from cte c2 join [broadcast] t1 on c2.v2 = t1.v5 where c2.v3 < 50";
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "CONJUNCTS:");
+        assertContains(plan, "RUNTIME FILTERS:");
+        assertNotContains(plan, "SELECT");
     }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -41,6 +41,7 @@ include "Types.thrift"
 include "Descriptors.thrift"
 include "Partitions.thrift"
 include "PlanNodes.thrift"
+include "RuntimeFilter.thrift"
 
 enum TDataSinkType {
     DATA_STREAM_SINK,
@@ -147,6 +148,12 @@ struct TDataStreamSink {
 
   // Specify limit on output columns
   7: optional i64 limit;
+
+  // Per-consumer conjuncts for MultiCast filter push-down
+  8: optional list<Exprs.TExpr> conjuncts
+
+  // Per-consumer runtime filters for MultiCast RF push-down
+  9: optional list<RuntimeFilter.TRuntimeFilterDescription> runtime_filters
 }
 
 struct TMultiCastDataStreamSink {


### PR DESCRIPTION
## Why I'm doing:
In CTE  scenarios, each consumer's predicates and runtime filters are currently evaluated after the ExchangeNode. This means all rows are transmitted to every consumer even if a consumer only needs a small subset

## What I'm doing:
Push down per-consumer conjuncts and runtime filters into the MultiCast SourceOperator, so filtering happens at the source side before data flows through the exchange pipeline. And Change MultiCast source DOP from hardcoded 1 to actual dop

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
