### PR TITLE
[Refactor] Refactors and simplifies the logic for checking partition columns when creating materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -31,14 +31,12 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.JDBCTable;
-import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MysqlTable;
@@ -46,7 +44,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
@@ -58,7 +55,6 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.mv.analyzer.MVPartitionSlotRefResolver;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
@@ -67,6 +63,8 @@ import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.mv.IVMAnalyzer;
+import com.starrocks.sql.analyzer.mv.MVBaseTablePartitionHandlers;
+import com.starrocks.sql.analyzer.mv.MVPartitionCheckContext;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -101,7 +99,6 @@ import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
-import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TimestampArithmeticExpr;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.sql.common.PListCell;
@@ -135,7 +132,6 @@ import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1069,30 +1065,17 @@ public class MaterializedViewAnalyzer {
                     throw new SemanticException("Materialized view partition expression %s could not ref to external table",
                             ExprToSql.toSql(slotRef));
                 }
-                if (table.isNativeTableOrMaterializedView()) {
-                    OlapTable olapTable = (OlapTable) table;
-                    if (changedPartitionByExprs.containsKey(i)) {
-                        // if generated column has changed partition by expr, use the new partition by expr
-                        Expr newPartitionByExpr = changedPartitionByExprs.get(i);
-                        if (!(newPartitionByExpr instanceof SlotRef)) {
-                            throw new SemanticException("Materialized view partition expression %s could only ref base table's " +
-                                    "partition expression without any change", ExprToSql.toSql(slotRef));
-                        }
-                        slotRef = (SlotRef) newPartitionByExpr;
+                // OlapTable generated column substitution
+                if (table.isNativeTableOrMaterializedView() && changedPartitionByExprs.containsKey(i)) {
+                    Expr newPartitionByExpr = changedPartitionByExprs.get(i);
+                    if (!(newPartitionByExpr instanceof SlotRef)) {
+                        throw new SemanticException("Materialized view partition expression %s could only ref base table's " +
+                                "partition expression without any change", ExprToSql.toSql(slotRef));
                     }
-                    checkPartitionColumnWithBaseOlapTable(slotRef, olapTable);
-                } else if (table.isHiveTable() || table.isHudiTable() || table.isOdpsTable()) {
-                    checkPartitionColumnWithBaseHMSTable(slotRef, table);
-                } else if (table.isIcebergTable()) {
-                    checkPartitionColumnWithBaseIcebergTable(statement, expr, slotRef, (IcebergTable) table);
-                } else if (table.isJDBCTable()) {
-                    checkPartitionColumnWithBaseJDBCTable(slotRef, (JDBCTable) table);
-                } else if (table.isPaimonTable()) {
-                    checkPartitionColumnWithBasePaimonTable(slotRef, (PaimonTable) table);
-                } else {
-                    throw new SemanticException("Materialized view with partition does not support base table type : %s",
-                            table.getType());
+                    slotRef = (SlotRef) newPartitionByExpr;
                 }
+                MVPartitionCheckContext context = new MVPartitionCheckContext(statement, expr, slotRef, table);
+                MVBaseTablePartitionHandlers.getHandler(table).checkPartitionColumn(context);
                 replaceTableAlias(slotRef, statement, tableNameTableMap);
             }
         }
@@ -1297,107 +1280,6 @@ public class MaterializedViewAnalyzer {
             }
         }
 
-        private void checkPartitionColumnWithBaseOlapTable(SlotRef slotRef, OlapTable table) {
-            PartitionInfo partitionInfo = table.getPartitionInfo();
-            if (partitionInfo.isUnPartitioned()) {
-                throw new SemanticException("Materialized view partition column in partition exp " +
-                        "must be base table partition column");
-            } else if (partitionInfo.isRangePartition()) {
-                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-                List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns(table.getIdToColumn());
-                if (partitionColumns.size() != 1) {
-                    throw new SemanticException("Materialized view related base table partition columns " +
-                            "only supports single column");
-                }
-                String partitionColumn = partitionColumns.get(0).getName();
-                if (!partitionColumn.equalsIgnoreCase(slotRef.getColumnName())) {
-                    throw new SemanticException("Materialized view partition column in partition exp " +
-                            "must be base table partition column");
-                }
-                partitionColumns.forEach(partitionColumn1 -> checkPartitionColumnType(partitionColumn1));
-                // disable from_unix_time/cast for creating materialized view
-                if (rangePartitionInfo instanceof ExpressionRangePartitionInfoV2) {
-                    ExpressionRangePartitionInfoV2 rangePartitionInfoV2 = (ExpressionRangePartitionInfoV2) rangePartitionInfo;
-                    if (rangePartitionInfoV2.getPartitionColumnIdExprs().size() != 1) {
-                        throw new SemanticException("Materialized view related base table partition columns " +
-                                "only supports single column");
-                    }
-                    Expr partitionColumnExpr = rangePartitionInfoV2.getPartitionColumnIdExprs().get(0).getExpr();
-                    checkBaseTableSupportedPartitionFunc(partitionColumnExpr, table);
-                }
-            } else if (partitionInfo.isListPartition()) {
-                ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-                Set<String> partitionColumns = listPartitionInfo.getPartitionColumns(table.getIdToColumn()).stream()
-                        .map(col -> col.getName())
-                        .collect(Collectors.toSet());
-                // mv's partition columns should be a subset of the base table's partition columns
-                if (!partitionColumns.contains(slotRef.getColumnName())) {
-                    throw new SemanticException("Materialized view partition column in partition exp " +
-                            "must be base table partition column");
-                }
-            } else {
-                throw new SemanticException("Materialized view related base table partition type: " +
-                        partitionInfo.getType().name() + " not supports");
-            }
-        }
-
-        /**
-         * Check if the partition function of base table is supported.
-         *
-         * @param partitionByExpr : base table's partition function
-         * @param table           : base table
-         */
-        private void checkBaseTableSupportedPartitionFunc(Expr partitionByExpr,
-                                                          OlapTable table) {
-            if (partitionByExpr instanceof SlotRef) {
-                // do nothing
-            } else if (partitionByExpr instanceof FunctionCallExpr) {
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
-                String functionName = functionCallExpr.getFunctionName();
-                if (!PartitionFunctionChecker.FN_NAME_TO_PATTERN.containsKey(functionName)) {
-                    throw new SemanticException(String.format("Materialized view partition function derived from " +
-                            functionName + " of base table %s is not supported yet", table.getName()),
-                            functionCallExpr.getPos());
-                }
-            } else {
-                throw new SemanticException(String.format("Materialized view partition function derived from " +
-                        ExprToSql.toSql(partitionByExpr) + " of base table %s is not supported yet", table.getName()),
-                        partitionByExpr.getPos());
-            }
-        }
-
-        private void checkPartitionColumnWithBaseTable(SlotRef slotRef, List<Column> partitionColumns, boolean unPartitioned) {
-            if (unPartitioned) {
-                throw new SemanticException("Materialized view partition column in partition exp " +
-                        "must be base table partition column");
-            } else {
-                boolean found = false;
-                for (Column partitionColumn : partitionColumns) {
-                    if (partitionColumn.getName().equalsIgnoreCase(slotRef.getColumnName())) {
-                        checkPartitionColumnType(partitionColumn);
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    throw new SemanticException("Materialized view partition column in partition exp " +
-                            "must be base table partition column");
-                }
-            }
-        }
-
-        private void checkPartitionColumnWithBaseHMSTable(SlotRef slotRef, Table table) {
-            checkPartitionColumnWithBaseTable(slotRef, table.getPartitionColumns(), table.isUnPartitioned());
-        }
-
-        private void checkPartitionColumnWithBaseJDBCTable(SlotRef slotRef, JDBCTable table) {
-            checkPartitionColumnWithBaseTable(slotRef, table.getPartitionColumns(), table.isUnPartitioned());
-            if (!SUPPORTED_JDBC_PARTITION_TYPE.contains(table.getProtocolType())) {
-                throw new SemanticException(String.format("Materialized view PARTITION BY for JDBC %s is not " +
-                        "supported, you could remove the PARTITION BY clause", table.getProtocolType()));
-            }
-        }
-
         // if mv is partitioned, mv will be refreshed by partition.
         // if mv has window functions, it should also be partitioned by and the partition by columns
         // should contain the partition column of mv
@@ -1412,98 +1294,6 @@ public class MaterializedViewAnalyzer {
                 PartitionExprAnalyzer.analyzePartitionExpr(refTablePartitionExpr, partitionSlotRef);
             }
             MVPartitionSlotRefResolver.checkWindowFunction(statement, refTablePartitionExprs);
-        }
-
-        private void checkPartitionColumnWithBaseIcebergTable(CreateMaterializedViewStatement statement,
-                                                              Expr partitionByExpr,
-                                                              SlotRef slotRef,
-                                                              IcebergTable table) {
-            org.apache.iceberg.Table icebergTable = table.getNativeTable();
-            PartitionSpec partitionSpec = icebergTable.spec();
-            if (partitionSpec.isUnpartitioned()) {
-                throw new SemanticException("Materialized view partition column in partition exp " +
-                        "must be base table partition column");
-            } else {
-                if (icebergTable.specs().size() > 1) {
-                    throw new SemanticException("Do not support create materialized view when " +
-                            "base iceberg table has partition evolution");
-                }
-                boolean found = false;
-                for (PartitionField partitionField : partitionSpec.fields()) {
-                    IcebergPartitionTransform transform =
-                            IcebergPartitionTransform.fromString(partitionField.transform().toString());
-                    String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
-                    if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
-                        checkPartitionColumnType(table.getColumn(partitionColumnName));
-                        found = true;
-                        switch (transform) {
-                            case YEAR:
-                            case MONTH:
-                            case DAY:
-                            case HOUR:
-                                if (!isDateTruncWithUnit(partitionByExpr, transform.name())) {
-                                    throw new SemanticException("Materialized view partition expr %s " +
-                                            "must be the same with base table partition transform %s, please use date_trunc" +
-                                            "(<transform>, <partition_colum_name>) instead.", ExprToSql.toSql(partitionByExpr),
-                                            transform.name());
-                                }
-                                // mark the statement with partition transform to use list partition mv later.
-                                statement.setRefBaseTablePartitionWithTransform(true);
-                                break;
-                            case IDENTITY:
-                                if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&
-                                        !MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
-                                    throw new SemanticException("Materialized view partition expr %s: " +
-                                            "only support ref partition column for transform %s, please use " +
-                                            "<partition_column_name> instead.",
-                                            ExprToSql.toSql(partitionByExpr), transform.name());
-                                }
-                                break;
-                            default:
-                                throw new SemanticException("Do not support create materialized view when " +
-                                        "base iceberg table partition transform is: " + transform.name());
-                        }
-                        break;
-                    }
-                }
-                if (!found) {
-                    throw new SemanticException("Materialized view partition column in partition exp " +
-                            "must be base table partition column");
-                }
-            }
-        }
-
-        private boolean isDateTruncWithUnit(Expr partitionExpr, String timeUnit) {
-            if (MvUtils.isFuncCallExpr(partitionExpr, FunctionSet.DATE_TRUNC)) {
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
-                if (!(functionCallExpr.getChild(0) instanceof StringLiteral)) {
-                    return false;
-                }
-                StringLiteral stringLiteral = (StringLiteral) functionCallExpr.getChild(0);
-                return stringLiteral.getStringValue().equalsIgnoreCase(timeUnit);
-            }
-            return false;
-        }
-
-        @VisibleForTesting
-        public void checkPartitionColumnWithBasePaimonTable(SlotRef slotRef, PaimonTable table) {
-            if (table.isUnPartitioned()) {
-                throw new SemanticException("Materialized view partition column in partition exp " +
-                        "must be base table partition column");
-            } else {
-                boolean found = false;
-                for (String partitionColumnName : table.getPartitionColumnNames()) {
-                    if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
-                        checkPartitionColumnType(table.getColumn(partitionColumnName));
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    throw new SemanticException("Materialized view partition column in partition exp " +
-                            "must be base table partition column");
-                }
-            }
         }
 
         private SlotRef getSlotRef(Expr expr) {
@@ -1564,13 +1354,6 @@ public class MaterializedViewAnalyzer {
             }
         }
 
-        private void checkPartitionColumnType(Column partitionColumn) {
-            PrimitiveType type = partitionColumn.getPrimitiveType();
-            if (!type.isFixedPointType() && !type.isDateType() && !type.isStringType()) {
-                throw new SemanticException("Materialized view partition exp column:"
-                        + partitionColumn.getName() + " with type " + type + " not supported");
-            }
-        }
 
         private void checkDistribution(ConnectContext connectContext,
                                        CreateMaterializedViewStatement statement,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/HMSTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/HMSTablePartitionHandler.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+/**
+ * Handler for HMS-based tables (Hive, Hudi, ODPS).
+ */
+public class HMSTablePartitionHandler implements MVBaseTablePartitionHandler {
+
+    @Override
+    public void checkPartitionColumn(MVPartitionCheckContext context) {
+        MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(
+                context.getSlotRef(), context.getTable());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.iceberg.IcebergPartitionTransform;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+
+/**
+ * Handler for Iceberg tables.
+ */
+public class IcebergTablePartitionHandler implements MVBaseTablePartitionHandler {
+
+    @Override
+    public void checkPartitionColumn(MVPartitionCheckContext context) {
+        IcebergTable table = (IcebergTable) context.getTable();
+        Expr partitionByExpr = context.getPartitionByExpr();
+        SlotRef slotRef = context.getSlotRef();
+
+        // Common validation: unpartitioned check + column name match + type check
+        MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(slotRef, table);
+
+        // Iceberg-specific: partition evolution and transform validation
+        org.apache.iceberg.Table icebergTable = table.getNativeTable();
+        PartitionSpec partitionSpec = icebergTable.spec();
+        if (icebergTable.specs().size() > 1) {
+            throw new SemanticException("Do not support create materialized view when " +
+                    "base iceberg table has partition evolution");
+        }
+        for (PartitionField partitionField : partitionSpec.fields()) {
+            String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
+            if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
+                IcebergPartitionTransform transform =
+                        IcebergPartitionTransform.fromString(partitionField.transform().toString());
+                switch (transform) {
+                    case YEAR:
+                    case MONTH:
+                    case DAY:
+                    case HOUR:
+                        if (!isDateTruncWithUnit(partitionByExpr, transform.name())) {
+                            throw new SemanticException("Materialized view partition expr %s " +
+                                    "must be the same with base table partition transform %s, please use date_trunc" +
+                                    "(<transform>, <partition_colum_name>) instead.",
+                                    ExprToSql.toSql(partitionByExpr), transform.name());
+                        }
+                        context.getStatement().setRefBaseTablePartitionWithTransform(true);
+                        break;
+                    case IDENTITY:
+                        if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&
+                                !MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
+                            throw new SemanticException("Materialized view partition expr %s: " +
+                                    "only support ref partition column for transform %s, please use " +
+                                    "<partition_column_name> instead.",
+                                    ExprToSql.toSql(partitionByExpr), transform.name());
+                        }
+                        break;
+                    default:
+                        throw new SemanticException("Do not support create materialized view when " +
+                                "base iceberg table partition transform is: " + transform.name());
+                }
+                break;
+            }
+        }
+    }
+
+    private static boolean isDateTruncWithUnit(Expr partitionExpr, String timeUnit) {
+        if (MvUtils.isFuncCallExpr(partitionExpr, FunctionSet.DATE_TRUNC)) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
+            if (!(functionCallExpr.getChild(0) instanceof StringLiteral)) {
+                return false;
+            }
+            StringLiteral stringLiteral = (StringLiteral) functionCallExpr.getChild(0);
+            return stringLiteral.getStringValue().equalsIgnoreCase(timeUnit);
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/JDBCTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/JDBCTablePartitionHandler.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.sql.analyzer.SemanticException;
+
+import java.util.Set;
+
+/**
+ * Handler for JDBC tables.
+ */
+public class JDBCTablePartitionHandler implements MVBaseTablePartitionHandler {
+
+    static final Set<JDBCTable.ProtocolType> SUPPORTED_JDBC_PARTITION_TYPE =
+            ImmutableSet.of(JDBCTable.ProtocolType.MYSQL, JDBCTable.ProtocolType.MARIADB);
+
+    @Override
+    public void checkPartitionColumn(MVPartitionCheckContext context) {
+        JDBCTable table = (JDBCTable) context.getTable();
+        MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(context.getSlotRef(), table);
+        if (!SUPPORTED_JDBC_PARTITION_TYPE.contains(table.getProtocolType())) {
+            throw new SemanticException(String.format("Materialized view PARTITION BY for JDBC %s is not " +
+                    "supported, you could remove the PARTITION BY clause", table.getProtocolType()));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVBaseTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVBaseTablePartitionHandler.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.type.PrimitiveType;
+
+/**
+ * Strategy interface for handling base-table-type-specific partition column validation
+ * in materialized view analysis.
+ * <p>
+ * Each supported base table type (OlapTable, Hive/Hudi/ODPS, Iceberg, JDBC, Paimon) provides
+ * its own implementation. This eliminates if-else branching by table type in
+ * {@code MaterializedViewAnalyzer}.
+ */
+public interface MVBaseTablePartitionHandler {
+
+    /**
+     * Validate that the MV partition column references a valid partition column in the base table.
+     */
+    void checkPartitionColumn(MVPartitionCheckContext context);
+
+    /**
+     * Validate that the MV partition expression references a valid partition column in the base table.
+     * <p>
+     * Checks performed:
+     * <ol>
+     *   <li>The base table must be partitioned.</li>
+     *   <li>The column referenced by {@code mvPartitionSlotRef} must exist in the base table's partition columns.</li>
+     *   <li>The matched partition column's type must be one of: fixed-point integer, date/datetime, or string.</li>
+     * </ol>
+     *
+     * @param mvPartitionSlotRef the slot reference from the MV's PARTITION BY expression
+     * @param baseTable          the base table that the MV is built on
+     * @throws SemanticException if the base table is unpartitioned, the referenced column is not a partition column,
+     *                           or the partition column type is not supported
+     */
+    static void checkPartitionColumnWithBaseTable(SlotRef mvPartitionSlotRef, Table baseTable) {
+        if (baseTable.isUnPartitioned()) {
+            throw new SemanticException("Materialized view partition column in partition exp " +
+                    "must be base table partition column");
+        }
+        boolean found = false;
+        for (Column partitionColumn : baseTable.getPartitionColumns()) {
+            if (partitionColumn.getName().equalsIgnoreCase(mvPartitionSlotRef.getColumnName())) {
+                PrimitiveType type = partitionColumn.getPrimitiveType();
+                if (!type.isFixedPointType() && !type.isDateType() && !type.isStringType()) {
+                    throw new SemanticException("Materialized view partition exp column:"
+                            + partitionColumn.getName() + " with type " + type + " not supported");
+                }
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            throw new SemanticException("Materialized view partition column in partition exp " +
+                    "must be base table partition column");
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVBaseTablePartitionHandlers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVBaseTablePartitionHandlers.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.analyzer.SemanticException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry for {@link MVBaseTablePartitionHandler} implementations.
+ * <p>
+ * To add support for a new base table type, register its handler in the static block below.
+ */
+public class MVBaseTablePartitionHandlers {
+
+    private static final Map<Table.TableType, MVBaseTablePartitionHandler> HANDLERS;
+
+    static {
+        HANDLERS = new HashMap<>();
+
+        OlapTablePartitionHandler olap = new OlapTablePartitionHandler();
+        HANDLERS.put(Table.TableType.OLAP, olap);
+        HANDLERS.put(Table.TableType.MATERIALIZED_VIEW, olap);
+        HANDLERS.put(Table.TableType.CLOUD_NATIVE, olap);
+        HANDLERS.put(Table.TableType.CLOUD_NATIVE_MATERIALIZED_VIEW, olap);
+
+        HMSTablePartitionHandler hms = new HMSTablePartitionHandler();
+        HANDLERS.put(Table.TableType.HIVE, hms);
+        HANDLERS.put(Table.TableType.HUDI, hms);
+        HANDLERS.put(Table.TableType.ODPS, hms);
+
+        HANDLERS.put(Table.TableType.ICEBERG, new IcebergTablePartitionHandler());
+        HANDLERS.put(Table.TableType.JDBC, new JDBCTablePartitionHandler());
+        HANDLERS.put(Table.TableType.PAIMON, new PaimonTablePartitionHandler());
+    }
+
+    /**
+     * Get the handler for the given table, throwing if no handler is registered.
+     */
+    public static MVBaseTablePartitionHandler getHandler(Table table) {
+        MVBaseTablePartitionHandler handler = HANDLERS.get(table.getType());
+        if (handler == null) {
+            throw new SemanticException(
+                    "Materialized view with partition does not support base table type : " + table.getType());
+        }
+        return handler;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVPartitionCheckContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/MVPartitionCheckContext.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+
+/**
+ * Context for {@link MVBaseTablePartitionHandler#checkPartitionColumn}.
+ */
+public class MVPartitionCheckContext {
+    private final CreateMaterializedViewStatement statement;
+    private final Expr partitionByExpr;
+    private final SlotRef slotRef;
+    private final Table table;
+
+    public MVPartitionCheckContext(CreateMaterializedViewStatement statement,
+                                  Expr partitionByExpr,
+                                  SlotRef slotRef,
+                                  Table table) {
+        this.statement = statement;
+        this.partitionByExpr = partitionByExpr;
+        this.slotRef = slotRef;
+        this.table = table;
+    }
+
+    public CreateMaterializedViewStatement getStatement() {
+        return statement;
+    }
+
+    public Expr getPartitionByExpr() {
+        return partitionByExpr;
+    }
+
+    public SlotRef getSlotRef() {
+        return slotRef;
+    }
+
+    public Table getTable() {
+        return table;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/OlapTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/OlapTablePartitionHandler.java
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.sql.analyzer.PartitionFunctionChecker;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Handler for OlapTable (including MaterializedView and CloudNative variants).
+ */
+public class OlapTablePartitionHandler implements MVBaseTablePartitionHandler {
+
+    @Override
+    public void checkPartitionColumn(MVPartitionCheckContext context) {
+        SlotRef slotRef = context.getSlotRef();
+        OlapTable table = (OlapTable) context.getTable();
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        if (partitionInfo.isUnPartitioned()) {
+            throw new SemanticException("Materialized view partition column in partition exp " +
+                    "must be base table partition column");
+        } else if (partitionInfo.isRangePartition()) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+            List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns(table.getIdToColumn());
+            if (partitionColumns.size() != 1) {
+                throw new SemanticException("Materialized view related base table partition columns " +
+                        "only supports single column");
+            }
+            // column name match + type check
+            MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(slotRef, table);
+            // disable from_unix_time/cast for creating materialized view
+            if (rangePartitionInfo instanceof ExpressionRangePartitionInfoV2) {
+                ExpressionRangePartitionInfoV2 rangePartitionInfoV2 =
+                        (ExpressionRangePartitionInfoV2) rangePartitionInfo;
+                if (rangePartitionInfoV2.getPartitionColumnIdExprs().size() != 1) {
+                    throw new SemanticException("Materialized view related base table partition columns " +
+                            "only supports single column");
+                }
+                Expr partitionColumnExpr = rangePartitionInfoV2.getPartitionColumnIdExprs().get(0).getExpr();
+                checkBaseTableSupportedPartitionFunc(partitionColumnExpr, table);
+            }
+        } else if (partitionInfo.isListPartition()) {
+            ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+            Set<String> partitionColumns = listPartitionInfo.getPartitionColumns(table.getIdToColumn()).stream()
+                    .map(Column::getName)
+                    .collect(Collectors.toSet());
+            // List partition intentionally skips type check (e.g., BOOLEAN is valid)
+            if (!partitionColumns.contains(slotRef.getColumnName())) {
+                throw new SemanticException("Materialized view partition column in partition exp " +
+                        "must be base table partition column");
+            }
+        } else {
+            throw new SemanticException("Materialized view related base table partition type: " +
+                    partitionInfo.getType().name() + " not supports");
+        }
+    }
+
+    private static void checkBaseTableSupportedPartitionFunc(Expr partitionByExpr, OlapTable table) {
+        if (partitionByExpr instanceof SlotRef) {
+            // do nothing
+        } else if (partitionByExpr instanceof FunctionCallExpr) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
+            String functionName = functionCallExpr.getFunctionName();
+            if (!PartitionFunctionChecker.FN_NAME_TO_PATTERN.containsKey(functionName)) {
+                throw new SemanticException(String.format("Materialized view partition function derived from " +
+                        functionName + " of base table %s is not supported yet", table.getName()),
+                        functionCallExpr.getPos());
+            }
+        } else {
+            throw new SemanticException(String.format("Materialized view partition function derived from " +
+                    ExprToSql.toSql(partitionByExpr) + " of base table %s is not supported yet", table.getName()),
+                    partitionByExpr.getPos());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/PaimonTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/PaimonTablePartitionHandler.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mv;
+
+/**
+ * Handler for Paimon tables.
+ */
+public class PaimonTablePartitionHandler implements MVBaseTablePartitionHandler {
+
+    @Override
+    public void checkPartitionColumn(MVPartitionCheckContext context) {
+        MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(
+                context.getSlotRef(), context.getTable());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.mv.MVPartitionCheckContext;
+import com.starrocks.sql.analyzer.mv.PaimonTablePartitionHandler;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -60,8 +62,7 @@ public class MaterializedViewAnalyzerWithPaimonTest {
 
     @Test
     public void testMaterializedAnalyPaimonTable(@Mocked SlotRef slotRef, @Mocked PaimonTable table) {
-        MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor materializedViewAnalyzerVisitor =
-                new MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor();
+        PaimonTablePartitionHandler handler = new PaimonTablePartitionHandler();
 
         new MockUp<MaterializedViewOptimizer>() {
             @Mock
@@ -75,15 +76,22 @@ public class MaterializedViewAnalyzerWithPaimonTest {
 
         {
             // test check partition column can not be found
+            Column dtColumn = new Column("dt", DateType.DATE);
             boolean checkSuccess = false;
             new Expectations() {
                 {
                     table.isUnPartitioned();
                     result = false;
+
+                    table.getPartitionColumns();
+                    result = Lists.newArrayList(dtColumn);
+
+                    slotRef.getColumnName();
+                    result = "other_col";
                 }
             };
             try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+                handler.checkPartitionColumn(new MVPartitionCheckContext(null, null, slotRef, table));
                 checkSuccess = true;
             } catch (Exception e) {
                 Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
@@ -95,24 +103,22 @@ public class MaterializedViewAnalyzerWithPaimonTest {
 
         {
             // test check successfully
+            Column dtColumn = new Column("dt", DateType.DATE);
             boolean checkSuccess = false;
             new Expectations() {
                 {
                     table.isUnPartitioned();
                     result = false;
 
-                    table.getPartitionColumnNames();
-                    result = Lists.newArrayList("dt");
+                    table.getPartitionColumns();
+                    result = Lists.newArrayList(dtColumn);
 
                     slotRef.getColumnName();
                     result = "dt";
-
-                    table.getColumn("dt");
-                    result = new Column("dt", DateType.DATE);
                 }
             };
             try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+                handler.checkPartitionColumn(new MVPartitionCheckContext(null, null, slotRef, table));
                 checkSuccess = true;
             } catch (Exception e) {
             }
@@ -120,7 +126,7 @@ public class MaterializedViewAnalyzerWithPaimonTest {
         }
 
         {
-            //test paimon table is unparitioned
+            //test paimon table is unpartitioned
             new Expectations() {
                 {
                     table.isUnPartitioned();
@@ -130,7 +136,7 @@ public class MaterializedViewAnalyzerWithPaimonTest {
 
             boolean checkSuccess = false;
             try {
-                materializedViewAnalyzerVisitor.checkPartitionColumnWithBasePaimonTable(slotRef, table);
+                handler.checkPartitionColumn(new MVPartitionCheckContext(null, null, slotRef, table));
             } catch (Exception e) {
                 Assertions.assertTrue(e.getMessage().contains("Materialized view partition column in partition exp " +
                                 "must be base table partition column"),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors and simplifies the logic for checking partition columns when creating materialized views, especially around supporting different base table types. The main change is to centralize the partition column checking logic into handler classes, improving maintainability and extensibility. Several table-specific checking methods are removed from `MaterializedViewAnalyzer` and replaced with a handler-based approach.

Partition column checking refactor:

* Replaces direct type checks and table-specific partition column validation logic in `MaterializedViewAnalyzer` with a handler-based approach using `MVBaseTablePartitionHandlers` and `MVPartitionCheckContext`. This centralizes and simplifies the logic for supporting new table types.
* Removes table-specific partition column checking methods (`checkPartitionColumnWithBaseOlapTable`, `checkPartitionColumnWithBaseHMSTable`, `checkPartitionColumnWithBaseIcebergTable`, `checkPartitionColumnWithBaseJDBCTable`, `checkPartitionColumnWithBasePaimonTable`) from `MaterializedViewAnalyzer`. [[1]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L1300-L1400) [[2]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L1417-L1508)
* Removes the method `checkPartitionColumnType` from `MaterializedViewAnalyzer`, delegating type checks to the new handler classes.

New handler implementation:

* Adds a new class `HMSTablePartitionHandler` implementing `MVBaseTablePartitionHandler`, which encapsulates the logic for checking partition columns for HMS-based tables (Hive, Hudi, ODPS).

Code cleanup:

* Cleans up unused imports as a result of the refactor, removing dependencies on table-specific partition info classes and other unused imports in `MaterializedViewAnalyzer`. [[1]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L34-L49) [[2]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L61) [[3]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0R66-R67) [[4]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L104) [[5]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L138)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
