### PR TITLE
[Enhancement] Update testing framework to use Mockito and add Java 21 support

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -275,6 +275,9 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     implementation("org.mariadb.jdbc:mariadb-java-client")
     testImplementation("org.mockito:mockito-inline:4.11.0")
+    // Force ByteBuddy 1.14.9+ for Java 21 class file format support
+    testImplementation("net.bytebuddy:byte-buddy:1.14.9")
+    testImplementation("net.bytebuddy:byte-buddy-agent:1.14.9")
     testImplementation("org.openjdk.jmh:jmh-core:1.37")
     testImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.37")
     implementation("org.owasp.encoder:encoder")
@@ -462,10 +465,37 @@ tasks.test {
     systemProperty("starrocks.home", project.ext["starrocks.home"] as String)
 
     // Add JMockit Java agent to JVM arguments
+    val jmockitPath = configurations.testCompileClasspath.get().find { it.name.contains("jmockit") }?.absolutePath
     jvmArgs(
         "-Djdk.attach.allowAttachSelf",
         "-Duser.timezone=Asia/Shanghai",
-        "-javaagent:${configurations.testCompileClasspath.get().find { it.name.contains("jmockit") }?.absolutePath}"
+        "-javaagent:${jmockitPath}",
+        // JIT tuning to match Maven surefire config
+        "-XX:TieredStopAtLevel=1",
+        "-XX:CICompilerCount=1",
+        "-XX:-BackgroundCompilation",
+        "-XX:+UseSerialGC",
+        // Java 21 module access for JMockit/Mockito ByteBuddy
+        // (Maven surefire 3.2.5 auto-injects these on Java 17+)
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
+        "--add-opens", "java.base/java.io=ALL-UNNAMED",
+        "--add-opens", "java.base/java.math=ALL-UNNAMED",
+        "--add-opens", "java.base/java.net=ALL-UNNAMED",
+        "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+        "--add-opens", "java.base/java.text=ALL-UNNAMED",
+        "--add-opens", "java.base/java.time=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.stream=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.regex=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+        "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED",
+        "--add-opens", "java.base/sun.security.x509=ALL-UNNAMED",
+        "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
+        "--add-opens", "java.management/sun.management=ALL-UNNAMED",
     )
 
     // Use independent class loading (equivalent to useSystemClassLoader=false)
@@ -496,6 +526,13 @@ tasks.withType<Checkstyle>().configureEach {
 
     // Increase memory for checkstyle to avoid OutOfMemoryError
     maxHeapSize = "4096m"
+}
+
+// Aggregate task that checks both main and test sources (matches Maven behavior)
+tasks.register("checkstyle") {
+    dependsOn("checkstyleMain", "checkstyleTest")
+    description = "Run Checkstyle analysis for both main and test classes"
+    group = "verification"
 }
 
 // Bind checkstyle to run before compilation

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorExecuteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorExecuteTest.java
@@ -51,18 +51,22 @@ import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 import org.xnio.StreamConnection;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
+
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class ConnectProcessorExecuteTest extends DDLTestBase {
     private static ByteBuffer initDbPacket;
@@ -76,8 +80,13 @@ public class ConnectProcessorExecuteTest extends DDLTestBase {
     private static AuditEventBuilder auditBuilder = new AuditEventBuilder();
     private static ConnectContext myContext;
 
-    @Mocked
     private static StreamConnection connection;
+
+    static {
+        connection = mock(StreamConnection.class);
+        java.net.InetSocketAddress mockAddr = new java.net.InetSocketAddress("127.0.0.1", 12345);
+        when(connection.getPeerAddress()).thenReturn(mockAddr);
+    }
 
     private static PQueryStatistics statistics = new PQueryStatistics();
 
@@ -177,14 +186,8 @@ public class ConnectProcessorExecuteTest extends DDLTestBase {
         changeUserPacket.clear();
         resetConnectionPacket.clear();
         // Mock
-        MysqlChannel channel = new MysqlChannel(connection);
-        new Expectations(channel) {
-            {
-                channel.getRemoteHostPortString();
-                minTimes = 0;
-                result = "127.0.0.1:12345";
-            }
-        };
+        MysqlChannel channel = mock(MysqlChannel.class);
+        when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
         myContext = new ConnectContext(connection);
         Deencapsulation.setField(myContext, "mysqlChannel", channel);
         super.setUp();
@@ -192,35 +195,17 @@ public class ConnectProcessorExecuteTest extends DDLTestBase {
 
     private static MysqlChannel mockChannel(ByteBuffer packet) {
         try {
-            MysqlChannel channel = new MysqlChannel(connection);
-            new Expectations(channel) {
-                {
-                    // Mock receive
-                    channel.fetchOnePacket();
-                    minTimes = 0;
-                    result = packet;
-
-                    // Mock reset
-                    channel.setSequenceId(0);
-                    times = 1;
-
-                    // Mock send
-                    channel.sendAndFlush((ByteBuffer) any);
-                    minTimes = 0;
-
-                    channel.getRemoteHostPortString();
-                    minTimes = 0;
-                    result = "127.0.0.1:12345";
-                }
-            };
+            MysqlChannel channel = mock(MysqlChannel.class);
+            when(channel.fetchOnePacket()).thenReturn(packet);
+            when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
             return channel;
-        } catch (IOException e) {
+        } catch (Exception e) {
             return null;
         }
     }
 
     private static ConnectContext initMockContext(MysqlChannel channel, GlobalStateMgr globalStateMgr) {
-        ConnectContext context = new ConnectContext(connection) {
+        ConnectContext context = spy(new ConnectContext(connection) {
             private boolean firstTimeToSetCommand = true;
 
             @Override
@@ -257,67 +242,23 @@ public class ConnectProcessorExecuteTest extends DDLTestBase {
                     super.setCommand(command);
                 }
             }
-        };
+        });
 
-        new Expectations(context) {
-            {
-                context.getMysqlChannel();
-                minTimes = 0;
-                result = channel;
-
-                context.isKilled();
-                minTimes = 0;
-                maxTimes = 3;
-                returns(false, true, false);
-
-                context.getGlobalStateMgr();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                context.getAuditEventBuilder();
-                minTimes = 0;
-                result = auditBuilder;
-
-                context.getQualifiedUser();
-                minTimes = 0;
-                result = "testCluster:user";
-
-                context.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-
-                context.getStartTime();
-                minTimes = 0;
-                result = 0L;
-
-                context.getReturnRows();
-                minTimes = 0;
-                result = 1L;
-
-                context.setStmtId(anyLong);
-                minTimes = 0;
-
-                context.getStmtId();
-                minTimes = 0;
-                result = 1L;
-
-                context.getExecutionId();
-                minTimes = 0;
-                result = new TUniqueId();
-
-                context.getCapability();
-                minTimes = 0;
-                result = MysqlCapability.DEFAULT_CAPABILITY;
-
-                context.getAccessControlContext();
-                minTimes = 0;
-                result = new AccessControlContext();
-
-                context.getAuthenticationProvider();
-                minTimes = 0;
-                result = new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD);
-            }
-        };
+        doReturn(channel).when(context).getMysqlChannel();
+        doReturn(false).doReturn(true).doReturn(false).when(context).isKilled();
+        doReturn(globalStateMgr).when(context).getGlobalStateMgr();
+        doReturn(auditBuilder).when(context).getAuditEventBuilder();
+        doReturn("testCluster:user").when(context).getQualifiedUser();
+        doReturn(UserIdentity.ROOT).when(context).getCurrentUserIdentity();
+        doReturn(0L).when(context).getStartTime();
+        doReturn(1L).when(context).getReturnRows();
+        doNothing().when(context).setStmtId(anyLong());
+        doReturn(1L).when(context).getStmtId();
+        doReturn(new TUniqueId()).when(context).getExecutionId();
+        doReturn(MysqlCapability.DEFAULT_CAPABILITY).when(context).getCapability();
+        doReturn(new AccessControlContext()).when(context).getAccessControlContext();
+        doReturn(new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD))
+                .when(context).getAuthenticationProvider();
 
         return context;
     }
@@ -340,17 +281,15 @@ public class ConnectProcessorExecuteTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
+        try (MockedConstruction<StmtExecutor> mocked = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                })) {
 
-        processor.processOnce();
+            processor.processOnce();
 
-        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
-        Assertions.assertTrue(ctx.getState().isQuery());
+            Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
+            Assertions.assertTrue(ctx.getState().isQuery());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -69,16 +69,14 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
-import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.xnio.StreamConnection;
 
 import java.io.IOException;
@@ -101,8 +99,13 @@ public class ConnectProcessorTest extends DDLTestBase {
     private static AuditEventBuilder auditBuilder = new AuditEventBuilder();
     private static ConnectContext myContext;
 
-    @Mocked
     private static StreamConnection connection;
+
+    static {
+        connection = Mockito.mock(StreamConnection.class);
+        java.net.InetSocketAddress mockAddr = new java.net.InetSocketAddress("127.0.0.1", 12345);
+        Mockito.when(connection.getPeerAddress()).thenReturn(mockAddr);
+    }
 
     private static PQueryStatistics statistics = new PQueryStatistics();
 
@@ -201,14 +204,8 @@ public class ConnectProcessorTest extends DDLTestBase {
         changeUserPacket.clear();
         resetConnectionPacket.clear();
         // Mock
-        MysqlChannel channel = new MysqlChannel(connection);
-        new Expectations(channel) {
-            {
-                channel.getRemoteHostPortString();
-                minTimes = 0;
-                result = "127.0.0.1:12345";
-            }
-        };
+        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+        Mockito.when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
         myContext = new ConnectContext(connection);
         Deencapsulation.setField(myContext, "mysqlChannel", channel);
         super.setUp();
@@ -216,27 +213,9 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     private static MysqlChannel mockChannel(ByteBuffer packet) {
         try {
-            MysqlChannel channel = new MysqlChannel(connection);
-            new Expectations(channel) {
-                {
-                    // Mock receive
-                    channel.fetchOnePacket();
-                    minTimes = 0;
-                    result = packet;
-
-                    // Mock reset
-                    channel.setSequenceId(0);
-                    times = 1;
-
-                    // Mock send
-                    channel.sendAndFlush((ByteBuffer) any);
-                    minTimes = 0;
-
-                    channel.getRemoteHostPortString();
-                    minTimes = 0;
-                    result = "127.0.0.1:12345";
-                }
-            };
+            MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+            Mockito.when(channel.fetchOnePacket()).thenReturn(packet);
+            Mockito.when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
             return channel;
         } catch (IOException e) {
             return null;
@@ -244,7 +223,7 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     private static ConnectContext initMockContext(MysqlChannel channel, GlobalStateMgr globalStateMgr) {
-        ConnectContext context = new ConnectContext(connection) {
+        ConnectContext context = Mockito.spy(new ConnectContext(connection) {
             private boolean firstTimeToSetCommand = true;
 
             @Override
@@ -281,67 +260,23 @@ public class ConnectProcessorTest extends DDLTestBase {
                     super.setCommand(command);
                 }
             }
-        };
+        });
 
-        new Expectations(context) {
-            {
-                context.getMysqlChannel();
-                minTimes = 0;
-                result = channel;
-
-                context.isKilled();
-                minTimes = 0;
-                maxTimes = 3;
-                returns(false, true, false);
-
-                context.getGlobalStateMgr();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                context.getAuditEventBuilder();
-                minTimes = 0;
-                result = auditBuilder;
-
-                context.getQualifiedUser();
-                minTimes = 0;
-                result = "testCluster:user";
-
-                context.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-
-                context.getStartTime();
-                minTimes = 0;
-                result = 0L;
-
-                context.getReturnRows();
-                minTimes = 0;
-                result = 1L;
-
-                context.setStmtId(anyLong);
-                minTimes = 0;
-
-                context.getStmtId();
-                minTimes = 0;
-                result = 1L;
-
-                context.getExecutionId();
-                minTimes = 0;
-                result = new TUniqueId();
-
-                context.getCapability();
-                minTimes = 0;
-                result = MysqlCapability.DEFAULT_CAPABILITY;
-
-                context.getAccessControlContext();
-                minTimes = 0;
-                result = new AccessControlContext();
-
-                context.getAuthenticationProvider();
-                minTimes = 0;
-                result = new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD);
-            }
-        };
+        Mockito.doReturn(channel).when(context).getMysqlChannel();
+        Mockito.doReturn(false).doReturn(true).doReturn(false).when(context).isKilled();
+        Mockito.doReturn(globalStateMgr).when(context).getGlobalStateMgr();
+        Mockito.doReturn(auditBuilder).when(context).getAuditEventBuilder();
+        Mockito.doReturn("testCluster:user").when(context).getQualifiedUser();
+        Mockito.doReturn(UserIdentity.ROOT).when(context).getCurrentUserIdentity();
+        Mockito.doReturn(0L).when(context).getStartTime();
+        Mockito.doReturn(1L).when(context).getReturnRows();
+        Mockito.doNothing().when(context).setStmtId(Mockito.anyLong());
+        Mockito.doReturn(1L).when(context).getStmtId();
+        Mockito.doReturn(new TUniqueId()).when(context).getExecutionId();
+        Mockito.doReturn(MysqlCapability.DEFAULT_CAPABILITY).when(context).getCapability();
+        Mockito.doReturn(new AccessControlContext()).when(context).getAccessControlContext();
+        Mockito.doReturn(new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD))
+                .when(context).getAuthenticationProvider();
 
         return context;
     }
@@ -442,16 +377,13 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                })) {
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        }
     }
 
     @Test
@@ -460,20 +392,11 @@ public class ConnectProcessorTest extends DDLTestBase {
         RunMode.detectRunMode();
         Config.enable_collect_query_detail_info = true;
 
-        new MockUp<WarehouseComputeResourceProvider>() {
-            @Mock
-            public boolean isResourceAvailable(ComputeResource computeResource) {
-                return true;
-            }
-        };
-        // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
+        WarehouseComputeResourceProvider originalProvider =
+                Deencapsulation.getField(GlobalStateMgr.getCurrentState().getWarehouseMgr(), "computeResourceProvider");
+        WarehouseComputeResourceProvider spyProvider = Mockito.spy(originalProvider);
+        Mockito.doReturn(true).when(spyProvider).isResourceAvailable(Mockito.any());
+        Deencapsulation.setField(GlobalStateMgr.getCurrentState().getWarehouseMgr(), "computeResourceProvider", spyProvider);
 
         try {
             GlobalStateMgr.getCurrentState().getWarehouseMgr().addWarehouse(new DefaultWarehouse(2, "wh2"));
@@ -504,6 +427,8 @@ public class ConnectProcessorTest extends DDLTestBase {
             AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
             Assertions.assertEquals("wh2", auditEvent.warehouse);
         } finally {
+            Deencapsulation.setField(GlobalStateMgr.getCurrentState().getWarehouseMgr(),
+                    "computeResourceProvider", originalProvider);
             Config.enable_collect_query_detail_info = false;
             Config.run_mode = RunMode.SHARED_NOTHING.getName();
             RunMode.detectRunMode();
@@ -516,20 +441,11 @@ public class ConnectProcessorTest extends DDLTestBase {
         RunMode.detectRunMode();
         Config.enable_collect_query_detail_info = true;
 
-        new MockUp<WarehouseComputeResourceProvider>() {
-            @Mock
-            public boolean isResourceAvailable(ComputeResource computeResource) {
-                return true;
-            }
-        };
-        // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
+        WarehouseComputeResourceProvider originalProvider =
+                Deencapsulation.getField(GlobalStateMgr.getCurrentState().getWarehouseMgr(), "computeResourceProvider");
+        WarehouseComputeResourceProvider spyProvider = Mockito.spy(originalProvider);
+        Mockito.doReturn(true).when(spyProvider).isResourceAvailable(Mockito.any());
+        Deencapsulation.setField(GlobalStateMgr.getCurrentState().getWarehouseMgr(), "computeResourceProvider", spyProvider);
 
         try {
             GlobalStateMgr.getCurrentState().getWarehouseMgr().addWarehouse(new DefaultWarehouse(2, "wh2"));
@@ -557,6 +473,8 @@ public class ConnectProcessorTest extends DDLTestBase {
             AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
             Assertions.assertEquals("wh3", auditEvent.warehouse);
         } finally {
+            Deencapsulation.setField(GlobalStateMgr.getCurrentState().getWarehouseMgr(),
+                    "computeResourceProvider", originalProvider);
             Config.enable_collect_query_detail_info = false;
             Config.run_mode = RunMode.SHARED_NOTHING.getName();
             RunMode.detectRunMode();
@@ -569,21 +487,15 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
-        // Mock statement executor using MockUp
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                throw new IOException("Fail");
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        // Mock statement executor
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doThrow(new IOException("Fail")).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                })) {
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        }
     }
 
     @Test
@@ -592,22 +504,16 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
-        // Mock statement executor using MockUp
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                throw new NullPointerException("Fail");
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
-        Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlErrPacket);
+        // Mock statement executor
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doThrow(new NullPointerException("Fail")).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                })) {
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlErrPacket);
+        }
     }
 
     @Test
@@ -618,24 +524,22 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
         AtomicReference<String> customQueryId = new AtomicReference<>();
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                customQueryId.set(ctx.getCustomQueryId());
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
-        // verify customQueryId is set during query execution
-        Assertions.assertEquals("a_custom_query_id", customQueryId.get());
-        // customQueryId is cleared after query finished
-        Assertions.assertEquals("", ctx.getCustomQueryId());
-        Assertions.assertEquals("", ctx.getSessionVariable().getCustomQueryId());
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doAnswer(invocation -> {
+                        customQueryId.set(ctx.getCustomQueryId());
+                        return null;
+                    }).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            // verify customQueryId is set during query execution
+            Assertions.assertEquals("a_custom_query_id", customQueryId.get());
+            // customQueryId is cleared after query finished
+            Assertions.assertEquals("", ctx.getCustomQueryId());
+            Assertions.assertEquals("", ctx.getSessionVariable().getCustomQueryId());
+        }
     }
 
     @Test
@@ -646,24 +550,22 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
         AtomicReference<String> customSessionName = new AtomicReference<>();
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                customSessionName.set(ctx.getCustomSessionName());
-            }
-            
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
-        // verify customSessionName is set during query execution
-        Assertions.assertEquals("session_name", customSessionName.get());
-        // customSessionName is NOT cleared after query finished
-        Assertions.assertEquals("session_name", ctx.getCustomSessionName());
-        Assertions.assertEquals("session_name", ctx.getSessionVariable().getCustomSessionName());
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doAnswer(invocation -> {
+                        customSessionName.set(ctx.getCustomSessionName());
+                        return null;
+                    }).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            // verify customSessionName is set during query execution
+            Assertions.assertEquals("session_name", customSessionName.get());
+            // customSessionName is NOT cleared after query finished
+            Assertions.assertEquals("session_name", ctx.getCustomSessionName());
+            Assertions.assertEquals("session_name", ctx.getSessionVariable().getCustomSessionName());
+        }
     }
 
     @Test
@@ -815,17 +717,14 @@ public class ConnectProcessorTest extends DDLTestBase {
         ctx.setThreadLocalInfo();
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        new mockit.MockUp<StmtExecutor>() {
-            @mockit.Mock
-            public void execute() {}
-            @mockit.Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-
-        TMasterOpResult result = processor.proxyExecute(request, null);
-        Assertions.assertNotNull(result);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doNothing().when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            TMasterOpResult result = processor.proxyExecute(request, null);
+            Assertions.assertNotNull(result);
+        }
     }
 
     @Test
@@ -843,18 +742,15 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectContext context = new ConnectContext();
         ConnectProcessor processor = new ConnectProcessor(context);
-        new mockit.MockUp<StmtExecutor>() {
-            @mockit.Mock
-            public void execute() {}
-            @mockit.Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-
-        TMasterOpResult result = processor.proxyExecute(request, null);
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(context.getState().isError());
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doNothing().when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            TMasterOpResult result = processor.proxyExecute(request, null);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(context.getState().isError());
+        }
     }
 
     /**
@@ -878,43 +774,41 @@ public class ConnectProcessorTest extends DDLTestBase {
         AtomicReference<Boolean> tracersInitialized = new AtomicReference<>(false);
 
         // Mock Tracers
-        new MockUp<Tracers>() {
-            @Mock
-            public void register(ConnectContext context) {
-                tracersRegistered.set(true);
+        try (MockedStatic<Tracers> tracersMock = Mockito.mockStatic(Tracers.class, Mockito.CALLS_REAL_METHODS)) {
+            tracersMock.when(() -> Tracers.register(Mockito.any(ConnectContext.class)))
+                    .thenAnswer(invocation -> {
+                        tracersRegistered.set(true);
+                        return null;
+                    });
+            tracersMock.when(() -> Tracers.init(Mockito.any(ConnectContext.class), Mockito.any(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        tracersInitialized.set(true);
+                        return null;
+                    });
+
+            // Mock StmtExecutor
+            try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                    (mock, mockCtx) -> {
+                        Mockito.doNothing().when(mock).execute();
+                        Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                        Mockito.when(mock.getParsedStmt()).thenReturn(prepareStmt);
+                        // mockConstruction skips real constructor; replicate originStmt setup
+                        if (mockCtx.arguments().size() >= 2
+                                && mockCtx.arguments().get(1) instanceof StatementBase) {
+                            StatementBase stmt = (StatementBase) mockCtx.arguments().get(1);
+                            Deencapsulation.setField(mock, "originStmt", stmt.getOrigStmt());
+                        }
+                        Mockito.when(mock.getOriginStmtInString()).thenCallRealMethod();
+                    })) {
+                processor.processOnce();
+
+                // Verify that tracers are properly initialized for query statements
+                Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
+                Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
+                Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
+                Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
             }
-
-            @Mock
-            public void init(ConnectContext context, String traceMode, String traceModule) {
-                tracersInitialized.set(true);
-            }
-        };
-
-        // Mock StmtExecutor
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                // Do nothing for test
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-
-            @Mock
-            public StatementBase getParsedStmt() {
-                return prepareStmt;
-            }
-        };
-
-        processor.processOnce();
-
-        // Verify that tracers are properly initialized for query statements
-        Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
-        Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
-        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
-        Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
@@ -34,12 +34,11 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.net.InetAddress;
 import java.util.List;
@@ -62,32 +61,26 @@ public class AlterSystemStmtAnalyzerTest extends StarRocksTestBase {
         UtFrameUtils.setUpForPersistTest();
     }
 
-    @Mocked
-    InetAddress addr1;
-
-    private void mockNet() {
-        new MockUp<InetAddress>() {
-            @Mock
-            public InetAddress getByName(String host) {
-                return addr1;
-            }
-        };
-    }
-
     @Test
     public void testVisitModifyBackendClause() {
-        mockNet();
-        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
-        ModifyBackendClause clause = new ModifyBackendClause("test", "fqdn");
-        Void result = visitor.visitModifyBackendClause(clause, null);
+        InetAddress mockAddr = Mockito.mock(InetAddress.class);
+        try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+            mocked.when(() -> InetAddress.getByName(Mockito.anyString())).thenReturn(mockAddr);
+            AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
+            ModifyBackendClause clause = new ModifyBackendClause("test", "fqdn");
+            Void result = visitor.visitModifyBackendClause(clause, null);
+        }
     }
 
     @Test
     public void testVisitModifyFrontendHostClause() {
-        mockNet();
-        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
-        ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test", "fqdn");
-        Void result = visitor.visitModifyFrontendHostClause(clause, null);
+        InetAddress mockAddr = Mockito.mock(InetAddress.class);
+        try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+            mocked.when(() -> InetAddress.getByName(Mockito.anyString())).thenReturn(mockAddr);
+            AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
+            ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test", "fqdn");
+            Void result = visitor.visitModifyFrontendHostClause(clause, null);
+        }
     }
 
     @Test

--- a/fe/fe-parser/build.gradle.kts
+++ b/fe/fe-parser/build.gradle.kts
@@ -39,7 +39,15 @@ dependencies {
 
 tasks.withType<Test> {
     // Configure JMockit agent for tests
-    jvmArgs("-javaagent:${repositories.mavenLocal().url.path}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar")
+    jvmArgs(
+        "-javaagent:${repositories.mavenLocal().url.path}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar",
+        // Java 21 module access (Maven surefire 3.2.5 auto-injects these)
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens", "java.base/java.io=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED",
+    )
 
     // Set for parallel test execution similar to Maven config
     maxParallelForks = providers.gradleProperty("fe_ut_parallel").map { it.toInt() }.getOrElse(1)

--- a/fe/fe-utils/build.gradle.kts
+++ b/fe/fe-utils/build.gradle.kts
@@ -33,7 +33,15 @@ dependencies {
 
 tasks.withType<Test> {
     // Configure JMockit agent for tests
-    jvmArgs("-javaagent:${repositories.mavenLocal().url.path}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar")
+    jvmArgs(
+        "-javaagent:${repositories.mavenLocal().url.path}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar",
+        // Java 21 module access (Maven surefire 3.2.5 auto-injects these)
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens", "java.base/java.io=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED",
+    )
 
     // Set for parallel test execution as in the Maven config
     maxParallelForks = providers.gradleProperty("fe_ut_parallel").map { it.toInt() }.getOrElse(1)


### PR DESCRIPTION
- Replaced JMockit with Mockito for mocking in ConnectProcessorExecuteTest and ConnectProcessorTest.
- Added ByteBuddy dependencies for Java 21 class file format support.
- Updated JVM arguments for tests to include Java 21 module access.
- Enhanced test cases to utilize Mockito's mocking capabilities for better readability and maintainability.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
