### PR TITLE
[Enhancement] Support write iceberg row lineage fields into data files during compaction (backport #70128)

### DIFF
--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -357,7 +357,7 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_reserved_iceberg_column_reader(co
     return _create_column_reader(column);
 }
 
-StatusOr<int64_t> GroupReader::_get_extended_bigint_value(SlotId slot_id) const {
+StatusOr<Datum> GroupReader::_get_extended_bigint_value(SlotId slot_id) const {
     if (_param.scan_range == nullptr || !_param.scan_range->__isset.extended_columns) {
         return Status::NotFound(strings::Substitute("Cannot find extended column for slot $0", slot_id));
     }
@@ -374,12 +374,15 @@ StatusOr<int64_t> GroupReader::_get_extended_bigint_value(SlotId slot_id) const 
     }
 
     const auto& node = expr.nodes[0];
+    if (node.node_type == TExprNodeType::NULL_LITERAL) {
+        return kNullDatum;
+    }
     if (node.node_type != TExprNodeType::INT_LITERAL || !node.__isset.int_literal) {
         return Status::InvalidArgument(
                 strings::Substitute("Unsupported extended column expression for slot $0", slot_id));
     }
 
-    return node.int_literal.value;
+    return Datum(node.int_literal.value);
 }
 
 Status GroupReader::_create_column_readers() {
@@ -422,31 +425,46 @@ Status GroupReader::_create_column_readers() {
     }
 
     if (_param.reserved_field_slots != nullptr && !_param.reserved_field_slots->empty()) {
+        bool use_legacy_lookup_row_id =
+                std::any_of(_param.reserved_field_slots->begin(), _param.reserved_field_slots->end(),
+                            [](const SlotDescriptor* slot) {
+                                return slot->col_name() == "_row_source_id" || slot->col_name() == "_scan_range_id";
+                            });
         for (const auto* slot : *_param.reserved_field_slots) {
             if (slot->col_name() == HdfsScanner::ICEBERG_ROW_ID) {
                 // Iceberg v3 row lineage: try physical column first (post-compaction files),
                 // fall back to computed row_id (firstRowId + position) for non-compacted files.
-                // FE guarantees firstRowId is present when _row_id is requested.
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(slot, HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID));
-                if (reader != nullptr) {
-                    _column_readers.emplace(slot->id(), std::move(reader));
-                } else {
-                    _column_readers.emplace(slot->id(), std::make_unique<IcebergRowIdReader>(_row_group_first_row_id));
-                }
+                std::optional<int64_t> first_row_id =
+                        _param.scan_range != nullptr && _param.scan_range->__isset.first_row_id
+                                ? std::optional<int64_t>(_row_group_first_row_id)
+                                : use_legacy_lookup_row_id ? std::optional<int64_t>(_row_group_first_row_id)
+                                                           : std::nullopt;
+                ColumnReaderPtr row_id_reader =
+                        reader != nullptr ? std::make_unique<IcebergRowIdReader>(std::move(reader), first_row_id)
+                                          : std::make_unique<IcebergRowIdReader>(first_row_id);
+                _column_readers.emplace(slot->id(), std::move(row_id_reader));
             } else if (slot->col_name() == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
                 // Iceberg v3 row lineage: try physical column first (post-compaction files),
                 // fall back to file-level dataSequenceNumber passed via extended_columns from FE.
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(
                                          slot, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID));
-                if (reader != nullptr) {
-                    _column_readers.emplace(slot->id(), std::move(reader));
-                } else {
-                    ASSIGN_OR_RETURN(auto sequence_number, _get_extended_bigint_value(slot->id()));
-                    _column_readers.emplace(slot->id(),
-                                            std::make_unique<FixedValueColumnReader>(Datum(sequence_number)));
+                Datum sequence_number = kNullDatum;
+                bool can_use_fallback = false;
+                auto sequence_number_or = _get_extended_bigint_value(slot->id());
+                if (sequence_number_or.ok()) {
+                    sequence_number = sequence_number_or.value();
+                    can_use_fallback = true;
+                } else if (!sequence_number_or.status().is_not_found()) {
+                    return sequence_number_or.status();
                 }
+                ColumnReaderPtr seq_reader =
+                        reader != nullptr ? std::make_unique<IcebergLastUpdatedSequenceNumberReader>(
+                                                    std::move(reader), can_use_fallback, sequence_number)
+                                          : std::make_unique<IcebergLastUpdatedSequenceNumberReader>(sequence_number);
+                _column_readers.emplace(slot->id(), std::move(seq_reader));
             } else if (slot->col_name() == "_row_source_id") {
                 if (auto opt = get_backend_id(); opt.has_value()) {
                     _column_readers.emplace(slot->id(), std::make_unique<RowSourceReader>(opt.value()));

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -159,7 +159,7 @@ private:
 
     Status _create_column_readers();
     StatusOr<ColumnReaderPtr> _create_reserved_iceberg_column_reader(const SlotDescriptor* slot, int32_t field_id);
-    StatusOr<int64_t> _get_extended_bigint_value(SlotId slot_id) const;
+    StatusOr<Datum> _get_extended_bigint_value(SlotId slot_id) const;
     StatusOr<ColumnReaderPtr> _create_column_reader(const GroupReaderParam::Column& column);
     Status _prepare_column_readers() const;
     ChunkPtr _create_read_chunk(const std::vector<int>& column_indices, bool ignore_reserved_field = false);

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -16,20 +16,88 @@
 
 #include <limits>
 
+#include "column/column_helper.h"
 #include "column/datum.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
+#include "formats/parquet/scalar_column_reader.h"
 #include "storage/range.h"
+#include "runtime/types.h"
 
 namespace starrocks::parquet {
 
+IcebergRowLineageReader::IcebergRowLineageReader(ColumnReaderPtr delegate)
+        : ColumnReader(delegate == nullptr ? nullptr : delegate->get_column_parquet_field()),
+          _delegate(std::move(delegate)) {}
+
+Status IcebergRowLineageReader::prepare() {
+    return _delegate == nullptr ? Status::OK() : _delegate->prepare();
+}
+
+void IcebergRowLineageReader::get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) {
+    if (_delegate != nullptr) {
+        _delegate->get_levels(def_levels, rep_levels, num_levels);
+    }
+}
+
+void IcebergRowLineageReader::set_need_parse_levels(bool need_parse_levels) {
+    if (_delegate != nullptr) {
+        _delegate->set_need_parse_levels(need_parse_levels);
+    }
+}
+
+void IcebergRowLineageReader::collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
+                                                      int64_t* end_offset, ColumnIOTypeFlags types, bool active) {
+    if (_delegate != nullptr) {
+        _delegate->collect_column_io_range(ranges, end_offset, types, active);
+    }
+}
+
+void IcebergRowLineageReader::select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) {
+    if (_delegate != nullptr) {
+        _delegate->select_offset_index(range, rg_first_row);
+    }
+}
+
+StatusOr<ColumnPtr> IcebergRowLineageReader::read_physical_bigint_range(const Range<uint64_t>& range,
+                                                                        const Filter* filter) const {
+    DCHECK(_delegate != nullptr);
+    ColumnPtr physical = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    RETURN_IF_ERROR(_delegate->read_range(range, filter, physical));
+    return physical;
+}
+
+IcebergRowIdReader::IcebergRowIdReader(std::optional<int64_t> first_row_id)
+        : IcebergRowLineageReader(nullptr), _first_row_id(first_row_id) {}
+
+IcebergRowIdReader::IcebergRowIdReader(ColumnReaderPtr delegate, std::optional<int64_t> first_row_id)
+        : IcebergRowLineageReader(std::move(delegate)), _first_row_id(first_row_id) {}
+
 Status IcebergRowIdReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
-    // Ignore filter and output all rows in range, consistent with other reserved column readers
-    // (FixedValueColumnReader, RowSourceReader, ParquetPosReader). The caller (GroupReader)
-    // applies chunk->filter_range() uniformly across all columns after reading.
     Column* dst_col = dst->as_mutable_raw_ptr();
+    if (has_physical_reader()) {
+        ASSIGN_OR_RETURN(ColumnPtr physical, read_physical_bigint_range(range, filter));
+        for (size_t i = 0; i < physical->size(); ++i) {
+            Datum datum = physical->get(i);
+            if (!datum.is_null()) {
+                dst_col->append_datum(datum);
+            } else if (_first_row_id.has_value()) {
+                dst_col->append_datum(Datum(_first_row_id.value() + range.begin() + i));
+            } else {
+                dst_col->append_datum(kNullDatum);
+            }
+        }
+        return Status::OK();
+    }
+
+    // Ignore filter and output all rows in range, consistent with other reserved column readers.
+    if (!_first_row_id.has_value()) {
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            dst_col->append_datum(kNullDatum);
+        }
+        return Status::OK();
+    }
     for (uint64_t i = range.begin(); i < range.end(); ++i) {
-        int64_t row_id = _first_row_id + i;
-        dst_col->append_datum(Datum(row_id));
+        dst_col->append_datum(Datum(_first_row_id.value() + i));
     }
     return Status::OK();
 }
@@ -43,8 +111,17 @@ StatusOr<bool> IcebergRowIdReader::row_group_zone_map_filter(const std::vector<c
                                                              CompoundNodeType pred_relation,
                                                              const uint64_t rg_first_row,
                                                              const uint64_t rg_num_rows) const {
-    ZoneMapDetail zone_map{Datum(_first_row_id + rg_first_row), Datum(_first_row_id + rg_first_row + rg_num_rows - 1),
-                           false};
+    if (has_physical_reader()) {
+        if (!_fallback_can_change_values()) {
+            return _delegate->row_group_zone_map_filter(predicates, pred_relation, rg_first_row, rg_num_rows);
+        }
+        return false;
+    }
+    if (!_first_row_id.has_value()) {
+        return false;
+    }
+    ZoneMapDetail zone_map{Datum(_first_row_id.value() + rg_first_row),
+                           Datum(_first_row_id.value() + rg_first_row + rg_num_rows - 1), false};
     bool ret = !PredicateFilterEvaluatorUtils::zonemap_satisfy(predicates, zone_map, pred_relation);
     return ret;
 }
@@ -53,7 +130,20 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
                                                               SparseRange<uint64_t>* row_ranges,
                                                               CompoundNodeType pred_relation,
                                                               const uint64_t rg_first_row, const uint64_t rg_num_rows) {
-    SparseRange<int64_t> row_id_range(_first_row_id + rg_first_row, _first_row_id + rg_first_row + rg_num_rows);
+    if (has_physical_reader()) {
+        if (!_fallback_can_change_values()) {
+            return _delegate->page_index_zone_map_filter(predicates, row_ranges, pred_relation, rg_first_row,
+                                                         rg_num_rows);
+        }
+        // Physical page stats only describe stored values, but this reader may replace NULLs with
+        // inherited row-lineage values. Pruning on physical stats would be unsound here.
+        return false;
+    }
+    if (!_first_row_id.has_value()) {
+        return false;
+    }
+    SparseRange<int64_t> row_id_range(_first_row_id.value() + rg_first_row,
+                                      _first_row_id.value() + rg_first_row + rg_num_rows);
 
     if (pred_relation == CompoundNodeType::AND) {
         // For AND relation, apply all predicates sequentially with intersection
@@ -109,7 +199,7 @@ StatusOr<bool> IcebergRowIdReader::page_index_zone_map_filter(const std::vector<
     // Convert row_id range to row ranges
     for (size_t i = 0; i < row_id_range.size(); i++) {
         Range<int64_t> range = row_id_range[i];
-        row_ranges->add(Range<uint64_t>(range.begin() - _first_row_id, range.end() - _first_row_id));
+        row_ranges->add(Range<uint64_t>(range.begin() - _first_row_id.value(), range.end() - _first_row_id.value()));
     }
 
     return true;
@@ -232,6 +322,69 @@ StatusOr<bool> IcebergRowIdReader::_apply_single_predicate(const ColumnPredicate
         return false;
     }
     }
+}
+
+IcebergLastUpdatedSequenceNumberReader::IcebergLastUpdatedSequenceNumberReader(Datum fallback_value)
+        : IcebergRowLineageReader(nullptr),
+          _can_use_fallback(!fallback_value.is_null()),
+          _fallback_value(std::move(fallback_value)) {}
+
+IcebergLastUpdatedSequenceNumberReader::IcebergLastUpdatedSequenceNumberReader(ColumnReaderPtr delegate,
+                                                                               bool can_use_fallback,
+                                                                               Datum fallback_value)
+        : IcebergRowLineageReader(std::move(delegate)),
+          _can_use_fallback(can_use_fallback),
+          _fallback_value(std::move(fallback_value)) {}
+
+Status IcebergLastUpdatedSequenceNumberReader::read_range(const Range<uint64_t>& range, const Filter* filter,
+                                                          ColumnPtr& dst) {
+    if (!has_physical_reader()) {
+        FixedValueColumnReader fallback_reader(_can_use_fallback ? _fallback_value : kNullDatum);
+        return fallback_reader.read_range(range, filter, dst);
+    }
+
+    ASSIGN_OR_RETURN(ColumnPtr physical, read_physical_bigint_range(range, filter));
+    Column* dst_col = dst->as_mutable_raw_ptr();
+    for (size_t i = 0; i < physical->size(); ++i) {
+        Datum datum = physical->get(i);
+        if (!datum.is_null()) {
+            dst_col->append_datum(datum);
+        } else if (_can_use_fallback && !_fallback_value.is_null()) {
+            dst_col->append_datum(_fallback_value);
+        } else {
+            dst_col->append_datum(kNullDatum);
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<bool> IcebergLastUpdatedSequenceNumberReader::row_group_zone_map_filter(
+        const std::vector<const ColumnPredicate*>& predicates, CompoundNodeType pred_relation,
+        const uint64_t rg_first_row, const uint64_t rg_num_rows) const {
+    if (has_physical_reader()) {
+        if (!_fallback_can_change_values()) {
+            return _delegate->row_group_zone_map_filter(predicates, pred_relation, rg_first_row, rg_num_rows);
+        }
+        return false;
+    }
+    FixedValueColumnReader fallback_reader(_can_use_fallback ? _fallback_value : kNullDatum);
+    return fallback_reader.row_group_zone_map_filter(predicates, pred_relation, rg_first_row, rg_num_rows);
+}
+
+StatusOr<bool> IcebergLastUpdatedSequenceNumberReader::page_index_zone_map_filter(
+        const std::vector<const ColumnPredicate*>& predicates, SparseRange<uint64_t>* row_ranges,
+        CompoundNodeType pred_relation, const uint64_t rg_first_row, const uint64_t rg_num_rows) {
+    if (has_physical_reader()) {
+        if (!_fallback_can_change_values()) {
+            return _delegate->page_index_zone_map_filter(predicates, row_ranges, pred_relation, rg_first_row,
+                                                         rg_num_rows);
+        }
+        // Physical page stats only describe stored values, but this reader may replace NULLs with
+        // file-level fallback values. Pruning on physical stats would be unsound here.
+        return false;
+    }
+    FixedValueColumnReader fallback_reader(_can_use_fallback ? _fallback_value : kNullDatum);
+    return fallback_reader.page_index_zone_map_filter(predicates, row_ranges, pred_relation, rg_first_row, rg_num_rows);
 }
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/iceberg_row_id_reader.cpp
+++ b/be/src/formats/parquet/iceberg_row_id_reader.cpp
@@ -20,8 +20,8 @@
 #include "column/datum.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
 #include "formats/parquet/scalar_column_reader.h"
-#include "storage/range.h"
 #include "runtime/types.h"
+#include "storage/range.h"
 
 namespace starrocks::parquet {
 

--- a/be/src/formats/parquet/iceberg_row_id_reader.h
+++ b/be/src/formats/parquet/iceberg_row_id_reader.h
@@ -14,32 +14,46 @@
 
 #pragma once
 
+#include <optional>
+
 #include "formats/parquet/column_reader.h"
 
 namespace starrocks::parquet {
 
-class IcebergRowIdReader final : public ColumnReader {
+class IcebergRowLineageReader : public ColumnReader {
 public:
-    explicit IcebergRowIdReader(int64_t first_row_id) : ColumnReader(nullptr), _first_row_id(first_row_id) {
-        _cur_row_id = _first_row_id;
-    }
+    explicit IcebergRowLineageReader(ColumnReaderPtr delegate);
+
+    Status prepare() override;
+
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override;
+
+    void set_need_parse_levels(bool need_parse_levels) override;
+
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override;
+
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override;
+
+protected:
+    bool has_physical_reader() const { return _delegate != nullptr; }
+
+    StatusOr<ColumnPtr> read_physical_bigint_range(const Range<uint64_t>& range, const Filter* filter) const;
+
+    ColumnReaderPtr _delegate;
+};
+
+class IcebergRowIdReader final : public IcebergRowLineageReader {
+public:
+    explicit IcebergRowIdReader(std::optional<int64_t> first_row_id);
+
+    IcebergRowIdReader(ColumnReaderPtr delegate, std::optional<int64_t> first_row_id);
 
     ~IcebergRowIdReader() override = default;
 
-    Status prepare() override { return Status::OK(); }
-
     Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override;
-    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {}
-    void set_need_parse_levels(bool need_parse_levels) override {}
 
     Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override;
-
-    // No IO ranges to collect for row id reader.
-    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
-                                 ColumnIOTypeFlags types, bool active) override {}
-
-    // No offset index selection needed for row id reader.
-    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
 
     StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                              CompoundNodeType pred_relation, const uint64_t rg_first_row,
@@ -53,7 +67,33 @@ private:
     // Helper method to apply a single predicate and return the resulting range
     StatusOr<bool> _apply_single_predicate(const ColumnPredicate* pred, SparseRange<int64_t>& result_range);
 
-    int64_t _first_row_id = 0;
-    int64_t _cur_row_id = 0;
+    bool _fallback_can_change_values() const { return _first_row_id.has_value(); }
+
+    std::optional<int64_t> _first_row_id;
+};
+
+class IcebergLastUpdatedSequenceNumberReader final : public IcebergRowLineageReader {
+public:
+    explicit IcebergLastUpdatedSequenceNumberReader(Datum fallback_value);
+
+    IcebergLastUpdatedSequenceNumberReader(ColumnReaderPtr delegate, bool can_use_fallback, Datum fallback_value);
+
+    ~IcebergLastUpdatedSequenceNumberReader() override = default;
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override;
+
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override;
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override;
+
+private:
+    bool _fallback_can_change_values() const { return _can_use_fallback && !_fallback_value.is_null(); }
+
+    bool _can_use_fallback = false;
+    Datum _fallback_value;
 };
 } // namespace starrocks::parquet

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -14,11 +14,59 @@
 
 #include "iceberg_table_sink.h"
 
+#include <unordered_map>
+
+#include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/expr.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
+
+namespace {
+
+std::unordered_map<std::string, formats::FileColumnId> build_top_level_field_id_map(
+        const std::vector<TIcebergSchemaField>& fields) {
+    std::unordered_map<std::string, formats::FileColumnId> field_ids_by_name;
+    auto field_ids = connector::IcebergUtils::generate_parquet_field_ids(fields);
+    field_ids_by_name.reserve(fields.size());
+    for (size_t i = 0; i < fields.size(); ++i) {
+        field_ids_by_name.emplace(fields[i].name, field_ids[i]);
+    }
+    return field_ids_by_name;
+}
+
+Status append_iceberg_sink_column(const SlotDescriptor* slot,
+                                  const std::unordered_map<std::string, formats::FileColumnId>& field_ids_by_name,
+                                  std::vector<std::string>* column_names,
+                                  std::vector<formats::FileColumnId>* parquet_field_ids) {
+    if (slot == nullptr) {
+        return Status::InternalError("Iceberg sink columns do not match output expressions");
+    }
+
+    const std::string& col_name = slot->col_name();
+    column_names->push_back(col_name);
+
+    auto it = field_ids_by_name.find(col_name);
+    if (it != field_ids_by_name.end()) {
+        parquet_field_ids->push_back(it->second);
+        return Status::OK();
+    }
+
+    formats::FileColumnId field_id;
+    if (col_name == HdfsScanner::ICEBERG_ROW_ID) {
+        field_id.field_id = HdfsScanner::ICEBERG_ROW_ID_COLUMN_ID;
+    } else if (col_name == HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER) {
+        field_id.field_id = HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_ID;
+    } else {
+        return Status::InternalError("Iceberg sink field ids do not match output expressions");
+    }
+
+    parquet_field_ids->push_back(field_id);
+    return Status::OK();
+}
+
+} // namespace
 
 IcebergTableSink::IcebergTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs)
         : _pool(pool), _t_output_expr(t_exprs) {}
@@ -199,7 +247,6 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
                                   ? t_iceberg_sink.data_location
                                   : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
     data_sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
-    data_sink_ctx->column_names = iceberg_table_desc->full_column_names();
     data_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
     data_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
     data_sink_ctx->format = t_iceberg_sink.file_format; // iceberg sink only supports parquet
@@ -207,9 +254,32 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
     if (t_iceberg_sink.__isset.target_max_file_size) {
         data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
     }
-    data_sink_ctx->parquet_field_ids =
-            connector::IcebergUtils::generate_parquet_field_ids(iceberg_table_desc->get_iceberg_schema()->fields);
     data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(this->get_output_expr(), runtime_state);
+
+    size_t num_evaluators = data_sink_ctx->column_evaluators.size();
+    TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
+    const auto* slots = tuple_desc != nullptr ? &tuple_desc->slots() : nullptr;
+    if (slots == nullptr || slots->size() < num_evaluators) {
+        return Status::InternalError("Iceberg sink columns do not match output expressions");
+    }
+
+    // Build sink schema from the actual output tuple. TIcebergTable.columns may still contain
+    // hidden metadata columns such as _file/_pos that are not written by compaction.
+    auto field_ids_by_name = build_top_level_field_id_map(iceberg_table_desc->get_iceberg_schema()->fields);
+    data_sink_ctx->column_names.clear();
+    data_sink_ctx->parquet_field_ids.clear();
+    data_sink_ctx->column_names.reserve(num_evaluators);
+    data_sink_ctx->parquet_field_ids.reserve(num_evaluators);
+    for (size_t i = 0; i < num_evaluators; ++i) {
+        RETURN_IF_ERROR(append_iceberg_sink_column((*slots)[i], field_ids_by_name, &data_sink_ctx->column_names,
+                                                   &data_sink_ctx->parquet_field_ids));
+    }
+
+    if (data_sink_ctx->column_names.size() != num_evaluators ||
+        data_sink_ctx->parquet_field_ids.size() != num_evaluators) {
+        return Status::InternalError("Iceberg sink schema metadata does not match output expressions");
+    }
+
     data_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
     data_sink_ctx->fragment_context = fragment_ctx;
     data_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -334,4 +334,256 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_delete_sink) {
     EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
 }
 
+// Test that row lineage columns are appended to column_names and parquet_field_ids
+// when output expressions have more columns than the table descriptor (compaction mode)
+TEST_F(IcebergTableSinkTest, row_lineage_columns_extended_during_compaction) {
+    // Create tuple descriptor with 3 slots: c1 (user col) + _row_id + _last_updated_sequence_number
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    auto slot2 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_row_id")
+                         .column_pos(1)
+                         .nullable(true)
+                         .build();
+    auto slot3 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_last_updated_sequence_number")
+                         .column_pos(2)
+                         .nullable(true)
+                         .build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.add_slot(slot2);
+    tuple_desc_builder.add_slot(slot3);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    // Table descriptor only has 1 column (c1) - simulates that toThrift() only sends user columns
+    TIcebergTable t_iceberg_table;
+    TColumn t_column;
+    t_column.__set_column_name("c1");
+    t_iceberg_table.__set_columns({t_column});
+
+    // Iceberg schema also only has 1 field (c1)
+    TIcebergSchemaField schema_field;
+    schema_field.__set_field_id(1);
+    schema_field.__set_name("c1");
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields({schema_field});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    TDataSink data_sink;
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("s3://bucket/table-location");
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    // 3 output expressions (c1 + _row_id + _last_updated_sequence_number)
+    std::vector<TExpr> exprs;
+    TExpr expr1, expr2, expr3;
+    exprs.push_back(expr1);
+    exprs.push_back(expr2);
+    exprs.push_back(expr3);
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+
+    // Verify column_names was extended with row lineage columns
+    ASSERT_EQ(sink_ctx->column_names.size(), 3);
+    EXPECT_EQ(sink_ctx->column_names[0], "c1");
+    EXPECT_EQ(sink_ctx->column_names[1], "_row_id");
+    EXPECT_EQ(sink_ctx->column_names[2], "_last_updated_sequence_number");
+
+    // Verify parquet_field_ids was extended with correct Iceberg reserved field IDs
+    ASSERT_EQ(sink_ctx->parquet_field_ids.size(), 3);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[0].field_id, 1);          // c1's field_id
+    EXPECT_EQ(sink_ctx->parquet_field_ids[1].field_id, 2147483540); // _row_id reserved field ID
+    EXPECT_EQ(sink_ctx->parquet_field_ids[2].field_id, 2147483539); // _last_updated_sequence_number reserved field ID
+}
+
+// Test that parquet_field_ids is extended even when column_names already includes
+// row lineage columns but iceberg_schema still only contains user columns.
+TEST_F(IcebergTableSinkTest, row_lineage_field_ids_extended_when_column_names_already_present) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    auto slot2 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_row_id")
+                         .column_pos(1)
+                         .nullable(true)
+                         .build();
+    auto slot3 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_last_updated_sequence_number")
+                         .column_pos(2)
+                         .nullable(true)
+                         .build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.add_slot(slot2);
+    tuple_desc_builder.add_slot(slot3);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    // Simulate FE already including row lineage columns in TIcebergTable.columns,
+    // while Iceberg schema still only describes user columns.
+    TIcebergTable t_iceberg_table;
+    TColumn col1;
+    col1.__set_column_name("c1");
+    TColumn col2;
+    col2.__set_column_name("_row_id");
+    TColumn col3;
+    col3.__set_column_name("_last_updated_sequence_number");
+    t_iceberg_table.__set_columns({col1, col2, col3});
+
+    TIcebergSchemaField schema_field;
+    schema_field.__set_field_id(1);
+    schema_field.__set_name("c1");
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields({schema_field});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    TDataSink data_sink;
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("s3://bucket/table-location");
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs;
+    TExpr expr1, expr2, expr3;
+    exprs.push_back(expr1);
+    exprs.push_back(expr2);
+    exprs.push_back(expr3);
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+
+    ASSERT_EQ(sink_ctx->column_names.size(), 3);
+    ASSERT_EQ(sink_ctx->parquet_field_ids.size(), 3);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[0].field_id, 1);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[1].field_id, 2147483540);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[2].field_id, 2147483539);
+}
+
+// Test that sink schema is rebuilt from tuple/output columns when TIcebergTable.columns
+// still contains hidden metadata columns that are not written by compaction.
+TEST_F(IcebergTableSinkTest, row_lineage_field_ids_ignore_non_written_hidden_columns) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    auto slot2 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_row_id")
+                         .column_pos(1)
+                         .nullable(true)
+                         .build();
+    auto slot3 = slot_desc_builder.type(LogicalType::TYPE_BIGINT)
+                         .column_name("_last_updated_sequence_number")
+                         .column_pos(2)
+                         .nullable(true)
+                         .build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.add_slot(slot2);
+    tuple_desc_builder.add_slot(slot3);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    // Simulate current FE thrift table schema ordering:
+    // user columns first, then hidden metadata columns such as _file/_pos, then row lineage columns.
+    TIcebergTable t_iceberg_table;
+    TColumn col1;
+    col1.__set_column_name("c1");
+    TColumn col2;
+    col2.__set_column_name("_file");
+    TColumn col3;
+    col3.__set_column_name("_pos");
+    TColumn col4;
+    col4.__set_column_name("_row_id");
+    TColumn col5;
+    col5.__set_column_name("_last_updated_sequence_number");
+    t_iceberg_table.__set_columns({col1, col2, col3, col4, col5});
+
+    TIcebergSchemaField schema_field;
+    schema_field.__set_field_id(1);
+    schema_field.__set_name("c1");
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields({schema_field});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    TDataSink data_sink;
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("s3://bucket/table-location");
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs;
+    TExpr expr1, expr2, expr3;
+    exprs.push_back(expr1);
+    exprs.push_back(expr2);
+    exprs.push_back(expr3);
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+
+    ASSERT_EQ(sink_ctx->column_names.size(), 3);
+    EXPECT_EQ(sink_ctx->column_names[0], "c1");
+    EXPECT_EQ(sink_ctx->column_names[1], "_row_id");
+    EXPECT_EQ(sink_ctx->column_names[2], "_last_updated_sequence_number");
+
+    ASSERT_EQ(sink_ctx->parquet_field_ids.size(), 3);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[0].field_id, 1);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[1].field_id, 2147483540);
+    EXPECT_EQ(sink_ctx->parquet_field_ids[2].field_id, 2147483539);
+}
+
 } // namespace starrocks

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -1298,7 +1298,7 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueSuccess) {
 
     auto result = group_reader->_get_extended_bigint_value(0);
     ASSERT_OK(result);
-    ASSERT_EQ(result.value(), 42);
+    ASSERT_EQ(result.value().get_int64(), 42);
 }
 
 TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderNotFound) {
@@ -1339,10 +1339,74 @@ TEST_F(GroupReaderTest, TestIcebergRowIdColumnReaderCreation) {
     param->chunk_size = config::vector_chunk_size;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
     ASSERT_OK(group_reader->init());
     ASSERT_NE(group_reader->_column_readers[100], nullptr);
-    delete group_reader;
+}
+
+TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdReturnsNull) {
+    auto* param = _create_group_reader_param();
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
+                                                     TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(row_id_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_OK(group_reader->_column_readers[100]->read_range(Range<uint64_t>(0, 4), nullptr, column));
+    ASSERT_EQ(4, column->size());
+    for (int i = 0; i < 4; ++i) {
+        ASSERT_TRUE(column->get(i).is_null());
+    }
+}
+
+TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdUsesRowPositionForLookupPath) {
+    auto* param = _create_group_reader_param();
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* row_id_slot = _pool.add(new SlotDescriptor(100, HdfsScanner::ICEBERG_ROW_ID,
+                                                     TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* scan_range_id_slot = _pool.add(
+            new SlotDescriptor(101, "_scan_range_id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)));
+    reserved_slots->push_back(row_id_slot);
+    reserved_slots->push_back(scan_range_id_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    auto* scan_range = new THdfsScanRange();
+    param->scan_range = _pool.add(scan_range);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 7, 7);
+    ASSERT_OK(group_reader->init());
+
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_OK(group_reader->_column_readers[100]->read_range(Range<uint64_t>(0, 4), nullptr, column));
+    ASSERT_EQ(4, column->size());
+    ASSERT_EQ(7, column->get(0).get_int64());
+    ASSERT_EQ(8, column->get(1).get_int64());
+    ASSERT_EQ(9, column->get(2).get_int64());
+    ASSERT_EQ(10, column->get(3).get_int64());
 }
 
 TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation) {
@@ -1377,10 +1441,49 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation
     param->chunk_size = config::vector_chunk_size;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
     ASSERT_OK(group_reader->init());
     ASSERT_NE(group_reader->_column_readers[101], nullptr);
-    delete group_reader;
+}
+
+TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberNullExtendedLiteralReturnsNull) {
+    auto* param = _create_group_reader_param();
+    auto* reserved_slots = new std::vector<SlotDescriptor*>();
+    auto* seq_slot = _pool.add(new SlotDescriptor(101, HdfsScanner::ICEBERG_LAST_UPDATED_SEQUENCE_NUMBER,
+                                                  TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    reserved_slots->push_back(seq_slot);
+    param->reserved_field_slots = _pool.add(reserved_slots);
+    param->timezone = "UTC";
+
+    std::map<int32_t, TExpr> extended_columns;
+    TExpr expr;
+    TExprNode node;
+    node.node_type = TExprNodeType::NULL_LITERAL;
+    expr.nodes.push_back(node);
+    extended_columns[101] = expr;
+
+    auto* scan_range = new THdfsScanRange();
+    scan_range->__set_extended_columns(extended_columns);
+    param->scan_range = _pool.add(scan_range);
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+
+    auto* file = _create_file();
+    param->file = file;
+    param->file_metadata = file_meta;
+    param->chunk_size = config::vector_chunk_size;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
+    ASSERT_OK(group_reader->init());
+
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_OK(group_reader->_column_readers[101]->read_range(Range<uint64_t>(0, 4), nullptr, column));
+    ASSERT_EQ(4, column->size());
+    for (int i = 0; i < 4; ++i) {
+        ASSERT_TRUE(column->get(i).is_null());
+    }
 }
 
 // Helper to build a tparquet::FileMetaData that includes the standard 6 read_cols
@@ -1504,11 +1607,10 @@ TEST_F(GroupReaderTest, TestIcebergRowIdPhysicalColumnReaderCreation) {
     param->chunk_size = config::vector_chunk_size;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
     ASSERT_OK(group_reader->init());
     // The _row_id column reader should be created from the physical column (not IcebergRowIdReader)
     ASSERT_NE(group_reader->_column_readers[100], nullptr);
-    delete group_reader;
 }
 
 TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation) {
@@ -1534,11 +1636,10 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation
     param->chunk_size = config::vector_chunk_size;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
     ASSERT_OK(group_reader->init());
     // The _last_updated_sequence_number reader should be created from the physical column
     ASSERT_NE(group_reader->_column_readers[101], nullptr);
-    delete group_reader;
 }
 
 TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
@@ -1567,12 +1668,11 @@ TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
     param->chunk_size = config::vector_chunk_size;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    auto* group_reader = new GroupReader(*param, 0, skip_rows_ctx, 0);
+    auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 0);
     ASSERT_OK(group_reader->init());
     // Both physical column readers should be created
     ASSERT_NE(group_reader->_column_readers[100], nullptr);
     ASSERT_NE(group_reader->_column_readers[101], nullptr);
-    delete group_reader;
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/iceberg_row_id_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_row_id_reader_test.cpp
@@ -34,6 +34,56 @@ protected:
     ObjectPool _pool;
 };
 
+class MockNullPhysicalReader : public ColumnReader {
+public:
+    MockNullPhysicalReader() : ColumnReader(nullptr) {}
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override {
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            dst->as_mutable_raw_ptr()->append_datum(kNullDatum);
+        }
+        return Status::OK();
+    }
+
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {}
+    void set_need_parse_levels(bool need_parse_levels) override {}
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {}
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
+};
+
+class MockPredicatePhysicalReader : public ColumnReader {
+public:
+    MockPredicatePhysicalReader() : ColumnReader(nullptr) {}
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override {
+        return Status::OK();
+    }
+
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override {
+        return true;
+    }
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override {
+        row_ranges->add(Range<uint64_t>(3, 7));
+        return true;
+    }
+
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {}
+    void set_need_parse_levels(bool need_parse_levels) override {}
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {}
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
+};
+
 // ==================== Basic read_range tests ====================
 
 TEST_F(IcebergRowIdReaderTest, TestReadRangeWithoutFilter) {
@@ -327,53 +377,146 @@ TEST_F(IcebergRowIdReaderTest, TestPageIndexFilterIsNotNull) {
     ASSERT_FALSE(result.value());
 }
 
-// ==================== FixedValueColumnReader for row lineage fallback ====================
+// ==================== Row lineage fallback readers ====================
 
-TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderForNullRowId) {
-    // When first_row_id is unavailable (late materialization on pre-v3 files),
-    // a FixedValueColumnReader with kNullDatum is used.
-    auto reader = std::make_unique<FixedValueColumnReader>(kNullDatum);
-    ASSERT_TRUE(reader->prepare().ok());
+TEST_F(IcebergRowIdReaderTest, TestRowIdReaderWithoutFirstRowIdReturnsNull) {
+    IcebergRowIdReader reader(std::nullopt);
+    ASSERT_TRUE(reader.prepare().ok());
 
     Range<uint64_t> range(0, 5);
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
 
-    ASSERT_TRUE(reader->read_range(range, nullptr, column).ok());
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
     ASSERT_EQ(column->size(), 5);
     for (int i = 0; i < 5; i++) {
         ASSERT_TRUE(column->get(i).is_null());
     }
 }
 
-TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderForSequenceNumber) {
-    // When the Parquet file has no physical _last_updated_sequence_number column,
-    // a FixedValueColumnReader with the file-level dataSequenceNumber is used.
-    int64_t sequence_number = 42;
-    auto reader = std::make_unique<FixedValueColumnReader>(Datum(sequence_number));
-    ASSERT_TRUE(reader->prepare().ok());
+TEST_F(IcebergRowIdReaderTest, TestRowIdPredicateFiltersDelegateWhenFallbackCannotChangeValues) {
+    IcebergRowIdReader reader(std::make_unique<MockPredicatePhysicalReader>(), std::nullopt);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+    Datum eq_val(static_cast<int64_t>(10));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto row_group = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(row_group.ok());
+    ASSERT_TRUE(row_group.value());
+
+    SparseRange<uint64_t> row_ranges;
+    auto page_index = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(page_index.ok());
+    ASSERT_TRUE(page_index.value());
+    ASSERT_EQ(1, row_ranges.size());
+    ASSERT_EQ(3, row_ranges[0].begin());
+    ASSERT_EQ(7, row_ranges[0].end());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestRowIdPredicateFiltersStayConservativeWhenFallbackCanChangeValues) {
+    IcebergRowIdReader reader(std::make_unique<MockPredicatePhysicalReader>(), 100);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+    Datum eq_val(static_cast<int64_t>(10));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto row_group = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(row_group.ok());
+    ASSERT_FALSE(row_group.value());
+
+    SparseRange<uint64_t> row_ranges;
+    auto page_index = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(page_index.ok());
+    ASSERT_FALSE(page_index.value());
+    ASSERT_TRUE(row_ranges.empty());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestSequenceNumberReaderWithoutPhysicalColumnUsesFallbackValue) {
+    IcebergLastUpdatedSequenceNumberReader reader(Datum(static_cast<int64_t>(42)));
+    ASSERT_TRUE(reader.prepare().ok());
 
     Range<uint64_t> range(0, 5);
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
 
-    ASSERT_TRUE(reader->read_range(range, nullptr, column).ok());
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
     ASSERT_EQ(column->size(), 5);
     for (int i = 0; i < 5; i++) {
         ASSERT_EQ(column->get(i).get_int64(), 42);
     }
 }
 
-TEST_F(IcebergRowIdReaderTest, TestFixedValueColumnReaderWithFilter) {
-    int64_t sequence_number = 99;
-    auto reader = std::make_unique<FixedValueColumnReader>(Datum(sequence_number));
-    ASSERT_TRUE(reader->prepare().ok());
+TEST_F(IcebergRowIdReaderTest, TestSequenceNumberReaderWithoutFallbackReturnsNull) {
+    IcebergLastUpdatedSequenceNumberReader reader(kNullDatum);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 4);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    ASSERT_EQ(column->size(), 4);
+    for (size_t i = 0; i < column->size(); i++) {
+        ASSERT_TRUE(column->get(i).is_null());
+    }
+}
+
+TEST_F(IcebergRowIdReaderTest, TestSequenceNumberPredicateFiltersDelegateWhenFallbackCannotChangeValues) {
+    IcebergLastUpdatedSequenceNumberReader reader(std::make_unique<MockPredicatePhysicalReader>(), false, kNullDatum);
+    ASSERT_TRUE(reader.prepare().ok());
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+    Datum eq_val(static_cast<int64_t>(10));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto row_group = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(row_group.ok());
+    ASSERT_TRUE(row_group.value());
+
+    SparseRange<uint64_t> row_ranges;
+    auto page_index = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(page_index.ok());
+    ASSERT_TRUE(page_index.value());
+    ASSERT_EQ(1, row_ranges.size());
+    ASSERT_EQ(3, row_ranges[0].begin());
+    ASSERT_EQ(7, row_ranges[0].end());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestSequenceNumberPredicateFiltersStayConservativeWhenFallbackCanChangeValues) {
+    IcebergLastUpdatedSequenceNumberReader reader(std::make_unique<MockPredicatePhysicalReader>(), true,
+                                                  Datum(static_cast<int64_t>(99)));
+    ASSERT_TRUE(reader.prepare().ok());
+
+    TypeInfoPtr type_info = get_type_info(LogicalType::TYPE_BIGINT);
+    Datum eq_val(static_cast<int64_t>(10));
+    ColumnPredicate* eq_pred = _pool.add(new_column_eq_predicate_from_datum(type_info, 0, eq_val));
+    std::vector<const ColumnPredicate*> predicates = {eq_pred};
+
+    auto row_group = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(row_group.ok());
+    ASSERT_FALSE(row_group.value());
+
+    SparseRange<uint64_t> row_ranges;
+    auto page_index = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 0, 10);
+    ASSERT_TRUE(page_index.ok());
+    ASSERT_FALSE(page_index.value());
+    ASSERT_TRUE(row_ranges.empty());
+}
+
+TEST_F(IcebergRowIdReaderTest, TestSequenceNumberReaderWithFilter) {
+    IcebergLastUpdatedSequenceNumberReader reader(Datum(static_cast<int64_t>(99)));
+    ASSERT_TRUE(reader.prepare().ok());
 
     Range<uint64_t> range(0, 4);
     Filter filter = {true, false, true, false};
 
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
 
-    ASSERT_TRUE(reader->read_range(range, &filter, column).ok());
-    // FixedValueColumnReader fills all rows in range (filter is applied later by caller)
+    ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
+    // Reserved field readers fill all rows in range; caller applies filter afterwards.
     ASSERT_EQ(column->size(), 4);
     for (size_t i = 0; i < column->size(); i++) {
         ASSERT_EQ(column->get(i).get_int64(), 99);
@@ -433,6 +576,35 @@ TEST_F(IcebergRowIdReaderTest, TestLargeFirstRowId) {
     ASSERT_EQ(column->get(0).get_int64(), large_first_row_id);
     ASSERT_EQ(column->get(1).get_int64(), large_first_row_id + 1);
     ASSERT_EQ(column->get(2).get_int64(), large_first_row_id + 2);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestNullPhysicalRowIdFallsBackToInheritance) {
+    IcebergRowIdReader reader(std::make_unique<MockNullPhysicalReader>(), std::optional<int64_t>(500));
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 3);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+
+    ASSERT_EQ(column->size(), 3);
+    ASSERT_EQ(column->get(0).get_int64(), 500);
+    ASSERT_EQ(column->get(1).get_int64(), 501);
+    ASSERT_EQ(column->get(2).get_int64(), 502);
+}
+
+TEST_F(IcebergRowIdReaderTest, TestNullPhysicalSequenceNumberFallsBackToInheritance) {
+    IcebergLastUpdatedSequenceNumberReader reader(std::make_unique<MockNullPhysicalReader>(), true,
+                                                  Datum(static_cast<int64_t>(42)));
+    ASSERT_TRUE(reader.prepare().ok());
+
+    Range<uint64_t> range(0, 3);
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), true);
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+
+    ASSERT_EQ(column->size(), 3);
+    ASSERT_EQ(column->get(0).get_int64(), 42);
+    ASSERT_EQ(column->get(1).get_int64(), 42);
+    ASSERT_EQ(column->get(2).get_int64(), 42);
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -719,6 +719,33 @@ TEST_F(ParquetFileWriterTest, TestWriteWithFieldID) {
     ASSERT_EQ(result.file_statistics.record_count, 8);
 }
 
+TEST_F(ParquetFileWriterTest, TestWriteWithIcebergRowLineageFieldIDs) {
+    std::vector type_descs{TYPE_INT_DESC, TYPE_VARCHAR_DESC, TYPE_BIGINT_DESC, TYPE_BIGINT_DESC};
+    _writer_options->column_ids = {FileColumnId{1, {}}, FileColumnId{2, {}}, FileColumnId{2147483540, {}},
+                                   FileColumnId{2147483539, {}}};
+    ASSIGN_OR_ASSERT_FAIL(auto writer,
+                          _create_writer(type_descs, {}, {"id", "name", "_row_id", "_last_updated_sequence_number"}));
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto id_col = ColumnTestHelper::build_nullable_column<int32_t>({1, 2}, {0, 0});
+        auto name_col = ColumnTestHelper::build_nullable_column<Slice>({"alice", "bob"}, {0, 0});
+        auto row_id_col = ColumnTestHelper::build_nullable_column<int64_t>({10, 11}, {0, 0});
+        auto seq_col = ColumnTestHelper::build_nullable_column<int64_t>({20, 21}, {0, 0});
+
+        chunk->append_column(std::move(id_col), 0);
+        chunk->append_column(std::move(name_col), 1);
+        chunk->append_column(std::move(row_id_col), 2);
+        chunk->append_column(std::move(seq_col), 3);
+    }
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 2);
+}
+
 TEST_F(ParquetFileWriterTest, TestUnknownCompression) {
     std::vector type_descs{TYPE_BOOLEAN_DESC};
     _compression_type = TCompressionType::UNKNOWN_COMPRESSION;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -43,6 +43,7 @@ import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
+import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.THdfsPartition;
@@ -358,14 +359,14 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         // fill extended column value
         List<SlotDescriptor> slots = desc.getSlots();
         Map<Integer, TExpr> extendedColumns = new HashMap<>();
-        boolean hasRowIdColumn = false;
+        Long firstRowId = task.file() == null ? null : task.file().firstRowId();
+        Long dataSequenceNumber = file.dataSequenceNumber();
         for (SlotDescriptor slot : slots) {
             String name = slot.getColumn().getName();
             // _row_id is handled as a reserved field in BE (not an extended column).
             // It is computed as firstRowId + row_position, or read from the physical Parquet column
             // if present (after compaction).
             if (name.equalsIgnoreCase(ROW_ID)) {
-                hasRowIdColumn = true;
                 continue;
             }
             if (name.equalsIgnoreCase("_row_source_id") || name.equalsIgnoreCase("_scan_range_id")) {
@@ -373,10 +374,12 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             }
             LiteralExpr value;
             if (name.equalsIgnoreCase(DATA_SEQUENCE_NUMBER)) {
-                value = LiteralExprFactory.create(String.valueOf(file.dataSequenceNumber()), IntegerType.BIGINT);
+                value = dataSequenceNumber == null ? new NullLiteral()
+                        : LiteralExprFactory.create(String.valueOf(dataSequenceNumber), IntegerType.BIGINT);
                 setExtendedColumns(slot, extendedColumns, value);
             } else if (name.equalsIgnoreCase(LAST_UPDATED_SEQUENCE_NUMBER)) {
-                value = LiteralExprFactory.create(String.valueOf(file.dataSequenceNumber()), IntegerType.BIGINT);
+                value = dataSequenceNumber == null ? new NullLiteral()
+                        : LiteralExprFactory.create(String.valueOf(dataSequenceNumber), IntegerType.BIGINT);
                 setExtendedColumns(slot, extendedColumns, value, false);
             } else if (name.equalsIgnoreCase(SPEC_ID)) {
                 value = LiteralExprFactory.create(String.valueOf(file.specId()), IntegerType.INT);
@@ -403,19 +406,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             hdfsScanRange.setMin_max_values(tExprMinMaxValueMap);
         }
 
-        if (hasRowIdColumn) {
-            // Always validate firstRowId when _row_id is requested, regardless of whether
-            // late materialization columns are present. The optimizer may reuse a user-requested
-            // _row_id while also adding _row_source_id/_scan_range_id, so we cannot assume
-            // _row_id is purely internal. Without firstRowId, BE would produce NULL _row_id
-            // which violates the lookup path's non-null assumption (lookup_request.cpp).
-            if (task.file() == null || task.file().firstRowId() == null) {
-                throw new StarRocksConnectorException(
-                        "Iceberg v3 row lineage requires first_row_id for _row_id, file: %s", filePath);
-            }
-            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
-        } else if (task.file() != null && task.file().firstRowId() != null) {
-            hdfsScanRange.setFirst_row_id(task.file().firstRowId());
+        if (firstRowId != null) {
+            hdfsScanRange.setFirst_row_id(firstRowId);
         }
 
         return hdfsScanRange;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
@@ -53,6 +53,7 @@ public class IcebergRewriteDataJob {
     private final boolean rewriteAll;
     private final long minFileSizeBytes;
     private final long batchSize;
+    private final boolean writeRowLineage;
     private final ConnectContext context;
     private final AlterTableStmt originAlterStmt;
     private IcebergRewriteStmt rewriteStmt;
@@ -142,6 +143,7 @@ public class IcebergRewriteDataJob {
                                  long minFileSizeBytes,
                                  long batchSize,
                                  long batchParallelism,
+                                 boolean writeRowLineage,
                                  ConnectContext context,
                                  AlterTableStmt stmt) {
         this.insertSql = insertSql;
@@ -149,6 +151,7 @@ public class IcebergRewriteDataJob {
         this.minFileSizeBytes = minFileSizeBytes;
         this.batchSize = batchSize;
         this.batchParallelism = batchParallelism;
+        this.writeRowLineage = writeRowLineage;
         this.context = context;
         this.originAlterStmt = stmt;
     }
@@ -158,8 +161,8 @@ public class IcebergRewriteDataJob {
                 .parse(insertSql, context.getSessionVariable())
                 .get(0);
 
-        this.rewriteStmt = new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll);
-        this.execPlan = StatementPlanner.plan(parsedStmt, context);
+        this.rewriteStmt = new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll, writeRowLineage);
+        this.execPlan = StatementPlanner.plan(rewriteStmt, context);
         this.scanNodes = execPlan.getFragments().stream()
                 .flatMap(fragment -> fragment.collectScanNodes().values().stream())
                 .filter(scan -> scan instanceof IcebergScanNode && "IcebergScanNode".equals(scan.getPlanNodeName()))
@@ -235,8 +238,9 @@ public class IcebergRewriteDataJob {
                 futures.add(executorService.submit(() -> {
                     ConnectContext subCtx = buildSubConnectContext(context);
                     try (var scope = subCtx.bindScope()) {
-                        IcebergRewriteStmt localStmt = new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll);
-                        ExecPlan localPlan = StatementPlanner.plan(parsedStmt, subCtx);
+                        IcebergRewriteStmt localStmt =
+                                new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll, writeRowLineage);
+                        ExecPlan localPlan = StatementPlanner.plan(localStmt, subCtx);
         
                         List<IcebergScanNode> localScanNodes = localPlan.getFragments().stream()
                                 .flatMap(f -> f.collectScanNodes().values().stream())

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRowLineageUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRowLineageUtils.java
@@ -1,0 +1,31 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.sql.ast.IcebergRewriteStmt;
+import com.starrocks.sql.ast.InsertStmt;
+
+public final class IcebergRowLineageUtils {
+
+    private IcebergRowLineageUtils() {
+    }
+
+    public static boolean shouldWriteRowLineageColumns(InsertStmt insertStmt, IcebergTable icebergTable) {
+        return insertStmt instanceof IcebergRewriteStmt rewriteStmt
+                && rewriteStmt.writeRowLineage()
+                && icebergTable.getFormatVersion() >= 3;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -20,6 +20,8 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergRewriteDataJob;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.metric.ConnectorMetricsMgr;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -31,6 +33,7 @@ import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.TypeFactory;
+import org.apache.iceberg.BaseTable;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.slf4j.Logger;
@@ -134,21 +137,17 @@ public class RewriteDataFilesProcedure extends IcebergTableProcedure {
             partitionFilterSql = ExprToSql.toSql(partitionFilter);
         }
         velCtx.put("partitionFilterSql", partitionFilterSql);
-        VelocityEngine defaultVelocityEngine = new VelocityEngine();
-        defaultVelocityEngine.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
-        StringWriter writer = new StringWriter();
-        defaultVelocityEngine.evaluate(velCtx, writer, "InsertSelectTemplate",
-                "INSERT INTO $catalogName.$dbName.$tableName" +
-                        " SELECT * FROM $catalogName.$dbName.$tableName" +
-                        " #if ($partitionFilterSql)" +
-                        " WHERE $partitionFilterSql" +
-                        " #end"
-        );
-        String executeStmt = writer.toString();
-        IcebergRewriteDataJob job = new IcebergRewriteDataJob(executeStmt, rewriteAll,
-                minFileSizeBytes, batchSize, batchParallelism, context.context(), stmt);
+
+        org.apache.iceberg.Table nativeTable = context.table();
+        SessionVariable sessionVariable = context.context().getSessionVariable();
+        boolean isV3Table = nativeTable instanceof BaseTable
+                && ((BaseTable) nativeTable).operations().current().formatVersion() >= 3;
+        boolean writeRowLineage = isV3Table && (sessionVariable == null
+                || sessionVariable.getEnableIcebergCompactionWithRowLineage());
         long durationMs = 0L;
         try {
+            IcebergRewriteDataJob job = newRewriteJob(velCtx, writeRowLineage, rewriteAll,
+                    minFileSizeBytes, batchSize, batchParallelism, context.context(), stmt);
             job.prepare();
             metrics = job.execute();
             success = true;
@@ -163,6 +162,36 @@ public class RewriteDataFilesProcedure extends IcebergTableProcedure {
             recordManualCompactionMetrics(success, durationMs, metrics, failureReason);
         }
         return getRewriteResult(context, metrics, durationMs);
+    }
+
+    private IcebergRewriteDataJob newRewriteJob(VelocityContext velCtx, boolean writeRowLineage, boolean rewriteAll,
+                                                long minFileSizeBytes, long batchSize, long batchParallelism,
+                                                ConnectContext context, AlterTableStmt stmt) {
+        return new IcebergRewriteDataJob(buildInsertSelectSql(velCtx, writeRowLineage), rewriteAll,
+                minFileSizeBytes, batchSize, batchParallelism, writeRowLineage, context, stmt);
+    }
+
+    private String buildInsertSelectSql(VelocityContext velCtx, boolean writeRowLineage) {
+        VelocityEngine defaultVelocityEngine = new VelocityEngine();
+        defaultVelocityEngine.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
+        StringWriter writer = new StringWriter();
+        if (writeRowLineage) {
+            defaultVelocityEngine.evaluate(velCtx, writer, "InsertSelectTemplate",
+                    "INSERT INTO $catalogName.$dbName.$tableName" +
+                            " SELECT *, _row_id, _last_updated_sequence_number" +
+                            " FROM $catalogName.$dbName.$tableName" +
+                            " #if ($partitionFilterSql)" +
+                            " WHERE $partitionFilterSql" +
+                            " #end");
+        } else {
+            defaultVelocityEngine.evaluate(velCtx, writer, "InsertSelectTemplate",
+                    "INSERT INTO $catalogName.$dbName.$tableName" +
+                            " SELECT * FROM $catalogName.$dbName.$tableName" +
+                            " #if ($partitionFilterSql)" +
+                            " WHERE $partitionFilterSql" +
+                            " #end");
+        }
+        return writer.toString();
     }
 
     private ShowResultSet getRewriteResult(IcebergTableProcedureContext context, 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -702,6 +702,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String LARGE_DECIMAL_UNDERLYING_TYPE = "large_decimal_underlying_type";
 
     public static final String ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE = "enable_iceberg_identity_column_optimize";
+
+    public static final String ENABLE_ICEBERG_COMPACTION_WITH_ROW_LINEAGE =
+            "enable_iceberg_compaction_with_row_lineage";
     public static final String ENABLE_PIPELINE_LEVEL_SHUFFLE = "enable_pipeline_level_shuffle";
     public static final String EXCHANGE_HASH_FUNCTION_VERSION = "exchange_hash_function_version";
 
@@ -3191,6 +3194,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE)
     private boolean enableIcebergIdentityColumnOptimize = true;
 
+    @VarAttr(name = ENABLE_ICEBERG_COMPACTION_WITH_ROW_LINEAGE, flag = VariableMgr.INVISIBLE)
+    private boolean enableIcebergCompactionWithRowLineage = true;
+
     @VarAttr(name = ENABLE_PLAN_SERIALIZE_CONCURRENTLY)
     private boolean enablePlanSerializeConcurrently = true;
 
@@ -5457,6 +5463,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableIcebergIdentityColumnOptimize(boolean enableIcebergIdentityColumnOptimize) {
         this.enableIcebergIdentityColumnOptimize = enableIcebergIdentityColumnOptimize;
+    }
+
+    public boolean getEnableIcebergCompactionWithRowLineage() {
+        return enableIcebergCompactionWithRowLineage;
+    }
+
+    public void setEnableIcebergCompactionWithRowLineage(boolean enableIcebergCompactionWithRowLineage) {
+        this.enableIcebergCompactionWithRowLineage = enableIcebergCompactionWithRowLineage;
     }
 
     public boolean getEnablePlanSerializeConcurrently() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -44,6 +44,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.ConnectorSinkSortScope;
 import com.starrocks.connector.iceberg.IcebergPartitionTransform;
+import com.starrocks.connector.iceberg.IcebergRowLineageUtils;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -312,10 +313,18 @@ public class InsertPlanner {
         }
 
         if (targetTable.isIcebergTable()) {
+            boolean preserveRowLineage = targetTable instanceof IcebergTable
+                    && IcebergRowLineageUtils.shouldWriteRowLineageColumns(insertStmt, (IcebergTable) targetTable);
+            Set<String> columnsToFilter = preserveRowLineage
+                    ? IcebergTable.ICEBERG_META_COLUMNS.stream()
+                            .filter(col -> !col.equals(IcebergTable.ROW_ID)
+                                    && !col.equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER))
+                            .collect(Collectors.toSet())
+                    : IcebergTable.ICEBERG_META_COLUMNS;
             outputBaseSchema = outputBaseSchema.stream().filter(col ->
-                    !IcebergTable.ICEBERG_META_COLUMNS.contains(col.getName())).toList();
+                    !columnsToFilter.contains(col.getName())).toList();
             outputFullSchema = outputFullSchema.stream().filter(col ->
-                    !IcebergTable.ICEBERG_META_COLUMNS.contains(col.getName())).toList();
+                    !columnsToFilter.contains(col.getName())).toList();
         }
 
         refreshExternalTable(insertStmt.getQueryStatement(), session);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -38,6 +38,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.iceberg.IcebergRowLineageUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -252,10 +253,14 @@ public class InsertAnalyzer {
                         .collect(Collectors.toSet()));
             } else if (table instanceof IcebergTable) {
                 IcebergTable icebergTable = (IcebergTable) table;
+                boolean writeRowLineage = IcebergRowLineageUtils.shouldWriteRowLineageColumns(insertStmt, icebergTable);
                 targetColumns = new ArrayList<>();
                 icebergTable.getFullSchema().forEach(column -> {
                     if (!column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX) &&
-                            !IcebergTable.ICEBERG_META_COLUMNS.contains(column.getName())) {
+                            (!IcebergTable.ICEBERG_META_COLUMNS.contains(column.getName())
+                                    || (writeRowLineage
+                                    && (column.getName().equals(IcebergTable.ROW_ID)
+                                    || column.getName().equals(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER))))) {
                         targetColumns.add(column);
                     }
                 });

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -343,6 +343,7 @@ public class SetStmtAnalyzer {
             PlanMode.fromName(resolvedExpression.getStringValue());
         }
 
+
         // check connector_sink_sort_scope
         if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SORT_SCOPE)) {
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/IcebergRewriteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/IcebergRewriteStmt.java
@@ -17,15 +17,21 @@ package com.starrocks.sql.ast;
 public class IcebergRewriteStmt extends InsertStmt {
 
     private final boolean rewriteAll;
+    private final boolean writeRowLineage;
 
-    public IcebergRewriteStmt(InsertStmt base, boolean rewriteAll) {
-        super(base.getTableRef(), base.getTargetPartitionNames(), base.getLabel(), base.getTargetColumnNames(), 
+    public IcebergRewriteStmt(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) {
+        super(base.getTableRef(), base.getTargetPartitionNames(), base.getLabel(), base.getTargetColumnNames(),
                 base.getQueryStatement(), base.isOverwrite(), base.getProperties(), base.getPos());
         super.setOrigStmt(base.getOrigStmt());
         this.rewriteAll = rewriteAll;
+        this.writeRowLineage = writeRowLineage;
     }
 
     public boolean rewriteAll() {
         return rewriteAll;
+    }
+
+    public boolean writeRowLineage() {
+        return writeRowLineage;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -20,12 +20,12 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
-import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.THdfsScanRange;
 import org.apache.iceberg.FileScanTask;
 import org.junit.jupiter.api.Assertions;
@@ -220,7 +220,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     }
 
     @Test
-    public void testBuildScanRangeFailFastWhenRowIdWithoutFirstRowId() throws Exception {
+    public void testBuildScanRangeReturnsNullRowIdWhenFirstRowIdMissing() throws Exception {
         TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(3));
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
         idSlot.setType(INT);
@@ -248,8 +248,9 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
         FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
         long partitionId = scanRangeSource.addPartition(fileScanTask);
-        Assertions.assertThrows(StarRocksConnectorException.class,
-                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
+        Assertions.assertFalse(hdfsScanRange.getExtended_columns().containsKey(rowIdSlot.getId().asInt()));
     }
 
     @Test
@@ -293,15 +294,43 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         }
     }
 
+    @Test
+    public void testBuildScanRangeWithRowIdWhenFirstRowIdMissingReturnsNullAtReadTime() throws Exception {
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(13));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_rowid_null", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
+        Assertions.assertFalse(hdfsScanRange.getExtended_columns().containsKey(rowIdSlot.getId().asInt()));
+    }
+
     /**
      * Test that when late materialization adds _row_id along with _row_source_id and _scan_range_id,
-     * and the file doesn't have firstRowId, the scan range building MUST throw exception.
-     * The optimizer may reuse a user-requested _row_id while also adding late materialization columns,
-     * so we cannot assume _row_id is purely internal. Allowing NULL _row_id would violate the
-     * lookup path's non-null assumption (lookup_request.cpp DCHECK).
+     * and the file doesn't have firstRowId, FE still builds the scan range without first_row_id.
+     * BE preserves the legacy lookup behavior by falling back to row_position for the internal fetch key.
      */
     @Test
-    public void testBuildScanRangeWithLateMaterializationColumnsThrowsWhenNoFirstRowId() throws Exception {
+    public void testBuildScanRangeWithLateMaterializationColumnsWithoutFirstRowIdUsesLegacyLookupKey() throws Exception {
         // Use v2 table which doesn't have firstRowId in files
         TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(5));
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
@@ -344,9 +373,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
         long partitionId = scanRangeSource.addPartition(fileScanTask);
 
-        // Must throw: _row_id requires firstRowId regardless of late materialization columns
-        Assertions.assertThrows(StarRocksConnectorException.class,
-                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
     }
 
     /**
@@ -471,6 +499,46 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         }
     }
 
+    @Test
+    public void testBuildScanRangeWithFullRowLineageColumnsWhenFirstRowIdMissingKeepsSequenceNumber() throws Exception {
+        TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(14));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+        localTupleDescriptor.addSlot(idSlot);
+
+        SlotDescriptor rowIdSlot = new SlotDescriptor(new SlotId(2), localTupleDescriptor);
+        rowIdSlot.setType(BIGINT);
+        rowIdSlot.setColumn(new Column(IcebergTable.ROW_ID, BIGINT));
+        localTupleDescriptor.addSlot(rowIdSlot);
+
+        SlotDescriptor seqSlot = new SlotDescriptor(new SlotId(3), localTupleDescriptor);
+        seqSlot.setType(BIGINT);
+        seqSlot.setColumn(new Column(IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, BIGINT));
+        localTupleDescriptor.addSlot(seqSlot);
+
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        List<Column> schema = Lists.newArrayList(new Column("id", INT), new Column("data", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table_full_null", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableA, Maps.newHashMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, localTupleDescriptor, Optional.empty(),
+                PartitionIdGenerator.of(), false, false);
+
+        FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
+        long partitionId = scanRangeSource.addPartition(fileScanTask);
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+
+        Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
+        Assertions.assertFalse(hdfsScanRange.getExtended_columns().containsKey(rowIdSlot.getId().asInt()));
+        Assertions.assertTrue(hdfsScanRange.getExtended_columns().containsKey(seqSlot.getId().asInt()));
+        var texpr = hdfsScanRange.getExtended_columns().get(seqSlot.getId().asInt());
+        Assertions.assertEquals(TExprNodeType.INT_LITERAL, texpr.getNodes().get(0).getNode_type());
+        Assertions.assertEquals(fileScanTask.file().dataSequenceNumber().longValue(),
+                texpr.getNodes().get(0).getInt_literal().getValue());
+    }
+
     /**
      * Test that _last_updated_sequence_number extended column value matches the file's dataSequenceNumber.
      * This is the fallback value used by BE when the physical column is not present (non-compacted files).
@@ -584,11 +652,10 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
     /**
      * Test that when _row_id is present with only _row_source_id (partial late materialization),
-     * and the file has no firstRowId, it must throw exception.
-     * Late materialization presence does not exempt the firstRowId requirement.
+     * and the file has no firstRowId, FE still leaves first_row_id unset so BE can fall back to row_position.
      */
     @Test
-    public void testBuildScanRangeWithOnlyRowSourceIdThrowsWhenNoFirstRowId() throws Exception {
+    public void testBuildScanRangeWithOnlyRowSourceIdWithoutFirstRowIdUsesLegacyLookupKey() throws Exception {
         // Use v2 table which doesn't have firstRowId in files
         TupleDescriptor localTupleDescriptor = new TupleDescriptor(new TupleId(7));
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), localTupleDescriptor);
@@ -625,8 +692,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         FileScanTask fileScanTask = Lists.newArrayList(mockedNativeTableA.newScan().planFiles()).get(0);
         long partitionId = scanRangeSource.addPartition(fileScanTask);
 
-        // Must throw: _row_id requires firstRowId regardless of late materialization columns
-        Assertions.assertThrows(StarRocksConnectorException.class,
-                () -> scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId));
+        THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
+        Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
@@ -35,8 +35,10 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TSinkCommitInfo;
@@ -78,6 +80,7 @@ public class IcebergRewriteDataJobTest {
                 0L,
                 10L,
                 1L,
+                false,
                 ctx,
                 alter
         );
@@ -119,7 +122,7 @@ public class IcebergRewriteDataJobTest {
         when(alter.getTableName()).thenReturn("t");
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, ctx, alter);
+                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
 
         IcebergScanNode scanNode = mock(IcebergScanNode.class);
         Deencapsulation.setField(job, "scanNodes", Collections.singletonList(scanNode));
@@ -168,7 +171,7 @@ public class IcebergRewriteDataJobTest {
         when(sv.clone()).thenReturn(sv);
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, ctx, alter);
+                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
 
         // ---- Prepare minimal fields required by execute() ----
         InsertStmt parsedInsert = mock(InsertStmt.class);
@@ -189,10 +192,12 @@ public class IcebergRewriteDataJobTest {
 
         IcebergScanNode localScanNode = mock(IcebergScanNode.class);
         ExecPlan localPlan = mockPlanWithOneIcebergScan(localScanNode);
+        final StatementBase[] plannedStmt = new StatementBase[1];
 
         new MockUp<StatementPlanner>() {
             @Mock
             public ExecPlan plan(StatementBase stmt, ConnectContext session) {
+                plannedStmt[0] = stmt;
                 return localPlan;
             }
         };
@@ -231,7 +236,7 @@ public class IcebergRewriteDataJobTest {
         Deencapsulation.setField(job, "parsedStmt", fakeInsertStmt);
         new mockit.Expectations() {
             {
-                new com.starrocks.sql.ast.IcebergRewriteStmt(fakeInsertStmt, anyBoolean);
+                new com.starrocks.sql.ast.IcebergRewriteStmt(fakeInsertStmt, anyBoolean, anyBoolean);
                 result = rewriteStmt;
                 minTimes = 0;
             }
@@ -255,7 +260,54 @@ public class IcebergRewriteDataJobTest {
         verify(localScanNode, times(1)).rebuildScanRange(eq(oneGroup));
 
         verify(executor, times(1)).handleDMLStmt(eq(localPlan), isA(com.starrocks.sql.ast.IcebergRewriteStmt.class));
+        Assertions.assertTrue(plannedStmt[0] instanceof IcebergRewriteStmt);
 
         verify(state, never()).setError(anyString());
+    }
+
+    @Test
+    public void prepare_shouldPlanWithRewriteStmt() throws Exception {
+        ConnectContext ctx = mock(ConnectContext.class, Mockito.RETURNS_DEEP_STUBS);
+        SessionVariable sessionVariable = mock(SessionVariable.class);
+        when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        AlterTableStmt alter = mock(AlterTableStmt.class);
+        when(alter.getTableName()).thenReturn("t");
+
+        ValuesRelation valuesRelation = new ValuesRelation(Collections.emptyList(), Collections.emptyList());
+        QueryStatement queryStatement = new QueryStatement(valuesRelation);
+        TableRef tableRef = new TableRef(QualifiedName.of(Lists.newArrayList("c", "db", "t")), null, NodePosition.ZERO);
+        InsertStmt parsedInsert = new InsertStmt(tableRef, queryStatement);
+        parsedInsert.setOrigStmt(new OriginStatement("insert into t select 1", 0));
+        IcebergScanNode scanNode = mock(IcebergScanNode.class);
+        IcebergConnectorScanRangeSource source = mock(IcebergConnectorScanRangeSource.class);
+        when(scanNode.getSourceRange()).thenReturn(source);
+        when(source.getSourceFileScanOutputs(Mockito.anyInt(), Mockito.anyLong(), Mockito.anyBoolean()))
+                .thenReturn(Collections.emptyList());
+
+        new MockUp<com.starrocks.sql.parser.SqlParser>() {
+            @Mock
+            public List<StatementBase> parse(String sql, SessionVariable ignoredSessionVariable) {
+                return Collections.singletonList(parsedInsert);
+            }
+        };
+
+        final StatementBase[] plannedStmt = new StatementBase[1];
+        ExecPlan execPlan = mockPlanWithOneIcebergScan(scanNode);
+        new MockUp<StatementPlanner>() {
+            @Mock
+            public ExecPlan plan(StatementBase stmt, ConnectContext session) {
+                plannedStmt[0] = stmt;
+                return execPlan;
+            }
+        };
+
+        IcebergRewriteDataJob job = new IcebergRewriteDataJob(
+                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
+
+        job.prepare();
+
+        Assertions.assertTrue(plannedStmt[0] instanceof IcebergRewriteStmt);
+        Assertions.assertNotSame(parsedInsert, plannedStmt[0]);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRowLineageUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRowLineageUtilsTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.sql.ast.IcebergRewriteStmt;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.OriginStatement;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class IcebergRowLineageUtilsTest {
+
+    @Test
+    public void shouldNotWriteRowLineageColumnsForRegularInsert() {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getFormatVersion()).thenReturn(3);
+
+        InsertStmt insertStmt = newInsertStmt();
+
+        Assertions.assertFalse(
+                IcebergRowLineageUtils.shouldWriteRowLineageColumns(insertStmt, icebergTable));
+    }
+
+    @Test
+    public void shouldWriteRowLineageColumnsForRewriteInsertOnV3Table() {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getFormatVersion()).thenReturn(3);
+
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true);
+
+        Assertions.assertTrue(
+                IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));
+    }
+
+    @Test
+    public void shouldNotWriteRowLineageColumnsWhenRewriteStmtDoesNotWriteRowLineage() {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getFormatVersion()).thenReturn(3);
+
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, false);
+
+        Assertions.assertFalse(
+                IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));
+    }
+
+    @Test
+    public void shouldNotWriteRowLineageColumnsForV2Table() {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getFormatVersion()).thenReturn(2);
+
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true);
+
+        Assertions.assertFalse(
+                IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));
+    }
+
+    private InsertStmt newInsertStmt() {
+        ValuesRelation valuesRelation = new ValuesRelation(Collections.emptyList(), Collections.emptyList());
+        QueryStatement queryStatement = new QueryStatement(valuesRelation);
+        TableRef tableRef = new TableRef(QualifiedName.of("catalog", "db", "tbl"), null, NodePosition.ZERO);
+        InsertStmt insertStmt = new InsertStmt(tableRef, queryStatement);
+        insertStmt.setOrigStmt(new OriginStatement("insert into tbl values ()", 0));
+        return insertStmt;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesTest.java
@@ -20,6 +20,7 @@ import com.starrocks.connector.iceberg.IcebergRewriteDataJob;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.expression.Expr;
@@ -29,8 +30,12 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -143,5 +148,252 @@ public class RewriteDataFilesTest {
         Assertions.assertTrue(ex.getMessage().contains("boom"));
     }
 
+    @Test
+    void rewriteDataFilesV3ShouldSkipRowLineageWhenHiddenSessionVariableIsDisabled(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog) throws Exception {
+        // --- arrange: create a v3 BaseTable mock
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata metadata = Mockito.mock(TableMetadata.class);
+        Mockito.when(metadata.formatVersion()).thenReturn(3);
+        Mockito.when(ops.current()).thenReturn(metadata);
+        BaseTable baseTable = Mockito.mock(BaseTable.class);
+        Mockito.when(baseTable.operations()).thenReturn(ops);
 
+        String catalog = "c1";
+        String db = "db";
+        String tbl = "table";
+
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        Mockito.when(stmt.getCatalogName()).thenReturn(catalog);
+        Mockito.when(stmt.getDbName()).thenReturn(db);
+        Mockito.when(stmt.getTableName()).thenReturn(tbl);
+
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        Mockito.when(clause.getWhere()).thenReturn(null);
+
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableIcebergCompactionWithRowLineage(false);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        QueryState queryState = new QueryState();
+        Mockito.when(ctx.getState()).thenReturn(queryState);
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        final String[] capturedSql = new String[1];
+        try (MockedConstruction<IcebergRewriteDataJob> mocked = Mockito.mockConstruction(IcebergRewriteDataJob.class,
+                (mock, context) -> {
+                    capturedSql[0] = (String) context.arguments().get(0);
+                    Mockito.doNothing().when(mock).prepare();
+                    Mockito.when(mock.execute()).thenReturn(new IcebergRewriteDataJob.RewriteMetrics(1, 10, 2));
+                })) {
+
+            IcebergTableProcedure procedure = RewriteDataFilesProcedure.getInstance();
+            IcebergTableProcedureContext procedureContext =
+                    new IcebergTableProcedureContext(icebergHiveCatalog, baseTable, ctx, null,
+                            HDFS_ENVIRONMENT, stmt, clause);
+            procedure.execute(procedureContext, Map.of());
+        }
+
+        Assertions.assertNotNull(capturedSql[0]);
+        Assertions.assertFalse(capturedSql[0].contains("_row_id"),
+                "disabled hidden switch should fall back to SELECT *: " + capturedSql[0]);
+    }
+
+    @Test
+    void rewriteDataFilesV3ShouldIncludeRowLineageColumnsByDefault(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog) throws Exception {
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata metadata = Mockito.mock(TableMetadata.class);
+        Mockito.when(metadata.formatVersion()).thenReturn(3);
+        Mockito.when(ops.current()).thenReturn(metadata);
+        BaseTable baseTable = Mockito.mock(BaseTable.class);
+        Mockito.when(baseTable.operations()).thenReturn(ops);
+
+        String catalog = "c1";
+        String db = "db";
+        String tbl = "table";
+
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        Mockito.when(stmt.getCatalogName()).thenReturn(catalog);
+        Mockito.when(stmt.getDbName()).thenReturn(db);
+        Mockito.when(stmt.getTableName()).thenReturn(tbl);
+
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        Mockito.when(clause.getWhere()).thenReturn(null);
+
+        SessionVariable sessionVariable = new SessionVariable();
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        QueryState queryState = new QueryState();
+        Mockito.when(ctx.getState()).thenReturn(queryState);
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        final String[] capturedSql = new String[1];
+        try (MockedConstruction<IcebergRewriteDataJob> mocked = Mockito.mockConstruction(IcebergRewriteDataJob.class,
+                (mock, context) -> {
+                    capturedSql[0] = (String) context.arguments().get(0);
+                    Mockito.doNothing().when(mock).prepare();
+                    Mockito.when(mock.execute()).thenReturn(new IcebergRewriteDataJob.RewriteMetrics(1, 10, 2));
+                })) {
+
+            IcebergTableProcedure procedure = RewriteDataFilesProcedure.getInstance();
+            IcebergTableProcedureContext procedureContext =
+                    new IcebergTableProcedureContext(icebergHiveCatalog, baseTable, ctx, null,
+                            HDFS_ENVIRONMENT, stmt, clause);
+            procedure.execute(procedureContext, Map.of());
+        }
+
+        Assertions.assertNotNull(capturedSql[0]);
+        Assertions.assertTrue(capturedSql[0].contains("_row_id"),
+                "default v3 rewrite should request _row_id: " + capturedSql[0]);
+        Assertions.assertTrue(capturedSql[0].contains("_last_updated_sequence_number"),
+                "default v3 rewrite should include sequence number: " + capturedSql[0]);
+    }
+
+    @Test
+    void rewriteDataFilesV3ShouldIncludeRowLineageColumnsWhenHiddenSwitchIsEnabled(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog) throws Exception {
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata metadata = Mockito.mock(TableMetadata.class);
+        Mockito.when(metadata.formatVersion()).thenReturn(3);
+        Mockito.when(ops.current()).thenReturn(metadata);
+        BaseTable baseTable = Mockito.mock(BaseTable.class);
+        Mockito.when(baseTable.operations()).thenReturn(ops);
+
+        String catalog = "c1";
+        String db = "db";
+        String tbl = "table";
+
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        Mockito.when(stmt.getCatalogName()).thenReturn(catalog);
+        Mockito.when(stmt.getDbName()).thenReturn(db);
+        Mockito.when(stmt.getTableName()).thenReturn(tbl);
+
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        Mockito.when(clause.getWhere()).thenReturn(null);
+
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableIcebergCompactionWithRowLineage(true);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        QueryState queryState = new QueryState();
+        Mockito.when(ctx.getState()).thenReturn(queryState);
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        final String[] capturedSql = new String[1];
+        try (MockedConstruction<IcebergRewriteDataJob> mocked = Mockito.mockConstruction(IcebergRewriteDataJob.class,
+                (mock, context) -> {
+                    capturedSql[0] = (String) context.arguments().get(0);
+                    Mockito.doNothing().when(mock).prepare();
+                    Mockito.when(mock.execute()).thenReturn(new IcebergRewriteDataJob.RewriteMetrics(1, 10, 2));
+                })) {
+
+            IcebergTableProcedure procedure = RewriteDataFilesProcedure.getInstance();
+            IcebergTableProcedureContext procedureContext =
+                    new IcebergTableProcedureContext(icebergHiveCatalog, baseTable, ctx, null,
+                            HDFS_ENVIRONMENT, stmt, clause);
+            procedure.execute(procedureContext, Map.of());
+        }
+
+        Assertions.assertNotNull(capturedSql[0]);
+        Assertions.assertTrue(capturedSql[0].contains("_row_id"),
+                "enabled hidden switch should request _row_id: " + capturedSql[0]);
+    }
+
+    @Test
+    void rewriteDataFilesV3ShouldNotIncludeRowLineageColumnsWhenHiddenSwitchIsDisabled(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog) throws Exception {
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata metadata = Mockito.mock(TableMetadata.class);
+        Mockito.when(metadata.formatVersion()).thenReturn(3);
+        Mockito.when(ops.current()).thenReturn(metadata);
+        BaseTable baseTable = Mockito.mock(BaseTable.class);
+        Mockito.when(baseTable.operations()).thenReturn(ops);
+
+        String catalog = "c1";
+        String db = "db";
+        String tbl = "table";
+
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        Mockito.when(stmt.getCatalogName()).thenReturn(catalog);
+        Mockito.when(stmt.getDbName()).thenReturn(db);
+        Mockito.when(stmt.getTableName()).thenReturn(tbl);
+
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        Mockito.when(clause.getWhere()).thenReturn(null);
+
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableIcebergCompactionWithRowLineage(false);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        QueryState queryState = new QueryState();
+        Mockito.when(ctx.getState()).thenReturn(queryState);
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        final String[] capturedSql = new String[1];
+        try (MockedConstruction<IcebergRewriteDataJob> mocked = Mockito.mockConstruction(IcebergRewriteDataJob.class,
+                (mock, context) -> {
+                    capturedSql[0] = (String) context.arguments().get(0);
+                    Mockito.doNothing().when(mock).prepare();
+                    Mockito.when(mock.execute()).thenReturn(new IcebergRewriteDataJob.RewriteMetrics(1, 10, 2));
+                })) {
+
+            IcebergTableProcedure procedure = RewriteDataFilesProcedure.getInstance();
+            IcebergTableProcedureContext procedureContext =
+                    new IcebergTableProcedureContext(icebergHiveCatalog, baseTable, ctx, null,
+                            HDFS_ENVIRONMENT, stmt, clause);
+            procedure.execute(procedureContext, Map.of());
+        }
+
+        Assertions.assertNotNull(capturedSql[0]);
+        Assertions.assertFalse(capturedSql[0].contains("_row_id"),
+                "disabled hidden switch should not request _row_id: " + capturedSql[0]);
+    }
+
+    @Test
+    void rewriteDataFilesV2ShouldNotIncludeRowLineageColumns(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog) throws Exception {
+        // --- arrange: v2 table (row lineage is v3-only feature)
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata metadata = Mockito.mock(TableMetadata.class);
+        Mockito.when(metadata.formatVersion()).thenReturn(2);
+        Mockito.when(ops.current()).thenReturn(metadata);
+        BaseTable baseTable = Mockito.mock(BaseTable.class);
+        Mockito.when(baseTable.operations()).thenReturn(ops);
+
+        String catalog = "c1";
+        String db = "db";
+        String tbl = "table";
+
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        Mockito.when(stmt.getCatalogName()).thenReturn(catalog);
+        Mockito.when(stmt.getDbName()).thenReturn(db);
+        Mockito.when(stmt.getTableName()).thenReturn(tbl);
+
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        Mockito.when(clause.getWhere()).thenReturn(null);
+
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableIcebergCompactionWithRowLineage(true);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        QueryState queryState = new QueryState();
+        Mockito.when(ctx.getState()).thenReturn(queryState);
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
+
+        final String[] capturedSql = new String[1];
+        try (MockedConstruction<IcebergRewriteDataJob> mocked = Mockito.mockConstruction(IcebergRewriteDataJob.class,
+                (mock, context) -> {
+                    capturedSql[0] = (String) context.arguments().get(0);
+                    Mockito.doNothing().when(mock).prepare();
+                    Mockito.when(mock.execute()).thenReturn(new IcebergRewriteDataJob.RewriteMetrics(1, 10, 2));
+                })) {
+
+            IcebergTableProcedure procedure = RewriteDataFilesProcedure.getInstance();
+            IcebergTableProcedureContext procedureContext =
+                    new IcebergTableProcedureContext(icebergHiveCatalog, baseTable, ctx, null,
+                            HDFS_ENVIRONMENT, stmt, clause);
+            procedure.execute(procedureContext, Map.of());
+        }
+
+        // v2 table should NOT include row lineage columns regardless of session variable
+        Assertions.assertNotNull(capturedSql[0]);
+        Assertions.assertFalse(capturedSql[0].contains("_row_id"),
+                "SQL should NOT include _row_id for v2 table: " + capturedSql[0]);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -848,13 +848,13 @@ public class IcebergScanNodeTest {
 
         new MockUp<IcebergRewriteStmt>() {
             @Mock
-            public void $init(InsertStmt base, boolean rewriteAll) {
+            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) {
                 //do nothing
             }
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select * from t", false, 0L, 10L, 1L, context, alter);
+                "insert into t select * from t", false, 0L, 10L, 1L, false, context, alter);
 
         job.prepare();
         Deencapsulation.setField(job, "execPlan", execPlan);
@@ -924,11 +924,7 @@ public class IcebergScanNodeTest {
         };
         new mockit.MockUp<IcebergRewriteStmt>() {
             @mockit.Mock
-            public void $init(InsertStmt base, boolean rewriteAll) { /* no-op */ }
-        };
-        new mockit.MockUp<IcebergScanNode>() {
-            @mockit.Mock
-            public void rebuildScanRange(List<RemoteFileInfo> splits) { /* no-op */ }
+            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) { /* no-op */ }
         };
 
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
@@ -950,7 +946,7 @@ public class IcebergScanNodeTest {
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, context, alter);
+                "insert into t select 1", false, 0L, 10L, 1L, false, context, alter);
 
         Deencapsulation.setField(job, "rewriteStmt", rewriteStmt);
         Deencapsulation.setField(job, "parsedStmt", parsedInsert);

--- a/test/sql/test_iceberg/R/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/R/test_iceberg_row_lineage
@@ -395,7 +395,7 @@ select id, name from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.
 -- !result
 select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
 -- result:
-1
+3
 -- !result
 insert into iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact values (7, 'grace'), (8, 'henry');
 -- result:
@@ -406,7 +406,14 @@ select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from ic
 -- !result
 select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
 -- result:
-2
+4
+-- !result
+select s.id, s.name, s.seq_num_before, t._last_updated_sequence_number as seq_num_after
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot s
+    join iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact t on s.id = t.id
+    where s.seq_num_before != t._last_updated_sequence_number
+    order by s.id;
+-- result:
 -- !result
 drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot;
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_row_lineage
+++ b/test/sql/test_iceberg/T/test_iceberg_row_lineage
@@ -295,6 +295,13 @@ select count(*) as total_rows, count(distinct _row_id) as unique_row_ids from ic
 -- Verify new rows have different _last_updated_sequence_number from compacted rows
 select count(distinct _last_updated_sequence_number) from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;
 
+-- Core check: verify _last_updated_sequence_number is preserved per row after compaction
+select s.id, s.name, s.seq_num_before, t._last_updated_sequence_number as seq_num_after
+    from iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot s
+    join iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact t on s.id = t.id
+    where s.seq_num_before != t._last_updated_sequence_number
+    order by s.id;
+
 -- Cleanup
 drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_snapshot;
 drop table iceberg_rl_compact_${uuid0}.iceberg_rl_compact_db_${uuid0}.t_compact;


### PR DESCRIPTION
## What I'm doing:

This pull request introduces support for writing Iceberg row lineage columns (`_row_id`, `_last_updated_sequence_number`) as physical columns during compaction for v3+ Iceberg tables, controlled by a new session variable. It ensures these columns are included in the compaction SQL and properly handled in the backend sink context, with comprehensive tests validating the feature and its configuration.

**Iceberg row lineage support during compaction**

* Added logic in `RewriteDataFilesProcedure` to conditionally include row lineage columns in compaction SQL for v3+ Iceberg tables when the new session variable is enabled.
* Updated `InsertPlanner` to preserve row lineage columns in the output schema for v3+ tables with row lineage enabled.
* Extended backend sink context in `iceberg_table_sink.cpp` to append row lineage columns to `column_names` and `parquet_field_ids` when output expressions exceed user columns (compaction mode).

**Session variable and configuration**

* Introduced the `enable_iceberg_compaction_with_row_lineage` session variable, with getter/setter and default enabled, to control whether row lineage columns are written during compaction. 

**Enhancements to Iceberg reserved column handling**

* Introduced new base class `IcebergRowLineageReader` and specialized readers (`IcebergRowIdReader`, `IcebergLastUpdatedSequenceNumberReader`) to encapsulate fallback and physical column logic for Iceberg reserved columns. This allows for unified handling of physical and computed values, including NULLs. 
* Updated `GroupReader::_create_column_readers` to instantiate the new reader classes and to correctly handle legacy fallback logic and NULL values for `_row_id` and `last_updated_sequence_number` columns.
* Modified fallback value retrieval for extended columns to return a `Datum` (supporting NULLs) instead of `int64_t`, and updated all related logic to handle NULL values appropriately. 


**Testing**

* Added comprehensive tests in `RewriteDataFilesTest` to verify that row lineage columns are included or excluded in the compaction SQL based on table version and session variable state.
* Added a new backend unit test to ensure that row lineage columns are properly appended in the sink context during compaction.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

