### PR TITLE
[BugFix] Fix int32 truncation in ACCUMULATED macro causing metric overflow

### DIFF
--- a/be/src/exec/pipeline/pipeline_metrics.cpp
+++ b/be/src/exec/pipeline/pipeline_metrics.cpp
@@ -85,10 +85,11 @@ void ScanExecutorMetrics::register_all_metrics(MetricRegistry* registry, const s
     registry->register_metric(base_name + "pending_tasks", &pending_tasks);
 }
 
-#define ACCUMULATED(array, field)                                                                                     \
-    [this]() {                                                                                                        \
-        std::lock_guard guard(_mutex);                                                                                \
-        return std::accumulate(array.begin(), array.end(), 0, [](int64_t a, const auto& b) { return a + b->field; }); \
+#define ACCUMULATED(array, field)                                                      \
+    [this]() {                                                                         \
+        std::lock_guard guard(_mutex);                                                 \
+        return std::accumulate(array.begin(), array.end(), (int64_t)0,                 \
+                               [](int64_t a, const auto& b) { return a + b->field; }); \
     }
 
 #define REGISTER_POOLS_METRICS(name, threadpool)                                                                     \


### PR DESCRIPTION
The ACCUMULATED macro in pipeline_metrics.cpp uses std::accumulate with init value 0 (int), causing the accumulator to be 32-bit. When accumulated nanosecond values exceed INT_MAX (~2.1s), the result overflows and wraps to a negative int, which then sign-extends to near-max uint64 in the UIntGauge. Fix by using (int64_t)0 as the init value.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
