### PR TITLE
[BugFix] Fix potential hash table data loss in aggregation spill set_finishing

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -280,8 +280,7 @@ Status SpillableAggregateBlockingSinkOperator::_spill_all_data(RuntimeState* sta
 
 std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_build_spill_task(
         RuntimeState* state, bool should_spill_hash_table) {
-    return [this, state, should_spill_hash_table,
-            iterator_initialized = false]() mutable -> StatusOr<ChunkPtr> {
+    return [this, state, should_spill_hash_table, iterator_initialized = false]() mutable -> StatusOr<ChunkPtr> {
         if (!_streaming_chunks.empty()) {
             auto chunk = _streaming_chunks.front();
             _streaming_chunks.pop();

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -68,12 +68,10 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
         RETURN_IF_ERROR(AggregateBlockingSinkOperator::set_finishing(state));
         return Status::OK();
     }
-    if (!_aggregator->spill_channel()->has_task()) {
-        if (_aggregator->hash_map_variant().size() > 0 || !_streaming_chunks.empty()) {
-            _aggregator->it_hash() = _aggregator->state_allocator().begin();
-            _aggregator->spill_channel()->add_spill_task(_build_spill_task(state));
-        }
-    }
+    // Always queue a spill task for residual hash table and streaming data.
+    // Even if channel has_task(), the in-flight task may have been created with
+    // should_spill_hash_table=false and won't drain the hash table.
+    _aggregator->spill_channel()->add_spill_task(_build_spill_task(state));
 
     auto flush_function = [this](RuntimeState* state) {
         auto& spiller = _aggregator->spiller();
@@ -275,9 +273,6 @@ Status SpillableAggregateBlockingSinkOperator::_try_to_spill_by_auto(RuntimeStat
 
 Status SpillableAggregateBlockingSinkOperator::_spill_all_data(RuntimeState* state, bool should_spill_hash_table) {
     RETURN_IF(_aggregator->hash_map_variant().size() == 0, Status::OK());
-    if (should_spill_hash_table) {
-        _aggregator->it_hash() = _aggregator->state_allocator().begin();
-    }
     CHECK(!_aggregator->spill_channel()->has_task());
     RETURN_IF_ERROR(_aggregator->spill_aggregate_data(state, _build_spill_task(state, should_spill_hash_table)));
     return Status::OK();
@@ -285,13 +280,18 @@ Status SpillableAggregateBlockingSinkOperator::_spill_all_data(RuntimeState* sta
 
 std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_build_spill_task(
         RuntimeState* state, bool should_spill_hash_table) {
-    return [this, state, should_spill_hash_table]() -> StatusOr<ChunkPtr> {
+    return [this, state, should_spill_hash_table,
+            iterator_initialized = false]() mutable -> StatusOr<ChunkPtr> {
         if (!_streaming_chunks.empty()) {
             auto chunk = _streaming_chunks.front();
             _streaming_chunks.pop();
             return chunk;
         }
-        if (should_spill_hash_table) {
+        if (should_spill_hash_table && _aggregator->hash_map_variant().size() > 0) {
+            if (!iterator_initialized) {
+                _aggregator->it_hash() = _aggregator->state_allocator().begin();
+                iterator_initialized = true;
+            }
             if (!_aggregator->is_ht_eos()) {
                 auto chunk = std::make_shared<Chunk>();
                 RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk, true));

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -314,7 +314,7 @@ std::function<StatusOr<ChunkPtr>()> SpillablePartitionWiseAggregateSinkOperator:
         _streaming_bytes = 0;
         return Status::EndOfFile("no more data in current aggregator");
     };
-    return [this, chunk_provider]() -> StatusOr<ChunkPtr> {
+    return [this, chunk_provider]() mutable -> StatusOr<ChunkPtr> {
         auto maybe_chunk = chunk_provider();
         if (maybe_chunk.ok()) {
             auto chunk = std::move(maybe_chunk.value());

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -49,12 +49,10 @@ Status SpillablePartitionWiseAggregateSinkOperator::set_finishing(RuntimeState* 
         RETURN_IF_ERROR(_agg_op->set_finishing(state));
         return Status::OK();
     }
-    if (!_agg_op->aggregator()->spill_channel()->has_task()) {
-        if (_agg_op->aggregator()->hash_map_variant().size() > 0 || !_streaming_chunks.empty()) {
-            _agg_op->aggregator()->it_hash() = _agg_op->aggregator()->state_allocator().begin();
-            _agg_op->aggregator()->spill_channel()->add_spill_task(_build_spill_task(state));
-        }
-    }
+    // Always queue a spill task for residual hash table and streaming data.
+    // Even if channel has_task(), the in-flight task may have been created with
+    // should_spill_hash_table=false and won't drain the hash table.
+    _agg_op->aggregator()->spill_channel()->add_spill_task(_build_spill_task(state));
 
     auto flush_function = [this](RuntimeState* state) {
         auto& spiller = _agg_op->aggregator()->spiller();
@@ -281,9 +279,6 @@ ChunkPtr& SpillablePartitionWiseAggregateSinkOperator::_append_hash_column(Chunk
 
 Status SpillablePartitionWiseAggregateSinkOperator::_spill_all_data(RuntimeState* state, bool should_spill_hash_table) {
     RETURN_IF(_agg_op->aggregator()->hash_map_variant().size() == 0, Status::OK());
-    if (should_spill_hash_table) {
-        _agg_op->aggregator()->it_hash() = _agg_op->aggregator()->state_allocator().begin();
-    }
     CHECK(!_agg_op->aggregator()->spill_channel()->has_task());
     RETURN_IF_ERROR(
             _agg_op->aggregator()->spill_aggregate_data(state, _build_spill_task(state, should_spill_hash_table)));
@@ -292,13 +287,18 @@ Status SpillablePartitionWiseAggregateSinkOperator::_spill_all_data(RuntimeState
 
 std::function<StatusOr<ChunkPtr>()> SpillablePartitionWiseAggregateSinkOperator::_build_spill_task(
         RuntimeState* state, bool should_spill_hash_table) {
-    auto chunk_provider = [this, state, should_spill_hash_table]() -> StatusOr<ChunkPtr> {
+    auto chunk_provider = [this, state, should_spill_hash_table,
+                           iterator_initialized = false]() mutable -> StatusOr<ChunkPtr> {
         if (!_streaming_chunks.empty()) {
             auto chunk = _streaming_chunks.front();
             _streaming_chunks.pop();
             return chunk;
         }
-        if (should_spill_hash_table) {
+        if (should_spill_hash_table && _agg_op->aggregator()->hash_map_variant().size() > 0) {
+            if (!iterator_initialized) {
+                _agg_op->aggregator()->it_hash() = _agg_op->aggregator()->state_allocator().begin();
+                iterator_initialized = true;
+            }
             if (!_agg_op->aggregator()->is_ht_eos()) {
                 auto chunk = std::make_shared<Chunk>();
                 RETURN_IF_ERROR(_agg_op->aggregator()->convert_hash_map_to_chunk(state->chunk_size(), &chunk, true));


### PR DESCRIPTION
## Why I'm doing:

In `SpillableAggregateBlockingSinkOperator::set_finishing`, hash table won't be spilled if `has_task()` is true. But the existing task in the channel may have been created with `should_spill_hash_table=false`, and the data in hash table will be ignored.

## What I'm doing:

Always spill hash table in set_finishing

Fixes #issue


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
