### PR TITLE
[Enhancement] AggDataTypeTraits support large binary column

### DIFF
--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -241,6 +241,7 @@ template <>
 struct RunTimeTypeTraits<TYPE_CHAR> {
     using CppType = Slice;
     using ColumnType = BinaryColumn;
+    using LargeColumnType = LargeBinaryColumn;
     using ImmContainerType = ColumnType::ImmContainer;
 };
 
@@ -248,6 +249,7 @@ template <>
 struct RunTimeTypeTraits<TYPE_VARCHAR> {
     using CppType = Slice;
     using ColumnType = BinaryColumn;
+    using LargeColumnType = LargeBinaryColumn;
     using ImmContainerType = ColumnType::ImmContainer;
 };
 
@@ -311,6 +313,7 @@ template <>
 struct RunTimeTypeTraits<TYPE_BINARY> {
     using CppType = Slice;
     using ColumnType = BinaryColumn;
+    using LargeColumnType = LargeBinaryColumn;
     using ImmContainerType = ColumnType::ImmContainer;
 };
 
@@ -318,6 +321,7 @@ template <>
 struct RunTimeTypeTraits<TYPE_VARBINARY> {
     using CppType = Slice;
     using ColumnType = BinaryColumn;
+    using LargeColumnType = LargeBinaryColumn;
     using ImmContainerType = ColumnType::ImmContainer;
 };
 
@@ -347,6 +351,9 @@ using RunTimeCppType = typename RunTimeTypeTraits<Type>::CppType;
 
 template <LogicalType Type>
 using RunTimeColumnType = typename RunTimeTypeTraits<Type>::ColumnType;
+
+template <LogicalType Type>
+using RunTimeLargeColumnType = typename RunTimeTypeTraits<Type>::LargeColumnType;
 
 template <LogicalType Type>
 using RunTimeImmContainerType = typename RunTimeTypeTraits<Type>::ImmContainerType;

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -37,7 +37,9 @@ struct AggDataTypeTraits<lt, FixedLengthLTGuard<lt>> {
 
     static void append_value(ColumnType* column, const ValueType& value) { column->append(value); }
 
-    static RefType get_row_ref(const ColumnType& column, size_t row) { return column.immutable_data()[row]; }
+    static RefType get_row_ref(const Column& column, size_t row) {
+        return down_cast<const ColumnType&>(column).immutable_data()[row];
+    }
     static RefType get_ref(const ValueType& value) { return value; }
 
     static void update_max(ValueType& current, const RefType& input) { current = std::max<ValueType>(current, input); }
@@ -68,7 +70,9 @@ struct AggDataTypeTraits<lt, ObjectFamilyLTGuard<lt>> {
     static void append_value(ColumnType* column, const ValueType& value) { column->append(&value); }
     static RefType get_ref(const ValueType& value) { return &value; }
 
-    static const RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_object(row); }
+    static const RefType get_row_ref(const Column& column, size_t row) {
+        return down_cast<const ColumnType&>(column).get_object(row);
+    }
 
     static void update_max(ValueType& current, const RefType& input) { current = std::max<ValueType>(current, *input); }
 
@@ -89,10 +93,10 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
     using ValueType = typename ColumnType::MutablePtr;
 
     struct RefType {
-        const ColumnType* column;
+        const Column* column;
         const size_t row;
 
-        RefType(const ColumnType* c, size_t r) : column(c), row(r) {}
+        RefType(const Column* c, size_t r) : column(c), row(r) {}
     };
 
     static void assign_value(ValueType& value, const RefType& ref) {
@@ -104,7 +108,7 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
         column->append_datum(value->get(0).template get<CppType>());
     }
 
-    static RefType get_row_ref(const ColumnType& column, size_t row) { return RefType(&column, row); }
+    static RefType get_row_ref(const Column& column, size_t row) { return RefType(&column, row); }
 
     static bool is_equal(const ValueType& lhs, const ValueType& rhs) {
         return lhs->get(0).template get<CppType>() == rhs->get(0).template get<CppType>();
@@ -118,6 +122,7 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
 template <LogicalType lt>
 struct AggDataTypeTraits<lt, StringOrBinaryGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
+    using LargeColumnType = RunTimeLargeColumnType<lt>;
     using ValueType = Buffer<uint8_t>;
     using RefType = Slice;
 
@@ -130,7 +135,12 @@ struct AggDataTypeTraits<lt, StringOrBinaryGuard<lt>> {
         column->append(Slice(value.data(), value.size()));
     }
 
-    static RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_slice(row); }
+    static RefType get_row_ref(const Column& column, size_t row) {
+        if (UNLIKELY(column.is_large_binary())) {
+            return down_cast<const LargeColumnType&>(column).get_slice(row);
+        }
+        return down_cast<const ColumnType&>(column).get_slice(row);
+    }
 
     static RefType get_ref(const ValueType& value) { return Slice(value.data(), value.size()); }
 

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -66,7 +66,7 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         DCHECK(!columns[0]->is_nullable());
-        const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+        const auto& column = *columns[0];
         OP()(this->data(state), AggDataTypeTraits<LT>::get_row_ref(column, row_num));
     }
 
@@ -77,8 +77,7 @@ public:
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(!column->is_nullable());
-        const auto& input_column = down_cast<const InputColumnType&>(*column);
-        OP()(this->data(state), AggDataTypeTraits<LT>::get_row_ref(input_column, row_num));
+        OP()(this->data(state), AggDataTypeTraits<LT>::get_row_ref(*column, row_num));
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/approx_top_k.h
+++ b/be/src/exprs/agg/approx_top_k.h
@@ -328,14 +328,9 @@ public:
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         init_state_if_necessary(ctx, state);
-        if constexpr (IsSlice<CppType>) {
-            const auto value = ColumnHelper::get_binary_slice(columns[0], row_num);
-            this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
-        } else {
-            const auto* column = down_cast<const InputColumnType*>(ColumnHelper::get_data_column(columns[0]));
-            const auto& value = AggDataTypeTraits<LT>::get_row_ref(*column, row_num);
-            this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
-        }
+        const auto* column = ColumnHelper::get_data_column(columns[0]);
+        const auto& value = AggDataTypeTraits<LT>::get_row_ref(*column, row_num);
+        this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -456,19 +451,10 @@ public:
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        if constexpr (IsSlice<CppType>) {
-            ColumnHelper::with_binary_data_column(columns[0], [&](const auto* typed_column) {
-                for (size_t i = frame_start; i < frame_end; i++) {
-                    const auto value = typed_column->get_slice(i);
-                    this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
-                }
-            });
-        } else {
-            const auto* column = down_cast<const InputColumnType*>(ColumnHelper::get_data_column(columns[0]));
-            for (size_t i = frame_start; i < frame_end; i++) {
-                const auto& value = AggDataTypeTraits<LT>::get_row_ref(*column, i);
-                this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
-            }
+        const auto* column = ColumnHelper::get_data_column(columns[0]);
+        for (size_t i = frame_start; i < frame_end; i++) {
+            const auto& value = AggDataTypeTraits<LT>::get_row_ref(*column, i);
+            this->data(state).template process<true>(ctx->mem_pool(), value, 1, false);
         }
     }
 

--- a/be/src/exprs/agg/minmax_n.h
+++ b/be/src/exprs/agg/minmax_n.h
@@ -178,8 +178,7 @@ public:
         init_state_if_necessary(ctx, state);
 
         const Column* data_col = ColumnHelper::get_data_column(columns[0]);
-        const auto* column = down_cast<const InputColumnType*>(data_col);
-        const auto& value = AggDataTypeTraits<LT>::get_row_ref(*column, row_num);
+        const auto& value = AggDataTypeTraits<LT>::get_row_ref(*data_col, row_num);
 
         this->data(state).template process<true>(ctx->mem_pool(), value);
     }
@@ -243,7 +242,7 @@ public:
         int32_t n = get_n_value(ctx);
         DCHECK(dst->is_binary());
         auto* dst_column = down_cast<BinaryColumn*>(dst.get());
-        auto* src_column = down_cast<const InputColumnType*>(src[0].get());
+        const auto* src_column = src[0].get();
 
         for (size_t i = 0; i < src_column->size(); ++i) {
             MinMaxNAggregateState<LT, IsMin> state;

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -113,20 +113,6 @@ class ValueWindowFunction : public WindowFunction<State> {
 public:
     using InputColumnType = RunTimeColumnType<LT>;
 
-    template <typename ColumnType>
-    static inline auto get_row_ref(const ColumnType* column, size_t row) {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            return ColumnHelper::get_binary_slice(column, row);
-        } else {
-            if constexpr (std::is_same_v<std::decay_t<ColumnType>, Column>) {
-                // When called with base Column*, down_cast to the concrete type.
-                return AggDataTypeTraits<LT>::get_row_ref(*down_cast<const RunTimeColumnType<LT>*>(column), row);
-            } else {
-                return AggDataTypeTraits<LT>::get_row_ref(*column, row);
-            }
-        }
-    }
-
     template <typename InputColumnType>
     void do_get_values_helper(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
         DCHECK_GT(end, start);
@@ -478,10 +464,10 @@ class FirstValueWindowFunction final : public ValueWindowFunction<LT, FirstValue
             }
         } else {
             const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            const auto* column = down_cast<const InputColumnType*>(data_column);
             this->data(state).is_null = false;
             this->data(state).has_value = true;
-            AggDataTypeTraits<LT>::assign_value(this->data(state).value, this->get_row_ref(column, value_index));
+            AggDataTypeTraits<LT>::assign_value(this->data(state).value,
+                                                AggDataTypeTraits<LT>::get_row_ref(*data_column, value_index));
         }
     }
 
@@ -548,10 +534,10 @@ class LastValueWindowFunction final : public ValueWindowFunction<LT, LastValueSt
             }
         } else {
             const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            const auto* column = down_cast<const InputColumnType*>(data_column);
             this->data(state).is_null = false;
             this->data(state).has_value = true;
-            AggDataTypeTraits<LT>::assign_value(this->data(state).value, this->get_row_ref(column, value_index));
+            AggDataTypeTraits<LT>::assign_value(this->data(state).value,
+                                                AggDataTypeTraits<LT>::get_row_ref(*data_column, value_index));
         }
     }
 
@@ -725,8 +711,9 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
                             this->data(state).is_null = def_col->is_null(static_cast<size_t>(current_row));
                             if (!this->data(state).is_null) {
                                 const Column* def_data_column = ColumnHelper::get_data_column(def_col);
-                                AggDataTypeTraits<LT>::assign_value(this->data(state).value,
-                                                                    this->get_row_ref(def_data_column, current_row));
+                                AggDataTypeTraits<LT>::assign_value(
+                                        this->data(state).value,
+                                        AggDataTypeTraits<LT>::get_row_ref(*def_data_column, current_row));
                             }
                         } else {
                             this->data(state).is_null = true;
@@ -735,9 +722,9 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
                 }
             } else {
                 const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-                const auto* column = down_cast<const InputColumnType*>(data_column);
                 this->data(state).is_null = false;
-                AggDataTypeTraits<LT>::assign_value(this->data(state).value, this->get_row_ref(column, value_index));
+                AggDataTypeTraits<LT>::assign_value(this->data(state).value,
+                                                    AggDataTypeTraits<LT>::get_row_ref(*data_column, value_index));
             }
         } else {
             // frame_start < peer_group_start is for lag function
@@ -765,8 +752,9 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
                         this->data(state).is_null = def_col->is_null(static_cast<size_t>(current_row_index));
                         if (!this->data(state).is_null) {
                             const Column* def_data_column = ColumnHelper::get_data_column(def_col);
-                            AggDataTypeTraits<LT>::assign_value(this->data(state).value,
-                                                                this->get_row_ref(def_data_column, current_row_index));
+                            AggDataTypeTraits<LT>::assign_value(
+                                    this->data(state).value,
+                                    AggDataTypeTraits<LT>::get_row_ref(*def_data_column, current_row_index));
                         }
                     } else {
                         this->data(state).is_null = true;
@@ -778,8 +766,8 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
             if (!columns[0]->is_null(frame_end - 1)) {
                 this->data(state).is_null = false;
                 const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-                const auto* column = down_cast<const InputColumnType*>(data_column);
-                AggDataTypeTraits<LT>::assign_value(this->data(state).value, this->get_row_ref(column, frame_end - 1));
+                AggDataTypeTraits<LT>::assign_value(this->data(state).value,
+                                                    AggDataTypeTraits<LT>::get_row_ref(*data_column, frame_end - 1));
             } else {
                 this->data(state).is_null = true;
             }
@@ -811,7 +799,7 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
                 this->data(state).default_is_null = true;
             } else {
                 if constexpr (lt_is_array<LT>) {
-                    const auto* column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(arg2));
+                    const auto* column = ColumnHelper::get_data_column(arg2);
                     AggDataTypeTraits<LT>::assign_value(this->data(state).default_value,
                                                         AggDataTypeTraits<LT>::get_row_ref(*column, 0));
                 } else {
@@ -874,7 +862,6 @@ public:
                                                  const Column** columns, int64_t peer_group_start,
                                                  int64_t peer_group_end, int64_t frame_start, int64_t frame_end) const {
         const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-        const InputColumnType* column = down_cast<const InputColumnType*>(data_column);
 
         DCHECK(frame_start < frame_end);
         if (frame_start > frame_end) {
@@ -886,13 +873,12 @@ public:
         if (columns[0]->is_null(current_row)) {
             this->data(state).is_null = true;
         } else {
-            auto current_value = ValueWindowFunction<LT, AllocateSessionState<LT>, T>::get_row_ref(column, current_row);
+            auto current_value = AggDataTypeTraits<LT>::get_row_ref(*data_column, current_row);
             if (this->data(state).has_value && current_value - this->data(state).last_not_null_value > delta) {
                 this->data(state).session_id++;
             }
             this->data(state).is_null = false;
-            this->data(state).last_not_null_value =
-                    ValueWindowFunction<LT, AllocateSessionState<LT>, T>::get_row_ref(column, frame_start);
+            this->data(state).last_not_null_value = AggDataTypeTraits<LT>::get_row_ref(*data_column, frame_start);
         }
         this->data(state).has_value = true;
     }


### PR DESCRIPTION
## Why I'm doing:

AggDataTypeTraits supports large binary columns. This is the 2nd refactor for https://github.com/StarRocks/starrocks/pull/69067, making the code cleaner and easier to backport to other branches

## What I'm doing:

AggDataTypeTraits::get_row_ref support large binary column

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
