### PR TITLE
[BugFix] Preserve null fractions for outer join columns (backport #70144)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1224,7 +1224,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             case LEFT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
                 joinStatsBuilder.setOutputRowCount(max(innerRowCount, leftRowCount));
-                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, rightStatistics, joinStatsBuilder);
+                computeNullFractionForOuterJoin(leftRowCount, innerRowCount, leftStatistics, rightStatistics,
+                        eqOnPredicates, joinStatsBuilder);
                 break;
             case LEFT_SEMI_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(StatisticsEstimateUtils.adjustStatisticsByRowCount(
@@ -1244,7 +1245,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             case RIGHT_OUTER_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
                 joinStatsBuilder.setOutputRowCount(max(innerRowCount, rightRowCount));
-                computeNullFractionForOuterJoin(rightRowCount, innerRowCount, leftStatistics, joinStatsBuilder);
+                computeNullFractionForOuterJoin(rightRowCount, innerRowCount, rightStatistics, leftStatistics,
+                        eqOnPredicates, joinStatsBuilder);
                 break;
             case RIGHT_ANTI_JOIN:
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
@@ -1256,9 +1258,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 joinStatsBuilder = Statistics.buildFrom(innerJoinStats);
                 joinStatsBuilder.setOutputRowCount(max(1, leftRowCount + rightRowCount - innerRowCount));
                 computeNullFractionForOuterJoin(leftRowCount + rightRowCount, innerRowCount, leftStatistics,
-                        joinStatsBuilder);
+                        leftStatistics, eqOnPredicates, joinStatsBuilder);
                 computeNullFractionForOuterJoin(leftRowCount + rightRowCount, innerRowCount, rightStatistics,
-                        joinStatsBuilder);
+                        rightStatistics, eqOnPredicates, joinStatsBuilder);
                 break;
             default:
                 throw new StarRocksPlannerException("Not support join type : " + joinType,
@@ -1320,11 +1322,48 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         return builder.build();
     }
 
+    // In an outer join, all rows from the outer (preserved) side are kept, including those with NULLs
+    // in the join key. The inner join estimation sets the null fraction to 0 for eq-join columns,
+    // which is correct for inner joins but not for the outer side of outer joins.
+    // This method first restores the original null fractions for the outer side's eq-join columns
+    // (the only columns whose null fractions are zeroed by the inner join estimation), then computes
+    // the new null fractions for the inner (nullable) side's columns to account for additional null rows.
     private void computeNullFractionForOuterJoin(double outerTableRowCount, double innerJoinRowCount,
-                                                 Statistics statistics, Statistics.Builder builder) {
+                                                 Statistics outerSideStatistics, Statistics innerSideStatistics,
+                                                 List<BinaryPredicateOperator> eqOnPredicates,
+                                                 Statistics.Builder builder) {
+        // Collect the eq-join column refs that belong to the outer (preserved) side.
+        // Only these columns had their null fractions zeroed during inner join estimation.
+        final var outerColumns = outerSideStatistics.getUsedColumns();
+        Set<ColumnRefOperator> outerEqJoinColumns = new HashSet<>();
+        for (final var eqOnPredicate : eqOnPredicates) {
+            for (final var child : eqOnPredicate.getChildren()) {
+                if (child instanceof ColumnRefOperator colRef && outerColumns.contains(colRef.getId())) {
+                    outerEqJoinColumns.add(colRef);
+                }
+            }
+        }
+
+        // Restore the original null fractions for the outer side's eq-join columns only.
+        // When outerTableRowCount < innerJoinRowCount (e.g. one-to-many matches), the output
+        // has more rows than the original outer table, so scale proportionally.
+        for (final var outerEqJoinColumn : outerEqJoinColumns) {
+            final var originalStat = outerSideStatistics.getColumnStatistic(outerEqJoinColumn);
+            final var currentStat = builder.getColumnStatistics(outerEqJoinColumn);
+            if (currentStat != null) {
+                double adjustedNullFraction = (outerTableRowCount < innerJoinRowCount)
+                        ? originalStat.getNullsFraction() * outerTableRowCount / Math.max(1, innerJoinRowCount)
+                        : originalStat.getNullsFraction();
+                builder.addColumnStatistic(outerEqJoinColumn, buildFrom(currentStat) //
+                        .setNullsFraction(adjustedNullFraction) //
+                        .build());
+            }
+        }
+
+        // Compute new null fractions for the inner (nullable) side's columns
         if (outerTableRowCount > innerJoinRowCount) {
             double nullRowCount = outerTableRowCount - innerJoinRowCount;
-            for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : statistics.getColumnStatistics().entrySet()) {
+            for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : innerSideStatistics.getColumnStatistics().entrySet()) {
                 ColumnStatistic columnStatistic = entry.getValue();
                 double columnNullCount = columnStatistic.getNullsFraction() * innerJoinRowCount;
                 double newNullFraction = (columnNullCount + nullRowCount) / outerTableRowCount;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -61,6 +61,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -695,6 +697,87 @@ public class StatisticsCalculatorTest {
         Statistics statistics = builder.build();
         Assertions.assertThrows(StarRocksPlannerException.class, () -> statistics.getColumnStatistic(v3));
     }
+
+    public enum OuterJoin {
+        LEFT_OUTER_JOIN,
+        RIGHT_OUTER_JOIN
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OuterJoin.class)
+    public void testOuterJoinPreservesOuterSideNullFraction(OuterJoin outerJoin) {
+        // GIVEN
+        ColumnRefOperator outerJoinKey = columnRefFactory.create("nullable_col", IntegerType.INT, true);
+        ColumnRefOperator outerOtherCol = columnRefFactory.create("other_col", IntegerType.INT, true);
+
+        final double outerNullFraction = 0.755;
+        Statistics.Builder outerBuilder = Statistics.builder();
+        outerBuilder.setOutputRowCount(1000000);
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerJoinKey, new ColumnStatistic(1, 100000, outerNullFraction, 8, 50000)));
+        outerBuilder.addColumnStatistics(ImmutableMap.of(
+                outerOtherCol, new ColumnStatistic(0, 100, 0.1, 8, 50)));
+
+        Group outerGroup = new Group(0);
+        outerGroup.setStatistics(outerBuilder.build());
+        outerGroup.setLogicalProperty(new LogicalProperty(
+                new ColumnRefSet(Lists.newArrayList(outerJoinKey, outerOtherCol))));
+
+        ColumnRefOperator innerKey = columnRefFactory.create("dim_id", IntegerType.INT, true);
+        ColumnRefOperator innerVal = columnRefFactory.create("dim_val", IntegerType.INT, true);
+
+        Statistics.Builder innerBuilder = Statistics.builder();
+        innerBuilder.setOutputRowCount(200000);
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerKey, new ColumnStatistic(1, 200000, 0, 8, 200000)));
+        innerBuilder.addColumnStatistics(ImmutableMap.of(
+                innerVal, new ColumnStatistic(0, 100, 0, 8, 50)));
+
+        Group innerGroup = new Group(1);
+        innerGroup.setStatistics(innerBuilder.build());
+        innerGroup.setLogicalProperty(new LogicalProperty(new ColumnRefSet(Lists.newArrayList(innerKey, innerVal))));
+
+        // LEFT JOIN: outer.nullable_col = inner.dim1_id
+        // RIGHT JOIN: inner.dim1_id = outer.nullable_col
+        JoinOperator joinType;
+        if (outerJoin == OuterJoin.LEFT_OUTER_JOIN) {
+            joinType = JoinOperator.LEFT_OUTER_JOIN;
+        } else {
+            joinType = JoinOperator.RIGHT_OUTER_JOIN;
+        }
+
+        BinaryPredicateOperator joinPred;
+        GroupExpression groupExpr;
+        if (joinType == JoinOperator.LEFT_OUTER_JOIN) {
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, outerJoinKey, innerKey);
+        } else {
+            joinPred = new BinaryPredicateOperator(BinaryType.EQ, innerKey, outerJoinKey);
+        }
+
+        LogicalJoinOperator joinOp = new LogicalJoinOperator(joinType, joinPred);
+
+        if (joinType == JoinOperator.LEFT_OUTER_JOIN) {
+            groupExpr = new GroupExpression(joinOp, Lists.newArrayList(outerGroup, innerGroup));
+        } else {
+            groupExpr = new GroupExpression(joinOp, Lists.newArrayList(innerGroup, outerGroup));
+        }
+
+        Group joinGroup = new Group(2);
+        groupExpr.setGroup(joinGroup);
+        ExpressionContext exprCtx = new ExpressionContext(groupExpr);
+        StatisticsCalculator calc = new StatisticsCalculator(exprCtx, columnRefFactory, optimizerContext);
+
+        // WHEN
+        // The outer side join key's null fraction should be preserved after LEFT JOIN
+        calc.estimatorStats();
+        Statistics joinStats = exprCtx.getStatistics();
+        ColumnStatistic outerJoinKeyStatAfterJoin = joinStats.getColumnStatistic(outerJoinKey);
+
+        // THEN
+        Assertions.assertEquals(outerNullFraction, outerJoinKeyStatAfterJoin.getNullsFraction(), 0.001,
+                "Outer join key null fraction should be preserved after " + outerJoin.name());
+    }
+
 
     private static File newFolder(File root, String... subDirs) throws IOException {
         String subFolder = String.join("/", subDirs);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -707,8 +707,8 @@ public class StatisticsCalculatorTest {
     @EnumSource(value = OuterJoin.class)
     public void testOuterJoinPreservesOuterSideNullFraction(OuterJoin outerJoin) {
         // GIVEN
-        ColumnRefOperator outerJoinKey = columnRefFactory.create("nullable_col", IntegerType.INT, true);
-        ColumnRefOperator outerOtherCol = columnRefFactory.create("other_col", IntegerType.INT, true);
+        ColumnRefOperator outerJoinKey = columnRefFactory.create("nullable_col", Type.INT, true);
+        ColumnRefOperator outerOtherCol = columnRefFactory.create("other_col", Type.INT, true);
 
         final double outerNullFraction = 0.755;
         Statistics.Builder outerBuilder = Statistics.builder();
@@ -723,8 +723,8 @@ public class StatisticsCalculatorTest {
         outerGroup.setLogicalProperty(new LogicalProperty(
                 new ColumnRefSet(Lists.newArrayList(outerJoinKey, outerOtherCol))));
 
-        ColumnRefOperator innerKey = columnRefFactory.create("dim_id", IntegerType.INT, true);
-        ColumnRefOperator innerVal = columnRefFactory.create("dim_val", IntegerType.INT, true);
+        ColumnRefOperator innerKey = columnRefFactory.create("dim_id", Type.INT, true);
+        ColumnRefOperator innerVal = columnRefFactory.create("dim_val", Type.INT, true);
 
         Statistics.Builder innerBuilder = Statistics.builder();
         innerBuilder.setOutputRowCount(200000);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -465,7 +465,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "  |  hasNullableGenerateChild: true\n" +
                 "  |  cardinality: 1\n" +
                 "  |  column statistics: \n" +
-                "  |  * count-->[0.0, 1.0420273298435367, 0.0, 8.0, 1.0] ESTIMATE\n" +
+                "  |  * count-->[0.0, 1.0397971264164303, 0.0, 8.0, 1.0] ESTIMATE\n" +
                 "  |  \n" +
                 "  95:Project\n" +
                 "  |  output columns:\n" +


### PR DESCRIPTION
## Why I'm doing:

Consider the following query:
```sql
explain costs
select
    *
from
    TABLE1 t1
    LEFT JOIN TABLE2 t2 ON t1.NULLABLE = t2.NULLABLE
    LEFT JOIN TABLE3 t3 ON t1.NULLABLE = t3.NULLABLE;
```

At the moment, even though `t1.NULLABLE` has proper null fractions (e.g. 0.8), the second join assumes that `t1.NULLABLE` has 0.0 null fractions. This is because for equality predicates, we [reset the null fractions to 0](https://github.com/StarRocks/starrocks/blob/623504c363b0be714cc04c8835f233b89822f9fc/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java#L409) since NULLs are not preserved. In the context of the predicate (and inner joins) this is right, but outer joins should not reset null fractions. Subsequent joins should re-use the original column null fractions instead.

See the following [EXPLAIN](https://gist.github.com/OliLay/cc33c1669a2a4d761d4cb5f375f09dc6) where the in the topmost join (7) 4: NULLABLE has 0 null fractions, while for the joins prior to that join the correct null fractions are shown. The fixed [EXPLAIN](https://gist.github.com/OliLay/e1c14bf67e7eefecdeed1e770e72dd92) contains the proper null fractions for 4: NULLABLE

Wrong null fractions lead to the join not being rewritten, e.g. by the join skew rule.

## What I'm doing:

For outer joins, do not reset the null fractions of columns used in join predicates.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

