### PR TITLE
[Refactor] Use BinaryImmContainer as the immutable container of all binary column

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -33,12 +33,12 @@ namespace starrocks {
 template <typename T>
 class BinaryColumnBase;
 
-class BinaryDataProxyContainer {
+class BinaryImmContainer {
 public:
-    BinaryDataProxyContainer() = default;
+    BinaryImmContainer() = default;
 
     template <typename T>
-    explicit BinaryDataProxyContainer(const BinaryColumnBase<T>& column) {
+    explicit BinaryImmContainer(const BinaryColumnBase<T>& column) {
         init(column);
     }
 
@@ -64,23 +64,10 @@ public:
     using Offset = T;
     using Offsets = Buffer<T>;
     using Byte = uint8_t;
-    using Bytes = starrocks::raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>>;
-
-    using ProxyContainer = ::starrocks::BinaryDataProxyContainer;
-
-    struct ImmContainer {
-        ImmContainer() = default;
-        explicit ImmContainer(const BinaryColumnBase& column) : _column(&column) {}
-
-        Slice operator[](size_t index) const { return _column->get_slice(index); }
-
-        size_t size() const { return _column->size(); }
-
-    private:
-        const BinaryColumnBase* _column = nullptr;
-    };
+    using Bytes = raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>>;
 
     using Container = Buffer<Slice>;
+    using ImmContainer = BinaryImmContainer;
     using GermanStringContainer = Buffer<GermanString>;
 
     // TODO(kks): when we create our own vector, we could let vector[-1] = 0,
@@ -349,8 +336,6 @@ public:
 
     ImmContainer immutable_data() const { return ImmContainer(*this); }
 
-    ProxyContainer get_proxy_data() const { return ProxyContainer(*this); }
-
     Bytes& get_bytes() {
         _ensure_materialized();
         return _bytes;
@@ -447,7 +432,7 @@ private:
 using Offsets = BinaryColumnBase<uint32_t>::Offsets;
 using LargeOffsets = BinaryColumnBase<uint64_t>::Offsets;
 
-inline Slice BinaryDataProxyContainer::operator[](size_t index) const {
+inline Slice BinaryImmContainer::operator[](size_t index) const {
     DCHECK(_column != nullptr);
     if (_is_large) {
         return down_cast<const LargeBinaryColumn*>(_column)->get_slice(index);
@@ -455,12 +440,12 @@ inline Slice BinaryDataProxyContainer::operator[](size_t index) const {
     return down_cast<const BinaryColumn*>(_column)->get_slice(index);
 }
 
-inline size_t BinaryDataProxyContainer::size() const {
+inline size_t BinaryImmContainer::size() const {
     return _column == nullptr ? 0 : _column->size();
 }
 
 template <typename T>
-inline void BinaryDataProxyContainer::init(const BinaryColumnBase<T>& column) {
+inline void BinaryImmContainer::init(const BinaryColumnBase<T>& column) {
     _column = &column;
     _is_large = std::is_same_v<T, uint64_t>;
 }

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -699,12 +699,12 @@ public:
         }
     }
 
-    static inline BinaryDataProxyContainer get_proxy_data(const BinaryColumn* column) {
-        return column->get_proxy_data();
+    static BinaryImmContainer get_proxy_data(const BinaryColumn* column) {
+        return column->immutable_data();
     }
 
-    static inline BinaryDataProxyContainer get_proxy_data(const LargeBinaryColumn* column) {
-        return column->get_proxy_data();
+    static BinaryImmContainer get_proxy_data(const LargeBinaryColumn* column) {
+        return column->immutable_data();
     }
 
     static inline size_t get_binary_bytes_size(const Column* column) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -699,13 +699,9 @@ public:
         }
     }
 
-    static BinaryImmContainer get_proxy_data(const BinaryColumn* column) {
-        return column->immutable_data();
-    }
+    static BinaryImmContainer get_proxy_data(const BinaryColumn* column) { return column->immutable_data(); }
 
-    static BinaryImmContainer get_proxy_data(const LargeBinaryColumn* column) {
-        return column->immutable_data();
-    }
+    static BinaryImmContainer get_proxy_data(const LargeBinaryColumn* column) { return column->immutable_data(); }
 
     static inline size_t get_binary_bytes_size(const Column* column) {
         if (column->is_large_binary()) {

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -75,8 +75,7 @@ public:
         // but they can not be compiled into SIMD instructions.
 
         // Use lambdas to make the compiler to better analyze code within smaller scopes, thereby ensuring vectorization.
-        using ImmutableContainer = std::conditional_t<lt_is_string_or_binary<Type>, BinaryDataProxyContainer,
-                                                      typename RunTimeColumnType<Type>::ImmContainer>;
+        using ImmutableContainer = typename RunTimeColumnType<Type>::ImmContainer;
         auto check_range = [](uint8_t* __restrict__ local_res, ImmutableContainer local_values, const size_t local_size,
                               const CppType min_value, const CppType max_value) {
             for (int i = 0; i < local_size; i++) {

--- a/be/src/runtime/runtime_filter.h
+++ b/be/src/runtime/runtime_filter.h
@@ -585,8 +585,7 @@ class MinMaxRuntimeFilter final : public RuntimeFilter {
 public:
     using CppType = RunTimeCppType<Type>;
     using ColumnType = RunTimeColumnType<Type>;
-    using ContainerType =
-            std::conditional_t<lt_is_string_or_binary<Type>, BinaryDataProxyContainer, RunTimeImmContainerType<Type>>;
+    using ContainerType = RunTimeImmContainerType<Type>;
 
     MinMaxRuntimeFilter() { _init_min_max(); }
     MinMaxRuntimeFilter(const MinMaxRuntimeFilter& rhs)
@@ -1205,8 +1204,7 @@ class TRuntimeBloomFilter final : public RuntimeMembershipFilter {
 public:
     using CppType = RunTimeCppType<Type>;
     using ColumnType = RunTimeColumnType<Type>;
-    using ContainerType =
-            std::conditional_t<lt_is_string_or_binary<Type>, BinaryDataProxyContainer, RunTimeImmContainerType<Type>>;
+    using ContainerType = RunTimeImmContainerType<Type>;
 
     TRuntimeBloomFilter() = default;
     explicit TRuntimeBloomFilter(const RuntimeMembershipFilter& base) : RuntimeMembershipFilter(base) {}


### PR DESCRIPTION
## Why I'm doing:

This is the 8st pr for https://github.com/StarRocks/starrocks/issues/69589

After completing the perf test, the is_large_binary() check has no effect on performance. So for the convenience of future refactoring, we will use BinaryImmContainer as the immutable container for all binary columns

Also the 1st refactor pr of https://github.com/StarRocks/starrocks/pull/69067

## What I'm doing:

Use BinaryImmContainer as the immutable container of all binary column

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
