### PR TITLE
[BugFix] Fix potential null pointer on join reordering

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
@@ -141,9 +141,11 @@ public class JoinReorderGreedy extends JoinOrder {
     }
 
     private GroupInfo getBestGroupInfo(List<GroupInfo> groupInfos) {
-        double bestCost = Double.MAX_VALUE;
-        GroupInfo bestExpr = null;
-        for (GroupInfo groupInfo : groupInfos) {
+        Preconditions.checkState(!groupInfos.isEmpty());
+        var bestExpr = groupInfos.get(0);
+        double bestCost = bestExpr.bestExprInfo.cost;
+        for (int i = 1; i < groupInfos.size(); i++) {
+            var groupInfo = groupInfos.get(i);
             if (groupInfo.bestExprInfo.cost < bestCost) {
                 bestExpr = groupInfo;
                 bestCost = groupInfo.bestExprInfo.cost;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
@@ -140,7 +140,7 @@ public class JoinReorderGreedy extends JoinOrder {
         }
     }
 
-    private GroupInfo getBestGroupInfo(List<GroupInfo> groupInfos) {
+    protected GroupInfo getBestGroupInfo(List<GroupInfo> groupInfos) {
         Preconditions.checkState(!groupInfos.isEmpty());
         var bestExpr = groupInfos.get(0);
         double bestCost = bestExpr.bestExprInfo.cost;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedyTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.join;
+
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class JoinReorderGreedyTest {
+
+    private JoinOrder.GroupInfo createGroupInfoWithCost(int atomIndex, double cost) {
+        final var atoms = new BitSet();
+        atoms.set(atomIndex);
+        JoinOrder.GroupInfo groupInfo = new JoinOrder.GroupInfo(atoms);
+        JoinOrder.ExpressionInfo exprInfo = new JoinOrder.ExpressionInfo(null);
+        exprInfo.cost = cost;
+        groupInfo.bestExprInfo = exprInfo;
+        groupInfo.lowestExprCost = cost;
+        return groupInfo;
+    }
+
+    @Test
+    public void testGetBestGroupInfoWithMaxValueCosts() {
+        // GIVEN
+        final var greedy = new JoinReorderGreedy(OptimizerFactory.mockContext(new ColumnRefFactory()));
+        final var group0 = createGroupInfoWithCost(0, Double.MAX_VALUE);
+        final var group1 = createGroupInfoWithCost(1, Double.MAX_VALUE);
+        final var groupInfos = List.of(group0, group1);
+
+        // WHEN
+        final var best = greedy.getBestGroupInfo(groupInfos);
+
+        // THEN
+        assertNotNull(best);
+        assertSame(group0, best);
+    }
+}
+
+


### PR DESCRIPTION
## Why I'm doing:

If the best cost of every group info is `Double.MAX_VALUE`, this method returns null (`bestExpr`) which leads to a `NullPointerException` upstream.

## What I'm doing:
If there is no best cost, return the first entry.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
