### PR TITLE
[UT] Fix ListPartitionInfo UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoMockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoMockTest.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.TypeFactory;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ListPartitionInfoMockTest {
+
+    @Test
+    public void testMultiListPartition(@Mocked OlapTable dstTable,
+                                       @Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
+
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tuple = descTable.createTupleDescriptor("DstTable");
+        // k1
+        SlotDescriptor k1 = descTable.addSlotDescriptor(tuple);
+        k1.setColumn(new Column("k1", IntegerType.BIGINT));
+        k1.setIsMaterialized(true);
+
+        // k2
+        SlotDescriptor k2 = descTable.addSlotDescriptor(tuple);
+        k2.setColumn(new Column("k2", TypeFactory.createVarcharType(25)));
+        k2.setIsMaterialized(true);
+        // v1
+        SlotDescriptor v1 = descTable.addSlotDescriptor(tuple);
+        v1.setColumn(new Column("v1", TypeFactory.createVarcharType(25)));
+        v1.setIsMaterialized(true);
+        // v2
+        SlotDescriptor v2 = descTable.addSlotDescriptor(tuple);
+        v2.setColumn(new Column("v2", IntegerType.BIGINT));
+        v2.setIsMaterialized(true);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
+                Lists.newArrayList(new Column("dt", StringType.STRING), new Column("province", StringType.STRING)));
+        List<String> multiItems = Lists.newArrayList("dt", "shanghai");
+        List<List<String>> multiValues = new ArrayList<>();
+        multiValues.add(multiItems);
+
+        listPartitionInfo.setMultiValues(1, multiValues);
+        listPartitionInfo.setReplicationNum(1, (short) 3);
+        MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
+        HashDistributionInfo distInfo = new HashDistributionInfo(
+                3, Lists.newArrayList(new Column("id", IntegerType.BIGINT)));
+        Partition partition = new Partition(1, 11, "p1", index, distInfo);
+
+        Map<ColumnId, Column> idToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);
+        idToColumn.put(ColumnId.create("dt"), new Column("dt", StringType.STRING));
+        idToColumn.put(ColumnId.create("province"), new Column("province", StringType.STRING));
+        new Expectations() {{
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
+                dstTable.getId();
+                result = 1;
+                dstTable.getPartitions();
+                result = Lists.newArrayList(partition);
+                dstTable.getPartition(1L);
+                result = partition;
+                dstTable.getPartitionInfo();
+                result = listPartitionInfo;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
+                dstTable.getIdToColumn();
+                result = idToColumn;
+            }};
+
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L),
+                TWriteQuorumType.MAJORITY, false, false, false);
+        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+        sink.complete();
+
+        Assertions.assertTrue(sink.toThrift() instanceof TDataSink);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -12,45 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.StarRocksException;
-import com.starrocks.planner.DescriptorTable;
-import com.starrocks.planner.OlapTableSink;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TruncateTableStmt;
-import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TDataSink;
-import com.starrocks.thrift.TUniqueId;
-import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.transaction.GlobalTransactionMgr;
-import com.starrocks.transaction.TransactionState;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
-import com.starrocks.type.StringType;
-import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,78 +91,6 @@ public class ListPartitionInfoTest {
         StmtExecutor executor = new StmtExecutor(ctx, statementBase);
         executor.execute();
         Assertions.assertNotEquals(QueryState.MysqlStateType.ERR, ctx.getState().getStateType());
-    }
-
-    @Test
-    public void testMultiListPartition(@Injectable OlapTable dstTable,
-                                       @Mocked GlobalStateMgr globalStateMgr,
-                                       @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
-
-        DescriptorTable descTable = new DescriptorTable();
-        TupleDescriptor tuple = descTable.createTupleDescriptor("DstTable");
-        // k1
-        SlotDescriptor k1 = descTable.addSlotDescriptor(tuple);
-        k1.setColumn(new Column("k1", IntegerType.BIGINT));
-        k1.setIsMaterialized(true);
-
-        // k2
-        SlotDescriptor k2 = descTable.addSlotDescriptor(tuple);
-        k2.setColumn(new Column("k2", TypeFactory.createVarcharType(25)));
-        k2.setIsMaterialized(true);
-        // v1
-        SlotDescriptor v1 = descTable.addSlotDescriptor(tuple);
-        v1.setColumn(new Column("v1", TypeFactory.createVarcharType(25)));
-        v1.setIsMaterialized(true);
-        // v2
-        SlotDescriptor v2 = descTable.addSlotDescriptor(tuple);
-        v2.setColumn(new Column("v2", IntegerType.BIGINT));
-        v2.setIsMaterialized(true);
-
-        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
-                Lists.newArrayList(new Column("dt", StringType.STRING), new Column("province", StringType.STRING)));
-        List<String> multiItems = Lists.newArrayList("dt", "shanghai");
-        List<List<String>> multiValues = new ArrayList<>();
-        multiValues.add(multiItems);
-
-        listPartitionInfo.setMultiValues(1, multiValues);
-        listPartitionInfo.setReplicationNum(1, (short) 3);
-        MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
-        HashDistributionInfo distInfo = new HashDistributionInfo(
-                3, Lists.newArrayList(new Column("id", IntegerType.BIGINT)));
-        Partition partition = new Partition(1, 11, "p1", index, distInfo);
-
-        Map<ColumnId, Column> idToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);
-        idToColumn.put(ColumnId.create("dt"), new Column("dt", StringType.STRING));
-        idToColumn.put(ColumnId.create("province"), new Column("province", StringType.STRING));
-        new Expectations() {{
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-                globalStateMgr.getGlobalTransactionMgr();
-                result = globalTransactionMgr;
-                globalTransactionMgr.getTransactionState(anyLong, anyLong);
-                result = new TransactionState();
-                globalStateMgr.getNodeMgr().getClusterInfo();
-                result = new SystemInfoService();
-                dstTable.getId();
-                result = 1;
-                dstTable.getPartitions();
-                result = Lists.newArrayList(partition);
-                dstTable.getPartition(1L);
-                result = partition;
-                dstTable.getPartitionInfo();
-                result = listPartitionInfo;
-                dstTable.getDefaultDistributionInfo();
-                result = distInfo;
-                dstTable.getIdToColumn();
-                result = idToColumn;
-            }};
-
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L),
-                TWriteQuorumType.MAJORITY, false, false, false);
-        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.complete();
-
-        Assertions.assertTrue(sink.toThrift() instanceof TDataSink);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

```
2026-03-20T09:59:56.4348566Z [[1;31mERROR[m] com.starrocks.catalog.ListPartitionInfoTest.testMultiListPartition(OlapTable, GlobalStateMgr, GlobalTransactionMgr) -- Time elapsed: 1.283 s <<< ERROR!
2026-03-20T09:59:56.4349098Z java.lang.IllegalArgumentException: Value of type Integer incompatible with return type com.starrocks.system.SystemInfoService of com.starrocks.server.NodeMgr#getClusterInfo()
2026-03-20T09:59:56.4349348Z 	at com.starrocks.catalog.ListPartitionInfoTest$1.<init>(ListPartitionInfoTest.java:166)
2026-03-20T09:59:56.4349674Z 	at com.starrocks.catalog.ListPartitionInfoTest.testMultiListPartition(ListPartitionInfoTest.java:156)
2026-03-20T09:59:56.4349771Z 	Suppressed: Missing 1 invocation to:
2026-03-20T09:59:56.4349920Z com.starrocks.server.GlobalStateMgr#getCurrentState()
2026-03-20T09:59:56.4350012Z 	Caused by: Missing invocations
2026-03-20T09:59:56.4350266Z 		at com.starrocks.catalog.ListPartitionInfoTest$1.<init>(ListPartitionInfoTest.java:157)
2026-03-20T09:59:56.4350586Z 		at com.starrocks.catalog.ListPartitionInfoTest.testMultiListPartition(ListPartitionInfoTest.java:156)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
