### PR TITLE
[BugFix] Attempt to get the column name for statistics before trying to split by dot (backport #71301)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -608,6 +608,10 @@ public class StatisticUtils {
     }
 
     public static Type getQueryStatisticsColumnType(Table table, String column) {
+        Column directMatch = table.getColumn(column);
+        if (directMatch != null) {
+            return directMatch.getType();
+        }
         String[] parts = column.split("\\.");
         Preconditions.checkState(parts.length >= 1);
         Column base = table.getColumn(parts[0]);


### PR DESCRIPTION
## Why I'm doing:

`StatisticUtils.getQueryStatisticsColumnType()` fails with `SemanticException: Unknown column` when processing columns whose names contain literal dots (e.g., `` `customer.is_verified_email` ``). The method immediately splits the column name on `.` and treats the first segment as a column name (assuming struct field access), but never checks if the full dot-containing string is itself a column name. This causes a continuous error storm from the statistics cache loader (`ColumnBasicStatsCacheLoader`), as every cache refresh attempt for such columns throws and retries indefinitely. In production we observed **533,000+ errors in 24 hours** from a single table with 8 dot-containing columns.

## What I'm doing:

Added a direct column lookup using the full column name **before** the dot-split logic in `getQueryStatisticsColumnType()`. If the full name (dots included) matches an existing column, return its type immediately. Otherwise, fall through to the existing struct field access resolution — no behavioral change for struct columns. This is consistent with the sibling method `quoting(Table, String)` in the same file which already performs this check.

Fixes https://github.com/StarRocks/starrocks/issues/70810

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [x] 3.4

