### PR TITLE
[Enhancement] Support schema evoluation for widening varchar length with key/non-key column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -132,6 +132,7 @@ import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TWriteQuorumType;
 import com.starrocks.type.ArrayType;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
@@ -147,6 +148,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -672,27 +674,43 @@ public class SchemaChangeHandler extends AlterHandler {
 
     // User can modify column type and column position
     private boolean processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
-                                        Map<Long, LinkedList<Column>> indexMetaIdToSchema) throws DdlException {
+                                        Map<Long, LinkedList<Column>> indexMetaIdToSchema,
+                                        Map<Long, Set<String>> alterIndexMetaIdToIncrVarcharLenColNames)
+            throws DdlException {
         // The fast schema evolution mechanism is only supported for modified columns in shared data mode.
+        // But fast schema evolution for widening varchar length can be performed in both shared data and share nothing.
         boolean fastSchemaEvolution = RunMode.isSharedDataMode() && olapTable.getUseFastSchemaEvolution();
         Column modColumn = buildColumnForModify(alterClause.getColumnDef(), olapTable);
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
-            if (olapTable.getBaseColumn(modColumn.getName()) != null && olapTable.getBaseColumn(modColumn.getName()).isKey()) {
-                throw new DdlException("Can not modify key column: " + modColumn.getName() + " for primary key table");
+            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
+            if (baseColumn != null) {
+                modColumn.setAggregationType(baseColumn.getAggregationType(), baseColumn.isAggregationTypeImplicit());
+                if (baseColumn.isKey()) {
+                    // backward compatibility: if user does not specify key attribute in modify column clause for pk table,
+                    // we will keep it as a key column which is the same as before.
+                    modColumn.setIsKey(baseColumn.isKey());
+                    if (!isVarcharLengthIncrease(baseColumn, modColumn)) {
+                        throw new DdlException(
+                            "Can not modify key column: " + modColumn.getName() +
+                                " for primary key table except for increasing varchar length");
+                    }
+                    if (modColumn.isAllowNull()) {
+                        throw new DdlException("primary key column[" + modColumn.getName() + "] cannot be nullable");
+                    }
+                }
             }
+
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
             if (indexMeta.getSortKeyIdxes() != null) {
                 for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                     if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
-                        throw new DdlException("Can not modify sort column in primary data model table");
+                        if (!isVarcharLengthIncrease(indexMeta.getSchema().get(sortKeyIdx), modColumn)) {
+                            throw new DdlException(
+                                "Can not modify sort column in primary data model table except for increasing varchar length");
+                        }
                     }
                 }
             }
-            if (modColumn.getAggregationType() != null && modColumn.getAggregationType() != AggregateType.REPLACE) {
-                throw new DdlException("Can not assign aggregation method on column in Primary data model table: " +
-                        modColumn.getName());
-            }
-            modColumn.setAggregationType(AggregateType.REPLACE, true);
         } else if (KeysType.AGG_KEYS == olapTable.getKeysType()) {
             if (modColumn.isKey() && null != modColumn.getAggregationType()) {
                 throw new DdlException("Can not assign aggregation method on key column: " + modColumn.getName());
@@ -846,12 +864,12 @@ public class SchemaChangeHandler extends AlterHandler {
 
         List<Column> otherIndexModifiedColumn = new ArrayList<>();
         // check if column being mod
+        List<Long> otherIndexMetaIds = new ArrayList<>();
         if (!modColumn.equals(oriColumn)) {
             // column is mod. we have to mod this column in all indices
 
             // handle other indices
             // 1 find other indices which contain this column
-            List<Long> otherIndexMetaIds = new ArrayList<>();
             for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexMetaIdToSchema().entrySet()) {
                 if (entry.getKey() == indexMetaIdForFindingColumn) {
                     // skip the index we used to find column. it has been handled before
@@ -926,6 +944,52 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } // end for handling other indices
 
+        boolean isVarcharLengthIncrease = isVarcharLengthIncrease(oriColumn, modColumn);
+        boolean isOnlyDifferentFromColumnType =
+                hasOnlyTypeChangeForVarcharLengthFastPath(oriColumn, modColumn);
+        boolean keyOrderChanged = false;
+        if (modColumn.isKey() && oriColumn.isKey()) {
+            List<String> oldKeyColumns =
+                    olapTable.getBaseSchema().stream().
+                        filter(Column::isKey).map(Column::getName).collect(Collectors.toList());
+            List<String> newKeyColumns =
+                    schemaForFinding.stream().filter(Column::isKey).
+                        map(c -> Column.removeNamePrefix(c.getName())).collect(Collectors.toList());
+            keyOrderChanged = !oldKeyColumns.equals(newKeyColumns);
+        } // sort key need not be considered here, because modify column can not change the order of sort key
+
+        alterIndexMetaIdToIncrVarcharLenColNames.putIfAbsent(indexMetaIdForFindingColumn, Sets.newHashSet());
+        for (long otherIndexMetaId : otherIndexMetaIds) {
+            alterIndexMetaIdToIncrVarcharLenColNames.putIfAbsent(otherIndexMetaId, Sets.newHashSet());
+        }
+        if (isOnlyDifferentFromColumnType && isVarcharLengthIncrease) {
+            alterIndexMetaIdToIncrVarcharLenColNames.get(indexMetaIdForFindingColumn).add(
+                    Column.removeNamePrefix(modColumn.getName()));
+            for (long otherIndexMetaId : otherIndexMetaIds) {
+                alterIndexMetaIdToIncrVarcharLenColNames.get(otherIndexMetaId).add(
+                        Column.removeNamePrefix(modColumn.getName()));
+            }
+            // This specified modify column can be perform by fast path for share nothing mode
+            if ((fastSchemaEvolution || (!RunMode.isSharedDataMode() && olapTable.getUseFastSchemaEvolution())) &&
+                    !keyOrderChanged) {
+                // In this special case, we can use fast schema evolution bypassing the key and index check.
+                return true;
+            }
+        } else {
+            alterIndexMetaIdToIncrVarcharLenColNames.get(indexMetaIdForFindingColumn).remove(
+                    Column.removeNamePrefix(modColumn.getName()));
+            for (long otherIndexMetaId : otherIndexMetaIds) {
+                alterIndexMetaIdToIncrVarcharLenColNames.get(otherIndexMetaId).remove(
+                        Column.removeNamePrefix(modColumn.getName()));
+            }
+        }
+
+        if (keyOrderChanged && KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
+            // exception for pk order change
+            throw new DdlException("Can not reorder pk keys by modify column");
+        } // non pk key order change will be charged by other rule, not throw exception here
+        // which is meet the previous behavior
+
         // fast schema evolution supports the conversion of scalar types to decimal types, but does not support the conversion
         // of decimal types to other scale types, due to the fact that the precision and scale of the decimal are not recorded
         // in the segment file
@@ -942,6 +1006,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
+        // Not need for widen varchar length
         if (!SchemaChangeTypeCompatibility.canReuseZonemapIndex(oriColumn.getType(), modColumn.getType())) {
             return false;
         }
@@ -950,6 +1015,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // 1. The index can be reused after type conversion, and BE has made necessary changes,
         //    such as casting new type values to old type values before querying the index.
         // 2. The index cannot be reused, and BE has made changes to skip it during queries.
+        // 3. Not need for widen varchar length
         // Currently, BLOOMFILTER and NGRAMBF indexes use rule 2 to support fast schema evolution. BE-side changes
         // for other indexes are not yet ready, so fast schema change is temporarily disabled for them. This feature
         // will be gradually enabled for these indexes once BE support is in place.
@@ -1420,7 +1486,9 @@ public class SchemaChangeHandler extends AlterHandler {
                                           Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                           Map<String, String> propertyMap,
                                           List<Index> indexes,
-                                          Set<String> modifyFieldColumns) throws StarRocksException {
+                                          Set<String> modifyFieldColumns,
+                                          Map<Long, Set<String>> alterIndexMetaIdToIncrVarcharLenColNames)
+                throws StarRocksException {
         if (olapTable.getState() == OlapTableState.ROLLUP) {
             throw new DdlException("Table[" + olapTable.getName() + "]'s is doing ROLLUP job");
         }
@@ -1655,13 +1723,16 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // 3. check partition key
-            checkPartitionColumnChange(olapTable, alterSchema, alterIndexMetaId);
+            checkPartitionColumnChange(olapTable, alterSchema, alterIndexMetaId,
+                                       alterIndexMetaIdToIncrVarcharLenColNames.get(alterIndexMetaId));
 
             // 4. check distribution key:
-            checkDistributionColumnChange(olapTable, alterSchema, alterIndexMetaId);
+            checkDistributionColumnChange(olapTable, alterSchema, alterIndexMetaId,
+                                          alterIndexMetaIdToIncrVarcharLenColNames.get(alterIndexMetaId));
 
             // 5. calc short key
-            calculateShortKey(olapTable, alterIndexMetaId, alterSchema, indexIdToProperties.get(alterIndexMetaId), dataBuilder);
+            calculateShortKey(olapTable, alterIndexMetaId, alterSchema, indexIdToProperties.get(alterIndexMetaId), dataBuilder,
+                              alterIndexMetaIdToIncrVarcharLenColNames.get(alterIndexMetaId));
 
             // 6. check the uniqueness of column unique id
             if (olapTable.getMaxColUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
@@ -1683,7 +1754,8 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void calculateShortKey(OlapTable olapTable, long alterIndexMetaId, List<Column> alterSchema,
-               Map<String, String> indexProperties, SchemaChangeData.Builder dataBuilder) throws DdlException {
+               Map<String, String> indexProperties, SchemaChangeData.Builder dataBuilder,
+               Set<String> incrVarcharLenColNames) throws DdlException {
         List<Integer> sortKeyIdxes = new ArrayList<>();
         List<Integer> sortKeyUniqueIds = new ArrayList<>();
         MaterializedIndexMeta index = olapTable.getIndexMetaByMetaId(alterIndexMetaId);
@@ -1727,7 +1799,8 @@ public class SchemaChangeHandler extends AlterHandler {
             for (int i = 0; i < newShortKeyCount; i++) {
                 newShortKeyColumns.add(alterSchema.get(sortKeyIdxes.get(i)));
             }
-            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
+            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns,
+                                                          incrVarcharLenColNames);
             dataBuilder.withNewIndexMetaIdToShortKeyCount(alterIndexMetaId,
                     newShortKeyCount, isShortKeyChanged).withNewIndexMetaIdToSchema(alterIndexMetaId, alterSchema);
             dataBuilder.withSortKeyIdxes(sortKeyIdxes);
@@ -1744,7 +1817,8 @@ public class SchemaChangeHandler extends AlterHandler {
             for (int i = 0; i < newShortKeyCount; i++) {
                 newShortKeyColumns.add(alterSchema.get(i));
             }
-            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
+            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns,
+                                                          incrVarcharLenColNames);
             dataBuilder.withNewIndexMetaIdToShortKeyCount(alterIndexMetaId,
                     newShortKeyCount, isShortKeyChanged).withNewIndexMetaIdToSchema(alterIndexMetaId, alterSchema);
         }
@@ -1775,15 +1849,21 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
-    private boolean isShortKeyChanged(List<Column> originShortKeyColumns, List<Column> newShortKeyColumns) {
+    private boolean isShortKeyChanged(List<Column> originShortKeyColumns, List<Column> newShortKeyColumns,
+                                      Set<String> incrVarcharLenColNames) {
         if (originShortKeyColumns.size() != newShortKeyColumns.size()) {
             return true;
         }
         for (int i = 0; i < originShortKeyColumns.size(); i++) {
             Column originColumn = originShortKeyColumns.get(i);
             Column newColumn = newShortKeyColumns.get(i);
+            if (originColumn.getName().equalsIgnoreCase(Column.removeNamePrefix(newColumn.getName())) &&
+                    incrVarcharLenColNames != null && incrVarcharLenColNames.contains(
+                        Column.removeNamePrefix(originColumn.getName()))) {
+                continue;
+            }
             if (!originColumn.getName().equalsIgnoreCase(newColumn.getName())
-                    || !originColumn.getType().equals(newColumn.getType())) {
+                    || (!originColumn.getType().equals(newColumn.getType()))) {
                 return true;
             }
         }
@@ -1826,7 +1906,8 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
-    private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId)
+    private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId,
+                                            Set<String> incrVarcharLenColNames)
             throws DdlException {
         // Since partition key and distribution key's schema change can only happen in base index,
         // only check it in base index.There may be some trivial changes between base index and other
@@ -1838,11 +1919,15 @@ public class SchemaChangeHandler extends AlterHandler {
         List<Column> partitionColumns = olapTable.getPartitionInfo().getPartitionColumns(olapTable.getIdToColumn());
         for (Column partitionCol : partitionColumns) {
             String colName = partitionCol.getName();
+            String normalizedColName = Column.removeNamePrefix(colName);
             Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
             // NOTE: partition column in partition info maybe changed(eg: str2date partition table), use original
             // table schema instead.
             Column refPartitionCol = olapTable.getColumn(partitionCol.getName());
             if (col.isPresent() && !col.get().equals(refPartitionCol)) {
+                if (incrVarcharLenColNames != null && incrVarcharLenColNames.contains(normalizedColName)) {
+                    continue;
+                }
                 throw new DdlException("Can not modify partition column[" + colName + "]. index["
                         + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
@@ -1856,7 +1941,8 @@ public class SchemaChangeHandler extends AlterHandler {
         } // end for partitionColumns
     }
 
-    private void checkDistributionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId)
+    private void checkDistributionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId,
+                                               Set<String> incrVarcharLenColNames)
             throws DdlException {
         // Since partition key and distribution key's schema change can only happen in base index,
         // only check it in base index.There may be some trivial changes between base index and other
@@ -1869,8 +1955,17 @@ public class SchemaChangeHandler extends AlterHandler {
                 olapTable, olapTable.getDefaultDistributionInfo().getDistributionColumns());
         for (Column distributionCol : distributionColumns) {
             String colName = distributionCol.getName();
+            String normalizedColName = Column.removeNamePrefix(colName);
             Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
             if (col.isPresent() && !col.get().equals(distributionCol)) {
+                if (incrVarcharLenColNames != null && incrVarcharLenColNames.contains(normalizedColName)) {
+                    if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(olapTable.getId())) {
+                        throw new DdlException("Can not modify distribution column[" + colName
+                                + "] for colocate table. index["
+                                + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
+                    }
+                    continue;
+                }
                 throw new DdlException("Can not modify distribution column[" + colName + "]. index["
                         + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
@@ -2015,6 +2110,7 @@ public class SchemaChangeHandler extends AlterHandler {
         List<Index> newIndexes = olapTable.getCopiedIndexes();
         Map<String, String> propertyMap = new HashMap<>();
         Set<String> modifyFieldColumns = new HashSet<>();
+        Map<Long, Set<String>> alterIndexMetaIdToIncrVarcharLenColNames = new HashMap<>();
         // NOTE: be very careful with the order of processing alter clauses and early return!!!
         // It is in a for-loop!
         for (AlterClause alterClause : alterClauses) {
@@ -2066,7 +2162,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
 
                 // modify column
-                fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexMetaIdToSchema);
+                fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexMetaIdToSchema,
+                                                           alterIndexMetaIdToIncrVarcharLenColNames);
             } else if (alterClause instanceof ModifyColumnCommentClause) {
                 // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
                 if (alterClauses.size() > 1) {
@@ -2145,7 +2242,7 @@ public class SchemaChangeHandler extends AlterHandler {
         } // end for alter clauses
 
         SchemaChangeData schemaChangeData = finalAnalyze(db, olapTable, indexMetaIdToSchema, propertyMap, newIndexes,
-                modifyFieldColumns);
+                modifyFieldColumns, alterIndexMetaIdToIncrVarcharLenColNames);
         if (schemaChangeData.isShortKeyChanged()) {
             fastSchemaEvolution = false;
         }
@@ -3126,6 +3223,31 @@ public class SchemaChangeHandler extends AlterHandler {
                             newSortKeyIdxes, newSortKeyUniqueIds);
                 }
 
+                if (newSortKeyIdxes.isEmpty() && currentIndexMeta.getSortKeyIdxes() != null) {
+                    // If the old table metadata does not contain sort key unique ids, fall back to sort key indexes.
+                    // In this case, a schema-only reorder still needs to rebuild sort key indexes for the new schema.
+                    List<Column> oldIndexSchema = currentIndexMeta.getSchema();
+                    boolean useFallbackSortKeyUniqueId = true;
+                    for (Integer oldSortKeyIdx : currentIndexMeta.getSortKeyIdxes()) {
+                        Column oldSortKeyColumn = oldIndexSchema.get(oldSortKeyIdx);
+                        Optional<Column> newSortKeyColumn = indexSchema.stream()
+                                .filter(c -> c.nameEquals(oldSortKeyColumn.getName(), true))
+                                .findFirst();
+                        Preconditions.checkState(newSortKeyColumn.isPresent(),
+                                "Sort key column %s not found in new schema", oldSortKeyColumn.getName());
+                        Column col = newSortKeyColumn.get();
+                        newSortKeyIdxes.add(indexSchema.indexOf(col));
+                        if (useFallbackSortKeyUniqueId && col.getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+                            newSortKeyUniqueIds.add(col.getUniqueId());
+                        } else {
+                            useFallbackSortKeyUniqueId = false;
+                            newSortKeyUniqueIds = null;
+                        }
+                    }
+                    appendNewKeyColumnsToSortKey(olapTable.getKeysType(), indexSchema,
+                            newSortKeyIdxes, useFallbackSortKeyUniqueId ? newSortKeyUniqueIds : null);
+                }
+
                 currentIndexMeta.setSchema(indexSchema);
                 if (!newSortKeyIdxes.isEmpty()) {
                     currentIndexMeta.setSortKeyIdxes(newSortKeyIdxes);
@@ -3380,5 +3502,25 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         return Optional.empty();
+    }
+
+    private static boolean isVarcharLengthIncrease(Column oriColumn, Column modColumn) {
+        return oriColumn.getPrimitiveType() == PrimitiveType.VARCHAR
+                && modColumn.getPrimitiveType() == PrimitiveType.VARCHAR
+                && modColumn.getStrLen() > oriColumn.getStrLen();
+    }
+
+    private static boolean hasOnlyTypeChangeForVarcharLengthFastPath(Column oriColumn, Column modColumn) {
+        if (oriColumn.isGeneratedColumn() || modColumn.isGeneratedColumn()) {
+            return false;
+        }
+
+        return oriColumn.nameEquals(modColumn.getName(), true)
+                && oriColumn.getAggregationType() == modColumn.getAggregationType()
+                && Objects.equals(oriColumn.getAggStateDesc(), modColumn.getAggStateDesc())
+                && oriColumn.isAggregationTypeImplicit() == modColumn.isAggregationTypeImplicit()
+                && oriColumn.isKey() == modColumn.isKey()
+                && oriColumn.isAllowNull() == modColumn.isAllowNull()
+                && oriColumn.isHidden() == modColumn.isHidden();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -992,7 +992,21 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
         }
         try {
             if (table.isOlapOrCloudNativeTable() && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS) {
-                columnDef.setAggregateType(AggregateType.REPLACE);
+                Column baseColumn = ((OlapTable) table).getBaseColumn(columnDef.getName());
+                if (baseColumn != null) {
+                    if (baseColumn.isKey()) {
+                        // Keep MODIFY COLUMN semantics aligned with CREATE TABLE: existing PK columns
+                        // are analyzed as key + implicit NOT NULL even if the clause omits these attributes.
+                        columnDef.setIsKey(true);
+                        columnDef.setPrimaryKeyNonNullable();
+                        if (columnDef.isAllowNull()) {
+                            throw new SemanticException("primary key column[" + columnDef.getName()
+                                    + "] cannot be nullable");
+                        }
+                    } else {
+                        columnDef.setAggregateType(AggregateType.REPLACE);
+                    }
+                }
             }
             ColumnDefAnalyzer.analyze(columnDef, true);
         } catch (AnalysisException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -258,6 +258,9 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
                         // so we choose to disable min/max rewrite to make sure correctness
                         // fast schema evolution don't support changing column type in shared-nothing mode,
                         // we only need to disable it in shared-data mode
+                        // But there is one case that share nothing can perform fast schema evolution:
+                        // widen varchar length, but such modification will not change the type in BE side
+                        // so it is safe for this rewrite rule.
                         if (RunMode.isSharedDataMode() && hasSchemaChange) {
                             return false;
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableVarcharWidenSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableVarcharWidenSchemaChangeTest.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.common.Config;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.type.PrimitiveType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class LakeTableVarcharWidenSchemaChangeTest extends LakeFastSchemaChangeTestBase {
+    private static final AtomicInteger TABLE_SUFFIX = new AtomicInteger(0);
+    private boolean originalEnableFastSchemaEvolutionInSharedDataMode;
+
+    @Override
+    protected boolean isFastSchemaEvolutionV2() {
+        return false;
+    }
+
+    @BeforeEach
+    public void beforeEachTest() {
+        connectContext.setThreadLocalInfo();
+        connectContext.setDatabase(DB_NAME);
+        originalEnableFastSchemaEvolutionInSharedDataMode = Config.enable_fast_schema_evolution_in_share_data_mode;
+        Config.enable_fast_schema_evolution_in_share_data_mode = true;
+        GlobalStateMgr.getCurrentState().getSchemaChangeHandler().clearJobs();
+    }
+
+    @AfterEach
+    public void afterEachTest() {
+        Config.enable_fast_schema_evolution_in_share_data_mode = originalEnableFastSchemaEvolutionInSharedDataMode;
+        GlobalStateMgr.getCurrentState().getSchemaChangeHandler().clearJobs();
+    }
+
+    @Test
+    public void testDistributionColumnFinalWidenCreatesAsyncFastSchemaChangeJob() throws Exception {
+        LakeTable table = createDistributionTable(uniqueName("t_dist_fast"));
+
+        AlterJobV2 job = executeAlterAndWaitFinish(table,
+                "ALTER TABLE " + table.getName() + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                true);
+
+        Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, job);
+        assertColumnType(table, table.getName(), "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(table, table.getName(), "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testDistributionColumnFinalNonWidenRejectedInSharedData() throws Exception {
+        LakeTable table = createDistributionTable(uniqueName("t_dist_reject"));
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> alterTable(connectContext,
+                        "ALTER TABLE " + table.getName() + " MODIFY COLUMN k1 INT KEY NOT NULL"));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not modify distribution column[k1]"),
+                exception.getMessage());
+        assertColumnType(table, table.getName(), "k1", PrimitiveType.VARCHAR, 10);
+        Assertions.assertTrue(
+                GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                        .getUnfinishedAlterJobV2ByTableId(table.getId()).isEmpty());
+    }
+
+    @Test
+    public void testKeyColumnNonWidenFallsBackToSchemaChangeJobInSharedData() throws Exception {
+        LakeTable table = createKeyColumnTable(uniqueName("t_key_job"));
+
+        AlterJobV2 job = executeAlterAndWaitFinish(table,
+                "ALTER TABLE " + table.getName() + " MODIFY COLUMN k1 INT KEY NOT NULL",
+                false);
+
+        Assertions.assertInstanceOf(LakeTableSchemaChangeJob.class, job);
+        assertColumnType(table, table.getName(), "k1", PrimitiveType.INT, 0);
+        assertIndexColumns(table, table.getName(), "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testBaseClauseRollupColumnWidenCreatesAsyncFastSchemaChangeJob() throws Exception {
+        LakeTable table = createRollupTable(uniqueName("t_rollup_fast"));
+
+        AlterJobV2 job = executeAlterAndWaitFinish(table,
+                "ALTER TABLE " + table.getName() + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                true);
+
+        Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, job);
+        assertColumnType(table, table.getName(), "k1", PrimitiveType.VARCHAR, 30);
+        assertColumnType(table, "r1", "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(table, "r1", "k2", "k1");
+    }
+
+    private static String uniqueName(String prefix) {
+        return prefix + "_" + TABLE_SUFFIX.incrementAndGet();
+    }
+
+    private LakeTable createDistributionTable(String tableName) throws Exception {
+        return createTable(connectContext, "CREATE TABLE " + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES('replication_num'='1', 'cloud_native_fast_schema_evolution_v2'='false');");
+    }
+
+    private LakeTable createKeyColumnTable(String tableName) throws Exception {
+        return createTable(connectContext, "CREATE TABLE " + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k2) BUCKETS 1\n"
+                + "PROPERTIES('replication_num'='1', 'cloud_native_fast_schema_evolution_v2'='false');");
+    }
+
+    private LakeTable createRollupTable(String tableName) throws Exception {
+        return createTable(connectContext, "CREATE TABLE " + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "ROLLUP(\n"
+                + "  r1(k2, k1)\n"
+                + ")\n"
+                + "PROPERTIES('replication_num'='1', 'cloud_native_fast_schema_evolution_v2'='false');");
+    }
+
+    private void assertColumnType(LakeTable table, String indexName, String columnName,
+                                  PrimitiveType primitiveType, int expectedLength) {
+        Column column = getColumn(table, indexName, columnName);
+        Assertions.assertEquals(primitiveType, column.getPrimitiveType());
+        if (primitiveType == PrimitiveType.VARCHAR) {
+            Assertions.assertEquals(expectedLength, column.getStrLen());
+        }
+    }
+
+    private Column getColumn(LakeTable table, String indexName, String columnName) {
+        Long indexMetaId = table.getIndexMetaIdByName(indexName);
+        Assertions.assertNotNull(indexMetaId, indexName);
+        return table.getSchemaByIndexMetaId(indexMetaId).stream()
+                .filter(column -> column.getName().equalsIgnoreCase(columnName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "column " + columnName + " not found in index " + indexName));
+    }
+
+    private void assertIndexColumns(LakeTable table, String indexName, String... expectedColumns) {
+        Long indexMetaId = table.getIndexMetaIdByName(indexName);
+        Assertions.assertNotNull(indexMetaId, indexName);
+        List<String> actualColumns = table.getSchemaByIndexMetaId(indexMetaId).stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(List.of(expectedColumns), actualColumns);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -906,6 +906,36 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         doTestSortKeyUpdatedAfterAddKeyColumn(tbl, "test.sc_uniq_sort_key");
     }
 
+    @Test
+    public void testSortKeyFallbackToIndexesWhenUniqueIdsMissing() throws Exception {
+        createTable("CREATE TABLE test.sc_agg_sort_key_fallback (\n"
+                + "k0 INT,\n"
+                + "k1 INT,\n"
+                + "k2 INT,\n"
+                + "k3 INT,\n"
+                + "v0 INT SUM DEFAULT '0'\n"
+                + ") AGGREGATE KEY(k0, k1, k2, k3)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k3, k2, k1, k0)\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "sc_agg_sort_key_fallback");
+        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
+        Assertions.assertEquals(Arrays.asList(3, 2, 1, 0), indexMeta.getSortKeyIdxes());
+        Assertions.assertNotNull(indexMeta.getSortKeyUniqueIds());
+
+        // Emulate legacy metadata: sort key indexes exist but unique ids are absent.
+        indexMeta.setSortKeyUniqueIds(null);
+        indexMeta.getSchema().get(1).setUniqueId(Column.COLUMN_UNIQUE_ID_INIT_VALUE);
+
+        executeAlterAndWaitDone("alter table test.sc_agg_sort_key_fallback add column new_v1 int MAX default '0'");
+
+        MaterializedIndexMeta updatedIndexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
+        Assertions.assertEquals(Arrays.asList(3, 2, 1, 0), updatedIndexMeta.getSortKeyIdxes());
+        Assertions.assertNull(updatedIndexMeta.getSortKeyUniqueIds());
+    }
+
     private void doTestSortKeyUpdatedAfterAddKeyColumn(OlapTable tbl, String qualifiedName) throws Exception {
         Assertions.assertEquals(Arrays.asList(3, 2, 1, 0), tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId()).getSortKeyIdxes());
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerVarcharWidenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerVarcharWidenTest.java
@@ -1,0 +1,466 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AlterClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.ModifyColumnClause;
+import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.TypeFactory;
+import com.starrocks.utframe.TestWithFeService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SchemaChangeHandlerVarcharWidenTest extends TestWithFeService {
+    private static final String DB_NAME = "test";
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase(DB_NAME);
+        useDatabase(DB_NAME);
+    }
+
+    @Override
+    protected void runBeforeEach() {
+        connectContext.setThreadLocalInfo();
+        useDatabase(DB_NAME);
+    }
+
+    @Override
+    protected void runAfterEach() {
+        GlobalStateMgr.getCurrentState().getSchemaChangeHandler().clearJobs();
+    }
+
+    @Test
+    public void testPartitionColumnWidenUsesFastPath() throws Exception {
+        String tableName = "t_partition_distribution_fast";
+        createPartitionAndDistributionTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                tableName);
+
+        Assertions.assertNull(job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testPartitionColumnFinalNonWidenRejected() throws Exception {
+        String tableName = "t_partition_distribution_reject";
+        createPartitionAndDistributionTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT KEY NOT NULL",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not modify partition column[k1]"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testDistributionColumnFinalNonWidenRejected() throws Exception {
+        String tableName = "t_distribution_reject";
+        createDistributionTable(tableName, false);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT KEY NOT NULL",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not modify distribution column[k1]"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testKeyColumnWidenUsesFastPath() throws Exception {
+        String tableName = "t_key_column_fast";
+        createKeyColumnTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                tableName);
+
+        Assertions.assertNull(job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testKeyColumnNonWidenCreatesJob() throws Exception {
+        String tableName = "t_key_column_job";
+        createKeyColumnTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT KEY NOT NULL",
+                tableName);
+
+        Assertions.assertNotNull(job);
+        Assertions.assertInstanceOf(SchemaChangeJobV2.class, job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testBaseClauseRollupColumnWidenUsesFastPath() throws Exception {
+        String tableName = "t_rollup_fast";
+        createRollupTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                tableName);
+
+        Assertions.assertNull(job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 30);
+        assertColumnType(tableName, "r1", "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+        assertIndexColumns(tableName, "r1", "k2", "k1");
+    }
+
+    @Test
+    public void testRollupClauseNonWidenRejectedByBaseDistribution() throws Exception {
+        String tableName = "t_rollup_reject";
+        createRollupTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT KEY NOT NULL FIRST FROM r1",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not modify distribution column[k1]"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+        assertColumnType(tableName, "r1", "k1", PrimitiveType.VARCHAR, 10);
+        assertIndexColumns(tableName, "r1", "k2", "k1");
+    }
+
+    @Test
+    public void testColocateDistributionColumnWidenRejected() throws Exception {
+        ColocateTableIndex originalColocateIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        try {
+            GlobalStateMgr.getCurrentState().setColocateTableIndex(new ColocateTableIndex());
+            String tableName = "t_colocate_reject";
+            createDistributionTable(tableName, true);
+
+            OlapTable table = getTable(tableName);
+            Assertions.assertTrue(
+                    GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(table.getId()));
+
+            Exception exception = Assertions.assertThrows(Exception.class,
+                    () -> analyzeAndCreateJob(
+                            "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(20) KEY NOT NULL",
+                            tableName));
+
+            Assertions.assertTrue(exception.getMessage().contains("for colocate table"),
+                    exception.getMessage());
+            assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+            assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+        } finally {
+            GlobalStateMgr.getCurrentState().setColocateTableIndex(originalColocateIndex);
+        }
+    }
+
+    @Test
+    public void testPrimaryKeyColumnWidenUsesFastPath() throws Exception {
+        String tableName = "t_pk_key_fast";
+        createPrimaryKeyTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30)",
+                tableName);
+
+        Assertions.assertNull(job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(tableName, tableName, "k1", "v1");
+    }
+
+    @Test
+    public void testPrimaryKeySortColumnWidenUsesFastPath() throws Exception {
+        String tableName = "t_pk_sort_fast";
+        createPrimaryKeySortTable(tableName);
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30)",
+                tableName);
+
+        Assertions.assertNull(job);
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 30);
+        assertIndexColumns(tableName, tableName, "k0", "k1", "v1");
+    }
+
+    @Test
+    public void testPrimaryKeyColumnNonWidenRejected() throws Exception {
+        String tableName = "t_pk_key_reject";
+        createPrimaryKeyTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains(
+                        "Can not modify key column: k1 for primary key table except for increasing varchar length"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+    }
+
+    @Test
+    public void testPrimaryKeySortColumnNonWidenRejected() throws Exception {
+        String tableName = "t_pk_sort_reject";
+        createPrimaryKeySortTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 BIGINT",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains(
+                        "Can not modify sort column in primary data model table except for increasing varchar length"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+    }
+
+    @Test
+    public void testPrimaryKeyKeyReorderRejected() throws Exception {
+        String tableName = "t_pk_reorder_reject";
+        createPrimaryKeyReorderTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k2 VARCHAR(30) FIRST",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not reorder pk keys by modify column"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k2", PrimitiveType.VARCHAR, 10);
+        assertIndexColumns(tableName, tableName, "k1", "k2", "v1");
+    }
+
+    @Test
+    public void testRollupBaseClauseNonWidenRejected() throws Exception {
+        String tableName = "t_rollup_base_non_widen_reject";
+        createRollupTable(tableName);
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(
+                        "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 INT KEY NOT NULL",
+                        tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("Can not modify distribution column[k1]"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+        assertColumnType(tableName, "r1", "k1", PrimitiveType.VARCHAR, 10);
+    }
+
+    @Test
+    public void testPrimaryKeyColumnWidenToNullableRejectedByHandler() throws Exception {
+        String tableName = "t_pk_nullable_reject";
+        createPrimaryKeyTable(tableName);
+
+        ColumnDef columnDef = new ColumnDef(
+                "k1",
+                new TypeDef(TypeFactory.createVarcharType(20)),
+                false,
+                null,
+                null,
+                true,
+                ColumnDef.DefaultValueDef.NOT_SET,
+                "");
+        ModifyColumnClause clause = new ModifyColumnClause(columnDef, null, null, Map.of());
+
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> analyzeAndCreateJob(List.of(clause), tableName));
+
+        Assertions.assertTrue(exception.getMessage().contains("primary key column[k1] cannot be nullable"),
+                exception.getMessage());
+        assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+    }
+
+    private AlterJobV2 analyzeAndCreateJob(String sql, String tableName) throws Exception {
+        connectContext.setThreadLocalInfo();
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(sql, connectContext);
+        return analyzeAndCreateJob(alterStmt.getAlterClauseList(), tableName);
+    }
+
+    private AlterJobV2 analyzeAndCreateJob(List<AlterClause> alterClauses, String tableName) throws Exception {
+        connectContext.setThreadLocalInfo();
+        Database db = getDatabase();
+        OlapTable table = getTable(tableName);
+        return GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .analyzeAndCreateJob(alterClauses, db, table);
+    }
+
+    private Database getDatabase() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+    }
+
+    private OlapTable getTable(String tableName) {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(getDatabase().getFullName(), tableName);
+    }
+
+    private Column getColumn(String tableName, String indexName, String columnName) {
+        OlapTable table = getTable(tableName);
+        Long indexMetaId = table.getIndexMetaIdByName(indexName);
+        Assertions.assertNotNull(indexMetaId, indexName);
+        return table.getSchemaByIndexMetaId(indexMetaId).stream()
+                .filter(column -> column.getName().equalsIgnoreCase(columnName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "column " + columnName + " not found in index " + indexName));
+    }
+
+    private void assertColumnType(String tableName, String indexName, String columnName,
+                                  PrimitiveType primitiveType, int expectedLength) {
+        Column column = getColumn(tableName, indexName, columnName);
+        Assertions.assertEquals(primitiveType, column.getPrimitiveType());
+        if (primitiveType == PrimitiveType.VARCHAR) {
+            Assertions.assertEquals(expectedLength, column.getStrLen());
+        }
+    }
+
+    private void assertIndexColumns(String tableName, String indexName, String... expectedColumns) {
+        OlapTable table = getTable(tableName);
+        Long indexMetaId = table.getIndexMetaIdByName(indexName);
+        Assertions.assertNotNull(indexMetaId, indexName);
+        List<String> actualColumns = table.getSchemaByIndexMetaId(indexMetaId).stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(List.of(expectedColumns), actualColumns);
+    }
+
+    private void createPartitionAndDistributionTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1, k2)\n"
+                + "PARTITION BY LIST(k1) (\n"
+                + "  PARTITION p1 VALUES IN (\"a\"),\n"
+                + "  PARTITION p2 VALUES IN (\"b\")\n"
+                + ")\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+
+    private void createDistributionTable(String tableName, boolean colocate) throws Exception {
+        String colocateProperty = colocate ? ",\n  \"colocate_with\" = \"cg_varchar_widen\"" : "";
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\""
+                + colocateProperty + "\n"
+                + ");");
+    }
+
+    private void createKeyColumnTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k2) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+
+    private void createRollupTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 INT NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "ROLLUP (\n"
+                + "  r1(k2, k1)\n"
+                + ")\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+
+    private void createPrimaryKeyTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "PRIMARY KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+
+    private void createPrimaryKeySortTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k0 INT NOT NULL,\n"
+                + "  k1 VARCHAR(10),\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "PRIMARY KEY(k0)\n"
+                + "DISTRIBUTED BY HASH(k0) BUCKETS 1\n"
+                + "ORDER BY(k1)\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+
+    private void createPrimaryKeyReorderTable(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  k2 VARCHAR(10) NOT NULL,\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "PRIMARY KEY(k1, k2)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterTest.java
@@ -89,12 +89,22 @@ public class AlterTest {
 
     @Test
     public void testAlterPKTableAddingBitmapColumnWithModifyClause() throws Exception {
-        String sql = "ALTER TABLE t0 MODIFY COLUMN c0 bitmap null";
+        createTable(connectContext, "CREATE TABLE t_bitmap_modify(c0 INT, c1 INT) primary key(c0) distributed by hash(c0)");
+        String sql = "ALTER TABLE t_bitmap_modify MODIFY COLUMN c1 bitmap null";
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
             Assertions.fail(
                     "Should not throw exception when modifying column to bitmap type with pk table in shared-data mode");
         }
+    }
+
+    @Test
+    public void testAlterPKTableModifyingPkColumnToBitmapNullRejected() {
+        String sql = "ALTER TABLE t0 MODIFY COLUMN c0 bitmap null";
+        Exception exception = Assertions.assertThrows(Exception.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+        Assertions.assertTrue(exception.getMessage().contains("primary key column[c0] cannot be nullable"),
+                exception.getMessage());
     }
 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2373,6 +2373,146 @@ class StarrocksSQLApiLib(object):
             sleep_time += 0.5
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
 
+    @staticmethod
+    def _canonical_json(value):
+        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+    def _show_proc_rows(self, path):
+        res = self.execute_sql("SHOW PROC '%s'" % path, True)
+        tools.assert_true(res["status"], "show proc failed for %s: %s" % (path, res.get("msg")))
+        return res["result"]
+
+    def _show_schema_change_rows(self, db_name, table_name):
+        sql = (
+            "SHOW ALTER TABLE COLUMN FROM %s WHERE TableName = '%s' ORDER BY JobId DESC"
+            % (db_name, table_name.replace("'", "\\'"))
+        )
+        res = self.retry_execute_sql(sql, True)
+        tools.assert_true(res["status"], "show alter table column failed: %s" % res.get("msg"))
+        return res["result"]
+
+    def wait_table_schema_change_finish(self, db_name, table_name, expect_state="FINISHED", timeout_sec=300):
+        """
+        wait schema change job for the specified table finish and return status
+        """
+        elapsed = 0
+        status = ""
+        while elapsed < timeout_sec:
+            rows = self._show_schema_change_rows(db_name, table_name)
+            if rows:
+                status = rows[0][9]
+                if status in ("FINISHED", "CANCELLED", ""):
+                    break
+            time.sleep(1)
+            elapsed += 1
+        tools.assert_equal(expect_state, status, "wait table schema change finish error for %s.%s" % (db_name, table_name))
+        return status
+
+    def get_schema_change_job_count(self, db_name, table_name):
+        rows = self._show_schema_change_rows(db_name, table_name)
+        return len({str(row[0]) for row in rows})
+
+    def assert_schema_change_job_count(self, db_name, table_name, expected_count):
+        actual_count = self.get_schema_change_job_count(db_name, table_name)
+        tools.assert_equal(int(expected_count), actual_count, "unexpected schema change job count for %s.%s" % (db_name, table_name))
+
+    def get_latest_schema_change_job_info(self, db_name, table_name):
+        rows = self._show_schema_change_rows(db_name, table_name)
+        if not rows:
+            return self._canonical_json({})
+        row = rows[0]
+        info = {
+            "job_id": str(row[0]),
+            "table_name": str(row[1]),
+            "index_name": str(row[4]),
+            "index_id": str(row[5]),
+            "origin_index_id": str(row[6]),
+            "schema_version": str(row[7]),
+            "transaction_id": str(row[8]),
+            "state": str(row[9]),
+            "msg": str(row[10]),
+            "progress": str(row[11]),
+            "timeout": str(row[12]),
+        }
+        if len(row) > 13:
+            info["warehouse"] = str(row[13])
+        return self._canonical_json(info)
+
+    def assert_latest_schema_change_job_path(self, db_name, table_name, expected_path):
+        info = json.loads(self.get_latest_schema_change_job_info(db_name, table_name))
+        tools.assert_true(info, "no schema change job found for %s.%s" % (db_name, table_name))
+        tools.assert_equal("FINISHED", info["state"], "latest schema change job is not finished for %s.%s" % (db_name, table_name))
+        same_index = info["index_id"] == info["origin_index_id"]
+        if expected_path == "slow":
+            tools.assert_false(same_index, "expected slow path for %s.%s, but latest job kept same index id" % (db_name, table_name))
+        elif expected_path in ("fast", "fast_v1"):
+            tools.assert_true(same_index, "expected fast path for %s.%s, but latest job used shadow index" % (db_name, table_name))
+        else:
+            tools.assert_true(False, "unknown schema change path expectation: %s" % expected_path)
+
+    def get_index_identity_snapshot(self, db_name, table_name):
+        rows = self._show_proc_rows("/dbs/%s/%s/index_schema" % (db_name, table_name))
+        identities = [{"index_id": str(row[0]), "index_name": str(row[1])} for row in rows]
+        identities.sort(key=lambda item: (item["index_name"], item["index_id"]))
+        return self._canonical_json(identities)
+
+    def get_index_schema_snapshot(self, db_name, table_name):
+        index_rows = self._show_proc_rows("/dbs/%s/%s/index_schema" % (db_name, table_name))
+        snapshot = []
+        for index_row in index_rows:
+            index_id = str(index_row[0])
+            index_name = str(index_row[1])
+            schema_rows = self._show_proc_rows("/dbs/%s/%s/index_schema/%s" % (db_name, table_name, index_id))
+            columns = []
+            for row in schema_rows:
+                columns.append({
+                    "field": str(row[0]),
+                    "type": str(row[1]),
+                    "null": str(row[2]),
+                    "key": str(row[3]),
+                })
+            snapshot.append({
+                "index_id": index_id,
+                "index_name": index_name,
+                "columns": columns,
+            })
+        snapshot.sort(key=lambda item: (item["index_name"], item["index_id"]))
+        return self._canonical_json(snapshot)
+
+    def assert_sync_fast_path(self, db_name, table_name, expected_previous_job_count, expected_index_snapshot):
+        self.assert_schema_change_job_count(db_name, table_name, int(expected_previous_job_count) + 1)
+        self.assert_latest_schema_change_job_path(db_name, table_name, "fast")
+        actual_index_snapshot = self.get_index_identity_snapshot(db_name, table_name)
+        tools.assert_equal(
+            expected_index_snapshot,
+            actual_index_snapshot,
+            "unexpected index identity snapshot for sync fast path on %s.%s" % (db_name, table_name),
+        )
+
+    def assert_index_identity_snapshot(self, db_name, table_name, expected_index_snapshot):
+        actual_index_snapshot = self.get_index_identity_snapshot(db_name, table_name)
+        tools.assert_equal(
+            expected_index_snapshot,
+            actual_index_snapshot,
+            "unexpected index identity snapshot for %s.%s" % (db_name, table_name),
+        )
+
+    def assert_index_schema_columns(self, db_name, table_name, index_name, *expected_columns):
+        snapshot = json.loads(self.get_index_schema_snapshot(db_name, table_name))
+        for index in snapshot:
+            if index["index_name"] == index_name:
+                actual_columns = [
+                    "%s|%s|%s|%s" % (column["field"], column["type"], column["null"], column["key"])
+                    for column in index["columns"]
+                ]
+                tools.assert_equal(
+                    list(expected_columns),
+                    actual_columns,
+                    "unexpected schema for index %s on %s.%s" % (index_name, db_name, table_name),
+                )
+                return
+        tools.assert_true(False, "index %s not found on %s.%s" % (index_name, db_name, table_name))
+
     def wait_alter_table_not_pending(self, alter_type="COLUMN"):
         """
         wait until the status of the latest alter table job becomes from PNEDING to others

--- a/test/sql/test_fast_schema_evolution/R/test_varchar_widen_cloud
+++ b/test/sql/test_fast_schema_evolution/R/test_varchar_widen_cloud
@@ -1,0 +1,431 @@
+-- name: test_varchar_widen_cloud_fast_paths @cloud
+create database test_varchar_widen_cloud_fast_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_cloud_fast_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_fast_v1 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "false"
+);
+-- result:
+-- !result
+insert into t_fast_v1 values ("a", 1, 31);
+-- result:
+-- !result
+[UC]function: fast_v1_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1")
+ALTER TABLE t_fast_v1 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1")
+-- result:
+FINISHED
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", 1)
+-- result:
+None
+-- !result
+function: assert_latest_schema_change_job_path("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", "fast_v1")
+-- result:
+None
+-- !result
+function: assert_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", '${fast_v1_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", "t_fast_v1", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_fast_v1 order by k1, k2;
+-- result:
+a	1	31
+-- !result
+CREATE TABLE t_fast_v2 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+insert into t_fast_v2 values ("b", 2, 32);
+-- result:
+-- !result
+[UC]function: fast_v2_job_count=get_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2")
+[UC]function: fast_v2_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2")
+ALTER TABLE t_fast_v2 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2", ${fast_v2_job_count}, '${fast_v2_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2", "t_fast_v2", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_fast_v2 order by k1, k2;
+-- result:
+b	2	32
+-- !result
+CREATE TABLE t_rollup_v2 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+insert into t_rollup_v2 values ("c", 3, 33);
+-- result:
+-- !result
+[UC]function: rollup_v2_job_count=get_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2")
+[UC]function: rollup_v2_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2")
+ALTER TABLE t_rollup_v2 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", ${rollup_v2_job_count}, '${rollup_v2_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", "t_rollup_v2", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", "r1", "k2|int|NO|true", "k1|varchar(30)|NO|true")
+-- result:
+None
+-- !result
+[ORDER]select * from t_rollup_v2 order by k1, k2;
+-- result:
+c	3	33
+-- !result
+drop database test_varchar_widen_cloud_fast_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_cloud_pk_fast_paths @cloud
+create database test_varchar_widen_cloud_pk_fast_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_cloud_pk_fast_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_pk_key_fast (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+insert into t_pk_key_fast values ("pk-a", 34);
+-- result:
+-- !result
+[UC]function: pk_key_fast_job_count=get_schema_change_job_count("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast")
+[UC]function: pk_key_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast")
+ALTER TABLE t_pk_key_fast MODIFY COLUMN k1 VARCHAR(30);
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast", ${pk_key_fast_job_count}, '${pk_key_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast", "t_pk_key_fast", "k1|varchar(30)|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_pk_key_fast order by k1;
+-- result:
+pk-a	34
+-- !result
+CREATE TABLE t_pk_sort_fast (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+)
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+insert into t_pk_sort_fast values (1, "sort-a", 35);
+-- result:
+-- !result
+[UC]function: pk_sort_fast_job_count=get_schema_change_job_count("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast")
+[UC]function: pk_sort_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast")
+ALTER TABLE t_pk_sort_fast MODIFY COLUMN k1 VARCHAR(30);
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast", ${pk_sort_fast_job_count}, '${pk_sort_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast", "t_pk_sort_fast", "k0|int|NO|true", "k1|varchar(30)|YES|false", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_pk_sort_fast order by k0;
+-- result:
+1	sort-a	35
+-- !result
+drop database test_varchar_widen_cloud_pk_fast_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_cloud_pk_guard_paths @cloud
+create database test_varchar_widen_cloud_pk_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_cloud_pk_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_pk_key_reject (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_key_reject MODIFY COLUMN k1 INT", "Can not modify key column: k1 for primary key table except for increasing varchar length")
+-- result:
+None
+-- !result
+CREATE TABLE t_pk_sort_reject (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+)
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_sort_reject MODIFY COLUMN k1 BIGINT", "Can not modify sort column in primary data model table except for increasing varchar length")
+-- result:
+None
+-- !result
+CREATE TABLE t_pk_reorder_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_reorder_reject MODIFY COLUMN k2 VARCHAR(30) FIRST", "Can not reorder pk keys by modify column")
+-- result:
+None
+-- !result
+CREATE TABLE t_rollup_base_non_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_rollup_base_non_widen_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+drop database test_varchar_widen_cloud_pk_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_cloud_slow_and_reject_paths @cloud
+create database test_varchar_widen_cloud_slow_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_cloud_slow_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "false"
+);
+-- result:
+-- !result
+insert into t_slow values ("1", 1, 41);
+-- result:
+-- !result
+ALTER TABLE t_slow MODIFY COLUMN k1 INT KEY NOT NULL;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_varchar_widen_cloud_slow_${uuid0}", "t_slow")
+-- result:
+FINISHED
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", 1)
+-- result:
+None
+-- !result
+function: assert_latest_schema_change_job_path("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", "slow")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", "t_slow", "k1|int|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_slow order by k1, k2;
+-- result:
+1	1	41
+-- !result
+CREATE TABLE t_multi_same (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_multi_same MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN k1 INT KEY NOT NULL", "Column[k1] does not exists")
+-- result:
+None
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_same", 0)
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_same", "t_multi_same", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+CREATE TABLE t_multi_cross (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_multi_cross MODIFY COLUMN v1 BIGINT, MODIFY COLUMN k1 INT KEY NOT NULL FIRST FROM r1", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", 0)
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", "t_multi_cross", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", "r1", "k2|int|NO|true", "k1|varchar(10)|NO|true")
+-- result:
+None
+-- !result
+CREATE TABLE t_pseudo_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pseudo_widen_reject MODIFY COLUMN k1 VARCHAR(30) KEY", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+CREATE TABLE t_colocate_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true",
+    "colocate_with" = "cg_varchar_widen_${uuid0}"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_colocate_reject MODIFY COLUMN k1 VARCHAR(20) KEY NOT NULL", "for colocate table")
+-- result:
+None
+-- !result
+drop database test_varchar_widen_cloud_slow_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_fast_schema_evolution/R/test_varchar_widen_native
+++ b/test/sql/test_fast_schema_evolution/R/test_varchar_widen_native
@@ -1,0 +1,585 @@
+-- name: test_varchar_widen_native_fast_paths @native
+create database test_varchar_widen_native_fast_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_native_fast_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_part_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+PARTITION BY LIST(k1) (
+    PARTITION p1 VALUES IN ("a"),
+    PARTITION p2 VALUES IN ("b")
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_part_fast values ("a", 1, 10);
+-- result:
+-- !result
+[UC]function: part_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_part_fast")
+[UC]function: part_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_part_fast")
+ALTER TABLE t_part_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_part_fast", ${part_fast_job_count}, '${part_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_part_fast", "t_part_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_part_fast order by k1, k2;
+-- result:
+a	1	10
+-- !result
+CREATE TABLE t_dist_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_dist_fast values ("a", 1, 11);
+-- result:
+-- !result
+[UC]function: dist_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast")
+[UC]function: dist_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast")
+ALTER TABLE t_dist_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast", ${dist_fast_job_count}, '${dist_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast", "t_dist_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_dist_fast order by k1, k2;
+-- result:
+a	1	11
+-- !result
+CREATE TABLE t_short_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_short_fast values ("a", 1, 12);
+-- result:
+-- !result
+[UC]function: short_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_short_fast")
+[UC]function: short_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_short_fast")
+ALTER TABLE t_short_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_short_fast", ${short_fast_job_count}, '${short_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_short_fast", "t_short_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_short_fast order by k1, k2;
+-- result:
+a	1	12
+-- !result
+CREATE TABLE t_rollup_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_rollup_fast values ("a", 1, 13);
+-- result:
+-- !result
+[UC]function: rollup_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast")
+[UC]function: rollup_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast")
+ALTER TABLE t_rollup_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", ${rollup_fast_job_count}, '${rollup_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", "t_rollup_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", "r1", "k2|int|NO|true", "k1|varchar(30)|NO|true")
+-- result:
+None
+-- !result
+[ORDER]select * from t_rollup_fast order by k1, k2;
+-- result:
+a	1	13
+-- !result
+drop database test_varchar_widen_native_fast_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_native_pk_fast_paths @native
+create database test_varchar_widen_native_pk_fast_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_native_pk_fast_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_pk_key_fast (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_pk_key_fast values ("pk-a", 14);
+-- result:
+-- !result
+[UC]function: pk_key_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast")
+[UC]function: pk_key_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast")
+ALTER TABLE t_pk_key_fast MODIFY COLUMN k1 VARCHAR(30);
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast", ${pk_key_fast_job_count}, '${pk_key_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast", "t_pk_key_fast", "k1|varchar(30)|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_pk_key_fast order by k1;
+-- result:
+pk-a	14
+-- !result
+CREATE TABLE t_pk_sort_fast (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_pk_sort_fast values (1, "sort-a", 15);
+-- result:
+-- !result
+[UC]function: pk_sort_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast")
+[UC]function: pk_sort_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast")
+ALTER TABLE t_pk_sort_fast MODIFY COLUMN k1 VARCHAR(30);
+-- result:
+-- !result
+function: assert_sync_fast_path("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast", ${pk_sort_fast_job_count}, '${pk_sort_fast_index_snapshot}')
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast", "t_pk_sort_fast", "k0|int|NO|true", "k1|varchar(30)|YES|false", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_pk_sort_fast order by k0;
+-- result:
+1	sort-a	15
+-- !result
+drop database test_varchar_widen_native_pk_fast_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_native_reject_paths @native
+create database test_varchar_widen_native_reject_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_native_reject_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_part_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+PARTITION BY LIST(k1) (
+    PARTITION p1 VALUES IN ("1"),
+    PARTITION p2 VALUES IN ("2")
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_part_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify partition column[k1]")
+-- result:
+None
+-- !result
+CREATE TABLE t_dist_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_dist_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+CREATE TABLE t_pseudo_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pseudo_widen_reject MODIFY COLUMN k1 VARCHAR(30) KEY", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+CREATE TABLE t_colocate_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true",
+    "colocate_with" = "cg_varchar_widen_${uuid0}"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_colocate_reject MODIFY COLUMN k1 VARCHAR(20) KEY NOT NULL", "for colocate table")
+-- result:
+None
+-- !result
+drop database test_varchar_widen_native_reject_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_native_pk_guard_paths @native
+create database test_varchar_widen_native_pk_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_native_pk_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_pk_key_reject (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_key_reject MODIFY COLUMN k1 INT", "Can not modify key column: k1 for primary key table except for increasing varchar length")
+-- result:
+None
+-- !result
+CREATE TABLE t_pk_sort_reject (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_sort_reject MODIFY COLUMN k1 BIGINT", "Can not modify sort column in primary data model table except for increasing varchar length")
+-- result:
+None
+-- !result
+CREATE TABLE t_pk_reorder_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_pk_reorder_reject MODIFY COLUMN k2 VARCHAR(30) FIRST", "Can not reorder pk keys by modify column")
+-- result:
+None
+-- !result
+CREATE TABLE t_rollup_base_non_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_rollup_base_non_widen_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+drop database test_varchar_widen_native_pk_${uuid0} force;
+-- result:
+-- !result
+
+
+-- name: test_varchar_widen_native_slow_and_multiclause @native
+create database test_varchar_widen_native_slow_${uuid0};
+-- result:
+-- !result
+use test_varchar_widen_native_slow_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_varchar_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "false"
+);
+-- result:
+-- !result
+insert into t_varchar_slow values ("a", 1, 20);
+-- result:
+-- !result
+ALTER TABLE t_varchar_slow MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow")
+-- result:
+FINISHED
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", 1)
+-- result:
+None
+-- !result
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", "slow")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", "t_varchar_slow", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_varchar_slow order by k1, k2;
+-- result:
+a	1	20
+-- !result
+CREATE TABLE t_short_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_short_slow values ("1", 1, 21);
+-- result:
+-- !result
+ALTER TABLE t_short_slow MODIFY COLUMN k1 INT KEY NOT NULL;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_short_slow")
+-- result:
+FINISHED
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", 1)
+-- result:
+None
+-- !result
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", "slow")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", "t_short_slow", "k1|int|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_short_slow order by k1, k2;
+-- result:
+1	1	21
+-- !result
+CREATE TABLE t_multi_success (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into t_multi_success values ("m", 1, 22);
+-- result:
+-- !result
+ALTER TABLE t_multi_success MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN v1 BIGINT;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_multi_success")
+-- result:
+FINISHED
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", 1)
+-- result:
+None
+-- !result
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", "slow")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", "t_multi_success", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|bigint|YES|false")
+-- result:
+None
+-- !result
+[ORDER]select * from t_multi_success order by k1, k2;
+-- result:
+m	1	22
+-- !result
+CREATE TABLE t_multi_same (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_multi_same MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN k1 INT KEY NOT NULL", "Column[k1] does not exists")
+-- result:
+None
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_same", 0)
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_same", "t_multi_same", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+CREATE TABLE t_multi_cross (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+function: assert_query_error_contains("ALTER TABLE t_multi_cross MODIFY COLUMN v1 BIGINT, MODIFY COLUMN k1 INT KEY NOT NULL FIRST FROM r1", "modify distribution column[k1]")
+-- result:
+None
+-- !result
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", 0)
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", "t_multi_cross", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+-- result:
+None
+-- !result
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", "r1", "k2|int|NO|true", "k1|varchar(10)|NO|true")
+-- result:
+None
+-- !result
+drop database test_varchar_widen_native_slow_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_fast_schema_evolution/T/test_varchar_widen_cloud
+++ b/test/sql/test_fast_schema_evolution/T/test_varchar_widen_cloud
@@ -1,0 +1,262 @@
+-- name: test_varchar_widen_cloud_fast_paths @cloud
+create database test_varchar_widen_cloud_fast_${uuid0};
+use test_varchar_widen_cloud_fast_${uuid0};
+
+CREATE TABLE t_fast_v1 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "false"
+);
+insert into t_fast_v1 values ("a", 1, 31);
+[UC]function: fast_v1_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1")
+ALTER TABLE t_fast_v1 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: wait_table_schema_change_finish("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1")
+function: assert_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", 1)
+function: assert_latest_schema_change_job_path("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", "fast_v1")
+function: assert_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", '${fast_v1_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v1", "t_fast_v1", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_fast_v1 order by k1, k2;
+
+CREATE TABLE t_fast_v2 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+insert into t_fast_v2 values ("b", 2, 32);
+[UC]function: fast_v2_job_count=get_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2")
+[UC]function: fast_v2_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2")
+ALTER TABLE t_fast_v2 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2", ${fast_v2_job_count}, '${fast_v2_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_fast_v2", "t_fast_v2", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_fast_v2 order by k1, k2;
+
+CREATE TABLE t_rollup_v2 (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+insert into t_rollup_v2 values ("c", 3, 33);
+[UC]function: rollup_v2_job_count=get_schema_change_job_count("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2")
+[UC]function: rollup_v2_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2")
+ALTER TABLE t_rollup_v2 MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", ${rollup_v2_job_count}, '${rollup_v2_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", "t_rollup_v2", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+function: assert_index_schema_columns("test_varchar_widen_cloud_fast_${uuid0}", "t_rollup_v2", "r1", "k2|int|NO|true", "k1|varchar(30)|NO|true")
+[ORDER]select * from t_rollup_v2 order by k1, k2;
+
+drop database test_varchar_widen_cloud_fast_${uuid0} force;
+
+
+-- name: test_varchar_widen_cloud_pk_fast_paths @cloud
+create database test_varchar_widen_cloud_pk_fast_${uuid0};
+use test_varchar_widen_cloud_pk_fast_${uuid0};
+
+CREATE TABLE t_pk_key_fast (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+insert into t_pk_key_fast values ("pk-a", 34);
+[UC]function: pk_key_fast_job_count=get_schema_change_job_count("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast")
+[UC]function: pk_key_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast")
+ALTER TABLE t_pk_key_fast MODIFY COLUMN k1 VARCHAR(30);
+function: assert_sync_fast_path("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast", ${pk_key_fast_job_count}, '${pk_key_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_key_fast", "t_pk_key_fast", "k1|varchar(30)|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_pk_key_fast order by k1;
+
+CREATE TABLE t_pk_sort_fast (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+)
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+insert into t_pk_sort_fast values (1, "sort-a", 35);
+[UC]function: pk_sort_fast_job_count=get_schema_change_job_count("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast")
+[UC]function: pk_sort_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast")
+ALTER TABLE t_pk_sort_fast MODIFY COLUMN k1 VARCHAR(30);
+function: assert_sync_fast_path("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast", ${pk_sort_fast_job_count}, '${pk_sort_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_cloud_pk_fast_${uuid0}", "t_pk_sort_fast", "t_pk_sort_fast", "k0|int|NO|true", "k1|varchar(30)|YES|false", "v1|int|YES|false")
+[ORDER]select * from t_pk_sort_fast order by k0;
+
+drop database test_varchar_widen_cloud_pk_fast_${uuid0} force;
+
+
+-- name: test_varchar_widen_cloud_pk_guard_paths @cloud
+create database test_varchar_widen_cloud_pk_${uuid0};
+use test_varchar_widen_cloud_pk_${uuid0};
+
+CREATE TABLE t_pk_key_reject (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_key_reject MODIFY COLUMN k1 INT", "Can not modify key column: k1 for primary key table except for increasing varchar length")
+
+CREATE TABLE t_pk_sort_reject (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+)
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_sort_reject MODIFY COLUMN k1 BIGINT", "Can not modify sort column in primary data model table except for increasing varchar length")
+
+CREATE TABLE t_pk_reorder_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 VARCHAR(10) NOT NULL,
+    v1 INT
+)
+PRIMARY KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_reorder_reject MODIFY COLUMN k2 VARCHAR(30) FIRST", "Can not reorder pk keys by modify column")
+
+CREATE TABLE t_rollup_base_non_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_rollup_base_non_widen_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+
+drop database test_varchar_widen_cloud_pk_${uuid0} force;
+
+
+-- name: test_varchar_widen_cloud_slow_and_reject_paths @cloud
+create database test_varchar_widen_cloud_slow_${uuid0};
+use test_varchar_widen_cloud_slow_${uuid0};
+
+CREATE TABLE t_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "false"
+);
+insert into t_slow values ("1", 1, 41);
+ALTER TABLE t_slow MODIFY COLUMN k1 INT KEY NOT NULL;
+function: wait_table_schema_change_finish("test_varchar_widen_cloud_slow_${uuid0}", "t_slow")
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", 1)
+function: assert_latest_schema_change_job_path("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", "slow")
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_slow", "t_slow", "k1|int|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_slow order by k1, k2;
+
+CREATE TABLE t_multi_same (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_multi_same MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN k1 INT KEY NOT NULL", "Column[k1] does not exists")
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_same", 0)
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_same", "t_multi_same", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+
+CREATE TABLE t_multi_cross (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_multi_cross MODIFY COLUMN v1 BIGINT, MODIFY COLUMN k1 INT KEY NOT NULL FIRST FROM r1", "modify distribution column[k1]")
+function: assert_schema_change_job_count("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", 0)
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", "t_multi_cross", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+function: assert_index_schema_columns("test_varchar_widen_cloud_slow_${uuid0}", "t_multi_cross", "r1", "k2|int|NO|true", "k1|varchar(10)|NO|true")
+
+CREATE TABLE t_pseudo_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pseudo_widen_reject MODIFY COLUMN k1 VARCHAR(30) KEY", "modify distribution column[k1]")
+
+CREATE TABLE t_colocate_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+)
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "cloud_native_fast_schema_evolution_v2" = "true",
+    "colocate_with" = "cg_varchar_widen_${uuid0}"
+);
+function: assert_query_error_contains("ALTER TABLE t_colocate_reject MODIFY COLUMN k1 VARCHAR(20) KEY NOT NULL", "for colocate table")
+
+drop database test_varchar_widen_cloud_slow_${uuid0} force;

--- a/test/sql/test_fast_schema_evolution/T/test_varchar_widen_native
+++ b/test/sql/test_fast_schema_evolution/T/test_varchar_widen_native
@@ -1,0 +1,358 @@
+-- name: test_varchar_widen_native_fast_paths @native
+create database test_varchar_widen_native_fast_${uuid0};
+use test_varchar_widen_native_fast_${uuid0};
+
+CREATE TABLE t_part_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+PARTITION BY LIST(k1) (
+    PARTITION p1 VALUES IN ("a"),
+    PARTITION p2 VALUES IN ("b")
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_part_fast values ("a", 1, 10);
+[UC]function: part_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_part_fast")
+[UC]function: part_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_part_fast")
+ALTER TABLE t_part_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_part_fast", ${part_fast_job_count}, '${part_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_part_fast", "t_part_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_part_fast order by k1, k2;
+
+CREATE TABLE t_dist_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_dist_fast values ("a", 1, 11);
+[UC]function: dist_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast")
+[UC]function: dist_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast")
+ALTER TABLE t_dist_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast", ${dist_fast_job_count}, '${dist_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_dist_fast", "t_dist_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_dist_fast order by k1, k2;
+
+CREATE TABLE t_short_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_short_fast values ("a", 1, 12);
+[UC]function: short_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_short_fast")
+[UC]function: short_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_short_fast")
+ALTER TABLE t_short_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_short_fast", ${short_fast_job_count}, '${short_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_short_fast", "t_short_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_short_fast order by k1, k2;
+
+CREATE TABLE t_rollup_fast (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_rollup_fast values ("a", 1, 13);
+[UC]function: rollup_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast")
+[UC]function: rollup_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast")
+ALTER TABLE t_rollup_fast MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: assert_sync_fast_path("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", ${rollup_fast_job_count}, '${rollup_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", "t_rollup_fast", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+function: assert_index_schema_columns("test_varchar_widen_native_fast_${uuid0}", "t_rollup_fast", "r1", "k2|int|NO|true", "k1|varchar(30)|NO|true")
+[ORDER]select * from t_rollup_fast order by k1, k2;
+
+drop database test_varchar_widen_native_fast_${uuid0} force;
+
+
+-- name: test_varchar_widen_native_pk_fast_paths @native
+create database test_varchar_widen_native_pk_fast_${uuid0};
+use test_varchar_widen_native_pk_fast_${uuid0};
+
+CREATE TABLE t_pk_key_fast (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_pk_key_fast values ("pk-a", 14);
+[UC]function: pk_key_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast")
+[UC]function: pk_key_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast")
+ALTER TABLE t_pk_key_fast MODIFY COLUMN k1 VARCHAR(30);
+function: assert_sync_fast_path("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast", ${pk_key_fast_job_count}, '${pk_key_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_key_fast", "t_pk_key_fast", "k1|varchar(30)|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_pk_key_fast order by k1;
+
+CREATE TABLE t_pk_sort_fast (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_pk_sort_fast values (1, "sort-a", 15);
+[UC]function: pk_sort_fast_job_count=get_schema_change_job_count("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast")
+[UC]function: pk_sort_fast_index_snapshot=get_index_identity_snapshot("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast")
+ALTER TABLE t_pk_sort_fast MODIFY COLUMN k1 VARCHAR(30);
+function: assert_sync_fast_path("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast", ${pk_sort_fast_job_count}, '${pk_sort_fast_index_snapshot}')
+function: assert_index_schema_columns("test_varchar_widen_native_pk_fast_${uuid0}", "t_pk_sort_fast", "t_pk_sort_fast", "k0|int|NO|true", "k1|varchar(30)|YES|false", "v1|int|YES|false")
+[ORDER]select * from t_pk_sort_fast order by k0;
+
+drop database test_varchar_widen_native_pk_fast_${uuid0} force;
+
+
+-- name: test_varchar_widen_native_reject_paths @native
+create database test_varchar_widen_native_reject_${uuid0};
+use test_varchar_widen_native_reject_${uuid0};
+
+CREATE TABLE t_part_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+PARTITION BY LIST(k1) (
+    PARTITION p1 VALUES IN ("1"),
+    PARTITION p2 VALUES IN ("2")
+)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_part_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify partition column[k1]")
+
+CREATE TABLE t_dist_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_dist_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+
+CREATE TABLE t_pseudo_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pseudo_widen_reject MODIFY COLUMN k1 VARCHAR(30) KEY", "modify distribution column[k1]")
+
+CREATE TABLE t_colocate_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true",
+    "colocate_with" = "cg_varchar_widen_${uuid0}"
+);
+function: assert_query_error_contains("ALTER TABLE t_colocate_reject MODIFY COLUMN k1 VARCHAR(20) KEY NOT NULL", "for colocate table")
+
+drop database test_varchar_widen_native_reject_${uuid0} force;
+
+
+-- name: test_varchar_widen_native_pk_guard_paths @native
+create database test_varchar_widen_native_pk_${uuid0};
+use test_varchar_widen_native_pk_${uuid0};
+
+CREATE TABLE t_pk_key_reject (
+    k1 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_key_reject MODIFY COLUMN k1 INT", "Can not modify key column: k1 for primary key table except for increasing varchar length")
+
+CREATE TABLE t_pk_sort_reject (
+    k0 INT NOT NULL,
+    k1 VARCHAR(10),
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k0)
+DISTRIBUTED BY HASH(k0) BUCKETS 1
+ORDER BY(k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_sort_reject MODIFY COLUMN k1 BIGINT", "Can not modify sort column in primary data model table except for increasing varchar length")
+
+CREATE TABLE t_pk_reorder_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 VARCHAR(10) NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+PRIMARY KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_pk_reorder_reject MODIFY COLUMN k2 VARCHAR(30) FIRST", "Can not reorder pk keys by modify column")
+
+CREATE TABLE t_rollup_base_non_widen_reject (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_rollup_base_non_widen_reject MODIFY COLUMN k1 INT KEY NOT NULL", "modify distribution column[k1]")
+
+drop database test_varchar_widen_native_pk_${uuid0} force;
+
+
+-- name: test_varchar_widen_native_slow_and_multiclause @native
+create database test_varchar_widen_native_slow_${uuid0};
+use test_varchar_widen_native_slow_${uuid0};
+
+CREATE TABLE t_varchar_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "false"
+);
+insert into t_varchar_slow values ("a", 1, 20);
+ALTER TABLE t_varchar_slow MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL;
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow")
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", 1)
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", "slow")
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_varchar_slow", "t_varchar_slow", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_varchar_slow order by k1, k2;
+
+CREATE TABLE t_short_slow (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_short_slow values ("1", 1, 21);
+ALTER TABLE t_short_slow MODIFY COLUMN k1 INT KEY NOT NULL;
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_short_slow")
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", 1)
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", "slow")
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_short_slow", "t_short_slow", "k1|int|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+[ORDER]select * from t_short_slow order by k1, k2;
+
+CREATE TABLE t_multi_success (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into t_multi_success values ("m", 1, 22);
+ALTER TABLE t_multi_success MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN v1 BIGINT;
+function: wait_table_schema_change_finish("test_varchar_widen_native_slow_${uuid0}", "t_multi_success")
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", 1)
+function: assert_latest_schema_change_job_path("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", "slow")
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_success", "t_multi_success", "k1|varchar(30)|NO|true", "k2|int|NO|true", "v1|bigint|YES|false")
+[ORDER]select * from t_multi_success order by k1, k2;
+
+CREATE TABLE t_multi_same (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_multi_same MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL, MODIFY COLUMN k1 INT KEY NOT NULL", "Column[k1] does not exists")
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_same", 0)
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_same", "t_multi_same", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+
+CREATE TABLE t_multi_cross (
+    k1 VARCHAR(10) NOT NULL,
+    k2 INT NOT NULL,
+    v1 INT
+) ENGINE=OLAP
+DUPLICATE KEY(k1, k2)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+ROLLUP (
+    r1(k2, k1)
+)
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+function: assert_query_error_contains("ALTER TABLE t_multi_cross MODIFY COLUMN v1 BIGINT, MODIFY COLUMN k1 INT KEY NOT NULL FIRST FROM r1", "modify distribution column[k1]")
+function: assert_schema_change_job_count("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", 0)
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", "t_multi_cross", "k1|varchar(10)|NO|true", "k2|int|NO|true", "v1|int|YES|false")
+function: assert_index_schema_columns("test_varchar_widen_native_slow_${uuid0}", "t_multi_cross", "r1", "k2|int|NO|true", "k1|varchar(10)|NO|true")
+
+drop database test_varchar_widen_native_slow_${uuid0} force;


### PR DESCRIPTION
## What I'm doing:
1. Support widening varchar length for key / sort key / distribution key / partition key in share nothing and share data for all table model.
3. Support regular and fast path widening varchar length.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
