### PR TITLE
[Enhancement] Add vector_index storage type in SegmentFooter

### DIFF
--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -201,6 +201,11 @@ message ColumnMetaPB {
     optional int32 compression_level = 34;
 }
 
+enum VectorIndexStorageTypePB {
+    VECTOR_INDEX_STORAGE_NONE = 0;          // no vector index generated
+    VECTOR_INDEX_STORAGE_STANDALONE = 1;    // standalone .vi file
+}
+
 message SegmentFooterPB {
     optional uint32 version = 1 [default = 1]; // file version
     repeated ColumnMetaPB columns = 2;         // tablet schema
@@ -214,6 +219,8 @@ message SegmentFooterPB {
 
     // Short key index's page
     optional PagePointerPB short_key_index_page = 9;
+    // vector index storage type
+    optional VectorIndexStorageTypePB vector_index_storage_type = 10;
 }
 
 message BTreeMetaPB {


### PR DESCRIPTION
## Why I'm doing:
Add vector_index storage type in SegmentFooter for compatibility with celerdata(https://github.com/CelerData/celerdata-enterprise/pull/51685).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
