### PR TITLE
[BugFix] Fix query-scope warehouse hint leaking ComputeResource in ConnectContext

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1146,7 +1146,13 @@ public class ConnectContext {
                 this.resetComputeResource();
                 throw new RuntimeException(errMsg);
             }
-            if (!warehouseManager.isResourceAvailable(computeResource)) {
+            // Re-acquire if the cached compute resource belongs to a different warehouse than the
+            // current session warehouse. This can happen when a query-scope warehouse hint modifies
+            // the session variable but the compute resource is not properly restored afterwards.
+            if (computeResource.getWarehouseId() != this.getCurrentWarehouseId()) {
+                this.resetComputeResource();
+                acquireComputeResource();
+            } else if (!warehouseManager.isResourceAvailable(computeResource)) {
                 if (state != null && !state.isRunning()) {
                     // if the query is not running, we can acquire a new compute resource.
                     acquireComputeResource();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -280,6 +280,7 @@ import com.starrocks.transaction.TransactionStmtExecutor;
 import com.starrocks.transaction.VisibleStateWaiter;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.WarehouseIdleChecker;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -819,8 +820,10 @@ public class StmtExecutor {
         context.setCurrentThreadId(Thread.currentThread().getId());
 
         SessionVariable sessionVariableBackup = context.getSessionVariable();
+        ComputeResource computeResourceBackup = context.getCurrentComputeResourceNoAcquire();
         // set true to change session variable
         boolean skipRestore = false;
+        boolean restoreComputeResourceForWarehouseHint = shouldRestoreComputeResourceForQueryScopeHint(parsedStmt);
         // set execution id.
         // For statements other than `cache select`, try to use query id as execution id when execute first time.
         UUID uuid = context.getQueryId();
@@ -1228,6 +1231,15 @@ public class StmtExecutor {
 
             // process post-action after query is finished
             context.onQueryFinished();
+
+            // Restore compute resource only when a query-scope hint changed the warehouse.
+            // For normal statements (no hint), the compute resource may have been legitimately
+            // updated during execution (e.g., reset due to unavailability), and we must not
+            // overwrite those safety updates. Restore after onQueryFinished() so that audit
+            // CN group reflects the actual execution resource.
+            if (!skipRestore && restoreComputeResourceForWarehouseHint) {
+                context.setCurrentComputeResource(computeResourceBackup);
+            }
             context.setOnlyReadIcebergCache(originSkipIcebergCache);
             if (cteExecutor != null) {
                 cteExecutor.finalizeRecursiveCTE();
@@ -1264,18 +1276,28 @@ public class StmtExecutor {
         }
     }
 
-    public void processQueryScopeSetVarHint() throws DdlException {
-        if (!parsedStmt.isExistQueryScopeHint()) {
-            return;
+    private Map<String, String> collectQueryScopeSetVarHints(StatementBase stmt) {
+        Map<String, String> hintSvs = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (stmt == null || !stmt.isExistQueryScopeHint()) {
+            return hintSvs;
         }
 
-        Map<String, String> hintSvs = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        for (HintNode hint : parsedStmt.getAllQueryScopeHints()) {
+        for (HintNode hint : stmt.getAllQueryScopeHints()) {
             if (!(hint instanceof SetVarHint)) {
                 continue;
             }
             hintSvs.putAll(hint.getValue());
         }
+        return hintSvs;
+    }
+
+    private boolean shouldRestoreComputeResourceForQueryScopeHint(StatementBase stmt) {
+        String hintedWarehouse = collectQueryScopeSetVarHints(stmt).get(SessionVariable.WAREHOUSE_NAME);
+        return hintedWarehouse != null && !StringUtils.equalsIgnoreCase(hintedWarehouse, context.getCurrentWarehouseName());
+    }
+
+    public void processQueryScopeSetVarHint() throws DdlException {
+        Map<String, String> hintSvs = collectQueryScopeSetVarHints(parsedStmt);
 
         if (hintSvs.isEmpty()) {
             return;
@@ -3693,6 +3715,8 @@ public class StmtExecutor {
         }
 
         SessionVariable sessionVariableBackup = context.getSessionVariable();
+        ComputeResource computeResourceBackup = context.getCurrentComputeResourceNoAcquire();
+        boolean restoreComputeResourceForWarehouseHint = shouldRestoreComputeResourceForQueryScopeHint(parsedStmt);
         try {
             processQueryScopeSetVarHint();
         } catch (DdlException e) {
@@ -3735,6 +3759,9 @@ public class StmtExecutor {
             QueryDetailQueue.addQueryDetail(queryDetail.copy());
         } finally {
             context.setSessionVariable(sessionVariableBackup);
+            if (restoreComputeResourceForWarehouseHint) {
+                context.setCurrentComputeResource(computeResourceBackup);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -595,6 +595,50 @@ public class ConnectContextTest {
     }
 
     @Test
+    public void getCurrentComputeResource_reacquiresWhenWarehouseIdMismatch(
+            @Mocked WarehouseManager warehouseManager) {
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        // computeResource belongs to warehouse 999, but session warehouse is default (id=0)
+        ComputeResource staleResource = WarehouseComputeResource.of(999L);
+        ComputeResource freshResource = WarehouseComputeResource.of(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        new Expectations() {
+            {
+                globalStateMgr.getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
+
+                warehouseManager.warehouseExists(anyString);
+                minTimes = 0;
+                result = true;
+
+                warehouseManager.acquireComputeResource(anyLong, (ComputeResource) any);
+                minTimes = 0;
+                result = freshResource;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        ctx.setGlobalStateMgr(globalStateMgr);
+        ctx.setCurrentComputeResource(staleResource);
+
+        // getCurrentComputeResource should detect the mismatch and re-acquire
+        ComputeResource result = ctx.getCurrentComputeResource();
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, result.getWarehouseId());
+        ComputeResource currentWithoutAcquire = ctx.getCurrentComputeResourceNoAcquire();
+        Assertions.assertNotNull(currentWithoutAcquire);
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, currentWithoutAcquire.getWarehouseId());
+        Assertions.assertNotEquals(staleResource, currentWithoutAcquire);
+    }
+
+    @Test
     public void testConnectContextNoGlobalStateMgrNPE() {
         ConnectContext connectContext = ConnectContext.get();
         if (connectContext == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
@@ -24,6 +24,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlSerializer;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -38,6 +39,7 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -653,6 +655,58 @@ public class StmtExecutorTest {
         Assertions.assertFalse(ctx.getState().isError());
         // TxnId should be cleared after commit
         Assertions.assertEquals(0, ctx.getTxnId());
+    }
+
+    @Test
+    public void testAddRunningQueryDetailRestoresComputeResource() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+        new MockUp<ConnectContext>() {
+            @Mock
+            public void applyWarehouseSessionVariable(String warehouse, SessionVariable sv) {
+                sv.setWarehouseName(warehouse);
+            }
+        };
+
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+
+        String originalWarehouse = ctx.getCurrentWarehouseName();
+        ComputeResource originalResource = WarehouseComputeResource.of(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        ctx.setCurrentComputeResource(originalResource);
+
+        String hintedWarehouse = "query_detail_hint_warehouse";
+        String sql = "select /*+ SET_VAR(warehouse='" + hintedWarehouse + "') */ 1";
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        stmt.setOrigStmt(new com.starrocks.sql.ast.OriginStatement(sql, 0));
+        StmtExecutor executor = new StmtExecutor(ctx, stmt);
+
+        // Enable query detail collection
+        boolean oldConfig = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        try {
+            executor.addRunningQueryDetail(stmt);
+        } finally {
+            Config.enable_collect_query_detail_info = oldConfig;
+        }
+
+        QueryDetail queryDetail = ctx.getQueryDetail();
+        Assertions.assertNotNull(queryDetail);
+        Assertions.assertEquals(hintedWarehouse, queryDetail.getWarehouse());
+        Assertions.assertEquals(originalWarehouse, ctx.getCurrentWarehouseName());
+
+        ComputeResource afterResource = ctx.getCurrentComputeResourceNoAcquire();
+        Assertions.assertEquals(originalResource, afterResource,
+                "ComputeResource should be restored after addRunningQueryDetail");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1552,6 +1552,8 @@ public class UtFrameUtils {
                 iterator.remove();
             }
         }
+        // Reset compute resource to avoid leaking a stale warehouse binding from query-scope hints.
+        context.resetComputeResource();
     }
 
     /***


### PR DESCRIPTION
## Why I'm doing:

  When a query uses a query-scope warehouse hint (e.g. `/*+ SET_VAR(warehouse='warehouse_query') */`),
  `StmtExecutor.processQueryScopeHint()` calls `applyWarehouseSessionVariable()` which resets
  `ConnectContext.computeResource` to match the hinted warehouse. However, after the statement finishes,
  only `SessionVariable` is restored — `computeResource` is not.

  If the connection is reused (e.g. via a connection pool), subsequent statements that do not explicitly
  specify a warehouse will still use the stale `computeResource` from the previous hint. This causes:
  - The load metadata to record `WAREHOUSE = default_warehouse`
  - But the actual execution workers to be selected from `warehouse_query`

  This was observed in production where an `INSERT INTO ... SELECT FROM FILES(...)` was dispatched to
  the wrong warehouse's BEs, leading to OOM on those nodes.

## What I'm doing:

  1. **`StmtExecutor.execute()`**: Backup `ComputeResource` before `processQueryScopeHint()` and
     restore it in the `finally` block, alongside the existing `SessionVariable` restore.

  2. **`StmtExecutor.addRunningQueryDetail()`**: Same backup/restore pattern for `ComputeResource`
     around `processQueryScopeSetVarHint()`.

  3. **`ConnectContext.getCurrentComputeResource()`**: Add a defensive check — if the cached
     `computeResource.getWarehouseId()` does not match `getCurrentWarehouseId()`, re-acquire
     the compute resource. This guards against any other code paths that might leak.

  4. **`UtFrameUtils.clearQueryScopeHintContext()`**: Reset compute resource to prevent test
     framework from leaking stale warehouse bindings across test cases.

  5. Added unit tests in `ConnectContextTest` and `StmtExecutorTest` to verify the fix.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
