### PR TITLE
[Enhancement] Add sql_digest_exclude_db session variable to support c…

### DIFF
--- a/docs/en/administration/sql_digest.md
+++ b/docs/en/administration/sql_digest.md
@@ -98,3 +98,41 @@ WHERE digest IN (SELECT digest FROM top_sql);
 - Constant values in SQL will be normalized. For example, similar SQL statements with `WHERE a = 1` and `WHERE a = 2` will have the same Digest.
 - IN predicates will be normalized. For example, similar SQL statements with `IN (1,2,3)` and `IN (1,2)` will have the same Digest.
 - `LIMIT N` clauses will be normalized. For example, similar SQL statements with `LIMIT 10` and `LIMIT 30` will have the same Digest.
+
+## Cross-database Digest
+
+By default, SQL Digest includes the database name in the computation. This means the same SQL pattern executed in different databases will produce different Digests. For example:
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- Digest: aaa...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- Digest: bbb... (different from above)
+```
+
+If you want the same SQL pattern to produce the same Digest regardless of which database it runs in, you can set the session variable `sql_digest_exclude_db` to `true`:
+
+```SQL
+SET sql_digest_exclude_db = true;
+```
+
+After enabling this option, the database name will be excluded from the Digest computation, allowing you to aggregate SQL patterns across different databases.
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- Digest: ccc...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- Digest: ccc... (same as above)
+```
+
+:::note
+
+External catalog names are always included in the Digest regardless of this setting.
+
+:::

--- a/docs/ja/administration/sql_digest.md
+++ b/docs/ja/administration/sql_digest.md
@@ -2,28 +2,28 @@
 displayed_sidebar: docs
 ---
 
-# SQL Digest
+# SQLダイジェスト
 
-このトピックでは、StarRocks の SQL Digest 機能について紹介します。この機能は v3.3.6 以降でサポートされています。
+このトピックでは、StarRocksのSQLダイジェスト機能について説明します。この機能はv3.3.6以降でサポートされています。
 
 ## 概要
 
-SQL Digest は、パラメータを削除した履歴 SQL ステートメントから生成されるフィンガープリントです。同じ構造で異なるパラメータを持つ SQL ステートメントをクラスタリングするのに役立ちます。
+SQLダイジェストは、パラメータが削除された過去のSQLステートメントによって生成されるフィンガープリントです。これにより、同じ構造だが異なるパラメータを持つSQLステートメントをクラスタリングできます。
 
-SQL Digest の一般的な使用例には以下があります:
+SQLダイジェストの一般的なユースケースは次のとおりです。
 
-- クエリ履歴で同じ構造だが異なるパラメータを持つ他の SQL ステートメントを見つける
-- 同じ構造の SQL の実行頻度、累積時間、その他の統計を追跡する
-- システム内で最も時間のかかる SQL パターンを特定する
+- クエリ履歴内で、同じ構造だが異なるパラメータを持つ他のSQLステートメントを見つける
+- 同じ構造を持つSQLの実行頻度、累積時間、その他の統計を追跡する
+- システム内で最も時間のかかるSQLパターンを特定する
 
-StarRocks では、SQL Digest は主に監査ログ **fe.audit.log** を通じて記録されます。例えば、次の 2 つの SQL ステートメントを実行します:
+StarRocksでは、SQLダイジェストは主に監査ログを通じて記録されます。**fe.audit.log**。例えば、次の2つのSQLステートメントを実行します。
 
 ```SQL
 SELECT count(*) FROM lineorder WHERE lo_orderdate > '19920101';
 SELECT count(*) FROM lineorder WHERE lo_orderdate > '19920202';
 ```
 
-2 つの同じ Digest が **fe.audit.log** に生成されます:
+2つの同じダイジェストが生成されます。**fe.audit.log**：
 
 ```SQL
 Digest=f58bb71850d112014f773717830e7f77
@@ -34,19 +34,19 @@ Digest=f58bb71850d112014f773717830e7f77
 
 ### 前提条件
 
-この機能を有効にするには、FE の設定項目 `enable_sql_digest` を `true` に設定する必要があります。
+この機能を有効にするには、FE構成項目`enable_sql_digest`を`true`に設定する必要があります。
 
-次のステートメントを実行して動的に有効にします:
+動的に有効にするには、次のステートメントを実行します。
 
 ```SQL
 ADMIN SET FRONTEND CONFIG ('enable_sql_digest'='true');
 ```
 
-永続的に有効にするには、FE 設定ファイル `fe.conf` に `enable_sql_digest = true` を追加し、FE を再起動する必要があります。
+永続的に有効にするには、FE構成ファイル`fe.conf`に`enable_sql_digest = true`を追加し、FEを再起動する必要があります。
 
-この機能を有効にした後、[AuditLoader](./management/audit_loader.md) プラグインをインストールして、SQL ステートメントの統計分析を行うことができます。
+この機能を有効にした後、[AuditLoader](./management/audit_loader.md)プラグインをインストールして、SQLステートメントの統計分析を実行できます。
 
-### 類似 SQL を見つける
+### 類似のSQLを見つける
 
 ```SQL
 SELECT * FROM starrocks_audit_db__.starrocks_audit_tbl__ 
@@ -54,7 +54,7 @@ WHERE digest = '<Digest>'
 LIMIT 1;
 ```
 
-### 類似 SQL の日次実行回数と時間を追跡する
+### 類似のSQLの1日の実行回数と時間を追跡する
 
 ```SQL
 SELECT 
@@ -71,7 +71,7 @@ ORDER BY query_date
 DESC LIMIT 30;
 ```
 
-### 類似 SQL の平均実行時間を計算する
+### 類似のSQLの平均実行時間を計算する
 
 ```SQL
 SELECT avg(queryTime), min(queryTime), max(queryTime), stddev(queryTime)
@@ -79,7 +79,7 @@ FROM starrocks_audit_db__.starrocks_audit_tbl__
 WHERE digest = '<Digest>';
 ```
 
-### 類似 SQL を集約して最も時間のかかるパターンを分析する
+### 類似のSQLを集計して、最も時間のかかるパターンを分析する
 
 ```SQL
 WITH top_sql AS (
@@ -95,6 +95,44 @@ WHERE digest IN (SELECT digest FROM top_sql);
 
 ## パラメータ正規化ルール
 
-- SQL 内の定数値は正規化されます。例えば、`WHERE a = 1` と `WHERE a = 2` を持つ類似の SQL ステートメントは同じ Digest を持ちます。
-- IN 述語は正規化されます。例えば、`IN (1,2,3)` と `IN (1,2)` を持つ類似の SQL ステートメントは同じ Digest を持ちます。
-- `LIMIT N` 句は正規化されます。例えば、`LIMIT 10` と `LIMIT 30` を持つ類似の SQL ステートメントは同じ Digest を持ちます。
+- SQL内の定数値は正規化されます。例えば、`WHERE a = 1`と`WHERE a = 2`を含む類似のSQLステートメントは同じダイジェストを持ちます。
+- IN述語は正規化されます。例えば、`IN (1,2,3)`と`IN (1,2)`を含む類似のSQLステートメントは同じダイジェストを持ちます。
+- `LIMIT N`句は正規化されます。例えば、`LIMIT 10`と`LIMIT 30`を含む類似のSQLステートメントは同じダイジェストを持ちます。
+
+## クロスデータベースダイジェスト
+
+デフォルトでは、SQLダイジェストは計算にデータベース名を含みます。これは、異なるデータベースで実行された同じSQLパターンが異なるダイジェストを生成することを意味します。例えば：
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- ダイジェスト: aaa...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- ダイジェスト: bbb... (上記とは異なる)
+```
+
+どのデータベースで実行されても同じSQLパターンが同じダイジェストを生成するようにしたい場合は、セッション変数`sql_digest_exclude_db`を`true`に設定できます。
+
+```SQL
+SET sql_digest_exclude_db = true;
+```
+
+このオプションを有効にすると、データベース名がダイジェスト計算から除外され、異なるデータベース間でSQLパターンを集計できるようになります。
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- ダイジェスト: ccc...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- ダイジェスト: ccc... (上記と同じ)
+```
+
+:::note
+
+外部カタログ名は、この設定に関わらず常にダイジェストに含まれます。
+
+:::

--- a/docs/zh/administration/sql_digest.md
+++ b/docs/zh/administration/sql_digest.md
@@ -94,3 +94,41 @@ WHERE digest IN (SELECT digest FROM top_sql);
 - SQL 中的常量值会被归一化。例如，包含 `WHERE a = 1` 和 `WHERE a = 2` 的相同类型 SQL 会生成相同的 Digest。
 - 对于 IN 谓词会进行归一化。例如，包含 `IN (1,2,3)` 和 `IN (1,2)` 的相同类型 SQL 会生成相同的 Digest。
 - 对于 `LIMIT N` 会进行归一化。例如，包含 `LIMIT 10` 和 `LIMIT 30` 的相同类型 SQL 会生成相同的 Digest。
+
+## 跨库 Digest
+
+默认情况下，SQL Digest 的计算包含数据库名。这意味着相同模式的 SQL 在不同数据库中执行会产生不同的 Digest。例如：
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- Digest: aaa...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- Digest: bbb...（与上面不同）
+```
+
+如果希望相同模式的 SQL 无论在哪个数据库执行都产生相同的 Digest，可以设置会话变量 `sql_digest_exclude_db` 为 `true`：
+
+```SQL
+SET sql_digest_exclude_db = true;
+```
+
+启用后，数据库名将从 Digest 计算中排除，从而支持跨库聚合相同模式的 SQL。
+
+```SQL
+USE db1;
+SELECT * FROM t WHERE id = 1;
+-- Digest: ccc...
+
+USE db2;
+SELECT * FROM t WHERE id = 1;
+-- Digest: ccc...（与上面相同）
+```
+
+:::note
+
+无论是否启用此选项，外部 Catalog 名称始终会包含在 Digest 中。
+
+:::

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableName.java
@@ -222,6 +222,15 @@ public class TableName implements Writable, GsonPreProcessable, GsonPostProcessa
         return stringBuilder.toString();
     }
 
+    public String toSqlWithoutDb() {
+        StringBuilder stringBuilder = new StringBuilder();
+        if (catalog != null && !CatalogMgr.isInternalCatalog(catalog)) {
+            stringBuilder.append("`").append(catalog).append("`.");
+        }
+        stringBuilder.append("`").append(tbl).append("`");
+        return stringBuilder.toString();
+    }
+
 
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -287,7 +287,8 @@ public class ConnectProcessor {
         if (ctx.getState().isQuery() || parsedStmt instanceof DmlStmt) {
             String digest = digestFromLeader;
             if (digest == null && (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest())) {
-                digest = computeStatementDigest(parsedStmt);
+                digest = computeStatementDigest(parsedStmt,
+                        ctx.getSessionVariable().isSqlDigestExcludeDb());
             }
             if (digest != null) {
                 ctx.getAuditEventBuilder().setDigest(digest);
@@ -338,12 +339,16 @@ public class ConnectProcessor {
     }
 
     public static String computeStatementDigest(StatementBase queryStmt) {
+        return computeStatementDigest(queryStmt, false);
+    }
+
+    public static String computeStatementDigest(StatementBase queryStmt, boolean excludeDb) {
         if (queryStmt == null) {
             return "";
         }
 
         try {
-            String digest = AstToSQLBuilder.toDigest(queryStmt);
+            String digest = AstToSQLBuilder.toDigest(queryStmt, excludeDb);
             MessageDigest md = MessageDigest.getInstance("MD5");
             md.reset();
             md.update(digest.getBytes());
@@ -1133,7 +1138,8 @@ public class ConnectProcessor {
             StatementBase parsedStmt = executor.getParsedStmt();
             if ((Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) &&
                     (ctx.getState().isQuery() || parsedStmt instanceof DmlStmt)) {
-                String digest = computeStatementDigest(parsedStmt);
+                String digest = computeStatementDigest(parsedStmt,
+                        ctx.getSessionVariable().isSqlDigestExcludeDb());
                 if (!digest.isEmpty()) {
                     result.setSql_digest(digest);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -433,6 +433,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY =
             "cbo_cte_force_reuse_limit_without_order_by";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
+    public static final String SQL_DIGEST_EXCLUDE_DB = "sql_digest_exclude_db";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
     public static final String CBO_PUSH_DOWN_AGGREGATE_MODE = "cbo_push_down_aggregate_mode";
@@ -1456,6 +1457,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
+
+    @VarAttr(name = SQL_DIGEST_EXCLUDE_DB)
+    private boolean sqlDigestExcludeDb = false;
 
     @VarAttr(name = CBO_USE_DB_LOCK, flag = VariableMgr.INVISIBLE)
     private boolean cboUseDBLock = false;
@@ -4856,6 +4860,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableSQLDigest() {
         return enableSQLDigest;
+    }
+
+    public boolean isSqlDigestExcludeDb() {
+        return sqlDigestExcludeDb;
     }
 
     public void enableJoinReorder(boolean value) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -950,7 +950,8 @@ public class StmtExecutor {
                     // If this sql is in blacklist, show message.
                     GlobalStateMgr.getCurrentState().getSqlBlackList().verifying(originSql);
                     if (Config.enable_sql_digest || context.getSessionVariable().isEnableSQLDigest()) {
-                        String digest = ConnectProcessor.computeStatementDigest(parsedStmt);
+                        String digest = ConnectProcessor.computeStatementDigest(parsedStmt,
+                                context.getSessionVariable().isSqlDigestExcludeDb());
                         if (!digest.isEmpty()) {
                             GlobalStateMgr.getCurrentState().getSqlDigestBlackList().verifying(digest);
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -80,13 +80,18 @@ public class AstToSQLBuilder {
     }
 
     public static String toDigest(StatementBase statement) {
+        return toDigest(statement, false);
+    }
+
+    public static String toDigest(StatementBase statement, boolean excludeDb) {
         return AST2SQLVisitor.withOptions(FormatOptions.allEnable()
                         .setColumnSimplifyTableName(false)
                         .setColumnWithTableName(false)
                         .setEnableNewLine(false)
                         .setEnableMassiveExpr(false)
                         .setPrintActualSelectItem(false)
-                        .setPrintLevelCompound(false))
+                        .setPrintLevelCompound(false)
+                        .setExcludeDbFromDigest(excludeDb))
                 .visit(statement);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -76,11 +76,19 @@ public class AST2SQLVisitor extends AST2StringVisitor {
     }
 
     // --------------------------------------- Statement -------------------------------------------------
+    @Override
+    protected String tableNameToSql(TableName tableName) {
+        if (options.isExcludeDbFromDigest()) {
+            return tableName.toSqlWithoutDb();
+        }
+        return tableName.toSql();
+    }
+
     private String buildColumnName(TableName tableName, String fieldName, String columnName) {
         String res = "";
         if (tableName != null && options.isColumnWithTableName()) {
             if (!options.isColumnSimplifyTableName()) {
-                res = tableName.toSql();
+                res = tableNameToSql(tableName);
             } else {
                 res = "`" + tableName.getTbl() + "`";
             }
@@ -98,7 +106,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         String res = "";
         if (tableName != null) {
             if (!options.isColumnSimplifyTableName()) {
-                res = tableName.toSql();
+                res = tableNameToSql(tableName);
             } else {
                 res = "`" + tableName.getTbl() + "`";
             }
@@ -377,7 +385,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
     @Override
     public String visitView(ViewRelation node, Void context) {
         StringBuilder sqlBuilder = new StringBuilder();
-        sqlBuilder.append(node.getName().toSql());
+        sqlBuilder.append(tableNameToSql(node.getName()));
 
         if (node.getAlias() != null) {
             sqlBuilder.append(" AS ");
@@ -389,7 +397,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
     @Override
     public String visitTable(TableRelation node, Void outerScope) {
         StringBuilder sqlBuilder = new StringBuilder();
-        sqlBuilder.append(node.getName().toSql());
+        sqlBuilder.append(tableNameToSql(node.getName()));
 
         if (node.getPartitionNames() != null) {
             List<String> partitionNames = node.getPartitionNames().getPartitionNames();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -157,6 +157,10 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
     //   printLevelCompound
     protected FormatOptions options = FormatOptions.allEnable();
 
+    protected String tableNameToSql(TableName tableName) {
+        return tableName.toSql();
+    }
+
     public static AST2StringVisitor withOptions(FormatOptions options) {
         AST2StringVisitor visitor = new AST2StringVisitor();
         visitor.options = options;
@@ -498,7 +502,7 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         } else {
             TableName tableName = new TableName(stmt.getCatalogName(), stmt.getDbName(),
                     stmt.getTableName(), stmt.getTableRef().getPos());
-            sb.append(tableName.toSql());
+            sb.append(tableNameToSql(tableName));
         }
 
         if (stmt.getPartitions() != null && !stmt.getPartitions().isEmpty()) {
@@ -994,7 +998,7 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
             TableRef tableRef = insert.getTableRef();
             TableName tableName = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
                     tableRef.getTableName(), tableRef.getPos());
-            sb.append(tableName.toSql());
+            sb.append(tableNameToSql(tableName));
         }
         sb.append(" ");
 
@@ -1061,7 +1065,7 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         TableRef tableRef = delete.getTableRef();
         TableName tableName = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
                 tableRef.getTableName(), tableRef.getPos());
-        sb.append(tableName.toSql());
+        sb.append(tableNameToSql(tableName));
 
         if (delete.getWherePredicate() != null) {
             sb.append(" WHERE ");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/FormatOptions.java
@@ -41,6 +41,8 @@ public class FormatOptions {
 
     private boolean enableHints = true;
 
+    private boolean excludeDbFromDigest = false;
+
     private boolean enablePrettyFormat = false;
 
     private int indentLevel = 0;
@@ -92,6 +94,10 @@ public class FormatOptions {
 
     public boolean isEnableHints() {
         return enableHints;
+    }
+
+    public boolean isExcludeDbFromDigest() {
+        return excludeDbFromDigest;
     }
 
     public boolean isEnablePrettyFormat() {
@@ -150,6 +156,11 @@ public class FormatOptions {
 
     public FormatOptions setEnableHints(boolean enableHints) {
         this.enableHints = enableHints;
+        return this;
+    }
+
+    public FormatOptions setExcludeDbFromDigest(boolean excludeDbFromDigest) {
+        this.excludeDbFromDigest = excludeDbFromDigest;
         return this;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -421,7 +421,7 @@ public class QueryPlannerTest {
             Assertions.assertEquals(digest, d);
         }
         try (MockedStatic<ConnectProcessor> digestMethod = Mockito.mockStatic(ConnectProcessor.class)) {
-            digestMethod.when(() -> ConnectProcessor.computeStatementDigest(Mockito.any())).thenReturn(digest);
+            digestMethod.when(() -> ConnectProcessor.computeStatementDigest(Mockito.any(), Mockito.anyBoolean())).thenReturn(digest);
 
             StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, sqlStmt);
             stmtExecutor2.execute();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DigestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DigestTest.java
@@ -15,8 +15,16 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.plugin.AuditEvent;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ConnectProcessor;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.formatter.AST2SQLVisitor;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -144,5 +152,129 @@ public class DigestTest extends PlanTestBase {
         String originStmt = "SELECT ltrim(rand(), '0.') from TABLE(generate_series(0, 100000000))";
         String digest1 = UtFrameUtils.getStmtDigest(connectContext, originStmt);
         Assertions.assertEquals(digest1, "");
+    }
+
+    @Test
+    public void testExcludeDbFromDigest() throws Exception {
+        // SQL with explicit db qualification
+        String sqlWithDb = "select s_address from test.supplier where a > 1";
+        // Same SQL without db qualification
+        String sqlWithoutDb = "select s_address from supplier where a > 1";
+
+        // With excludeDb=false (default), different digests because one has "test." prefix
+        String digest1Default = UtFrameUtils.getStmtDigest(connectContext, sqlWithDb, false);
+        String digest2Default = UtFrameUtils.getStmtDigest(connectContext, sqlWithoutDb, false);
+        Assertions.assertNotEquals(digest1Default, digest2Default,
+                "Default mode: qualified and unqualified table should have different digests");
+
+        // With excludeDb=true, both should produce the same digest
+        String digest1ExcludeDb = UtFrameUtils.getStmtDigest(connectContext, sqlWithDb, true);
+        String digest2ExcludeDb = UtFrameUtils.getStmtDigest(connectContext, sqlWithoutDb, true);
+        Assertions.assertEquals(digest1ExcludeDb, digest2ExcludeDb,
+                "ExcludeDb mode: qualified and unqualified table should have same digest");
+
+        // Verify the normalized SQL content
+        StatementBase stmt = SqlParser.parse(sqlWithDb, connectContext.getSessionVariable()).get(0);
+        String normalizedWithDb = AstToSQLBuilder.toDigest(stmt, false);
+        String normalizedWithoutDb = AstToSQLBuilder.toDigest(stmt, true);
+        Assertions.assertTrue(normalizedWithDb.contains("`test`"),
+                "Default digest should contain db name for qualified table");
+        Assertions.assertFalse(normalizedWithoutDb.contains("`test`"),
+                "ExcludeDb digest should not contain db name");
+        Assertions.assertTrue(normalizedWithoutDb.contains("`supplier`"),
+                "ExcludeDb digest should still contain table name");
+
+        // Test no-arg AstToSQLBuilder.toDigest() (default includes db name)
+        String normalizedDefault = AstToSQLBuilder.toDigest(stmt);
+        Assertions.assertEquals(normalizedWithDb, normalizedDefault,
+                "No-arg toDigest should behave same as toDigest(stmt, false)");
+
+        // Test no-arg ConnectProcessor.computeStatementDigest()
+        String digestNoArg = ConnectProcessor.computeStatementDigest(stmt);
+        Assertions.assertEquals(digest1Default, digestNoArg,
+                "No-arg computeStatementDigest should behave same as computeStatementDigest(stmt, false)");
+
+        // Test session variable sql_digest_exclude_db
+        Assertions.assertFalse(connectContext.getSessionVariable().isSqlDigestExcludeDb(),
+                "sql_digest_exclude_db should default to false");
+    }
+
+    @Test
+    public void testExcludeDbFromDigestCrossDatabase() throws Exception {
+        // Create a second database with the same table schema
+        String db2 = "test2";
+        starRocksAssert.withDatabase(db2);
+        starRocksAssert.useDatabase(db2);
+        starRocksAssert.withTable("CREATE TABLE `t0` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        String sql = "select * from t0 where v1 > 1";
+
+        // Simulate: USE test; SELECT * FROM t0 WHERE v1 > 1;
+        starRocksAssert.useDatabase("test");
+        connectContext.setDatabase("test");
+        String digestDb1Default = UtFrameUtils.getStmtDigest(connectContext, "select * from test.t0 where v1 > 1", false);
+        String digestDb1ExcludeDb = UtFrameUtils.getStmtDigest(connectContext, "select * from test.t0 where v1 > 1", true);
+
+        // Simulate: USE test2; SELECT * FROM t0 WHERE v1 > 1;
+        starRocksAssert.useDatabase(db2);
+        connectContext.setDatabase(db2);
+        String digestDb2Default = UtFrameUtils.getStmtDigest(connectContext, "select * from test2.t0 where v1 > 1", false);
+        String digestDb2ExcludeDb = UtFrameUtils.getStmtDigest(connectContext, "select * from test2.t0 where v1 > 1", true);
+
+        // Default mode: different db → different digest
+        Assertions.assertNotEquals(digestDb1Default, digestDb2Default,
+                "Default mode: same SQL in different databases should have different digests");
+
+        // ExcludeDb mode: different db → same digest
+        Assertions.assertEquals(digestDb1ExcludeDb, digestDb2ExcludeDb,
+                "ExcludeDb mode: same SQL in different databases should have same digest");
+
+        // Restore database context
+        starRocksAssert.useDatabase("test");
+        connectContext.setDatabase("test");
+    }
+
+    @Test
+    public void testDigestInAuditPath() throws Exception {
+        String sql = "select s_address from supplier where a > 1";
+        StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+
+        // Set up context for audit path
+        ConnectContext testContext = new ConnectContext();
+        testContext.setGlobalStateMgr(connectContext.getGlobalStateMgr());
+        testContext.setCurrentUserIdentity(connectContext.getCurrentUserIdentity());
+        testContext.setQualifiedUser(connectContext.getQualifiedUser());
+        testContext.setDatabase("test");
+        testContext.setCurrentCatalog("default_catalog");
+        testContext.setQueryId(UUIDUtil.genUUID());
+        testContext.setStartTime();
+        testContext.getState().setIsQuery(true);
+        testContext.setThreadLocalInfo();
+
+        // Enable sql_digest via Config to trigger audit path digest computation
+        boolean origConfigDigest = Config.enable_sql_digest;
+        try {
+            Config.enable_sql_digest = true;
+
+            ConnectProcessor processor = new ConnectProcessor(testContext);
+            processor.auditAfterExec(sql, stmt, null);
+
+            // Verify digest was set in audit event
+            AuditEvent event = testContext.getAuditEventBuilder().build();
+            Assertions.assertNotNull(event.digest, "Digest should be set in audit event");
+            Assertions.assertFalse(event.digest.isEmpty(), "Digest should not be empty");
+        } finally {
+            Config.enable_sql_digest = origConfigDigest;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -784,6 +784,15 @@ public class UtFrameUtils {
         return ConnectProcessor.computeStatementDigest(statementBase);
     }
 
+    public static String getStmtDigest(ConnectContext connectContext, String originStmt, boolean excludeDb)
+            throws Exception {
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable())
+                        .get(0);
+        Preconditions.checkState(statementBase instanceof QueryStatement);
+        return ConnectProcessor.computeStatementDigest(statementBase, excludeDb);
+    }
+
     private static String initMockEnv(ConnectContext connectContext, QueryDumpInfo replayDumpInfo) throws Exception {
         // mock statistics table
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);


### PR DESCRIPTION
…ross-database SQL digest aggregation

By default, SQL Digest includes the database name in its computation, causing the same SQL pattern executed in different databases to produce different digests. This makes it difficult to aggregate and analyze SQL patterns across databases.

This PR adds a new session variable `sql_digest_exclude_db` (default false) that when enabled, excludes the database name from the digest computation, allowing the same SQL pattern to produce identical digests regardless of which database it runs in. External catalog names are always preserved.

Changes:
- Add `sql_digest_exclude_db` session variable in SessionVariable
- Add `toSqlWithoutDb()` method in TableName
- Add `excludeDbFromDigest` option in FormatOptions
- Update AST2SQLVisitor to conditionally exclude db names
- Add overloaded methods in AstToSQLBuilder and ConnectProcessor
- Add unit tests for cross-database digest consistency
- Update en/zh documentation for sql_digest

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4