### PR TITLE
[UT] Add double-quoted credential coverage for user auth redaction

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterUserStmtTest.java
@@ -139,6 +139,47 @@ public class AlterUserStmtTest {
     }
 
     @Test
+    public void testToStringWithDoubleQuotedPasswordLiteral() throws Exception {
+        String sql = "ALTER USER 'user' IDENTIFIED BY \"passwd\"";
+        AlterUserStmt stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals("ALTER USER 'user'@'%' IDENTIFIED BY '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                        StandardCharsets.UTF_8),
+                "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertNull(stmt.getAuthOption().getAuthPlugin());
+
+        sql = "ALTER USER 'user' IDENTIFIED BY PASSWORD \"*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0\"";
+        stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals("ALTER USER 'user'@'%' IDENTIFIED BY PASSWORD '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                        StandardCharsets.UTF_8),
+                "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertNull(stmt.getAuthOption().getAuthPlugin());
+
+        sql = "ALTER USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY \"passwd\"";
+        stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals("ALTER USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                        StandardCharsets.UTF_8),
+                "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertEquals(AuthPlugin.Server.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthOption().getAuthPlugin());
+
+        sql = "ALTER USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS "
+                + "\"*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0\"";
+        stmt = (AlterUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals(
+                "ALTER USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                        StandardCharsets.UTF_8),
+                "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertEquals(AuthPlugin.Server.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthOption().getAuthPlugin());
+    }
+
+    @Test
     public void testEmptyUser() {
         assertThrows(AnalysisException.class, () -> {
             String sql = "ALTER USER '' IDENTIFIED BY 'passwd'";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateUserStmtTest.java
@@ -146,6 +146,44 @@ public class CreateUserStmtTest {
     }
 
     @Test
+    public void testToStringWithDoubleQuotedPasswordLiteral() throws Exception {
+        String sql = "CREATE USER 'user' IDENTIFIED BY \"passwd\"";
+        CreateUserStmt stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals("CREATE USER 'user'@'%' IDENTIFIED BY '*XXX'", AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                        StandardCharsets.UTF_8),
+                "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertNull(stmt.getAuthOption().getAuthPlugin());
+
+        sql = "CREATE USER 'user' IDENTIFIED BY PASSWORD \"*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0\"";
+        stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals(
+                "CREATE USER 'user'@'%' IDENTIFIED BY PASSWORD '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                StandardCharsets.UTF_8), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertNull(stmt.getAuthOption().getAuthPlugin());
+
+        sql = "CREATE USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY \"passwd\"";
+        stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals("CREATE USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                StandardCharsets.UTF_8), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertEquals(AuthPlugin.Server.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthOption().getAuthPlugin());
+
+        sql = "CREATE USER 'user' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS "
+                + "\"*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0\"";
+        stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ConnectContext.get());
+        Assertions.assertEquals(
+                "CREATE USER 'user'@'%' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*XXX'",
+                AstToSQLBuilder.toSQL(stmt));
+        Assertions.assertEquals(new String(new UserAuthenticationInfo(stmt.getUser(), stmt.getAuthOption()).getPassword(),
+                StandardCharsets.UTF_8), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
+        Assertions.assertEquals(AuthPlugin.Server.MYSQL_NATIVE_PASSWORD.name(), stmt.getAuthOption().getAuthPlugin());
+    }
+
+    @Test
     public void testEmptyUser() {
         assertThrows(AnalysisException.class, () -> {
             String sql = "CREATE USER '' IDENTIFIED BY 'passwd'";

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -266,33 +266,67 @@ public class SqlCredentialRedactorTest {
         Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED BY '***'",
                 SqlCredentialRedactor.redact(createPlainSql));
 
+        String createPlainDoubleQuotedSql = "CREATE USER 'u1' IDENTIFIED BY \"secret\"";
+        Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED BY \"***\"",
+                SqlCredentialRedactor.redact(createPlainDoubleQuotedSql));
+
         String createHashedSql = "CREATE USER 'u1' IDENTIFIED BY PASSWORD '*59C70DA2'";
         Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED BY PASSWORD '***'",
                 SqlCredentialRedactor.redact(createHashedSql));
+
+        String createHashedDoubleQuotedSql = "CREATE USER 'u1' IDENTIFIED BY PASSWORD \"*59C70DA2\"";
+        Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED BY PASSWORD \"***\"",
+                SqlCredentialRedactor.redact(createHashedDoubleQuotedSql));
 
         String createNativePluginSql = "CREATE USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '*59C70DA2'";
         Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS '***'",
                 SqlCredentialRedactor.redact(createNativePluginSql));
 
+        String createNativePluginDoubleQuotedSql = "CREATE USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS "
+                + "\"*59C70DA2\"";
+        Assertions.assertEquals("CREATE USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD AS \"***\"",
+                SqlCredentialRedactor.redact(createNativePluginDoubleQuotedSql));
+
         String createLdapSql = "CREATE USER 'u1' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE "
                 + "AS 'uid=test,dc=example,dc=io'";
         Assertions.assertEquals(createLdapSql, SqlCredentialRedactor.redact(createLdapSql));
+
+        String createLdapDoubleQuotedSql = "CREATE USER 'u1' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE "
+                + "AS \"uid=test,dc=example,dc=io\"";
+        Assertions.assertEquals(createLdapDoubleQuotedSql, SqlCredentialRedactor.redact(createLdapDoubleQuotedSql));
 
         String alterPlainSql = "ALTER USER 'u1' IDENTIFIED BY 'secret'";
         Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED BY '***'",
                 SqlCredentialRedactor.redact(alterPlainSql));
 
+        String alterPlainDoubleQuotedSql = "ALTER USER 'u1' IDENTIFIED BY \"secret\"";
+        Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED BY \"***\"",
+                SqlCredentialRedactor.redact(alterPlainDoubleQuotedSql));
+
         String alterHashedSql = "ALTER USER 'u1' IDENTIFIED BY PASSWORD '*59C70DA2'";
         Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED BY PASSWORD '***'",
                 SqlCredentialRedactor.redact(alterHashedSql));
+
+        String alterHashedDoubleQuotedSql = "ALTER USER 'u1' IDENTIFIED BY PASSWORD \"*59C70DA2\"";
+        Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED BY PASSWORD \"***\"",
+                SqlCredentialRedactor.redact(alterHashedDoubleQuotedSql));
 
         String alterNativePluginSql = "ALTER USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY 'secret'";
         Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY '***'",
                 SqlCredentialRedactor.redact(alterNativePluginSql));
 
+        String alterNativePluginDoubleQuotedSql = "ALTER USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY "
+                + "\"secret\"";
+        Assertions.assertEquals("ALTER USER 'u1' IDENTIFIED WITH MYSQL_NATIVE_PASSWORD BY \"***\"",
+                SqlCredentialRedactor.redact(alterNativePluginDoubleQuotedSql));
+
         String alterLdapSql = "ALTER USER 'u1' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE "
                 + "BY 'uid=test,dc=example,dc=io'";
         Assertions.assertEquals(alterLdapSql, SqlCredentialRedactor.redact(alterLdapSql));
+
+        String alterLdapDoubleQuotedSql = "ALTER USER 'u1' IDENTIFIED WITH AUTHENTICATION_LDAP_SIMPLE "
+                + "BY \"uid=test,dc=example,dc=io\"";
+        Assertions.assertEquals(alterLdapDoubleQuotedSql, SqlCredentialRedactor.redact(alterLdapDoubleQuotedSql));
     }
 
     @Test
@@ -300,13 +334,24 @@ public class SqlCredentialRedactorTest {
         String plainSql = "SET PASSWORD = 'secret'";
         Assertions.assertEquals("SET PASSWORD = '***'", SqlCredentialRedactor.redact(plainSql));
 
+        String doubleQuotedPlainSql = "SET PASSWORD = \"secret\"";
+        Assertions.assertEquals("SET PASSWORD = \"***\"", SqlCredentialRedactor.redact(doubleQuotedPlainSql));
+
         String plainForUserSql = "SET PASSWORD FOR 'test'@'%' = 'secret'";
         Assertions.assertEquals("SET PASSWORD FOR 'test'@'%' = '***'",
                 SqlCredentialRedactor.redact(plainForUserSql));
 
+        String doubleQuotedPlainForUserSql = "SET PASSWORD FOR 'test'@'%' = \"secret\"";
+        Assertions.assertEquals("SET PASSWORD FOR 'test'@'%' = \"***\"",
+                SqlCredentialRedactor.redact(doubleQuotedPlainForUserSql));
+
         String sql = "SET PASSWORD FOR 'test'@'%' = PASSWORD('secret')";
         String redacted = SqlCredentialRedactor.redact(sql);
         Assertions.assertEquals("SET PASSWORD FOR 'test'@'%' = PASSWORD('***')", redacted);
+
+        String doubleQuotedFunctionSql = "SET PASSWORD FOR 'test'@'%' = PASSWORD(\"secret\")";
+        redacted = SqlCredentialRedactor.redact(doubleQuotedFunctionSql);
+        Assertions.assertEquals("SET PASSWORD FOR 'test'@'%' = PASSWORD(\"***\")", redacted);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
@@ -104,4 +104,14 @@ public class SetPasswordTest {
         System.out.println(setSql);
     }
 
+    @Test
+    public void testAuditSetPasswordWithDoubleQuotedLiteral() {
+        String sql = "SET PASSWORD FOR admin = PASSWORD(\"testPass\"), pipeline_dop = 2";
+        SetStmt setStmt = (SetStmt) parseSql(sql);
+        String setSql = AstToStringBuilder.toString(setStmt);
+        Assertions.assertTrue(setSql.contains("PASSWORD FOR"));
+        Assertions.assertTrue(setSql.contains("PASSWORD('***')"));
+        Assertions.assertTrue(setSql.contains("`pipeline_dop` = 2"));
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
The credential masking change in #70360 is already merged into `main`, but the related unit tests only cover credentials wrapped in single quotes.

In practice, statements such as `SET PASSWORD FOR 'user' = PASSWORD("123456")` are accepted and should be covered as well. We should add regression coverage for double-quoted credential literals to make sure user auth redaction keeps working for both quoting styles.

## What I'm doing:
- Add double-quoted credential test cases for `CREATE USER` and `ALTER USER`
- Add double-quoted credential test cases for `SqlCredentialRedactor`
- Add double-quoted `SET PASSWORD` audit formatting test cases
- Verify these cases work under the default `sql_mode`, without requiring `MODE_DOUBLE_LITERAL`

Fixes #<issue_number>

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4