### PR TITLE
[BugFix] Move load spill directory cleanup from destructor to DeltaWriter::close()

### DIFF
--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -182,6 +182,9 @@ SpillPartitionChunkWriter::~SpillPartitionChunkWriter() {
     if (_block_merge_token) {
         _block_merge_token->shutdown();
     }
+    if (_load_spill_block_mgr != nullptr) {
+        (void)_load_spill_block_mgr->clear_parent_path();
+    }
 }
 
 Status SpillPartitionChunkWriter::init() {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -1020,6 +1020,11 @@ void DeltaWriterImpl::close() {
     _tablet_writer.reset();
     _mem_table.reset();
     _mem_table_sink.reset();
+    if (_load_spill_block_mgr != nullptr) {
+        // ignore the return status of clear_parent_path,
+        // because the spill blocks will be cleared by GC later.
+        (void)_load_spill_block_mgr->clear_parent_path();
+    }
     {
         // Take exclusive lock before resetting _flush_token to prevent race with cancel()
         // and get_flush_token(), which may be accessing _flush_token concurrently.

--- a/be/src/storage/load_spill_block_manager.cpp
+++ b/be/src/storage/load_spill_block_manager.cpp
@@ -111,22 +111,29 @@ spill::BlockPtr LoadSpillBlockContainer::get_block(size_t gid, size_t bid) {
 LoadSpillBlockManager::~LoadSpillBlockManager() {
     // release blocks before block manager
     _block_container.reset();
+}
+
+Status LoadSpillBlockManager::clear_parent_path() {
     // _remote_dir_manager is initialized in init(), skip cleanup if init() was not called or failed
+    Status status = Status::OK();
     if (_remote_dir_manager != nullptr) {
-        auto status = clear_parent_path();
+        spill::AcquireDirOptions acquire_dir_opts;
+        acquire_dir_opts.data_size = 1; // just need acquire a dir
+        auto dir_st = _remote_dir_manager->acquire_writable_dir(acquire_dir_opts);
+        if (!dir_st.ok()) {
+            LOG(WARNING) << "Failed to acquire dir for clearing load spill parent path, load_id=" << print_id(_load_id)
+                         << ", error=" << dir_st.status();
+            return dir_st.status();
+        }
+        auto dir = std::move(dir_st).value();
+        std::string parent_path = dir->dir() + "/" + print_id(_load_id);
+        status = dir->fs()->delete_dir(parent_path);
         if (!status.ok() && !status.is_not_found()) {
             LOG(WARNING) << "Failed to clear load spill parent path, load_id=" << print_id(_load_id)
                          << ", error=" << status;
         }
     }
-}
-
-Status LoadSpillBlockManager::clear_parent_path() {
-    spill::AcquireDirOptions acquire_dir_opts;
-    acquire_dir_opts.data_size = 1; // just need acquire a dir
-    ASSIGN_OR_RETURN(auto dir, _remote_dir_manager->acquire_writable_dir(acquire_dir_opts));
-    std::string parent_path = dir->dir() + "/" + print_id(_load_id);
-    return dir->fs()->delete_dir(parent_path);
+    return status;
 }
 
 Status LoadSpillBlockManager::init() {

--- a/be/test/storage/load_spill_block_manager_test.cpp
+++ b/be/test/storage/load_spill_block_manager_test.cpp
@@ -67,8 +67,8 @@ TEST_F(LoadSpillBlockManagerTest, test_write_read) {
     ASSERT_OK(block_manager->release_block(block));
 }
 
-// Test that the spill parent directory is cleaned up after LoadSpillBlockManager is destroyed.
-TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_on_destroy) {
+// Test that clear_parent_path() cleans up the spill parent directory.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path) {
     TUniqueId load_id;
     load_id.hi = 12345;
     load_id.lo = 67890;
@@ -88,12 +88,48 @@ TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_on_destroy) {
     ASSERT_OK(block_manager->release_block(block));
     block.reset();
 
-    // Destroy the manager — should clean up the parent path
-    block_manager.reset();
+    // Explicitly call clear_parent_path() — should clean up the parent path
+    ASSERT_OK(block_manager->clear_parent_path());
 
     // The parent directory should have been deleted
     status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
     ASSERT_TRUE(status.is_not_found()) << "Expected parent path to be deleted, but got: " << status;
+}
+
+// Test that destroying LoadSpillBlockManager does NOT clean up the spill parent directory.
+// The cleanup should be done explicitly via clear_parent_path() in DeltaWriter::close().
+TEST_F(LoadSpillBlockManagerTest, test_destroy_does_not_clear_parent_path) {
+    TUniqueId load_id;
+    load_id.hi = 12345;
+    load_id.lo = 67890;
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(load_id, TUniqueId(), kTestDir, nullptr);
+    ASSERT_OK(block_manager->init());
+
+    // Acquire a block with force_remote=true to create the remote spill directory
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024, /*force_remote=*/true));
+    ASSERT_OK(block->append({Slice("test_data")}));
+    ASSERT_OK(block->flush());
+
+    std::string parent_path = std::string(kTestDir) + "/load_spill/" + print_id(load_id);
+    auto status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_OK(status);
+
+    ASSERT_OK(block_manager->release_block(block));
+    block.reset();
+
+    // Destroy without calling clear_parent_path()
+    block_manager.reset();
+
+    // The parent directory should still exist — destructor no longer cleans it up
+    status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_OK(status) << "Expected parent path to still exist after destroy, but got: " << status;
+}
+
+// Test that clear_parent_path() is safe to call when init() was not called.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_without_init) {
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(TUniqueId(), TUniqueId(), kTestDir, nullptr);
+    // Call clear_parent_path() without init() — should return OK without crashing
+    ASSERT_OK(block_manager->clear_parent_path());
 }
 
 class LoadSpillBlockMergeExecutorTest : public ::testing::Test {

--- a/be/test/storage/load_spill_block_manager_test.cpp
+++ b/be/test/storage/load_spill_block_manager_test.cpp
@@ -122,7 +122,7 @@ TEST_F(LoadSpillBlockManagerTest, test_destroy_does_not_clear_parent_path) {
 
     // The parent directory should still exist — destructor no longer cleans it up
     status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
-    ASSERT_OK(status) << "Expected parent path to still exist after destroy, but got: " << status;
+    ASSERT_TRUE(status.ok()) << "Expected parent path to still exist after destroy, but got: " << status;
 }
 
 // Test that clear_parent_path() is safe to call when init() was not called.


### PR DESCRIPTION
## Why I'm doing:
The `LoadSpillBlockManager` destructor could be called in a brpc thread, where performing I/O operations (`acquire_writable_dir`, `delete_dir`) is problematic and may cause issues. The cleanup logic needs to be moved to a safe execution context.

## What I'm doing:
- Move the `clear_parent_path()` call from `~LoadSpillBlockManager()` to `DeltaWriterImpl::close()`, which is guaranteed to run outside brpc/bthread threads (enforced by `DCHECK_EQ(0, bthread_self())`) and covers all exit paths (success, failure, cancel).
- Improve error handling in `clear_parent_path()`: log a warning when `acquire_writable_dir` fails instead of silently propagating the error via `ASSIGN_OR_RETURN`.
- The destructor now only releases `_block_container`, avoiding I/O in destructor context.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4