### PR TITLE
[Enhancement] Support constant folding for regexp_replace in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -37,6 +37,9 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import com.google.re2j.PatternSyntaxException;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -1563,6 +1566,89 @@ public class ScalarOperatorFunctions {
                                            ConstantOperator replacement) {
         return ConstantOperator.createVarchar(
                 StringUtils.replace(value.getVarchar(), target.getVarchar(), replacement.getVarchar()));
+    }
+
+    @ConstantFunction(name = "regexp_replace", argTypes = {VARCHAR, VARCHAR, VARCHAR}, returnType = VARCHAR)
+    public static ConstantOperator regexpReplace(ConstantOperator value, ConstantOperator pattern,
+                                                 ConstantOperator replacement) {
+        String patternText = pattern.getVarchar();
+        if (patternText.isEmpty()) {
+            throw new IllegalArgumentException("empty regex falls back to BE");
+        }
+
+        final Pattern compiled;
+        try {
+            compiled = Pattern.compile(patternText, Pattern.DOTALL);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("invalid regex falls back to BE", e);
+        }
+
+        boolean globalMode = !patternText.startsWith("^") && !patternText.endsWith("$");
+        String replaced = regexpReplaceWithBERewrite(value.getVarchar(), compiled, replacement.getVarchar(), globalMode);
+        return ConstantOperator.createVarchar(replaced);
+    }
+
+    private static String regexpReplaceWithBERewrite(String input, Pattern pattern, String rewrite, boolean globalMode) {
+        Matcher matcher = pattern.matcher(input);
+        if (!matcher.find()) {
+            return input;
+        }
+
+        StringBuilder result = new StringBuilder(input.length());
+        int lastEnd = 0;
+        do {
+            int start = matcher.start();
+            int end = matcher.end();
+            if (start == end) {
+                if (globalMode && start == input.length()) {
+                    break;
+                }
+                throw new IllegalArgumentException("zero-length regex match falls back to BE");
+            }
+            result.append(input, lastEnd, start);
+            appendBEStyleRegexRewrite(result, rewrite, matcher);
+            lastEnd = end;
+            if (!globalMode) {
+                break;
+            }
+        } while (matcher.find());
+
+        result.append(input, lastEnd, input.length());
+        return result.toString();
+    }
+
+    private static void appendBEStyleRegexRewrite(StringBuilder out, String rewrite, Matcher matcher) {
+        for (int i = 0; i < rewrite.length(); i++) {
+            char ch = rewrite.charAt(i);
+            if (ch != '\\') {
+                out.append(ch);
+                continue;
+            }
+
+            if (i + 1 >= rewrite.length()) {
+                throw new IllegalArgumentException("dangling replacement escape falls back to BE");
+            }
+
+            char next = rewrite.charAt(++i);
+            if (next == '\\') {
+                out.append('\\');
+                continue;
+            }
+
+            if (next >= '0' && next <= '9') {
+                int group = next - '0';
+                if (group > matcher.groupCount()) {
+                    throw new IllegalArgumentException("replacement group falls back to BE");
+                }
+                String groupValue = matcher.group(group);
+                if (groupValue != null) {
+                    out.append(groupValue);
+                }
+                continue;
+            }
+
+            throw new IllegalArgumentException("unsupported replacement escape falls back to BE");
+        }
     }
 
     private static ConstantOperator createDecimalConstant(BigDecimal result) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1263,6 +1263,6 @@ public class TrinoQueryTest extends TrinoTestBase {
     @Test
     public void testRegexpReplace() throws Exception {
         String sql = "select regexp_replace('123', '321')";
-        assertPlanContains(sql, "regexp_replace('123', '321', '')");
+        assertPlanContains(sql, "<slot 2> : '123'");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
@@ -92,6 +92,96 @@ public class ScalarOperatorEvaluatorTest {
     }
 
     @Test
+    public void evaluationRegexpReplace() {
+        CallOperator operator = new CallOperator(FunctionSet.REGEXP_REPLACE, VarcharType.VARCHAR,
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar("a b c"),
+                        ConstantOperator.createVarchar("(b)"),
+                        ConstantOperator.createVarchar("<\\1>")));
+
+        Function fn = new Function(new FunctionName(FunctionSet.REGEXP_REPLACE),
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR}, VarcharType.VARCHAR, false);
+
+        new Expectations(operator) {
+            {
+                operator.getFunction();
+                result = fn;
+            }
+        };
+
+        ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
+        assertEquals(OperatorType.CONSTANT, result.getOpType());
+        assertEquals("a <b> c", ((ConstantOperator) result).getVarchar());
+    }
+
+    @Test
+    public void evaluationRegexpReplaceFallbackToBE() {
+        CallOperator operator = new CallOperator(FunctionSet.REGEXP_REPLACE, VarcharType.VARCHAR,
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar("abcd"),
+                        ConstantOperator.createVarchar("(unclosed"),
+                        ConstantOperator.createVarchar("xx")));
+
+        Function fn = new Function(new FunctionName(FunctionSet.REGEXP_REPLACE),
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR}, VarcharType.VARCHAR, false);
+
+        new Expectations(operator) {
+            {
+                operator.getFunction();
+                result = fn;
+            }
+        };
+
+        ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
+        assertEquals(operator, result);
+    }
+
+    @Test
+    public void evaluationRegexpReplaceEmptyPatternFallbackToBE() {
+        CallOperator operator = new CallOperator(FunctionSet.REGEXP_REPLACE, VarcharType.VARCHAR,
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar(""),
+                        ConstantOperator.createVarchar(""),
+                        ConstantOperator.createVarchar("xx")));
+
+        Function fn = new Function(new FunctionName(FunctionSet.REGEXP_REPLACE),
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR}, VarcharType.VARCHAR, false);
+
+        new Expectations(operator) {
+            {
+                operator.getFunction();
+                result = fn;
+            }
+        };
+
+        ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
+        assertEquals(operator, result);
+    }
+
+    @Test
+    public void evaluationRegexpReplaceGlobal() {
+        CallOperator operator = new CallOperator(FunctionSet.REGEXP_REPLACE, VarcharType.VARCHAR,
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar("xxxx"),
+                        ConstantOperator.createVarchar("xx"),
+                        ConstantOperator.createVarchar("-")));
+
+        Function fn = new Function(new FunctionName(FunctionSet.REGEXP_REPLACE),
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR}, VarcharType.VARCHAR, false);
+
+        new Expectations(operator) {
+            {
+                operator.getFunction();
+                result = fn;
+            }
+        };
+
+        ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
+        assertEquals(OperatorType.CONSTANT, result.getOpType());
+        assertEquals("--", ((ConstantOperator) result).getVarchar());
+    }
+
+    @Test
     public void evaluationFromUtc() {
         CallOperator operator = new CallOperator(FunctionSet.STR_TO_DATE, VarcharType.VARCHAR, Lists.newArrayList(
                 ConstantOperator.createVarchar("2003-10-11 23:56:25"),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -585,6 +585,60 @@ public class ConstantExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testRegexpReplace() throws Exception {
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('abcd', '.*', 'xx')");
+            assertContains(plan, "<slot 2> : 'xx'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('a b c', '(b)', '<\\\\1>')");
+            assertContains(plan, "<slot 2> : 'a <b> c'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('ab\\ncd', 'a.*d', 'xx')");
+            assertContains(plan, "<slot 2> : 'xx'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('xxxx', 'xx', '-')");
+            assertContains(plan, "<slot 2> : '--'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('xxxx', 'not', 'xxxxxxxx')");
+            assertContains(plan, "<slot 2> : 'xxxx'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace(NULL, 'abc', 'xx')");
+            assertContains(plan, "<slot 2> : NULL");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('', '', 'xx')");
+            assertContains(plan, "regexp_replace('', '', 'xx')");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT regexp_replace('abcd', '(unclosed', 'xx')");
+            assertContains(plan, "regexp_replace('abcd', '(unclosed', 'xx')");
+        }
+
+        {
+            String plan = getFragmentPlan("select column_value " +
+                    "from (values ('root'), ('other')) as t(column_value) " +
+                    "where column_value = replace(" +
+                    "regexp_replace(" +
+                    "regexp_replace(" +
+                    "regexp_replace(current_user(), '\\'@.*$', ''), '^\\'', ''), " +
+                    "'^(.*)_dot_(.*)_(tl|bi|dh)_user$', '\\\\1.\\\\2'), '__', '-')");
+            assertContains(plan, "predicates: 1: column_value = 'root'");
+        }
+    }
+
+    @Test
     public void testDivisionByZeroWithSqlMode() throws Exception {
         long savedSqlMode = connectContext.getSessionVariable().getSqlMode();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -220,6 +220,28 @@ public class SelectConstTest extends PlanTestBase {
     }
 
     @Test
+    public void testRegexpReplaceExecuteInFe() throws Exception {
+        String[][] cases = new String[][] {
+                {"select regexp_replace('a b c', ' ', '-')", "a-b-c", "<slot 2> : 'a-b-c'"},
+                {"select regexp_replace('a sdfwe b c', '( )', '<\\\\1>')", "a< >sdfwe< >b< >c",
+                        "<slot 2> : 'a< >sdfwe< >b< >c'"},
+                {"select regexp_replace('a b c', '(b)', '<\\\\1>')", "a <b> c", "<slot 2> : 'a <b> c'"},
+                {"select regexp_replace('xxxx', 'xx', '-')", "--", "<slot 2> : '--'"},
+                {"select regexp_replace('xxxx', 'xxx', '-')", "-x", "<slot 2> : '-x'"},
+                {"select regexp_replace('abcd', 'bc', 'xx')", "axxd", "<slot 2> : 'axxd'"},
+                {"select regexp_replace('abc中文def', '[\\\\p{Han}]+', 'xx')", "abcxxdef",
+                        "<slot 2> : 'abcxxdef'"},
+                {"select regexp_replace('ab\\ncd', 'a.*d', 'xx')", "xx", "<slot 2> : 'xx'"}
+        };
+
+        for (String[] tc : cases) {
+            String sql = tc[0];
+            assertPlanContains(sql, tc[2]);
+            assertFeExecuteResult(sql, tc[1]);
+        }
+    }
+
+    @Test
     public void testExecuteInFEWithComplexQuery() throws Exception {
         String sql = "select 1, -1, 1.23456, cast(1.123 as float), cast(1.123 as double), " +
                 "cast(10 as bigint), cast(100 as largeint),\n" +

--- a/test/sql/test_function/R/test_regex
+++ b/test/sql/test_function/R/test_regex
@@ -60,6 +60,14 @@ select regexp_replace('a b c', " ", "-");
 -- result:
 a-b-c
 -- !result
+select regexp_replace('a b c', '(b)', '<\\1>');
+-- result:
+a <b> c
+-- !result
+select regexp_replace('abcd', '^a.*$', 'xx');
+-- result:
+xx
+-- !result
 select regexp_replace('           XXXX', '       ', '');
 -- result:
     XXXX

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -24,6 +24,8 @@ select regexp_replace(NULL, '', 'xx');
 select regexp_replace('abc中文def', '中文', 'xx');
 select regexp_replace('abc中文def', '[\\p{Han}]+', 'xx');
 select regexp_replace('a b c', " ", "-");
+select regexp_replace('a b c', '(b)', '<\\1>');
+select regexp_replace('abcd', '^a.*$', 'xx');
 select regexp_replace('           XXXX', '       ', '');
 select regexp_replace('xxxx', "x", "-");
 select regexp_replace('xxxx', "xx", "-"); 


### PR DESCRIPTION
## Why I'm doing:

`regexp_replace` with constant arguments is currently always evaluated in BE, which misses an FE constant-folding optimization opportunity.  
This change enables FE constant folding for supported constant `regexp_replace` calls, while preserving correctness by falling back to BE for unsupported or risky cases.

## What I'm doing:

Add FE-side constant folding support for `regexp_replace(VARCHAR, VARCHAR, VARCHAR)` in `ScalarOperatorFunctions`.  
The implementation evaluates safe constant cases in FE, keeps the replacement behavior aligned with current BE semantics for supported patterns, and falls back to BE when the regex or rewrite pattern is not safely supported.  


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
