### PR TITLE
[Enhancement] Support materialization hints for CTEs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -372,7 +372,7 @@ public class QueryAnalyzer {
                 if (isRecursive
                         && withQuery.getMaterializationHint() != CTERelation.CTEMaterializationHint.NONE) {
                     throw new SemanticException(
-                            "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs",
+                            "[materialized]/[not_materialized] hints are not allowed on recursive CTEs",
                             withQuery.getPos());
                 }
                 if (!isRecursive) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -100,6 +100,7 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.dump.HiveMetaStoreTableDumpInfo;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
@@ -367,6 +368,12 @@ public class QueryAnalyzer {
                 boolean isRecursive = stmt.isHasRecursiveCTE();
                 if (isRecursive) {
                     isRecursive = tryProcessRecursiveCte(withQuery, cteScope);
+                }
+                if (isRecursive
+                        && withQuery.getMaterializationHint() != CTERelation.CTEMaterializationHint.NONE) {
+                    throw new SemanticException(
+                            "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs",
+                            withQuery.getPos());
                 }
                 if (!isRecursive) {
                     processCteRelation(withQuery, cteScope);
@@ -662,7 +669,8 @@ public class QueryAnalyzer {
                         // cte used in outer query and sub-query can't use same relation-id and field
                         CTERelation newCteRelation = new CTERelation(withRelation.getCteMouldId(), tableName.getTbl(),
                                 withRelation.getColumnOutputNames(), withRelation.getCteQueryStatement(),
-                                withRelation.isRecursive(), false);
+                                withRelation.isRecursive(), false, NodePosition.ZERO,
+                                withRelation.getMaterializationHint());
                         newCteRelation.setAlias(tableRelation.getAlias());
                         newCteRelation.setResolvedInFromClause(true);
                         newCteRelation.setScope(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -20,6 +20,12 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.List;
 
 public class CTERelation extends Relation {
+    public enum CTEMaterializationHint {
+        NONE,
+        MATERIALIZED,
+        NOT_MATERIALIZED
+    }
+
     private final int cteMouldId;
     private final String name;
     private final QueryStatement cteQueryStatement;
@@ -27,14 +33,17 @@ public class CTERelation extends Relation {
     private final boolean isAnchor;
     private int refs = 0; // consume refs
     private boolean isRecursive;
+    private final CTEMaterializationHint materializationHint;
 
     public CTERelation(int cteMouldId, String name, List<String> columnOutputNames,
                        QueryStatement cteQueryStatement, boolean isRecursive, boolean isAnchor) {
-        this(cteMouldId, name, columnOutputNames, cteQueryStatement, isRecursive, isAnchor, NodePosition.ZERO);
+        this(cteMouldId, name, columnOutputNames, cteQueryStatement, isRecursive, isAnchor, NodePosition.ZERO,
+                CTEMaterializationHint.NONE);
     }
 
     public CTERelation(int cteMouldId, String name, List<String> columnOutputNames, QueryStatement cteQueryStatement,
-                       boolean isRecursive, boolean isAnchor, NodePosition pos) {
+                       boolean isRecursive, boolean isAnchor, NodePosition pos,
+                       CTEMaterializationHint materializationHint) {
         super(pos);
         this.cteMouldId = cteMouldId;
         this.name = name;
@@ -43,6 +52,7 @@ public class CTERelation extends Relation {
         this.refs = 0;
         this.isRecursive = isRecursive;
         this.isAnchor = isAnchor;
+        this.materializationHint = materializationHint;
     }
 
     public int getCteMouldId() {
@@ -83,6 +93,10 @@ public class CTERelation extends Relation {
 
     public boolean isAnchor() {
         return isAnchor;
+    }
+
+    public CTEMaterializationHint getMaterializationHint() {
+        return materializationHint;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
@@ -193,13 +193,12 @@ public class SqlWithIdUtils {
                                 relation.getColumnOutputNames().stream().map(c -> "`" + c + "`").collect(toList())))
                         .append(")");
             }
-            sqlBuilder.append(" AS ");
+            sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
             if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
-                sqlBuilder.append("MATERIALIZED ");
+                sqlBuilder.append("[materialized] ");
             } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
-                sqlBuilder.append("NOT MATERIALIZED ");
+                sqlBuilder.append("[not_materialized] ");
             }
-            sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
             return sqlBuilder.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlWithIdUtils.java
@@ -193,7 +193,13 @@ public class SqlWithIdUtils {
                                 relation.getColumnOutputNames().stream().map(c -> "`" + c + "`").collect(toList())))
                         .append(")");
             }
-            sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
+            sqlBuilder.append(" AS ");
+            if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
+                sqlBuilder.append("MATERIALIZED ");
+            } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
+                sqlBuilder.append("NOT MATERIALIZED ");
+            }
+            sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
             return sqlBuilder.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -290,8 +290,14 @@ public class AST2SQLVisitor extends AST2StringVisitor {
                     .append(")");
         }
         
-        sqlBuilder.append(" AS (");
-        
+        sqlBuilder.append(" AS ");
+        if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
+            sqlBuilder.append("MATERIALIZED ");
+        } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
+            sqlBuilder.append("NOT MATERIALIZED ");
+        }
+        sqlBuilder.append("(");
+
         if (options.isEnablePrettyFormat()) {
             // Pretty format: CTE definition with proper indentation
             options.increaseIndent();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -290,16 +290,9 @@ public class AST2SQLVisitor extends AST2StringVisitor {
                     .append(")");
         }
         
-        sqlBuilder.append(" AS ");
-        if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
-            sqlBuilder.append("MATERIALIZED ");
-        } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
-            sqlBuilder.append("NOT MATERIALIZED ");
-        }
-        sqlBuilder.append("(");
+        sqlBuilder.append(" AS (");
 
         if (options.isEnablePrettyFormat()) {
-            // Pretty format: CTE definition with proper indentation
             options.increaseIndent();
             try {
                 sqlBuilder.append(options.indent());
@@ -309,11 +302,15 @@ public class AST2SQLVisitor extends AST2StringVisitor {
             }
             sqlBuilder.append(options.indent()).append(")");
         } else {
-            // Default format: inline
             sqlBuilder.append(visit(relation.getCteQueryStatement()));
             sqlBuilder.append(") ");
         }
-        
+        if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
+            sqlBuilder.append("[materialized] ");
+        } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
+            sqlBuilder.append("[not_materialized] ");
+        }
+
         return sqlBuilder.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -575,7 +575,13 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
             sqlBuilder.append("(")
                     .append(Joiner.on(", ").join(relation.getColumnOutputNames())).append(")");
         }
-        sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
+        sqlBuilder.append(" AS ");
+        if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
+            sqlBuilder.append("MATERIALIZED ");
+        } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
+            sqlBuilder.append("NOT MATERIALIZED ");
+        }
+        sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
         return sqlBuilder.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -575,13 +575,12 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
             sqlBuilder.append("(")
                     .append(Joiner.on(", ").join(relation.getColumnOutputNames())).append(")");
         }
-        sqlBuilder.append(" AS ");
+        sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
         if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
-            sqlBuilder.append("MATERIALIZED ");
+            sqlBuilder.append("[materialized] ");
         } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
-            sqlBuilder.append("NOT MATERIALIZED ");
+            sqlBuilder.append("[not_materialized] ");
         }
-        sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
         return sqlBuilder.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -248,13 +248,12 @@ public class DesensitizedSQLBuilder {
                                         .collect(toList())))
                         .append(")");
             }
-            sqlBuilder.append(" AS ");
+            sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
             if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
-                sqlBuilder.append("MATERIALIZED ");
+                sqlBuilder.append("[materialized] ");
             } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
-                sqlBuilder.append("NOT MATERIALIZED ");
+                sqlBuilder.append("[not_materialized] ");
             }
-            sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
             return sqlBuilder.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -248,7 +248,13 @@ public class DesensitizedSQLBuilder {
                                         .collect(toList())))
                         .append(")");
             }
-            sqlBuilder.append(" AS (").append(visit(relation.getCteQueryStatement())).append(") ");
+            sqlBuilder.append(" AS ");
+            if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.MATERIALIZED) {
+                sqlBuilder.append("MATERIALIZED ");
+            } else if (relation.getMaterializationHint() == CTERelation.CTEMaterializationHint.NOT_MATERIALIZED) {
+                sqlBuilder.append("NOT MATERIALIZED ");
+            }
+            sqlBuilder.append("(").append(visit(relation.getCteQueryStatement())).append(") ");
             return sqlBuilder.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -16,8 +16,10 @@
 package com.starrocks.sql.optimizer.transformer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -36,12 +38,16 @@ public class CTETransformerContext {
 
     private final int cteMaxLimit;
 
+    // Stores CTEs specified with MATERIALIZED in the query string
+    private final List<Integer> forceCTEList;
+
     public CTETransformerContext(int cteMaxLimit) {
         this.cteExpressions = new HashMap<>();
         this.cteRefIdMapping = new HashMap<>();
         this.cteIdToNodeCount = new HashMap<>();
         this.uniqueId = new AtomicInteger();
         this.cteMaxLimit = cteMaxLimit;
+        this.forceCTEList = Lists.newArrayList();
     }
 
     public Map<Integer, ExpressionMapping> getCteExpressions() {
@@ -108,5 +114,13 @@ public class CTETransformerContext {
 
     public boolean isForceInline() {
         return cteRefIdMapping.size() > cteMaxLimit;
+    }
+
+    public void addForceCTE(int cteId) {
+        forceCTEList.add(cteId);
+    }
+
+    public boolean isForceCTE(int cteId) {
+        return forceCTEList.contains(cteId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -164,6 +164,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
+import static com.starrocks.sql.ast.CTERelation.CTEMaterializationHint.MATERIALIZED;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
@@ -219,8 +220,8 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
     public LogicalPlan transform(Relation relation) {
         if (relation instanceof QueryRelation && !((QueryRelation) relation).getCteRelations().isEmpty()) {
             QueryRelation queryRelation = (QueryRelation) relation;
-            if (queryRelation.getCteRelations().stream().noneMatch(c -> c.getRefs() > 1)) {
-                // all cte is only referenced once, no need to reuse
+            if (queryRelation.getCteRelations().stream().noneMatch(c -> c.getRefs() > 1
+                    || c.getMaterializationHint() == MATERIALIZED)) {
                 return visit(relation);
             }
 
@@ -242,11 +243,19 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         OptExprBuilder root = null;
         OptExprBuilder anchorOptBuilder = null;
         for (CTERelation cteRelation : node.getCteRelations()) {
-            if (cteRelation.getRefs() <= 1 || cteContext.isForceInline()) {
+            boolean shouldInline = switch (cteRelation.getMaterializationHint()) {
+                case NOT_MATERIALIZED -> true;
+                case MATERIALIZED -> false;
+                case NONE -> cteRelation.getRefs() <= 1 || cteContext.isForceInline();
+            };
+            if (shouldInline) {
                 continue;
             }
 
             int cteId = cteContext.registerCte(cteRelation.getCteMouldId());
+            if (cteRelation.getMaterializationHint() == MATERIALIZED) {
+                cteContext.addForceCTE(cteId);
+            }
             LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteId);
             LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteId);
             LogicalPlan producerPlan =
@@ -854,16 +863,10 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
         int forceReuseThreshold = session.getSessionVariable().getCboCTEForceReuseNodeCount();
 
-        if (forceReuseThreshold <= 0 || producerNodeCount < forceReuseThreshold) {
-            LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());
-            Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = checkCtePlanOutput(cteId, childPlan, node);
-            LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(cteId, cteOutputColumnRefMap);
-            consumeBuilder = new OptExprBuilder(consume, Lists.newArrayList(childPlan.getRootBuilder()),
-                    new ExpressionMapping(node.getScope(), childPlan.getOutputColumn(),
-                            childPlan.getRootBuilder().getColumnRefToConstOperators()));
-            outputColumns = childPlan.getOutputColumn();
-        } else {
-            // Force reuse for CTE with excessive nodes to avoid long optimizer time.
+        if (cteContext.isForceCTE(cteId) || (forceReuseThreshold > 0 && producerNodeCount >= forceReuseThreshold)) {
+            // Force materialization when
+            // 1. the CTE is specified as MATERIALIZED in the query string, or
+            // 2. the CTE has excessive nodes (to avoid long optimizer time)
             ExpressionMapping expressionMapping = cteContext.getCteExpressions().get(cteId);
             ImmutableMap.Builder<ColumnRefOperator, ColumnRefOperator> mapBuilder = ImmutableMap.builder();
 
@@ -874,9 +877,16 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
             }
 
             LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(cteId, mapBuilder.build());
-            consumeBuilder = new OptExprBuilder(consume, List.of(),
-                    new ExpressionMapping(node.getScope(), outputColumns, null)
-            );
+            consumeBuilder = new OptExprBuilder(consume, List.of(), new ExpressionMapping(node.getScope(), outputColumns, null));
+        } else {
+            // Leave the optimizer to decide later whether to materialize or inline
+            LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());
+            Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = checkCtePlanOutput(cteId, childPlan, node);
+            LogicalCTEConsumeOperator consume = new LogicalCTEConsumeOperator(cteId, cteOutputColumnRefMap);
+            consumeBuilder = new OptExprBuilder(consume, Lists.newArrayList(childPlan.getRootBuilder()),
+                    new ExpressionMapping(node.getScope(), childPlan.getOutputColumn(),
+                            childPlan.getRootBuilder().getColumnRefToConstOperators()));
+            outputColumns = childPlan.getOutputColumn();
         }
 
         return new LogicalPlan(consumeBuilder, outputColumns, List.of());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6010,11 +6010,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         QueryRelation queryRelation = (QueryRelation) visit(context.queryRelation());
 
         CTERelation.CTEMaterializationHint hint = CTERelation.CTEMaterializationHint.NONE;
-        if (context.MATERIALIZED() != null) {
-            if (context.NOT() != null) {
-                hint = CTERelation.CTEMaterializationHint.NOT_MATERIALIZED;
-            } else {
+        if (context.bracketHint() != null) {
+            String hintText = ((Identifier) visit(context.bracketHint().identifier(0))).getValue().toLowerCase();
+            if (hintText.equals("materialized")) {
                 hint = CTERelation.CTEMaterializationHint.MATERIALIZED;
+            } else if (hintText.equals("not_materialized")) {
+                hint = CTERelation.CTEMaterializationHint.NOT_MATERIALIZED;
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6011,11 +6011,21 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         CTERelation.CTEMaterializationHint hint = CTERelation.CTEMaterializationHint.NONE;
         if (context.bracketHint() != null) {
-            String hintText = ((Identifier) visit(context.bracketHint().identifier(0))).getValue().toLowerCase();
+            List<Identifier> hintIdentifiers = visit(context.bracketHint().identifier(), Identifier.class);
+            if (hintIdentifiers.size() != 1) {
+                throw new ParsingException(
+                        "CTE hint must be a single [materialized] or [not_materialized]",
+                        createPos(context.bracketHint()));
+            }
+            String hintText = hintIdentifiers.get(0).getValue().toLowerCase();
             if (hintText.equals("materialized")) {
                 hint = CTERelation.CTEMaterializationHint.MATERIALIZED;
             } else if (hintText.equals("not_materialized")) {
                 hint = CTERelation.CTEMaterializationHint.NOT_MATERIALIZED;
+            } else {
+                throw new ParsingException(
+                        "Unknown CTE hint [" + hintText + "]. Use [materialized] or [not_materialized]",
+                        createPos(context.bracketHint()));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6008,7 +6008,16 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitCommonTableExpression(com.starrocks.sql.parser.StarRocksParser.CommonTableExpressionContext context) {
         QueryRelation queryRelation = (QueryRelation) visit(context.queryRelation());
-        // Regenerate cteID when generating plan
+
+        CTERelation.CTEMaterializationHint hint = CTERelation.CTEMaterializationHint.NONE;
+        if (context.MATERIALIZED() != null) {
+            if (context.NOT() != null) {
+                hint = CTERelation.CTEMaterializationHint.NOT_MATERIALIZED;
+            } else {
+                hint = CTERelation.CTEMaterializationHint.MATERIALIZED;
+            }
+        }
+
         return new CTERelation(
                 RelationId.of(queryRelation).hashCode(),
                 normalizeName(((Identifier) visit(context.name)).getValue()),
@@ -6016,7 +6025,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 new QueryStatement(queryRelation),
                 false,
                 true,
-                queryRelation.getPos());
+                queryRelation.getPos(),
+                hint);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAstCheckVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAstCheckVisitor.java
@@ -148,6 +148,9 @@ public class SPMAstCheckVisitor implements AstVisitorExtendInterface<Boolean, Pa
     @Override
     public Boolean visitCTE(CTERelation stmt, ParseNode context) {
         CTERelation other = cast(context);
+        if (stmt.getMaterializationHint() != other.getMaterializationHint()) {
+            return false;
+        }
         return check(stmt.getCteQueryStatement(), other.getCteQueryStatement());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -15,10 +15,10 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.EmptyStatisticStorage;
 import org.apache.commons.lang3.StringUtils;
@@ -1203,8 +1203,8 @@ public class CTEPlanTest extends PlanTestBase {
         String planNoHint = getFragmentPlan(sqlNoHint);
         assertNotContains(planNoHint, "MultiCastDataSinks");
 
-        // With MATERIALIZED hint: forced reuse regardless of cost
-        String sqlHint = "with xx as MATERIALIZED (select * from t0) " +
+        // With [materialized] hint: forced reuse regardless of cost
+        String sqlHint = "with xx as (select * from t0) [materialized] " +
                 "select v1 from xx union all select v2 from xx;";
         String planHint = getFragmentPlan(sqlHint);
         assertContains(planHint, "MultiCastDataSinks");
@@ -1222,8 +1222,8 @@ public class CTEPlanTest extends PlanTestBase {
         String planNoHint = getFragmentPlan(sqlNoHint);
         assertContains(planNoHint, "MultiCastDataSinks");
 
-        // With NOT MATERIALIZED hint: forced inline
-        String sqlHint = "with xx as NOT MATERIALIZED (select * from t0) " +
+        // With [not_materialized] hint: forced inline
+        String sqlHint = "with xx as (select * from t0) [not_materialized] " +
                 "select v1 from xx union all select v2 from xx;";
         String planHint = getFragmentPlan(sqlHint);
         assertNotContains(planHint, "MultiCastDataSinks");
@@ -1235,8 +1235,8 @@ public class CTEPlanTest extends PlanTestBase {
     public void testCTEMixedMaterializationHints(int forceReuseNodeCount) throws Exception {
         connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
 
-        String sql = "with x0 as MATERIALIZED (select * from t0), " +
-                "x1 as NOT MATERIALIZED (select * from t1) " +
+        String sql = "with x0 as (select * from t0) [materialized], " +
+                "x1 as (select * from t1) [not_materialized] " +
                 "select * from (" +
                 "select * from x0 union all select * from x0 union all " +
                 "select * from x1 union all select * from x1) tt;";
@@ -1258,8 +1258,8 @@ public class CTEPlanTest extends PlanTestBase {
         String planNoHint = getFragmentPlan(sqlNoHint);
         assertNotContains(planNoHint, "MultiCastDataSinks");
 
-        // With MATERIALIZED hint, even single-referenced CTE is materialized
-        String sqlHint = "with xx as MATERIALIZED (select * from t0) select * from xx;";
+        // With [materialized] hint, even single-referenced CTE is materialized
+        String sqlHint = "with xx as (select * from t0) [materialized] select * from xx;";
         String planHint = getFragmentPlan(sqlHint);
         assertContains(planHint, "MultiCastDataSinks");
     }
@@ -1269,8 +1269,8 @@ public class CTEPlanTest extends PlanTestBase {
     public void testCTENotMaterializedWithJoin(int forceReuseNodeCount) throws Exception {
         connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
 
-        // CTE used in a self-join with NOT MATERIALIZED: both references should be inlined
-        String sql = "with xx as NOT MATERIALIZED (select * from t0) " +
+        // CTE used in a self-join with [not_materialized]: both references should be inlined
+        String sql = "with xx as (select * from t0) [not_materialized] " +
                 "select x1.v1 from xx x1 join xx x2 on x1.v2 = x2.v3;";
         String plan = getFragmentPlan(sql);
         assertNotContains(plan, "MultiCastDataSinks");
@@ -1290,8 +1290,8 @@ public class CTEPlanTest extends PlanTestBase {
         assertContains(planNoHint, "MultiCastDataSinks");
         assertContains(planNoHint, "rand()");
 
-        // With MATERIALIZED hint: both hint and ForceCTEReuseRule agree, should materialize
-        String sqlHint = "with xx as MATERIALIZED (select rand() as r, v1 from t0) " +
+        // With [materialized] hint: both hint and ForceCTEReuseRule agree, should materialize
+        String sqlHint = "with xx as (select rand() as r, v1 from t0) [materialized] " +
                 "select r from xx union all select r from xx;";
         String planHint = getFragmentPlan(sqlHint);
         assertContains(planHint, "MultiCastDataSinks");
@@ -1309,8 +1309,8 @@ public class CTEPlanTest extends PlanTestBase {
         String planNoHint = getFragmentPlan(sqlNoHint);
         assertContains(planNoHint, "MultiCastDataSinks");
 
-        // With NOT MATERIALIZED hint: hint overrides ForceCTEReuseRule, CTE is inlined
-        String sqlHint = "with xx as NOT MATERIALIZED (select rand() as r, v1 from t0) " +
+        // With [not_materialized] hint: hint overrides ForceCTEReuseRule, CTE is inlined
+        String sqlHint = "with xx as (select rand() as r, v1 from t0) [not_materialized] " +
                 "select r from xx union all select r from xx;";
         String planHint = getFragmentPlan(sqlHint);
         assertNotContains(planHint, "MultiCastDataSinks");
@@ -1323,8 +1323,8 @@ public class CTEPlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
         connectContext.getSessionVariable().setCboCTERuseRatio(10000000);
 
-        String sql = "with x0 as MATERIALIZED (select rand() as r, v1 from t0), " +
-                "x1 as NOT MATERIALIZED (select random() as r, v4 from t1) " +
+        String sql = "with x0 as (select rand() as r, v1 from t0) [materialized], " +
+                "x1 as (select random() as r, v4 from t1) [not_materialized] " +
                 "select * from (" +
                 "select r, v1 from x0 union all select r, v1 from x0 union all " +
                 "select r, v4 from x1 union all select r, v4 from x1) tt;";
@@ -1340,16 +1340,16 @@ public class CTEPlanTest extends PlanTestBase {
     public void testRecursiveCTERejectsMaterializationHint() {
         Assertions.assertThrows(SemanticException.class,
                 () -> getFragmentPlan(
-                        "with recursive cte(a) as MATERIALIZED (" +
-                        "select 1 union all select a + 1 from cte where a < 10) " +
+                        "with recursive cte(a) as (" +
+                        "select 1 union all select a + 1 from cte where a < 10) [materialized] " +
                         "select * from cte"),
-                "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs");
+                "[materialized]/[not_materialized] hints are not allowed on recursive CTEs");
 
         Assertions.assertThrows(SemanticException.class,
                 () -> getFragmentPlan(
-                        "with recursive cte(a) as NOT MATERIALIZED (" +
-                        "select 1 union all select a + 1 from cte where a < 10) " +
+                        "with recursive cte(a) as (" +
+                        "select 1 union all select a + 1 from cte where a < 10) [not_materialized] " +
                         "select * from cte"),
-                "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs");
+                "[materialized]/[not_materialized] hints are not allowed on recursive CTEs");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -1187,5 +1189,167 @@ public class CTEPlanTest extends PlanTestBase {
         // Should not force CTE reuse when variable is disabled
         // (CTE reuse decision will be based on other factors like ratio and consume count)
         // Note: The actual behavior depends on CTE reuse ratio and consume count
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0})
+    public void testCTEMaterializedHintForcesReuse(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000000);
+
+        // Without hint: cost-based inlines because reuse ratio is very high
+        String sqlNoHint = "with xx as (select * from t0) " +
+                "select v1 from xx union all select v2 from xx;";
+        String planNoHint = getFragmentPlan(sqlNoHint);
+        assertNotContains(planNoHint, "MultiCastDataSinks");
+
+        // With MATERIALIZED hint: forced reuse regardless of cost
+        String sqlHint = "with xx as MATERIALIZED (select * from t0) " +
+                "select v1 from xx union all select v2 from xx;";
+        String planHint = getFragmentPlan(sqlHint);
+        assertContains(planHint, "MultiCastDataSinks");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTENotMaterializedHintForcesInline(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        // @BeforeEach sets setCboCTERuseRatio(0) which means always reuse
+
+        // Without hint: CTE is materialized
+        String sqlNoHint = "with xx as (select * from t0) " +
+                "select v1 from xx union all select v2 from xx;";
+        String planNoHint = getFragmentPlan(sqlNoHint);
+        assertContains(planNoHint, "MultiCastDataSinks");
+
+        // With NOT MATERIALIZED hint: forced inline
+        String sqlHint = "with xx as NOT MATERIALIZED (select * from t0) " +
+                "select v1 from xx union all select v2 from xx;";
+        String planHint = getFragmentPlan(sqlHint);
+        assertNotContains(planHint, "MultiCastDataSinks");
+        Assertions.assertEquals(2, StringUtils.countMatches(planHint, "TABLE: t0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEMixedMaterializationHints(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+
+        String sql = "with x0 as MATERIALIZED (select * from t0), " +
+                "x1 as NOT MATERIALIZED (select * from t1) " +
+                "select * from (" +
+                "select * from x0 union all select * from x0 union all " +
+                "select * from x1 union all select * from x1) tt;";
+        String plan = getFragmentPlan(sql);
+        // x0 is materialized: t0 scanned once, distributed via MultiCast
+        assertContains(plan, "MultiCastDataSinks");
+        Assertions.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        // x1 is inlined: t1 scanned twice (once per reference)
+        Assertions.assertEquals(2, StringUtils.countMatches(plan, "TABLE: t1"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0})
+    public void testCTEMaterializedHintSingleRef(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+
+        // Without hint, single-referenced CTE is inlined
+        String sqlNoHint = "with xx as (select * from t0) select * from xx;";
+        String planNoHint = getFragmentPlan(sqlNoHint);
+        assertNotContains(planNoHint, "MultiCastDataSinks");
+
+        // With MATERIALIZED hint, even single-referenced CTE is materialized
+        String sqlHint = "with xx as MATERIALIZED (select * from t0) select * from xx;";
+        String planHint = getFragmentPlan(sqlHint);
+        assertContains(planHint, "MultiCastDataSinks");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTENotMaterializedWithJoin(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+
+        // CTE used in a self-join with NOT MATERIALIZED: both references should be inlined
+        String sql = "with xx as NOT MATERIALIZED (select * from t0) " +
+                "select x1.v1 from xx x1 join xx x2 on x1.v2 = x2.v3;";
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "MultiCastDataSinks");
+        Assertions.assertEquals(2, StringUtils.countMatches(plan, "TABLE: t0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testNonDeterministicCTEWithMaterializedHint(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000000);
+
+        // Without hint: ForceCTEReuseRule forces materialization despite high reuse ratio
+        String sqlNoHint = "with xx as (select rand() as r, v1 from t0) " +
+                "select r from xx union all select r from xx;";
+        String planNoHint = getFragmentPlan(sqlNoHint);
+        assertContains(planNoHint, "MultiCastDataSinks");
+        assertContains(planNoHint, "rand()");
+
+        // With MATERIALIZED hint: both hint and ForceCTEReuseRule agree, should materialize
+        String sqlHint = "with xx as MATERIALIZED (select rand() as r, v1 from t0) " +
+                "select r from xx union all select r from xx;";
+        String planHint = getFragmentPlan(sqlHint);
+        assertContains(planHint, "MultiCastDataSinks");
+        assertContains(planHint, "rand()");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testNonDeterministicCTEWithNotMaterializedHint(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+
+        // Without hint: ForceCTEReuseRule forces materialization for non-deterministic CTE
+        String sqlNoHint = "with xx as (select rand() as r, v1 from t0) " +
+                "select r from xx union all select r from xx;";
+        String planNoHint = getFragmentPlan(sqlNoHint);
+        assertContains(planNoHint, "MultiCastDataSinks");
+
+        // With NOT MATERIALIZED hint: hint overrides ForceCTEReuseRule, CTE is inlined
+        String sqlHint = "with xx as NOT MATERIALIZED (select rand() as r, v1 from t0) " +
+                "select r from xx union all select r from xx;";
+        String planHint = getFragmentPlan(sqlHint);
+        assertNotContains(planHint, "MultiCastDataSinks");
+        Assertions.assertEquals(2, StringUtils.countMatches(planHint, "TABLE: t0"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testNonDeterministicCTEMixedHints(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setCboCTERuseRatio(10000000);
+
+        String sql = "with x0 as MATERIALIZED (select rand() as r, v1 from t0), " +
+                "x1 as NOT MATERIALIZED (select random() as r, v4 from t1) " +
+                "select * from (" +
+                "select r, v1 from x0 union all select r, v1 from x0 union all " +
+                "select r, v4 from x1 union all select r, v4 from x1) tt;";
+        String plan = getFragmentPlan(sql);
+        // x0 with MATERIALIZED: materialized despite high ratio, t0 scanned once
+        assertContains(plan, "MultiCastDataSinks");
+        Assertions.assertEquals(1, StringUtils.countMatches(plan, "TABLE: t0"));
+        // x1 with NOT MATERIALIZED: inlined even though it has random(), t1 scanned twice
+        Assertions.assertEquals(2, StringUtils.countMatches(plan, "TABLE: t1"));
+    }
+
+    @Test
+    public void testRecursiveCTERejectsMaterializationHint() {
+        Assertions.assertThrows(SemanticException.class,
+                () -> getFragmentPlan(
+                        "with recursive cte(a) as MATERIALIZED (" +
+                        "select 1 union all select a + 1 from cte where a < 10) " +
+                        "select * from cte"),
+                "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs");
+
+        Assertions.assertThrows(SemanticException.class,
+                () -> getFragmentPlan(
+                        "with recursive cte(a) as NOT MATERIALIZED (" +
+                        "select 1 union all select a + 1 from cte where a < 10) " +
+                        "select * from cte"),
+                "MATERIALIZED/NOT MATERIALIZED hints are not allowed on recursive CTEs");
     }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2464,9 +2464,7 @@ groupingSet
     ;
 
 commonTableExpression
-    : name=identifier (columnAliases)? AS MATERIALIZED '(' queryRelation ')'
-    | name=identifier (columnAliases)? AS NOT MATERIALIZED '(' queryRelation ')'
-    | name=identifier (columnAliases)? AS '(' queryRelation ')'
+    : name=identifier (columnAliases)? AS '(' queryRelation ')' bracketHint?
     ;
 
 setQuantifier

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2464,7 +2464,9 @@ groupingSet
     ;
 
 commonTableExpression
-    : name=identifier (columnAliases)? AS '(' queryRelation ')'
+    : name=identifier (columnAliases)? AS MATERIALIZED '(' queryRelation ')'
+    | name=identifier (columnAliases)? AS NOT MATERIALIZED '(' queryRelation ')'
+    | name=identifier (columnAliases)? AS '(' queryRelation ')'
     ;
 
 setQuantifier


### PR DESCRIPTION
## Why I'm doing:

Implements https://github.com/StarRocks/starrocks/issues/66230. (cc @LiShuMing )

An additional benefit apart from those mentioned in https://github.com/StarRocks/starrocks/issues/66230:
- It allows the users to prevent inlining an CTE when the inlining will incur a too complex scalar expression. For complex deeply-nested CTEs like the below one, inlining will create a scalar expression that has an excessive number of nodes. 
```sql
WITH cte1 AS (
  SELECT
    ...,
    (CASE
      WHEN col < val1 THEN ..
      WHEN col >= val1 AND col < val2 THEN ..
      ...
      WHEN col >= valN-1 AND col >= valN THEN ..
      ELSE NULL
      END
    ) AS case_when_result_col1
  FROM tbl1
),
cte2 AS (
  SELECT
    ...,
    (CASE
      WHEN case_when_result_col = 'aa' AND col = 'xx' THEN ..
      WHEN case_when_result_col = 'bb' AND col = 'xx' THEN ..
      ...
      ELSE NULL
      END
    ) AS case_when_result_col2
  FROM cte1
),
...
SELECT ... FROM cteN
```


## What I'm doing:
Implements https://github.com/StarRocks/starrocks/issues/66230.

Allow users to control CTE materialization strategy via SQL syntax hints:
```sql
WITH cte AS (SELECT * FROM t0) [materialized]
SELECT v1 FROM cte UNION ALL SELECT v2 FROM cte;

WITH cte AS (SELECT rand() AS r, v1 FROM t0) [not_materialized]
SELECT r FROM cte UNION ALL SELECT r FROM cte;
```
- `[materialized]` forces the CTE to be materialized regardless of reference count and cost evaluation.
- `[not_materialized]` forces inlining regardless of whether it contains non-deterministic functions, and cost evaluation.
- Without a hint, existing behaviors are retained.

Please note that, the hint takes precedence over existing behaviors. For example, `WITH cte (SELECT rand() AS r, v1 FROM t0) [not_materialized]` will make the CTE inlined. The motivation is to allow users have full control over whether a CTE is materialized or inlined. 


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
