### PR TITLE
[BugFix] Guard warmup_pk_index_sst_files with USE_STAROS

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -779,6 +779,9 @@ bool has_all_pk_columns_selected(const TabletSchema* tablet_schema, const std::v
 }
 
 Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletManager* tablet_mgr) {
+#ifndef USE_STAROS
+    return Status::OK();
+#else
     if (metadata == nullptr) {
         return Status::OK();
     }
@@ -821,6 +824,7 @@ Status warmup_pk_index_sst_files(const TabletMetadataPB* metadata, lake::TabletM
     }
 
     return Status::OK();
+#endif // USE_STAROS
 }
 
 Status LakeDataSource::build_scan_range(RuntimeState* state) {


### PR DESCRIPTION
## Why I'm doing:
`warmup_pk_index_sst_files` (introduced in #70389) uses `config::starlet_fs_stream_buffer_size_bytes`, which is only defined under `#ifdef USE_STAROS` in `config_starlet_fwd.h`. This causes compilation failure in non-starlet (shared-nothing) builds.

## What I'm doing:
Wrap the entire function body with `#ifndef USE_STAROS` / `#else` / `#endif` guard, returning `Status::OK()` immediately in non-starlet builds. This is consistent with how segment warmup is protected in `SegmentIterator::_do_get_next`.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)