### PR TITLE
[Enhancement] Support multi-column predicate push down

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinMultiColumnPredicateDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinMultiColumnPredicateDeriver.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.google.common.collect.Sets;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.JoinHelper;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Derives multi-column predicates for inner/cross joins, using column equality mappings.
+ * (Not used for ASOF joins; see {@link JoinPredicatePushdown#equivalenceDerive}.)
+ */
+public final class JoinMultiColumnPredicateDeriver {
+
+    private static final int MAX_DERIVED_MULTI_COLUMN_PREDICATES = 16;
+
+    private JoinMultiColumnPredicateDeriver() {
+    }
+
+    /**
+     * Adds derived predicates into {@code allPredicate}.
+     */
+    public static void derive(OptExpression joinOptExpression,
+                              List<ScalarOperator> inputPredicates,
+                              Set<ScalarOperator> allPredicate) {
+        ColumnRefSet leftColumns = joinOptExpression.inputAt(0).getOutputColumns();
+        ColumnRefSet rightColumns = joinOptExpression.inputAt(1).getOutputColumns();
+        Map<ColumnRefOperator, ColumnRefOperator> leftToRight = new HashMap<>();
+        Map<ColumnRefOperator, ColumnRefOperator> rightToLeft = new HashMap<>();
+        buildJoinColumnMappings(joinOptExpression, leftToRight, rightToLeft);
+
+        if (leftToRight.isEmpty() && rightToLeft.isEmpty()) {
+            return;
+        }
+
+        int derivedCount = 0;
+        for (ScalarOperator input : inputPredicates) {
+            if (derivedCount >= MAX_DERIVED_MULTI_COLUMN_PREDICATES) {
+                break;
+            }
+            if (!Utils.canPushDownPredicate(input) || Utils.countColumnRef(input) <= 1) {
+                continue;
+            }
+
+            ColumnRefSet used = input.getUsedColumns();
+            // Correlated subquery / EXISTS rewrites often produce (join-side column) = (non-trivial expr) with
+            // columns from both join inputs. Remapping only the join-key column through equality mapping yields
+            // wrong semantics (e.g. v4 = CAST(<exists state> AS BIGINT)). Same-side col = expr can still be
+            // mapped safely (e.g. v4 = f(v5) when both keys are known on one side).
+            boolean spansBothJoinSides =
+                    !(leftColumns.containsAll(used) || rightColumns.containsAll(used));
+            if (spansBothJoinSides && isEquivalenceBetweenColumnAndNonTrivialExpr(input)) {
+                continue;
+            }
+            if (leftColumns.containsAll(used)) {
+                ScalarOperator mapped = rewritePredicateWithMapping(input, leftToRight);
+                if (mapped != null && !isTrivialSelfEquivalence(mapped)
+                        && rightColumns.containsAll(mapped.getUsedColumns())) {
+                    allPredicate.add(mapped);
+                    derivedCount++;
+                }
+            } else if (rightColumns.containsAll(used)) {
+                ScalarOperator mapped = rewritePredicateWithMapping(input, rightToLeft);
+                if (mapped != null && !isTrivialSelfEquivalence(mapped)
+                        && leftColumns.containsAll(mapped.getUsedColumns())) {
+                    allPredicate.add(mapped);
+                    derivedCount++;
+                }
+            } else {
+                ScalarOperator mappedToRight = rewritePredicateToTargetSide(input, leftToRight, rightColumns);
+                if (mappedToRight != null) {
+                    allPredicate.add(mappedToRight);
+                    derivedCount++;
+                    if (derivedCount >= MAX_DERIVED_MULTI_COLUMN_PREDICATES) {
+                        break;
+                    }
+                }
+                ScalarOperator mappedToLeft = rewritePredicateToTargetSide(input, rightToLeft, leftColumns);
+                if (mappedToLeft != null) {
+                    allPredicate.add(mappedToLeft);
+                    derivedCount++;
+                }
+            }
+        }
+    }
+
+    private static void buildJoinColumnMappings(OptExpression joinOptExpression,
+                                                Map<ColumnRefOperator, ColumnRefOperator> leftToRight,
+                                                Map<ColumnRefOperator, ColumnRefOperator> rightToLeft) {
+        Set<ColumnRefOperator> leftConflict = new HashSet<>();
+        Set<ColumnRefOperator> rightConflict = new HashSet<>();
+        Pair<List<BinaryPredicateOperator>, List<ScalarOperator>> splitOnPredicates =
+                JoinHelper.separateEqualPredicatesFromOthers(joinOptExpression);
+        List<BinaryPredicateOperator> onEqualPredicates = splitOnPredicates.first;
+        for (BinaryPredicateOperator bpo : onEqualPredicates) {
+            if (!(bpo.getChild(0) instanceof ColumnRefOperator) || !(bpo.getChild(1) instanceof ColumnRefOperator)) {
+                continue;
+            }
+            ColumnRefOperator leftCol = (ColumnRefOperator) bpo.getChild(0);
+            ColumnRefOperator rightCol = (ColumnRefOperator) bpo.getChild(1);
+            addMappingWithConflict(leftToRight, leftConflict, leftCol, rightCol);
+            addMappingWithConflict(rightToLeft, rightConflict, rightCol, leftCol);
+        }
+    }
+
+    private static void addMappingWithConflict(Map<ColumnRefOperator, ColumnRefOperator> mapping,
+                                               Set<ColumnRefOperator> conflicts,
+                                               ColumnRefOperator source,
+                                               ColumnRefOperator target) {
+        if (conflicts.contains(source)) {
+            return;
+        }
+        ColumnRefOperator old = mapping.computeIfAbsent(source, k -> target);
+        if (old.equals(target)) {
+            return;
+        }
+        mapping.remove(source);
+        conflicts.add(source);
+    }
+
+    private static ScalarOperator rewritePredicateWithMapping(ScalarOperator input,
+                                                                Map<ColumnRefOperator, ColumnRefOperator> mapping) {
+        if (mapping.isEmpty()) {
+            return null;
+        }
+        Set<ColumnRefOperator> refs = Sets.newHashSet(Utils.extractColumnRef(input));
+        if (!mapping.keySet().containsAll(refs)) {
+            return null;
+        }
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(mapping);
+        return rewriter.rewrite(input);
+    }
+
+    private static ScalarOperator rewritePredicateToTargetSide(ScalarOperator input,
+                                                               Map<ColumnRefOperator, ColumnRefOperator> mapping,
+                                                               ColumnRefSet targetColumns) {
+        if (mapping.isEmpty()) {
+            return null;
+        }
+        Set<ColumnRefOperator> refs = Sets.newHashSet(Utils.extractColumnRef(input));
+        Map<ColumnRefOperator, ColumnRefOperator> rewriteMap = new HashMap<>();
+        boolean hasRewrite = false;
+        for (ColumnRefOperator ref : refs) {
+            if (targetColumns.contains(ref.getId())) {
+                continue;
+            }
+            ColumnRefOperator mapped = mapping.get(ref);
+            if (mapped == null) {
+                return null;
+            }
+            rewriteMap.put(ref, mapped);
+            hasRewrite = true;
+        }
+        if (!hasRewrite) {
+            return null;
+        }
+        ScalarOperator mapped = new ReplaceColumnRefRewriter(rewriteMap).rewrite(input);
+        if (isTrivialSelfEquivalence(mapped)) {
+            return null;
+        }
+        return targetColumns.containsAll(mapped.getUsedColumns()) ? mapped : null;
+    }
+
+    /**
+     * Drop {@code col = col} and {@code col <=> col}. {@code BinaryType.isEqual()} is only true for {@code =},
+     * not {@code <=>}, so callers must use {@code isEquivalence()} for both.
+     */
+    private static boolean isTrivialSelfEquivalence(ScalarOperator op) {
+        if (!(op instanceof BinaryPredicateOperator)) {
+            return false;
+        }
+        BinaryPredicateOperator bpo = (BinaryPredicateOperator) op;
+        return bpo.getBinaryType().isEquivalence() && bpo.getChild(0).equals(bpo.getChild(1));
+    }
+
+    /**
+     * True for {@code col <=> expr} / {@code col = expr} where one operand is a bare column ref and the other is
+     * neither a column ref nor a constant (CAST, CASE, subquery artifacts, etc.).
+     */
+    private static boolean isEquivalenceBetweenColumnAndNonTrivialExpr(ScalarOperator input) {
+        if (!(input instanceof BinaryPredicateOperator)) {
+            return false;
+        }
+        BinaryPredicateOperator bpo = (BinaryPredicateOperator) input;
+        if (!bpo.getBinaryType().isEquivalence()) {
+            return false;
+        }
+        ScalarOperator c0 = bpo.getChild(0);
+        ScalarOperator c1 = bpo.getChild(1);
+        return oneSideColumnOtherNonTrivial(c0, c1) || oneSideColumnOtherNonTrivial(c1, c0);
+    }
+
+    private static boolean oneSideColumnOtherNonTrivial(ScalarOperator a, ScalarOperator b) {
+        if (!(a instanceof ColumnRefOperator)) {
+            return false;
+        }
+        return !(b instanceof ColumnRefOperator) && !(b instanceof ConstantOperator);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -541,6 +541,13 @@ public class JoinPredicatePushdown {
             }
         }
 
+        // For inner/cross join: derive multi-column predicates through join equal-column mappings.
+        // Example: t0.v1 = t1.v4 AND t0.v2 = t1.v5 AND (t0.v1 + t0.v2 > 2) => t1.v4 + t1.v5  > 2
+        LogicalJoinOperator join = joinOptExpression.getOp().cast();
+        if (join != null && join.isInnerOrCrossJoin()) {
+            JoinMultiColumnPredicateDeriver.derive(joinOptExpression, inputPredicates, allPredicate);
+        }
+
         if (!returnInputPredicate) {
             inputPredicates.forEach(allPredicate::remove);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -249,7 +249,10 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 LOG.warn("normalized rewritePlan: \n{}", actual);
                 LOG.warn("normalized expect: \n{}", normalizedExpect);
             }
-            Assertions.assertTrue(contained);
+            Assertions.assertTrue(contained,
+                    () -> "Plan does not contain expected substring.\n--- normalized expect ---\n"
+                            + normalizedExpect + "\n--- normalized actual plan ---\n" + actual
+                            + "\n--- raw rewritePlan ---\n" + rewritePlan);
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -295,8 +295,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=2/5")
                 .contains("     TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
-                        "     partitions=5/5");
+                        "     PREDICATES: (21: c3 >= 2000) OR (21: c3 IS NULL), 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
+                        "     partitions=2/5");
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
@@ -382,8 +382,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=2/5")
                 .contains("     TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
-                        "     partitions=5/5");
+                        "     PREDICATES: (21: c3 >= 2000) OR (21: c3 IS NULL), 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
+                        "     partitions=2/5");
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinMultiColumnPredicateDeriverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinMultiColumnPredicateDeriverTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+/**
+ * Regression tests for {@link JoinMultiColumnPredicateDeriver} (invoked from {@link JoinPredicatePushdown}).
+ */
+public class JoinMultiColumnPredicateDeriverTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testDeriveMultiColumnExpressionAcrossJoinKeys() throws Exception {
+        String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 and t0.v2 = t1.v5 where t0.v1 + t0.v2 > 2";
+        String plan = getFragmentPlan(sql);
+        // Derived predicate may sit on a SELECT above the scan (not only OlapScanNode PREDICATES).
+        PlanTestBase.assertContains(plan, "predicates: 4: v4 + 5: v5 > 2");
+    }
+
+    @Test
+    public void testDeriveMixedSidePredicateToRight() throws Exception {
+        String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 where t0.v1 + t1.v5 > 2";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertContains(plan, "predicates: 4: v4 + 5: v5 > 2");
+    }
+
+    @Test
+    public void testDeriveMixedSidePredicateToLeft() throws Exception {
+        String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 where t1.v4 + t0.v2 > 2";
+        String plan = getFragmentPlan(sql);
+        // v4 rewrites to v1; v2 stays on the left.
+        PlanTestBase.assertContains(plan, "predicates: 1: v1 + 2: v2 > 2");
+    }
+
+    @Test
+    public void testIncompleteMappingDoesNotDeriveOppositeMultiColumnPredicate() throws Exception {
+        // Only t0.v1 = t1.v4; t0.v2 has no mapping to t1, so cannot derive v4 + v5 form.
+        String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 where t0.v1 + t0.v2 > 2";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertNotContains(plan, "predicates: 4: v4 + 5: v5 > 2");
+    }
+
+    @Test
+    public void testConflictingSourceMappingDoesNotDeriveMultiColumnPredicate() throws Exception {
+        // t0.v1 maps to both t1.v4 and t1.v5: conflict drops mapping for v1, so no v4+v5 derivation.
+        String sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 and t0.v1 = t1.v5 where t0.v1 + t0.v2 > 2";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertNotContains(plan, "predicates: 4: v4 + 5: v5 > 2");
+    }
+
+    @Test
+    public void testExistOnClauseNotRemappedAsJoinKeyEqualsApplyArtifact() throws Exception {
+        String sql = "select * from t0 join t1 on t0.v1 = t1.v4 "
+                + "and t0.v1 = (exists (select v7 from t2 where t2.v8 = t1.v5))";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertFalse(
+                Pattern.compile("v4\\s*=\\s*CAST\\([^\\n]*countRows").matcher(plan).find(),
+                "must not derive v4 = CAST(...countRows...) via join mapping; got plan:\n" + plan);
+        PlanTestBase.assertContains(plan, "countRows IS NOT NULL AS BIGINT) IS NOT NULL");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2139,7 +2139,7 @@ public class JoinTest extends PlanTestBase {
     public void testEquivalenceLoopDependency() throws Exception {
         String sql = "select * from t0 join t1 on t0.v1 = t1.v4 and cast(t0.v1 as STRING) = t0.v1";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "equal join conjunct: 4: v4 = 1: v1");
+        assertContains(plan, "equal join conjunct: 1: v1 = 4: v4");
         assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: CAST(1: v1 AS VARCHAR(65533)) = CAST(1: v1 AS VARCHAR(1048576))\n" +
@@ -2159,8 +2159,9 @@ public class JoinTest extends PlanTestBase {
                 "SELECT t0.v1 from t0 join test_all_type on t0.v2 = test_all_type.t1d where t0.v1 = test_all_type.t1d";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "join op: INNER JOIN");
-        assertContains(plan, "  |  equal join conjunct: 2: v2 = 7: t1d\n"
-                + "  |  equal join conjunct: 1: v1 = 7: t1d");
+        // Order of multiple equal join conjuncts in EXPLAIN is not stable (e.g. HashSet / rewrite order).
+        assertContains(plan, "equal join conjunct: 7: t1d = 2: v2");
+        assertContains(plan, "equal join conjunct: 7: t1d = 1: v1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -110,11 +110,15 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
             String ignoreExpect = normalizeLogicalPlan(text);
             for (String actual : pattern) {
                 String ignoreActual = normalizeLogicalPlan(actual);
-                Assertions.assertTrue(ignoreExpect.contains(ignoreActual), text);
+                Assertions.assertTrue(ignoreExpect.contains(ignoreActual),
+                        () -> "Plan missing expected substring (column refs normalized):\n\""
+                                + ignoreActual + "\"\n\nNormalized plan:\n" + ignoreExpect
+                                + "\n\nRaw plan:\n" + text);
             }
-        }  else {
+        } else {
             for (String s : pattern) {
-                Assertions.assertTrue(text.contains(s), text);
+                Assertions.assertTrue(text.contains(s),
+                        () -> "Plan missing expected substring:\n\"" + s + "\"\n\nFull plan:\n" + text);
             }
         }
     }
@@ -630,8 +634,17 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
                         actualSchedulerPlan);
             }
             if (isEnumerate) {
-                Assertions.assertEquals(planCount, execPlan.getPlanCount(), "plan count mismatch");
-                checkWithIgnoreTabletList(planEnumerate.toString().trim(), pair.first.trim());
+                Assertions.assertEquals(planCount, execPlan.getPlanCount(),
+                        "plan count mismatch: expected " + planCount + ", actual " + execPlan.getPlanCount());
+                String expect = planEnumerate.toString().trim();
+                String actual = pair.first.trim();
+                try {
+                    checkWithIgnoreTabletList(expect, actual);
+                } catch (AssertionError e) {
+                    System.err.println("--- expected [plan-" + nth + "] ---\n" + expect);
+                    System.err.println("--- actual [plan-" + nth + "] ---\n" + actual);
+                    throw e;
+                }
                 connectContext.getSessionVariable().setUseNthExecPlan(0);
             }
         } catch (Error error) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1252,7 +1252,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "from (select JSON_OBJECT('p1', t0.v1, 'p2', js0.v1, 'p3', 3) as v3, js0.j1 as v4 " +
                 "      from t0 left join js0 on js0.v1 = t0.v2 where cast(js0.j1 -> 'v4' as int) + t0.v2 > 1) x";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  4:HASH JOIN\n" +
+        assertContains(plan, "  5:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [3: v1, BIGINT, true] = [2: v2, BIGINT, true]\n" +
                 "  |  other join predicates: " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RangeExtractTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RangeExtractTest.java
@@ -112,8 +112,11 @@ public class RangeExtractTest extends PlanTestBase {
         String sql =
                 "select t0.* from t0 inner join t1 on v1 = v4 and ((v1 = 1 and abs(v4) > 2) or (v1 = 3 and abs(v4) = 8))";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("PREDICATES: 1: v1 IN (1, 3), abs(1: v1) > 2\n"));
-        Assertions.assertTrue(plan.contains("PREDICATES: abs(4: v4) > 2, 4: v4 IN (1, 3)\n"));
+        // Comma-separated scan predicates may be reordered after range extract / normalization.
+        PlanTestNoneDBBase.assertContains(plan, "1: v1 IN (1, 3)");
+        PlanTestNoneDBBase.assertContains(plan, "abs(1: v1) > 2");
+        PlanTestNoneDBBase.assertContains(plan, "abs(4: v4) > 2");
+        PlanTestNoneDBBase.assertContains(plan, "4: v4 IN (1, 3)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -387,8 +387,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/merge_group_delete_best_expression"), null,
                         TExplainLevel.NORMAL);
-        // check without exception
-        Assertions.assertTrue(replayPair.second.contains("14:HASH JOIN\n" +
+        // check without exception (operator id updated when plan shape shifts, e.g. 14 -> 13)
+        Assertions.assertTrue(replayPair.second.contains("13:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)"), replayPair.second);
     }
 

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -10,80 +10,54 @@ where
     and ps_partkey = l_partkey
     and p_name like '%peru%';
 [planCount]
-6
+4
 [plan-1]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
     EXCHANGE GATHER
         INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-            CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                EXCHANGE BROADCAST
-                    SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-            EXCHANGE BROADCAST
-                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
-[end]
-[plan-2]
-AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
-    EXCHANGE GATHER
-        INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-            CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
+            INNER JOIN (join-predicate [39: cast = 38: cast] post-join-predicate [null])
+                SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[cast(11: PS_PARTKEY as bigint(20)) IS NOT NULL])
                 EXCHANGE BROADCAST
                     SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
             EXCHANGE SHUFFLE[18]
                 EXCHANGE SHUFFLE[37, 19, 18]
                     SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
-[plan-3]
+[plan-2]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-            SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
+        INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY AND 39: cast = 38: cast] post-join-predicate [null])
+            SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[cast(11: PS_PARTKEY as bigint(20)) IS NOT NULL])
             EXCHANGE SHUFFLE[18]
-                EXCHANGE SHUFFLE[19, 18]
-                    INNER JOIN (join-predicate [36: cast = 37: cast] post-join-predicate [null])
-                        EXCHANGE SHUFFLE[36]
+                EXCHANGE SHUFFLE[19, 18, 38]
+                    INNER JOIN (join-predicate [37: cast = 36: cast] post-join-predicate [null])
+                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+                        EXCHANGE BROADCAST
                             SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                        EXCHANGE SHUFFLE[37]
-                            SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+[end]
+[plan-3]
+AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
+    EXCHANGE GATHER
+        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
+            INNER JOIN (join-predicate [37: cast = 36: cast AND 19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
+                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+                EXCHANGE BROADCAST
+                    INNER JOIN (join-predicate [38: cast = 39: cast] post-join-predicate [null])
+                        EXCHANGE SHUFFLE[38]
+                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+                        EXCHANGE SHUFFLE[39]
+                            SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[cast(11: PS_PARTKEY as bigint(20)) IS NOT NULL])
 [end]
 [plan-4]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
-            INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-                CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                    SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                    EXCHANGE BROADCAST
-                        SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
+            INNER JOIN (join-predicate [37: cast = 36: cast AND 19: L_SUPPKEY = 12: PS_SUPPKEY AND 18: L_PARTKEY = 11: PS_PARTKEY] post-join-predicate [null])
+                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
                 EXCHANGE BROADCAST
-                    SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
+                    INNER JOIN (join-predicate [39: cast = 38: cast] post-join-predicate [null])
+                        EXCHANGE SHUFFLE[39]
+                            SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[cast(11: PS_PARTKEY as bigint(20)) IS NOT NULL])
+                        EXCHANGE SHUFFLE[38]
+                            SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
 [end]
-[plan-5]
-AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
-    EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
-            INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-                CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                    SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                    EXCHANGE BROADCAST
-                        SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                EXCHANGE SHUFFLE[18]
-                    EXCHANGE SHUFFLE[37, 19, 18]
-                        SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
-[end]
-[plan-6]
-AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
-    EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
-            INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
-                SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
-                EXCHANGE SHUFFLE[18]
-                    EXCHANGE SHUFFLE[19, 18]
-                        INNER JOIN (join-predicate [36: cast = 37: cast] post-join-predicate [null])
-                            EXCHANGE SHUFFLE[36]
-                                SCAN (columns[1: P_PARTKEY, 2: P_NAME] predicate[2: P_NAME LIKE %peru%])
-                            EXCHANGE SHUFFLE[37]
-                                SCAN (columns[18: L_PARTKEY, 19: L_SUPPKEY, 21: L_QUANTITY, 22: L_EXTENDEDPRICE, 23: L_DISCOUNT] predicate[cast(18: L_PARTKEY as bigint(20)) IS NOT NULL])
-[end]
-

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-disable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-disable_on_broadcast_join.sql
@@ -463,17 +463,17 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
                         EXCHANGE SHUFFLE[2]
-                            SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                            SCAN (columns[2: v2] predicate[add(2: v2, 2: v2) = 1])
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
                         EXCHANGE SHUFFLE[5]
-                            SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                            SCAN (columns[5: v5] predicate[add(5: v5, 5: v5) = 1])
             EXCHANGE BROADCAST
                 UNION
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        SCAN (columns[11: v5] predicate[add(11: v5, 11: v5) = 1])
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        SCAN (columns[14: v8] predicate[add(14: v8, 14: v8) = 1])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
@@ -463,17 +463,17 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([GLOBAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
                         EXCHANGE SHUFFLE[2]
-                            SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                            SCAN (columns[2: v2] predicate[add(2: v2, 2: v2) = 1])
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
                         EXCHANGE SHUFFLE[5]
-                            SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                            SCAN (columns[5: v5] predicate[add(5: v5, 5: v5) = 1])
             EXCHANGE BROADCAST
                 UNION
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        SCAN (columns[11: v5] predicate[add(11: v5, 11: v5) = 1])
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        SCAN (columns[14: v8] predicate[add(14: v8, 14: v8) = 1])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-disable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-disable_on_broadcast_join.sql
@@ -292,16 +292,16 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
             UNION
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                        SCAN (columns[2: v2] predicate[add(2: v2, 2: v2) = 1])
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                        SCAN (columns[5: v5] predicate[add(5: v5, 5: v5) = 1])
             EXCHANGE BROADCAST
                 UNION
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        SCAN (columns[11: v5] predicate[add(11: v5, 11: v5) = 1])
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        SCAN (columns[14: v8] predicate[add(14: v8, 14: v8) = 1])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-enable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown-enable_on_broadcast_join.sql
@@ -292,16 +292,16 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having
             UNION
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
-                        SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                        SCAN (columns[2: v2] predicate[add(2: v2, 2: v2) = 1])
                 EXCHANGE ROUND_ROBIN
                     AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
-                        SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+                        SCAN (columns[5: v5] predicate[add(5: v5, 5: v5) = 1])
             EXCHANGE BROADCAST
                 UNION
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                        SCAN (columns[11: v5] predicate[add(11: v5, 11: v5) = 1])
                     EXCHANGE ROUND_ROBIN
-                        SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+                        SCAN (columns[14: v8] predicate[add(14: v8, 14: v8) = 1])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
@@ -88,9 +88,9 @@ INNER JOIN (join-predicate [3: v3 = 4: v4] post-join-predicate [null])
 select v1 from t0 inner join t1 on v3 = v4 where (v2 = 2 or v2 = 3) and (v3 = 3 or v4 = 4);
 [result]
 INNER JOIN (join-predicate [3: v3 = 4: v4 AND 3: v3 = 3 OR 4: v4 = 4] post-join-predicate [null])
-    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[2: v2 IN (2, 3)])
+    SCAN (columns[1: v1, 2: v2, 3: v3] predicate[3: v3 IN (3, 4) AND 2: v2 IN (2, 3)])
     EXCHANGE BROADCAST
-        SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+        SCAN (columns[4: v4] predicate[4: v4 IN (3, 4)])
 [end]
 
 [sql]


### PR DESCRIPTION
## Why I'm doing:
The join query optimizer currently supports predicate pushdown only for single-column conditions. Multi-column compound predicates (e.g. t1.a + t1.b > 2) cannot yet be derived and pushed down.

## What I'm doing:
- Support  multi‑column predicate pushdown for join (inner join/cross join)


SQL TEST：
```
EXPLAIN
SELECT *
FROM t1_multi_eq t1
JOIN t2_multi_eq t2
on t1.a = t2.x AND t1.b = t2.y 
where t1.a + t1.b > 2;
```

Result without multi‑column predicate pushdown support
<img width="524" height="669" alt="WechatIMG250" src="https://github.com/user-attachments/assets/4d757d7a-32b4-425a-916a-a43befb3516a" />

Result with multi‑column predicate pushdown support
<img width="522" height="712" alt="WechatIMG249" src="https://github.com/user-attachments/assets/ab8a0b7d-c268-4971-b126-15c16e8ef024" />




Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
