### PR TITLE
[BugFix] reset content-length when proxy_pass_request_body is off

### DIFF
--- a/docker/dockerfiles/allin1/services/feproxy/feproxy.conf.template
+++ b/docker/dockerfiles/allin1/services/feproxy/feproxy.conf.template
@@ -38,6 +38,7 @@ http {
         location /api/transaction/load {
             proxy_pass http://127.0.0.1:{{fewebport}};
             proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
             proxy_set_header Expect $http_expect;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -48,6 +49,7 @@ http {
         location ~ ^/api/.*/.*/_stream_load$ {
             proxy_pass http://127.0.0.1:{{fewebport}};
             proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
             proxy_set_header Expect $http_expect;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
* fix request hanging due to Content-Length set but request body off

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
