### PR TITLE
[BugFix] Default plain VARBINARY to 1MB for new OLAP tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -549,7 +549,10 @@ import com.starrocks.type.AnyMapType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
@@ -1171,6 +1174,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         String columnName = colIdentifier.getValue();
         Pair<Type, AggStateDesc> typeWithAggStateDesc = getAggStateDesc(context.aggDesc());
 
+        // get column's agg state desc
+        AggStateDesc aggStateDesc = typeWithAggStateDesc == null ? null : typeWithAggStateDesc.second;
+
         // get column's type
         Type columnType = null;
         if (context.type() == null) {
@@ -1185,8 +1191,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             columnType = TypeParser.getType(context.type());
         }
 
-        // get column's agg state desc
-        AggStateDesc aggStateDesc = typeWithAggStateDesc == null ? null : typeWithAggStateDesc.second;
+        // Only plain column definitions should materialize the documented 1MB default
+        // length for VARBINARY. Agg-state columns must keep their opaque intermediate type.
+        if (aggStateDesc == null && columnType.isScalarType()) {
+            ScalarType scalarType = (ScalarType) columnType;
+            if (scalarType.getPrimitiveType() == PrimitiveType.VARBINARY && scalarType.getLength() < 0) {
+                columnType = TypeFactory.createVarbinary(TypeFactory.getOlapMaxVarcharLength());
+            }
+        }
         NodePosition pos = context.type() == null ? NodePosition.ZERO : createPos(context.type());
         TypeDef typeDef = new TypeDef(columnType, pos);
         String charsetName = context.charsetName() != null ?

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -19,6 +19,9 @@ import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,6 +68,19 @@ public class AnalyzeCreateTableTest {
         Assertions.assertEquals("table1", stmt.getTableName());
         Assertions.assertNull(stmt.getPartitionDesc());
         Assertions.assertNull(stmt.getProperties());
+    }
+
+    @Test
+    public void testVarbinaryWithoutLengthMaterializesDefaultLength() {
+        CreateTableStmt stmt = (CreateTableStmt) analyzeSuccess(
+                "create table test.table_varbinary_default (col1 int, col2 varbinary) engine=olap " +
+                        "duplicate key(col1) distributed by hash(col1) buckets 10");
+        ScalarType type = (ScalarType) stmt.getColumnDefs().get(1).getType();
+
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), type.getLength());
+        Assertions.assertEquals("varbinary(" + TypeFactory.getOlapMaxVarcharLength() + ")",
+                type.toSql());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

For hand-written OLAP table DDL, `VARBINARY` without an explicit length should follow the documented default semantics and behave as `VARBINARY(1M)`.

Previously, a plain column definition like `col2 varbinary` could still keep the internal "unspecified length" form during parsing, which made it inconsistent with explicitly declared `VARBINARY(1048576)`.

This PR intentionally limits the fix to plain column definitions in manual `CREATE TABLE` / column DDL parsing. It does not change CTAS, MV, or external table type derivation.

## What I'm doing:

- Materialize omitted `VARBINARY` length to the default `1MB` in the parser layer when building plain column definitions.
- Keep agg-state columns unchanged, so their opaque intermediate `VARBINARY` type semantics are preserved.
- Add a regression test to verify that `CREATE TABLE ... col VARBINARY` is analyzed as `VARBINARY(1048576)`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4