### PR TITLE
[BugFix] Validate Iceberg manifest cache completeness on read

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -252,8 +252,8 @@ public class StarRocksIcebergTableScan
         Set<DeleteFile> matchingCachedDeleteFiles = Sets.newHashSet();
         if (deleteFileCache != null) {
             for (ManifestFile manifestFile : deleteManifests) {
-                Set<DeleteFile> deleteFiles = deleteFileCache.getIfPresent(manifestFile.path());
-                if (deleteFiles != null && !deleteFiles.isEmpty()) {
+                Set<DeleteFile> deleteFiles = getCompleteCachedFiles(deleteFileCache, manifestFile);
+                if (deleteFiles != null) {
                     scanMetrics().scannedDeleteManifests().increment();
                     int entrySize = deleteFiles.size();
                     if (filter() != null && filter() != Expressions.alwaysTrue()) {
@@ -286,10 +286,12 @@ public class StarRocksIcebergTableScan
         List<Pair<ManifestFile, Set<DataFile>>> dataManifestWithCache = new ArrayList<>();
         List<ManifestFile> dataManifestWithoutCache = new ArrayList<>();
         for (ManifestFile manifestFile : dataManifests) {
-            Set<DataFile> dataFiles = dataFileCache.getIfPresent(manifestFile.path());
-            if (dataFiles != null && !dataFiles.isEmpty()) {
-                dataManifestWithCache.add(new Pair(manifestFile, dataFiles));
+            Set<DataFile> dataFiles = getCompleteCachedFiles(dataFileCache, manifestFile);
+            if (dataFiles != null) {
                 scanMetrics().scannedDataManifests().increment();
+                if (!dataFiles.isEmpty()) {
+                    dataManifestWithCache.add(new Pair(manifestFile, dataFiles));
+                }
             } else {
                 if (!onlyReadCache) {
                     dataFileCache.put(manifestFile.path(), ConcurrentHashMap.newKeySet());
@@ -401,8 +403,8 @@ public class StarRocksIcebergTableScan
         Set<DeleteFile> matchingCachedDeleteFiles = Sets.newHashSet();
         if (deleteFileCache != null) {
             for (ManifestFile manifestFile : deleteManifests) {
-                Set<DeleteFile> deleteFiles = deleteFileCache.getIfPresent(manifestFile.path());
-                if (deleteFiles != null && !deleteFiles.isEmpty()) {
+                Set<DeleteFile> deleteFiles = getCompleteCachedFiles(deleteFileCache, manifestFile);
+                if (deleteFiles != null) {
                     deleteFiles = deleteFiles.stream()
                             .filter(f -> f.content() == fileContent)
                             .collect(Collectors.toSet());
@@ -549,5 +551,41 @@ public class StarRocksIcebergTableScan
 
     public IcebergMetricsReporter getMetricsReporter() {
         return metricsReporter;
+    }
+
+    static Integer expectedLiveFilesCount(ManifestFile manifest) {
+        Integer existingFilesCount = manifest.existingFilesCount();
+        Integer addedFilesCount = manifest.addedFilesCount();
+        if (existingFilesCount == null || addedFilesCount == null) {
+            return null;
+        }
+        return existingFilesCount + addedFilesCount;
+    }
+
+    static boolean isCompleteCachedFiles(ManifestFile manifest, Set<?> files) {
+        if (files == null) {
+            return false;
+        }
+
+        Integer expectedLiveFilesCount = expectedLiveFilesCount(manifest);
+        if (expectedLiveFilesCount == null) {
+            // Without manifest counts, keep the previous "non-empty means usable" behavior,
+            // but still reject empty placeholders so they don't look like valid cache hits.
+            return !files.isEmpty();
+        }
+
+        return files.size() == expectedLiveFilesCount;
+    }
+
+    static <F> Set<F> getCompleteCachedFiles(Cache<String, Set<F>> cache, ManifestFile manifest) {
+        Set<F> files = cache.getIfPresent(manifest.path());
+        if (isCompleteCachedFiles(manifest, files)) {
+            return files;
+        }
+
+        if (files != null) {
+            cache.invalidate(manifest.path());
+        }
+        return null;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/iceberg/StarRocksIcebergTableScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/iceberg/StarRocksIcebergTableScanTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+public class StarRocksIcebergTableScanTest {
+    @Test
+    public void testGetCompleteCachedFilesReturnsMatchingCacheEntry() {
+        ManifestFile manifest = mockManifestFile("matching-manifest", 1, 1);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> cache = Mockito.mock(Cache.class);
+        Set<DataFile> files = Set.of(Mockito.mock(DataFile.class), Mockito.mock(DataFile.class));
+        Mockito.when(cache.getIfPresent(manifest.path())).thenReturn(files);
+
+        Set<DataFile> cachedFiles = StarRocksIcebergTableScan.getCompleteCachedFiles(cache, manifest);
+
+        Assertions.assertSame(files, cachedFiles);
+        Mockito.verify(cache, Mockito.never()).invalidate(manifest.path());
+    }
+
+    @Test
+    public void testGetCompleteCachedFilesInvalidatesPartialCacheEntry() {
+        ManifestFile manifest = mockManifestFile("partial-manifest", 2, 1);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> cache = Mockito.mock(Cache.class);
+        Set<DataFile> files = Set.of(Mockito.mock(DataFile.class), Mockito.mock(DataFile.class));
+        Mockito.when(cache.getIfPresent(manifest.path())).thenReturn(files);
+
+        Set<DataFile> cachedFiles = StarRocksIcebergTableScan.getCompleteCachedFiles(cache, manifest);
+
+        Assertions.assertNull(cachedFiles);
+        Mockito.verify(cache, Mockito.times(1)).invalidate(manifest.path());
+    }
+
+    @Test
+    public void testGetCompleteCachedFilesRejectsEmptyPlaceholderWhenCountsUnknown() {
+        ManifestFile manifest = mockManifestFile("placeholder-manifest", null, null);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> cache = Mockito.mock(Cache.class);
+        Set<DataFile> files = Set.of();
+        Mockito.when(cache.getIfPresent(manifest.path())).thenReturn(files);
+
+        Set<DataFile> cachedFiles = StarRocksIcebergTableScan.getCompleteCachedFiles(cache, manifest);
+
+        Assertions.assertNull(cachedFiles);
+        Mockito.verify(cache, Mockito.times(1)).invalidate(manifest.path());
+    }
+
+    @Test
+    public void testGetCompleteCachedFilesKeepsNonEmptyCacheWhenCountsUnknown() {
+        ManifestFile manifest = mockManifestFile("unknown-count-manifest", null, null);
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DeleteFile>> cache = Mockito.mock(Cache.class);
+        Set<DeleteFile> files = Set.of(Mockito.mock(DeleteFile.class));
+        Mockito.when(cache.getIfPresent(manifest.path())).thenReturn(files);
+
+        Set<DeleteFile> cachedFiles = StarRocksIcebergTableScan.getCompleteCachedFiles(cache, manifest);
+
+        Assertions.assertSame(files, cachedFiles);
+        Mockito.verify(cache, Mockito.never()).invalidate(manifest.path());
+    }
+
+    private ManifestFile mockManifestFile(String path, Integer existingFilesCount, Integer addedFilesCount) {
+        ManifestFile manifest = Mockito.mock(ManifestFile.class);
+        Mockito.when(manifest.path()).thenReturn(path);
+        Mockito.when(manifest.existingFilesCount()).thenReturn(existingFilesCount);
+        Mockito.when(manifest.addedFilesCount()).thenReturn(addedFilesCount);
+        return manifest;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Fix #70522

Validate cached manifest entries against the manifest live file counts before using them in data and delete scan planning.

If a cached entry is partial, invalidate it and fall back to manifest reading instead of treating any non-empty cache entry as a valid hit.

## What I'm doing:
This pull request enhances the caching logic for manifest files in `StarRocksIcebergTableScan` to ensure cache entries are only used when they are complete, preventing partial or placeholder cache data from being used. It introduces utility methods for cache validation and adds comprehensive unit tests to verify the new behavior.

**Caching improvements and validation:**

* Added `expectedLiveFilesCount`, `isCompleteCachedFiles`, and `getCompleteCachedFiles` static methods to `StarRocksIcebergTableScan` to check that cached file sets match the expected manifest file counts and to invalidate incomplete or placeholder cache entries.
* Updated cache usage in `planDeletesLocallyWithCache`, `planTaskWithCache`, and `getDeleteFiles` to use `getCompleteCachedFiles`, ensuring only complete cache entries are used and incomplete ones are invalidated. 

**Testing:**

* Added a new test class `StarRocksIcebergTableScanTest` with unit tests for the cache validation logic, covering scenarios for matching, partial, placeholder, and unknown-count cache entries.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
