### PR TITLE
[Enhancement] AggDataTypeTraits support append_values

### DIFF
--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -73,8 +73,13 @@ struct AggDataTypeTraits<lt, ObjectFamilyLTGuard<lt>> {
     static void append_value(ColumnType* column, const ValueType& value) { column->append(&value); }
 
     static void append_values(Column* column, const ValueType& value, size_t count) {
+        if (count == 0) {
+            return;
+        }
+        auto* col = down_cast<ColumnType*>(column);
+        col->reserve(col->size() + count);
         for (size_t i = 0; i < count; ++i) {
-            down_cast<ColumnType*>(column)->append(&value);
+            col->append(&value);
         }
     }
 

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -36,6 +36,9 @@ struct AggDataTypeTraits<lt, FixedLengthLTGuard<lt>> {
     static void assign_value(ColumnType* column, size_t row, const RefType& ref) { column->get_data()[row] = ref; }
 
     static void append_value(ColumnType* column, const ValueType& value) { column->append(value); }
+    static void append_values(Column* column, const ValueType& value, size_t count) {
+        down_cast<ColumnType*>(column)->append_value_multiple_times(&value, count);
+    }
 
     static RefType get_row_ref(const Column& column, size_t row) {
         return down_cast<const ColumnType&>(column).immutable_data()[row];
@@ -68,6 +71,13 @@ struct AggDataTypeTraits<lt, ObjectFamilyLTGuard<lt>> {
     static void assign_value(ColumnType* column, size_t row, const ValueType& ref) { *column->get_object(row) = ref; }
 
     static void append_value(ColumnType* column, const ValueType& value) { column->append(&value); }
+
+    static void append_values(Column* column, const ValueType& value, size_t count) {
+        for (size_t i = 0; i < count; ++i) {
+            down_cast<ColumnType*>(column)->append(&value);
+        }
+    }
+
     static RefType get_ref(const ValueType& value) { return &value; }
 
     static const RefType get_row_ref(const Column& column, size_t row) {
@@ -107,6 +117,10 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
     static void append_value(ColumnType* column, const ValueType& value) {
         column->append_datum(value->get(0).template get<CppType>());
     }
+    static void append_values(Column* column, const ValueType& value, size_t count) {
+        Datum d(value->get(0).template get<CppType>());
+        column->append_value_multiple_times(&d, count);
+    }
 
     static RefType get_row_ref(const Column& column, size_t row) { return RefType(&column, row); }
 
@@ -133,6 +147,16 @@ struct AggDataTypeTraits<lt, StringOrBinaryGuard<lt>> {
 
     static void append_value(ColumnType* column, const ValueType& value) {
         column->append(Slice(value.data(), value.size()));
+    }
+
+    static void append_values(Column* column, const ValueType& value, size_t count) {
+        if (UNLIKELY(column->is_large_binary())) {
+            Slice slice(value.data(), value.size());
+            down_cast<LargeColumnType*>(column)->append_value_multiple_times(&slice, count);
+        } else {
+            Slice slice(value.data(), value.size());
+            down_cast<ColumnType*>(column)->append_value_multiple_times(&slice, count);
+        }
     }
 
     static RefType get_row_ref(const Column& column, size_t row) {

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -113,8 +113,7 @@ class ValueWindowFunction : public WindowFunction<State> {
 public:
     using InputColumnType = RunTimeColumnType<LT>;
 
-    template <typename InputColumnType>
-    void do_get_values_helper(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
+    void get_values_helper(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
         DCHECK_GT(end, start);
         DCHECK(dst->is_nullable());
         auto* nullable_column = down_cast<NullableColumn*>(dst);
@@ -131,17 +130,7 @@ public:
 
             Column* data_column = nullable_column->data_column_raw_ptr();
             auto& value = AggregateFunctionStateHelper<State>::data(state).value;
-            auto* column = down_cast<InputColumnType*>(data_column);
-            if constexpr (lt_is_string_or_binary<LT>) {
-                auto slice = AggDataTypeTraits<LT>::get_ref(value);
-                for (size_t i = start; i < end; ++i) {
-                    column->append(slice);
-                }
-            } else {
-                for (size_t i = start; i < end; ++i) {
-                    AggDataTypeTraits<LT>::append_value(column, value);
-                }
-            }
+            AggDataTypeTraits<LT>::append_values(data_column, value, end - start);
         } else {
             /// The dst column has been resized.
             if (AggregateFunctionStateHelper<State>::data(state).is_null) {
@@ -157,17 +146,6 @@ public:
                 AggDataTypeTraits<LT>::assign_value(column, i, value);
             }
         }
-    }
-
-    void get_values_helper(ConstAggDataPtr __restrict state, Column* dst, size_t start, size_t end) const {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            const Column* data_column = ColumnHelper::get_data_column(dst);
-            if (data_column->is_large_binary()) {
-                do_get_values_helper<LargeBinaryColumn>(state, dst, start, end);
-                return;
-            }
-        }
-        do_get_values_helper<InputColumnType>(state, dst, start, end);
     }
 };
 
@@ -437,10 +415,9 @@ template <LogicalType LT, bool ignoreNulls, typename T = RunTimeCppType<LT>, typ
 class FirstValueWindowFunction final : public ValueWindowFunction<LT, FirstValueState<LT>, T> {
     using InputColumnType = typename ValueWindowFunction<LT, FirstValueState<LT>, T>::InputColumnType;
 
-    template <typename InputColumnType>
-    void do_update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state,
-                                                 const Column** columns, int64_t peer_group_start,
-                                                 int64_t peer_group_end, int64_t frame_start, int64_t frame_end) const {
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const {
         // For cases like: rows between 2 preceding and 1 preceding
         // If frame_start ge frame_end, means the frame is empty
         if (frame_start >= frame_end) {
@@ -477,21 +454,6 @@ class FirstValueWindowFunction final : public ValueWindowFunction<LT, FirstValue
         this->data(state).has_value = false;
     }
 
-    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
-                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const override {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            if (data_column->is_large_binary()) {
-                do_update_batch_single_state_with_frame<LargeBinaryColumn>(ctx, state, columns, peer_group_start,
-                                                                           peer_group_end, frame_start, frame_end);
-                return;
-            }
-        }
-        do_update_batch_single_state_with_frame<InputColumnType>(ctx, state, columns, peer_group_start, peer_group_end,
-                                                                 frame_start, frame_end);
-    }
-
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         this->get_values_helper(state, dst, start, end);
@@ -512,10 +474,9 @@ template <LogicalType LT, bool ignoreNulls, typename T = RunTimeCppType<LT>>
 class LastValueWindowFunction final : public ValueWindowFunction<LT, LastValueState<LT, ignoreNulls>, T> {
     using InputColumnType = typename ValueWindowFunction<LT, FirstValueState<LT>, T>::InputColumnType;
 
-    template <typename InputColumnType>
-    void do_update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state,
-                                                 const Column** columns, int64_t peer_group_start,
-                                                 int64_t peer_group_end, int64_t frame_start, int64_t frame_end) const {
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const {
         if (frame_start >= frame_end) {
             if (!this->data(state).has_value) {
                 this->data(state).is_null = true;
@@ -545,21 +506,6 @@ class LastValueWindowFunction final : public ValueWindowFunction<LT, LastValueSt
         this->data(state).value = {};
         this->data(state).is_null = false;
         this->data(state).has_value = false;
-    }
-
-    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
-                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const override {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            if (data_column->is_large_binary()) {
-                do_update_batch_single_state_with_frame<LargeBinaryColumn>(ctx, state, columns, peer_group_start,
-                                                                           peer_group_end, frame_start, frame_end);
-                return;
-            }
-        }
-        do_update_batch_single_state_with_frame<InputColumnType>(ctx, state, columns, peer_group_start, peer_group_end,
-                                                                 frame_start, frame_end);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
@@ -598,10 +544,9 @@ template <LogicalType LT, bool ignoreNulls, bool isLag, typename T = RunTimeCppT
 class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<LT, ignoreNulls>, T> {
     using InputColumnType = typename ValueWindowFunction<LT, FirstValueState<LT>, T>::InputColumnType;
 
-    template <typename InputColumnType>
-    void do_update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state,
-                                                 const Column** columns, int64_t peer_group_start,
-                                                 int64_t peer_group_end, int64_t frame_start, int64_t frame_end) const {
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const {
         // for lead/lag, [peer_group_start, peer_group_end] equals to [partition_start, partition_end]
         // when lead/lag called, the whole partitoin's data has already been here, so we can just check all the way to the begining or the end
         if constexpr (ignoreNulls) {
@@ -818,21 +763,6 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
         }
     }
 
-    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
-                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const override {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            if (data_column->is_large_binary()) {
-                do_update_batch_single_state_with_frame<LargeBinaryColumn>(ctx, state, columns, peer_group_start,
-                                                                           peer_group_end, frame_start, frame_end);
-                return;
-            }
-        }
-        do_update_batch_single_state_with_frame<InputColumnType>(ctx, state, columns, peer_group_start, peer_group_end,
-                                                                 frame_start, frame_end);
-    }
-
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         this->get_values_helper(state, dst, start, end);
@@ -857,10 +787,9 @@ class SessionNumberWindowFunction final : public WindowFunction<AllocateSessionS
 public:
     using InputColumnType = RunTimeColumnType<LT>;
 
-    template <typename InputColumnType>
-    void do_update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state,
-                                                 const Column** columns, int64_t peer_group_start,
-                                                 int64_t peer_group_end, int64_t frame_start, int64_t frame_end) const {
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const {
         const Column* data_column = ColumnHelper::get_data_column(columns[0]);
 
         DCHECK(frame_start < frame_end);
@@ -894,21 +823,6 @@ public:
         if (!delta_column->only_null() && !delta_column->empty()) {
             this->data(state).delta = ColumnHelper::get_const_value<LogicalType::TYPE_INT>(args[1]);
         }
-    }
-
-    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
-                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const override {
-        if constexpr (lt_is_string_or_binary<LT>) {
-            const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-            if (data_column->is_large_binary()) {
-                do_update_batch_single_state_with_frame<LargeBinaryColumn>(ctx, state, columns, peer_group_start,
-                                                                           peer_group_end, frame_start, frame_end);
-                return;
-            }
-        }
-        do_update_batch_single_state_with_frame<InputColumnType>(ctx, state, columns, peer_group_start, peer_group_end,
-                                                                 frame_start, frame_end);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -417,7 +417,7 @@ class FirstValueWindowFunction final : public ValueWindowFunction<LT, FirstValue
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const {
+                                              int64_t frame_end) const override {
         // For cases like: rows between 2 preceding and 1 preceding
         // If frame_start ge frame_end, means the frame is empty
         if (frame_start >= frame_end) {
@@ -476,7 +476,7 @@ class LastValueWindowFunction final : public ValueWindowFunction<LT, LastValueSt
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const {
+                                              int64_t frame_end) const override {
         if (frame_start >= frame_end) {
             if (!this->data(state).has_value) {
                 this->data(state).is_null = true;
@@ -546,7 +546,7 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const {
+                                              int64_t frame_end) const override {
         // for lead/lag, [peer_group_start, peer_group_end] equals to [partition_start, partition_end]
         // when lead/lag called, the whole partitoin's data has already been here, so we can just check all the way to the begining or the end
         if constexpr (ignoreNulls) {
@@ -789,7 +789,7 @@ public:
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
-                                              int64_t frame_end) const {
+                                              int64_t frame_end) const override {
         const Column* data_column = ColumnHelper::get_data_column(columns[0]);
 
         DCHECK(frame_start < frame_end);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -133,6 +133,7 @@ set(EXEC_FILES
         ./exprs/agg/window_test.cpp
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp
+        ./exprs/agg/aggregate_traits_test.cpp
         ./exprs/ai_functions_test.cpp
         ./exprs/arithmetic_operation_test.cpp
         ./exprs/decimal_binary_function_test.cpp

--- a/be/test/exprs/agg/aggregate_traits_test.cpp
+++ b/be/test/exprs/agg/aggregate_traits_test.cpp
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/agg/aggregate_traits.h"
+
+#include <gtest/gtest.h>
+
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column_builder.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/object_column.h"
+#include "runtime/mem_pool.h"
+#include "types/bitmap_value.h"
+
+namespace starrocks {
+
+class AggregateTraitsTest : public testing::Test {
+public:
+    AggregateTraitsTest() = default;
+
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(AggregateTraitsTest, FixedLength_append_values_int32) {
+    using Traits = AggDataTypeTraits<TYPE_INT>;
+    auto col = Int32Column::create();
+    Traits::ValueType value = 42;
+    Traits::append_values(col.get(), value, 5);
+    EXPECT_EQ(col->debug_string(), "[42, 42, 42, 42, 42]");
+}
+
+TEST_F(AggregateTraitsTest, ObjectFamily_append_values_bitmap) {
+    using Traits = AggDataTypeTraits<TYPE_OBJECT>;
+    auto col = BitmapColumn::create();
+    BitmapValue value;
+    value.add(1);
+    value.add(2);
+    value.add(3);
+    Traits::append_values(col.get(), value, 3);
+    EXPECT_EQ(col->debug_string(), "[1,2,3, 1,2,3, 1,2,3]");
+}
+
+TEST_F(AggregateTraitsTest, StringOrBinary_append_values_varchar) {
+    using Traits = AggDataTypeTraits<TYPE_VARCHAR>;
+    auto col = BinaryColumn::create();
+    Traits::ValueType value{'h', 'e', 'l', 'l', 'o'};
+    Traits::append_values(col.get(), value, 4);
+    EXPECT_EQ(col->debug_string(), "['hello', 'hello', 'hello', 'hello']");
+}
+
+TEST_F(AggregateTraitsTest, StringOrBinary_append_values_large_binary) {
+    using Traits = AggDataTypeTraits<TYPE_VARCHAR>;
+    auto col = LargeBinaryColumn::create();
+    Traits::ValueType value{'f', 'o', 'o'};
+    Traits::append_values(col.get(), value, 3);
+    EXPECT_EQ(col->debug_string(), "['foo', 'foo', 'foo']");
+}
+
+TEST_F(AggregateTraitsTest, Array_append_values) {
+    using Traits = AggDataTypeTraits<TYPE_ARRAY>;
+
+    // Build value: ArrayColumn holding one row [1, 2, 3]
+    auto value_elem = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto value_offs = UInt32Column::create();
+    auto value = ArrayColumn::create(std::move(value_elem), std::move(value_offs));
+    value->append_datum(DatumArray{(int32_t)1, (int32_t)2, (int32_t)3});
+
+    // Build destination column
+    auto dst_elem = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto dst_offs = UInt32Column::create();
+    auto col = ArrayColumn::create(std::move(dst_elem), std::move(dst_offs));
+
+    Traits::append_values(col.get(), value, 3);
+
+    EXPECT_EQ(col->debug_string(), "[[1,2,3], [1,2,3], [1,2,3]]");
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

AggDataTypeTraits supports append_values. This is the 3nd refactor for https://github.com/StarRocks/starrocks/pull/69067, making the code cleaner and easier to backport to other branches

## What I'm doing:

AggDataTypeTraits support append_values

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
