### PR TITLE
[BugFix] Wait for journal replay in changeCatalogDb on follower FE  (backport #69917)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1407,8 +1407,32 @@ public class ConnectContext {
         }
 
         if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
-            LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);
-            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            // On a follower FE, the database may have been created on the leader but the
+            // corresponding journal entry has not been replayed locally yet. Wait for the
+            // local replayer to catch up to the latest committed journal before giving up.
+            // This avoids spurious "Unknown database" errors when DDL statements are issued
+            // immediately after CREATE DATABASE hits a different FE pod.
+            if (!globalStateMgr.isLeader()) {
+                try {
+                    // Fetch the leader's current max journal ID via a lightweight forward RPC.
+                    // Using the local journal.getMaxJournalId() is insufficient because BDBJE
+                    // replication itself may not have delivered the latest entries to the local
+                    // BDB database yet. The leader's value is authoritative and guaranteed to be
+                    // >= any journal ID written before this USE/COM_INIT_DB arrived.
+                    long leaderMaxJournalId = LeaderOpExecutor.fetchLeaderMaxJournalId(this);
+                    if (leaderMaxJournalId > 0) {
+                        int timeoutMs = (int) (getSessionVariable().getQueryTimeoutS() * 1000L);
+                        globalStateMgr.getJournalObservable().waitOn(leaderMaxJournalId, timeoutMs);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to wait for journal replay in changeCatalogDb, db={}: {}",
+                            dbName, e.getMessage());
+                }
+            }
+            if (metadataMgr.getDb(this, this.getCurrentCatalog(), dbName) == null) {
+                LOG.debug("Unknown catalog {} and db {}", this.getCurrentCatalog(), dbName);
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
         }
 
         // Here we check the request permission that sent by the mysql client or jdbc.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -265,6 +265,49 @@ public class LeaderOpExecutor {
         this.result = result;
     }
 
+    /**
+     * Makes a lightweight Thrift call to the leader FE to retrieve its current maximum
+     * journal ID. This is used by followers to determine what journal position they need
+     * to wait for before validating metadata that was recently written by the leader.
+     * <p>
+     * A minimal {@code SELECT 1} statement is forwarded; the leader always sets
+     * {@code maxJournalId} in the response regardless of whether the query succeeds.
+     *
+     * @return the leader's current max journal ID, or -1 if the value is unavailable
+     */
+    public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+        try {
+            Pair<String, Integer> leaderAddr =
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getLeaderIpAndRpcPort();
+            if (leaderAddr == null) {
+                return -1;
+            }
+            TNetworkAddress thriftAddr = new TNetworkAddress(leaderAddr.first, leaderAddr.second);
+
+            TMasterOpRequest params = new TMasterOpRequest();
+            params.setCluster(SystemInfoService.DEFAULT_CLUSTER);
+            params.setSql("SELECT 1");
+            params.setStmtIdx(0);
+            params.setUser(ctx.getQualifiedUser() != null ? ctx.getQualifiedUser() : "");
+            params.setCatalog(ctx.getCurrentCatalog());
+            params.setDb(ctx.getDatabase() != null ? ctx.getDatabase() : "");
+            params.setStmt_id(ctx.getStmtId());
+            params.setForward_times(1);
+            params.setConnectionId(ctx.getConnectionId());
+
+            int timeoutMs = ctx.getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
+            TMasterOpResult leaderResult = ThriftRPCRequestExecutor.call(
+                    ThriftConnectionPool.frontendPool,
+                    thriftAddr,
+                    timeoutMs,
+                    client -> client.forward(params));
+            return leaderResult != null && leaderResult.isSetMaxJournalId() ? leaderResult.maxJournalId : -1;
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch leader max journal id: {}", e.getMessage());
+            return -1;
+        }
+    }
+
     public TMasterOpRequest createTMasterOpRequest(ConnectContext ctx, int forwardTimes) {
         TMasterOpRequest params = new TMasterOpRequest();
         params.setCluster(SystemInfoService.DEFAULT_CLUSTER);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -35,13 +35,18 @@
 package com.starrocks.qe;
 
 import com.starrocks.analysis.TableName;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.ValuesRelation;
@@ -50,10 +55,13 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.warehouse.DefaultWarehouse;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.xnio.StreamConnection;
 
 import java.util.List;
@@ -373,5 +381,311 @@ public class ConnectContextTest {
         // set globalStateMgr explicitly
         connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         Assertions.assertNotNull(ConnectContext.get().getGlobalStateMgr());
+    }
+
+    @Test
+    public void testOnQueryFinished_withListeners() {
+        ConnectContext ctx = new ConnectContext(connection);
+
+        // Mock listener
+        ConnectContext.Listener listener1 = Mockito.mock(ConnectContext.Listener.class);
+        ConnectContext.Listener listener2 = Mockito.mock(ConnectContext.Listener.class);
+
+        ctx.registerListener(listener1);
+        ctx.registerListener(listener2);
+
+        // Execute
+        ctx.onQueryFinished();
+
+        // Verify all listeners are called
+        Mockito.verify(listener1).onQueryFinished(ctx);
+        Mockito.verify(listener2).onQueryFinished(ctx);
+    }
+
+    @Test
+    public void testOnQueryFinished_listenerThrowsException() {
+        ConnectContext ctx = new ConnectContext(connection);
+
+        ConnectContext.Listener listener1 = Mockito.mock(ConnectContext.Listener.class);
+        ConnectContext.Listener listener2 = Mockito.mock(ConnectContext.Listener.class);
+
+        Mockito.doThrow(new RuntimeException("listener error")).when(listener1).onQueryFinished(ctx);
+
+        ctx.registerListener(listener1);
+        ctx.registerListener(listener2);
+
+        // Should not throw exception, other listeners should still be called
+        ctx.onQueryFinished();
+
+        Mockito.verify(listener1).onQueryFinished(ctx);
+        Mockito.verify(listener2).onQueryFinished(ctx);
+    }
+
+    @Test
+    public void testOnQueryFinished_clearsListeners() {
+        ConnectContext ctx = new ConnectContext(connection);
+
+        ConnectContext.Listener listener = Mockito.mock(ConnectContext.Listener.class);
+        ctx.registerListener(listener);
+
+        // First call
+        ctx.onQueryFinished();
+        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
+
+        // Second call - listener should not be called again (cleared after first call)
+        ctx.onQueryFinished();
+        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
+    }
+
+    @Test
+    public void testOnQueryFinished_withoutListeners() {
+        ConnectContext ctx = new ConnectContext(connection);
+
+        // Should not throw exception when no listeners
+        Assertions.assertDoesNotThrow(() -> ctx.onQueryFinished());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for changeCatalogDb() journal-replay wait on follower FE
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testChangeCatalogDb_followerWaitsForJournalAndSucceeds(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        Database mockDb = new Database(1L, "testdb");
+
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                returns(null, mockDb);
+
+                journalObservable.waitOn(100L, anyInt);
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext ctx, String catalog, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertDoesNotThrow(() -> ctx.changeCatalogDb("testdb"));
+        Assertions.assertEquals("testdb", ctx.getDatabase());
+    }
+
+    @Test
+    public void testChangeCatalogDb_followerThrowsWhenDbStillMissingAfterWait(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                journalObservable.waitOn(100L, anyInt);
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("nonexistent"));
+    }
+
+    @Test
+    public void testChangeCatalogDb_followerSkipsWaitWhenLeaderJournalIdNegative(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return -1L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                journalObservable.waitOn(anyLong, anyInt);
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("missingdb"));
+    }
+
+    @Test
+    public void testChangeCatalogDb_followerSucceedsWithoutWaitWhenDbAppearsAfterFetchFails(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws Exception {
+        Database mockDb = new Database(2L, "latedb");
+
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return -1L;
+            }
+        };
+
+        new MockUp<Authorizer>() {
+            @Mock
+            public void checkAnyActionOnOrInDb(ConnectContext ctx, String catalog, String db)
+                    throws AccessDeniedException {
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                returns(null, mockDb);
+
+                journalObservable.waitOn(anyLong, anyInt);
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertDoesNotThrow(() -> ctx.changeCatalogDb("latedb"));
+        Assertions.assertEquals("latedb", ctx.getDatabase());
+    }
+
+    @Test
+    public void testChangeCatalogDb_leaderDoesNotWaitForJournal(
+            @Mocked MetadataMgr metadataMgr) {
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = true;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                globalStateMgr.getJournalObservable();
+                times = 0;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("somedb"));
+    }
+
+    @Test
+    public void testChangeCatalogDb_followerThrowsDbErrorAfterJournalWaitTimeout(
+            @Mocked MetadataMgr metadataMgr,
+            @Mocked JournalObservable journalObservable) throws DdlException {
+        new MockUp<LeaderOpExecutor>() {
+            @Mock
+            public static long fetchLeaderMaxJournalId(ConnectContext ctx) {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                globalStateMgr.isLeader();
+                result = false;
+                minTimes = 0;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                globalStateMgr.getJournalObservable();
+                result = journalObservable;
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, anyString, anyString);
+                result = null;
+
+                journalObservable.waitOn(100L, anyInt);
+                result = new DdlException("journal replay timeout");
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setGlobalStateMgr(globalStateMgr);
+
+        Assertions.assertThrows(DdlException.class, () -> ctx.changeCatalogDb("nonexistent"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -422,22 +422,6 @@ public class ConnectContextTest {
     }
 
     @Test
-    public void testOnQueryFinished_clearsListeners() {
-        ConnectContext ctx = new ConnectContext(connection);
-
-        ConnectContext.Listener listener = Mockito.mock(ConnectContext.Listener.class);
-        ctx.registerListener(listener);
-
-        // First call
-        ctx.onQueryFinished();
-        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
-
-        // Second call - listener should not be called again (cleared after first call)
-        ctx.onQueryFinished();
-        Mockito.verify(listener, Mockito.times(1)).onQueryFinished(ctx);
-    }
-
-    @Test
     public void testOnQueryFinished_withoutListeners() {
         ConnectContext ctx = new ConnectContext(connection);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
@@ -1,0 +1,161 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.analysis.RedirectStatus;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class LeaderOpExecutorMockTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static PseudoCluster cluster;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        Config.bdbje_heartbeat_timeout_second = 60;
+        Config.bdbje_replica_ack_timeout_second = 60;
+        Config.bdbje_lock_timeout_second = 60;
+        // set some parameters to speedup test
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
+        cluster = PseudoCluster.getInstance();
+
+        FeConstants.runningUnitTest = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("d1").useDatabase("d1")
+                .withTable(
+                        "CREATE TABLE d1.t1(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                .withTable(
+                        "CREATE TABLE d1.t2(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testTxnForward() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setTxn_id(1);
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftConnectionPoolMockedStatic =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftConnectionPoolMockedStatic.when(()
+                            -> ThriftRPCRequestExecutor.call(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            LeaderOpExecutor executor =
+                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false,
+                            null);
+            executor.execute();
+
+            Assertions.assertEquals(1, connectContext.getTxnId());
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_success() throws Exception {
+        TMasterOpResult result = new TMasterOpResult();
+        result.setMaxJournalId(200L);
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(result);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(200L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_leaderAddrNull() throws Exception {
+        try (MockedStatic<GlobalStateMgr> gsmMock = Mockito.mockStatic(GlobalStateMgr.class)) {
+            GlobalStateMgr mockGsm = Mockito.mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = Mockito.mock(NodeMgr.class);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            Mockito.when(mockGsm.getNodeMgr()).thenReturn(mockNodeMgr);
+            Mockito.when(mockNodeMgr.getLeaderIpAndRpcPort()).thenReturn(null);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_resultWithoutMaxJournalId() throws Exception {
+        TMasterOpResult result = new TMasterOpResult();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(result);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_rpcException() throws Exception {
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenThrow(new RuntimeException("RPC failed"));
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+
+    @Test
+    public void testFetchLeaderMaxJournalId_nullResult() throws Exception {
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(null);
+
+            long journalId = LeaderOpExecutor.fetchLeaderMaxJournalId(connectContext);
+            Assertions.assertEquals(-1L, journalId);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -270,7 +270,7 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 FROM TB1 CROSS JOIN TB2;
                 """;
         String plan = getVerboseExplain(sql);
-        String expected = "  12:Project\n" +
+        String expected = "  10:Project\n" +
                 "  |  output columns:\n" +
                 "  |  5 <-> named_struct[('col1', DictDecode(11: VARCHAR_COL, [<place-holder>], 13: " +
                 "row.col1[true])); args: VARCHAR,VARCHAR; result: struct<col1 " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -670,9 +670,9 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
         // tbl_mock_015
         Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 4, probe_expr = (<slot 79> 79: mock_004)"), plan);
+                "     - filter_id = 4, probe_expr = (<slot 81> 81: mock_004)"), plan);
         Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 3, probe_expr = (<slot 62> 62: mock_004)"), plan);
+                "     - filter_id = 3, probe_expr = (<slot 64> 64: mock_004)"), plan);
     }
 
     @Test


### PR DESCRIPTION
## What I'm doing:

Backport of https://github.com/StarRocks/starrocks/pull/69917

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

