### PR TITLE
[BugFix] Clear inherited garbage metadata for split and identical tablets in shared-data mode

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -263,6 +263,9 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
     new_tablet_new_metadata->set_version(new_version);
     new_tablet_new_metadata->set_commit_time(txn_info.commit_time());
     new_tablet_new_metadata->set_gtid(txn_info.gtid());
+    new_tablet_new_metadata->clear_compaction_inputs();
+    new_tablet_new_metadata->clear_orphan_files();
+    new_tablet_new_metadata->clear_prev_garbage_version();
     new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(new_tablet_new_metadata));
     return Status::OK();
 }

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -389,6 +389,9 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         new_tablet_metadata->set_version(new_version);
         new_tablet_metadata->set_commit_time(txn_info.commit_time());
         new_tablet_metadata->set_gtid(txn_info.gtid());
+        new_tablet_metadata->clear_compaction_inputs();
+        new_tablet_metadata->clear_orphan_files();
+        new_tablet_metadata->clear_prev_garbage_version();
         new_metadatas.emplace(new_tablet_metadata->id(), std::move(new_tablet_metadata));
         return new_metadatas;
     }
@@ -400,6 +403,9 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         new_tablet_new_metadata->set_version(new_version);
         new_tablet_new_metadata->set_commit_time(txn_info.commit_time());
         new_tablet_new_metadata->set_gtid(txn_info.gtid());
+        new_tablet_new_metadata->clear_compaction_inputs();
+        new_tablet_new_metadata->clear_orphan_files();
+        new_tablet_new_metadata->clear_prev_garbage_version();
         new_tablet_new_metadata->mutable_range()->CopyFrom(split_ranges[i].range);
         tablet_reshard_helper::set_all_data_files_shared(new_tablet_new_metadata.get());
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1032,6 +1032,61 @@ TEST_F(LakeServiceTest, test_publish_splitting_tablet) {
     }
 }
 
+TEST_F(LakeServiceTest, test_publish_splitting_tablet_clears_inherited_garbage) {
+    auto txn_log = generate_write_txn_log(2, 100, 100);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    PublishVersionRequest publish_request;
+    publish_request.set_base_version(1);
+    publish_request.set_new_version(2);
+    publish_request.add_tablet_ids(_tablet_id);
+    publish_request.add_txn_ids(txn_log.txn_id());
+
+    PublishVersionResponse response;
+    _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+    ASSERT_EQ(0, response.status().status_code());
+
+    ASSIGN_OR_ABORT(auto base_metadata, _tablet_mgr->get_tablet_metadata(_tablet_id, 2));
+    ASSERT_GT(base_metadata->rowsets_size(), 0);
+    auto dirty_metadata = std::make_shared<TabletMetadataPB>(*base_metadata);
+    dirty_metadata->add_compaction_inputs()->CopyFrom(base_metadata->rowsets(0));
+    auto* orphan_file = dirty_metadata->add_orphan_files();
+    orphan_file->set_name("split_orphan.dat");
+    orphan_file->set_size(1);
+    dirty_metadata->set_prev_garbage_version(1);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(dirty_metadata));
+
+    ReshardingTabletInfoPB resharding_tablet_info;
+    auto* splitting_tablet_info = resharding_tablet_info.mutable_splitting_tablet_info();
+    splitting_tablet_info->set_old_tablet_id(_tablet_id);
+    std::vector<int64_t> new_tablet_ids{next_id(), next_id()};
+    for (auto new_tablet_id : new_tablet_ids) {
+        splitting_tablet_info->add_new_tablet_ids(new_tablet_id);
+    }
+
+    PublishVersionRequest reshard_request;
+    reshard_request.set_base_version(2);
+    reshard_request.set_new_version(3);
+    auto* txn_info = reshard_request.add_txn_infos();
+    txn_info->set_txn_id(next_id());
+    txn_info->set_txn_type(TXN_TABLET_RESHARD);
+    txn_info->set_combined_txn_log(false);
+    txn_info->set_commit_time(12345);
+    txn_info->set_force_publish(false);
+    reshard_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+    PublishVersionResponse reshard_response;
+    _lake_service.publish_version(nullptr, &reshard_request, &reshard_response, nullptr);
+    ASSERT_EQ(0, reshard_response.status().status_code());
+
+    for (auto new_tablet_id : new_tablet_ids) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(new_tablet_id, 3));
+        EXPECT_EQ(0, metadata->compaction_inputs_size());
+        EXPECT_EQ(0, metadata->orphan_files_size());
+        EXPECT_FALSE(metadata->has_prev_garbage_version());
+    }
+}
+
 TEST_F(LakeServiceTest, test_splitting_tablet_split_count_three_with_tail_stats) {
     auto txn_log = generate_write_txn_log_with_segments({0, 100, 200, 300}, {100, 200, 300, 400}, {34, 34, 34, 1},
                                                         {100, 100, 100, 10});
@@ -1244,6 +1299,16 @@ TEST_F(LakeServiceTest, test_splitting_tablet_split_count_too_large_fallback) {
     _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
     ASSERT_EQ(0, response.status().status_code());
 
+    ASSIGN_OR_ABORT(auto base_metadata, _tablet_mgr->get_tablet_metadata(_tablet_id, 2));
+    ASSERT_GT(base_metadata->rowsets_size(), 0);
+    auto dirty_metadata = std::make_shared<TabletMetadataPB>(*base_metadata);
+    dirty_metadata->add_compaction_inputs()->CopyFrom(base_metadata->rowsets(0));
+    auto* orphan_file = dirty_metadata->add_orphan_files();
+    orphan_file->set_name("split_fallback_orphan.dat");
+    orphan_file->set_size(1);
+    dirty_metadata->set_prev_garbage_version(1);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(dirty_metadata));
+
     ReshardingTabletInfoPB resharding_tablet_info;
     auto* splitting_tablet_info = resharding_tablet_info.mutable_splitting_tablet_info();
     splitting_tablet_info->set_old_tablet_id(_tablet_id);
@@ -1270,6 +1335,9 @@ TEST_F(LakeServiceTest, test_splitting_tablet_split_count_too_large_fallback) {
 
     ASSIGN_OR_ABORT(auto metadata_first, _tablet_mgr->get_tablet_metadata(new_tablet_ids.front(), 3));
     EXPECT_EQ(new_tablet_ids.front(), metadata_first->id());
+    EXPECT_EQ(0, metadata_first->compaction_inputs_size());
+    EXPECT_EQ(0, metadata_first->orphan_files_size());
+    EXPECT_FALSE(metadata_first->has_prev_garbage_version());
     auto metadata_second = _tablet_mgr->get_tablet_metadata(new_tablet_ids[1], 3);
     EXPECT_TRUE(metadata_second.status().is_not_found());
     auto metadata_third = _tablet_mgr->get_tablet_metadata(new_tablet_ids[2], 3);
@@ -1669,6 +1737,57 @@ TEST_F(LakeServiceTest, test_publish_identical_tablet) {
             ASSERT_EQ(0, response.tablet_ranges_size());
         }
     }
+}
+
+TEST_F(LakeServiceTest, test_publish_identical_tablet_clears_inherited_garbage) {
+    auto txn_log = generate_write_txn_log(1, 100, 100);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    PublishVersionRequest publish_request;
+    publish_request.set_base_version(1);
+    publish_request.set_new_version(2);
+    publish_request.add_tablet_ids(_tablet_id);
+    publish_request.add_txn_ids(txn_log.txn_id());
+
+    PublishVersionResponse response;
+    _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+    ASSERT_EQ(0, response.status().status_code());
+
+    ASSIGN_OR_ABORT(auto base_metadata, _tablet_mgr->get_tablet_metadata(_tablet_id, 2));
+    ASSERT_GT(base_metadata->rowsets_size(), 0);
+    auto dirty_metadata = std::make_shared<TabletMetadataPB>(*base_metadata);
+    dirty_metadata->add_compaction_inputs()->CopyFrom(base_metadata->rowsets(0));
+    auto* orphan_file = dirty_metadata->add_orphan_files();
+    orphan_file->set_name("identical_orphan.dat");
+    orphan_file->set_size(1);
+    dirty_metadata->set_prev_garbage_version(1);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(dirty_metadata));
+
+    ReshardingTabletInfoPB resharding_tablet_info;
+    auto* identical_tablet_info = resharding_tablet_info.mutable_identical_tablet_info();
+    identical_tablet_info->set_old_tablet_id(_tablet_id);
+    const int64_t new_tablet_id = next_id();
+    identical_tablet_info->set_new_tablet_id(new_tablet_id);
+
+    PublishVersionRequest reshard_request;
+    reshard_request.set_base_version(2);
+    reshard_request.set_new_version(3);
+    auto* txn_info = reshard_request.add_txn_infos();
+    txn_info->set_txn_id(next_id());
+    txn_info->set_txn_type(TXN_TABLET_RESHARD);
+    txn_info->set_combined_txn_log(false);
+    txn_info->set_commit_time(12345);
+    txn_info->set_force_publish(false);
+    reshard_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+    PublishVersionResponse reshard_response;
+    _lake_service.publish_version(nullptr, &reshard_request, &reshard_response, nullptr);
+    ASSERT_EQ(0, reshard_response.status().status_code());
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(new_tablet_id, 3));
+    EXPECT_EQ(0, metadata->compaction_inputs_size());
+    EXPECT_EQ(0, metadata->orphan_files_size());
+    EXPECT_FALSE(metadata->has_prev_garbage_version());
 }
 
 TEST_F(LakeServiceTest, test_abort) {


### PR DESCRIPTION
## Why I'm doing:

  In shared-data mode, range distribution table resharding may clone tablet metadata from the source tablet when publishing split tablets or identical tablets.

  The cloned metadata could retain stale garbage-collection fields:
  - `compaction_inputs`
  - `orphan_files`
  - `prev_garbage_version`

  These fields belong to the source tablet's garbage state and should not be inherited by newly created tablets. Keeping them may make the new tablet carry incorrect GC history.

## What I'm doing:

  This PR clears inherited garbage metadata when building new tablet metadata for:
  - split tablets
  - split fallback path
  - identical tablets

  Specifically, the new tablet metadata now clears:
  - `compaction_inputs`
  - `orphan_files`
  - `prev_garbage_version`


Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
