### PR TITLE
[BugFix] Reset scan range source on query retry for connector scan nodes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorScanRangeSource.java
@@ -86,6 +86,15 @@ public class HiveConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
     }
 
+    public void reset() {
+        remoteFileInfoSource = null;
+        iterator = null;
+        buffer = null;
+        hasMoreOutput = true;
+        backendSplitFile = true;
+        backendSplitCount = 0;
+    }
+
     public void setup() {
         Collection<Long> selectedPartitionIds = scanNodePredicates.getSelectedPartitionIds();
         if (selectedPartitionIds.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -53,10 +53,19 @@ public class DeltaLakeScanNode extends ScanNode {
     private DeltaConnectorScanRangeSource scanRangeSource = null;
     private volatile boolean reachLimit = false;
     private int selectedPartitionCount = -1;
+    private final ScalarOperator predicate;
+    private final List<String> fieldNames;
+    private final PartitionIdGenerator partitionIdGenerator;
+    private boolean enableIncrementalScanRanges = false;
 
-    public DeltaLakeScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
+    public DeltaLakeScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
+                             ScalarOperator predicate, List<String> fieldNames,
+                             PartitionIdGenerator partitionIdGenerator) {
         super(id, desc, planNodeName);
         deltaLakeTable = (DeltaLakeTable) desc.getTable();
+        this.predicate = predicate;
+        this.fieldNames = fieldNames;
+        this.partitionIdGenerator = partitionIdGenerator;
         setupCloudCredential();
     }
 
@@ -119,10 +128,8 @@ public class DeltaLakeScanNode extends ScanNode {
         scanRangeSource = null;
     }
 
-    public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames,
-                                     PartitionIdGenerator partitionIdGenerator,
-                                     boolean enableIncrementalScanRanges)
-            throws StarRocksException {
+    public void setupScanRangeSource(boolean enableIncrementalScanRanges) throws StarRocksException {
+        this.enableIncrementalScanRanges = enableIncrementalScanRanges;
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         DeltaUtils.checkProtocolAndMetadata(snapshot.getProtocol(), snapshot.getMetadata());
         Engine engine = deltaLakeTable.getDeltaEngine();
@@ -228,6 +235,17 @@ public class DeltaLakeScanNode extends ScanNode {
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
+    }
+
+    @Override
+    public void prepareRetry() {
+        clear();
+        reachLimit = false;
+        try {
+            setupScanRangeSource(enableIncrementalScanRanges);
+        } catch (StarRocksException e) {
+            throw new RuntimeException("Failed to reset DeltaLakeScanNode for retry", e);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -305,4 +305,10 @@ public class HdfsScanNode extends ScanNode {
     public void setScanSampleStrategy(RemoteFilesSampleStrategy strategy) {
         scanRangeSource.setSampleStrategy(strategy);
     }
+
+    @Override
+    public void prepareRetry() {
+        reachLimit = false;
+        this.scanRangeSource.reset();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -158,4 +158,9 @@ public class HudiScanNode extends ScanNode {
     public boolean canUseRuntimeAdaptiveDop() {
         return true;
     }
+
+    @Override
+    public void prepareRetry() {
+        this.scanRangeSource.reset();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -75,6 +75,7 @@ public class IcebergScanNode extends ScanNode {
     private IcebergMetricsReporter icebergScanMetricsReporter;
     private boolean usedForDelete = false;
     private boolean enableGlobalLateMaterialization = false;
+    private boolean enableIncrementalScanRanges = false;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
                            IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
@@ -166,6 +167,7 @@ public class IcebergScanNode extends ScanNode {
     }
 
     public void setupScanRangeLocations(boolean enableIncrementalScanRanges) throws StarRocksException {
+        this.enableIncrementalScanRanges = enableIncrementalScanRanges;
         Preconditions.checkNotNull(tvrVersionRange, "tvrVersionRange id is null");
         if (tvrVersionRange.isEmpty()) {
             LOG.warn(String.format("Table %s has no snapshot!", icebergTable.getCatalogTableName()));
@@ -416,6 +418,17 @@ public class IcebergScanNode extends ScanNode {
             tHdfsScanNode.setColumn_access_paths(columnAccessPathToThrift());
         }
         bucketProperties.ifPresent(properties -> HdfsScanNode.setBucketProperties(tHdfsScanNode, properties));
+    }
+
+    @Override
+    public void prepareRetry() {
+        clear();
+        reachLimit = false;
+        try {
+            setupScanRangeLocations(enableIncrementalScanRanges);
+        } catch (StarRocksException e) {
+            throw new RuntimeException("Failed to reset IcebergScanNode for retry", e);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -276,4 +276,8 @@ public abstract class ScanNode extends PlanNode {
     public Map<SlotId, Expr> getHeavyExprs() {
         return heavyExprs;
     }
+
+    public void prepareRetry() {
+        // default no-op: subclasses that maintain streaming scan state should override
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -15,7 +15,7 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.Pair;
@@ -29,7 +29,10 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.GlobalDictNotMatchException;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.connector.statistics.ConnectorTableColumnKey;
+import com.starrocks.planner.DeltaLakeScanNode;
 import com.starrocks.planner.HdfsScanNode;
+import com.starrocks.planner.HudiScanNode;
+import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.SlotId;
 import com.starrocks.rpc.RpcException;
@@ -215,24 +218,42 @@ public class ExecuteExceptionHandler {
         List<ScanNode> scanNodes = context.execPlan.getScanNodes();
         boolean existExternalCatalog = false;
         for (ScanNode scanNode : scanNodes) {
+            Table table = null;
             if (scanNode instanceof HdfsScanNode) {
-                HiveTable hiveTable = ((HdfsScanNode) scanNode).getHiveTable();
-                String catalogName = hiveTable.getCatalogName();
-                if (CatalogMgr.isExternalCatalog(catalogName)) {
-                    existExternalCatalog = true;
-                    ConnectorMetadata metadata = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .getOptionalMetadata(hiveTable.getCatalogName()).get();
-                    // refresh catalog level metadata cache
-                    metadata.refreshTable(hiveTable.getCatalogDBName(), hiveTable, new ArrayList<>(), true);
-                    // clear query level metadata cache
-                    metadata.clear();
-                }
+                table = ((HdfsScanNode) scanNode).getHiveTable();
+            } else if (scanNode instanceof IcebergScanNode) {
+                table = ((IcebergScanNode) scanNode).getIcebergTable();
+            } else if (scanNode instanceof DeltaLakeScanNode) {
+                table = ((DeltaLakeScanNode) scanNode).getDeltaLakeTable();
+            } else if (scanNode instanceof HudiScanNode) {
+                table = ((HudiScanNode) scanNode).getHudiTable();
+            }
+            if (table != null) {
+                existExternalCatalog |= refreshExternalTableIfNeeded(table);
             }
         }
         if (!existExternalCatalog) {
             throw e;
         }
         Tracers.record(Tracers.Module.EXTERNAL, "HMS.RETRY", String.valueOf(context.retryTime + 1));
+    }
+
+    /**
+     * Refreshes the connector metadata cache for an external catalog table.
+     * Returns true if the table belongs to an external catalog and was refreshed.
+     */
+    private static boolean refreshExternalTableIfNeeded(Table table) {
+        String catalogName = table.getCatalogName();
+        if (!CatalogMgr.isExternalCatalog(catalogName)) {
+            return false;
+        }
+        ConnectorMetadata metadata = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getOptionalMetadata(catalogName).get();
+        // refresh catalog level metadata cache
+        metadata.refreshTable(table.getCatalogDBName(), table, new ArrayList<>(), true);
+        // clear query level metadata cache
+        metadata.clear();
+        return true;
     }
 
     private static void tryTriggerRefreshDictAsync(GlobalDictNotMatchException e, RetryContext context) {
@@ -333,6 +354,13 @@ public class ExecuteExceptionHandler {
             this.execPlan = execPlan;
             this.connectContext = connectContext;
             this.parsedStmt = parsedStmt;
+        }
+
+        public void prepareRetry() {
+            List<ScanNode> scanNodes = execPlan.getScanNodes();
+            for (ScanNode scanNode : scanNodes) {
+                scanNode.prepareRetry();
+            }
         }
 
         public ExecPlan getExecPlan() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -982,6 +982,7 @@ public class StmtExecutor {
                             LOG.info("transfer QueryId: {} to {}", DebugUtil.printId(context.getQueryId()),
                                     DebugUtil.printId(uuid));
                             context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
+                            retryContext.prepareRetry();
                         }
 
                         handleQueryStmt(retryContext.getExecPlan());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1358,8 +1358,12 @@ public class PlanFragmentBuilder {
             prepareContextSlots(node, context, tupleDescriptor);
 
             PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
+            List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
+                    .map(ColumnRefOperator::getName)
+                    .collect(Collectors.toList());
             DeltaLakeScanNode deltaLakeScanNode =
-                    new DeltaLakeScanNode(context.getNextNodeId(), tupleDescriptor, "DeltaLakeScanNode");
+                    new DeltaLakeScanNode(context.getNextNodeId(), tupleDescriptor, "DeltaLakeScanNode",
+                            node.getPredicate(), fieldNames, partitionIdGenerator);
             deltaLakeScanNode.computeStatistics(optExpression.getStatistics());
             deltaLakeScanNode.setScanOptimizeOption(node.getScanOptimizeOption());
             currentExecGroup.add(deltaLakeScanNode, true);
@@ -1373,10 +1377,7 @@ public class PlanFragmentBuilder {
                             .add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
                 }
 
-                List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
-                        .map(ColumnRefOperator::getName)
-                        .collect(Collectors.toList());
-                deltaLakeScanNode.setupScanRangeSource(node.getPredicate(), fieldNames, partitionIdGenerator,
+                deltaLakeScanNode.setupScanRangeSource(
                         context.getConnectContext().getSessionVariable().isEnableConnectorIncrementalScanRanges());
 
                 HDFSScanNodePredicates scanNodePredicates = deltaLakeScanNode.getScanNodePredicates();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -21,12 +21,6 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
-import com.starrocks.connector.ConnectorProperties;
-import com.starrocks.connector.ConnectorScanRangeSource;
-import com.starrocks.connector.ConnectorType;
-import com.starrocks.connector.GetRemoteFilesParams;
-import com.starrocks.connector.HdfsEnvironment;
-import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.delta.DeltaConnectorScanRangeSource;
 import com.starrocks.connector.delta.DeltaLakeAddFileStatsSerDe;
 import com.starrocks.connector.delta.DeltaLakeMetadata;
@@ -126,7 +120,6 @@ public class ExternalResourceCleanupTest {
         schema.add(new Column("id", IntegerType.INT));
         schema.add(new Column("k1", IntegerType.INT));
         schema.add(new Column("k2", VarcharType.VARCHAR));
-
 
         // minimal IcebergTable: nativeTable can be null for this test because getNativeTable isn't invoked in close().
         IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
@@ -253,7 +246,8 @@ public class ExternalResourceCleanupTest {
         TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
         tupleDescriptor.setTable(table);
 
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaLakeScanNode scanNode =
+                new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode", null, null, null);
         DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
 
         Field field = DeltaLakeScanNode.class.getDeclaredField("scanRangeSource");
@@ -273,7 +267,8 @@ public class ExternalResourceCleanupTest {
         TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
         tupleDescriptor.setTable(table);
 
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaLakeScanNode scanNode =
+                new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode", null, null, null);
         DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
 
         Field field = DeltaLakeScanNode.class.getDeclaredField("scanRangeSource");
@@ -294,7 +289,8 @@ public class ExternalResourceCleanupTest {
         TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
         tupleDescriptor.setTable(table);
 
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaLakeScanNode scanNode =
+                new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode", null, null, null);
         // scanRangeSource remains null
         scanNode.clear(); // should not throw
     }
@@ -423,7 +419,7 @@ public class ExternalResourceCleanupTest {
             internalMock.when(() -> InternalScanFileUtils.getDeletionVectorDescriptorFromRow(row))
                     .thenReturn((DeletionVectorDescriptor) null);
             scanFileMock.when(() -> ScanFileUtils.convertFromRowToFileScanTask(
-                    Mockito.anyBoolean(), Mockito.eq(row), Mockito.eq(meta), Mockito.anyLong(), Mockito.isNull()))
+                            Mockito.anyBoolean(), Mockito.eq(row), Mockito.eq(meta), Mockito.anyLong(), Mockito.isNull()))
                     .thenReturn(Pair.create(fileTask, serDe));
 
             // invoke iterator
@@ -722,7 +718,8 @@ public class ExternalResourceCleanupTest {
         TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
         tupleDescriptor.setTable(table);
 
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaLakeScanNode scanNode =
+                new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode", null, null, null);
         DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
         Mockito.doThrow(new RuntimeException("close error")).when(scanRangeSource).close();
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorScanRangeSourceTest.java
@@ -36,6 +36,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,5 +112,38 @@ public class HiveConnectorScanRangeSourceTest {
         public void invokeInitRemoteFileInfoSource() {
             super.initRemoteFileInfoSource();
         }
+    }
+
+    @Test
+    public void testReset() throws Exception {
+        HiveTable table = Mockito.mock(HiveTable.class);
+        HDFSScanNodePredicates predicates = new HDFSScanNodePredicates();
+        DescriptorTable descriptorTable = new DescriptorTable();
+        HiveConnectorScanRangeSource source =
+                new HiveConnectorScanRangeSource(descriptorTable, table, predicates);
+
+        // simulate partially consumed state
+        setField(source, "hasMoreOutput", false);
+        setField(source, "backendSplitCount", 5L);
+
+        source.reset();
+
+        assertThat((boolean) getField(source, "hasMoreOutput")).isTrue();
+        assertThat((long) getField(source, "backendSplitCount")).isZero();
+        assertThat(getField(source, "remoteFileInfoSource")).isNull();
+        assertThat(getField(source, "iterator")).isNull();
+        assertThat(getField(source, "buffer")).isNull();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = HiveConnectorScanRangeSource.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static Object getField(Object target, String fieldName) throws Exception {
+        Field f = HiveConnectorScanRangeSource.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return f.get(target);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
@@ -15,7 +15,10 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.delta.DeltaConnectorScanRangeSource;
 import com.starrocks.connector.delta.DeltaLakeEngine;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -23,6 +26,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExplainLevel;
 import io.delta.kernel.Snapshot;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -51,7 +56,7 @@ public class DeltaLakeScanNodeTest {
         };
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "XXX");
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "XXX", null, null, null);
         scanNode.setReachLimit();
     }
 
@@ -82,7 +87,7 @@ public class DeltaLakeScanNodeTest {
         };
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node");
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node", null, null, null);
         Assertions.assertFalse(scanNode.getNodeExplainString("", TExplainLevel.NORMAL).contains("partitions"));
         Assertions.assertTrue(scanNode.getNodeExplainString("", TExplainLevel.VERBOSE).contains("partitions"));
     }
@@ -126,8 +131,47 @@ public class DeltaLakeScanNodeTest {
             }};
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
-        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node");
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node", null, null, null);
         String explainString = scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
         assertThat(explainString, containsString("TABLE VERSION: 123"));
+    }
+
+    @Test
+    public void testPrepareRetry(@Mocked GlobalStateMgr globalStateMgr,
+                                 @Mocked CatalogConnector connector,
+                                 @Mocked DeltaLakeTable table,
+                                 @Mocked DeltaConnectorScanRangeSource mockSource) {
+        String catalog = "delta_cat";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+            result = connector;
+            connector.getMetadata().getCloudConfiguration();
+            result = cc;
+            table.getCatalogName();
+            result = catalog;
+        }};
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node", null, null, null);
+
+        // Stub setupScanRangeSource so it does not invoke real Delta kernel objects
+        new MockUp<DeltaLakeScanNode>() {
+            @Mock
+            public void setupScanRangeSource(boolean enableIncrementalScanRanges) throws StarRocksException {
+                // no-op
+            }
+        };
+
+        // Simulate partially consumed state
+        Deencapsulation.setField(scanNode, "scanRangeSource", mockSource);
+        Deencapsulation.setField(scanNode, "reachLimit", true);
+
+        scanNode.prepareRetry();
+
+        Assertions.assertFalse((boolean) Deencapsulation.getField(scanNode, "reachLimit"),
+                "reachLimit should be reset to false");
+        Assertions.assertNull(Deencapsulation.getField(scanNode, "scanRangeSource"),
+                "scanRangeSource should be cleared by clear()");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
@@ -15,12 +15,15 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.HudiTable;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.hudi.HudiConnectorScanRangeSource;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -46,5 +49,33 @@ public class HudiScanNodeTest {
         desc.setTable(table);
         HudiScanNode scanNode = new HudiScanNode(new PlanNodeId(0), desc, "XXX");
         scanNode.setReachLimit();
+    }
+
+    @Test
+    public void testPrepareRetry(@Mocked GlobalStateMgr globalStateMgr,
+                                 @Mocked CatalogConnector connector,
+                                 @Mocked HudiTable table,
+                                 @Mocked HudiConnectorScanRangeSource mockSource) {
+        String catalog = "hudi_cat";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+            result = connector;
+            connector.getMetadata().getCloudConfiguration();
+            result = cc;
+            table.getCatalogName();
+            result = catalog;
+        }};
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        HudiScanNode scanNode = new HudiScanNode(new PlanNodeId(0), desc, "XXX");
+        Deencapsulation.setField(scanNode, "scanRangeSource", mockSource);
+
+        scanNode.prepareRetry();
+
+        new Verifications() {{
+            mockSource.reset();
+            times = 1;
+        }};
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -965,6 +965,29 @@ public class IcebergScanNodeTest {
     }
 
     @Test
+    public void testPrepareRetry(@Mocked IcebergTable table,
+                                 @Mocked IcebergConnectorScanRangeSource mockSource) throws Exception {
+        // setupCloudCredential returns early when catalogName is null (mocked default)
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        IcebergScanNode scanNode = new IcebergScanNode(
+                new PlanNodeId(0), desc, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null);
+        // Set empty snapshot so setupScanRangeLocations returns early
+        scanNode.setTvrVersionRange(TvrTableSnapshot.empty());
+        // Simulate partially consumed state
+        Deencapsulation.setField(scanNode, "scanRangeSource", mockSource);
+        Deencapsulation.setField(scanNode, "reachLimit", true);
+
+        scanNode.prepareRetry();
+
+        Assertions.assertFalse((boolean) Deencapsulation.getField(scanNode, "reachLimit"),
+                "reachLimit should be reset to false");
+        Assertions.assertNull(Deencapsulation.getField(scanNode, "scanRangeSource"),
+                "scanRangeSource should be cleared");
+    }
+
+    @Test
     public void testGetBucketNums(@Mocked IcebergTable table) {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);


### PR DESCRIPTION
## Why I'm doing this

When a query is retried (e.g. due to `REMOTE_FILE_NOT_FOUND`), the same `ExecPlan` and its `ScanNode` objects are reused. However, the `ConnectorScanRangeSource` inside each scan node maintains internal streaming state (iterator, buffer,
`remoteFileInfoSource`, etc.) that was partially or fully consumed during the failed attempt. Without resetting this state, the retry reads from where the previous attempt left off — or produces no output at all — instead of starting fresh.

## What I'm doing

- **`ScanNode.prepareRetry()`**: change default from `UnsupportedOperationException` to a no-op; only nodes with streaming state need to override it.
- **`HiveConnectorScanRangeSource.reset()`**: add a `reset()` method that clears all streaming state so remote files are re-fetched lazily on the next scan.
- **`HdfsScanNode` / `HudiScanNode`**: override `prepareRetry()` to call `scanRangeSource.reset()`.
- **`IcebergScanNode` / `DeltaLakeScanNode`**: override `prepareRetry()` to close the old source via `clear()` and recreate it (necessary because their source holds a `final` field that cannot be reset in-place). The setup parameters are stored
at construction/first-setup time and reused on retry.
- **`DeltaLakeScanNode`** (minor refactor): move `predicate`, `fieldNames`, `partitionIdGenerator` into the constructor as immutable fields, consistent with `IcebergScanNode`'s style.
- **`ExecuteExceptionHandler.handleRemoteFileNotFound()`**: extend to handle `IcebergScanNode`, `DeltaLakeScanNode`, and `HudiScanNode` (previously only `HdfsScanNode` was handled). Extract the shared refresh logic into
`refreshExternalTableIfNeeded(Table)`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
