### PR TITLE
[BugFix] Fix race condition in _all_global_rf_ready_or_timeout

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -367,12 +367,13 @@ public:
         if (_all_global_rf_ready_or_timeout) {
             return false;
         }
-        _all_global_rf_ready_or_timeout = true;
 
         // timeout check
         if (_precondition_block_timer_sw->elapsed_time() >= _global_rf_wait_timeout_ns) {
             return false;
         }
+
+        bool all_ready = true;
         // check if all the remote RFs are ready.
         for (auto* rf_desc : _global_rf_descriptors) {
             if (rf_desc->is_local() || rf_desc->runtime_filter(-1) != nullptr) {
@@ -381,9 +382,10 @@ public:
             if (rf_waiting_set != nullptr) {
                 rf_waiting_set->append(std::to_string(rf_desc->filter_id()) + ",");
             }
-            _all_global_rf_ready_or_timeout = false;
+            all_ready = false;
         }
-        return !_all_global_rf_ready_or_timeout;
+        _all_global_rf_ready_or_timeout = _all_global_rf_ready_or_timeout || all_ready;
+        return !all_ready;
     }
 
     // return true if either dependencies_block or local_rf_block return true, which means that the current driver


### PR DESCRIPTION
## Why I'm doing:

RFScanTask will call set_all_global_rf_timeout. At the same time, if `global_rf_block` is being called, it will override this event.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
