### PR TITLE
[BugFix] Preserve CTE consumer references in OptExpressionDuplicator if CTE producer is not duplicated (backport #69963)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -680,12 +680,22 @@ public class OptExpressionDuplicator {
             LogicalCTEConsumeOperator cteConsumeOperator = (LogicalCTEConsumeOperator) optExpression.getOp();
             LogicalCTEConsumeOperator.Builder opBuilder = OperatorBuilderFactory.build(optExpression.getOp());
             opBuilder.withOperator(cteConsumeOperator);
-            opBuilder.setCteId(getOrCreateCteId(cteConsumeOperator.getCteId()));
+
+            // If the CTE anchor/produce for this consumer was also duplicated, remap the CTE ID
+            // and both sides of the output column map. Otherwise, keep the original CTE ID and
+            // only remap the consumer-side columns, preserving the producer-side
+            // column refs so the consumer still references the original producer.
+            boolean hasMatchingProducer = cteIdMapping.containsKey(cteConsumeOperator.getCteId());
+            if (hasMatchingProducer) {
+                opBuilder.setCteId(getOrCreateCteId(cteConsumeOperator.getCteId()));
+            }
 
             // cteOutputColumnRefMap
             Map<ColumnRefOperator, ColumnRefOperator> newCteOutputColumnRefMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, ColumnRefOperator> e : cteConsumeOperator.getCteOutputColumnRefMap().entrySet()) {
-                newCteOutputColumnRefMap.put(getOrCreateColRef(e.getKey()), getOrCreateColRef(e.getValue()));
+                ColumnRefOperator newKey = getOrCreateColRef(e.getKey());
+                ColumnRefOperator newValue = hasMatchingProducer ? getOrCreateColRef(e.getValue()) : e.getValue();
+                newCteOutputColumnRefMap.put(newKey, newValue);
             }
             opBuilder.setCteOutputColumnRefMap(newCteOutputColumnRefMap);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -181,4 +181,21 @@ public class JoinPredicatePushdownTest extends PlanTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 4: v4 > 2");
     }
+
+    @Test
+    public void testJoinORToUnionWithCTEAndMultiDistinct() throws Exception {
+        connectContext.getSessionVariable().setEnabledRewriteOrToUnionAllJoin(true);
+        try {
+            String sql = "with shared as (\n" +
+                    "    select v1, v2, v3 from t0\n" +
+                    ")\n" +
+                    "select count(distinct a.v2), count(distinct b.v3)\n" +
+                    "from shared a\n" +
+                    "join shared b on a.v1 = b.v2 or a.v1 = b.v3;";
+
+            getFragmentPlan(sql);
+        } finally {
+            connectContext.getSessionVariable().setEnabledRewriteOrToUnionAllJoin(false);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -19,6 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Histogram;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.thrift.TExplainLevel;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,9 +30,14 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WindowSkewTest extends PlanTestBase {
+    private static final String TABLE_NAME = "window_skew_table";
+    private static final List<String> ALL_COLUMNS = List.of("p", "s", "x");
+    private static final String BASIC_WINDOW_SQL =
+            "select p, s, sum(x) over (partition by p order by s) from " + TABLE_NAME;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -80,31 +86,65 @@ class WindowSkewTest extends PlanTestBase {
         super.setUp();
         connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(true);
 
-        final var table = getOlapTable("window_skew_table");
+        final var table = table();
         setTableStatistics(table, 1000);
+    }
+
+    private OlapTable table() {
+        return getOlapTable(TABLE_NAME);
+    }
+
+    private StatisticStorage storage() {
+        return connectContext.getGlobalStateMgr().getStatisticStorage();
+    }
+
+    private void setColumnStatForP(double nullsFraction) {
+        final var stat = ColumnStatistic.builder().setNullsFraction(nullsFraction).build();
+        storage().addColumnStatistic(table(), "p", stat);
+        storage().getColumnStatistics(table(), ALL_COLUMNS);
+    }
+
+    private void refreshAndSetColumnStatForP(ColumnStatistic stat) {
+        storage().refreshColumnStatistics(table(), ALL_COLUMNS, true);
+        storage().addColumnStatistic(table(), "p", stat);
+        storage().getColumnStatistics(table(), ALL_COLUMNS);
+    }
+
+    private String getCostPlan(String sql) throws Exception {
+        return getFragmentPlan(sql, TExplainLevel.COSTS, "");
+    }
+
+    private void assertPlanHasUnionAndAnalytic(String plan, int expectedAnalyticCount) {
+        assertContains(plan, "UNION");
+        long analyticCount = plan.lines().filter(l -> l.contains("ANALYTIC")).count();
+        assertEquals(expectedAnalyticCount, analyticCount,
+                "Expected exactly 2 ANALYTIC operators after UNION split, but found " + analyticCount);
+    }
+
+    private void assertPlanHasUnionAndAnalytic(String plan) {
+        assertPlanHasUnionAndAnalytic(plan, 2);
+    }
+
+    private void assertPlanHasNoUnionButAnalytic(String plan) {
+        assertNotContains(plan, "UNION");
+        assertContains(plan, "ANALYTIC");
+    }
+
+    private void assertNullSplit(String plan) {
+        assertContains(plan, "IS NOT NULL");
+        assertContains(plan, "IS NULL");
     }
 
     @Test
     void testWindowWithSkew() throws Exception {
+        refreshAndSetColumnStatForP(
+                ColumnStatistic.builder().setNullsFraction(0.3).build());
 
-        final var table = getOlapTable("window_skew_table");
-
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.3).build();
-
-        statisticStorage.refreshColumnStatistics(table, List.of("p", "s", "x"), true);
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
-
-        String sql = "select p, s, sum(x) over (partition by p order by s) from window_skew_table";
-
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(BASIC_WINDOW_SQL);
 
         assertContains(plan, "Output Exprs:1: p | 2: s | 4: sum(3: x)");
-        assertContains(plan, "UNION");
-        // Validate that data is split into NULL and NOT NULL paths
-        assertContains(plan, "Predicates: 5: p IS NOT NULL");
-        assertContains(plan, "Predicates: 1: p IS NULL");
+        assertPlanHasUnionAndAnalytic(plan);
+        assertNullSplit(plan);
         // Validate Union child expressions match the expected columns from both branches
         assertContains(plan,
                 "ANALYTIC\n" +
@@ -136,60 +176,41 @@ class WindowSkewTest extends PlanTestBase {
 
     @Test
     void testWindowWithoutSkew() throws Exception {
-        String sql = "select p, s, sum(x) over (partition by p order by s) from window_skew_table";
+        setColumnStatForP(0.1);
 
-        final var nonSkewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.1).build();
+        String plan = getFragmentPlan(BASIC_WINDOW_SQL);
 
-        final var table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        statisticStorage.addColumnStatistic(table, "p", nonSkewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
-
-        String plan = getFragmentPlan(sql);
-
-        assertNotContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasNoUnionButAnalytic(plan);
     }
 
     @Test
     void testWindowWithMultipleSkewedColumns() throws Exception {
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-
         final var skewedP = ColumnStatistic.builder().setNullsFraction(0.4).build();
         final var skewedS = ColumnStatistic.builder().setNullsFraction(0.4).build();
 
-        statisticStorage.refreshColumnStatistics(table, List.of("p", "s", "x"), true);
-        statisticStorage.addColumnStatistic(table, "p", skewedP);
-        statisticStorage.addColumnStatistic(table, "s", skewedS);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
+        storage().refreshColumnStatistics(table(), ALL_COLUMNS, true);
+        storage().addColumnStatistic(table(), "p", skewedP);
+        storage().addColumnStatistic(table(), "s", skewedS);
+        storage().getColumnStatistics(table(), ALL_COLUMNS);
 
         // Partition by multiple columns
-        String sql = "select p, s, sum(x) over (partition by p, s order by x) from window_skew_table";
+        String sql = "select p, s, sum(x) over (partition by p, s order by x) from " + TABLE_NAME;
 
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(sql);
 
-        assertNotContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasNoUnionButAnalytic(plan);
     }
 
     @Test
     void testWindowWithMCVSkew() throws Exception {
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-
         Histogram histogram = new Histogram(
                 /* buckets */ List.of(),
                 /* mcv */ Map.of("1", 300L));
 
-        final var skewedMCV = ColumnStatistic.builder().setNullsFraction(0.0).setHistogram(histogram).build();
+        refreshAndSetColumnStatForP(
+                ColumnStatistic.builder().setNullsFraction(0.0).setHistogram(histogram).build());
 
-        statisticStorage.refreshColumnStatistics(table, List.of("p", "s", "x"), true);
-        statisticStorage.addColumnStatistic(table, "p", skewedMCV);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
-
-        String sql = "select p, s, sum(x) over (partition by p order by s) from window_skew_table";
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(BASIC_WINDOW_SQL);
 
         assertContains(plan, "UNION");
         assertContains(plan, "Predicates: [1: p, INT, true] = 1");
@@ -225,16 +246,12 @@ class WindowSkewTest extends PlanTestBase {
 
     @Test
     void testOtherAnalyticalFunctionsWithSkew() throws Exception {
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.5).build();
-
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
+        setColumnStatForP(0.5);
 
         String sql = "select p, s, avg(x) over (partition by p order by s), " +
-                "rank() over (partition by p order by s) from window_skew_table";
+                "rank() over (partition by p order by s) from " + TABLE_NAME;
 
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(sql);
 
         assertContains(plan, "Output Exprs:1: p | 2: s | 4: avg(3: x) | 5: rank()");
         assertContains(plan, "UNION");
@@ -245,84 +262,59 @@ class WindowSkewTest extends PlanTestBase {
     @Test
     void testWindowSkewOptimizationDisabled() throws Exception {
         connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.3).build();
+        setColumnStatForP(0.3);
 
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
+        String plan = getFragmentPlan(BASIC_WINDOW_SQL);
 
-        String sql = "select p, s, sum(x) over (partition by p order by s) from window_skew_table";
-
-        String plan = getFragmentPlan(sql);
-
-        assertNotContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
-
+        assertPlanHasNoUnionButAnalytic(plan);
     }
 
     @Test
     void testWindowWithoutOrderBy() throws Exception {
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.3).build();
+        setColumnStatForP(0.3);
 
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
-
-        String sql = "select p, s, sum(x) over (partition by p) from window_skew_table";
+        String sql = "select p, s, sum(x) over (partition by p) from " + TABLE_NAME;
 
         String plan = getFragmentPlan(sql);
 
-        assertNotContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasNoUnionButAnalytic(plan);
     }
 
     @Test
     void testWindowWithComplexPartition() throws Exception {
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.3).build();
-
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
+        setColumnStatForP(0.3);
 
         // Partition by expression (case when) instead of direct column
         String sql = "select p, s, sum(x) " +
-                "over (partition by case when p is null then -1 else p end order by s) from window_skew_table";
+                "over (partition by case when p is null then -1 else p end order by s) from " + TABLE_NAME;
 
         String plan = getFragmentPlan(sql);
 
-        assertNotContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasNoUnionButAnalytic(plan);
     }
 
     @Test
-    @Disabled // todo(martinr0x) enable once is merged https://github.com/StarRocks/starrocks/pull/68964
+    @Disabled
+        // todo(martinr0x) enable once is merged https://github.com/StarRocks/starrocks/pull/68964
     void testWindowSkewHintWithJoinBeforeWindow() throws Exception {
         // Test that the skew hint works correctly when there is a join before the window function
-        final var table = getOlapTable("window_skew_table");
         final var joinTable = getOlapTable("window_skew_table_join");
 
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.3).build();
-        setTableStatistics(table, 1000);
+        setTableStatistics(table(), 1000);
         setTableStatistics(joinTable, 500);
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
+        setColumnStatForP(0.3);
 
         String sql = "select a.p, a.s, b.val, sum(a.x) over (partition by a.p order by a.s) " +
-                "from window_skew_table a " +
+                "from " + TABLE_NAME + " a " +
                 "join [skew|b.id(NULL)] window_skew_table_join b on a.p = b.id";
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(sql);
 
         // Verify UNION rewrite is triggered
         assertContains(plan, "UNION");
         // Verify JOIN is present in the plan
         assertContains(plan, "JOIN");
         // Verify the NULL/NOT NULL predicates for skew handling
-        assertContains(plan, "IS NULL");
-        assertContains(plan, "IS NOT NULL");
+        assertNullSplit(plan);
         // Verify ANALYTIC window function is present
         assertContains(plan, "ANALYTIC");
     }
@@ -331,14 +323,12 @@ class WindowSkewTest extends PlanTestBase {
     void testWindowSkewHintWithExplicitNullValue() throws Exception {
         // Test that the skew hint syntax with explicit column and NULL value triggers the UNION rewrite
         // The hint [skew|p(NULL)] should be parsed and used by SplitWindowSkewToUnionRule
-        String sql = "select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) from window_skew_table";
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String sql = "select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) from " + TABLE_NAME;
+        String plan = getCostPlan(sql);
 
         // Verify UNION rewrite is triggered
         assertContains(plan, "UNION");
-
-        assertContains(plan, "Predicates: 1: p IS NULL");
-        assertContains(plan, "Predicates: 5: p IS NOT NULL");
+        assertNullSplit(plan);
 
         assertContains(plan,
                 "ANALYTIC\n" +
@@ -356,8 +346,8 @@ class WindowSkewTest extends PlanTestBase {
     @Test
     void testWindowSkewHintWithNonNullValue() throws Exception {
         // Test skew hint with a non-null integer value triggers the UNION rewrite
-        String sql = "select p, s, sum(x) over ([skew|p(1)] partition by p order by s) from window_skew_table";
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String sql = "select p, s, sum(x) over ([skew|p(1)] partition by p order by s) from " + TABLE_NAME;
+        String plan = getCostPlan(sql);
 
         // Verify UNION rewrite is triggered
         assertContains(plan, "UNION");
@@ -399,7 +389,7 @@ class WindowSkewTest extends PlanTestBase {
         final var table = getOlapTable("window_skew_table_str");
         setTableStatistics(table, 1000);
         String sql = "select p, s, sum(x) over ([skew|p('abc')] partition by p order by s) from window_skew_table_str";
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(sql);
 
         assertContains(plan, "UNION");
         assertContains(plan, "Predicates: [1: p, VARCHAR, true] = 'abc'");
@@ -412,28 +402,21 @@ class WindowSkewTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
 
         // Even with explicit skew hint, the optimization should NOT be applied
-        String sql = "select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) from window_skew_table";
+        String sql = "select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) from " + TABLE_NAME;
         String plan = getFragmentPlan(sql);
 
         // Verify UNION rewrite is NOT triggered
-        assertNotContains(plan, "UNION");
-        // But the query should still work with normal ANALYTIC
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasNoUnionButAnalytic(plan);
         assertContains(plan, "partition by: 1: p");
     }
 
     @Test
     void testWindowSkewHintWithWrongColumn() throws Exception {
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.0).build();
-
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
+        setColumnStatForP(0.0);
 
         // Test providing a skew hint for a column that is not in the partition clause
         // Skew hint on 's' but partitioned by 'p'
-        String sql = "select p, s, sum(x) over ([skew|s(1)] partition by p order by s) from window_skew_table";
+        String sql = "select p, s, sum(x) over ([skew|s(1)] partition by p order by s) from " + TABLE_NAME;
 
         assertThrows(Exception.class, () ->
                 getFragmentPlan(sql)
@@ -443,7 +426,7 @@ class WindowSkewTest extends PlanTestBase {
 
     @Test
     void testWindowSkewHintWithNonConstantValue() {
-        String sql = "select p, s, sum(x) over ([skew|p(s)] partition by p order by s) from window_skew_table";
+        String sql = "select p, s, sum(x) over ([skew|p(s)] partition by p order by s) from " + TABLE_NAME;
 
         assertThrows(Exception.class, () ->
                 getFragmentPlan(sql)
@@ -456,34 +439,28 @@ class WindowSkewTest extends PlanTestBase {
         String sql1 = "select p, s, " +
                 "sum(x) over ([skew|p(NULL)] partition by p order by s), " +
                 "avg(x) over (partition by p order by s) " +
-                "from window_skew_table";
+                "from " + TABLE_NAME;
 
-        String plan1 = getFragmentPlan(sql1, TExplainLevel.COSTS, "");
+        String plan1 = getCostPlan(sql1);
         assertContains(plan1, "UNION");
-        assertContains(plan1, "Predicates: 1: p IS NULL");
-        assertContains(plan1, "Predicates: 6: p IS NOT NULL");
+        assertNullSplit(plan1);
 
         // Case 2: Skew hint on the second window function
         String sql2 = "select p, s, " +
                 "sum(x) over (partition by p order by s), " +
                 "avg(x) over ([skew|p(NULL)] partition by p order by s) " +
-                "from window_skew_table";
+                "from " + TABLE_NAME;
 
-        String plan2 = getFragmentPlan(sql2, TExplainLevel.COSTS, "");
+        String plan2 = getCostPlan(sql2);
 
         assertContains(plan2, "UNION");
-        assertContains(plan2, "Predicates: 1: p IS NULL");
-        assertContains(plan2, "Predicates: 6: p IS NOT NULL");
+        assertNullSplit(plan2);
     }
 
     @Test
     void testMixedWindowPartitionsWithSkewHint() throws Exception {
-        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.0).build();
+        setColumnStatForP(0.0);
 
-        OlapTable table = getOlapTable("window_skew_table");
-        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
-        statisticStorage.addColumnStatistic(table, "p", skewedColumnStat);
-        statisticStorage.getColumnStatistics(table, List.of("p", "s", "x"));
         // Three analytical windows:
         // 1. partition by p (with skew hint)
         // 2. partition by p (no skew hint)
@@ -492,23 +469,22 @@ class WindowSkewTest extends PlanTestBase {
                 "sum(x) over ([skew|p(NULL)] partition by p order by s), " +
                 "avg(x) over (partition by p order by s), " +
                 "count(x) over (partition by s order by p) " +
-                "from window_skew_table";
+                "from " + TABLE_NAME;
 
-        String plan = getFragmentPlan(sql, TExplainLevel.COSTS, "");
+        String plan = getCostPlan(sql);
         assertContains(plan, "UNION");
         // Verify that the skew hint on 'p' triggered the split
-        assertContains(plan, "Predicates: 1: p IS NULL");
-        assertContains(plan, "Predicates: 7: p IS NOT NULL");
+        assertNullSplit(plan);
     }
 
     @Test
     void testWindowSkewHintRejectsMultipleValues() {
         // Window skew hint currently only supports a single value
-        String sql = "select p, s, sum(x) over ([skew|p(1, 2)] partition by p order by s) from window_skew_table";
+        String sql = "select p, s, sum(x) over ([skew|p(1, 2)] partition by p order by s) from " + TABLE_NAME;
         Exception e = assertThrows(Exception.class, () -> getFragmentPlan(sql));
         assertContains(e.getMessage(), "Window skew hint currently supports only a single value, but got 2 values");
 
-        String sql2 = "select p, s, sum(x) over ([skew|p(NULL, 2)] partition by p order by s) from window_skew_table";
+        String sql2 = "select p, s, sum(x) over ([skew|p(NULL, 2)] partition by p order by s) from " + TABLE_NAME;
         Exception e2 = assertThrows(Exception.class, () -> getFragmentPlan(sql2));
         assertContains(e2.getMessage(), "Window skew hint currently supports only a single value, but got 2 values");
     }
@@ -516,7 +492,7 @@ class WindowSkewTest extends PlanTestBase {
     @Test
     void testWindowSkewHintWithWrongValueType() {
         // Column 'p' is INT, but the skew hint provides a string value that cannot be cast to INT
-        String sql = "select p, s, sum(x) over ([skew|p('abc')] partition by p order by s) from window_skew_table";
+        String sql = "select p, s, sum(x) over ([skew|p('abc')] partition by p order by s) from " + TABLE_NAME;
 
         Exception e = assertThrows(Exception.class, () -> getFragmentPlan(sql));
         assertContains(e.getMessage(), "Window skew hint value type mismatch");
@@ -549,5 +525,137 @@ class WindowSkewTest extends PlanTestBase {
 
         Exception e = assertThrows(Exception.class, () -> getFragmentPlan(sql));
         assertContains(e.getMessage(), "Window skew hint value type mismatch");
+    }
+
+    @Test
+    void testWindowWithAggBug() throws Exception {
+        String sql = "with cte_0 as (\n" +
+                "    select  p, s as o,x+1 as s from window_skew_table\n" +
+                "),\n" +
+                "cte_1 as (\n" +
+                "    select p, s as o, sum(s) over ([skew|p(NULL)]partition by p order by s) as s from cte_0\n" +
+                "),\n" +
+                "cte_2 as (\n" +
+                "    select p, o, s from cte_1\n" +
+                "    union all\n" +
+                "    select p, o, s from cte_0\n" +
+                ")\n" +
+                "select count(distinct s), count(distinct o) from cte_2;";
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan);
+    }
+
+    @Test
+    void testWindowSkewStatisticsBasedWithCTEAndMultiDistinct() throws Exception {
+        Histogram histogram = new Histogram(List.of(), Map.of("1", 300L));
+        refreshAndSetColumnStatForP(
+                ColumnStatistic.builder().setNullsFraction(0.0).setHistogram(histogram).build());
+
+        String sql = "with cte_0 as (\n" +
+                "    select p, s, x from window_skew_table\n" +
+                "),\n" +
+                "cte_1 as (\n" +
+                "    select p, s, sum(x) over (partition by p order by s) as wx from cte_0\n" +
+                "),\n" +
+                "cte_2 as (\n" +
+                "    select p, s, wx from cte_1\n" +
+                "    union all\n" +
+                "    select p, s, x from cte_0\n" +
+                ")\n" +
+                "select count(distinct wx), count(distinct s) from cte_2;";
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan);
+    }
+
+    @Test
+    void testWindowSkewWithJoinedCTEConsumersAndMultiDistinct() throws Exception {
+        String sql = "with base as (\n" +
+                "    select p, s, x from window_skew_table\n" +
+                "),\n" +
+                "joined as (\n" +
+                "    select a.p, a.s, a.x + b.x as combined_x\n" +
+                "    from base a join base b on a.p = b.p\n" +
+                "),\n" +
+                "windowed as (\n" +
+                "    select p, s, sum(combined_x) over ([skew|p(NULL)] partition by p order by s) as wx from joined\n" +
+                ")\n" +
+                "select count(distinct wx), count(distinct s) from windowed;";
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+        assertContains(plan, "ANALYTIC");
+    }
+
+    @Test
+    void testWindowSkewWithCTEUsedInSubqueryAndMultiDistinct() throws Exception {
+        String sql = "with base as (\n" +
+                "    select p, s, x from window_skew_table\n" +
+                "),\n" +
+                "windowed as (\n" +
+                "    select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) as wx from base\n" +
+                "),\n" +
+                "agg_source as (\n" +
+                "    select w.p, w.s, w.wx, b.x as orig_x\n" +
+                "    from windowed w\n" +
+                "    join base b on w.p = b.p\n" +
+                ")\n" +
+                "select count(distinct wx), count(distinct orig_x) from agg_source;";
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan);
+    }
+
+    @Test
+    void testWindowSkewMCVHintWithCTEAndMultiDistinct() throws Exception {
+        String sql = "with cte_0 as (\n" +
+                "    select p, s as o, x+1 as s from window_skew_table\n" +
+                "),\n" +
+                "cte_1 as (\n" +
+                "    select p, s as o, sum(s) over ([skew|p(1)] partition by p order by s) as s from cte_0\n" +
+                "),\n" +
+                "cte_2 as (\n" +
+                "    select p, o, s from cte_1\n" +
+                "    union all\n" +
+                "    select p, o, s from cte_0\n" +
+                ")\n" +
+                "select count(distinct s), count(distinct o) from cte_2;";
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan);
+    }
+
+    @Test
+    void testTwoSkewedWindowsOverSharedCTEWithMultiDistinct() throws Exception {
+        String sql = "with shared as (\n" +
+                "    select p, s, x from window_skew_table\n" +
+                "),\n" +
+                "win1 as (\n" +
+                "    select p, s, sum(x) over ([skew|p(NULL)] partition by p order by s) as wx from shared\n" +
+                "),\n" +
+                "win2 as (\n" +
+                "    select p, s, avg(x) over ([skew|p(NULL)] partition by p order by s) as ax from shared\n" +
+                "),\n" +
+                "combined as (\n" +
+                "    select p, s, wx as val from win1\n" +
+                "    union all\n" +
+                "    select p, s, cast(ax as bigint) as val from win2\n" +
+                "    union all\n" +
+                "    select p, s, x from shared\n" +
+                ")\n" +
+                "select count(distinct val), count(distinct s) from combined;";
+
+        setColumnStatForP(0.1);
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan, 4);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -295,7 +295,7 @@ class WindowSkewTest extends PlanTestBase {
 
     @Test
     @Disabled
-        // todo(martinr0x) enable once is merged https://github.com/StarRocks/starrocks/pull/68964
+    // todo(martinr0x) enable once is merged https://github.com/StarRocks/starrocks/pull/68964
     void testWindowSkewHintWithJoinBeforeWindow() throws Exception {
         // Test that the skew hint works correctly when there is a join before the window function
         final var joinTable = getOlapTable("window_skew_table_join");


### PR DESCRIPTION
Backport of https://github.com/StarRocks/starrocks/pull/69963

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
