### PR TITLE
[BugFix] Fix schema push-down with partial columns for INSERT INTO BY NAME from FILES()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -455,13 +455,6 @@ public class InsertAnalyzer {
             Locker locker = new Locker(session.getQueryId());
             locker.lockTableWithIntensiveDbLock(database.getId(), targetTable.getId(), LockType.READ);
             try {
-                // get target column names
-                List<String> targetColumnNames = insertStmt.getTargetColumnNames();
-                if (targetColumnNames == null) {
-                    targetColumnNames = ((OlapTable) targetTable).getBaseSchemaWithoutGeneratedColumn().stream()
-                            .map(Column::getName).collect(Collectors.toList());
-                }
-
                 // get select column names, null if it is not slot ref column.
                 // selectColumnNames: source column names used to locate the file column to rewrite.
                 // selectOutputNames: output names (alias if present, else source name) used to look up the
@@ -491,6 +484,18 @@ public class InsertAnalyzer {
                     selectOutputNames.add(null);
                 }
 
+                // get target column names
+                List<String> targetColumnNames;
+                if (insertStmt.isColumnMatchByName()) {
+                    targetColumnNames = selectOutputNames;
+                } else {
+                    targetColumnNames = insertStmt.getTargetColumnNames();
+                    if (targetColumnNames == null) {
+                        targetColumnNames = ((OlapTable) targetTable).getBaseSchemaWithoutGeneratedColumn().stream()
+                                .map(Column::getName).collect(Collectors.toList());
+                    }
+                }
+
                 if (targetColumnNames.size() != selectColumnNames.size()) {
                     return;
                 }
@@ -507,14 +512,7 @@ public class InsertAnalyzer {
                         continue;
                     }
 
-                    // In BY NAME mode the output name (alias) is what gets matched to the target column,
-                    // so use selectOutputNames to find the right target column type.
-                    String targetColumnName;
-                    if (insertStmt.isColumnMatchByName()) {
-                        targetColumnName = selectOutputNames.get(i);
-                    } else {
-                        targetColumnName = targetColumnNames.get(i);
-                    }
+                    String targetColumnName = targetColumnNames.get(i);
                     if (!targetTableColumns.containsKey(targetColumnName)) {
                         continue;
                     }

--- a/test/sql/test_files/R/test_insert_by_name_from_files
+++ b/test/sql/test_files/R/test_insert_by_name_from_files
@@ -12,7 +12,7 @@ insert into files(
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}")
-select "a" as k2, 1 as k1;
+select "abc" as k2, 1 as k1;
 -- result:
 -- !result
 
@@ -43,7 +43,7 @@ insert into t1 by name select * from files(
 
 select * from t1;
 -- result:
-1	a
+1	abc
 -- !result
 
 
@@ -62,7 +62,21 @@ insert into t2 by name select k2 as k1, k1 as k2 from files(
 
 select * from t2;
 -- result:
-a	1
+abc	1
+-- !result
+
+
+-- Test BY NAME with partial columns and data filter
+create table t3 (k1 int, k2 varchar(2));
+
+insert into t3 by name select k2 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+[REGEX].*Insert has filtered data.*
 -- !result
 
 

--- a/test/sql/test_files/T/test_insert_by_name_from_files
+++ b/test/sql/test_files/T/test_insert_by_name_from_files
@@ -11,7 +11,7 @@ insert into files(
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}")
-select "a" as k2, 1 as k1;
+select "abc" as k2, 1 as k1;
 
 desc files(
     "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
@@ -34,10 +34,10 @@ select * from t1;
 
 
 -- Test BY NAME with cross-column aliases: SELECT k2 AS k1, k1 AS k2 FROM files(...)
--- The parquet file has k2(varchar='a') and k1(int=1).
+-- The parquet file has k2(varchar='abc') and k1(int=1).
 -- With cross-aliases the schema push-down must use the output name (alias) to resolve the
 -- target column type, not the raw source column name.  If it used the source name it would
--- push INT onto file column k2 and reject 'a', or push VARCHAR onto file column k1 and
+-- push INT onto file column k2 and reject 'abc', or push VARCHAR onto file column k1 and
 -- then fail to cast '1' to the INT target, depending on strict mode.
 create table t2 (k1 varchar(10), k2 int);
 
@@ -49,6 +49,17 @@ insert into t2 by name select k2 as k1, k1 as k2 from files(
     "aws.s3.endpoint" = "${oss_endpoint}");
 
 select * from t2;
+
+
+-- Test BY NAME with partial columns and data filter: k2 varchar length < length("abc")
+create table t3 (k1 int, k2 varchar(2));
+
+insert into t3 by name select k2 from files(
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
 
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

In `INSERT INTO ... BY NAME` statement, if the number of selected columns does not match the total number of target table columns, `InsertAnalyzer` would return early due to the check `targetColumnNames.size() != selectColumnNames.size()`. This skipped important analysis and type mappings for the source columns, which could lead to missed type casts or missing data filters when inserting partial columns from external files.

## What I'm doing:

Update `InsertAnalyzer` to use `selectOutputNames` as `targetColumnNames` when `isColumnMatchByName()` is true. This ensures the sizes match correctly and prevents the erroneous early return.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
