### PR TITLE
[Enhancement] Add tablet_reshard_enable_tablet_merge config to disable MergeTabletJob creation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -83,6 +83,10 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
 
     public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
             throws StarRocksException {
+        if (!Config.tablet_reshard_enable_tablet_merge) {
+            throw new StarRocksException("Tablet merge is disabled. " +
+                    "Set tablet_reshard_enable_tablet_merge=true to enable it.");
+        }
         TabletReshardJob job = new MergeTabletJobFactory(db, table, mergeTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4336,6 +4336,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "The max number of new tablets that an old tablet can be split into.")
     public static int tablet_reshard_max_split_count = 1024;
 
+    @ConfField(mutable = true, comment = "Whether to enable tablet merge in tablet reshard. " +
+            "Only takes effect for tables in clusters with run_mode=shared_data.")
+    public static boolean tablet_reshard_enable_tablet_merge = false;
+
     /**
      * Whether to enable tracing historical nodes when cluster scale
      */


### PR DESCRIPTION
## Why I'm doing:

  The tablet merge implementation for range distribution tables in shared-data mode currently has known issues. A config switch is needed to disable MergeTabletJob creation until the merge functionality is fixed and stabilized.

## What I'm doing:

  Add a new mutable FE config `tablet_reshard_enable_tablet_merge` (default `false`). When disabled, a `StarRocksException` is thrown at the entry point of `TabletReshardJobMgr.createTabletReshardJob(db, table, MergeTabletClause)`, which is the single convergence point
   of both merge creation paths:

  - **Automatic path** (`TabletStatMgr.triggerTabletReshard`): the exception is caught by the existing try-catch and logged as a warning, without affecting other logic.
  - **Manual path** (`ALTER TABLE ... MERGE TABLET`): the exception is propagated back to the user as an error message.

  Once the merge functionality is fixed and stabilized, the default value will be changed to `true` or the config will be removed.


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
