### PR TITLE
[Enhancement] Stop leader task safely part1: Add leader demotion lease, journal seal, and failure-visible edit log APIs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
@@ -25,8 +25,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class JournalTask implements Future<Boolean> {
+    public enum TaskKind {
+        APPEND,
+        BARRIER
+    }
+
     // serialized JournalEntity
     private final DataOutputBuffer buffer;
+    private final TaskKind taskKind;
     // write result
     private Boolean isSucceed = null;
     // count down latch, the producer which called logEdit() will wait on it.
@@ -36,10 +42,17 @@ public class JournalTask implements Future<Boolean> {
     // JournalWrite will commit immediately if received a log with betterCommitBeforeTime > now
     protected long betterCommitBeforeTimeInNano;
     private final long startTimeNano;
+    private volatile JournalWriter.DrainResult.Status drainStatus;
+    private volatile long committedJournalId = -1L;
 
     public JournalTask(long startTimeNano, DataOutputBuffer buffer, long maxWaitIntervalMs) {
+        this(startTimeNano, buffer, maxWaitIntervalMs, TaskKind.APPEND);
+    }
+
+    private JournalTask(long startTimeNano, DataOutputBuffer buffer, long maxWaitIntervalMs, TaskKind taskKind) {
         this.startTimeNano = startTimeNano;
         this.buffer = buffer;
+        this.taskKind = taskKind;
         this.latch = new CountDownLatch(1);
         if (maxWaitIntervalMs > 0) {
             this.betterCommitBeforeTimeInNano = System.nanoTime() + maxWaitIntervalMs * 1000000;
@@ -48,8 +61,20 @@ public class JournalTask implements Future<Boolean> {
         }
     }
 
+    public static JournalTask createBarrierTask() {
+        return new JournalTask(System.nanoTime(), null, -1, TaskKind.BARRIER);
+    }
+
     public long getStartTimeNano() {
         return startTimeNano;
+    }
+
+    public TaskKind getTaskKind() {
+        return taskKind;
+    }
+
+    public boolean isBarrierTask() {
+        return taskKind == TaskKind.BARRIER;
     }
 
     public void markSucceed() {
@@ -67,17 +92,40 @@ public class JournalTask implements Future<Boolean> {
         latch.countDown();
     }
 
+    public void markBarrierReached(long committedJournalId) {
+        this.committedJournalId = committedJournalId;
+        this.drainStatus = JournalWriter.DrainResult.Status.BARRIER_REACHED;
+        markSucceed();
+    }
+
+    public void markBarrierFailed(JournalWriter.DrainResult.Status drainStatus, long committedJournalId, Exception e) {
+        this.committedJournalId = committedJournalId;
+        this.drainStatus = drainStatus;
+        markAbort(e);
+    }
+
     public long getBetterCommitBeforeTimeInNano() {
         return betterCommitBeforeTimeInNano;
     }
 
     public long estimatedSizeByte() {
+        if (buffer == null) {
+            return 0L;
+        }
         // journal id + buffer
         return Long.SIZE / 8 + (long) buffer.getLength();
     }
 
     public DataOutputBuffer getBuffer() {
         return buffer;
+    }
+
+    public JournalWriter.DrainResult.Status getDrainStatus() {
+        return drainStatus;
+    }
+
+    public long getCommittedJournalId() {
+        return committedJournalId;
     }
 
     @Override
@@ -98,7 +146,7 @@ public class JournalTask implements Future<Boolean> {
     public Boolean get(long timeout, @NotNull TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         if (!latch.await(timeout, unit)) {
-            return false;
+            throw new TimeoutException("journal task wait timed out");
         }
         if (executeException != null) {
             throw new ExecutionException(executeException);

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
@@ -25,14 +25,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class JournalTask implements Future<Boolean> {
-    public enum TaskKind {
+    public enum TaskType {
+        // A normal edit log append that consumes a real journal id and writes data to the journal.
         APPEND,
+        // An internal in-memory barrier used to seal the writer and observe the last committed
+        // journal watermark. It does not write a journal entry or consume a journal id.
         BARRIER
     }
 
     // serialized JournalEntity
     private final DataOutputBuffer buffer;
-    private final TaskKind taskKind;
+    private final TaskType taskType;
     // write result
     private Boolean isSucceed = null;
     // count down latch, the producer which called logEdit() will wait on it.
@@ -46,13 +49,13 @@ public class JournalTask implements Future<Boolean> {
     private volatile long committedJournalId = -1L;
 
     public JournalTask(long startTimeNano, DataOutputBuffer buffer, long maxWaitIntervalMs) {
-        this(startTimeNano, buffer, maxWaitIntervalMs, TaskKind.APPEND);
+        this(startTimeNano, buffer, maxWaitIntervalMs, TaskType.APPEND);
     }
 
-    private JournalTask(long startTimeNano, DataOutputBuffer buffer, long maxWaitIntervalMs, TaskKind taskKind) {
+    private JournalTask(long startTimeNano, DataOutputBuffer buffer, long maxWaitIntervalMs, TaskType taskType) {
         this.startTimeNano = startTimeNano;
         this.buffer = buffer;
-        this.taskKind = taskKind;
+        this.taskType = taskType;
         this.latch = new CountDownLatch(1);
         if (maxWaitIntervalMs > 0) {
             this.betterCommitBeforeTimeInNano = System.nanoTime() + maxWaitIntervalMs * 1000000;
@@ -62,19 +65,19 @@ public class JournalTask implements Future<Boolean> {
     }
 
     public static JournalTask createBarrierTask() {
-        return new JournalTask(System.nanoTime(), null, -1, TaskKind.BARRIER);
+        return new JournalTask(System.nanoTime(), null, -1, TaskType.BARRIER);
     }
 
     public long getStartTimeNano() {
         return startTimeNano;
     }
 
-    public TaskKind getTaskKind() {
-        return taskKind;
+    public TaskType getTaskType() {
+        return taskType;
     }
 
     public boolean isBarrierTask() {
-        return taskKind == TaskKind.BARRIER;
+        return taskType == TaskType.BARRIER;
     }
 
     public void markSucceed() {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriteException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriteException.java
@@ -16,9 +16,14 @@ package com.starrocks.journal;
 
 public class JournalWriteException extends Exception {
     public enum Reason {
+        // The caller tried to submit leader-only journal work on a node that is not leader.
         NOT_LEADER,
+        // Local leader demotion has started, so new leader-only journal work must be rejected
+        // even if the FE type has not fully switched yet.
         ADMISSION_CLOSED,
+        // The task was accepted before, but the writer aborted it while sealing or closing.
         WRITER_ABORTED,
+        // Waiting for a journal task exceeded the caller-provided timeout.
         TIMEOUT
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriteException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriteException.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.journal;
+
+public class JournalWriteException extends Exception {
+    public enum Reason {
+        NOT_LEADER,
+        ADMISSION_CLOSED,
+        WRITER_ABORTED,
+        TIMEOUT
+    }
+
+    private final Reason reason;
+
+    public JournalWriteException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    public JournalWriteException(Reason reason, String message, Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -25,6 +25,10 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An independent thread to write journals by batch asynchronously.
@@ -33,6 +37,36 @@ import java.util.concurrent.BlockingQueue;
  * After committing, JournalWriter will notify the caller thread for consistency.
  */
 public class JournalWriter {
+    private enum WriterState {
+        RUNNING,
+        SEALING,
+        CLOSED
+    }
+
+    public static class DrainResult {
+        public enum Status {
+            BARRIER_REACHED,
+            LEADER_LOST,
+            TIMEOUT
+        }
+
+        private final Status status;
+        private final long lastCommittedJournalId;
+
+        public DrainResult(Status status, long lastCommittedJournalId) {
+            this.status = status;
+            this.lastCommittedJournalId = lastCommittedJournalId;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public long getLastCommittedJournalId() {
+            return lastCommittedJournalId;
+        }
+    }
+
     public static final Logger LOG = LogManager.getLogger(JournalWriter.class);
     // other threads can put log to this queue by calling Editlog.logEdit()
     private final BlockingQueue<JournalTask> journalQueue;
@@ -43,6 +77,7 @@ public class JournalWriter {
     // increment journal id
     // this is the persisted journal id
     protected long nextVisibleJournalId = -1;
+    private volatile long lastCommittedJournalId = -1L;
 
     // belows are variables that will reset every batch
     // store journal tasks of this batch
@@ -65,6 +100,9 @@ public class JournalWriter {
     private long lastLogTimeForDelayTriggeredCommit = -1;
 
     private long lastSlowEditLogTimeNs = -1L;
+    private final AtomicReference<WriterState> writerState = new AtomicReference<>(WriterState.RUNNING);
+    private volatile DrainResult latestDrainResult;
+    private volatile JournalTask activeDrainBarrierTask;
 
     public JournalWriter(Journal journal, BlockingQueue<JournalTask> journalQueue) {
         this.journal = journal;
@@ -76,6 +114,10 @@ public class JournalWriter {
      */
     public void init(long maxJournalId) throws JournalException {
         this.nextVisibleJournalId = maxJournalId + 1;
+        this.lastCommittedJournalId = maxJournalId;
+        this.latestDrainResult = null;
+        this.activeDrainBarrierTask = null;
+        this.writerState.set(WriterState.RUNNING);
         this.journal.rollJournal(this.nextVisibleJournalId);
     }
 
@@ -103,7 +145,20 @@ public class JournalWriter {
         // waiting if necessary until an element becomes available
         currentJournal = journalQueue.take();
 
+        if (writerState.get() == WriterState.CLOSED) {
+            drainClosedTasks(currentJournal);
+            return;
+        }
+
+        if (currentJournal.isBarrierTask()) {
+            completeBarrier(currentJournal, DrainResult.Status.BARRIER_REACHED, lastCommittedJournalId, null);
+            writerState.set(WriterState.CLOSED);
+            drainClosedTasks(journalQueue.poll());
+            return;
+        }
+
         long nextJournalId = nextVisibleJournalId;
+        JournalTask barrierTask = null;
         initBatch();
 
         try {
@@ -119,6 +174,10 @@ public class JournalWriter {
                 }
 
                 currentJournal = journalQueue.take();
+                if (currentJournal.isBarrierTask()) {
+                    barrierTask = currentJournal;
+                    break;
+                }
             }
         } catch (JournalException e) {
             // abort current task
@@ -130,7 +189,12 @@ public class JournalWriter {
                 journal.batchWriteCommit();
                 LOG.debug("batch write commit success, from {} - {}", nextVisibleJournalId, nextJournalId);
                 nextVisibleJournalId = nextJournalId;
+                lastCommittedJournalId = nextJournalId - 1;
                 markCurrentBatchSucceed();
+                if (barrierTask != null) {
+                    completeBarrier(barrierTask, DrainResult.Status.BARRIER_REACHED, lastCommittedJournalId, null);
+                    writerState.set(WriterState.CLOSED);
+                }
             } catch (JournalException e) {
                 // abort
                 LOG.warn("failed to commit batch, will abort current {} journals.",
@@ -140,8 +204,31 @@ public class JournalWriter {
                 } catch (JournalException e2) {
                     LOG.warn("failed to abort batch, will ignore and continue.", e);
                 }
-                abortCurrentBatch(e.getMessage());
+                if (writerState.get() == WriterState.SEALING) {
+                    JournalWriteException abortException = new JournalWriteException(
+                            JournalWriteException.Reason.WRITER_ABORTED,
+                            "journal commit failed while sealing", e);
+                    abortCurrentBatch(e.getMessage(), abortException);
+                    latestDrainResult = new DrainResult(DrainResult.Status.LEADER_LOST, lastCommittedJournalId);
+                    if (barrierTask != null) {
+                        completeBarrier(barrierTask, DrainResult.Status.LEADER_LOST, lastCommittedJournalId,
+                                abortException);
+                    }
+                    writerState.set(WriterState.CLOSED);
+                } else {
+                    abortCurrentBatch(e.getMessage());
+                }
             }
+        }
+
+        if (writerState.get() == WriterState.CLOSED) {
+            drainClosedTasks(journalQueue.poll());
+            return;
+        }
+
+        if (writerState.get() != WriterState.RUNNING) {
+            updateBatchMetrics();
+            return;
         }
 
         rollJournalAfterBatch();
@@ -167,6 +254,12 @@ public class JournalWriter {
         }
     }
 
+    private void abortCurrentBatch(String errMsg, Exception cause) {
+        for (JournalTask t : currentBatchTasks) {
+            abortJournalTask(t, errMsg, cause);
+        }
+    }
+
     /**
      * We should notify the caller to rollback or report error on abort, like this.
      * task.markAbort();
@@ -174,6 +267,17 @@ public class JournalWriter {
      * Note that if we exit here, the final clause(commit current batch) will not be executed.
      */
     protected void abortJournalTask(JournalTask task, String msg) {
+        abortJournalTask(task, msg, null);
+    }
+
+    protected void abortJournalTask(JournalTask task, String msg, Exception cause) {
+        if (writerState.get() != WriterState.RUNNING) {
+            if (task != null) {
+                task.markAbort(cause != null ? cause : new JournalWriteException(
+                        JournalWriteException.Reason.WRITER_ABORTED, msg));
+            }
+            return;
+        }
         LOG.error(msg);
         Util.stdoutWithTime(msg);
         System.exit(-1);
@@ -249,6 +353,26 @@ public class JournalWriter {
         forceRollJournal = true;
     }
 
+    public long getLastCommittedJournalId() {
+        return lastCommittedJournalId;
+    }
+
+    public synchronized DrainResult sealAndGetCommittedWatermark(long timeoutMs) throws InterruptedException {
+        if (writerState.get() == WriterState.CLOSED) {
+            return latestDrainResult != null
+                    ? latestDrainResult
+                    : new DrainResult(DrainResult.Status.BARRIER_REACHED, lastCommittedJournalId);
+        }
+
+        if (activeDrainBarrierTask == null) {
+            writerState.compareAndSet(WriterState.RUNNING, WriterState.SEALING);
+            activeDrainBarrierTask = JournalTask.createBarrierTask();
+            journalQueue.put(activeDrainBarrierTask);
+        }
+
+        return waitForDrainResult(activeDrainBarrierTask, timeoutMs);
+    }
+
     private boolean needForceRollJournal() {
         if (forceRollJournal) {
             // Reset flag, alter system create image only trigger new image once
@@ -280,6 +404,67 @@ public class JournalWriter {
             }
             LOG.info("edit log rolled because {}", reason);
             rollJournalCounter = 0;
+        }
+    }
+
+    private DrainResult waitForDrainResult(JournalTask barrierTask, long timeoutMs) throws InterruptedException {
+        try {
+            if (timeoutMs < 0) {
+                barrierTask.get();
+            } else {
+                barrierTask.get(timeoutMs, TimeUnit.MILLISECONDS);
+            }
+            return buildDrainResult(barrierTask, DrainResult.Status.BARRIER_REACHED);
+        } catch (ExecutionException e) {
+            return buildDrainResult(barrierTask, DrainResult.Status.LEADER_LOST);
+        } catch (TimeoutException e) {
+            return new DrainResult(DrainResult.Status.TIMEOUT, lastCommittedJournalId);
+        }
+    }
+
+    private DrainResult buildDrainResult(JournalTask barrierTask, DrainResult.Status fallbackStatus) {
+        DrainResult.Status status = barrierTask.getDrainStatus() == null ? fallbackStatus : barrierTask.getDrainStatus();
+        DrainResult result = new DrainResult(status,
+                barrierTask.getCommittedJournalId() >= 0 ? barrierTask.getCommittedJournalId() : lastCommittedJournalId);
+        if (status != DrainResult.Status.TIMEOUT) {
+            latestDrainResult = result;
+        }
+        return result;
+    }
+
+    private void completeBarrier(JournalTask barrierTask, DrainResult.Status status,
+                                 long committedJournalId, Exception cause) {
+        if (barrierTask == null) {
+            return;
+        }
+        if (status == DrainResult.Status.BARRIER_REACHED) {
+            barrierTask.markBarrierReached(committedJournalId);
+        } else {
+            barrierTask.markBarrierFailed(status, committedJournalId, cause);
+        }
+        activeDrainBarrierTask = null;
+        latestDrainResult = new DrainResult(status, committedJournalId);
+    }
+
+    private void drainClosedTasks(JournalTask firstTask) {
+        JournalTask task = firstTask;
+        while (task != null) {
+            if (task.isBarrierTask()) {
+                DrainResult result = latestDrainResult != null
+                        ? latestDrainResult
+                        : new DrainResult(DrainResult.Status.BARRIER_REACHED, lastCommittedJournalId);
+                Exception cause = null;
+                if (result.getStatus() == DrainResult.Status.LEADER_LOST) {
+                    cause = new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED,
+                            "journal writer already closed after sealing");
+                }
+                completeBarrier(task, result.getStatus(), result.getLastCommittedJournalId(), cause);
+            } else {
+                abortJournalTask(task, "journal writer is closed after sealing",
+                        new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED,
+                                "journal writer is closed after sealing"));
+            }
+            task = journalQueue.poll();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -38,15 +38,25 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class JournalWriter {
     private enum WriterState {
+        // Normal serving state. New append tasks are accepted and fatal journal failures
+        // keep the historical process-exit behavior.
         RUNNING,
+        // Demotion drain is in progress. New append tasks should be rejected/aborted and
+        // commit failures are converted into drain results instead of exiting the process.
         SEALING,
+        // The writer has finished sealing and will not process any more append tasks.
         CLOSED
     }
 
     public static class DrainResult {
         public enum Status {
+            // The barrier was observed after all earlier committed appends became durable.
             BARRIER_REACHED,
+            // The writer lost the ability to commit while sealing, so the returned watermark
+            // is only the last successfully committed journal id.
             LEADER_LOST,
+            // The caller stopped waiting before the barrier completed. The returned watermark
+            // is the latest committed journal id visible at timeout.
             TIMEOUT
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -61,6 +61,7 @@ import com.starrocks.ha.LeaderInfo;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.JournalTask;
+import com.starrocks.journal.JournalWriteException;
 import com.starrocks.journal.SerializeException;
 import com.starrocks.journal.bdbje.Timestamp;
 import com.starrocks.load.DeleteMgr;
@@ -120,6 +121,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
 /**
@@ -1371,6 +1374,20 @@ public class EditLog {
         walApplier.apply(writable);
     }
 
+    public void logJsonObjectOrThrow(short op, Object obj, WALApplier applier)
+            throws JournalWriteException, InterruptedException {
+        JournalTask task = submitLogOrThrow(op, new Writable() {
+            @Override
+            public void write(DataOutput out) throws IOException {
+                Text.writeString(out, GsonUtils.GSON.toJson(obj));
+            }
+        }, -1);
+        waitOrThrow(task, -1);
+        if (applier != null) {
+            applier.apply(obj);
+        }
+    }
+
     public void logJsonObject(short op, Object obj) {
         logEdit(op, new Writable() {
             @Override
@@ -1441,6 +1458,25 @@ public class EditLog {
         return task;
     }
 
+    public JournalTask submitLogOrThrow(short op, Writable writable, long maxWaitIntervalMs)
+            throws JournalWriteException, InterruptedException {
+        ensureLeaderWorkAdmission(op);
+        long startTimeNano = System.nanoTime();
+        DataOutputBuffer buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
+
+        try {
+            buffer.writeShort(op);
+            writable.write(buffer);
+        } catch (IOException | JsonParseException e) {
+            LOG.info("failed to serialize journal data", e);
+            throw new SerializeException("failed to serialize journal data");
+        }
+
+        JournalTask task = new JournalTask(startTimeNano, buffer, maxWaitIntervalMs);
+        this.journalQueue.put(task);
+        return task;
+    }
+
     /**
      * wait for JournalWriter commit all logs
      */
@@ -1469,6 +1505,55 @@ public class EditLog {
         if (MetricRepo.hasInit) {
             MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((System.nanoTime() - startTimeNano) / 1000000);
         }
+    }
+
+    public static void waitOrThrow(JournalTask task, long timeoutMs) throws JournalWriteException, InterruptedException {
+        long startTimeNano = task.getStartTimeNano();
+        boolean result;
+        try {
+            if (timeoutMs < 0) {
+                result = task.get();
+            } else {
+                result = task.get(timeoutMs, TimeUnit.MILLISECONDS);
+            }
+        } catch (ExecutionException e) {
+            throw toJournalWriteException(e.getCause());
+        } catch (TimeoutException e) {
+            throw new JournalWriteException(JournalWriteException.Reason.TIMEOUT, "timed out waiting for journal task",
+                    e);
+        }
+
+        if (!result) {
+            throw new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED,
+                    "journal task aborted without detailed cause");
+        }
+        if (MetricRepo.hasInit) {
+            MetricRepo.HISTO_EDIT_LOG_WRITE_LATENCY.update((System.nanoTime() - startTimeNano) / 1000000);
+        }
+    }
+
+    private void ensureLeaderWorkAdmission(short op) throws JournalWriteException {
+        if (op == OperationType.OP_STARMGR) {
+            return;
+        }
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        if (!globalStateMgr.isLeader()) {
+            throw new JournalWriteException(JournalWriteException.Reason.NOT_LEADER,
+                    String.format("Current node is not leader, but %s, submit log is not allowed",
+                            globalStateMgr.getFeType()));
+        }
+        if (!globalStateMgr.isLeaderWorkAdmissionOpen()) {
+            throw new JournalWriteException(JournalWriteException.Reason.ADMISSION_CLOSED,
+                    "leader work admission is closed");
+        }
+    }
+
+    private static JournalWriteException toJournalWriteException(Throwable cause) {
+        if (cause instanceof JournalWriteException) {
+            return (JournalWriteException) cause;
+        }
+        return new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED,
+                "journal task aborted", cause);
     }
 
     public void logSaveNextId(long nextId, WALApplier walApplier) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -555,9 +555,16 @@ public class GlobalStateMgr {
     private final TabletReshardJobMgr tabletReshardJobMgr;
 
     enum LeaderRoleState {
+        // This FE is not serving leader-only work. It may be a follower/observer,
+        // or a previous leader activation attempt may have been rolled back.
         INACTIVE,
+        // Leader activation is in progress. Journal/open/fencing related steps are
+        // still being initialized, so leader-only work must not be admitted yet.
         ACTIVATING,
+        // Leader activation has completed and this FE can admit new leader-only work.
         ACTIVE,
+        // Leader demotion has started. New leader-only work must be rejected and
+        // in-flight work should treat the current lease as expired.
         DEMOTING
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -353,6 +353,12 @@ public class GlobalStateMgr {
 
     // True indicates that the node is transferring to the leader, using this state avoids forwarding stmt to its own node.
     private volatile boolean isInTransferringToLeader = false;
+    private final AtomicLong leaderGeneration = new AtomicLong(0L);
+    private final AtomicBoolean leaderWorkAdmissionOpen = new AtomicBoolean(false);
+    private volatile LeaderLease activeLeaderLease = LeaderLease.INVALID;
+    private volatile LeaderRoleState leaderRoleState = LeaderRoleState.INACTIVE;
+    private volatile FrontendNodeType pendingDemotionTargetType;
+    private volatile long leaderRoleStateSinceMs = System.currentTimeMillis();
 
     // false if default_warehouse is not created.
     private boolean isDefaultWarehouseCreated = false;
@@ -547,6 +553,13 @@ public class GlobalStateMgr {
     private JwkMgr jwkMgr;
 
     private final TabletReshardJobMgr tabletReshardJobMgr;
+
+    enum LeaderRoleState {
+        INACTIVE,
+        ACTIVATING,
+        ACTIVE,
+        DEMOTING
+    }
 
     public NodeMgr getNodeMgr() {
         return nodeMgr;
@@ -1305,6 +1318,8 @@ public class GlobalStateMgr {
             initDefaultWarehouse();
         }
 
+        beginLeaderActivation();
+
         // set this after replay thread stopped. to avoid replay thread modify them.
         isReady.set(false);
 
@@ -1332,6 +1347,8 @@ public class GlobalStateMgr {
         dominationStartTimeMs = System.currentTimeMillis();
 
         try {
+            publishLeaderLease(getEpoch());
+
             if (Config.bdbje_reset_election_group || nodeMgr.isFirstTimeStartUp()) {
                 nodeMgr.resetFrontends();
             }
@@ -1375,8 +1392,14 @@ public class GlobalStateMgr {
             checkCaseInsensitive();
         } catch (StarRocksException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);
+            if (!isReady.get()) {
+                rollbackLeaderActivation();
+                feType = oldType;
+                throw new RuntimeException("transfer to leader failed", e);
+            }
         } catch (Throwable t) {
             LOG.warn("transfer to leader failed with error", t);
+            rollbackLeaderActivation();
             feType = oldType;
             throw t;
         }
@@ -1401,6 +1424,95 @@ public class GlobalStateMgr {
     public void setFrontendNodeType(FrontendNodeType newType) {
         // just for test, don't call it directly
         feType = newType;
+    }
+
+    @VisibleForTesting
+    void beginLeaderActivation() {
+        leaderWorkAdmissionOpen.set(false);
+        activeLeaderLease = LeaderLease.INVALID;
+        pendingDemotionTargetType = null;
+        updateLeaderRoleState(LeaderRoleState.ACTIVATING);
+    }
+
+    @VisibleForTesting
+    void publishLeaderLease(long haEpoch) {
+        Preconditions.checkState(haEpoch >= 0, "leader epoch must be non-negative, actual: %s", haEpoch);
+        Preconditions.checkState(feType == FrontendNodeType.LEADER,
+                "can only publish leader lease when FE type is LEADER, actual: %s", feType);
+        Preconditions.checkState(leaderRoleState == LeaderRoleState.ACTIVATING,
+                "can only publish leader lease during activation, actual state: %s", leaderRoleState);
+        long generation = leaderGeneration.incrementAndGet();
+        activeLeaderLease = new LeaderLease(haEpoch, generation);
+        leaderWorkAdmissionOpen.set(true);
+        pendingDemotionTargetType = null;
+        updateLeaderRoleState(LeaderRoleState.ACTIVE);
+    }
+
+    @VisibleForTesting
+    void rollbackLeaderActivation() {
+        leaderWorkAdmissionOpen.set(false);
+        activeLeaderLease = LeaderLease.INVALID;
+        pendingDemotionTargetType = null;
+        updateLeaderRoleState(LeaderRoleState.INACTIVE);
+    }
+
+    @VisibleForTesting
+    void beginLeaderDemotion(FrontendNodeType targetType) {
+        leaderWorkAdmissionOpen.set(false);
+        leaderGeneration.incrementAndGet();
+        activeLeaderLease = LeaderLease.INVALID;
+        pendingDemotionTargetType = targetType;
+        updateLeaderRoleState(LeaderRoleState.DEMOTING);
+    }
+
+    public LeaderLease captureLeaderLease() {
+        return activeLeaderLease;
+    }
+
+    public LeaderLease captureLeaderLeaseOrThrow() {
+        LeaderLease lease = activeLeaderLease;
+        Preconditions.checkState(isLeaderLeaseValid(lease),
+                "leader lease is not available. feType=%s, state=%s, admissionOpen=%s, lease=%s",
+                feType, leaderRoleState, leaderWorkAdmissionOpen.get(), lease);
+        return lease;
+    }
+
+    public boolean isLeaderLeaseValid(LeaderLease lease) {
+        return lease != null
+                && lease.isValid()
+                && lease.equals(activeLeaderLease)
+                && leaderWorkAdmissionOpen.get()
+                && feType == FrontendNodeType.LEADER
+                && leaderRoleState == LeaderRoleState.ACTIVE;
+    }
+
+    public void checkLeaderLease(LeaderLease lease) {
+        Preconditions.checkState(isLeaderLeaseValid(lease),
+                "leader lease is stale. expected=%s, actual=%s, state=%s, admissionOpen=%s",
+                lease, activeLeaderLease, leaderRoleState, leaderWorkAdmissionOpen.get());
+    }
+
+    public boolean isLeaderWorkAdmissionOpen() {
+        return leaderWorkAdmissionOpen.get();
+    }
+
+    public boolean isLeaderDemoting() {
+        return leaderRoleState == LeaderRoleState.DEMOTING;
+    }
+
+    @VisibleForTesting
+    LeaderRoleState getLeaderRoleState() {
+        return leaderRoleState;
+    }
+
+    @VisibleForTesting
+    FrontendNodeType getPendingDemotionTargetType() {
+        return pendingDemotionTargetType;
+    }
+
+    private void updateLeaderRoleState(LeaderRoleState newState) {
+        leaderRoleState = newState;
+        leaderRoleStateSinceMs = System.currentTimeMillis();
     }
 
     // start all daemon threads only running on Master
@@ -2396,6 +2508,11 @@ public class GlobalStateMgr {
 
     public boolean isLeader() {
         return feType == FrontendNodeType.LEADER;
+    }
+
+    @VisibleForTesting
+    long getLeaderRoleStateSinceMs() {
+        return leaderRoleStateSinceMs;
     }
 
     public void setSynchronizedTime(long time) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LeaderLease.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LeaderLease.java
@@ -36,7 +36,7 @@ public final class LeaderLease {
     }
 
     public boolean isValid() {
-        return haEpoch > 0 && generation > 0;
+        return haEpoch >= 0 && generation > 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/LeaderLease.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LeaderLease.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import java.util.Objects;
+
+public final class LeaderLease {
+    public static final LeaderLease INVALID = new LeaderLease(-1L, -1L);
+
+    private final long haEpoch;
+    private final long generation;
+
+    public LeaderLease(long haEpoch, long generation) {
+        this.haEpoch = haEpoch;
+        this.generation = generation;
+    }
+
+    public long getHaEpoch() {
+        return haEpoch;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public boolean isValid() {
+        return haEpoch > 0 && generation > 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LeaderLease)) {
+            return false;
+        }
+        LeaderLease that = (LeaderLease) obj;
+        return haEpoch == that.haEpoch && generation == that.generation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(haEpoch, generation);
+    }
+
+    @Override
+    public String toString() {
+        return "LeaderLease{"
+                + "haEpoch=" + haEpoch
+                + ", generation=" + generation
+                + '}';
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterSealTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterSealTest.java
@@ -1,0 +1,216 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.journal;
+
+import com.starrocks.common.io.DataOutputBuffer;
+import com.starrocks.common.io.Text;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class JournalWriterSealTest {
+    @Test
+    public void testSealOnEmptyQueueReturnsCommittedWatermark() throws Exception {
+        TestJournal journal = new TestJournal();
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(3L);
+
+        CompletableFuture<JournalWriter.DrainResult> resultFuture = runSeal(writer, 5000L);
+        waitUntilQueueSize(queue, 1);
+
+        writer.writeOneBatch();
+
+        JournalWriter.DrainResult result = resultFuture.get(5, TimeUnit.SECONDS);
+        Assertions.assertEquals(JournalWriter.DrainResult.Status.BARRIER_REACHED, result.getStatus());
+        Assertions.assertEquals(3L, result.getLastCommittedJournalId());
+        Assertions.assertEquals(3L, writer.getLastCommittedJournalId());
+    }
+
+    @Test
+    public void testSealBarrierCutsBatchAndAbortsPostBarrierTasks() throws Exception {
+        TestJournal journal = new TestJournal();
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(3L);
+
+        JournalTask task1 = new JournalTask(System.nanoTime(), makeBuffer(10), -1);
+        JournalTask task2 = new JournalTask(System.nanoTime(), makeBuffer(11), -1);
+        JournalTask task3 = new JournalTask(System.nanoTime(), makeBuffer(12), -1);
+        queue.put(task1);
+        queue.put(task2);
+
+        CompletableFuture<JournalWriter.DrainResult> resultFuture = runSeal(writer, 5000L);
+        waitUntilQueueSize(queue, 3);
+        queue.put(task3);
+
+        writer.writeOneBatch();
+
+        JournalWriter.DrainResult result = resultFuture.get(5, TimeUnit.SECONDS);
+        Assertions.assertEquals(JournalWriter.DrainResult.Status.BARRIER_REACHED, result.getStatus());
+        Assertions.assertEquals(5L, result.getLastCommittedJournalId());
+        Assertions.assertTrue(task1.get());
+        Assertions.assertTrue(task2.get());
+
+        ExecutionException abortException = Assertions.assertThrows(ExecutionException.class, task3::get);
+        Assertions.assertInstanceOf(JournalWriteException.class, abortException.getCause());
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED,
+                ((JournalWriteException) abortException.getCause()).getReason());
+        Assertions.assertEquals(List.of(4L, 5L), journal.getCommittedJournalIds());
+    }
+
+    @Test
+    public void testSealCommitFailureReturnsLeaderLost() throws Exception {
+        TestJournal journal = new TestJournal();
+        journal.setCommitFailure(true);
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(3L);
+
+        JournalTask task = new JournalTask(System.nanoTime(), makeBuffer(10), -1);
+        queue.put(task);
+
+        CompletableFuture<JournalWriter.DrainResult> resultFuture = runSeal(writer, 5000L);
+        waitUntilQueueSize(queue, 2);
+
+        writer.writeOneBatch();
+
+        JournalWriter.DrainResult result = resultFuture.get(5, TimeUnit.SECONDS);
+        Assertions.assertEquals(JournalWriter.DrainResult.Status.LEADER_LOST, result.getStatus());
+        Assertions.assertEquals(3L, result.getLastCommittedJournalId());
+
+        ExecutionException abortException = Assertions.assertThrows(ExecutionException.class, task::get);
+        Assertions.assertInstanceOf(JournalWriteException.class, abortException.getCause());
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED,
+                ((JournalWriteException) abortException.getCause()).getReason());
+    }
+
+    private CompletableFuture<JournalWriter.DrainResult> runSeal(JournalWriter writer, long timeoutMs) {
+        CompletableFuture<JournalWriter.DrainResult> future = new CompletableFuture<>();
+        Thread thread = new Thread(() -> {
+            try {
+                future.complete(writer.sealAndGetCommittedWatermark(timeoutMs));
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        thread.start();
+        return future;
+    }
+
+    private void waitUntilQueueSize(BlockingQueue<JournalTask> queue, int expectedSize) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (queue.size() < expectedSize && System.nanoTime() < deadline) {
+            Thread.sleep(10L);
+        }
+        Assertions.assertTrue(queue.size() >= expectedSize,
+                "expected queue size >= " + expectedSize + ", actual=" + queue.size());
+    }
+
+    private DataOutputBuffer makeBuffer(int size) throws IOException {
+        DataOutputBuffer buffer = new DataOutputBuffer();
+        Text.writeString(buffer, "x".repeat(size - 4));
+        return buffer;
+    }
+
+    private static final class TestJournal implements Journal {
+        private long maxJournalId = 0L;
+        private boolean commitFailure;
+        private final List<Long> stagingJournalIds = new ArrayList<>();
+        private final List<Long> committedJournalIds = new ArrayList<>();
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public void rollJournal(long journalId) throws JournalException {
+        }
+
+        @Override
+        public long getMaxJournalId() {
+            return maxJournalId;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public JournalCursor read(long fromKey, long toKey) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteJournals(long deleteJournalToId) {
+        }
+
+        @Override
+        public long getFinalizedJournalId() {
+            return 0;
+        }
+
+        @Override
+        public List<Long> getDatabaseNames() {
+            return List.of();
+        }
+
+        @Override
+        public void batchWriteBegin() {
+            stagingJournalIds.clear();
+        }
+
+        @Override
+        public void batchWriteAppend(long journalId, DataOutputBuffer buffer) {
+            stagingJournalIds.add(journalId);
+        }
+
+        @Override
+        public void batchWriteCommit() throws JournalException {
+            if (commitFailure) {
+                throw new JournalException("mock commit failure");
+            }
+            committedJournalIds.addAll(stagingJournalIds);
+            maxJournalId += stagingJournalIds.size();
+            stagingJournalIds.clear();
+        }
+
+        @Override
+        public void batchWriteAbort() {
+            stagingJournalIds.clear();
+        }
+
+        @Override
+        public String getPrefix() {
+            return "";
+        }
+
+        public void setCommitFailure(boolean commitFailure) {
+            this.commitFailure = commitFailure;
+        }
+
+        public List<Long> getCommittedJournalIds() {
+            return committedJournalIds;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterSealTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterSealTest.java
@@ -105,6 +105,52 @@ public class JournalWriterSealTest {
                 ((JournalWriteException) abortException.getCause()).getReason());
     }
 
+    @Test
+    public void testSealTimeoutReturnsLatestCommittedWatermark() throws Exception {
+        TestJournal journal = new TestJournal();
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(7L);
+
+        JournalWriter.DrainResult result = writer.sealAndGetCommittedWatermark(1L);
+
+        Assertions.assertEquals(JournalWriter.DrainResult.Status.TIMEOUT, result.getStatus());
+        Assertions.assertEquals(7L, result.getLastCommittedJournalId());
+    }
+
+    @Test
+    public void testSealOnClosedWriterReturnsCachedResult() throws Exception {
+        TestJournal journal = new TestJournal();
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(3L);
+
+        CompletableFuture<JournalWriter.DrainResult> resultFuture = runSeal(writer, 5000L);
+        waitUntilQueueSize(queue, 1);
+        writer.writeOneBatch();
+
+        JournalWriter.DrainResult first = resultFuture.get(5, TimeUnit.SECONDS);
+        JournalWriter.DrainResult second = writer.sealAndGetCommittedWatermark(100L);
+
+        Assertions.assertEquals(first.getStatus(), second.getStatus());
+        Assertions.assertEquals(first.getLastCommittedJournalId(), second.getLastCommittedJournalId());
+    }
+
+    @Test
+    public void testForceRollJournalTriggersManualRollReason() throws Exception {
+        TestJournal journal = new TestJournal();
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(16);
+        JournalWriter writer = new JournalWriter(journal, queue);
+        writer.init(3L);
+        journal.clearRollJournalIds();
+
+        queue.put(new JournalTask(System.nanoTime(), makeBuffer(10), -1));
+        writer.setForceRollJournal();
+        writer.writeOneBatch();
+
+        Assertions.assertEquals(List.of(5L), journal.getRollJournalIds());
+    }
+
     private CompletableFuture<JournalWriter.DrainResult> runSeal(JournalWriter writer, long timeoutMs) {
         CompletableFuture<JournalWriter.DrainResult> future = new CompletableFuture<>();
         Thread thread = new Thread(() -> {
@@ -138,6 +184,7 @@ public class JournalWriterSealTest {
         private boolean commitFailure;
         private final List<Long> stagingJournalIds = new ArrayList<>();
         private final List<Long> committedJournalIds = new ArrayList<>();
+        private final List<Long> rollJournalIds = new ArrayList<>();
 
         @Override
         public void open() {
@@ -145,6 +192,7 @@ public class JournalWriterSealTest {
 
         @Override
         public void rollJournal(long journalId) throws JournalException {
+            rollJournalIds.add(journalId);
         }
 
         @Override
@@ -211,6 +259,14 @@ public class JournalWriterSealTest {
 
         public List<Long> getCommittedJournalIds() {
             return committedJournalIds;
+        }
+
+        public void clearRollJournalIds() {
+            rollJournalIds.clear();
+        }
+
+        public List<Long> getRollJournalIds() {
+            return rollJournalIds;
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogFailureVisibleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogFailureVisibleTest.java
@@ -16,9 +16,11 @@ package com.starrocks.persist;
 
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.journal.JournalWriteException;
+import com.starrocks.journal.SerializeException;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +50,41 @@ public class EditLogFailureVisibleTest {
     }
 
     @Test
+    public void testSubmitLogOrThrowRejectsNotLeader() throws Exception {
+        EditLog editLog = new EditLog(new ArrayBlockingQueue<>(4));
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> editLog.submitLogOrThrow((short) 1, new Text("111"), -1));
+        Assertions.assertEquals(JournalWriteException.Reason.NOT_LEADER, exception.getReason());
+    }
+
+    @Test
+    public void testSubmitLogOrThrowAllowsStarMgrOnFollower() throws Exception {
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(4);
+        EditLog editLog = new EditLog(queue);
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
+
+        JournalTask task = editLog.submitLogOrThrow(OperationType.OP_STARMGR, new Text("111"), -1);
+
+        Assertions.assertSame(task, queue.poll(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testSubmitLogOrThrowSerializeFailure() throws Exception {
+        EditLog editLog = new EditLog(new ArrayBlockingQueue<>(4));
+        setLeaderWorkAdmissionOpen(true);
+
+        Assertions.assertThrows(SerializeException.class,
+                () -> editLog.submitLogOrThrow((short) 1, new Writable() {
+                    @Override
+                    public void write(java.io.DataOutput out) throws IOException {
+                        throw new IOException("boom");
+                    }
+                }, -1));
+    }
+
+    @Test
     public void testWaitOrThrowPropagatesAbortReason() throws Exception {
         JournalTask task = new JournalTask(System.nanoTime(), makeBuffer(8), -1);
         task.markAbort(new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED, "writer sealed"));
@@ -58,12 +95,70 @@ public class EditLogFailureVisibleTest {
     }
 
     @Test
+    public void testWaitOrThrowWrapsUnknownAbortCause() throws Exception {
+        JournalTask task = new JournalTask(System.nanoTime(), makeBuffer(8), -1);
+        RuntimeException cause = new RuntimeException("boom");
+        task.markAbort(cause);
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> EditLog.waitOrThrow(task, 1000L));
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED, exception.getReason());
+        Assertions.assertSame(cause, exception.getCause());
+    }
+
+    @Test
+    public void testWaitOrThrowRejectsAbortWithoutDetailedCause() throws Exception {
+        JournalTask task = new JournalTask(System.nanoTime(), makeBuffer(8), -1);
+        task.markAbort();
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> EditLog.waitOrThrow(task, -1L));
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED, exception.getReason());
+    }
+
+    @Test
     public void testWaitOrThrowTimesOut() {
         JournalTask task = new JournalTask(System.nanoTime(), new DataOutputBuffer(), -1);
 
         JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
                 () -> EditLog.waitOrThrow(task, 1L));
         Assertions.assertEquals(JournalWriteException.Reason.TIMEOUT, exception.getReason());
+    }
+
+    @Test
+    public void testLogJsonObjectLegacyCompletesSuccessfully() throws Exception {
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(4);
+        EditLog editLog = new EditLog(queue);
+
+        Thread consumer = succeedQueuedTaskAsync(queue);
+        editLog.logJsonObject((short) 1, "payload");
+        consumer.join();
+    }
+
+    @Test
+    public void testLogJsonObjectLegacyWalApplierAppliesOnSuccess() throws Exception {
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(4);
+        EditLog editLog = new EditLog(queue);
+        AtomicBoolean applied = new AtomicBoolean(false);
+
+        Thread consumer = succeedQueuedTaskAsync(queue);
+        editLog.logJsonObject((short) 1, "payload", obj -> applied.set(true));
+        consumer.join();
+
+        Assertions.assertTrue(applied.get());
+    }
+
+    @Test
+    public void testLogJsonObjectOrThrowAppliesOnSuccess() throws Exception {
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(4);
+        EditLog editLog = new EditLog(queue);
+        AtomicBoolean applied = new AtomicBoolean(false);
+
+        Thread consumer = succeedQueuedTaskAsync(queue);
+        editLog.logJsonObjectOrThrow(OperationType.OP_STARMGR, "payload", obj -> applied.set(true));
+        consumer.join();
+
+        Assertions.assertTrue(applied.get());
     }
 
     @Test
@@ -91,6 +186,21 @@ public class EditLogFailureVisibleTest {
 
         Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED, exception.getReason());
         Assertions.assertFalse(applied.get());
+    }
+
+    private Thread succeedQueuedTaskAsync(BlockingQueue<JournalTask> queue) {
+        Thread consumer = new Thread(() -> {
+            try {
+                JournalTask task = queue.poll(5, TimeUnit.SECONDS);
+                if (task != null) {
+                    task.markSucceed();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        consumer.start();
+        return consumer;
     }
 
     private DataOutputBuffer makeBuffer(int size) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogFailureVisibleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogFailureVisibleTest.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.starrocks.common.io.DataOutputBuffer;
+import com.starrocks.common.io.Text;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.journal.JournalTask;
+import com.starrocks.journal.JournalWriteException;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EditLogFailureVisibleTest {
+    @BeforeEach
+    public void setUp() throws Exception {
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
+        setLeaderWorkAdmissionOpen(false);
+    }
+
+    @Test
+    public void testSubmitLogOrThrowRejectsClosedAdmission() {
+        EditLog editLog = new EditLog(new ArrayBlockingQueue<>(4));
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> editLog.submitLogOrThrow((short) 1, new Text("111"), -1));
+        Assertions.assertEquals(JournalWriteException.Reason.ADMISSION_CLOSED, exception.getReason());
+    }
+
+    @Test
+    public void testWaitOrThrowPropagatesAbortReason() throws Exception {
+        JournalTask task = new JournalTask(System.nanoTime(), makeBuffer(8), -1);
+        task.markAbort(new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED, "writer sealed"));
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> EditLog.waitOrThrow(task, 1000L));
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED, exception.getReason());
+    }
+
+    @Test
+    public void testWaitOrThrowTimesOut() {
+        JournalTask task = new JournalTask(System.nanoTime(), new DataOutputBuffer(), -1);
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> EditLog.waitOrThrow(task, 1L));
+        Assertions.assertEquals(JournalWriteException.Reason.TIMEOUT, exception.getReason());
+    }
+
+    @Test
+    public void testLogJsonObjectOrThrowDoesNotApplyOnAbort() throws Exception {
+        BlockingQueue<JournalTask> queue = new ArrayBlockingQueue<>(4);
+        EditLog editLog = new EditLog(queue);
+        AtomicBoolean applied = new AtomicBoolean(false);
+
+        Thread consumer = new Thread(() -> {
+            try {
+                JournalTask task = queue.poll(5, TimeUnit.SECONDS);
+                if (task != null) {
+                    task.markAbort(new JournalWriteException(JournalWriteException.Reason.WRITER_ABORTED,
+                            "journal writer closed"));
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        consumer.start();
+
+        JournalWriteException exception = Assertions.assertThrows(JournalWriteException.class,
+                () -> editLog.logJsonObjectOrThrow(OperationType.OP_STARMGR, "payload", obj -> applied.set(true)));
+        consumer.join();
+
+        Assertions.assertEquals(JournalWriteException.Reason.WRITER_ABORTED, exception.getReason());
+        Assertions.assertFalse(applied.get());
+    }
+
+    private DataOutputBuffer makeBuffer(int size) throws IOException {
+        DataOutputBuffer buffer = new DataOutputBuffer();
+        Text.writeString(buffer, "x".repeat(size - 4));
+        return buffer;
+    }
+
+    private void setLeaderWorkAdmissionOpen(boolean open) throws Exception {
+        Field field = GlobalStateMgr.class.getDeclaredField("leaderWorkAdmissionOpen");
+        field.setAccessible(true);
+        AtomicBoolean admissionOpen = (AtomicBoolean) field.get(GlobalStateMgr.getCurrentState());
+        admissionOpen.set(open);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -232,6 +232,83 @@ public class GlobalStateMgrTest {
         Config.metadata_enable_recovery_mode = originVal;
     }
 
+    @Test
+    public void testLeaderLeaseActivation() {
+        GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
+        globalStateMgr.beginLeaderActivation();
+        Assertions.assertEquals(GlobalStateMgr.LeaderRoleState.ACTIVATING, globalStateMgr.getLeaderRoleState());
+        Assertions.assertFalse(globalStateMgr.isLeaderWorkAdmissionOpen());
+        Assertions.assertEquals(LeaderLease.INVALID, globalStateMgr.captureLeaderLease());
+
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(101L);
+
+        LeaderLease lease = globalStateMgr.captureLeaderLeaseOrThrow();
+        Assertions.assertEquals(101L, lease.getHaEpoch());
+        Assertions.assertEquals(1L, lease.getGeneration());
+        Assertions.assertTrue(globalStateMgr.isLeaderLeaseValid(lease));
+        Assertions.assertTrue(globalStateMgr.isLeaderWorkAdmissionOpen());
+        Assertions.assertEquals(GlobalStateMgr.LeaderRoleState.ACTIVE, globalStateMgr.getLeaderRoleState());
+        Assertions.assertNull(globalStateMgr.getPendingDemotionTargetType());
+    }
+
+    @Test
+    public void testLeaderLeaseInvalidatedByDemotionSkeleton() {
+        GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
+        globalStateMgr.beginLeaderActivation();
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(102L);
+        LeaderLease lease = globalStateMgr.captureLeaderLeaseOrThrow();
+
+        globalStateMgr.beginLeaderDemotion(FrontendNodeType.FOLLOWER);
+
+        Assertions.assertFalse(globalStateMgr.isLeaderWorkAdmissionOpen());
+        Assertions.assertTrue(globalStateMgr.isLeaderDemoting());
+        Assertions.assertFalse(globalStateMgr.isLeaderLeaseValid(lease));
+        Assertions.assertEquals(LeaderLease.INVALID, globalStateMgr.captureLeaderLease());
+        Assertions.assertEquals(GlobalStateMgr.LeaderRoleState.DEMOTING, globalStateMgr.getLeaderRoleState());
+        Assertions.assertEquals(FrontendNodeType.FOLLOWER, globalStateMgr.getPendingDemotionTargetType());
+        Assertions.assertThrows(IllegalStateException.class, globalStateMgr::captureLeaderLeaseOrThrow);
+    }
+
+    @Test
+    public void testLeaderGenerationBumpsAcrossDemotionAndReelection() {
+        GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
+        globalStateMgr.beginLeaderActivation();
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(103L);
+        LeaderLease firstLease = globalStateMgr.captureLeaderLeaseOrThrow();
+
+        globalStateMgr.beginLeaderDemotion(FrontendNodeType.FOLLOWER);
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.FOLLOWER);
+
+        globalStateMgr.beginLeaderActivation();
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(104L);
+        LeaderLease secondLease = globalStateMgr.captureLeaderLeaseOrThrow();
+
+        Assertions.assertTrue(secondLease.getGeneration() > firstLease.getGeneration());
+        Assertions.assertEquals(104L, secondLease.getHaEpoch());
+        Assertions.assertFalse(globalStateMgr.isLeaderLeaseValid(firstLease));
+    }
+
+    @Test
+    public void testLeaderLeaseRollbackAfterActivationFailure() {
+        GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
+        globalStateMgr.beginLeaderActivation();
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(105L);
+        LeaderLease lease = globalStateMgr.captureLeaderLeaseOrThrow();
+
+        globalStateMgr.rollbackLeaderActivation();
+
+        Assertions.assertFalse(globalStateMgr.isLeaderWorkAdmissionOpen());
+        Assertions.assertFalse(globalStateMgr.isLeaderLeaseValid(lease));
+        Assertions.assertEquals(LeaderLease.INVALID, globalStateMgr.captureLeaderLease());
+        Assertions.assertEquals(GlobalStateMgr.LeaderRoleState.INACTIVE, globalStateMgr.getLeaderRoleState());
+        Assertions.assertNull(globalStateMgr.getPendingDemotionTargetType());
+    }
+
     private static class MyGlobalStateMgr extends GlobalStateMgr {
         public static final String ERROR_MESSAGE = "Create Exception here.";
         private final boolean throwException;

--- a/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/GlobalStateMgrTest.java
@@ -253,6 +253,19 @@ public class GlobalStateMgrTest {
     }
 
     @Test
+    public void testLeaderLeaseActivationAllowsEpochZero() {
+        GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
+        globalStateMgr.beginLeaderActivation();
+        globalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
+        globalStateMgr.publishLeaderLease(0L);
+
+        LeaderLease lease = globalStateMgr.captureLeaderLeaseOrThrow();
+        Assertions.assertEquals(0L, lease.getHaEpoch());
+        Assertions.assertTrue(lease.isValid());
+        Assertions.assertTrue(globalStateMgr.isLeaderLeaseValid(lease));
+    }
+
+    @Test
     public void testLeaderLeaseInvalidatedByDemotionSkeleton() {
         GlobalStateMgr globalStateMgr = new GlobalStateMgr(new NodeMgr());
         globalStateMgr.beginLeaderActivation();


### PR DESCRIPTION
## Why I'm doing:
Safe leader demotion needs a few foundational pieces before the actual role-transition cutover can be enabled.

This PR adds three building blocks in FE:
1. a local leader lease and admission fence, so new leader-only work can be rejected immediately during demotion
2. a journal sealing path that can return the last committed journal watermark without requiring all pre-barrier writes to succeed
3. a failure-visible edit log path, so future demotion-aware WAL callers can stop on journal failure instead of retrying forever

This PR does not change the current `LEADER -> non-LEADER` exit behavior yet. It only adds the infrastructure needed for the later cutover.

## What I'm doing:
- Add `LeaderLease(haEpoch, generation)`, leader work admission state, and coarse leader role state in `GlobalStateMgr`
- Publish the leader lease after successful leader activation and invalidate it on demotion skeleton / activation rollback
- Add barrier-aware journal tasks in `JournalTask`
- Add `RUNNING / SEALING / CLOSED` states in `JournalWriter`
- Add `sealAndGetCommittedWatermark()` and `DrainResult(lastCommittedJournalId)` in `JournalWriter`
- Keep the current fatal-exit behavior for journal failures in normal `RUNNING` mode
- Add `JournalWriteException` for failure-visible journal task results
- Add new failure-visible APIs in `EditLog`: `submitLogOrThrow()`, `waitOrThrow()`, and `logJsonObjectOrThrow()`
- Keep existing `logEdit()`, `waitInfinity()`, and `logJsonObject(..., WALApplier)` behavior unchanged for now
- Add unit tests for leader lease lifecycle, journal sealing/watermark behavior, and failure-visible edit log waits

Part of #63357

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
