### PR TITLE
[Enhancement] Skip inactivating MVs for bucket-only optimize on base table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -222,15 +222,26 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         HashDistributionDesc hashDistributionDesc = (HashDistributionDesc) distributionDesc;
-        HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
-        if (hashDistributionDesc.getBuckets() <= 0
-                || hashDistributionDesc.getBuckets() == hashDistributionInfo.getBucketNum()) {
+        if (hashDistributionDesc.getBuckets() <= 0 || optimizeClause.getSourcePartitionIds().isEmpty()) {
             return false;
         }
 
-        List<String> originalDistributionColumns = MetaUtils.getColumnNamesByColumnIds(
-                olapTable.getIdToColumn(), hashDistributionInfo.getDistributionColumns());
-        return originalDistributionColumns.equals(hashDistributionDesc.getDistributionColumnNames());
+        boolean hasBucketCountChange = false;
+        for (long partitionId : optimizeClause.getSourcePartitionIds()) {
+            Partition partition = olapTable.getPartition(partitionId);
+            if (partition == null || !(partition.getDistributionInfo() instanceof HashDistributionInfo)) {
+                return false;
+            }
+
+            HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) partition.getDistributionInfo();
+            List<String> originalDistributionColumns = MetaUtils.getColumnNamesByColumnIds(
+                    olapTable.getIdToColumn(), hashDistributionInfo.getDistributionColumns());
+            if (!originalDistributionColumns.equals(hashDistributionDesc.getDistributionColumnNames())) {
+                return false;
+            }
+            hasBucketCountChange |= hashDistributionDesc.getBuckets() != hashDistributionInfo.getBucketNum();
+        }
+        return hasBucketCountChange;
     }
 
     private Column buildColumnForAdd(ColumnDef columnDef, OlapTable table) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -48,7 +48,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.FlatJsonConfig;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
@@ -108,10 +110,12 @@ import com.starrocks.sql.ast.CancelStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnPosition;
 import com.starrocks.sql.ast.CreateIndexClause;
+import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropFieldClause;
 import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.DropPersistentIndexClause;
+import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.KeysType;
@@ -178,9 +182,12 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("Table[" + olapTable.getName() + "]'s is not in NORMAL state");
         }
 
-        // If optimized olap table contains related mvs, set those mv state to inactive.
-        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
-                MaterializedViewExceptions.inactiveReasonForBaseTableOptimized(olapTable.getName()));
+        // Bucket-only optimize changes the physical layout without changing the MV-visible semantics,
+        // so we skip inactivating related MVs in that case.
+        if (shouldInactiveRelatedMaterializedViewsForOptimize(optimizeClause, olapTable)) {
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
+                    MaterializedViewExceptions.inactiveReasonForBaseTableOptimized(olapTable.getName()));
+        }
 
         long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
 
@@ -193,6 +200,37 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withComputeResource(ConnectContext.get().getCurrentComputeResource());
 
         return jobBuilder.build();
+    }
+
+    private boolean shouldInactiveRelatedMaterializedViewsForOptimize(OptimizeClause optimizeClause, OlapTable olapTable) {
+        return !isBucketCountOnlyOptimize(optimizeClause, olapTable);
+    }
+
+    private boolean isBucketCountOnlyOptimize(OptimizeClause optimizeClause, OlapTable olapTable) {
+        if (optimizeClause.getKeysDesc() != null
+                || optimizeClause.getPartitionDesc() != null
+                || optimizeClause.getSortKeys() != null
+                || optimizeClause.getRange() != null) {
+            return false;
+        }
+
+        DistributionDesc distributionDesc = optimizeClause.getDistributionDesc();
+        DistributionInfo defaultDistributionInfo = olapTable.getDefaultDistributionInfo();
+        if (!(distributionDesc instanceof HashDistributionDesc)
+                || !(defaultDistributionInfo instanceof HashDistributionInfo)) {
+            return false;
+        }
+
+        HashDistributionDesc hashDistributionDesc = (HashDistributionDesc) distributionDesc;
+        HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
+        if (hashDistributionDesc.getBuckets() <= 0
+                || hashDistributionDesc.getBuckets() == hashDistributionInfo.getBucketNum()) {
+            return false;
+        }
+
+        List<String> originalDistributionColumns = MetaUtils.getColumnNamesByColumnIds(
+                olapTable.getIdToColumn(), hashDistributionInfo.getDistributionColumns());
+        return originalDistributionColumns.equals(hashDistributionDesc.getDistributionColumnNames());
     }
 
     private Column buildColumnForAdd(ColumnDef columnDef, OlapTable table) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -618,6 +618,62 @@ public class AlterMaterializedViewTest extends MVTestBase  {
     }
 
     @Test
+    public void testAlterBaseTableWithOptimizeBucketOnly() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t_bucket (\n" +
+                "  k1 int,\n" +
+                "  k2 date,\n" +
+                "  k3 string\n" +
+                "  )\n" +
+                "  DUPLICATE KEY(k1)\n" +
+                "  PARTITION BY RANGE(k2) (\n" +
+                "    PARTITION p1 VALUES [('2020-06-01'), ('2020-07-01')),\n" +
+                "    PARTITION p2 VALUES [('2020-07-01'), ('2020-08-01'))\n" +
+                "  )\n" +
+                "  DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "  PROPERTIES(\"replication_num\" = \"1\");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv_bucket \n" +
+                " REFRESH MANUAL\n" +
+                " AS select sum(k1), k2 from base_t_bucket group by k2;");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "test_mv_bucket");
+        Assertions.assertTrue(mv.isActive());
+
+        starRocksAssert.ddl("alter table base_t_bucket PARTITION(p1) DISTRIBUTED BY HASH(k1) BUCKETS 1;");
+
+        mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "test_mv_bucket");
+        Assertions.assertTrue(mv.isActive());
+    }
+
+    @Test
+    public void testAlterBaseTableWithOptimizeBucketAndSortKey() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t_bucket_sort (\n" +
+                "  k1 int,\n" +
+                "  k2 date,\n" +
+                "  k3 string\n" +
+                "  )\n" +
+                "  DUPLICATE KEY(k1)\n" +
+                "  PARTITION BY RANGE(k2) (\n" +
+                "    PARTITION p1 VALUES [('2020-06-01'), ('2020-07-01')),\n" +
+                "    PARTITION p2 VALUES [('2020-07-01'), ('2020-08-01'))\n" +
+                "  )\n" +
+                "  DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "  PROPERTIES(\"replication_num\" = \"1\");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv_bucket_sort \n" +
+                " REFRESH MANUAL\n" +
+                " AS select sum(k1), k2 from base_t_bucket_sort group by k2;");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(
+                connectContext.getDatabase(), "test_mv_bucket_sort");
+        Assertions.assertTrue(mv.isActive());
+
+        // Changing sort key along with bucket count is NOT a bucket-only optimize, MV should be inactivated.
+        starRocksAssert.ddl("alter table base_t_bucket_sort ORDER BY (k2, k1) " +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1;");
+
+        mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "test_mv_bucket_sort");
+        Assertions.assertFalse(mv.isActive());
+        Assertions.assertTrue(mv.getInactiveReason().contains("base-table optimized:"));
+    }
+
+    @Test
     public void testMaterializedViewRename() throws Exception {
         starRocksAssert.withTable("CREATE TABLE base_t1 (\n" +
                 "  k1 int,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
@@ -640,6 +641,42 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         starRocksAssert.ddl("alter table base_t_bucket PARTITION(p1) DISTRIBUTED BY HASH(k1) BUCKETS 1;");
 
         mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "test_mv_bucket");
+        Assertions.assertTrue(mv.isActive());
+    }
+
+    @Test
+    public void testAlterBaseTableWithOptimizeBucketOnlyUsesTargetPartitionBuckets() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t_bucket_target_partition (\n" +
+                "  k1 int,\n" +
+                "  k2 date,\n" +
+                "  k3 string\n" +
+                "  )\n" +
+                "  DUPLICATE KEY(k1)\n" +
+                "  PARTITION BY RANGE(k2) (\n" +
+                "    PARTITION p1 VALUES [('2020-06-01'), ('2020-07-01')),\n" +
+                "    PARTITION p2 VALUES [('2020-07-01'), ('2020-08-01'))\n" +
+                "  )\n" +
+                "  DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "  PROPERTIES(\"replication_num\" = \"1\");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv_bucket_target_partition \n" +
+                " REFRESH MANUAL\n" +
+                " AS select sum(k1), k2 from base_t_bucket_target_partition group by k2;");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(
+                connectContext.getDatabase(), "test_mv_bucket_target_partition");
+        Assertions.assertTrue(mv.isActive());
+
+        OlapTable table = (OlapTable) starRocksAssert.getTable(
+                connectContext.getDatabase(), "base_t_bucket_target_partition");
+        Column k1 = table.getColumn("k1");
+        table.getPartition("p1").setDistributionInfo(new HashDistributionInfo(1, Lists.newArrayList(k1)));
+        Assertions.assertEquals(3, table.getDefaultDistributionInfo().getBucketNum());
+        Assertions.assertEquals(1, table.getPartition("p1").getDistributionInfo().getBucketNum());
+
+        starRocksAssert.ddl("alter table base_t_bucket_target_partition PARTITION(p1) " +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3;");
+
+        mv = (MaterializedView) starRocksAssert.getTable(
+                connectContext.getDatabase(), "test_mv_bucket_target_partition");
         Assertions.assertTrue(mv.isActive());
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_bucket_only_optimize.result
+++ b/test/sql/test_materialized_view/R/test_mv_bucket_only_optimize.result
@@ -1,0 +1,79 @@
+-- name: test_mv_bucket_only_optimize @slow @native
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(k2) (
+    PARTITION p1 VALUES [('2020-06-01'), ('2020-07-01')),
+    PARTITION p2 VALUES [('2020-07-01'), ('2020-08-01'))
+)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+ALTER TABLE t1 PARTITION(p1) DISTRIBUTED BY HASH(k1) BUCKETS 1;
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+INSERT INTO t1 VALUES (4,'2020-06-02','BJ');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+-- result:
+True
+-- !result
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+-- result:
+2020-06-02	BJ	5
+2020-06-02	SZ	3
+2020-07-02	SH	2
+-- !result
+select * from mv1 order by 2, 3;
+-- result:
+5	2020-06-02	BJ
+3	2020-06-02	SZ
+2	2020-07-02	SH
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_bucket_only_optimize.sql
+++ b/test/sql/test_materialized_view/T/test_mv_bucket_only_optimize.sql
@@ -1,0 +1,47 @@
+-- name: test_mv_bucket_only_optimize @slow @native
+-- Test Point: verify a bucket-only optimize on the base table does not set the async materialized view inactive.
+-- 1. The MV should stay active after `ALTER TABLE ... PARTITION(...) DISTRIBUTED BY HASH(...) BUCKETS ...`.
+-- 2. After the optimize, new rows written into the base table should be refreshed into the MV correctly.
+-- 3. The MV should still support sync refresh, transparent rewrite, and direct MV reads after the optimize finishes.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t1 (
+    k1 int,
+    k2 date,
+    k3 string
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(k2) (
+    PARTITION p1 VALUES [('2020-06-01'), ('2020-07-01')),
+    PARTITION p2 VALUES [('2020-07-01'), ('2020-08-01'))
+)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t1 VALUES (1,'2020-06-02','BJ'),(3,'2020-06-02','SZ'),(2,'2020-07-02','SH');
+
+CREATE MATERIALIZED VIEW mv1
+REFRESH MANUAL
+AS select sum(k1), k2, k3 from t1 group by k2, k3;
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+
+ALTER TABLE t1 PARTITION(p1) DISTRIBUTED BY HASH(k1) BUCKETS 1;
+function: wait_optimize_table_finish()
+
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+INSERT INTO t1 VALUES (4,'2020-06-02','BJ');
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views
+WHERE table_name = 'mv1' and TABLE_SCHEMA = 'db_${uuid0}';
+function: print_hit_materialized_view("select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;", "mv1")
+select k2, k3, sum(k1) from t1 group by k2, k3 order by 1,2;
+select * from mv1 order by 2, 3;
+
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request updates the schema change logic for StarRocks to improve how materialized views (MVs) are handled during table optimizations, specifically distinguishing between "bucket-only" optimizations (which change only the physical layout) and more significant schema changes. The key improvement is that MVs are no longer set to inactive when a base table undergoes a bucket-only optimization, reducing unnecessary MV invalidations. The changes also add comprehensive tests to validate this behavior.

**Materialized View Inactivation Logic Improvements:**

- Added logic in `SchemaChangeHandler` to detect "bucket-only" optimizations (i.e., changes that only modify the bucket count/distribution, without altering keys, partitions, or sort keys) and prevent related materialized views from being set to inactive in these cases. This is handled by the new `shouldInactiveRelatedMaterializedViewsForOptimize` and `isBucketCountOnlyOptimize` methods. [[1]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cL179-R188) [[2]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR203-R233)

- Updated imports in `SchemaChangeHandler` to support the new logic for handling distribution and hash distribution descriptors. [[1]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR51-R53) [[2]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR113-R118)

**Testing Enhancements:**

- Added new test cases in `AlterMaterializedViewTest` to verify that:
    - MVs remain active after a bucket-only optimize.
    - MVs are set inactive if the optimize includes changes to sort keys (i.e., not bucket-only).

- Introduced a new SQL test script (`test_mv_bucket_only_optimize.sql`) and corresponding result file to verify end-to-end that bucket-only optimizations do not inactivate MVs, and that MVs continue to function correctly after such optimizations. [[1]](diffhunk://#diff-70bf21d051f738295bb6e41fad1955bbcec53d175017af0a6707512066205131R1-R47) [[2]](diffhunk://#diff-8ec0b3db5e5a219cb69c870857930de570607e4a53591f30a5b704d01aede7f6R1-R79)
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
