### PR TITLE
[BugFix] Clear useless conjuncts in MySqlScanNode/JDBCScanNode which cause BE report error VectorizedInPredicate type not same

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -180,6 +180,10 @@ public class JDBCScanNode extends ScanNode {
         }
 
         ArrayList<Expr> jdbcConjuncts = ExprUtils.cloneList(conjuncts, sMap);
+        // Filters instead of conjuncts are used in BE to filter rows, the types of conjuncts' children
+        // would be unmatched after remove cast operator in PushDownPredicateTOExternalTableScanRule, which
+        // would cause BE report error "VectorizedInPredicate type not same";
+        conjuncts.clear();
         for (Expr p : jdbcConjuncts) {
             p = ExprUtils.replaceLargeStringLiteral(p);
             filters.add(AstToStringBuilder.toString(p));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
@@ -150,6 +150,10 @@ public class MysqlScanNode extends ScanNode {
             sMap.put(slotRef, tmpRef);
         }
         ArrayList<Expr> mysqlConjuncts = ExprUtils.cloneList(conjuncts, sMap);
+        // Filters instead of conjuncts are used in BE to filter rows, the types of conjuncts' children
+        // would be unmatched after remove cast operator in PushDownPredicateTOExternalTableScanRule, which
+        // would cause BE report error "VectorizedInPredicate type not same";
+        conjuncts.clear();
         for (Expr p : mysqlConjuncts) {
             p = ExprUtils.replaceLargeStringLiteral(p);
             filters.add(ExprToSql.toMySql(p));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.api.client.util.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
@@ -23,11 +24,16 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.FeConstants;
+import com.starrocks.planner.JDBCScanNode;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ExternalTableTest extends PlanTestBase {
 
@@ -295,4 +301,21 @@ public class ExternalTableTest extends PlanTestBase {
         Assertions.assertTrue(explainString.contains("4:SCAN MYSQL"));
     }
 
+    @Test
+    public void testPushDownMoveAroundPredicatesOfJdbcTable() throws Exception {
+        String sql = "select t0.* from t0  inner join[broadcast] jdbc_key_words_test t2 on t0.v1 =  t2.a " +
+                "where t0.v1 in (1,2,3);";
+        ExecPlan execPlan = getExecPlan(sql);
+        List<JDBCScanNode> scanNodes = Lists.newArrayList();
+        execPlan.getTopFragment().getPlanRoot().collect(JDBCScanNode.class, scanNodes);
+        Assertions.assertEquals(1, scanNodes.size());
+        List<InPredicate> predicates = scanNodes.get(0).getConjuncts().stream()
+                .filter(expr -> expr instanceof InPredicate)
+                .map(expr -> (InPredicate) expr).collect(Collectors.toList());
+        Assertions.assertTrue(predicates.isEmpty());
+        String plan = getCostExplain(sql);
+        assertCContains(plan, "  1:SCAN JDBC\n" +
+                "     TABLE: `test_table`\n" +
+                "     QUERY: SELECT `a` FROM `test_table` WHERE (`a` IN (1, 2, 3)) AND (`a` IS NOT NULL)");
+    }
 }

--- a/test/sql/test_external_mysql/R/test_clear_conjuncts_on_mysql_or_jdbc_scan_node
+++ b/test/sql/test_external_mysql/R/test_clear_conjuncts_on_mysql_or_jdbc_scan_node
@@ -1,0 +1,65 @@
+-- name: test_clear_conjuncts_on_mysql_or_jdbc_scan_node
+DROP DATABASE IF EXISTS db_${uuid0};
+-- result:
+-- !result
+CREATE DATABASE db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `department_id` bigint(20) NULL COMMENT 'department id',
+  `project_id` int(11) NULL COMMENT 'project id',
+  `department_name` varchar(255) NULL COMMENT 'department name'
+) ENGINE=OLAP
+DUPLICATE KEY(`department_id`)
+DISTRIBUTED BY HASH(`project_id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+(10, 10001, 'head_office'),
+(20, 10001, 'sales'),
+(30, 10002, 'engineering'),
+(40, 10003, 'sales_team_1'),
+(50, 10004, 'sales_team_2');
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mysql_db_${uuid0}; DROP TABLE IF EXISTS t2; CREATE TABLE t2 (id bigint(20) NOT NULL COMMENT "primary key id", project_id bigint(20) NULL COMMENT "project id", department_id int(11) NULL COMMENT "department id", lock_status int(11) NULL COMMENT "lock status: 1 locked, 0 unlocked");'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mysql_db_${uuid0}; INSERT INTO t2 VALUES (1,10001,10,1),(2,10001,20,0),(3,10002,30,1),(4,10003,40,0),(5,10004,50,1);'
+-- result:
+0
+
+-- !result
+create external catalog jdbc_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${jdbc_url}",
+    "driver_class"="com.mysql.jdbc.Driver"
+);
+-- result:
+-- !result
+select t1.department_id, t1.department_name from t1 left join [broadcast] jdbc_mysql_${uuid0}.mysql_db_${uuid0}.t2 t2 on t1.department_id = t2.department_id and t1.project_id = t2.project_id where t1.department_id in (10,20) order by t1.department_id, t1.department_name;
+-- result:
+10	head_office
+20	sales
+-- !result
+select * from jdbc_mysql_${uuid0}.mysql_db_${uuid0}.t2 where department_id in(17179869184, 17179869185);
+-- result:
+-- !result

--- a/test/sql/test_external_mysql/T/test_clear_conjuncts_on_mysql_or_jdbc_scan_node
+++ b/test/sql/test_external_mysql/T/test_clear_conjuncts_on_mysql_or_jdbc_scan_node
@@ -1,0 +1,40 @@
+-- name: test_clear_conjuncts_on_mysql_or_jdbc_scan_node
+DROP DATABASE IF EXISTS db_${uuid0};
+CREATE DATABASE db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `t1` (
+  `department_id` bigint(20) NULL COMMENT 'department id',
+  `project_id` int(11) NULL COMMENT 'project id',
+  `department_name` varchar(255) NULL COMMENT 'department name'
+) ENGINE=OLAP
+DUPLICATE KEY(`department_id`)
+DISTRIBUTED BY HASH(`project_id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t1 VALUES
+(10, 10001, 'head_office'),
+(20, 10001, 'sales'),
+(30, 10002, 'engineering'),
+(40, 10003, 'sales_team_1'),
+(50, 10004, 'sales_team_2');
+
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mysql_db_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mysql_db_${uuid0}; DROP TABLE IF EXISTS t2; CREATE TABLE t2 (id bigint(20) NOT NULL COMMENT "primary key id", project_id bigint(20) NULL COMMENT "project id", department_id int(11) NULL COMMENT "department id", lock_status int(11) NULL COMMENT "lock status: 1 locked, 0 unlocked");'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mysql_db_${uuid0}; INSERT INTO t2 VALUES (1,10001,10,1),(2,10001,20,0),(3,10002,30,1),(4,10003,40,0),(5,10004,50,1);'
+
+create external catalog jdbc_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="${jdbc_url}",
+    "driver_class"="com.mysql.jdbc.Driver"
+);
+
+select t1.department_id, t1.department_name from t1 left join [broadcast] jdbc_mysql_${uuid0}.mysql_db_${uuid0}.t2 t2 on t1.department_id = t2.department_id and t1.project_id = t2.project_id where t1.department_id in (10,20) order by t1.department_id, t1.department_name;
+
+select * from jdbc_mysql_${uuid0}.mysql_db_${uuid0}.t2 where department_id in(17179869184, 17179869185);


### PR DESCRIPTION
## Why I'm doing:

Move-around-predicate feature would generate predicates containing implicit cast operator,  when attempting to push down such predicates  down to external MySQL Scan Operator,  since MySQL can not recognize cast operator, so cast operators are removed from predicates, which make the types of predicates's children are unmatched, BE can not handle this, so it reports error "VectorizedInPredicate type not same".

Reproduce case

1. prepare data
```sql
-- StarRocks建表与测试数据
CREATE TABLE `t1` (
  `department_id` bigint(20) NULL COMMENT '部门id',
  `project_id` int(11) NULL COMMENT '项目id',
  `department_name` varchar(255) NULL COMMENT '部门名称'
)
ENGINE=OLAP
DUPLICATE KEY(`department_id`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`project_id`) BUCKETS 1
PROPERTIES (
  "replication_num" = "1"
);

INSERT INTO t1 VALUES
(10, 10001, '总部'),
(20, 10001, '销售部'),
(30, 10002, '技术部'),
(40, 10003, '销售一部'),
(50, 10004, '销售二部');


-- mysql 建表与测试数据
CREATE TABLE `t2` (
  `id` bigint(20) NOT NULL COMMENT '主键ID',
  `project_id` bigint(20) NULL COMMENT '项目id',
  `department_id` int(11) NULL COMMENT '部门id',
  `lock_status` int(11) NULL COMMENT '加锁状态：1已加锁，0：未加锁'
);

INSERT INTO t2 VALUES
(1, 10001, 10, 1),
(2, 10001, 20, 0),
(3, 10002, 30, 1),
(4, 10003, 40, 0),
(5, 10004, 50, 1);

mysql catalog创建语句
CREATE EXTERNAL CATALOG jdbc1
PROPERTIES
(
    "type"="jdbc",
    "user"="root",
    "password"="root",
    "jdbc_uri"="jdbc:mysql://192.168.110.***:3306",
    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
    "driver_class"="com.mysql.cj.jdbc.Driver"
);

```

2. query reports error "VectorizedInPredicate type not same"
```sql
select
    t2.department_id  
  , t2.department_name 
from test.t1 t2
left join jdbc1.test.t2 t4
on t2.department_id = t4.department_id and t2.project_id = t4.project_id
where t2.department_id in (10, 20);  -- 报错
```

## What I'm doing:

Conjuncts in MySqlScanNode/JDBCScanNode is useless after constructing filters which are used to cook mysql sql statement in BE, so type-mismatch conjuncts disrupt BE's execution and it can be cleared safely in FE.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
