### PR TITLE
[Enhancement] Skip compression instead of erroring when chunk size exceeds codec max input size

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -264,6 +264,8 @@ CONF_Bool(compress_rowbatches, "true");
 // Compress ratio when shuffle row_batches in network, not in storage engine.
 // If ratio is less than this value, use uncompressed data instead.
 CONF_mDouble(rpc_compress_ratio_threshold, "1.1");
+// If true, skip compression when serialized_size exceeds the codec's max input size limit (instead of returning an error).
+CONF_mBool(enable_rpc_compress_overflow_skip, "true");
 // Acceleration of LZ4 Compression, the larger the acceleration value, the faster the algorithm, but also the lesser the compression.
 // Default 1, MIN=1, MAX=65537
 CONF_mInt32(lz4_acceleration, "1");

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -27,6 +27,8 @@ CONF_Bool(compress_rowbatches, "true");
 // Compress ratio when shuffle row_batches in network, not in storage engine.
 // If ratio is less than this value, use uncompressed data instead.
 CONF_mDouble(rpc_compress_ratio_threshold, "1.1");
+// If true, skip compression when serialized_size exceeds the codec's max input size limit (instead of returning an error).
+CONF_mBool(enable_rpc_compress_overflow_skip, "true");
 
 // (Advanced) Maximum size of per-query receive-side buffer.
 CONF_mInt32(exchg_node_buffer_size_bytes, "10485760");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -137,6 +137,7 @@
       "configs": [
         "compress_rowbatches",
         "rpc_compress_ratio_threshold",
+        "enable_rpc_compress_overflow_skip",
         "exchg_node_buffer_size_bytes",
         "result_buffer_cancelled_interval_time",
         "es_scroll_keepalive",

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -745,17 +745,23 @@ Status ExchangeSinkOperator::serialize_chunk(const Chunk* src, ChunkPB* dst, boo
     const size_t serialized_size = dst->uncompressed_size();
     COUNTER_UPDATE(_serialized_bytes_counter, serialized_size * num_receivers);
 
-    if (_compress_codec != nullptr && _compress_codec->exceed_max_input_size(serialized_size)) {
-        return Status::InternalError(strings::Substitute("The input size for compression should be less than $0",
-                                                         _compress_codec->max_input_size()));
-    }
-
-    // try compress the ChunkPB data
     bool use_compression = true;
-    if (_compress_strategy) {
+    // TODO: Better split the large chunk to smaller size and then compress.
+    if (_compress_codec != nullptr && _compress_codec->exceed_max_input_size(serialized_size)) {
+        if (config::enable_rpc_compress_overflow_skip) {
+            LOG(WARNING) << "Serialized size " << serialized_size << " exceeds compression codec max input size "
+                         << _compress_codec->max_input_size() << ", skipping compression";
+            use_compression = false;
+        } else {
+            return Status::InternalError(Substitute("The input size for compression should be less than $0",
+                                                    _compress_codec->max_input_size()));
+        }
+    } else if (_compress_strategy) {
+        // try compress the ChunkPB data
         use_compression = _compress_strategy->decide();
     }
-    if (_compress_codec != nullptr && serialized_size > 0 && use_compression) {
+
+    if (use_compression && _compress_codec != nullptr && serialized_size > 0) {
         ScopedTimer<MonotonicStopWatch> _timer(_compress_timer);
 
         if (use_compression_pool(_compress_codec->type())) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -753,8 +753,8 @@ Status ExchangeSinkOperator::serialize_chunk(const Chunk* src, ChunkPB* dst, boo
                          << _compress_codec->max_input_size() << ", skipping compression";
             use_compression = false;
         } else {
-            return Status::InternalError(Substitute("The input size for compression should be less than $0",
-                                                    _compress_codec->max_input_size()));
+            return Status::InternalError(strings::Substitute("The input size for compression should be less than $0",
+                                                             _compress_codec->max_input_size()));
         }
     } else if (_compress_strategy) {
         // try compress the ChunkPB data

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -94,6 +94,9 @@ public:
 
     void set_execute_mode(int performance_level) override;
 
+    // For testing only: inject a custom codec to simulate exceed_max_input_size scenarios.
+    void set_compress_codec_for_testing(const BlockCompressionCodec* codec) { _compress_codec = codec; }
+
 private:
     bool _is_large_chunk(size_t sz) const {
         // ref olap_scan_node.cpp release_large_columns

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -94,8 +94,10 @@ public:
 
     void set_execute_mode(int performance_level) override;
 
+#ifdef BE_TEST
     // For testing only: inject a custom codec to simulate exceed_max_input_size scenarios.
     void set_compress_codec_for_testing(const BlockCompressionCodec* codec) { _compress_codec = codec; }
+#endif
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(EXEC_FILES
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/multi_cast_local_exchange_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
+        ./exec/pipeline/exchange_sink_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/exchange/exchange_sink_operator.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "common/config_exec_flow_fwd.h"
+#include "common/config_network_fwd.h"
+#include "exec/pipeline/fragment_context.h"
+#include "gen_cpp/DataSinks_types.h"
+#include "gen_cpp/InternalService_types.h"
+#include "gen_cpp/Partitions_types.h"
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/data.pb.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "testutil/column_test_helper.h"
+#include "util/compression/block_compression.h"
+
+namespace starrocks::pipeline {
+
+// Mock codec that always reports exceed_max_input_size for any non-zero payload.
+class AlwaysOverflowCodec final : public BlockCompressionCodec {
+public:
+    AlwaysOverflowCodec() : BlockCompressionCodec(LZ4) {}
+
+    Status compress(const Slice& input, Slice* output, bool use_compression_buffer, size_t uncompressed_size,
+                    faststring* compressed_body1, raw::RawString* compressed_body2) const override {
+        return Status::NotSupported("mock");
+    }
+
+    Status decompress(const Slice& input, Slice* output) const override { return Status::NotSupported("mock"); }
+
+    size_t max_compressed_len(size_t len) const override { return len; }
+
+    bool exceed_max_input_size(size_t len) const override { return len > 0; }
+
+    size_t max_input_size() const override { return 0; }
+};
+
+class ExchangeSinkOperatorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        BackendOptions::set_localhost("0.0.0.0");
+
+        _exec_env = ExecEnv::GetInstance();
+
+        _query_context = std::make_shared<QueryContext>();
+        _query_context->set_exec_env(_exec_env);
+        _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals, _exec_env);
+        _runtime_state->set_query_ctx(_query_context.get());
+        _runtime_state->init_instance_mem_tracker();
+
+        _fragment_context = std::make_shared<FragmentContext>();
+        _fragment_context->set_fragment_instance_id(_fragment_id);
+        _fragment_context->set_runtime_state(std::shared_ptr{_runtime_state});
+        _runtime_state->set_fragment_ctx(_fragment_context.get());
+        _runtime_state->set_fragment_dict_state(_fragment_context->dict_state());
+
+        TNetworkAddress address;
+        address.__set_hostname(BackendOptions::get_local_ip());
+        address.__set_port(config::brpc_port);
+        // Set lo=-1 so Channel::init skips brpc stub creation (no brpc infra in test env).
+        TUniqueId dest_fragment_id;
+        dest_fragment_id.__set_lo(-1);
+        dest_fragment_id.__set_hi(0);
+        _destination.__set_fragment_instance_id(dest_fragment_id);
+        _destination.__set_brpc_server(address);
+
+        _destinations = {_destination};
+        _sink_buffer = std::make_shared<SinkBuffer>(_fragment_context.get(), _destinations, /*is_dest_merge*/ false);
+
+        _factory = std::make_shared<ExchangeSinkOperatorFactory>(
+                0, 0, _sink_buffer, TPartitionType::UNPARTITIONED, _destinations,
+                /*is_pipeline_level_shuffle*/ false, /*num_shuffles_per_channel*/ 1,
+                /*sender_id*/ 0, /*dest_node_id*/ 0, /*partition_exprs*/ std::vector<ExprContext*>(),
+                /*enable_exchange_pass_through*/ false, /*enable_exchange_perf*/ false, _fragment_context.get(),
+                /*output_columns*/ std::vector<int32_t>(),
+                /*bucket_properties*/ std::vector<TBucketProperty>());
+        _factory->set_runtime_state(_runtime_state.get());
+    }
+
+    void TearDown() override { _query_context->set_exec_env(nullptr); }
+
+    // Build a minimal single-column INT chunk.
+    static ChunkPtr make_chunk() {
+        auto chunk = std::make_shared<Chunk>();
+        auto col = ColumnTestHelper::build_column<int32_t>({1, 2, 3});
+        chunk->append_column(std::move(col), 0);
+        return chunk;
+    }
+
+protected:
+    TUniqueId _fragment_id;
+    ExecEnv* _exec_env = nullptr;
+    std::shared_ptr<QueryContext> _query_context;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::shared_ptr<FragmentContext> _fragment_context;
+    std::vector<TPlanFragmentDestination> _destinations;
+    std::shared_ptr<SinkBuffer> _sink_buffer;
+    std::shared_ptr<ExchangeSinkOperatorFactory> _factory;
+    TPlanFragmentDestination _destination;
+
+    AlwaysOverflowCodec _overflow_codec;
+};
+
+// When enable_rpc_compress_overflow_skip=true and the codec reports overflow,
+// serialize_chunk should succeed (skip compression rather than error).
+TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_enabled) {
+    auto op = _factory->create(1, 0);
+    ASSERT_OK(op->prepare_local_state(_runtime_state.get()));
+
+    auto* sink = reinterpret_cast<ExchangeSinkOperator*>(op.get());
+    sink->set_compress_codec_for_testing(&_overflow_codec);
+
+    bool prev = config::enable_rpc_compress_overflow_skip;
+    DeferOp restore([&] { config::enable_rpc_compress_overflow_skip = prev; });
+    config::enable_rpc_compress_overflow_skip = true;
+
+    ChunkPB chunk_pb;
+    bool is_first = true;
+    EXPECT_OK(sink->serialize_chunk(make_chunk().get(), &chunk_pb, &is_first));
+    // No compression applied: compress_type stays at default (NO_COMPRESSION).
+    EXPECT_NE(chunk_pb.compress_type(), CompressionTypePB::LZ4);
+
+    op->close(_runtime_state.get());
+}
+
+// When enable_rpc_compress_overflow_skip=false and the codec reports overflow,
+// serialize_chunk should return InternalError.
+TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_disabled) {
+    auto op = _factory->create(1, 0);
+    ASSERT_OK(op->prepare_local_state(_runtime_state.get()));
+
+    auto* sink = reinterpret_cast<ExchangeSinkOperator*>(op.get());
+    sink->set_compress_codec_for_testing(&_overflow_codec);
+
+    bool prev = config::enable_rpc_compress_overflow_skip;
+    DeferOp restore([&] { config::enable_rpc_compress_overflow_skip = prev; });
+    config::enable_rpc_compress_overflow_skip = false;
+
+    ChunkPB chunk_pb;
+    bool is_first = true;
+    auto st = sink->serialize_chunk(make_chunk().get(), &chunk_pb, &is_first);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+
+    op->close(_runtime_state.get());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
-#include "gutil/casts.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "common/config_exec_flow_fwd.h"
@@ -28,6 +27,7 @@
 #include "gen_cpp/Partitions_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/data.pb.h"
+#include "gutil/casts.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "testutil/column_test_helper.h"

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
+#include "gutil/casts.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "common/config_exec_flow_fwd.h"
@@ -129,7 +130,7 @@ TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_enabled) {
     auto op = _factory->create(1, 0);
     ASSERT_OK(op->prepare_local_state(_runtime_state.get()));
 
-    auto* sink = reinterpret_cast<ExchangeSinkOperator*>(op.get());
+    auto* sink = down_cast<ExchangeSinkOperator*>(op.get());
     sink->set_compress_codec_for_testing(&_overflow_codec);
 
     bool prev = config::enable_rpc_compress_overflow_skip;
@@ -140,7 +141,7 @@ TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_enabled) {
     bool is_first = true;
     EXPECT_OK(sink->serialize_chunk(make_chunk().get(), &chunk_pb, &is_first));
     // No compression applied: compress_type stays at default (NO_COMPRESSION).
-    EXPECT_NE(chunk_pb.compress_type(), CompressionTypePB::LZ4);
+    EXPECT_EQ(chunk_pb.compress_type(), CompressionTypePB::NO_COMPRESSION);
 
     op->close(_runtime_state.get());
 }
@@ -151,7 +152,7 @@ TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_disabled) {
     auto op = _factory->create(1, 0);
     ASSERT_OK(op->prepare_local_state(_runtime_state.get()));
 
-    auto* sink = reinterpret_cast<ExchangeSinkOperator*>(op.get());
+    auto* sink = down_cast<ExchangeSinkOperator*>(op.get());
     sink->set_compress_codec_for_testing(&_overflow_codec);
 
     bool prev = config::enable_rpc_compress_overflow_skip;

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -460,6 +460,15 @@ This topic introduces the following types of FE configurations:
 - Description: Threshold (uncompressed_size / compressed_size) used when deciding whether to send serialized row-batches over the network in compressed form. When compression is attempted (e.g., in DataStreamSender, exchange sink, tablet sink index channel, dictionary cache writer), StarRocks computes compress_ratio = uncompressed_size / compressed_size; it uses the compressed payload only if compress_ratio `>` rpc_compress_ratio_threshold. With the default 1.1, compressed data must be at least ~9.1% smaller than uncompressed to be used. Lower the value to prefer compression (more CPU for smaller bandwidth savings); raise it to avoid compression overhead unless it yields larger size reductions. Note: this applies to RPC/shuffle serialization and is effective only when row-batch compression is enabled (compress_rowbatches).
 - Introduced in: v3.2.0
 
+### enable_rpc_compress_overflow_skip
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls the behavior when the serialized chunk size exceeds the compression codec's maximum allowed input size. When set to `true` (default), StarRocks logs a warning and skips compression, sending the data uncompressed instead. When set to `false`, StarRocks returns an `InternalError` and aborts the RPC.
+- Introduced in: -
+
 ### ssl_private_key_path
 
 - Default: An empty string

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -357,6 +357,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 複数の IP アドレスを持つサーバーの選択戦略を宣言します。注意すべき点は、このパラメータで指定されたリストと一致する IP アドレスは最大で 1 つでなければなりません。このパラメータの値は、CIDR 表記でセミコロン (;) で区切られたエントリからなるリストです。例: `10.10.10.0/24`。このリストのエントリと一致する IP アドレスがない場合、サーバーの利用可能な IP アドレスがランダムに選択されます。v3.3.0 から、StarRocks は IPv6 に基づくデプロイをサポートしています。サーバーが IPv4 と IPv6 の両方のアドレスを持っている場合、このパラメータが指定されていない場合、システムはデフォルトで IPv4 アドレスを使用します。この動作を変更するには、`net_use_ipv6_when_priority_networks_empty` を `true` に設定します。
 - 導入バージョン: -
 
+### enable_rpc_compress_overflow_skip
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: シリアライズされた chunk のサイズが圧縮コーデックの最大入力サイズを超えた場合の動作を制御します。`true`（デフォルト）に設定すると、StarRocks は警告ログを記録して圧縮をスキップし、非圧縮のままデータを送信します。`false` に設定すると、StarRocks は `InternalError` を返して RPC を中断します。
+- 導入バージョン: -
+
 ### ssl_private_key_path
 
 - デフォルト: An empty string

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -470,6 +470,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：在决定是否以压缩形式通过网络发送序列化的 row-batches 时使用的阈值（uncompressed_size / compressed_size）。当尝试压缩时（例如在 DataStreamSender、exchange sink、tablet sink 的索引通道、dictionary cache writer 中），StarRocks 会计算 compress_ratio = uncompressed_size / compressed_size；仅当 compress_ratio `>` rpc_compress_ratio_threshold 时才使用压缩后的负载。默认值 1.1 意味着压缩数据必须至少比未压缩小约 9.1% 才会被使用。将该值调低以偏好压缩（以更多 CPU 换取更小的带宽）；将其调高以避免压缩开销，除非压缩能带来更大的尺寸缩减。注意：此项适用于 RPC/shuffle 序列化，仅在启用 row-batch 压缩（compress_rowbatches）时生效。
 - 引入版本：v3.2.0
 
+### enable_rpc_compress_overflow_skip
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：控制序列化的 chunk 大小超过压缩 codec 允许的最大输入大小时的行为。设置为 `true`（默认）时，StarRocks 记录一条警告日志并跳过压缩，以未压缩形式发送数据。设置为 `false` 时，StarRocks 返回 `InternalError` 并中止 RPC。
+- 引入版本：-
+
 ### ssl_private_key_path
 
 - 默认值：空字符串


### PR DESCRIPTION
## Why I'm doing:

Some compression codecs (e.g. LZ4) have a hard limit on max input size. When a serialized chunk exceeds this limit, ExchangeSinkOperator::serialize_chunk previously returned InternalError, causing the query to fail. In practice this is rare but can happen with very large chunks. Failing the query entirely is overly aggressive — sending uncompressed data is a safe fallback.

```
ERROR 1064 (HY000): The input size for compression should be less than 2113929216: BE:1000
```

## What I'm doing:

Add a new BE config enable_rpc_compress_overflow_skip (default: true). 
- When true: if the serialized chunk size exceeds the codec's max input size, skip compression and send the data uncompressed, with a WARNING log. The query continues normally. 
- When false: preserve the original behavior and return InternalError. 

Also adds a unit test (ExchangeSinkOperatorTest) covering both behaviors.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4