### PR TITLE
[Enhancement] Support shredded VARIANT virtual-column reads for Iceberg Parquet

### DIFF
--- a/be/src/column/variant_merger.cpp
+++ b/be/src/column/variant_merger.cpp
@@ -21,6 +21,7 @@
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/variant_column.h"
+#include "column/variant_converter.h"
 #include "column/variant_encoder.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
@@ -181,6 +182,38 @@ static StatusOr<MutableColumnPtr> cast_numeric_column(const Column& src_col, Log
     return dst_col;
 }
 
+template <LogicalType ResultType>
+static StatusOr<MutableColumnPtr> cast_variant_column_to_scalar(const Column& src_col, const cctz::time_zone& zone) {
+    const auto* variant_col = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(&src_col));
+    if (variant_col == nullptr) {
+        return Status::InvalidArgument("input variant column is invalid");
+    }
+    ColumnBuilder<ResultType> builder(src_col.size());
+    const bool is_const = src_col.is_constant();
+    VariantRowRef row_ref;
+    VariantRowValue row_buffer;
+    for (size_t i = 0; i < src_col.size(); ++i) {
+        if (src_col.is_null(i)) {
+            builder.append_null();
+            continue;
+        }
+        size_t variant_row = is_const ? 0 : i;
+        if (variant_col->try_get_row_ref(variant_row, &row_ref)) {
+            Status cast_status = VariantRowConverter::cast_to<ResultType, false>(row_ref, zone, builder);
+            RETURN_IF_ERROR(cast_status);
+            continue;
+        }
+        const VariantRowValue* row = variant_col->get_row_value(variant_row, &row_buffer);
+        if (row == nullptr) {
+            builder.append_null();
+            continue;
+        }
+        Status cast_status = VariantRowConverter::cast_to<ResultType, false>(row->as_ref(), zone, builder);
+        RETURN_IF_ERROR(cast_status);
+    }
+    return builder.build(false);
+}
+
 static StatusOr<int128_t> datum_to_decimalv3_int128(const Datum& datum, LogicalType src_type) {
     switch (src_type) {
     case TYPE_DECIMAL32:
@@ -258,11 +291,52 @@ StatusOr<TypeDescriptor> VariantColumnMerger::choose_common_type(const TypeDescr
 StatusOr<MutableColumnPtr> VariantColumnMerger::cast_typed_column(const Column& src_col,
                                                                   const TypeDescriptor& src_type_desc,
                                                                   const TypeDescriptor& dst_type_desc) {
+    if (src_type_desc.type == TYPE_VARIANT &&
+        (dst_type_desc.type == TYPE_DATE || dst_type_desc.type == TYPE_DATETIME || dst_type_desc.type == TYPE_TIME)) {
+        return Status::NotSupported("variant merge cast to temporal type requires explicit timezone context");
+    }
+    return cast_typed_column(src_col, src_type_desc, dst_type_desc, cctz::local_time_zone());
+}
+
+StatusOr<MutableColumnPtr> VariantColumnMerger::cast_typed_column(const Column& src_col,
+                                                                  const TypeDescriptor& src_type_desc,
+                                                                  const TypeDescriptor& dst_type_desc,
+                                                                  const cctz::time_zone& timezone) {
     if (src_type_desc == dst_type_desc) {
         return src_col.clone();
     }
     if (dst_type_desc.type == TYPE_VARIANT) {
         return cast_column_to_variant(src_col, src_type_desc);
+    }
+    if (src_type_desc.type == TYPE_VARIANT) {
+        switch (dst_type_desc.type) {
+        case TYPE_BOOLEAN:
+            return cast_variant_column_to_scalar<TYPE_BOOLEAN>(src_col, timezone);
+        case TYPE_TINYINT:
+            return cast_variant_column_to_scalar<TYPE_TINYINT>(src_col, timezone);
+        case TYPE_SMALLINT:
+            return cast_variant_column_to_scalar<TYPE_SMALLINT>(src_col, timezone);
+        case TYPE_INT:
+            return cast_variant_column_to_scalar<TYPE_INT>(src_col, timezone);
+        case TYPE_BIGINT:
+            return cast_variant_column_to_scalar<TYPE_BIGINT>(src_col, timezone);
+        case TYPE_LARGEINT:
+            return cast_variant_column_to_scalar<TYPE_LARGEINT>(src_col, timezone);
+        case TYPE_FLOAT:
+            return cast_variant_column_to_scalar<TYPE_FLOAT>(src_col, timezone);
+        case TYPE_DOUBLE:
+            return cast_variant_column_to_scalar<TYPE_DOUBLE>(src_col, timezone);
+        case TYPE_VARCHAR:
+            return cast_variant_column_to_scalar<TYPE_VARCHAR>(src_col, timezone);
+        case TYPE_DATE:
+            return cast_variant_column_to_scalar<TYPE_DATE>(src_col, timezone);
+        case TYPE_DATETIME:
+            return cast_variant_column_to_scalar<TYPE_DATETIME>(src_col, timezone);
+        case TYPE_TIME:
+            return cast_variant_column_to_scalar<TYPE_TIME>(src_col, timezone);
+        default:
+            break;
+        }
     }
     if (src_type_desc.is_decimalv3_type() && dst_type_desc.is_decimalv3_type()) {
         return cast_decimalv3_column(src_col, src_type_desc, dst_type_desc);

--- a/be/src/column/variant_merger.h
+++ b/be/src/column/variant_merger.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cctz/time_zone.h>
+
 #include "base/status.h"
 #include "base/statusor.h"
 #include "column/column.h"
@@ -51,8 +53,21 @@ class VariantColumnMerger {
 public:
     static StatusOr<TypeDescriptor> choose_common_type(const TypeDescriptor& lhs, const TypeDescriptor& rhs);
 
+    // Compatibility wrapper for callers that do not carry session timezone context.
+    //
+    // This overload is safe for non-temporal casts. For VARIANT -> DATE/TIME/DATETIME it
+    // intentionally rejects the cast instead of silently using a process-local timezone,
+    // because temporal cast semantics must follow the query/session timezone.
     static StatusOr<MutableColumnPtr> cast_typed_column(const Column& src_col, const TypeDescriptor& src_type_desc,
                                                         const TypeDescriptor& dst_type_desc);
+
+    // Main implementation for callers that already have the query/session timezone.
+    //
+    // Use this overload for any cast path that may produce temporal results from VARIANT,
+    // so DATE/TIME/DATETIME conversion uses the explicit runtime timezone context.
+    static StatusOr<MutableColumnPtr> cast_typed_column(const Column& src_col, const TypeDescriptor& src_type_desc,
+                                                        const TypeDescriptor& dst_type_desc,
+                                                        const cctz::time_zone& timezone);
 
     // Reconcile overlapping shredded path type conflicts between dst and src.
     // Numeric/decimalv3 paths are widened when possible; unsupported conflicts are hoisted to TYPE_VARIANT.

--- a/be/src/exprs/variant_functions.cpp
+++ b/be/src/exprs/variant_functions.cpp
@@ -149,7 +149,9 @@ static ColumnPtr _build_typed_cast_result(FunctionContext* context, const Column
                                           size_t num_rows) {
     if constexpr (ResultType == TYPE_BIGINT || ResultType == TYPE_DOUBLE) {
         TypeDescriptor result_type_desc = TypeDescriptor::from_logical_type(ResultType);
-        auto casted = VariantColumnMerger::cast_typed_column(*typed_col, typed_type_desc, result_type_desc);
+        cctz::time_zone zone =
+                (context->state() == nullptr) ? cctz::local_time_zone() : context->state()->timezone_obj();
+        auto casted = VariantColumnMerger::cast_typed_column(*typed_col, typed_type_desc, result_type_desc, zone);
         if (casted.ok()) {
             return _build_typed_bulk_result<ResultType>(casted.value().get(), variant_col, num_rows);
         }

--- a/be/src/formats/parquet/column_reader_factory.cpp
+++ b/be/src/formats/parquet/column_reader_factory.cpp
@@ -440,7 +440,8 @@ StatusOr<ColumnReaderPtr> ColumnReaderFactory::create(const ColumnReaderOptions&
 
         std::vector<int32_t> subfield_pos(col_type.children.size());
         std::vector<const TIcebergSchemaField*> lake_schema_subfield(col_type.children.size());
-        get_subfield_pos_with_pruned_type(*field, col_type, opts.case_sensitive, lake_schema_field, subfield_pos,
+        get_subfield_pos_with_pruned_type(*field, col_type, opts.case_sensitive, lake_schema_field,
+                                          opts.file_meta_data->schema().exist_filed_id(), subfield_pos,
                                           lake_schema_subfield);
 
         std::map<std::string, std::unique_ptr<ColumnReader>> children_readers;
@@ -595,7 +596,7 @@ void ColumnReaderFactory::get_subfield_pos_with_pruned_type(const ParquetField& 
 
 void ColumnReaderFactory::get_subfield_pos_with_pruned_type(
         const ParquetField& field, const TypeDescriptor& col_type, bool case_sensitive,
-        const TIcebergSchemaField* lake_schema_field, std::vector<int32_t>& pos,
+        const TIcebergSchemaField* lake_schema_field, bool parquet_has_field_id, std::vector<int32_t>& pos,
         std::vector<const TIcebergSchemaField*>& lake_schema_subfield) {
     // For Struct type with schema change, we need to consider a subfield not existed situation.
     // When Iceberg adds a new struct subfield, the original parquet file does not contain the newly added subfield.
@@ -606,36 +607,52 @@ void ColumnReaderFactory::get_subfield_pos_with_pruned_type(
     }
 
     std::unordered_map<int32_t, size_t> field_id_2_pos{};
+    std::unordered_map<std::string, size_t> field_name_2_pos{};
     for (size_t i = 0; i < field.children.size(); i++) {
-        field_id_2_pos.emplace(field.children[i].field_id, i);
+        if (parquet_has_field_id) {
+            field_id_2_pos.emplace(field.children[i].field_id, i);
+        } else {
+            field_name_2_pos.emplace(Utils::format_name(field.children[i].name, case_sensitive), i);
+        }
     }
     for (size_t i = 0; i < col_type.children.size(); i++) {
-        const auto& format_subfield_name =
+        const auto schema_subfield_name =
                 case_sensitive ? col_type.field_names[i] : boost::algorithm::to_lower_copy(col_type.field_names[i]);
+        const auto parquet_subfield_name =
+                !col_type.field_physical_names.empty()
+                        ? Utils::format_name(col_type.field_physical_names[i], case_sensitive)
+                        : schema_subfield_name;
 
-        auto iceberg_it = subfield_name_2_field_schema.find(format_subfield_name);
+        auto iceberg_it = subfield_name_2_field_schema.find(schema_subfield_name);
         if (iceberg_it == subfield_name_2_field_schema.end()) {
             // This situation should not be happened, means table's struct subfield not existed in iceberg schema
             // Below code is defensive
-            DCHECK(false) << "Struct subfield name: " + format_subfield_name + " not found in iceberg schema.";
+            DCHECK(false) << "Struct subfield name: " + schema_subfield_name + " not found in iceberg schema.";
             pos[i] = -1;
             lake_schema_subfield[i] = nullptr;
             continue;
         }
 
-        int32_t field_id = iceberg_it->second->field_id;
-
-        auto parquet_field_it = field_id_2_pos.find(field_id);
-        if (parquet_field_it == field_id_2_pos.end()) {
-            // Means newly added struct subfield not existed in an original parquet file, we put nullptr
-            // column reader in children_reader, we will append the default value for this subfield later.
-            pos[i] = -1;
-            lake_schema_subfield[i] = nullptr;
-            continue;
+        if (parquet_has_field_id) {
+            int32_t field_id = iceberg_it->second->field_id;
+            auto parquet_field_it = field_id_2_pos.find(field_id);
+            if (parquet_field_it == field_id_2_pos.end()) {
+                pos[i] = -1;
+                lake_schema_subfield[i] = nullptr;
+                continue;
+            }
+            pos[i] = parquet_field_it->second;
+            lake_schema_subfield[i] = iceberg_it->second;
+        } else {
+            auto parquet_field_it = field_name_2_pos.find(parquet_subfield_name);
+            if (parquet_field_it == field_name_2_pos.end()) {
+                pos[i] = -1;
+                lake_schema_subfield[i] = nullptr;
+                continue;
+            }
+            pos[i] = parquet_field_it->second;
+            lake_schema_subfield[i] = iceberg_it->second;
         }
-
-        pos[i] = parquet_field_it->second;
-        lake_schema_subfield[i] = iceberg_it->second;
     }
 }
 

--- a/be/src/formats/parquet/column_reader_factory.h
+++ b/be/src/formats/parquet/column_reader_factory.h
@@ -53,7 +53,7 @@ private:
     // for schema changed
     static void get_subfield_pos_with_pruned_type(const ParquetField& field, const TypeDescriptor& col_type,
                                                   bool case_sensitive, const TIcebergSchemaField* lake_schema_field,
-                                                  std::vector<int32_t>& pos,
+                                                  bool parquet_has_field_id, std::vector<int32_t>& pos,
                                                   std::vector<const TIcebergSchemaField*>& lake_schema_subfield);
 };
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -86,9 +86,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
 }
 
 std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
-    if (_scanner_ctx->lake_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
-        // If we want read this parquet file with iceberg/paimon schema,
-        // we also need to make sure it contains parquet field id.
+    if (_scanner_ctx->lake_schema != nullptr) {
         return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->case_sensitive,
                                                 _scanner_ctx->lake_schema);
     } else {
@@ -211,8 +209,8 @@ StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& gro
 }
 
 void FileReader::_prepare_read_columns(std::unordered_set<std::string>& existed_column_names) {
-    _meta_helper->prepare_read_columns(_scanner_ctx->materialized_columns, _group_reader_param.read_cols,
-                                       existed_column_names);
+    _meta_helper->prepare_read_columns(_scanner_ctx->materialized_columns, _scanner_ctx->column_access_paths,
+                                       _group_reader_param.read_cols, existed_column_names);
     _no_materialized_column_scan =
             (_group_reader_param.read_cols.empty() && _scanner_ctx->reserved_field_slots.empty());
 }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -24,8 +24,13 @@
 #include "agent/master_info.h"
 #include "base/concurrency/stopwatch.hpp"
 #include "base/simd/simd.h"
+#include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
+#include "column/column_builder.h"
+#include "column/column_helper.h"
+#include "column/variant_column.h"
+#include "column/variant_converter.h"
 #include "column/variant_path_parser.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/runtime_profile.h"
@@ -35,6 +40,7 @@
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "exprs/variant_path_reader.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
 #include "formats/parquet/metadata.h"
@@ -52,6 +58,200 @@
 namespace starrocks::parquet {
 
 namespace {
+
+// Deduplicate exact-duplicate IO ranges collected from multiple column readers.
+//
+// VariantColumnReader::collect_column_io_range walks both the top-level field readers
+// (_top_level.value_reader, _top_level.metadata_reader, etc.) and the shredded-field
+// subtree.  A shredded field's value_reader may point to the same underlying parquet
+// column chunk as the top-level value_reader, causing the same (offset, size) pair to
+// be registered more than once.  When that happens the two entries are collapsed into
+// one, with is_active set to the logical OR so that a range used by either an active
+// or a lazy reader is treated as active.
+//
+// Note: this only handles *exact* duplicates (identical offset and size).  True byte-range
+// overlaps are not expected because the parquet format guarantees that column chunks for
+// different columns occupy non-overlapping byte ranges within the file.
+void deduplicate_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges) {
+    if (ranges == nullptr || ranges->size() <= 1) {
+        return;
+    }
+
+    std::sort(ranges->begin(), ranges->end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.offset != rhs.offset) {
+            return lhs.offset < rhs.offset;
+        }
+        if (lhs.size != rhs.size) {
+            return lhs.size < rhs.size;
+        }
+        return lhs.is_active < rhs.is_active;
+    });
+
+    size_t write_idx = 0;
+    for (size_t read_idx = 1; read_idx < ranges->size(); ++read_idx) {
+        auto& current = (*ranges)[write_idx];
+        const auto& next = (*ranges)[read_idx];
+        if (current.offset == next.offset && current.size == next.size) {
+            current.is_active = current.is_active || next.is_active;
+            continue;
+        }
+        ++write_idx;
+        if (write_idx != read_idx) {
+            (*ranges)[write_idx] = next;
+        }
+    }
+    ranges->erase(ranges->begin() + static_cast<std::ptrdiff_t>(write_idx + 1), ranges->end());
+}
+
+StatusOr<ColumnPtr> build_exact_typed_variant_projection(const VariantColumn* variant_column,
+                                                         const ColumnPtr& variant_src, const VariantPath& path,
+                                                         const TypeDescriptor& target_type) {
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+    if (!reader.is_typed_exact()) {
+        return Status::NotFound("variant path is not an exact typed leaf");
+    }
+    if (reader.typed_type_desc() != target_type) {
+        return Status::NotFound("variant typed leaf type does not match target slot type");
+    }
+
+    const size_t num_rows = variant_src->size();
+    const Column* typed_col = reader.typed_column();
+
+    // Early exit: const variant whose single row is null → broadcast null to all rows.
+    if (variant_src->is_constant() && variant_src->is_null(0)) {
+        auto all_null = ColumnHelper::create_column(target_type, true);
+        all_null->append_nulls(num_rows);
+        return all_null;
+    }
+
+    // Normalise: expand a const variant source so both typed_col and variant_src have
+    // num_rows rows, letting the null-merge and data-clone logic below work uniformly.
+    ColumnPtr expanded_typed;
+    if (variant_src->is_constant()) {
+        // typed_col has 1 row (the single VariantColumn row); replicate it to num_rows.
+        expanded_typed = typed_col->clone();
+        expanded_typed->as_mutable_ptr()->assign(num_rows, 0);
+    }
+    const Column* eff_typed = variant_src->is_constant() ? expanded_typed.get() : typed_col;
+    DCHECK_EQ(eff_typed->size(), num_rows);
+
+    // Merge null masks: result is null when either the outer variant or the typed leaf
+    // is null.  Outer nulls only exist for non-const variant_src (const-null was handled
+    // above; const-non-null has no outer null mask to propagate).
+    const bool has_outer_nulls = !variant_src->is_constant() && variant_src->is_nullable() &&
+                                 down_cast<const NullableColumn*>(variant_src.get())->has_null();
+    const bool has_typed_nulls = eff_typed->is_nullable() && down_cast<const NullableColumn*>(eff_typed)->has_null();
+
+    auto result_null = NullColumn::create(num_rows, 0);
+    NullData& result_null_data = result_null->get_data();
+
+    if (has_outer_nulls && has_typed_nulls) {
+        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
+        const auto typed = down_cast<const NullableColumn*>(eff_typed)->immutable_null_column_data();
+        for (size_t i = 0; i < num_rows; ++i) {
+            result_null_data[i] = outer[i] | typed[i];
+        }
+    } else if (has_outer_nulls) {
+        const auto outer = down_cast<const NullableColumn*>(variant_src.get())->immutable_null_column_data();
+        std::copy(outer.begin(), outer.end(), result_null_data.begin());
+    } else if (has_typed_nulls) {
+        const auto typed = down_cast<const NullableColumn*>(eff_typed)->immutable_null_column_data();
+        std::copy(typed.begin(), typed.end(), result_null_data.begin());
+    }
+    // else: no nulls anywhere — result_null stays all-zero.
+
+    auto result_data = ColumnHelper::get_data_column(eff_typed)->clone();
+    auto result = NullableColumn::create(std::move(result_data), std::move(result_null));
+    result->update_has_null();
+    return result;
+}
+
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
+                                                    const VariantPath& path, const cctz::time_zone& zone) {
+    const size_t num_rows = variant_src->size();
+
+    ColumnBuilder<ResultType> builder(num_rows);
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+
+    for (size_t row = 0; row < num_rows; ++row) {
+        if (variant_src->is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+        size_t variant_row = variant_src->is_constant() ? 0 : row;
+        VariantReadResult read = reader.read_row(variant_row);
+        if (read.state != VariantReadState::kValue) {
+            builder.append_null();
+            continue;
+        }
+        auto cast_status = VariantRowConverter::cast_to<ResultType, false>(read.value.as_ref(), zone, builder);
+        RETURN_IF_ERROR(cast_status);
+    }
+
+    return builder.build(false);
+}
+
+StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, const VariantPath& path,
+                                                const TypeDescriptor& target_type, const cctz::time_zone& zone) {
+    auto* variant_column = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(variant_src.get()));
+    if (variant_column == nullptr) {
+        return Status::InternalError("variant source column is invalid");
+    }
+
+    auto exact_typed_result = build_exact_typed_variant_projection(variant_column, variant_src, path, target_type);
+    if (exact_typed_result.ok()) {
+        return exact_typed_result;
+    }
+
+    switch (target_type.type) {
+    case TYPE_BOOLEAN:
+        return build_variant_projection_column<TYPE_BOOLEAN>(variant_column, variant_src, path, zone);
+    case TYPE_TINYINT:
+        return build_variant_projection_column<TYPE_TINYINT>(variant_column, variant_src, path, zone);
+    case TYPE_SMALLINT:
+        return build_variant_projection_column<TYPE_SMALLINT>(variant_column, variant_src, path, zone);
+    case TYPE_INT:
+        return build_variant_projection_column<TYPE_INT>(variant_column, variant_src, path, zone);
+    case TYPE_BIGINT:
+        return build_variant_projection_column<TYPE_BIGINT>(variant_column, variant_src, path, zone);
+    case TYPE_LARGEINT:
+        return build_variant_projection_column<TYPE_LARGEINT>(variant_column, variant_src, path, zone);
+    case TYPE_FLOAT:
+        return build_variant_projection_column<TYPE_FLOAT>(variant_column, variant_src, path, zone);
+    case TYPE_DOUBLE:
+        return build_variant_projection_column<TYPE_DOUBLE>(variant_column, variant_src, path, zone);
+    case TYPE_VARCHAR:
+        return build_variant_projection_column<TYPE_VARCHAR>(variant_column, variant_src, path, zone);
+    case TYPE_DATE:
+        return build_variant_projection_column<TYPE_DATE>(variant_column, variant_src, path, zone);
+    case TYPE_DATETIME:
+        return build_variant_projection_column<TYPE_DATETIME>(variant_column, variant_src, path, zone);
+    case TYPE_TIME:
+        return build_variant_projection_column<TYPE_TIME>(variant_column, variant_src, path, zone);
+    case TYPE_VARIANT:
+        return build_variant_projection_column<TYPE_VARIANT>(variant_column, variant_src, path, zone);
+    default:
+        return Status::NotSupported("unsupported variant virtual column target type");
+    }
+}
+
+StatusOr<ColumnPtr> get_variant_projection_source_column(const ChunkPtr& output_chunk, const ChunkPtr& read_chunk,
+                                                         const ChunkPtr& hidden_read_chunk, SlotId slot_id) {
+    if (output_chunk->is_slot_exist(slot_id)) {
+        return output_chunk->get_column_by_slot_id(slot_id);
+    }
+    if (read_chunk->is_slot_exist(slot_id)) {
+        return read_chunk->get_column_by_slot_id(slot_id);
+    }
+    if (!hidden_read_chunk->is_slot_exist(slot_id)) {
+        return Status::InternalError(
+                strings::Substitute("variant virtual column source slot $0 not found in any chunk", slot_id));
+    }
+    return hidden_read_chunk->get_column_by_slot_id(slot_id);
+}
 
 bool collect_variant_leaf_paths(const ColumnAccessPath* node, std::vector<VariantSegment>* segments,
                                 std::vector<std::string>* shredded_paths) {
@@ -270,11 +470,53 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
             active_chunk->merge(std::move(*lazy_chunk));
         }
 
-        *row_count = active_chunk->num_rows();
+        if (!_hidden_variant_sources.empty()) {
+            if (has_filter) {
+                Range<uint64_t> hidden_read_range = r.filter(&chunk_filter);
+                DCHECK(hidden_read_range.span_size() > 0);
+                Filter hidden_filter = {chunk_filter.begin() + hidden_read_range.begin() - r.begin(),
+                                        chunk_filter.begin() + hidden_read_range.end() - r.begin()};
+                for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+                    auto& hidden_column = _read_chunk->get_column_by_slot_id(hidden_source.slot_id);
+                    RETURN_IF_ERROR(hidden_source.reader->read_range(hidden_read_range, &hidden_filter, hidden_column));
+                    hidden_column->as_mutable_ptr()->filter_range(hidden_filter, 0, hidden_read_range.span_size());
+                }
+            } else {
+                for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+                    auto& hidden_column = _read_chunk->get_column_by_slot_id(hidden_source.slot_id);
+                    RETURN_IF_ERROR(hidden_source.reader->read_range(r, nullptr, hidden_column));
+                }
+            }
+        }
 
         SCOPED_RAW_TIMER(&_param.stats->group_dict_decode_ns);
         // convert from _read_chunk to chunk.
         RETURN_IF_ERROR(_fill_dst_chunk(active_chunk, chunk));
+        // (*chunk)->num_rows() uses _columns[0]->size(), which may be a not-existed column
+        // (e.g. a renamed-away Iceberg column) that is filled later by the file reader and
+        // so still has size 0 here.  Read the count from the first read_cols slot that is
+        // present in *chunk instead; fall back to active_chunk if read_cols is empty.
+        auto filled_num_rows = [&]() -> size_t {
+            for (const auto& col : _param.read_cols) {
+                SlotId sid = col.slot_id();
+                if ((*chunk)->is_slot_exist(sid)) {
+                    return (*chunk)->get_column_by_slot_id(sid)->size();
+                }
+            }
+            return active_chunk->num_rows();
+        };
+        if (!_deferred_variant_virtual_conjunct_ctxs.empty()) {
+            SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);
+            RETURN_IF_ERROR(
+                    ChunkPredicateEvaluator::eval_conjuncts(_deferred_variant_virtual_conjunct_ctxs, chunk->get()));
+            if (filled_num_rows() == 0) {
+                (*chunk)->reset();
+                _read_chunk->reset();
+                _param.stats->late_materialize_skip_rows += count;
+                continue;
+            }
+        }
+        *row_count = filled_num_rows();
         break;
     }
 
@@ -454,6 +696,21 @@ VariantShreddedReadHints GroupReader::_get_variant_shredded_hints(const std::str
     hints.shredded_paths.erase(std::remove_if(hints.shredded_paths.begin(), hints.shredded_paths.end(),
                                               [](const std::string& path) { return path.empty(); }),
                                hints.shredded_paths.end());
+
+    // Remove paths that are strict prefixes of another hint path.
+    // e.g. if both "a.b" and "a.b.c" are collected, "a.b" is redundant.
+    // A shredded path p is a prefix of q if q starts with p followed by '.' or '['.
+    auto is_prefix_of_another = [&](const std::string& p) {
+        for (const auto& q : hints.shredded_paths) {
+            if (q.size() <= p.size()) continue;
+            if (q[p.size()] != '.' && q[p.size()] != '[') continue;
+            if (q.compare(0, p.size(), p) == 0) return true;
+        }
+        return false;
+    };
+    hints.shredded_paths.erase(
+            std::remove_if(hints.shredded_paths.begin(), hints.shredded_paths.end(), is_prefix_of_another),
+            hints.shredded_paths.end());
     return hints;
 }
 
@@ -473,7 +730,43 @@ Status GroupReader::_create_column_readers() {
     opts.modification_time = _param.modification_time;
     opts.file_size = _param.file_size;
     opts.datacache_options = _param.datacache_options;
+
+    std::unordered_map<std::string, SlotId> physical_variant_slots_by_name;
     for (const auto& column : _param.read_cols) {
+        if (!column.is_extended_variant_virtual && column.slot_type().type == LogicalType::TYPE_VARIANT) {
+            physical_variant_slots_by_name.emplace(column.slot_desc->col_name(), column.slot_id());
+        }
+    }
+
+    for (const auto& column : _param.read_cols) {
+        if (column.is_extended_variant_virtual) {
+            ASSIGN_OR_RETURN(auto parsed_path, VariantPathParser::parse_shredded_path(
+                                                       std::string_view(column.variant_virtual_leaf_path)));
+            VariantVirtualProjection projection{
+                    .parsed_path = std::move(parsed_path), .target_type = column.slot_type(), .source_slot_id = 0};
+            auto physical_it = physical_variant_slots_by_name.find(column.source_variant_column_name);
+            if (physical_it != physical_variant_slots_by_name.end()) {
+                projection.source_slot_id = physical_it->second;
+            } else if (_hidden_variant_sources.find(column.source_variant_column_name) ==
+                       _hidden_variant_sources.end()) {
+                const auto* source_schema_node =
+                        _param.file_metadata->schema().get_stored_column_by_field_idx(column.idx_in_parquet);
+                DCHECK(source_schema_node != nullptr);
+                DCHECK(source_schema_node->type == ColumnType::STRUCT);
+                VariantShreddedReadHints hints = _get_variant_shredded_hints(column.source_variant_column_name);
+                ASSIGN_OR_RETURN(auto hidden_reader, ColumnReaderFactory::create_variant_column_reader(
+                                                             _column_reader_opts, source_schema_node, hints));
+                _hidden_variant_sources.emplace(
+                        column.source_variant_column_name,
+                        HiddenVariantSource{.slot_id = _next_hidden_slot_id--, .reader = std::move(hidden_reader)});
+            }
+            if (physical_it == physical_variant_slots_by_name.end()) {
+                projection.source_slot_id =
+                        _hidden_variant_sources.find(column.source_variant_column_name)->second.slot_id;
+            }
+            _variant_virtual_projections.emplace(column.slot_id(), std::move(projection));
+            continue;
+        }
         ASSIGN_OR_RETURN(ColumnReaderPtr column_reader, _create_column_reader(column));
         _column_readers[column.slot_id()] = std::move(column_reader);
     }
@@ -596,6 +889,15 @@ Status GroupReader::_prepare_column_readers() const {
             column_reader->set_need_parse_levels(true);
         }
     }
+    for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+        RETURN_IF_ERROR(hidden_source.reader->prepare());
+        if (hidden_source.reader->get_column_parquet_field() != nullptr &&
+            hidden_source.reader->get_column_parquet_field()->is_complex_type()) {
+            // Hidden VARIANT sources share the same complex reader path and also rely on
+            // def/rep levels for correct nullability reconstruction.
+            hidden_source.reader->set_need_parse_levels(true);
+        }
+    }
     return Status::OK();
 }
 
@@ -604,6 +906,16 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     int read_col_idx = 0;
 
     for (auto& column : _param.read_cols) {
+        if (column.is_extended_variant_virtual) {
+            SlotId slot_id = column.slot_id();
+            if (conjunct_ctxs_by_slot.find(slot_id) != conjunct_ctxs_by_slot.end()) {
+                for (ExprContext* ctx : conjunct_ctxs_by_slot.at(slot_id)) {
+                    _deferred_variant_virtual_conjunct_ctxs.emplace_back(ctx);
+                }
+            }
+            ++read_col_idx;
+            continue;
+        }
         SlotId slot_id = column.slot_id();
         if (conjunct_ctxs_by_slot.find(slot_id) != conjunct_ctxs_by_slot.end()) {
             for (ExprContext* ctx : conjunct_ctxs_by_slot.at(slot_id)) {
@@ -724,6 +1036,10 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
         SlotId slot_id = column.slot_id();
         _column_readers[slot_id]->collect_column_io_range(ranges, &end, types, false);
     }
+    for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+        hidden_source.reader->collect_column_io_range(ranges, &end, types, true);
+    }
+    deduplicate_io_ranges(ranges);
     *end_offset = end;
 }
 
@@ -740,6 +1056,10 @@ Status GroupReader::_init_read_chunk() {
     }
     size_t chunk_size = _param.chunk_size;
     ASSIGN_OR_RETURN(_read_chunk, ChunkHelper::new_chunk_checked(read_slots, chunk_size));
+    for (const auto& [name, hidden_source] : _hidden_variant_sources) {
+        auto hidden_column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_VARIANT), true);
+        _read_chunk->append_column(std::move(hidden_column), hidden_source.slot_id);
+    }
     return Status::OK();
 }
 
@@ -783,10 +1103,29 @@ StatusOr<bool> GroupReader::_filter_chunk_with_dict_filter(ChunkPtr* chunk, Filt
     return true;
 }
 
+const cctz::time_zone& GroupReader::_get_variant_projection_timezone() {
+    if (_timezone_resolved) {
+        return _timezone_obj;
+    }
+
+    _timezone_resolved = true;
+    if (_param.timezone.empty()) {
+        return _timezone_obj;
+    }
+    if (!TimezoneUtils::find_cctz_time_zone(_param.timezone, _timezone_obj)) {
+        LOG(WARNING) << "GroupReader: fallback to UTC for invalid timezone: " << _param.timezone;
+        _timezone_obj = cctz::utc_time_zone();
+    }
+    return _timezone_obj;
+}
+
 Status GroupReader::_fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk) {
     read_chunk->check_or_die();
     for (const auto& column : _param.read_cols) {
         SlotId slot_id = column.slot_id();
+        if (_variant_virtual_projections.find(slot_id) != _variant_virtual_projections.end()) {
+            continue;
+        }
         RETURN_IF_ERROR(_column_readers[slot_id]->fill_dst_column((*chunk)->get_column_by_slot_id(slot_id),
                                                                   read_chunk->get_column_by_slot_id(slot_id)));
     }
@@ -797,6 +1136,23 @@ Status GroupReader::_fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk) {
                                                                       read_chunk->get_column_by_slot_id(slot_id)));
         }
     }
+
+    for (const auto& column : _param.read_cols) {
+        SlotId slot_id = column.slot_id();
+        auto projection_it = _variant_virtual_projections.find(slot_id);
+        if (projection_it == _variant_virtual_projections.end()) {
+            continue;
+        }
+
+        const auto& projection = projection_it->second;
+        ASSIGN_OR_RETURN(ColumnPtr source_column, get_variant_projection_source_column(*chunk, read_chunk, _read_chunk,
+                                                                                       projection.source_slot_id));
+        ASSIGN_OR_RETURN(auto result_column,
+                         project_variant_leaf_column(source_column, projection.parsed_path, projection.target_type,
+                                                     _get_variant_projection_timezone()));
+        (*chunk)->get_column_by_slot_id(slot_id) = std::move(result_column);
+    }
+
     read_chunk->check_or_die();
     return Status::OK();
 }

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -14,14 +14,18 @@
 
 #pragma once
 
+#include <cctz/time_zone.h>
+
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "column/column_access_path.h"
+#include "column/variant_path_parser.h"
 #include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
@@ -66,6 +70,9 @@ struct GroupReaderParam {
         const TIcebergSchemaField* t_lake_schema_field = nullptr;
 
         bool decode_needed;
+        bool is_extended_variant_virtual = false;
+        std::string source_variant_column_name;
+        std::string variant_virtual_leaf_path;
 
         const TypeDescriptor& slot_type() const { return slot_desc->type(); }
         const SlotId slot_id() const { return slot_desc->id(); }
@@ -146,6 +153,28 @@ public:
     bool& get_is_group_filtered() { return _is_group_filtered; }
 
 private:
+    // Describes a virtual sub-path projection from a variant column, e.g. "data.id" in
+    // "SELECT data.id FROM t" where data is a VARIANT column.  The virtual column has no
+    // physical counterpart in the parquet file; it is computed by extracting parsed_path
+    // from the source variant column identified by source_slot_id.
+    struct VariantVirtualProjection {
+        VariantPath parsed_path;    // sub-path to extract, e.g. ["id"]
+        TypeDescriptor target_type; // expected output type of the projected sub-field
+        SlotId source_slot_id;      // slot that holds the source VARIANT column data
+                                    // (either a physical slot or a hidden slot with a negative id)
+    };
+
+    // A VARIANT column that must be read to serve virtual projections but is not itself
+    // present in the output chunk (i.e. not in the user's SELECT list).
+    // A temporary column is allocated in _read_chunk under a synthetic negative slot_id so
+    // that _variant_virtual_projections can reference it without colliding with real slots.
+    // One HiddenVariantSource is created per unique source column name; multiple virtual
+    // columns referencing the same VARIANT source share the same hidden entry.
+    struct HiddenVariantSource {
+        SlotId slot_id;                       // synthetic negative id (-1, -2, ...) in _read_chunk
+        std::unique_ptr<ColumnReader> reader; // reader for the underlying VARIANT column
+    };
+
     void _set_end_offset(int64_t value) { _end_offset = value; }
 
     // deal_with_pageindex need collect pageindex io range first, it will collect all row groups' io together,
@@ -158,6 +187,7 @@ private:
 
     StatusOr<bool> _filter_chunk_with_dict_filter(ChunkPtr* chunk, Filter* filter);
     Status _fill_dst_chunk(ChunkPtr& read_chunk, ChunkPtr* chunk);
+    const cctz::time_zone& _get_variant_projection_timezone();
 
     Status _create_column_readers();
     StatusOr<ColumnReaderPtr> _create_reserved_iceberg_column_reader(const SlotDescriptor* slot, int32_t field_id);
@@ -188,8 +218,25 @@ private:
     // column readers for column chunk in row group
     std::unordered_map<SlotId, std::unique_ptr<ColumnReader>> _column_readers;
 
+    // Maps each virtual-column slot id to its projection descriptor.
+    // Virtual columns (e.g. "data.id") are skipped in the normal fill path and handled
+    // separately in _fill_dst_chunk by extracting the sub-path from the source variant column.
+    std::unordered_map<SlotId, VariantVirtualProjection> _variant_virtual_projections;
+
+    // Maps source variant column name to its hidden reader and temporary slot.
+    // Only populated when the source VARIANT column is not itself in the output (no physical slot).
+    // If the source column IS selected by the user, its physical slot is used directly and no
+    // hidden entry is created, avoiding a double read.
+    std::unordered_map<std::string, HiddenVariantSource> _hidden_variant_sources;
+
+    // Counter for assigning synthetic slot ids to hidden variant sources.
+    // Starts at -1 and decrements so as not to collide with real (non-negative) slot ids.
+    SlotId _next_hidden_slot_id = -1;
+
     // conjunct ctxs that eval after chunk is dict decoded
     std::vector<ExprContext*> _left_conjunct_ctxs;
+    // variant virtual-column conjuncts can only be evaluated after post-read projection.
+    std::vector<ExprContext*> _deferred_variant_virtual_conjunct_ctxs;
 
     // active columns that hold read_col index
     std::vector<int> _active_column_indices;
@@ -225,6 +272,11 @@ private:
 
     // a flag to reflect prepare() is called
     bool _has_prepared = false;
+
+    // Parsed lazily for VARIANT virtual projections only. Most Parquet readers do not need
+    // this value, so avoid failing unrelated scans on malformed session timezone strings.
+    cctz::time_zone _timezone_obj = cctz::utc_time_zone();
+    bool _timezone_resolved = false;
 };
 
 using GroupReaderPtr = std::shared_ptr<GroupReader>;

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -14,6 +14,8 @@
 
 #include "meta_helper.h"
 
+#include <optional>
+
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/schema.h"
 #include "formats/utils.h"
@@ -22,14 +24,50 @@
 
 namespace starrocks::parquet {
 
+namespace {
+
+struct ExtendedVariantVirtualBinding {
+    const ColumnAccessPath* access_path = nullptr;
+    std::string leaf_path;
+};
+
+std::optional<ExtendedVariantVirtualBinding> find_extended_variant_virtual_binding(
+        const std::vector<ColumnAccessPathPtr>* column_access_paths, std::string_view slot_name) {
+    if (column_access_paths == nullptr) {
+        return std::nullopt;
+    }
+    for (const auto& access_path : *column_access_paths) {
+        if (access_path == nullptr || !access_path->is_extended()) {
+            continue;
+        }
+        if (access_path->linear_path() != slot_name || access_path->children().empty()) {
+            continue;
+        }
+        ExtendedVariantVirtualBinding binding;
+        binding.access_path = access_path.get();
+        binding.leaf_path = access_path->children()[0]->linear_path();
+        return binding;
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
 void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
+                                             const std::vector<ColumnAccessPathPtr>* column_access_paths,
                                              std::vector<GroupReaderParam::Column>& read_cols,
                                              std::unordered_set<std::string>& existed_column_names) const {
     for (auto& materialized_column : materialized_columns) {
         const SlotDescriptor* slotDesc = materialized_column.slot_desc;
+        auto extended_variant_binding =
+                find_extended_variant_virtual_binding(column_access_paths, materialized_column.name());
 
         int32_t field_idx = -1;
-        if (slotDesc->col_unique_id() != -1) {
+        if (extended_variant_binding.has_value()) {
+            field_idx = _file_metadata->schema().get_field_idx_by_column_name(
+                    extended_variant_binding->access_path->path());
+            if (field_idx < 0) continue;
+        } else if (slotDesc->col_unique_id() != -1) {
             field_idx = _file_metadata->schema().get_field_idx_by_field_id(materialized_column.col_unique_id());
             if (field_idx < 0) continue;
         } else if (!slotDesc->col_physical_name().empty()) {
@@ -42,13 +80,19 @@ void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
 
         const ParquetField* parquet_field = _file_metadata->schema().get_stored_column_by_field_idx(field_idx);
         // check is type is invalid
-        if (!_is_valid_type(parquet_field, &materialized_column.slot_desc->type())) {
+        if (!extended_variant_binding.has_value() &&
+            !_is_valid_type(parquet_field, &materialized_column.slot_desc->type())) {
             continue;
         }
 
         auto parquet_type = parquet_field->physical_type;
         GroupReaderParam::Column column = _build_column(field_idx, parquet_type, materialized_column.slot_desc,
                                                         materialized_column.decode_needed);
+        if (extended_variant_binding.has_value()) {
+            column.is_extended_variant_virtual = true;
+            column.source_variant_column_name = std::string(extended_variant_binding->access_path->path());
+            column.variant_virtual_leaf_path = std::move(extended_variant_binding->leaf_path);
+        }
         read_cols.emplace_back(column);
         existed_column_names.emplace(Utils::format_name(materialized_column.name(), _case_sensitive));
     }
@@ -166,34 +210,62 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
             return true;
         }
 
-        std::unordered_map<int32_t, const TIcebergSchemaField*> field_id_2_lake_schema{};
-        std::unordered_map<int32_t, const TypeDescriptor*> field_id_2_type{};
-        for (const auto& field : field_schema->children) {
-            field_id_2_lake_schema.emplace(field.field_id, &field);
-            for (size_t i = 0; i < type_descriptor->field_names.size(); i++) {
-                if (type_descriptor->field_names[i] == field.name) {
-                    field_id_2_type.emplace(field.field_id, &type_descriptor->children[i]);
+        if (_file_metadata->schema().exist_filed_id()) {
+            std::unordered_map<int32_t, const TIcebergSchemaField*> field_id_2_lake_schema{};
+            std::unordered_map<int32_t, const TypeDescriptor*> field_id_2_type{};
+            for (const auto& field : field_schema->children) {
+                field_id_2_lake_schema.emplace(field.field_id, &field);
+                for (size_t i = 0; i < type_descriptor->field_names.size(); i++) {
+                    if (type_descriptor->field_names[i] == field.name) {
+                        field_id_2_type.emplace(field.field_id, &type_descriptor->children[i]);
+                        break;
+                    }
+                }
+            }
+
+            for (const auto& child_parquet_field : parquet_field->children) {
+                auto it = field_id_2_lake_schema.find(child_parquet_field.field_id);
+                if (it == field_id_2_lake_schema.end()) {
+                    continue;
+                }
+
+                auto it_td = field_id_2_type.find(child_parquet_field.field_id);
+                if (it_td == field_id_2_type.end()) {
+                    continue;
+                }
+
+                if (_is_valid_type(&child_parquet_field, it->second, it_td->second)) {
+                    has_valid_child = true;
                     break;
                 }
             }
-        }
-
-        // start to check struct type
-        for (const auto& child_parquet_field : parquet_field->children) {
-            auto it = field_id_2_lake_schema.find(child_parquet_field.field_id);
-            if (it == field_id_2_lake_schema.end()) {
-                continue;
+        } else {
+            std::unordered_map<std::string, const TIcebergSchemaField*> field_name_2_lake_schema{};
+            std::unordered_map<std::string, const TypeDescriptor*> field_name_2_type{};
+            for (const auto& field : field_schema->children) {
+                field_name_2_lake_schema.emplace(Utils::format_name(field.name, _case_sensitive), &field);
+            }
+            for (size_t i = 0; i < type_descriptor->field_names.size(); i++) {
+                field_name_2_type.emplace(Utils::format_name(type_descriptor->field_names[i], _case_sensitive),
+                                          &type_descriptor->children[i]);
             }
 
-            auto it_td = field_id_2_type.find(child_parquet_field.field_id);
-            if (it_td == field_id_2_type.end()) {
-                continue;
-            }
+            for (const auto& child_parquet_field : parquet_field->children) {
+                const auto formatted_child_name = Utils::format_name(child_parquet_field.name, _case_sensitive);
+                auto it = field_name_2_lake_schema.find(formatted_child_name);
+                if (it == field_name_2_lake_schema.end()) {
+                    continue;
+                }
 
-            // is compelx type, recursive check it's children
-            if (_is_valid_type(&child_parquet_field, it->second, it_td->second)) {
-                has_valid_child = true;
-                break;
+                auto it_td = field_name_2_type.find(formatted_child_name);
+                if (it_td == field_name_2_type.end()) {
+                    continue;
+                }
+
+                if (_is_valid_type(&child_parquet_field, it->second, it_td->second)) {
+                    has_valid_child = true;
+                    break;
+                }
             }
         }
     }
@@ -202,10 +274,18 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
 }
 
 void LakeMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
+                                          const std::vector<ColumnAccessPathPtr>* column_access_paths,
                                           std::vector<GroupReaderParam::Column>& read_cols,
                                           std::unordered_set<std::string>& existed_column_names) const {
+    const bool parquet_has_field_id = _file_metadata->schema().exist_filed_id();
     for (auto& materialized_column : materialized_columns) {
-        const std::string& formatted_name = Utils::format_name(materialized_column.name(), _case_sensitive);
+        auto extended_variant_binding =
+                find_extended_variant_virtual_binding(column_access_paths, materialized_column.name());
+        const std::string formatted_name =
+                extended_variant_binding.has_value()
+                        ? Utils::format_name(std::string(extended_variant_binding->access_path->path()),
+                                             _case_sensitive)
+                        : Utils::format_name(materialized_column.name(), _case_sensitive);
         auto lake_it = _field_name_2_lake_field.find(formatted_name);
         if (lake_it == _field_name_2_lake_field.end()) {
             continue;
@@ -213,12 +293,20 @@ void LakeMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContext::
 
         int32_t field_id = lake_it->second->field_id;
 
-        int32_t field_idx = _file_metadata->schema().get_field_idx_by_field_id(field_id);
+        int32_t field_idx = parquet_has_field_id
+                                    ? _file_metadata->schema().get_field_idx_by_field_id(field_id)
+                                    : _file_metadata->schema().get_field_idx_by_column_name(
+                                              extended_variant_binding.has_value()
+                                                      ? std::string(extended_variant_binding->access_path->path())
+                                                      : materialized_column.name());
         if (field_idx < 0) continue;
 
-        const ParquetField* parquet_field = _file_metadata->schema().get_stored_column_by_field_id(field_id);
+        const ParquetField* parquet_field =
+                parquet_has_field_id ? _file_metadata->schema().get_stored_column_by_field_id(field_id)
+                                     : _file_metadata->schema().get_stored_column_by_field_idx(field_idx);
         // check is type is invalid
-        if (!_is_valid_type(parquet_field, lake_it->second, &materialized_column.slot_desc->type())) {
+        if (!extended_variant_binding.has_value() &&
+            !_is_valid_type(parquet_field, lake_it->second, &materialized_column.slot_desc->type())) {
             continue;
         }
 
@@ -226,8 +314,13 @@ void LakeMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContext::
 
         GroupReaderParam::Column column = _build_column(field_idx, parquet_type, materialized_column.slot_desc,
                                                         materialized_column.decode_needed, lake_it->second);
+        if (extended_variant_binding.has_value()) {
+            column.is_extended_variant_virtual = true;
+            column.source_variant_column_name = std::string(extended_variant_binding->access_path->path());
+            column.variant_virtual_leaf_path = std::move(extended_variant_binding->leaf_path);
+        }
         read_cols.emplace_back(column);
-        existed_column_names.emplace(formatted_name);
+        existed_column_names.emplace(Utils::format_name(materialized_column.name(), _case_sensitive));
     }
 }
 

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -49,6 +49,7 @@ public:
     virtual ~MetaHelper() = default;
 
     virtual void prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
+                                      const std::vector<ColumnAccessPathPtr>* column_access_paths,
                                       std::vector<GroupReaderParam::Column>& read_cols,
                                       std::unordered_set<std::string>& existed_column_names) const = 0;
 
@@ -76,6 +77,7 @@ public:
     ~ParquetMetaHelper() override = default;
 
     void prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
+                              const std::vector<ColumnAccessPathPtr>* column_access_paths,
                               std::vector<GroupReaderParam::Column>& read_cols,
                               std::unordered_set<std::string>& existed_column_names) const override;
 
@@ -95,6 +97,7 @@ public:
     ~LakeMetaHelper() override = default;
 
     void prepare_read_columns(const std::vector<HdfsScannerContext::ColumnInfo>& materialized_columns,
+                              const std::vector<ColumnAccessPathPtr>* column_access_paths,
                               std::vector<GroupReaderParam::Column>& read_cols,
                               std::unordered_set<std::string>& existed_column_names) const override;
 

--- a/be/test/column/variant_merger_test.cpp
+++ b/be/test/column/variant_merger_test.cpp
@@ -20,11 +20,14 @@
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/decimalv3_column.h"
+#include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/variant_column.h"
+#include "column/variant_converter.h"
 #include "column/variant_encoder.h"
 #include "gutil/casts.h"
 #include "types/decimalv2_value.h"
+#include "types/timestamp_value.h"
 
 namespace starrocks {
 
@@ -186,6 +189,49 @@ static void assert_variant_row_json(const VariantColumn* col, size_t row, std::s
     ASSERT_EQ(expected_json, json.value());
 }
 
+static MutableColumnPtr build_nullable_variant_column_from_json(const std::vector<std::string>& json_rows,
+                                                                const std::vector<uint8_t>& is_null) {
+    DCHECK_EQ(json_rows.size(), is_null.size());
+    ColumnBuilder<TYPE_VARIANT> builder(json_rows.size());
+    for (size_t i = 0; i < json_rows.size(); ++i) {
+        if (is_null[i]) {
+            builder.append_null();
+            continue;
+        }
+        auto encoded = VariantEncoder::encode_json_text_to_variant(json_rows[i]);
+        DCHECK(encoded.ok()) << encoded.status().to_string();
+        builder.append(std::move(encoded).value());
+    }
+    return builder.build(false);
+}
+
+static MutableColumnPtr build_nullable_variant_column_from_timestamp_ntz_micros(const std::vector<int64_t>& values,
+                                                                                const std::vector<uint8_t>& is_null) {
+    DCHECK_EQ(values.size(), is_null.size());
+    auto datetime_data = TimestampColumn::create();
+    auto datetime_null = NullColumn::create();
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (is_null[i]) {
+            datetime_data->append_default();
+            datetime_null->append(1);
+            continue;
+        }
+        TimestampValue ts;
+        ts.from_unix_second(values[i] / USECS_PER_SEC, values[i] % USECS_PER_SEC);
+        datetime_data->append(ts);
+        datetime_null->append(0);
+    }
+
+    auto datetime_col = NullableColumn::create(std::move(datetime_data), std::move(datetime_null));
+    ColumnBuilder<TYPE_VARIANT> builder(values.size());
+    auto st = VariantEncoder::encode_column(datetime_col, TypeDescriptor(TYPE_DATETIME), &builder, false);
+    DCHECK(st.ok()) << st.to_string();
+    if (!st.ok()) {
+        return nullptr;
+    }
+    return builder.build(false);
+}
+
 PARALLEL_TEST(VariantColumnMergerTest, choose_common_type_numeric_and_decimal_cases) {
     auto numeric = VariantColumnMerger::choose_common_type(TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_DOUBLE));
     ASSERT_TRUE(numeric.ok());
@@ -201,6 +247,90 @@ PARALLEL_TEST(VariantColumnMergerTest, choose_common_type_numeric_and_decimal_ca
             TypeDescriptor::create_array_type(TypeDescriptor(TYPE_BIGINT)), TypeDescriptor(TYPE_BIGINT));
     ASSERT_TRUE(array_conflict.ok());
     ASSERT_EQ(TypeDescriptor(TYPE_VARIANT), array_conflict.value());
+}
+
+PARALLEL_TEST(VariantColumnMergerTest, cast_variant_typed_column_to_bigint_preserves_query_cast_semantics) {
+    auto src = build_nullable_variant_column_from_json({"1", "\"L2\"", "3", "null"}, {0, 0, 0, 0});
+    auto casted =
+            VariantColumnMerger::cast_typed_column(*src, TypeDescriptor(TYPE_VARIANT), TypeDescriptor(TYPE_BIGINT));
+    ASSERT_TRUE(casted.ok()) << casted.status().to_string();
+
+    const auto* nullable = down_cast<const NullableColumn*>(casted.value().get());
+    ASSERT_EQ(4, nullable->size());
+    EXPECT_EQ(1, nullable->get(0).get_int64());
+    EXPECT_TRUE(nullable->get(1).is_null());
+    EXPECT_EQ(3, nullable->get(2).get_int64());
+    EXPECT_TRUE(nullable->get(3).is_null());
+}
+
+PARALLEL_TEST(VariantColumnMergerTest, cast_const_variant_typed_column_uses_outer_constness) {
+    auto data = build_nullable_variant_column_from_json({"1"}, {0});
+    auto src = ConstColumn::create(std::move(data), 3);
+    auto casted =
+            VariantColumnMerger::cast_typed_column(*src, TypeDescriptor(TYPE_VARIANT), TypeDescriptor(TYPE_BIGINT));
+    ASSERT_TRUE(casted.ok()) << casted.status().to_string();
+
+    const Column* result = casted.value().get();
+    ASSERT_EQ(3, result->size());
+    EXPECT_EQ(1, result->get(0).get_int64());
+    EXPECT_EQ(1, result->get(1).get_int64());
+    EXPECT_EQ(1, result->get(2).get_int64());
+}
+
+PARALLEL_TEST(VariantColumnMergerTest, cast_variant_typed_column_to_varchar_formats_rows) {
+    auto src = build_nullable_variant_column_from_json({"\"dept_0\"", "100", "null"}, {0, 0, 0});
+    auto casted =
+            VariantColumnMerger::cast_typed_column(*src, TypeDescriptor(TYPE_VARIANT), TypeDescriptor(TYPE_VARCHAR));
+    ASSERT_TRUE(casted.ok()) << casted.status().to_string();
+
+    const auto* nullable = down_cast<const NullableColumn*>(casted.value().get());
+    ASSERT_EQ(3, nullable->size());
+    EXPECT_EQ("dept_0", nullable->get(0).get_slice().to_string());
+    EXPECT_EQ("100", nullable->get(1).get_slice().to_string());
+    EXPECT_TRUE(nullable->get(2).is_null());
+}
+
+PARALLEL_TEST(VariantColumnMergerTest, cast_variant_typed_column_to_datetime_requires_explicit_timezone_context) {
+    auto src = build_nullable_variant_column_from_json({"1711497600"}, {0});
+    auto casted =
+            VariantColumnMerger::cast_typed_column(*src, TypeDescriptor(TYPE_VARIANT), TypeDescriptor(TYPE_DATETIME));
+    ASSERT_FALSE(casted.ok());
+    ASSERT_TRUE(casted.status().is_not_supported());
+}
+
+PARALLEL_TEST(VariantColumnMergerTest, cast_variant_typed_column_to_datetime_with_timezone_context) {
+    TimestampValue expected;
+    expected.from_unix_second(1711497600L, 0);
+
+    auto src = build_nullable_variant_column_from_timestamp_ntz_micros({1711497600L * USECS_PER_SEC}, {0});
+    const auto* variant = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(src.get()));
+    ASSERT_NE(nullptr, variant);
+    VariantRowValue row_buffer;
+    const VariantRowValue* row = variant->get_row_value(0, &row_buffer);
+    ASSERT_NE(nullptr, row);
+    EXPECT_EQ(VariantType::TIMESTAMP_NTZ, row->as_ref().get_value().type());
+    ASSERT_TRUE(row->as_ref().get_value().get_timestamp_micros_ntz().ok());
+    EXPECT_EQ(1711497600L * USECS_PER_SEC, row->as_ref().get_value().get_timestamp_micros_ntz().value());
+
+    ColumnBuilder<TYPE_DATETIME> direct_builder(1);
+    auto direct_status =
+            VariantRowConverter::cast_to<TYPE_DATETIME, true>(row->as_ref(), cctz::utc_time_zone(), direct_builder);
+    ASSERT_TRUE(direct_status.ok()) << direct_status.to_string();
+    auto direct_column = direct_builder.build(false);
+    const auto* direct_data = ColumnHelper::cast_to_raw<TYPE_DATETIME>(direct_column.get());
+    ASSERT_NE(nullptr, direct_data);
+    EXPECT_EQ(expected, direct_data->get_data()[0]);
+
+    auto casted = VariantColumnMerger::cast_typed_column(*src, TypeDescriptor(TYPE_VARIANT),
+                                                         TypeDescriptor(TYPE_DATETIME), cctz::utc_time_zone());
+    ASSERT_TRUE(casted.ok()) << casted.status().to_string();
+
+    const Column* result = casted.value().get();
+    ASSERT_EQ(1, result->size());
+    EXPECT_FALSE(result->is_null(0));
+    const auto* data = ColumnHelper::cast_to_raw<TYPE_DATETIME>(ColumnHelper::get_data_column(result));
+    ASSERT_NE(nullptr, data);
+    EXPECT_EQ(expected, data->get_data()[0]);
 }
 
 PARALLEL_TEST(VariantColumnMergerTest, merge_shredded_schema_union) {

--- a/be/test/formats/parquet/column_reader_factory_test.cpp
+++ b/be/test/formats/parquet/column_reader_factory_test.cpp
@@ -18,6 +18,7 @@
 
 #include <sstream>
 
+#include "base/testutil/assert.h"
 #include "formats/parquet/complex_column_reader.h"
 
 namespace starrocks::parquet {
@@ -344,6 +345,116 @@ TEST(ColumnReaderFactoryTest, VariantShreddedCollectIoRangeAndSelectOffsetIndex)
     SparseRange<uint64_t> sparse_range;
     sparse_range.add(Range<uint64_t>(0, 8));
     st.value()->select_offset_index(sparse_range, 0);
+}
+
+TEST(ColumnReaderFactoryTest, StructWithoutFieldIdMatchesIcebergSubfieldsByName) {
+    ParquetField field;
+    field.name = "col";
+    field.type = ColumnType::STRUCT;
+    field.children.emplace_back(make_scalar_field("a", 0, tparquet::Type::INT32));
+    field.children.emplace_back(make_scalar_field("b", 1, tparquet::Type::INT32));
+
+    TypeDescriptor col_type = TypeDescriptor::from_logical_type(TYPE_STRUCT);
+    col_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    col_type.field_names.emplace_back("a");
+    col_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    col_type.field_names.emplace_back("missing");
+
+    TIcebergSchemaField field_a;
+    field_a.__set_field_id(1);
+    field_a.__set_name("a");
+    TIcebergSchemaField field_missing;
+    field_missing.__set_field_id(2);
+    field_missing.__set_name("missing");
+    TIcebergSchemaField root_field;
+    root_field.__set_field_id(10);
+    root_field.__set_name("col");
+    root_field.__set_children(std::vector<TIcebergSchemaField>{field_a, field_missing});
+
+    tparquet::FileMetaData file_meta;
+    tparquet::SchemaElement root_schema;
+    root_schema.__set_name("table");
+    root_schema.__set_num_children(1);
+    tparquet::SchemaElement col_schema;
+    col_schema.__set_name("col");
+    col_schema.__set_num_children(2);
+    tparquet::SchemaElement a_schema;
+    a_schema.__set_name("a");
+    a_schema.__set_type(tparquet::Type::INT32);
+    a_schema.__set_num_children(0);
+    tparquet::SchemaElement b_schema;
+    b_schema.__set_name("b");
+    b_schema.__set_type(tparquet::Type::INT32);
+    b_schema.__set_num_children(0);
+    file_meta.__set_schema(std::vector<tparquet::SchemaElement>{root_schema, col_schema, a_schema, b_schema});
+
+    auto opts = make_opts_with_num_cols(2);
+    FileMetaData parsed_meta;
+    ASSERT_OK(parsed_meta.init(file_meta, true));
+    opts.file_meta_data = &parsed_meta;
+
+    auto reader_or = ColumnReaderFactory::create(opts, &field, col_type, &root_field);
+    ASSERT_TRUE(reader_or.ok()) << reader_or.status().to_string();
+    auto* struct_reader = dynamic_cast<StructColumnReader*>(reader_or.value().get());
+    ASSERT_NE(struct_reader, nullptr);
+    ASSERT_NE(struct_reader->get_child_column_reader("a"), nullptr);
+    ASSERT_EQ(struct_reader->get_child_column_reader("missing"), nullptr);
+}
+
+TEST(ColumnReaderFactoryTest, StructWithoutFieldIdMatchesIcebergSubfieldsByPhysicalName) {
+    ParquetField field;
+    field.name = "col";
+    field.type = ColumnType::STRUCT;
+    field.children.emplace_back(make_scalar_field("a_phys", 0, tparquet::Type::INT32));
+    field.children.emplace_back(make_scalar_field("b_phys", 1, tparquet::Type::INT32));
+
+    TypeDescriptor col_type = TypeDescriptor::from_logical_type(TYPE_STRUCT);
+    col_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    col_type.field_names.emplace_back("a");
+    col_type.field_physical_names.emplace_back("a_phys");
+    col_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    col_type.field_names.emplace_back("missing");
+    col_type.field_physical_names.emplace_back("missing_phys");
+
+    TIcebergSchemaField field_a;
+    field_a.__set_field_id(1);
+    field_a.__set_name("a");
+    TIcebergSchemaField field_missing;
+    field_missing.__set_field_id(2);
+    field_missing.__set_name("missing");
+    TIcebergSchemaField root_field;
+    root_field.__set_field_id(10);
+    root_field.__set_name("col");
+    root_field.__set_children(std::vector<TIcebergSchemaField>{field_a, field_missing});
+
+    tparquet::FileMetaData file_meta;
+    tparquet::SchemaElement root_schema;
+    root_schema.__set_name("table");
+    root_schema.__set_num_children(1);
+    tparquet::SchemaElement col_schema;
+    col_schema.__set_name("col");
+    col_schema.__set_num_children(2);
+    tparquet::SchemaElement a_schema;
+    a_schema.__set_name("a_phys");
+    a_schema.__set_type(tparquet::Type::INT32);
+    a_schema.__set_num_children(0);
+    tparquet::SchemaElement b_schema;
+    b_schema.__set_name("b_phys");
+    b_schema.__set_type(tparquet::Type::INT32);
+    b_schema.__set_num_children(0);
+    file_meta.__set_schema(std::vector<tparquet::SchemaElement>{root_schema, col_schema, a_schema, b_schema});
+
+    auto opts = make_opts_with_num_cols(2);
+    FileMetaData parsed_meta;
+    ASSERT_OK(parsed_meta.init(file_meta, true));
+    opts.file_meta_data = &parsed_meta;
+
+    auto reader_or = ColumnReaderFactory::create(opts, &field, col_type, &root_field);
+    ASSERT_TRUE(reader_or.ok()) << reader_or.status().to_string();
+    auto* struct_reader = dynamic_cast<StructColumnReader*>(reader_or.value().get());
+    ASSERT_NE(struct_reader, nullptr);
+    ASSERT_NE(struct_reader->get_child_column_reader("a"), nullptr);
+    ASSERT_EQ(struct_reader->get_child_column_reader("missing"), nullptr);
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -24,6 +24,7 @@
 #include "column/const_column.h"
 #include "common/config_exec_fwd.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
+#include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
 #include "formats/parquet/column_reader_factory.h"
@@ -31,6 +32,7 @@
 #include "formats/parquet/utils.h"
 #include "fs/fs.h"
 #include "runtime/descriptor_helper.h"
+#include "runtime/global_dict/parser.h"
 #include "runtime/runtime_state.h"
 #include "storage/column_expr_predicate.h"
 #include "testutil/exprs_test_helper.h"
@@ -170,6 +172,68 @@ public:
     }
 };
 
+class MockVariantSourceColumnReader : public ColumnReader {
+public:
+    explicit MockVariantSourceColumnReader(ColumnPtr source_column)
+            : ColumnReader(nullptr), _source_column(std::move(source_column)) {}
+    ~MockVariantSourceColumnReader() override = default;
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst_col) override {
+        dst_col = _source_column;
+        return Status::OK();
+    }
+
+    Status fill_dst_column(ColumnPtr& dst, ColumnPtr& src) override {
+        dst = src;
+        return Status::OK();
+    }
+
+    void set_need_parse_levels(bool need_parse_levels) override {}
+    void get_levels(int16_t** def_levels, int16_t** rep_levels, size_t* num_levels) override {}
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {}
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
+
+private:
+    ColumnPtr _source_column;
+};
+
+class MockIORangeColumnReader : public ColumnReader {
+public:
+    explicit MockIORangeColumnReader(std::vector<io::SharedBufferedInputStream::IORange> ranges)
+            : ColumnReader(nullptr), _ranges(std::move(ranges)) {}
+    ~MockIORangeColumnReader() override = default;
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst_col) override {
+        dst_col->as_mutable_ptr()->append_default(range.span_size());
+        return Status::OK();
+    }
+
+    void set_need_parse_levels(bool need_parse_levels) override {}
+    void get_levels(int16_t** def_levels, int16_t** rep_levels, size_t* num_levels) override {}
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
+
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {
+        if (ranges == nullptr) {
+            return;
+        }
+        for (const auto& range : _ranges) {
+            ranges->emplace_back(range.offset, range.size, active);
+            if (end_offset != nullptr) {
+                *end_offset = std::max(*end_offset, range.offset + range.size);
+            }
+        }
+    }
+
+private:
+    std::vector<io::SharedBufferedInputStream::IORange> _ranges;
+};
+
 class GroupReaderTest : public ::testing::Test {
 protected:
     void SetUp() override {}
@@ -251,6 +315,62 @@ static StatusOr<const ColumnPredicate*> create_struct_subfield_eq_predicate(Obje
                      ColumnExprPredicate::make_column_expr_predicate(get_type_info(LogicalType::TYPE_VARCHAR),
                                                                      column_id, state, conjunct_ctxs[0], nullptr));
     return pred;
+}
+
+static StatusOr<std::string> variant_json_at(const ColumnPtr& column, size_t row_num) {
+    const Column* data_col = ColumnHelper::get_data_column(column.get());
+    auto* variant_col = down_cast<const VariantColumn*>(data_col);
+    VariantRowValue cell;
+    const VariantRowValue* row = variant_col->get_row_value(row_num, &cell);
+    if (row == nullptr) {
+        return Status::InvalidArgument("failed to get variant row value");
+    }
+    return row->to_json();
+}
+
+static ColumnPtr make_typed_only_variant_column_for_virtual_column_test() {
+    auto variant = VariantColumn::create();
+    MutableColumns typed_columns;
+    auto typed_col = ColumnHelper::create_column(TypeDescriptor(TYPE_BIGINT), true);
+    typed_col->append_datum(int64_t(11));
+    typed_col->append_datum(int64_t(22));
+    typed_columns.emplace_back(typed_col->as_mutable_ptr());
+    variant->set_shredded_columns({"a.b.c"}, {TypeDescriptor(TYPE_BIGINT)}, std::move(typed_columns), nullptr, nullptr);
+    return variant;
+}
+
+static ColumnPtr make_nullable_typed_variant_column_for_virtual_column_test() {
+    auto data = make_typed_only_variant_column_for_virtual_column_test();
+    auto nulls = NullColumn::create();
+    nulls->append(1);
+    nulls->append(0);
+    return NullableColumn::create(data->as_mutable_ptr(), std::move(nulls));
+}
+
+static Status create_bigint_eq_conjunct_ctxs(ObjectPool* pool, RuntimeState* state, SlotId slot_id, int64_t value,
+                                             std::vector<ExprContext*>* conjunct_ctxs) {
+    TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::BIGINT, TExprOpcode::EQ);
+    TExprNode slot_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_BIGINT>(0, slot_id, true);
+    TExprNode literal = ExprsTestHelper::create_literal<TYPE_BIGINT, int64_t>(value, false);
+
+    TExpr expr;
+    expr.nodes.emplace_back(pred_node);
+    expr.nodes.emplace_back(slot_ref);
+    expr.nodes.emplace_back(literal);
+
+    std::vector<TExpr> conjunct_exprs{expr};
+    RETURN_IF_ERROR(ExprFactory::create_expr_trees(pool, conjunct_exprs, conjunct_ctxs, nullptr));
+    RETURN_IF_ERROR(ExprExecutor::prepare(*conjunct_ctxs, state));
+    DictOptimizeParser::disable_open_rewrite(conjunct_ctxs);
+    RETURN_IF_ERROR(ExprExecutor::open(*conjunct_ctxs, state));
+    return Status::OK();
+}
+
+static StatusOr<GroupReader::VariantVirtualProjection> make_virtual_projection_for_test(
+        const std::string& leaf_path, const TypeDescriptor& target_type, SlotId source_slot_id) {
+    ASSIGN_OR_RETURN(auto parsed_path, VariantPathParser::parse_shredded_path(std::string_view(leaf_path)));
+    return GroupReader::VariantVirtualProjection{
+            .parsed_path = std::move(parsed_path), .target_type = target_type, .source_slot_id = source_slot_id};
 }
 
 ChunkPtr GroupReaderTest::_create_chunk(GroupReaderParam* param) {
@@ -2325,6 +2445,382 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation
     ASSERT_OK(group_reader->init());
     // The _last_updated_sequence_number reader should be created from the physical column
     ASSERT_NE(group_reader->_column_readers[101], nullptr);
+}
+
+TEST_F(GroupReaderTest, VariantVirtualColumnMapsPrefixAndLeafPathsIndependently) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* leaf_slot = _pool.add(
+            new SlotDescriptor(120, "data.a.b.c", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* prefix_slot = _pool.add(
+            new SlotDescriptor(121, "data.a.b", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT)));
+    auto* source_slot =
+            _pool.add(new SlotDescriptor(122, "data", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT)));
+
+    param->read_cols.clear();
+    GroupReaderParam::Column leaf_col{};
+    leaf_col.slot_desc = leaf_slot;
+    GroupReaderParam::Column prefix_col{};
+    prefix_col.slot_desc = prefix_slot;
+    GroupReaderParam::Column source_col{};
+    source_col.slot_desc = source_slot;
+    param->read_cols.emplace_back(leaf_col);
+    param->read_cols.emplace_back(prefix_col);
+    param->read_cols.emplace_back(source_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ColumnPtr variant_source = make_typed_only_variant_column_for_virtual_column_test();
+    ASSIGN_OR_ABORT(auto leaf_projection,
+                    make_virtual_projection_for_test("a.b.c", leaf_slot->type(), source_slot->id()));
+    ASSIGN_OR_ABORT(auto prefix_projection,
+                    make_virtual_projection_for_test("a.b", prefix_slot->type(), source_slot->id()));
+    group_reader->_variant_virtual_projections.emplace(leaf_slot->id(), std::move(leaf_projection));
+    group_reader->_variant_virtual_projections.emplace(prefix_slot->id(), std::move(prefix_projection));
+    group_reader->_column_readers.emplace(source_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_source, source_slot->id());
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(leaf_slot->type(), true), leaf_slot->id());
+    dst_chunk->append_column(ColumnHelper::create_column(prefix_slot->type(), true), prefix_slot->id());
+    dst_chunk->append_column(ColumnHelper::create_column(source_slot->type(), true), source_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+
+    const auto& leaf_result = dst_chunk->get_column_by_slot_id(leaf_slot->id());
+    ASSERT_EQ(2, leaf_result->size());
+    EXPECT_EQ(11, leaf_result->get(0).get_int64());
+    EXPECT_EQ(22, leaf_result->get(1).get_int64());
+
+    const auto& prefix_result = dst_chunk->get_column_by_slot_id(prefix_slot->id());
+    ASSERT_EQ(2, prefix_result->size());
+    auto row0_json = variant_json_at(prefix_result, 0);
+    auto row1_json = variant_json_at(prefix_result, 1);
+    ASSERT_TRUE(row0_json.ok()) << row0_json.status();
+    ASSERT_TRUE(row1_json.ok()) << row1_json.status();
+    EXPECT_EQ("{\"c\":11}", std::move(row0_json).value());
+    EXPECT_EQ("{\"c\":22}", std::move(row1_json).value());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnFromPhysicalSourceSlot) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(100, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(200)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(200));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ(11, result->get(0).get_int64());
+    EXPECT_EQ(22, result->get(1).get_int64());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnReturnsNullForNullAndMissingLeafRows) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(103, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection,
+                    make_virtual_projection_for_test("missing.leaf", virtual_slot->type(), SlotId(300)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_nullable_typed_variant_column_for_virtual_column_test(), SlotId(300));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_TRUE(result->is_null(0));
+    EXPECT_TRUE(result->is_null(1));
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsExactTypedVirtualColumnRespectsSourceNullMask) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(105, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(302)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_nullable_typed_variant_column_for_virtual_column_test(), SlotId(302));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_TRUE(result->is_null(0));
+    EXPECT_EQ(22, result->get(1).get_int64());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualVarcharColumnFromPhysicalSourceSlot) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(104, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR)));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(301)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(301));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ("11", result->get(0).get_slice().to_string());
+    EXPECT_EQ("22", result->get(1).get_slice().to_string());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnFromHiddenVariantSource) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(101, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(-1)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_hidden_variant_sources.emplace(
+            "data", GroupReader::HiddenVariantSource{.slot_id = SlotId(-1), .reader = nullptr});
+
+    group_reader->_read_chunk = std::make_shared<Chunk>();
+    group_reader->_read_chunk->append_column(make_typed_only_variant_column_for_virtual_column_test(), SlotId(-1));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ(11, result->get(0).get_int64());
+    EXPECT_EQ(22, result->get(1).get_int64());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualColumnWhenVirtualSlotPrecedesSourceSlot) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(101, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* source_slot =
+            _pool.add(new SlotDescriptor(102, "data", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT)));
+
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    GroupReaderParam::Column source_col{};
+    source_col.slot_desc = source_slot;
+    param->read_cols.emplace_back(virtual_col);
+    param->read_cols.emplace_back(source_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    auto variant_source = make_typed_only_variant_column_for_virtual_column_test();
+    ASSIGN_OR_ABORT(auto projection,
+                    make_virtual_projection_for_test("a.b.c", virtual_slot->type(), source_slot->id()));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_column_readers.emplace(source_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_source, source_slot->id());
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+    dst_chunk->append_column(ColumnHelper::create_column(source_slot->type(), true), source_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+
+    const auto& projected = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, projected->size());
+    EXPECT_EQ(11, projected->get(0).get_int64());
+    EXPECT_EQ(22, projected->get(1).get_int64());
+
+    const auto& source = dst_chunk->get_column_by_slot_id(source_slot->id());
+    ASSERT_EQ(2, source->size());
+}
+
+TEST_F(GroupReaderTest, CollectIORangesDeduplicatesIdenticalRangesAcrossReaders) {
+    auto* file = _create_file();
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_TRUE(_create_filemeta(&file_meta, param).ok());
+
+    param->chunk_size = config::vector_chunk_size;
+    param->file = file;
+    param->file_metadata = file_meta;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    ASSERT_OK(group_reader->init());
+
+    group_reader->_column_readers.clear();
+    group_reader->_active_column_indices = {0};
+    group_reader->_lazy_column_indices = {1};
+    group_reader->_column_readers.emplace(0, std::make_unique<MockIORangeColumnReader>(
+                                                     std::vector<io::SharedBufferedInputStream::IORange>{{100, 20}}));
+    group_reader->_column_readers.emplace(
+            1, std::make_unique<MockIORangeColumnReader>(
+                       std::vector<io::SharedBufferedInputStream::IORange>{{100, 20}, {200, 10}}));
+
+    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+    int64_t end_offset = 0;
+    group_reader->collect_io_ranges(&ranges, &end_offset, ColumnIOType::PAGES);
+
+    ASSERT_EQ(2, ranges.size());
+    EXPECT_EQ(100, ranges[0].offset);
+    EXPECT_EQ(20, ranges[0].size);
+    EXPECT_TRUE(ranges[0].is_active);
+    EXPECT_EQ(200, ranges[1].offset);
+    EXPECT_EQ(10, ranges[1].size);
+    EXPECT_FALSE(ranges[1].is_active);
+    EXPECT_EQ(210, end_offset);
+}
+
+TEST_F(GroupReaderTest, ProcessColumnsDefersVirtualColumnConjunctsUntilAfterProjection) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto* virtual_slot =
+            _pool.add(new SlotDescriptor(110, "data.id", TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
+    auto* source_slot =
+            _pool.add(new SlotDescriptor(111, "data", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT)));
+
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    virtual_col.is_extended_variant_virtual = true;
+    virtual_col.source_variant_column_name = "data";
+    virtual_col.variant_virtual_leaf_path = "a.b.c";
+    GroupReaderParam::Column source_col{};
+    source_col.slot_desc = source_slot;
+    param->read_cols.emplace_back(virtual_col);
+    param->read_cols.emplace_back(source_col);
+
+    RuntimeState runtime_state{TQueryGlobals()};
+    std::vector<ExprContext*> conjunct_ctxs;
+    ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, virtual_slot->id(), 22, &conjunct_ctxs));
+    param->conjunct_ctxs_by_slot[virtual_slot->id()] = conjunct_ctxs;
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+    auto variant_source = make_typed_only_variant_column_for_virtual_column_test();
+
+    ASSIGN_OR_ABORT(auto projection,
+                    make_virtual_projection_for_test("a.b.c", virtual_slot->type(), source_slot->id()));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+    group_reader->_column_readers.emplace(source_slot->id(),
+                                          std::make_unique<MockVariantSourceColumnReader>(variant_source->clone()));
+
+    group_reader->_process_columns_and_conjunct_ctxs();
+    ASSERT_EQ(1, group_reader->_deferred_variant_virtual_conjunct_ctxs.size());
+    ASSERT_TRUE(group_reader->_left_conjunct_ctxs.empty());
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_source, source_slot->id());
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+    dst_chunk->append_column(ColumnHelper::create_column(source_slot->type(), true), source_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    ASSERT_EQ(2, dst_chunk->num_rows());
+
+    ASSERT_OK(ChunkPredicateEvaluator::eval_conjuncts(group_reader->_deferred_variant_virtual_conjunct_ctxs,
+                                                      dst_chunk.get()));
+    ASSERT_EQ(1, dst_chunk->num_rows());
+    EXPECT_EQ(22, dst_chunk->get_column_by_slot_id(virtual_slot->id())->get(0).get_int64());
 }
 
 TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 
 #include "base/testutil/assert.h"
+#include "column/column_access_path.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "common/config_exec_fwd.h"
@@ -28,6 +29,7 @@
 #include "exprs/expr_factory.h"
 #include "formats/parquet/column_chunk_reader.h"
 #include "formats/parquet/file_reader.h"
+#include "formats/parquet/meta_helper.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/page_reader.h"
 #include "formats/parquet/parquet_ut_base.h"
@@ -38,6 +40,7 @@
 #include "runtime/descriptor_helper.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
+#include "testutil/exprs_test_helper.h"
 #include "types/logical_type.h"
 
 namespace starrocks::parquet {
@@ -118,6 +121,153 @@ protected:
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
 };
+
+static tparquet::ColumnChunk make_test_column_chunk(int idx) {
+    tparquet::ColumnChunk chunk;
+    chunk.__set_file_path("col" + std::to_string(idx));
+    chunk.file_offset = 0;
+    chunk.meta_data.data_page_offset = 4;
+    return chunk;
+}
+
+static TColumnAccessPath make_extended_access_path(const std::string& root, const std::string& leaf) {
+    TColumnAccessPath root_path;
+    root_path.__set_type(TAccessPathType::type::ROOT);
+    root_path.__set_from_predicate(false);
+    root_path.__set_extended(true);
+    TExpr root_expr;
+    root_expr.nodes.emplace_back(ExprsTestHelper::create_literal<TYPE_VARCHAR, std::string>(root, false));
+    root_path.__set_path(root_expr);
+
+    TColumnAccessPath child_path;
+    child_path.__set_type(TAccessPathType::type::FIELD);
+    child_path.__set_from_predicate(false);
+    child_path.__set_extended(true);
+    TExpr child_expr;
+    child_expr.nodes.emplace_back(ExprsTestHelper::create_literal<TYPE_VARCHAR, std::string>(leaf, false));
+    child_path.__set_path(child_expr);
+
+    root_path.children.emplace_back(child_path);
+    return root_path;
+}
+
+static FileMetaData init_file_meta_from_thrift(const tparquet::FileMetaData& t_file_meta) {
+    auto meta = t_file_meta;
+    FileMetaData file_meta;
+    EXPECT_OK(file_meta.init(meta, true));
+    return file_meta;
+}
+
+TEST_F(IcebergSchemaEvolutionTest, ParquetMetaHelperMarksExtendedVariantVirtualColumn) {
+    tparquet::SchemaElement root;
+    root.__set_name("table");
+    root.__set_num_children(1);
+
+    tparquet::SchemaElement data;
+    data.__set_name("data");
+    data.__set_type(tparquet::Type::INT64);
+    data.__set_num_children(0);
+
+    tparquet::RowGroup row_group;
+    row_group.__set_columns(std::vector<tparquet::ColumnChunk>{make_test_column_chunk(0)});
+    row_group.__set_num_rows(1);
+
+    tparquet::FileMetaData t_file_meta;
+    t_file_meta.__set_version(1);
+    t_file_meta.__set_schema(std::vector<tparquet::SchemaElement>{root, data});
+    t_file_meta.__set_row_groups(std::vector<tparquet::RowGroup>{row_group});
+    auto file_meta = init_file_meta_from_thrift(t_file_meta);
+
+    TypeDescriptor slot_type = TypeDescriptor::from_logical_type(TYPE_BIGINT);
+    Utils::SlotDesc slot_descs[] = {{"data.id", slot_type}, {""}};
+    auto* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+
+    std::vector<HdfsScannerContext::ColumnInfo> materialized_columns;
+    Utils::make_column_info_vector(tuple_desc, &materialized_columns);
+
+    TColumnAccessPath t_access_path = make_extended_access_path("data", "id");
+    auto access_path_or = ColumnAccessPath::create(t_access_path, _runtime_state, &_pool);
+    ASSERT_TRUE(access_path_or.ok()) << access_path_or.status().to_string();
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+    column_access_paths.emplace_back(std::move(access_path_or).value());
+
+    ParquetMetaHelper helper(&file_meta, true);
+    std::vector<GroupReaderParam::Column> read_cols;
+    std::unordered_set<std::string> existed_column_names;
+    helper.prepare_read_columns(materialized_columns, &column_access_paths, read_cols, existed_column_names);
+
+    ASSERT_EQ(1, read_cols.size());
+    EXPECT_TRUE(read_cols[0].is_extended_variant_virtual);
+    EXPECT_EQ("data", read_cols[0].source_variant_column_name);
+    EXPECT_EQ("id", read_cols[0].variant_virtual_leaf_path);
+}
+
+TEST_F(IcebergSchemaEvolutionTest, LakeMetaHelperWithoutFieldIdMatchesNestedStructChildrenByName) {
+    tparquet::SchemaElement root;
+    root.__set_name("table");
+    root.__set_num_children(1);
+
+    tparquet::SchemaElement col;
+    col.__set_name("col");
+    col.__set_num_children(3);
+
+    tparquet::SchemaElement c;
+    c.__set_name("c");
+    c.__set_type(tparquet::Type::INT32);
+    c.__set_num_children(0);
+
+    tparquet::SchemaElement b;
+    b.__set_name("b");
+    b.__set_type(tparquet::Type::INT32);
+    b.__set_num_children(0);
+
+    tparquet::SchemaElement a;
+    a.__set_name("a");
+    a.__set_type(tparquet::Type::INT32);
+    a.__set_num_children(0);
+
+    tparquet::RowGroup row_group;
+    row_group.__set_columns(std::vector<tparquet::ColumnChunk>{make_test_column_chunk(0), make_test_column_chunk(1),
+                                                               make_test_column_chunk(2)});
+    row_group.__set_num_rows(1);
+
+    tparquet::FileMetaData t_file_meta;
+    t_file_meta.__set_version(1);
+    t_file_meta.__set_schema(std::vector<tparquet::SchemaElement>{root, col, c, b, a});
+    t_file_meta.__set_row_groups(std::vector<tparquet::RowGroup>{row_group});
+    auto file_meta = init_file_meta_from_thrift(t_file_meta);
+
+    TIcebergSchemaField field_a;
+    field_a.__set_field_id(3);
+    field_a.__set_name("a");
+    TIcebergSchemaField field_b;
+    field_b.__set_field_id(2);
+    field_b.__set_name("b");
+    TIcebergSchemaField field_col;
+    field_col.__set_field_id(1);
+    field_col.__set_name("col");
+    field_col.__set_children(std::vector<TIcebergSchemaField>{field_a, field_b});
+
+    TIcebergSchema schema;
+    schema.__set_fields(std::vector<TIcebergSchemaField>{field_col});
+
+    TypeDescriptor col_type = TypeDescriptor::from_logical_type(TYPE_STRUCT);
+    col_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    col_type.field_names.emplace_back("a");
+
+    Utils::SlotDesc slot_descs[] = {{"col", col_type}, {""}};
+    auto* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+    std::vector<HdfsScannerContext::ColumnInfo> materialized_columns;
+    Utils::make_column_info_vector(tuple_desc, &materialized_columns);
+
+    LakeMetaHelper helper(&file_meta, true, &schema);
+    std::vector<GroupReaderParam::Column> read_cols;
+    std::unordered_set<std::string> existed_column_names;
+    helper.prepare_read_columns(materialized_columns, nullptr, read_cols, existed_column_names);
+
+    ASSERT_EQ(1, read_cols.size());
+    EXPECT_EQ("col", read_cols[0].slot_desc->col_name());
+}
 
 TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
@@ -890,7 +1040,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    ctx->scan_range = (_create_scan_range(no_field_id_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);

--- a/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
@@ -57,7 +57,7 @@ function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.p
 -- result:
 True
 -- !result
-set cbo_variant_path_rewrite = false;
+set cbo_variant_path_rewrite = true;
 -- result:
 -- !result
 select get_variant_int(data, '$.id') as id

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -31,7 +31,7 @@ function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') 
 function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.rank') as bigint) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/rank(bigint(20))]")
 function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.profile.metrics.views')) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/metrics(bigint(20))/views(bigint(20))]")
 
-set cbo_variant_path_rewrite = false;
+set cbo_variant_path_rewrite = true;
 
 select get_variant_int(data, '$.id') as id
 from test_variant_virtual_column


### PR DESCRIPTION
## Why I'm doing:

FE already rewrites eligible VARIANT leaf paths into synthetic virtual columns, but BE could not read them end-to-end from Parquet shredded VARIANT data.

This PR makes that rewrite executable and correct for projection, cast, aggregate, and predicate-evaluation cases. Predicate pushdown is intentionally left to a follow-up PR.

## What I'm doing:

- extend FE rewrite coverage for supported cast(variant_query(...)) expressions
- project virtual columns after read from the source VARIANT result
- evaluate rewritten virtual-column predicates after projection for correctness

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
