### PR TITLE
[BugFix] Use explicit cast in skew rules for MCVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -185,6 +185,11 @@ public class SkewJoinOptimizeRule extends TransformationRule {
                             .filter(Optional::isPresent) //
                             .map(Optional::get) //
                             .collect(Collectors.toList());
+
+                    if (skewValues.isEmpty()) {
+                        // If all explicit casts failed.
+                        continue;
+                    }
                 } else {
                     throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -66,6 +66,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /***
@@ -179,7 +180,10 @@ public class SkewJoinOptimizeRule extends TransformationRule {
                     // Use MCV-based skew values
                     skewValues = skewInfo.maybeMcvs().get()
                             .stream() //
-                            .map(pair -> ConstantOperator.createVarchar(pair.first)) //
+                            .map(mcv -> ConstantOperator.createVarchar(mcv.first) //
+                                    .castTo(skewJoinColumn.getType())) //
+                            .filter(Optional::isPresent) //
+                            .map(Optional::get) //
                             .collect(Collectors.toList());
                 } else {
                     throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
@@ -374,8 +374,12 @@ public class SplitWindowSkewToUnionRule extends TransformationRule {
                     return List.of(new SkewedInfo(col, ConstantOperator.createNull(col.getType())));
                 }
 
-                return skewInfo.maybeMcvs().stream().flatMap(Collection::stream).map(p -> (new SkewedInfo(col,
-                        ConstantOperator.createVarchar(p.first)))).toList();
+                return skewInfo.maybeMcvs().stream() //
+                        .flatMap(Collection::stream) //
+                        .map(mcv -> ConstantOperator.createVarchar(mcv.first).castTo(col.getType())) //
+                        .filter(Optional::isPresent) //
+                        .map(value -> new SkewedInfo(col, value.get())) //
+                        .toList();
             }
         }
         return Collections.emptyList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -418,7 +418,7 @@ public class SkewJoinTest extends PlanTestBase {
             assertCContains(plan, "IS NULL THEN");
 
             // In this case, the MCV should be selected since:
-            //  - 0.3 null fractions * 1337 rows < 400 rows (11) + 300 rows (22)
+            //  - 0.3 null fractions * 1337 rows < 400 rows (11) + 200 rows (22)
             assertCContains(plan, """
                       5:Project
                       |  <slot 9> : [11,22]

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -391,7 +391,7 @@ public class SkewJoinTest extends PlanTestBase {
                     if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1")) {
                         return ColumnStatistic.builder() //
                                 .setNullsFraction(0.3) // NULL skew
-                                .setHistogram(new Histogram(List.of(), Map.of("a", 400L, "b", 200L))) // MCV skew
+                                .setHistogram(new Histogram(List.of(), Map.of("11", 400L, "22", 200L))) // MCV skew
                                 .build();
                     }
 
@@ -418,10 +418,10 @@ public class SkewJoinTest extends PlanTestBase {
             assertCContains(plan, "IS NULL THEN");
 
             // In this case, the MCV should be selected since:
-            //  - 0.3 null fractions * 1337 rows < 400 rows (a) + 300 rows (b)
+            //  - 0.3 null fractions * 1337 rows < 400 rows (11) + 300 rows (22)
             assertCContains(plan, """
                       5:Project
-                      |  <slot 9> : ['a','b']
+                      |  <slot 9> : [11,22]
                     """);
         } finally {
             // Restore threshold

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -215,7 +215,7 @@ class WindowSkewTest extends PlanTestBase {
         assertContains(plan, "UNION");
         assertContains(plan, "Predicates: [1: p, INT, true] = 1");
         // Ensure that unskewed partition preserves NULLs
-        assertContains(plan, "Predicates: ([5: p, INT, true] != 1) OR ([5: p, INT, true] IS NULL)\n");
+        assertContains(plan, "Predicates: ([5: p, INT, true] != 1) OR ([5: p, INT, true] IS NULL)");
 
         assertContains(plan,
                 "ANALYTIC\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -215,7 +215,7 @@ class WindowSkewTest extends PlanTestBase {
         assertContains(plan, "UNION");
         assertContains(plan, "Predicates: [1: p, INT, true] = 1");
         // Ensure that unskewed partition preserves NULLs
-        assertContains(plan, "Predicates: (5: p != 1) OR (5: p IS NULL)");
+        assertContains(plan, "Predicates: ([5: p, INT, true] != 1) OR ([5: p, INT, true] IS NULL)\n");
 
         assertContains(plan,
                 "ANALYTIC\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -77,6 +77,7 @@ class WindowSkewTest extends PlanTestBase {
             StatisticsMetaManager m = new StatisticsMetaManager();
             m.createStatisticsTablesForTest();
         }
+
     }
 
     @BeforeEach
@@ -214,8 +215,7 @@ class WindowSkewTest extends PlanTestBase {
         assertContains(plan, "UNION");
         assertContains(plan, "Predicates: [1: p, INT, true] = 1");
         // Ensure that unskewed partition preserves NULLs
-        assertContains(plan, "Predicates: (cast([5: p, INT, true] as VARCHAR(1048576)) != '1') " +
-                "OR ([5: p, INT, true] IS NULL)");
+        assertContains(plan, "Predicates: (5: p != 1) OR (5: p IS NULL)");
 
         assertContains(plan,
                 "ANALYTIC\n" +


### PR DESCRIPTION
## Why I'm doing:

In the skew rules when we have MCVs that show skew, we always use `ConstantOperator.createVarchar(mcvValue)` to create `ScalarOperators` from the skew values. Note that the skew columns could also be e.g. an INT column (so no VARCHAR). This usually works since the planner will add an implicit cast from the VARCHAR to the actual column type at some point in the planning, **but** before adding the implicit cast, other rules may be applied (such as branch elimination for the window skew rewrite) which can undo the skew optimization again. 

## What I'm doing:
This PR adds an explicit cast when using the MCVs for the skew values instead of relying on the implicit cast.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
