### PR TITLE
[BugFix] Support log_rejected_record_num session variable propagation

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -85,11 +85,6 @@ Status FileDataSource::_create_scanner() {
     if (_scan_range.ranges.empty()) {
         return Status::EndOfFile("scan range is empty");
     }
-    if (_runtime_state->enable_log_rejected_record() &&
-        _scan_range.ranges[0].format_type != TFileFormatType::FORMAT_CSV_PLAIN &&
-        _scan_range.ranges[0].format_type != TFileFormatType::FORMAT_JSON) {
-        return Status::InternalError("only support csv/json format to log rejected record");
-    }
     // create scanner object and open
     if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_ORC) {
         _scanner = std::make_unique<ORCScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -237,11 +237,6 @@ Status FileScanNode::_scanner_scan(const TBrokerScanRange& scan_range, const std
     if (scan_range.ranges.empty()) {
         return Status::EndOfFile("scan range is empty");
     }
-    if (runtime_state()->enable_log_rejected_record() &&
-        scan_range.ranges[0].format_type != TFileFormatType::FORMAT_CSV_PLAIN &&
-        scan_range.ranges[0].format_type != TFileFormatType::FORMAT_JSON) {
-        return Status::InternalError("only support csv/json format to log rejected record");
-    }
     //create scanner object and open
     std::unique_ptr<FileScanner> scanner = _create_scanner(scan_range, counter);
     if (scanner == nullptr) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -6216,6 +6216,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_hash_join_range_direct_mapping_opt(enableHashJoinRangeDirectMappingOpt);
         tResult.setEnable_hash_join_linear_chained_opt(enableHashJoinLinearChainedOpt);
         tResult.setEnable_hash_join_serialize_fixed_size_string(enableHashJoinSerializeFixedSizeString);
+        tResult.setLog_rejected_record_num(logRejectedRecordNum);
 
         return tResult;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.qe;
 
+import com.starrocks.thrift.TQueryOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -111,6 +112,26 @@ public class SessionVariableTest {
         com.starrocks.common.jmockit.Deencapsulation.setField(sessionVariable, "connectorSinkShuffleMode", "never");
         Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.NEVER,
                 sessionVariable.getConnectorSinkShuffleMode());
+    }
+
+    @Test
+    public void testLogRejectedRecordNumInToThrift() {
+        SessionVariable sessionVariable = new SessionVariable();
+
+        // Default value (0) should be propagated to TQueryOptions
+        TQueryOptions options = sessionVariable.toThrift();
+        Assertions.assertTrue(options.isSetLog_rejected_record_num());
+        Assertions.assertEquals(0L, options.getLog_rejected_record_num());
+
+        // Set to -1 (unlimited) and verify propagation
+        sessionVariable.setLogRejectedRecordNum(-1);
+        options = sessionVariable.toThrift();
+        Assertions.assertEquals(-1L, options.getLog_rejected_record_num());
+
+        // Set to a positive value and verify propagation
+        sessionVariable.setLogRejectedRecordNum(10000);
+        options = sessionVariable.toThrift();
+        Assertions.assertEquals(10000L, options.getLog_rejected_record_num());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -304,7 +304,8 @@ public class JobSpecTest extends SchedulerTestBase {
         // Check created jobSpec for sessionVariables.
         Assertions.assertEquals(TCompressionType.NO_COMPRESSION,
                 jobSpec.getQueryOptions().getLoad_transmission_compression_type());
-        Assertions.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+        // log_rejected_record_num is always set via toThrift() with default value 0
+        Assertions.assertEquals(0L, jobSpec.getQueryOptions().getLog_rejected_record_num());
 
         sessionVariables = ImmutableMap.of(
                 SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",
@@ -374,7 +375,8 @@ public class JobSpecTest extends SchedulerTestBase {
         // Check created jobSpec for sessionVariables.
         Assertions.assertEquals(TCompressionType.NO_COMPRESSION,
                 jobSpec.getQueryOptions().getLoad_transmission_compression_type());
-        Assertions.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+        // log_rejected_record_num is always set via toThrift() with default value 0
+        Assertions.assertEquals(0L, jobSpec.getQueryOptions().getLog_rejected_record_num());
 
         sessionVariables = ImmutableMap.of(
                 SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -145,6 +145,43 @@ public class JobSpecTest extends SchedulerTestBase {
         Assertions.assertEquals(LOAD_RESOURCE_GROUP, jobSpec.getResourceGroup());
     }
 
+    @Test
+    public void testInsertSchedulerLogRejectedRecordNum() throws Exception {
+        String sql = "select * from lineitem";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        TUniqueId queryId = new TUniqueId(2, 3);
+        connectContext.setExecutionId(queryId);
+        DescriptorTable descTable = new DescriptorTable();
+        List<PlanFragment> fragments = execPlan.getFragments();
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+
+        // Default value (0) should be propagated via toThrift
+        connectContext.getSessionVariable().setLogRejectedRecordNum(0);
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createInsertScheduler(
+                connectContext, fragments, scanNodes, descTable.toThrift(), execPlan);
+        JobSpec jobSpec = coordinator.getJobSpec();
+        Assertions.assertEquals(TQueryType.LOAD, jobSpec.getQueryOptions().getQuery_type());
+        Assertions.assertEquals(0L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+
+        // Set to -1 (unlimited) and verify propagation through INSERT path
+        connectContext.getSessionVariable().setLogRejectedRecordNum(-1);
+        coordinator = COORDINATOR_FACTORY.createInsertScheduler(
+                connectContext, fragments, scanNodes, descTable.toThrift(), execPlan);
+        jobSpec = coordinator.getJobSpec();
+        Assertions.assertEquals(-1L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+
+        // Set to a positive value and verify propagation through INSERT path
+        connectContext.getSessionVariable().setLogRejectedRecordNum(10000);
+        coordinator = COORDINATOR_FACTORY.createInsertScheduler(
+                connectContext, fragments, scanNodes, descTable.toThrift(), execPlan);
+        jobSpec = coordinator.getJobSpec();
+        Assertions.assertEquals(10000L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+
+        // Reset to default
+        connectContext.getSessionVariable().setLogRejectedRecordNum(0);
+    }
+
     /**
      * Mock {@link ResourceGroupMgr#chooseResourceGroup(ConnectContext, ResourceGroupClassifier.QueryType, Set)}.
      */


### PR DESCRIPTION
## Why I'm doing:

The `log_rejected_record_num` session variable was not being properly propagated through the query execution pipeline, particularly in INSERT/LOAD operations. Additionally, there were unnecessary format restrictions in the backend that prevented logging rejected records for non-CSV/JSON formats.

## What I'm doing:

1. **Frontend Changes:**
   - Added `log_rejected_record_num` field propagation in `SessionVariable.toThrift()` to ensure the session variable is included in `TQueryOptions`
   - Added comprehensive unit tests in `SessionVariableTest` to verify the variable is correctly serialized to Thrift with various values (0, -1, positive numbers)
   - Added integration test in `JobSpecTest` to verify the variable is properly propagated through the INSERT scheduler path

2. **Backend Changes:**
   - Removed format type restrictions in `FileDataSource::_create_scanner()` that only allowed CSV/JSON formats when logging rejected records
   - Removed the same format type restrictions in `FileScanNode::_scanner_scan()` to allow all file formats to support rejected record logging

These changes enable users to control rejected record logging behavior consistently across different file formats and query types.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4