### PR TITLE
[Enhancement] Calculate null fractions for CASE WHEN expressions (backport #70221)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -87,7 +87,9 @@ public class ExpressionStatisticCalculator {
         @Override
         public ColumnStatistic visitConstant(ConstantOperator operator, Void context) {
             if (operator.isNull()) {
-                return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0, 1, 1);
+                // NULL has no distinct non-null values and is always null.
+                return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1.0,
+                        operator.getType().getTypeSize(), 0);
             }
             OptionalDouble value = ConstantOperatorUtils.doubleValueFromConstant(operator);
             if (value.isPresent()) {
@@ -111,14 +113,25 @@ public class ExpressionStatisticCalculator {
             }
             if (caseWhenOperator.hasElse()) {
                 childrenColumnStatistics.add(caseWhenOperator.getElseClause().accept(this, context));
+            } else {
+                // A missing ELSE is an implicit ELSE that returns NULL.
+                childrenColumnStatistics.add(ColumnStatistic.builder() //
+                        .setNullsFraction(1.0) //
+                        .setDistinctValuesCount(0) //
+                        .build());
             }
-            // 2. use sum of then clause and else clause's distinct values as column distinctValues
-            double distinctValues = childrenColumnStatistics.stream().mapToDouble(
-                    ColumnStatistic::getDistinctValuesCount).sum();
+            // 2. use sum of then clause and else clause's distinct values as column distinctValues.
+            // NULL branches should only contribute to nullsFraction, not to distinctValues.
+            double distinctValues = childrenColumnStatistics.stream()
+                    .mapToDouble(childStat -> childStat.getNullsFraction() >= 1.0 ? 0 : childStat.getDistinctValuesCount()) //
+                    .sum();
+            // 3. Use the average null fraction of all branches.
+            double nullFractions = childrenColumnStatistics.stream().mapToDouble(ColumnStatistic::getNullsFraction).sum()
+                    / childrenColumnStatistics.size();
             return ColumnStatistic.builder()
                     .setMinValue(Double.NEGATIVE_INFINITY)
                     .setMaxValue(Double.POSITIVE_INFINITY)
-                    .setNullsFraction(0)
+                    .setNullsFraction(nullFractions)
                     .setAverageRowSize(caseWhenOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
                     .build();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -630,6 +630,79 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testCaseWhenOperatorNullFractionWithoutElse() {
+        // GIVEN
+        // CASE WHEN col = 1 THEN '1' WHEN col = 2 THEN '2' END  (no ELSE)
+        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var whenOperator1 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
+                ConstantOperator.createInt(1));
+        final var constantOperator1 = ConstantOperator.createChar("1");
+        final var whenOperator2 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
+                ConstantOperator.createInt(2));
+        final var constantOperator2 = ConstantOperator.createChar("2");
+
+        // No ELSE clause: elseClause = null
+        CaseWhenOperator caseWhenOperator = new CaseWhenOperator(VarcharType.VARCHAR, null, null,
+                ImmutableList.of(whenOperator1, constantOperator1, whenOperator2, constantOperator2));
+
+        // WHEN
+        final var columnStatistic = ExpressionStatisticCalculator.calculate(caseWhenOperator,
+                Statistics.builder().setOutputRowCount(100).build());
+
+        // THEN
+        Assertions.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.001);
+        // The implicit ELSE NULL branch has nullsFraction=1.0, the two THEN constant branches have nullsFraction=0.0.
+        Assertions.assertEquals(1.0 / 3.0, columnStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testCaseWhenOperatorNullFractionWithElse() {
+        // GIVEN
+        // CASE WHEN col = 1 THEN '1' WHEN col = 2 THEN '2' ELSE 'others' END
+        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var whenOperator1 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
+                ConstantOperator.createInt(1));
+        final var constantOperator1 = ConstantOperator.createChar("1");
+        final var whenOperator2 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
+                ConstantOperator.createInt(2));
+        final var constantOperator2 = ConstantOperator.createChar("2");
+
+        final var caseWhenOperator =
+                new CaseWhenOperator(VarcharType.VARCHAR, null, ConstantOperator.createChar("others", VarcharType.VARCHAR),
+                        ImmutableList.of(whenOperator1, constantOperator1, whenOperator2, constantOperator2));
+
+        // WHEN
+        final var columnStatistic = ExpressionStatisticCalculator.calculate(caseWhenOperator,
+                Statistics.builder().setOutputRowCount(100).build());
+
+        // THEN
+        // All 3 branches (2 THEN + 1 ELSE) are non-null constants => average nullFraction = 0.0
+        Assertions.assertEquals(0.0, columnStatistic.getNullsFraction(), 0.001);
+        Assertions.assertEquals(3, columnStatistic.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testCaseWhenOperatorExplicitElseNull() {
+        // GIVEN
+        // CASE WHEN col = 1 THEN 'x' ELSE NULL END
+        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var whenOperator = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
+                ConstantOperator.createInt(1));
+        final var thenOperator = ConstantOperator.createChar("x");
+
+        final var caseWhenOperator = new CaseWhenOperator(VarcharType.VARCHAR, null,
+                ConstantOperator.createNull(VarcharType.VARCHAR), ImmutableList.of(whenOperator, thenOperator));
+
+        // WHEN
+        final var columnStatistic = ExpressionStatisticCalculator.calculate(caseWhenOperator,
+                Statistics.builder().setOutputRowCount(100).build());
+
+        // THEN
+        Assertions.assertEquals(1, columnStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(0.5, columnStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
     public void testFromDays() {
         ColumnRefOperator columnRefOperator = new ColumnRefOperator(1, Type.INT, "", true);
         CallOperator callOperator = new CallOperator(FunctionSet.FROM_DAYS, Type.DOUBLE, Lists.newArrayList(columnRefOperator));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -633,7 +633,7 @@ public class ExpressionStatisticsCalculatorTest {
     public void testCaseWhenOperatorNullFractionWithoutElse() {
         // GIVEN
         // CASE WHEN col = 1 THEN '1' WHEN col = 2 THEN '2' END  (no ELSE)
-        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var columnRefOperator = new ColumnRefOperator(1, Type.INT, "", true);
         final var whenOperator1 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
                 ConstantOperator.createInt(1));
         final var constantOperator1 = ConstantOperator.createChar("1");
@@ -642,7 +642,7 @@ public class ExpressionStatisticsCalculatorTest {
         final var constantOperator2 = ConstantOperator.createChar("2");
 
         // No ELSE clause: elseClause = null
-        CaseWhenOperator caseWhenOperator = new CaseWhenOperator(VarcharType.VARCHAR, null, null,
+        CaseWhenOperator caseWhenOperator = new CaseWhenOperator(Type.VARCHAR, null, null,
                 ImmutableList.of(whenOperator1, constantOperator1, whenOperator2, constantOperator2));
 
         // WHEN
@@ -659,7 +659,7 @@ public class ExpressionStatisticsCalculatorTest {
     public void testCaseWhenOperatorNullFractionWithElse() {
         // GIVEN
         // CASE WHEN col = 1 THEN '1' WHEN col = 2 THEN '2' ELSE 'others' END
-        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var columnRefOperator = new ColumnRefOperator(1, Type.INT, "", true);
         final var whenOperator1 = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
                 ConstantOperator.createInt(1));
         final var constantOperator1 = ConstantOperator.createChar("1");
@@ -668,7 +668,7 @@ public class ExpressionStatisticsCalculatorTest {
         final var constantOperator2 = ConstantOperator.createChar("2");
 
         final var caseWhenOperator =
-                new CaseWhenOperator(VarcharType.VARCHAR, null, ConstantOperator.createChar("others", VarcharType.VARCHAR),
+                new CaseWhenOperator(Type.VARCHAR, null, ConstantOperator.createChar("others", Type.VARCHAR),
                         ImmutableList.of(whenOperator1, constantOperator1, whenOperator2, constantOperator2));
 
         // WHEN
@@ -685,13 +685,13 @@ public class ExpressionStatisticsCalculatorTest {
     public void testCaseWhenOperatorExplicitElseNull() {
         // GIVEN
         // CASE WHEN col = 1 THEN 'x' ELSE NULL END
-        final var columnRefOperator = new ColumnRefOperator(1, IntegerType.INT, "", true);
+        final var columnRefOperator = new ColumnRefOperator(1, Type.INT, "", true);
         final var whenOperator = new BinaryPredicateOperator(BinaryType.EQ, columnRefOperator,
                 ConstantOperator.createInt(1));
         final var thenOperator = ConstantOperator.createChar("x");
 
-        final var caseWhenOperator = new CaseWhenOperator(VarcharType.VARCHAR, null,
-                ConstantOperator.createNull(VarcharType.VARCHAR), ImmutableList.of(whenOperator, thenOperator));
+        final var caseWhenOperator = new CaseWhenOperator(Type.VARCHAR, null,
+                ConstantOperator.createNull(Type.VARCHAR), ImmutableList.of(whenOperator, thenOperator));
 
         // WHEN
         final var columnStatistic = ExpressionStatisticCalculator.calculate(caseWhenOperator,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -82,7 +82,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 " WHEN NOT CASE  WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6  ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 " +
                 "THEN l_shipdate ELSE NULL END, 3))), 2) ELSE NULL END) from lineitem";
         String plan = getCostExplain(sql);
-        assertContains(plan, "concat-->[-Infinity, Infinity, 0.0, 3.0, 412.0] ESTIMATE");
+        assertContains(plan, "concat-->[-Infinity, Infinity, 0.7037037037037036, 3.0, 412.0] ESTIMATE");
     }
 
     @Test
@@ -902,8 +902,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         sql = "select (case when `O_ORDERKEY` = 0 then 'ALGERIA' when `O_ORDERKEY` = 1 then 'ARGENTINA' end) a " +
                 "from orders group by 1";
         plan = getCostExplain(sql);
-        assertContains(plan, "cardinality: 2");
-        assertContains(plan, "* case-->[-Infinity, Infinity, 0.0, 16.0, 2.0]");
+        assertContains(plan, "cardinality: 3");
+        assertContains(plan, "* case-->[-Infinity, Infinity, 0.3333333333333333, 16.0, 2.0]");
 
         sql = "select (case when `O_ORDERKEY` = 0 then O_ORDERSTATUS when `O_ORDERKEY` = 1 then 'ARGENTINA' " +
                 "else 'other' end) a from orders group by 1";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -124,7 +124,7 @@ public class InsertPlanTest extends PlanTestBase {
                 "     tabletRatio=0/0\n" +
                 "     tabletList=\n" +
                 "     cardinality=1\n" +
-                "     avgRowSize=3.0\n"));
+                "     avgRowSize=17.0\n"));
     }
 
     @Test
@@ -323,7 +323,7 @@ public class InsertPlanTest extends PlanTestBase {
                 "     tabletRatio=0/0\n" +
                 "     tabletList=\n" +
                 "     cardinality=1\n" +
-                "     avgRowSize=3.0\n"));
+                "     avgRowSize=6.0\n"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Assume you have a query with a CASE WHEN where the WHENs likely do not match, e.g. like this:
```sql
SELECT
    CASE
        WHEN LIKE(`STRING`, "%pat1%") THEN `ID`
        WHEN LIKE(`STRING`, "%pat2%") THEN `ID2`
    END
FROM
    TABLE1
```
There is an implicit ELSE that returns NULL. The SR stats of such an expressions are the following:
```
* ID1-->[0.0, 9999999.0, 0.0, 8.0, 909299.0] ESTIMATE
* ID2-->[0.0, 9999999.0, 0.0, 8.0, 909299.0] ESTIMATE
* case-->[-Infinity, Infinity, 0.0, 8.0, 1832770.0] ESTIMATE
```
Note the 0.0 null fractions. Since it is hard to evaluate the predicates, in a first step it makes sense to assume equal probability of each WHEN and the ELSE branches to get an good approximation of null fractions instead of defaulting them to 0.0. Later we can also look at predicate probabilities and use these to weigh the branches.

## What I'm doing:
Instead of defaulting null fractions of CASE WHENs to 0.0, I am weighting all branches in the CASE WHEN equally and compute the average over all the null fractions and use this as stat output.
In our case, if we assume ID1 and ID2 have 0.0 null fractions, the CASE WHEN would propagate 0.33 null fractions since `(0.0 + 0.0 + 1.0) / 3`.
```
* ID1-->[0.0, 9999999.0, 0.0, 8.0, 909299.0] ESTIMATE
* ID2-->[0.0, 9999999.0, 0.0, 8.0, 909299.0] ESTIMATE
* case-->[-Infinity, Infinity, 0.3333333333333333, 8.0, 1818599.0] ESTIMATE
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

