### PR TITLE
[BugFix] Fix PK tablet rowset meta loss caused by GC race during disk re-migration (A→B→A)

### DIFF
--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -36,12 +36,11 @@
 
 #include <fmt/format.h>
 
-#include "base/testutil/sync_point.h"
-
 #include <iterator>
 #include <map>
 #include <set>
 
+#include "base/testutil/sync_point.h"
 #include "common/config_storage_fwd.h"
 #include "fs/fs.h"
 #include "gen_cpp/Types_constants.h"

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -36,6 +36,8 @@
 
 #include <fmt/format.h>
 
+#include "base/testutil/sync_point.h"
+
 #include <iterator>
 #include <map>
 #include <set>
@@ -838,7 +840,9 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
         rowset_meta_pb.set_rowset_id(new_rowset_id.to_string());
         // reset rowsetid means that it is different from the rowset in snapshot meta.
         // It is reasonable that reset the creation time here.
-        rowset_meta_pb.set_creation_time(UnixSeconds());
+        int64_t new_creation_time = UnixSeconds();
+        TEST_SYNC_POINT_CALLBACK("SnapshotManager::assign_new_rowset_id:creation_time", &new_creation_time);
+        rowset_meta_pb.set_creation_time(new_creation_time);
     }
     return Status::OK();
 }

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -40,7 +40,6 @@
 #include <map>
 #include <set>
 
-#include "base/testutil/sync_point.h"
 #include "common/config_storage_fwd.h"
 #include "fs/fs.h"
 #include "gen_cpp/Types_constants.h"
@@ -839,9 +838,7 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
         rowset_meta_pb.set_rowset_id(new_rowset_id.to_string());
         // reset rowsetid means that it is different from the rowset in snapshot meta.
         // It is reasonable that reset the creation time here.
-        int64_t new_creation_time = UnixSeconds();
-        TEST_SYNC_POINT_CALLBACK("SnapshotManager::assign_new_rowset_id:creation_time", &new_creation_time);
-        rowset_meta_pb.set_creation_time(new_creation_time);
+        rowset_meta_pb.set_creation_time(UnixSeconds());
     }
     return Status::OK();
 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1931,7 +1931,7 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
                 // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
                 st = _remove_tablet_meta(tablet);
                 if (!st.ok()) {
-                    LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+                    LOG(WARNING) << "Fail to remove previous tablet meta, id: " << tablet_id << " status: " << st;
                 }
             }
         }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -41,8 +41,8 @@
 #include <ctime>
 #include <memory>
 
-#include "base/failpoint/fail_point.h"
 #include "base/path/path_util.h"
+#include "base/testutil/sync_point.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
@@ -1187,9 +1187,7 @@ Status TabletManager::start_trash_sweep() {
         sweep_shutdown_tablet(info, finished_tablets_redundant);
     }
 
-    // Test hook: keep finished shutdown entries in the queues after phase 1 has already
-    // removed their on-disk meta/files, so migration can observe a stale shutdown entry.
-    FAIL_POINT_TRIGGER_RETURN(start_trash_sweep_skip_shutdown_tablets_cleanup, Status::OK());
+    TEST_SYNC_POINT("TabletManager::start_trash_sweep:1");
 
     if (!finished_tablets.empty() || !finished_tablets_redundant.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
@@ -1942,7 +1940,5 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
     }
     _shutdown_tablets.emplace(tablet_id, drop_info);
 }
-
-DEFINE_FAIL_POINT(start_trash_sweep_skip_shutdown_tablets_cleanup);
 
 } // end namespace starrocks

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -41,6 +41,7 @@
 #include <ctime>
 #include <memory>
 
+#include "base/failpoint/fail_point.h"
 #include "base/path/path_util.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -1186,6 +1187,10 @@ Status TabletManager::start_trash_sweep() {
         sweep_shutdown_tablet(info, finished_tablets_redundant);
     }
 
+    // Test hook: keep finished shutdown entries in the queues after phase 1 has already
+    // removed their on-disk meta/files, so migration can observe a stale shutdown entry.
+    FAIL_POINT_TRIGGER_RETURN(start_trash_sweep_skip_shutdown_tablets_cleanup, Status::OK());
+
     if (!finished_tablets.empty() || !finished_tablets_redundant.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
         for (const auto& tablet_info_finished : finished_tablets) {
@@ -1906,10 +1911,28 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
     auto iter = _shutdown_tablets.find(tablet_id);
     if (iter != _shutdown_tablets.end()) {
         if ((iter->second).tablet != nullptr) {
-            // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
-            auto st = _remove_tablet_meta((iter->second).tablet);
-            if (!st.ok()) {
-                LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+            // Re-check the on-disk meta before destructive cleanup. During rapid re-migration
+            // a stale shutdown entry may still exist after ownership has already moved to a
+            // newer tablet instance on the same path. For PK tablets, _remove_tablet_meta()
+            // can clear rowset meta by tablet_id, so running it from the stale entry would
+            // wipe the new tablet's metadata. When uid/state no longer matches, leave this
+            // entry to the normal shutdown queues instead of eagerly clearing meta here.
+            auto& tablet = (iter->second).tablet;
+            TabletMeta tablet_meta;
+            Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(),
+                                                           tablet->schema_hash(), &tablet_meta);
+            if (st.ok() &&
+                (tablet_meta.tablet_uid() != tablet->tablet_uid() || tablet_meta.tablet_state() != TABLET_SHUTDOWN)) {
+                LOG(INFO) << "Skip removing stale shutdown tablet meta due to "
+                          << (tablet_meta.tablet_uid() != tablet->tablet_uid() ? "uid mismatch" : "state mismatch")
+                          << ". tablet_id=" << tablet->tablet_id() << ", path=" << tablet->data_dir()->path()
+                          << ", state=" << tablet_meta.tablet_state();
+            } else {
+                // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
+                st = _remove_tablet_meta(tablet);
+                if (!st.ok()) {
+                    LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+                }
             }
         }
         auto drop_info_redundant = iter->second;
@@ -1919,5 +1942,7 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
     }
     _shutdown_tablets.emplace(tablet_id, drop_info);
 }
+
+DEFINE_FAIL_POINT(start_trash_sweep_skip_shutdown_tablets_cleanup);
 
 } // end namespace starrocks

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -18,8 +18,9 @@
 #include <butil/files/file_path.h>
 #include <gtest/gtest.h>
 
-#include "base/failpoint/fail_point.h"
 #include "base/path/file_util.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "base/testutil/assert.h"
 #include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
@@ -619,24 +620,31 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
 }
 
 // Verifies that rapid PK tablet re-migration (disk A->B->A) preserves the
-// new tablet's rowset metadata when GC leaves a stale shutdown entry behind.
+// new tablet's rowset metadata when GC and migration race concurrently.
 //
 // Test flow:
-//   1. Migration A->B: V1 enters _shutdown_tablets, V2 becomes active on disk_b.
-//   2. GC sweep removes V1's on-disk meta from disk_a, but a fail point keeps
-//      the stale V1 entry in _shutdown_tablets.
-//   3. Migration B->A succeeds, and the new tablet on disk_a still has its
-//      rowset metadata.
+//   1. Create PK tablet with rowset on disk_a, migrate A->B.
+//   2. GC sweep phase 1 clears V1's meta from disk_a; a sync point callback
+//      runs migration B->A before phase 2 removes the stale queue entry.
+//   3. Verify V3's rowset metadata on disk_a is intact.
 TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_tablet_meta) {
+    // Migration's assign_new_rowset_id sets creation_time = UnixSeconds().
+    // _add_tablet_unlocked requires new_time > old_time for same-version replacement.
+    // Poll at 10ms until UnixSeconds() passes the reference time (max 30s).
+    auto wait_until_after = [](int64_t ref_time) {
+        for (int i = 0; i < 3000 && UnixSeconds() <= ref_time; i++) {
+            usleep(10000);
+        }
+        CHECK_GT(UnixSeconds(), ref_time);
+    };
+
     int64_t tablet_id = 77777;
     int32_t schema_hash = 7777;
     TabletManager* tablet_manager = StorageEngine::instance()->tablet_manager();
 
-    // Clean leftovers from previous tests so the shutdown queues start empty.
     ASSERT_OK(tablet_manager->start_trash_sweep());
 
-    // Step 1: Create PK tablet with one committed rowset so we can verify whether
-    // metadata survives the second migration.
+    // Step 1: Create PK tablet with one committed rowset.
     TabletSharedPtr tablet = create_pk_tablet(tablet_id, schema_hash);
     tablet->set_enable_persistent_index(false);
     ASSERT_TRUE(tablet != nullptr);
@@ -645,10 +653,8 @@ TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_t
 
     std::vector<int64_t> keys = {1, 2, 3, 4, 5};
     auto rowset = create_pk_rowset(tablet, keys);
+    int64_t rowset_time = rowset->creation_time();
     ASSERT_OK(tablet->rowset_commit(2, rowset));
-
-    // Ensure the first migration gets a strictly newer rowset creation time than V1.
-    sleep(1);
 
     DataDir* disk_a = tablet->data_dir();
     DataDir* disk_b = nullptr;
@@ -661,47 +667,40 @@ TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_t
     ASSERT_TRUE(disk_b != nullptr);
     tablet.reset();
 
-    // Step 2: Migrate A->B. V1 goes to _shutdown_tablets, V2 becomes active on disk_b.
-    EngineStorageMigrationTask migration1(tablet_id, schema_hash, disk_b, false);
-    ASSERT_OK(migration1.execute());
+    // Step 2: Migrate A->B. Wait until clock passes rowset_time so migration1 wins.
+    wait_until_after(rowset_time);
+    ASSERT_OK(EngineStorageMigrationTask(tablet_id, schema_hash, disk_b, false).execute());
 
     tablet = tablet_manager->get_tablet(tablet_id);
     ASSERT_TRUE(tablet != nullptr);
     ASSERT_EQ(tablet->data_dir(), disk_b);
+    int64_t v2_time = tablet->updates()->max_rowset_creation_time();
     tablet.reset();
 
-    // Step 3: Run GC with a fail point so phase 1 removes V1's on-disk meta, but
-    // the shutdown queue entry for V1 remains stale in _shutdown_tablets.
-    PFailPointTriggerMode trigger_mode;
-    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
-            "start_trash_sweep_skip_shutdown_tablets_cleanup");
-    ASSERT_TRUE(fp != nullptr);
-    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
-    fp->setMode(trigger_mode);
-    DeferOp defer_disable_fp([&]() {
-        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-        fp->setMode(trigger_mode);
+    // Step 3: GC runs synchronously. A sync point callback injects migration B->A
+    // between phase 1 (sweep) and phase 2 (cleanup), reproducing the real race
+    // window where a stale V1 entry is still in _shutdown_tablets.
+    Status migration2_status;
+    SyncPoint::GetInstance()->SetCallBack("TabletManager::start_trash_sweep:1", [&](void*) {
+        wait_until_after(v2_time);
+        EngineStorageMigrationTask migration2(tablet_id, schema_hash, disk_a, false);
+        migration2_status = migration2.execute();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sync([&]() {
+        SyncPoint::GetInstance()->DisableProcessing();
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->ClearTrace();
     });
 
     ASSERT_OK(tablet_manager->start_trash_sweep());
+    ASSERT_OK(migration2_status);
 
-    TabletMeta tmp_meta;
-    ASSERT_TRUE(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &tmp_meta).is_not_found());
-
-    // Ensure the second migration gets a strictly newer rowset creation time than V2.
-    sleep(1);
-
-    // Step 4: Migrate B->A. With the fix, stale V1 is detected and skipped, so V3's
-    // metadata on disk_a is preserved instead of being wiped.
-    EngineStorageMigrationTask migration2(tablet_id, schema_hash, disk_a, false);
-    ASSERT_OK(migration2.execute());
-
+    // Step 4: Verify V3 on disk_a has its rowset metadata intact.
     tablet = tablet_manager->get_tablet(tablet_id);
     ASSERT_TRUE(tablet != nullptr);
     ASSERT_EQ(tablet->data_dir(), disk_a);
 
-    // Step 5: Verify the fixed behavior. If the old bug is present, rowset_count
-    // becomes 0 after V1 clears V3's metadata by tablet_id.
     int rowset_count = 0;
     ASSERT_OK(TabletMetaManager::rowset_iterate(disk_a, tablet_id, [&](const RowsetMetaSharedPtr&) -> bool {
         rowset_count++;
@@ -709,29 +708,24 @@ TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_t
     }));
     ASSERT_GT(rowset_count, 0);
 
-    // Step 6: Simulate restart-time loading through the normal load path:
-    // remove the in-memory tablet while keeping on-disk meta/files, then load
-    // it back from persisted meta using the same arguments as startup loading.
+    // Step 5: Verify restart-loading works — proves on-disk meta is complete.
     tablet.reset();
     ASSERT_OK(tablet_manager->drop_tablet(tablet_id, kKeepMetaAndFiles));
-    ASSERT_EQ(nullptr, tablet_manager->get_tablet(tablet_id));
 
     TabletMeta reloaded_meta;
     ASSERT_OK(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &reloaded_meta));
 
     std::string meta_binary;
     ASSERT_OK(reloaded_meta.serialize(&meta_binary));
-
     ASSERT_OK(tablet_manager->load_tablet_from_meta(disk_a, tablet_id, schema_hash, meta_binary, false, false, false,
                                                     false));
 
-    TabletSharedPtr reloaded_tablet = tablet_manager->get_tablet(tablet_id);
-    ASSERT_TRUE(reloaded_tablet != nullptr);
-    ASSERT_EQ(reloaded_tablet->data_dir(), disk_a);
-    ASSERT_TRUE(reloaded_tablet->updates() != nullptr);
-    ASSERT_EQ(2, reloaded_tablet->updates()->max_version());
+    TabletSharedPtr reloaded = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(reloaded != nullptr);
+    ASSERT_EQ(reloaded->data_dir(), disk_a);
+    ASSERT_EQ(2, reloaded->updates()->max_version());
 
-    reloaded_tablet.reset();
+    reloaded.reset();
     ASSERT_OK(tablet_manager->start_trash_sweep());
 }
 

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -20,6 +20,7 @@
 
 #include "base/failpoint/fail_point.h"
 #include "base/path/file_util.h"
+#include "base/utility/defer_op.h"
 #include "base/testutil/assert.h"
 #include "base/time/timezone_utils.h"
 #include "common/config_exec_fwd.h"
@@ -677,11 +678,12 @@ TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_t
     ASSERT_TRUE(fp != nullptr);
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     fp->setMode(trigger_mode);
+    DeferOp defer_disable_fp([&]() {
+        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        fp->setMode(trigger_mode);
+    });
 
     ASSERT_OK(tablet_manager->start_trash_sweep());
-
-    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-    fp->setMode(trigger_mode);
 
     TabletMeta tmp_meta;
     ASSERT_TRUE(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &tmp_meta).is_not_found());

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -18,6 +18,7 @@
 #include <butil/files/file_path.h>
 #include <gtest/gtest.h>
 
+#include "base/failpoint/fail_point.h"
 #include "base/path/file_util.h"
 #include "base/testutil/assert.h"
 #include "base/time/timezone_utils.h"
@@ -44,6 +45,7 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_meta_manager.h"
 #include "storage/update_manager.h"
 #include "types/time_types.h"
 #include "util/logging.h"
@@ -613,6 +615,122 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
     tablet.reset();
     EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path, false);
     ASSERT_OK(migration_task.execute());
+}
+
+// Verifies that rapid PK tablet re-migration (disk A->B->A) preserves the
+// new tablet's rowset metadata when GC leaves a stale shutdown entry behind.
+//
+// Test flow:
+//   1. Migration A->B: V1 enters _shutdown_tablets, V2 becomes active on disk_b.
+//   2. GC sweep removes V1's on-disk meta from disk_a, but a fail point keeps
+//      the stale V1 entry in _shutdown_tablets.
+//   3. Migration B->A succeeds, and the new tablet on disk_a still has its
+//      rowset metadata.
+TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_tablet_meta) {
+    int64_t tablet_id = 77777;
+    int32_t schema_hash = 7777;
+    TabletManager* tablet_manager = StorageEngine::instance()->tablet_manager();
+
+    // Clean leftovers from previous tests so the shutdown queues start empty.
+    ASSERT_OK(tablet_manager->start_trash_sweep());
+
+    // Step 1: Create PK tablet with one committed rowset so we can verify whether
+    // metadata survives the second migration.
+    TabletSharedPtr tablet = create_pk_tablet(tablet_id, schema_hash);
+    tablet->set_enable_persistent_index(false);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_OK(tablet->set_tablet_state(TABLET_RUNNING));
+    tablet->save_meta();
+
+    std::vector<int64_t> keys = {1, 2, 3, 4, 5};
+    auto rowset = create_pk_rowset(tablet, keys);
+    ASSERT_OK(tablet->rowset_commit(2, rowset));
+
+    // Ensure the first migration gets a strictly newer rowset creation time than V1.
+    sleep(1);
+
+    DataDir* disk_a = tablet->data_dir();
+    DataDir* disk_b = nullptr;
+    for (auto* store : StorageEngine::instance()->get_stores()) {
+        if (store != disk_a) {
+            disk_b = store;
+            break;
+        }
+    }
+    ASSERT_TRUE(disk_b != nullptr);
+    tablet.reset();
+
+    // Step 2: Migrate A->B. V1 goes to _shutdown_tablets, V2 becomes active on disk_b.
+    EngineStorageMigrationTask migration1(tablet_id, schema_hash, disk_b, false);
+    ASSERT_OK(migration1.execute());
+
+    tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_EQ(tablet->data_dir(), disk_b);
+    tablet.reset();
+
+    // Step 3: Run GC with a fail point so phase 1 removes V1's on-disk meta, but
+    // the shutdown queue entry for V1 remains stale in _shutdown_tablets.
+    PFailPointTriggerMode trigger_mode;
+    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
+            "start_trash_sweep_skip_shutdown_tablets_cleanup");
+    ASSERT_TRUE(fp != nullptr);
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    fp->setMode(trigger_mode);
+
+    ASSERT_OK(tablet_manager->start_trash_sweep());
+
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+
+    TabletMeta tmp_meta;
+    ASSERT_TRUE(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &tmp_meta).is_not_found());
+
+    // Ensure the second migration gets a strictly newer rowset creation time than V2.
+    sleep(1);
+
+    // Step 4: Migrate B->A. With the fix, stale V1 is detected and skipped, so V3's
+    // metadata on disk_a is preserved instead of being wiped.
+    EngineStorageMigrationTask migration2(tablet_id, schema_hash, disk_a, false);
+    ASSERT_OK(migration2.execute());
+
+    tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_EQ(tablet->data_dir(), disk_a);
+
+    // Step 5: Verify the fixed behavior. If the old bug is present, rowset_count
+    // becomes 0 after V1 clears V3's metadata by tablet_id.
+    int rowset_count = 0;
+    ASSERT_OK(TabletMetaManager::rowset_iterate(disk_a, tablet_id, [&](const RowsetMetaSharedPtr&) -> bool {
+        rowset_count++;
+        return true;
+    }));
+    ASSERT_GT(rowset_count, 0);
+
+    // Step 6: Simulate restart-time loading through the normal load path:
+    // remove the in-memory tablet while keeping on-disk meta/files, then load
+    // it back from persisted meta using the same arguments as startup loading.
+    tablet.reset();
+    ASSERT_OK(tablet_manager->drop_tablet(tablet_id, kKeepMetaAndFiles));
+    ASSERT_EQ(nullptr, tablet_manager->get_tablet(tablet_id));
+
+    TabletMeta reloaded_meta;
+    ASSERT_OK(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &reloaded_meta));
+
+    std::string meta_binary;
+    ASSERT_OK(reloaded_meta.serialize(&meta_binary));
+
+    ASSERT_OK(tablet_manager->load_tablet_from_meta(disk_a, tablet_id, schema_hash, meta_binary, false, false, false,
+                                                    false));
+
+    TabletSharedPtr reloaded_tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(reloaded_tablet != nullptr);
+    ASSERT_EQ(reloaded_tablet->data_dir(), disk_a);
+    ASSERT_TRUE(reloaded_tablet->updates() != nullptr);
+    ASSERT_EQ(2, reloaded_tablet->updates()->max_version());
+
+    reloaded_tablet.reset();
+    ASSERT_OK(tablet_manager->start_trash_sweep());
 }
 
 } // namespace starrocks

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -19,9 +19,8 @@
 #include <gtest/gtest.h>
 
 #include "base/path/file_util.h"
-#include "base/testutil/sync_point.h"
-#include "base/utility/defer_op.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
 #include "common/config_exec_fwd.h"

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -20,9 +20,9 @@
 
 #include "base/failpoint/fail_point.h"
 #include "base/path/file_util.h"
-#include "base/utility/defer_op.h"
 #include "base/testutil/assert.h"
 #include "base/time/timezone_utils.h"
+#include "base/utility/defer_op.h"
 #include "common/config_exec_fwd.h"
 #include "common/config_path_fwd.h"
 #include "common/config_rowset_fwd.h"


### PR DESCRIPTION
## Why I'm doing:

### Symptom

After BE restart, some primary-key tablets fail to load:

```text
tablet init missing rowset, tablet:8199056 #version:1 [129 129@0 129]
  #pending:0 all: active:0,1 missing:0,1
```

The tablet can still work before restart because the active tablet serves from memory.
The problem only becomes visible when RocksDB is re-read during startup.

### Scope

- Only affects **primary-key tables** in **shared-nothing mode**
- Triggered when the same tablet migrates between disks in an `A -> B -> A` pattern within a short time window

### Root cause

An `A -> B -> A` migration produces three instances of the same tablet:

- `V1`: original tablet on disk `A`
- `V2`: new tablet on disk `B` after the first migration `A -> B`
- `V3`: new tablet on disk `A` after the second migration `B -> A`

The problematic interleaving is:

```text
GC thread                                 Migration thread (B->A)
---------                                 -----------------------
start_trash_sweep()
Phase 1:
  sweep_shutdown_tablet(V1)
  -> remove V1 meta from disk A
  -> move V1 files to trash
  -> mark V1 finished

                                          write V3 meta to disk A
                                          register V3, retire V2
                                          _add_shutdown_tablet_unlocked()
                                            finds stale V1 by tablet_id
                                            _remove_tablet_meta(V1)
                                            -> clear_meta(tablet_id)
                                            -> wipes V3 rowset meta on disk A

Phase 2:
  erase finished V1 entry from _shutdown_tablets
```

The corruption happens in `TabletManager::_add_shutdown_tablet_unlocked()`.

If a previous shutdown entry with the same `tablet_id` is still present, the code
tries to remove its metadata unconditionally. For PK tablets,
`TabletUpdates::clear_meta()` deletes rowset metas by `tablet_id` without checking
`tablet_uid`. When ownership has already moved to `V3`, the stale `V1` cleanup can
wipe `V3`'s rowset metadata on disk `A`.

`save_meta()` later writes back only `TabletMetaPB`, not the rowset metas, so the
problem stays hidden until restart reloads the tablet from RocksDB.

## What I'm doing:

This PR adds a stale-entry ownership check in
`TabletManager::_add_shutdown_tablet_unlocked()`.

When a previous shutdown entry with the same `tablet_id` already exists:

1. Re-read on-disk `TabletMeta` from the old shutdown tablet's original `data_dir`.
2. If `get_tablet_meta()` returns `ok()` and the on-disk meta shows either:
   - `tablet_uid` no longer matches the old shutdown entry, or
   - `tablet_state != TABLET_SHUTDOWN`
   then treat that old shutdown entry as stale.
3. For a stale entry, skip `_remove_tablet_meta()` in this duplicate-entry path.
4. Keep the rest of the existing queue flow unchanged:
   - move the old entry from `_shutdown_tablets` to `_shutdown_tablets_redundant_map`
   - insert the new `drop_info` into `_shutdown_tablets`
   - let the normal shutdown sweep retire the stale entry later

This keeps the fix local to the destructive cleanup point and avoids changing the
normal migration flow.

### Why this is safe

- The ownership check is colocated with the destructive operation.
- The stale entry is still retired by the existing shutdown queues.
- The production change only skips eager destructive cleanup when ownership has
  already changed.
- The guard is based on ownership semantics, so it is safe to apply generically,
  although the visible corruption is on PK tablets.

### Why the guard only triggers on explicit stale evidence

This PR only skips destructive cleanup when `get_tablet_meta()` returns `ok()` and
the meta positively proves that ownership has changed:

- `tablet_uid` mismatch
- or `tablet_state != TABLET_SHUTDOWN`

`NotFound` is not treated as stale evidence, because it may simply mean GC has
already removed the old meta and does not prove that a newer tablet instance now
owns the same path.

## Test

This PR adds a deterministic regression test for the `A -> B -> A` GC race.

Test flow:

1. Create a PK tablet and commit one rowset.
2. Migrate `A -> B`.
3. Run `start_trash_sweep()` with a test-only failpoint after phase-1 cleanup, so
   the old on-disk meta is removed but the stale shutdown entry is intentionally
   kept in `_shutdown_tablets`.
4. Migrate `B -> A`.
5. Verify that rowset metadata on disk `A` is still present.
6. Drop only the in-memory tablet with `kKeepMetaAndFiles`.
7. Reload the tablet through the normal `load_tablet_from_meta()` path and verify
   the PK update state is preserved.

## What type of PR is this:

- [x] BugFix
- [ ] UT
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] 4.1
- [x] 4.0
- [x] 3.5
- [ ] 3.4