### PR TITLE
[Feature] Support Composite Storage Volume for cross-bucket partition distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -57,6 +57,7 @@ import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.SwapTableOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -101,6 +102,7 @@ import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncatePartitionClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.expression.DateLiteral;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
@@ -586,6 +588,53 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME)) {
+                        String volumeName = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME);
+                        StorageVolumeMgr svm = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
+
+                        // 1. Pre-validation: ensure the new SV exists and is enabled before any mutation
+                        StorageVolume newSv = svm.getStorageVolumeByName(volumeName);
+                        if (newSv == null) {
+                            throw new DdlException(String.format("Storage volume '%s' not found", volumeName));
+                        }
+                        if (!newSv.getEnabled()) {
+                            throw new DdlException(String.format("Storage volume '%s' is disabled", volumeName));
+                        }
+
+                        // 2. Remember old SV for rollback on failure
+                        String oldSvId = svm.getStorageVolumeIdOfTable(olapTable.getId());
+
+                        // 3. Unbind + bind with rollback on failure
+                        svm.unbindTableToStorageVolume(olapTable.getId());
+                        try {
+                            if (!svm.bindTableToStorageVolume(volumeName, db.getId(), olapTable.getId())) {
+                                throw new DdlException(
+                                        String.format("Failed to bind table to storage volume '%s'", volumeName));
+                            }
+                            // 4. Update table StorageInfo so future partition creation uses the new SV
+                            String storageVolumeId = svm.getStorageVolumeIdOfTable(olapTable.getId());
+                            GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .setLakeStorageInfo(db, olapTable, storageVolumeId, new java.util.HashMap<>());
+                        } catch (Exception e) {
+                            // Rollback: restore the old SV binding
+                            if (oldSvId != null) {
+                                try {
+                                    StorageVolume oldSv = svm.getStorageVolume(oldSvId);
+                                    if (oldSv != null) {
+                                        svm.bindTableToStorageVolume(oldSv.getName(), db.getId(), olapTable.getId());
+                                    }
+                                } catch (Exception rollbackEx) {
+                                    LOG.warn("Failed to rollback SV binding for table {}: {}",
+                                            olapTable.getName(), rollbackEx.getMessage());
+                                }
+                            }
+                            throw (e instanceof DdlException) ? (DdlException) e : new DdlException(e.getMessage());
+                        }
+
+                        // 5. Log: existing partitions/tablets remain on the previous SV's bucket
+                        LOG.info("Changed storage_volume of table {}.{} to '{}'. "
+                                + "NOTE: existing partitions remain on the previous storage volume.",
+                                db.getOriginName(), olapTable.getName(), volumeName);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -28,13 +29,22 @@ import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.StorageVolumeMgr;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /*
  * SHOW PROC /dbs/dbId/tableId/partitions/partitionId/indexId
@@ -42,9 +52,18 @@ import java.util.List;
  * for LakeTablet
  */
 public class LakeTabletsProcDir implements ProcDirInterface {
+    private static final Logger LOG = LogManager.getLogger(LakeTabletsProcDir.class);
+
+    /**
+     * Columns returned by both {@code SHOW TABLETS FROM table} and
+     * {@code SHOW PROC /dbs/.../partitions/indexId[/tabletId]}.
+     * <p>
+     * The last two columns (StorageVolume, StoragePath) are populated by a
+     * best-effort StarOS RPC call in {@link #fetchComparableResult()}.
+     */
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
-            .add("MinVersion").add("Range")
+            .add("MinVersion").add("Range").add("StorageVolume").add("StoragePath")
             .build();
 
     private final Database db;
@@ -68,30 +87,75 @@ public class LakeTabletsProcDir implements ProcDirInterface {
         throw new AnalysisException("Title name[" + columnName + "] does not exist");
     }
 
+    /**
+     * Returns one 8-element row per tablet:
+     * [TabletId, BackendId, DataSize, RowCount, MinVersion, Range, StorageVolume, StoragePath].
+     * <p>
+     * Phase 1 (under DB read lock): collect basic tablet info and tablet IDs.
+     * Phase 2 (outside DB lock): batch-query ShardInfo from StarOS and enrich
+     * StorageVolume / StoragePath.  StarOS errors are logged and silently swallowed
+     * so that the command always returns something even when StarOS is unavailable.
+     */
     public List<List<Comparable>> fetchComparableResult() {
         Preconditions.checkNotNull(db);
         Preconditions.checkNotNull(index);
         Preconditions.checkState(table.isCloudNativeTableOrMaterializedView());
 
         List<List<Comparable>> tabletInfos = Lists.newArrayList();
+        List<Long> tabletIds = new ArrayList<>();
 
+        // Phase 1: collect basic info under DB read lock
         Locker locker = new Locker();
         locker.lockDatabase(db.getId(), LockType.READ);
         try {
             for (Tablet tablet : index.getTablets()) {
-                List<Comparable> tabletInfo = Lists.newArrayList();
                 LakeTablet lakeTablet = (LakeTablet) tablet;
-                tabletInfo.add(lakeTablet.getId());
-                tabletInfo.add(new Gson().toJson(lakeTablet.getBackendIds(ConnectContext.get().getCurrentComputeResource())));
-                tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
-                tabletInfo.add(lakeTablet.getRowCount(0L));
-                tabletInfo.add(lakeTablet.getMinVersion());
-                tabletInfo.add(String.valueOf(lakeTablet.getRange()));
-                tabletInfos.add(tabletInfo);
+                List<Comparable> row = Lists.newArrayList();
+                row.add(lakeTablet.getId());
+                row.add(new Gson().toJson(lakeTablet.getBackendIds(ConnectContext.get().getCurrentComputeResource())));
+                row.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
+                row.add(lakeTablet.getRowCount(0L));
+                row.add(lakeTablet.getMinVersion());
+                row.add(String.valueOf(lakeTablet.getRange()));
+                row.add("");  // StorageVolume placeholder
+                row.add("");  // StoragePath  placeholder
+                tabletInfos.add(row);
+                tabletIds.add(lakeTablet.getId());
             }
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
+
+        // Phase 2: enrich with StarOS shard info (best-effort, outside DB lock)
+        if (!tabletIds.isEmpty()) {
+            try {
+                ComputeResource computeResource = ConnectContext.get().getCurrentComputeResource();
+                long workerGroupId = computeResource.getWorkerGroupId();
+                StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+                List<ShardInfo> shardInfos = starOSAgent.getShardInfoBatch(tabletIds, workerGroupId);
+
+                Map<Long, ShardInfo> shardInfoMap = new HashMap<>();
+                for (ShardInfo si : shardInfos) {
+                    shardInfoMap.put(si.getShardId(), si);
+                }
+
+                StorageVolumeMgr svm = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
+                for (List<Comparable> row : tabletInfos) {
+                    long tabletId = (Long) row.get(0);
+                    ShardInfo si = shardInfoMap.get(tabletId);
+                    if (si != null && si.hasFilePath()) {
+                        String fullPath = si.getFilePath().getFullPath();
+                        String fsKey = si.getFilePath().getFsInfo().getFsKey();
+                        StorageVolume sv = svm.getStorageVolume(fsKey);
+                        row.set(6, sv != null ? sv.getName() : fsKey);
+                        row.set(7, fullPath);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to fetch shard info for LakeTabletsProcDir", e);
+            }
+        }
+
         return tabletInfos;
     }
 
@@ -99,19 +163,17 @@ public class LakeTabletsProcDir implements ProcDirInterface {
     public ProcResult fetchResult() {
         List<List<Comparable>> tabletInfos = fetchComparableResult();
 
-        // sort by tabletId
-        ListComparator<List<Comparable>> comparator = new ListComparator<List<Comparable>>(0);
+        // Sort by tabletId
+        ListComparator<List<Comparable>> comparator = new ListComparator<>(0);
         Collections.sort(tabletInfos, comparator);
 
-        // set result
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
 
-        for (int i = 0; i < tabletInfos.size(); i++) {
-            List<Comparable> info = tabletInfos.get(i);
-            List<String> row = Lists.newArrayListWithCapacity(info.size());
-            for (int j = 0; j < info.size(); j++) {
-                row.add(info.get(j).toString());
+        for (List<Comparable> info : tabletInfos) {
+            List<String> row = new ArrayList<>(info.size());
+            for (Comparable c : info) {
+                row.add(c.toString());
             }
             result.addRow(row);
         }
@@ -152,6 +214,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
 
     // Handle showing single tablet info
     public static class LakeTabletProcNode implements ProcNodeInterface {
+        private static final Logger LOG = LogManager.getLogger(LakeTabletProcNode.class);
+
         private final LakeTablet tablet;
 
         public LakeTabletProcNode(LakeTablet tablet) {
@@ -163,15 +227,35 @@ public class LakeTabletsProcDir implements ProcDirInterface {
             BaseProcResult result = new BaseProcResult();
             result.setNames(TITLE_NAMES);
 
-            // get current warehouse
+            // get current warehouse and compute resource
             ComputeResource computeResource = ConnectContext.get().getCurrentComputeResource();
+            String svName = "";
+            String storagePath = "";
+            try {
+                long workerGroupId = computeResource.getWorkerGroupId();
+                StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+                ShardInfo si = starOSAgent.getShardInfo(tablet.getId(), workerGroupId);
+                if (si != null && si.hasFilePath()) {
+                    storagePath = si.getFilePath().getFullPath();
+                    String fsKey = si.getFilePath().getFsInfo().getFsKey();
+                    StorageVolumeMgr svm = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
+                    StorageVolume sv = svm.getStorageVolume(fsKey);
+                    svName = (sv != null) ? sv.getName() : fsKey;
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to fetch shard info for tablet {}", tablet.getId(), e);
+            }
+
+
             List<String> row = Arrays.asList(
                     String.valueOf(tablet.getId()),
                     new Gson().toJson(tablet.getBackendIds(computeResource)),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
                     String.valueOf(tablet.getRowCount(0L)),
                     String.valueOf(tablet.getMinVersion()),
-                    String.valueOf(tablet.getRange())
+                    String.valueOf(tablet.getRange()),
+                    svName,
+                    storagePath
             );
             result.addRow(row);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StorageVolumeProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StorageVolumeProcNode.java
@@ -14,11 +14,17 @@
 
 package com.starrocks.common.proc;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.StorageVolumeMgr;
+import com.starrocks.storagevolume.CompositeStorageVolume;
 import com.starrocks.storagevolume.StorageVolume;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StorageVolumeProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> STORAGE_VOLUME_PROC_NODE_TITLE_NAMES = new ImmutableList.Builder<String>()
@@ -47,6 +53,35 @@ public class StorageVolumeProcNode implements ProcNodeInterface {
         if (sv == null) {
             return result;
         }
+
+        // Composite SVs are stored only in FE and have no StarOS cloud configuration.
+        // Build a dedicated row that shows child SV names in the Params column so that
+        // DESC STORAGE VOLUME <composite_sv> gives useful output (TC-SMOKE-01).
+        if (sv.isComposite()) {
+            CompositeStorageVolume csv =
+                    storageVolumeMgr.getCompositeStorageVolumeByName(storageVolumeName);
+            if (csv != null) {
+                // Resolve child IDs → names; fall back to raw ID on lookup failure
+                List<String> childNames = csv.getChildVolumeIds().stream()
+                        .map(id -> {
+                            StorageVolume child = storageVolumeMgr.getStorageVolume(id);
+                            return child != null ? child.getName() : id;
+                        })
+                        .collect(Collectors.toList());
+                String childVolumesCsv = Joiner.on(",").join(childNames);
+                boolean isDefault = storageVolumeMgr.getDefaultStorageVolumeId().equals(csv.getId());
+                result.addRow(Lists.newArrayList(
+                        csv.getName(),
+                        "COMPOSITE",
+                        String.valueOf(isDefault),
+                        "",   // Location: not applicable for Composite SV
+                        "{\"child_volumes\":\"" + childVolumesCsv + "\"}",
+                        String.valueOf(csv.isEnabled()),
+                        csv.getComment()));
+                return result;
+            }
+        }
+
         sv.getProcNodeData(result);
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -287,6 +287,11 @@ public class LakeTableHelper {
         }
     }
 
+    /**
+     * Check if this partition uses a shared directory layout by sampling the first tablet.
+     * Under Composite SV, all tablets within the same partition share the same physical root
+     * (partition-level distribution), so sampling one tablet is sufficient.
+     */
     public static boolean isSharedPartitionDirectory(PhysicalPartition physicalPartition, ComputeResource computeResource)
             throws StarClientException {
         ShardInfo shardInfo = getAssociatedShardInfo(physicalPartition, computeResource).orElse(null);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -80,6 +80,10 @@ import javax.validation.constraints.NotNull;
  */
 public class StarOSAgent {
     private static final Logger LOG = LogManager.getLogger(StarOSAgent.class);
+    // allocateFilePath uses deterministic suffix (dbId/tableId), so bounded retry is safe.
+    // Keep retries conservative to avoid amplifying StarOS load under persistent failures.
+    private static final int ALLOCATE_FILE_PATH_MAX_ATTEMPTS = 3;
+    private static final long ALLOCATE_FILE_PATH_BASE_BACKOFF_MS = 100L;
 
     public static final String SERVICE_NAME = "starrocks";
 
@@ -242,20 +246,49 @@ public class StarOSAgent {
         return String.format("db%d/%d", dbId, tableId);
     }
 
-    public FilePathInfo allocateFilePath(long dbId, long tableId) throws DdlException {
-        prepare();
-        try {
-            FileStoreType fsType = getFileStoreType(Config.cloud_native_storage_type);
-            if (fsType == null || fsType == FileStoreType.INVALID) {
-                throw new DdlException("Invalid cloud native storage type: " + Config.cloud_native_storage_type);
-            }
-            String suffix = constructTablePath(dbId, tableId);
-            FilePathInfo pathInfo = client.allocateFilePath(serviceId, fsType, suffix);
-            LOG.debug("Allocate file path from starmgr: {}", pathInfo);
-            return pathInfo;
-        } catch (StarClientException e) {
-            throw new DdlException("Failed to allocate file path from StarMgr, error: " + e.getMessage());
+    @FunctionalInterface
+    private interface AllocatePathCall {
+        FilePathInfo call() throws StarClientException;
+    }
+
+    private static boolean isRetryableAllocatePathError(StarClientException e) {
+        String msg = e.getMessage();
+        if (msg == null) {
+            return false;
         }
+        String lower = msg.toLowerCase();
+        return lower.contains("timeout")
+                || lower.contains("deadline")
+                || lower.contains("temporarily unavailable")
+                || lower.contains("resource busy")
+                || lower.contains("try again");
+    }
+
+    private FilePathInfo allocateFilePathWithRetry(AllocatePathCall call, String requestDesc) throws DdlException {
+        prepare();
+        for (int attempt = 1; attempt <= ALLOCATE_FILE_PATH_MAX_ATTEMPTS; attempt++) {
+            try {
+                FilePathInfo pathInfo = call.call();
+                LOG.debug("Allocate file path from starmgr: {}", pathInfo);
+                return pathInfo;
+            } catch (StarClientException e) {
+                boolean canRetry = attempt < ALLOCATE_FILE_PATH_MAX_ATTEMPTS && isRetryableAllocatePathError(e);
+                if (!canRetry) {
+                    throw new DdlException("Failed to allocate file path from StarMgr, request="
+                            + requestDesc + ", error: " + e.getMessage());
+                }
+                long backoffMs = ALLOCATE_FILE_PATH_BASE_BACKOFF_MS << (attempt - 1);
+                LOG.warn("Retry allocateFilePath after transient failure, request={}, attempt={}/{}, backoff={}ms, err={}",
+                        requestDesc, attempt, ALLOCATE_FILE_PATH_MAX_ATTEMPTS, backoffMs, e.getMessage());
+                try {
+                    Thread.sleep(backoffMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new DdlException("Interrupted while retrying allocate file path from StarMgr");
+                }
+            }
+        }
+        throw new DdlException("Failed to allocate file path from StarMgr");
     }
 
     /**
@@ -277,16 +310,20 @@ public class StarOSAgent {
         }
     }
 
-    public FilePathInfo allocateFilePath(String storageVolumeId, long dbId, long tableId) throws DdlException {
-        prepare();
-        try {
-            String suffix = constructTablePath(dbId, tableId);
-            FilePathInfo pathInfo = client.allocateFilePath(serviceId, storageVolumeId, suffix);
-            LOG.debug("Allocate file path from starmgr: {}", pathInfo);
-            return pathInfo;
-        } catch (StarClientException e) {
-            throw new DdlException("Failed to allocate file path from StarMgr, error: " + e.getMessage());
+    public FilePathInfo allocateFilePath(long dbId, long tableId) throws DdlException {
+        FileStoreType fsType = getFileStoreType(Config.cloud_native_storage_type);
+        if (fsType == null || fsType == FileStoreType.INVALID) {
+            throw new DdlException("Invalid cloud native storage type: " + Config.cloud_native_storage_type);
         }
+        String suffix = constructTablePath(dbId, tableId);
+        return allocateFilePathWithRetry(() -> client.allocateFilePath(serviceId, fsType, suffix),
+                String.format("default fsType=%s suffix=%s", fsType, suffix));
+    }
+
+    public FilePathInfo allocateFilePath(String storageVolumeId, long dbId, long tableId) throws DdlException {
+        String suffix = constructTablePath(dbId, tableId);
+        return allocateFilePathWithRetry(() -> client.allocateFilePath(serviceId, storageVolumeId, suffix),
+                String.format("svId=%s suffix=%s", storageVolumeId, suffix));
     }
 
     public FilePathInfo allocateFilePath(String storageVolumeId, String rootDir) throws DdlException {
@@ -1130,5 +1167,40 @@ public class StarOSAgent {
     public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo, long physicalPartitionId) {
         String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(physicalPartitionId));
         return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, physicalPartitionId)).build();
+    }
+
+    /**
+     * Allocate a partition-scoped {@link FilePathInfo} for a specific child SV of a Composite SV.
+     * Each partition is assigned to one child SV via round-robin; all tablets within the same
+     * partition share this path.
+     *
+     * @param storageVolumeId child SV id (must be a regular SV known to StarOS)
+     * @param dbId            database id
+     * @param tableId         table id
+     * @param partitionId     physical partition id (used for file path construction)
+     * @return partition-level FilePathInfo with fs_info from the specified child SV
+     */
+    public FilePathInfo allocatePartitionFilePathInfoForChildSv(String storageVolumeId,
+                                                                long dbId, long tableId, long partitionId)
+            throws DdlException {
+        FilePathInfo tablePathInfo = allocateFilePath(storageVolumeId, dbId, tableId);
+        return allocatePartitionFilePathInfo(tablePathInfo, partitionId);
+    }
+
+    /**
+     * Batch query {@link ShardInfo} for multiple shards in a single StarOS RPC.
+     * Significantly reduces RPC overhead vs. calling {@link #getShardInfo} per shard.
+     *
+     * @param shardIds      shard ids to query
+     * @param workerGroupId worker group id
+     * @return list of ShardInfo (order matches the StarOS response, not input order)
+     */
+    public List<ShardInfo> getShardInfoBatch(List<Long> shardIds, long workerGroupId)
+            throws StarClientException {
+        if (shardIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        prepare();
+        return client.getShardInfo(serviceId, shardIds, workerGroupId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -2191,6 +2191,10 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS, tableStorageInfos, walApplier);
     }
 
+    // Composite SV log methods removed: composite SV definitions are persisted in StarOS only.
+    // The OP_CREATE/UPDATE/DROP_COMPOSITE_STORAGE_VOLUME opcodes are retained in OperationType
+    // for backward compatibility (old EditLog entries), but replay is a no-op.
+
     public void logReplicationJob(ReplicationJob replicationJob, WALApplier walApplier) {
         ReplicationJobLog replicationJobLog = new ReplicationJobLog(replicationJob);
         logJsonObject(OperationType.OP_REPLICATION_JOB, replicationJobLog, walApplier);

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -40,6 +40,7 @@ import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.TableStorageInfo;
 import com.starrocks.persist.TableStorageInfos;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.storagevolume.CompositeStorageVolume;
 import com.starrocks.storagevolume.StorageVolume;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -48,6 +49,7 @@ import org.apache.logging.log4j.Logger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,9 +72,17 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     public StorageVolume getStorageVolumeByName(String svName) {
         try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
             try {
-                FileStoreInfo fileStoreInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStoreByName(svName);
+                FileStoreInfo fileStoreInfo =
+                        GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStoreByName(svName);
                 if (fileStoreInfo == null) {
                     return null;
+                }
+                if (StorageVolume.isCompositeFileStoreInfo(fileStoreInfo)) {
+                    CompositeStorageVolume csv = new CompositeStorageVolume(fileStoreInfo.getFsKey(),
+                            fileStoreInfo.getFsName(), parseCompositeChildFsKeys(fileStoreInfo),
+                            fileStoreInfo.getEnabled(), fileStoreInfo.getComment());
+                    return StorageVolume.createCompositeWrapper(
+                            csv.getId(), csv.getName(), csv.isEnabled(), csv.getComment());
                 }
                 return StorageVolume.fromFileStoreInfo(fileStoreInfo);
             } catch (DdlException e) {
@@ -85,9 +95,17 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     public StorageVolume getStorageVolume(String svId) {
         try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
             try {
-                FileStoreInfo fileStoreInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStore(svId);
+                FileStoreInfo fileStoreInfo =
+                        GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStore(svId);
                 if (fileStoreInfo == null) {
                     return null;
+                }
+                if (StorageVolume.isCompositeFileStoreInfo(fileStoreInfo)) {
+                    CompositeStorageVolume csv = new CompositeStorageVolume(fileStoreInfo.getFsKey(),
+                            fileStoreInfo.getFsName(), parseCompositeChildFsKeys(fileStoreInfo),
+                            fileStoreInfo.getEnabled(), fileStoreInfo.getComment());
+                    return StorageVolume.createCompositeWrapper(
+                            csv.getId(), csv.getName(), csv.isEnabled(), csv.getComment());
                 }
                 return StorageVolume.fromFileStoreInfo(fileStoreInfo);
             } catch (DdlException e) {
@@ -99,8 +117,10 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     @Override
     public List<String> listStorageVolumeNames() throws DdlException {
         try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
-            return GlobalStateMgr.getCurrentState().getStarOSAgent().listFileStore()
-                    .stream().map(FileStoreInfo::getFsName).collect(Collectors.toList());
+            List<String> names = new ArrayList<>();
+            GlobalStateMgr.getCurrentState().getStarOSAgent().listFileStore()
+                    .stream().map(FileStoreInfo::getFsName).forEach(names::add);
+            return names;
         }
     }
 
@@ -676,6 +696,17 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
             default:
                 return "";
         }
+    }
+
+    private List<String> parseCompositeChildFsKeys(FileStoreInfo fsInfo) {
+        String csv = fsInfo.getPropertiesMap().getOrDefault(StorageVolume.COMPOSITE_CHILD_FS_KEYS, "");
+        if (csv.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -18,7 +18,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
 import com.staros.util.LockCloseable;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidConfException;
@@ -41,6 +44,7 @@ import com.starrocks.sql.ast.AlterStorageVolumeStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
 import com.starrocks.sql.ast.DropStorageVolumeStmt;
 import com.starrocks.sql.ast.SetDefaultStorageVolumeStmt;
+import com.starrocks.storagevolume.CompositeStorageVolume;
 import com.starrocks.storagevolume.StorageVolume;
 
 import java.io.DataInput;
@@ -48,6 +52,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,7 +64,38 @@ import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
+// =====================================================================
+// Composite SV Metadata Persistence Design
+// =====================================================================
+//
+// Composite SV follows the SAME StarOS-only persistence model as regular SVs
+// in shared-data mode (SharedDataStorageVolumeMgr):
+//
+// 1. SV DEFINITION (name, children, enabled, comment):
+//    - Source of truth: StarOS FileStore (fsType = COMPOSITE_FS_TYPE_VALUE)
+//    - FE does NOT cache SV definitions locally
+//    - All reads go through StarOS RPC: getFileStore() / getFileStoreByName()
+//    - This ensures FE failover does NOT lose Composite SV state
+//
+// 2. BINDING RELATIONSHIPS (table→SV, db→SV, default SV):
+//    - Source of truth: FE Image + EditLog (same as regular SVs)
+//    - Stored in storageVolumeToDbs / storageVolumeToTables
+//    - Replayed on Follower via EditLog
+//
+// 3. CHILD REFERENCE CHECK (checkNotReferencedAsChildSv):
+//    - Real-time query to StarOS listFileStore() (no local index)
+//    - Only called during DROP/DISABLE operations (low frequency)
+//
+// Why NOT cache Composite SV definitions in FE:
+// - Regular SVs don't cache either (SharedDataStorageVolumeMgr.getStorageVolume
+//   always queries StarOS), so Composite SVs should not be special-cased
+// - Eliminates dual-source-of-truth risk between FE in-memory cache and StarOS
+// - Eliminates FE failover state loss (no EditLog replay needed for SV definitions)
+// - Simplifies code: no cache invalidation, no replay methods, no rebuild logic
+//
 public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable {
     private static final String ENABLED = "enabled";
 
@@ -76,6 +114,8 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     private static final String GS = "gs";
 
     private static final String HDFS = "hdfs";
+
+    public static final String COMPOSITE = "composite";
 
     @SerializedName("defaultSVId")
     protected String defaultStorageVolumeId = "";
@@ -120,6 +160,16 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     public String createStorageVolume(String name, String svType, List<String> locations, Map<String, String> params,
             Optional<Boolean> enabled, String comment)
             throws DdlException, AlreadyExistsException {
+        // Route COMPOSITE type to composite-specific creation logic
+        if (svType.equalsIgnoreCase(COMPOSITE)) {
+            String childVolumesCsv = params.getOrDefault("child_volumes", "");
+            if (childVolumesCsv.isEmpty()) {
+                throw new DdlException(
+                        "COMPOSITE storage volume requires property 'child_volumes' (comma-separated SV names)");
+            }
+            List<String> childNames = Arrays.asList(childVolumesCsv.split(","));
+            return createCompositeStorageVolume(name, childNames, enabled.orElse(true), comment);
+        }
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             validateParams(svType, params);
             validateLocations(svType, locations);
@@ -130,12 +180,292 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         }
     }
 
+    // =====================================================================
+    // Composite SV management
+    // =====================================================================
+
+    /**
+     * Create a COMPOSITE storage volume.
+     *
+     * <p><b>Persistence:</b> The Composite SV is persisted to StarOS FileStore via
+     * {@link #createInternalNoLock}, following the same StarOS-only model as regular SVs.
+     * No FE EditLog or local cache is used for SV definitions.
+     *
+     * @param name        composite SV name
+     * @param childNames  ordered list of child SV names (will be resolved to IDs)
+     * @param enabled     initial enabled state
+     * @param comment     optional comment
+     * @return composite SV id
+     */
+    public String createCompositeStorageVolume(String name, List<String> childNames,
+                                               boolean enabled, String comment)
+            throws DdlException, AlreadyExistsException {
+        try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            if (existsNoLock(name)) {
+                throw new AlreadyExistsException(String.format("Storage volume '%s' already exists", name));
+            }
+            if (childNames.isEmpty()) {
+                throw new DdlException("COMPOSITE storage volume must have at least one child SV");
+            }
+            // Resolve child names → IDs and validate
+            List<String> childIds = resolveChildNamesToIds(childNames);
+            Map<String, String> params = new HashMap<>();
+            params.put(StorageVolume.COMPOSITE_CHILD_FS_KEYS, String.join(",", childIds));
+            // Writes to StarOS FileStore — the sole source of truth for SV definitions
+            return createInternalNoLock(name, COMPOSITE, Collections.emptyList(), params, Optional.of(enabled), comment);
+        }
+    }
+
+    /**
+     * Add a child SV to an existing Composite SV.
+     * Increments membershipVersion so in-progress tablet creations see the old snapshot.
+     * Updated state is written to StarOS FileStore (no local cache).
+     */
+    public void addChildToCompositeStorageVolume(String compositeName, String childName)
+            throws DdlException {
+        try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            CompositeStorageVolume csv = getCompositeStorageVolumeByNameNoLock(compositeName);
+            if (csv == null) {
+                throw new DdlException("Composite storage volume '" + compositeName + "' not found");
+            }
+            StorageVolume child = getStorageVolumeByName(childName);
+            if (child == null) {
+                throw new DdlException("Child storage volume '" + childName + "' not found");
+            }
+            if (child.isComposite()) {
+                throw new DdlException("Cannot add Composite SV '" + childName
+                        + "' as child of '" + compositeName + "' (nesting not allowed)");
+            }
+            if (csv.getChildVolumeIds().contains(child.getId())) {
+                throw new DdlException("Child SV '" + childName + "' is already in Composite SV '"
+                        + compositeName + "'");
+            }
+            // Validate type consistency with existing children
+            if (!csv.getChildVolumeIds().isEmpty()) {
+                StorageVolume firstChild = getStorageVolume(csv.getChildVolumeIds().get(0));
+                if (firstChild != null) {
+                    String existingType = firstChild.getType().toUpperCase();
+                    String newType = child.getType().toUpperCase();
+                    if (!existingType.equals(newType)) {
+                        throw new DdlException("Child SV '" + childName + "' type=" + newType
+                                + " differs from existing children type=" + existingType
+                                + " in Composite SV '" + compositeName + "'");
+                    }
+                }
+            }
+            CompositeStorageVolume updated = csv.withAddedChild(child.getId());
+            // Persist to StarOS FileStore — the sole source of truth
+            updateInternalNoLock(buildCompositeStorageVolumeNoLock(updated));
+        }
+    }
+
+    /**
+     * Remove a child SV from a Composite SV.
+     *
+     * <p><b>Safety guard (TC-RISK-02)</b>: If any tables are currently bound to this Composite SV,
+     * existing tablets on the BE may physically reside on {@code childName}'s storage paths. Removing
+     * the child from the Composite's membership would silently break the bucket→child mapping for
+     * those tablets, causing potential data loss or path-resolution failures. To prevent this,
+     * we refuse the operation when bound tables exist and require the user to unbind all tables
+     * from the Composite SV first.
+     *
+     * <p>Precise per-shard verification via StarOS queries is left for a future enhancement once
+     * an in-place child-swap workflow is designed.
+     */
+    public void removeChildFromCompositeStorageVolume(String compositeName, String childName)
+            throws DdlException {
+        try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            CompositeStorageVolume csv = getCompositeStorageVolumeByNameNoLock(compositeName);
+            if (csv == null) {
+                throw new DdlException("Composite storage volume '" + compositeName + "' not found");
+            }
+            // Resolve child name → id (might be regular SV, need to look it up)
+            StorageVolume child = getStorageVolumeByName(childName);
+            if (child == null) {
+                throw new DdlException("Storage volume '" + childName + "' not found");
+            }
+            String childId = child.getId();
+            if (!csv.getChildVolumeIds().contains(childId)) {
+                throw new DdlException("SV '" + childName + "' is not a child of Composite SV '"
+                        + compositeName + "'");
+            }
+
+            // Safety guard: refuse REMOVE VOLUME when tables are bound to this Composite SV.
+            // Existing tablets may physically reside on the child's storage paths; removing the
+            // child from the membership would break bucket→child mapping for those tablets.
+            Set<Long> boundTables = storageVolumeToTables.getOrDefault(csv.getId(), Collections.emptySet());
+            Set<Long> boundDbs = storageVolumeToDbs.getOrDefault(csv.getId(), Collections.emptySet());
+            if (!boundTables.isEmpty() || !boundDbs.isEmpty()) {
+                throw new DdlException("[SV_COMPOSITE_HAS_BOUND_TABLES] Cannot remove child storage volume '"
+                        + childName + "' from Composite SV '" + compositeName + "': "
+                        + boundTables.size() + " table(s) and " + boundDbs.size()
+                        + " database(s) are currently bound to this Composite SV. "
+                        + "Unbind all tables and databases before modifying its child volumes.");
+            }
+
+            // Block removing child from the default Composite SV
+            if (defaultStorageVolumeId.equals(csv.getId())) {
+                throw new DdlException("Cannot remove child from default Composite SV '"
+                        + compositeName + "'. Unset it as default first.");
+            }
+
+            CompositeStorageVolume updated = csv.withRemovedChild(childId);
+            // Persist to StarOS FileStore — the sole source of truth
+            updateInternalNoLock(buildCompositeStorageVolumeNoLock(updated));
+        }
+    }
+
+    /** Returns the {@link CompositeStorageVolume} by name, or {@code null} if not found. */
+    public CompositeStorageVolume getCompositeStorageVolumeByName(String name) {
+        try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
+            return getCompositeStorageVolumeByNameNoLock(name);
+        }
+    }
+
+    /** Returns the {@link CompositeStorageVolume} by ID, or {@code null} if not found. */
+    public CompositeStorageVolume getCompositeStorageVolume(String id) {
+        try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
+            return getCompositeStorageVolumeByIdNoLock(id);
+        }
+    }
+
+    /**
+     * Check that the given SV is NOT referenced as a child of any Composite SV.
+     * Call this before DROP / DISABLE of a regular SV.
+     *
+     * <p><b>Implementation:</b> Real-time query to StarOS {@code listFileStore()} — no local
+     * index is maintained. This is acceptable because DROP/DISABLE operations are infrequent.
+     * This approach is consistent with the StarOS-only persistence model: FE never caches
+     * Composite SV definitions, so there is no local reverse index to consult.
+     */
+    public void checkNotReferencedAsChildSv(String svId, String svName) throws DdlException {
+        // Query all FileStores from StarOS, filter for COMPOSITE type, check child references
+        List<String> referencingCompositeNames = new ArrayList<>();
+        for (FileStoreInfo fsInfo : GlobalStateMgr.getCurrentState().getStarOSAgent().listFileStore()) {
+            if (!StorageVolume.isCompositeFileStoreInfo(fsInfo)) {
+                continue;
+            }
+            List<String> childIds = parseCompositeChildFsKeysFromFsInfo(fsInfo);
+            if (childIds.contains(svId)) {
+                referencingCompositeNames.add(fsInfo.getFsName());
+            }
+        }
+        if (!referencingCompositeNames.isEmpty()) {
+            throw new DdlException("[SV_CHILD_REFERENCED_BY_COMPOSITE] Cannot drop/disable storage volume '"
+                    + svName + "': still referenced by Composite SVs: " + referencingCompositeNames);
+        }
+    }
+
+    // ---- private helpers for Composite SV ----
+    // All queries go directly to StarOS — no local cache. See class-level Javadoc.
+
+    /**
+     * Query StarOS by name. Returns null if not found or not a COMPOSITE type.
+     */
+    private CompositeStorageVolume getCompositeStorageVolumeByNameNoLock(String name) {
+        try {
+            FileStoreInfo fsInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStoreByName(name);
+            if (!StorageVolume.isCompositeFileStoreInfo(fsInfo)) {
+                return null;
+            }
+            return new CompositeStorageVolume(fsInfo.getFsKey(), fsInfo.getFsName(),
+                    parseCompositeChildFsKeysFromFsInfo(fsInfo), fsInfo.getEnabled(), fsInfo.getComment());
+        } catch (DdlException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Query StarOS by id. Returns null if not found or not a COMPOSITE type.
+     */
+    protected CompositeStorageVolume getCompositeStorageVolumeByIdNoLock(String id) {
+        try {
+            FileStoreInfo fsInfo = GlobalStateMgr.getCurrentState().getStarOSAgent().getFileStore(id);
+            if (!StorageVolume.isCompositeFileStoreInfo(fsInfo)) {
+                return null;
+            }
+            return new CompositeStorageVolume(fsInfo.getFsKey(), fsInfo.getFsName(),
+                    parseCompositeChildFsKeysFromFsInfo(fsInfo), fsInfo.getEnabled(), fsInfo.getComment());
+        } catch (DdlException e) {
+            return null;
+        }
+    }
+
+    private StorageVolume buildCompositeStorageVolumeNoLock(CompositeStorageVolume csv) throws DdlException {
+        Map<String, String> params = new HashMap<>();
+        params.put(StorageVolume.COMPOSITE_CHILD_FS_KEYS, String.join(",", csv.getChildVolumeIds()));
+        return new StorageVolume(csv.getId(), csv.getName(), COMPOSITE, Collections.emptyList(),
+                params, csv.isEnabled(), csv.getComment());
+    }
+
+    /** Resolve a list of child SV names to IDs, validating constraints. */
+    private List<String> resolveChildNamesToIds(List<String> childNames) throws DdlException {
+        List<String> childIds = new ArrayList<>(childNames.size());
+        StorageVolume.StorageVolumeType expectedType = null;
+        for (String childName : childNames) {
+            childName = childName.trim();
+            StorageVolume child = getStorageVolumeByName(childName);
+            if (child == null) {
+                throw new DdlException("Child storage volume '" + childName + "' not found");
+            }
+            if (child.isComposite()) {
+                throw new DdlException("Nested Composite SV is not allowed: '" + childName + "'");
+            }
+            StorageVolume.StorageVolumeType childType =
+                    StorageVolume.StorageVolumeType.valueOf(child.getType().toUpperCase());
+            if (expectedType == null) {
+                expectedType = childType;
+            } else if (expectedType != childType) {
+                throw new DdlException("Child SV type mismatch: all child SVs must be the same type."
+                        + " Expected " + expectedType + " but got " + childType
+                        + " for SV '" + childName + "'");
+            }
+            childIds.add(child.getId());
+        }
+        return childIds;
+    }
+
+    private boolean existsNoLock(String svName) {
+        if (getCompositeStorageVolumeByNameNoLock(svName) != null) {
+            return true;
+        }
+        return getStorageVolumeByName(svName) != null;
+    }
+
+    private List<String> parseCompositeChildFsKeysFromFsInfo(FileStoreInfo fsInfo) {
+        String csv = fsInfo.getPropertiesMap().getOrDefault(StorageVolume.COMPOSITE_CHILD_FS_KEYS, "");
+        if (csv.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
     public void removeStorageVolume(DropStorageVolumeStmt stmt) throws DdlException, MetaNotFoundException {
         removeStorageVolume(stmt.getName());
     }
 
     public void removeStorageVolume(String name) throws DdlException, MetaNotFoundException {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            // Handle Composite SV removal — query StarOS directly (no local cache)
+            CompositeStorageVolume csv = getCompositeStorageVolumeByNameNoLock(name);
+            if (csv != null) {
+                Preconditions.checkState(!defaultStorageVolumeId.equals(csv.getId()),
+                        "default storage volume can not be removed");
+                // Block drop if Composite SV is still referenced by dbs or tables
+                Set<Long> dbs = storageVolumeToDbs.getOrDefault(csv.getId(), new HashSet<>());
+                Set<Long> tables = storageVolumeToTables.getOrDefault(csv.getId(), new HashSet<>());
+                Preconditions.checkState(dbs.isEmpty() && tables.isEmpty(),
+                        "Storage volume '%s' is referenced by dbs or tables, dbs: %s, tables: %s",
+                        name, dbs.toString(), tables.toString());
+                // Removes from StarOS FileStore — the sole source of truth
+                removeInternalNoLock(buildCompositeStorageVolumeNoLock(csv));
+                return;
+            }
+
+            // Regular SV: original logic + composite reference check
             StorageVolume sv = getStorageVolumeByName(name);
             if (sv == null) {
                 throw new MetaNotFoundException(String.format("Storage volume '%s' does not exist", name));
@@ -146,6 +476,8 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
             }
             Preconditions.checkState(!defaultStorageVolumeId.equals(sv.getId()),
                     "default storage volume can not be removed");
+            // V4: block drop if this SV is a child of any Composite SV
+            checkNotReferencedAsChildSv(sv.getId(), name);
             Set<Long> dbs = storageVolumeToDbs.getOrDefault(sv.getId(), new HashSet<>());
             Set<Long> tables = storageVolumeToTables.getOrDefault(sv.getId(), new HashSet<>());
             if (name.equals(BUILTIN_STORAGE_VOLUME)) {
@@ -161,6 +493,16 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     }
 
     public void updateStorageVolume(AlterStorageVolumeStmt stmt) throws DdlException, MetaNotFoundException {
+        // Handle ADD VOLUME / REMOVE VOLUME for Composite SV
+        if (stmt.isAddVolume()) {
+            addChildToCompositeStorageVolume(stmt.getName(), stmt.getAddVolumeName());
+            return;
+        }
+        if (stmt.isRemoveVolume()) {
+            removeChildFromCompositeStorageVolume(stmt.getName(), stmt.getRemoveVolumeName());
+            return;
+        }
+        // Regular property/comment modification
         updateStorageVolume(stmt.getName(), null, null, stmt.getProperties(), stmt.getComment());
     }
 
@@ -181,6 +523,13 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
             }
         }
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            // Composite SVs have no cloud config — detect and route to dedicated update path.
+            CompositeStorageVolume csv = getCompositeStorageVolumeByNameNoLock(name);
+            if (csv != null) {
+                updateCompositeStorageVolumeNoLock(csv, params, enabled, comment);
+                return;
+            }
+
             StorageVolume sv = getStorageVolumeByName(name);
             if (sv == null) {
                 throw new MetaNotFoundException(String.format("Storage volume '%s' does not exist", name));
@@ -193,6 +542,10 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
                 if (!enabledValue) {
                     Preconditions.checkState(!copied.getId().equals(defaultStorageVolumeId),
                             "Default volume can not be disabled");
+                    // [BUG-1 FIX] Block disabling a regular SV that is referenced as a child
+                    // of any Composite SV. Disabling such an SV would cause Fail-Fast during
+                    // new partition creation on all bound Composite SV tables.
+                    checkNotReferencedAsChildSv(sv.getId(), name);
                 }
                 copied.setEnabled(enabledValue);
             }
@@ -290,10 +643,52 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         throw new DdlException("Not implemented");
     }
 
+    /**
+     * Update path for Composite SVs (enabled/comment only, no cloud config).
+     *
+     * <p>Composite SVs have no cloud configuration of their own, so only {@code COMMENT} and
+     * the {@code enabled} property are supported. Cloud configuration params are rejected.
+     * Updated state is persisted to StarOS FileStore via {@link #updateInternalNoLock}.
+     *
+     * <p>Must be called while holding the write lock.
+     */
+    private void updateCompositeStorageVolumeNoLock(CompositeStorageVolume csv,
+                                                     Map<String, String> params,
+                                                     Optional<Boolean> enabled,
+                                                     String comment) throws DdlException {
+        if (!params.isEmpty()) {
+            throw new DdlException(
+                    "COMPOSITE storage volume does not support cloud configuration parameters. "
+                            + "Only COMMENT and the 'enabled' property are supported.");
+        }
+        if (enabled.isPresent()) {
+            boolean enabledValue = enabled.get();
+            if (!enabledValue) {
+                Preconditions.checkState(!defaultStorageVolumeId.equals(csv.getId()),
+                        "Default storage volume can not be disabled");
+            }
+            csv.setEnabled(enabledValue);
+        }
+        if (!comment.isEmpty()) {
+            csv.setComment(comment);
+        }
+        updateInternalNoLock(buildCompositeStorageVolumeNoLock(csv));
+    }
+
     public void setDefaultStorageVolume(SetDefaultStorageVolumeStmt stmt) {
         setDefaultStorageVolume(stmt.getName());
     }
 
+    /**
+     * Sets the given storage volume (regular or Composite) as the cluster-wide default.
+     *
+     * <p>For Composite SVs, {@link SharedDataStorageVolumeMgr#getStorageVolumeByName} returns a
+     * lightweight {@link StorageVolume#createCompositeWrapper wrapper} whose {@code id} is the
+     * Composite SV's UUID. That UUID is persisted in the {@link SetDefaultStorageVolumeLog} and
+     * restored on FE restart. Subsequent calls to {@link #getDefaultStorageVolume()} resolve the
+     * Composite SV via {@link SharedDataStorageVolumeMgr#getStorageVolume(String)}, which queries
+     * StarOS by id — no local cache needed.
+     */
     public void setDefaultStorageVolume(String svName) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             StorageVolume sv = getStorageVolumeByName(svName);
@@ -311,6 +706,9 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
 
     public boolean exists(String svName) throws DdlException {
         try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
+            if (getCompositeStorageVolumeByNameNoLock(svName) != null) {
+                return true;
+            }
             StorageVolume sv = getStorageVolumeByName(svName);
             return sv != null;
         }
@@ -389,6 +787,46 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
 
     public void replayUpdateTableStorageInfos(TableStorageInfos tableStorageInfos) {
         throw new RuntimeException("Not implemented");
+    }
+
+    /**
+     * For a table bound to a Composite SV, resolve the child SV for the given partition via round-robin
+     * and return a partition-scoped {@link FilePathInfo}. Returns {@code null} if the table is not
+     * bound to a Composite SV.
+     *
+     * @param table               the lake table
+     * @param dbId                database ID
+     * @param partitionId         logical partition ID (used for round-robin child selection)
+     * @param physicalPartitionId physical partition ID (used for file path construction)
+     */
+    @Nullable
+    public FilePathInfo resolveCompositePartitionFilePathInfo(OlapTable table, long dbId,
+                                                              long partitionId, long physicalPartitionId)
+            throws DdlException {
+        String svId = getStorageVolumeIdOfTable(table.getId());
+        if (svId == null) {
+            return null;
+        }
+        CompositeStorageVolume csv = getCompositeStorageVolume(svId);
+        if (csv == null) {
+            return null;
+        }
+        CompositeStorageVolume.ChildVolumesSnapshot snapshot = csv.resolveChildVolumesStrict(this);
+        int childIndex = (int) (Math.abs(partitionId % snapshot.childVolumes.size()));
+        StorageVolume selectedChild = snapshot.childVolumes.get(childIndex);
+        return GlobalStateMgr.getCurrentState().getStarOSAgent().allocatePartitionFilePathInfoForChildSv(
+                selectedChild.getId(), dbId, table.getId(), physicalPartitionId);
+    }
+
+    /**
+     * Returns the correct partition {@link FilePathInfo} for creating shards, handling both
+     * Composite SV (round-robin child selection) and regular SV (table-level default).
+     */
+    public FilePathInfo getPartitionFilePathInfo(OlapTable table, long dbId,
+                                                  long partitionId, long physicalPartitionId)
+            throws DdlException {
+        FilePathInfo overridePath = resolveCompositePartitionFilePathInfo(table, dbId, partitionId, physicalPartitionId);
+        return overridePath != null ? overridePath : table.getPartitionFilePathInfo(physicalPartitionId);
     }
 
     protected void validateParams(String svType, Map<String, String> params) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -500,6 +500,18 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                         "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
                                 " must be bool type(false/true)");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME)) {
+            // Validate storage_volume: only cloud-native tables support changing storage volume
+            if (!table.isCloudNativeTableOrMaterializedView()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property '" + PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME +
+                                "' is only supported for cloud-native (shared-data) tables");
+            }
+            String volumeName = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME);
+            if (volumeName == null || volumeName.isEmpty()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property '" + PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME + "' must not be empty");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageVolumeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageVolumeAnalyzer.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.ast.ShowStorageVolumesStmt;
 import com.starrocks.sql.ast.StatementBase;
 
 import java.util.List;
+import java.util.Map;
 
 public class StorageVolumeAnalyzer {
     public static void analyze(StatementBase stmt, ConnectContext session) {
@@ -53,19 +54,27 @@ public class StorageVolumeAnalyzer {
                         StorageVolumeMgr.BUILTIN_STORAGE_VOLUME));
             }
 
-            List<String> locations = statement.getStorageLocations();
-            if (locations.isEmpty()) {
-                throw new SemanticException("'location' field is required to create the storage volume");
-            }
-            for (String location : locations) {
-                if (location.isEmpty()) {
-                    throw new SemanticException("'location' field is required to create the storage volume");
-                }
-            }
-
             String svType = statement.getStorageVolumeType();
             if (Strings.isNullOrEmpty((svType))) {
                 throw new SemanticException("'storage volume type' can not be null or empty");
+            }
+            List<String> locations = statement.getStorageLocations();
+            if (svType.equalsIgnoreCase(StorageVolumeMgr.COMPOSITE)) {
+                Map<String, String> properties = statement.getProperties();
+                String childVolumes = properties.getOrDefault("child_volumes", "");
+                if (childVolumes.trim().isEmpty()) {
+                    throw new SemanticException(
+                            "'child_volumes' property is required to create COMPOSITE storage volume");
+                }
+            } else {
+                if (locations.isEmpty()) {
+                    throw new SemanticException("'location' field is required to create the storage volume");
+                }
+                for (String location : locations) {
+                    if (location.isEmpty()) {
+                        throw new SemanticException("'location' field is required to create the storage volume");
+                    }
+                }
             }
 
             FeNameFormat.checkStorageVolumeName(svName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateStorageVolumeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateStorageVolumeStmt.java
@@ -84,15 +84,17 @@ public class CreateStorageVolumeStmt extends DdlStmt {
         }
         sb.append(storageVolumeName);
         sb.append(" TYPE = ").append(storageVolumeType);
-        sb.append(" LOCATIONS = (");
-        for (int i = 0; i < locations.size(); ++i) {
-            if (i == 0) {
-                sb.append("'").append(locations.get(i)).append("'");
-            } else {
-                sb.append(", '").append(locations.get(i)).append("'");
+        if (!locations.isEmpty()) {
+            sb.append(" LOCATIONS = (");
+            for (int i = 0; i < locations.size(); ++i) {
+                if (i == 0) {
+                    sb.append("'").append(locations.get(i)).append("'");
+                } else {
+                    sb.append(", '").append(locations.get(i)).append("'");
+                }
             }
+            sb.append(")");
         }
-        sb.append(")");
         if (!comment.isEmpty()) {
             sb.append(" COMMENT '").append(comment).append("'");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.ast.AddPartitionColumnClause;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
 import com.starrocks.sql.ast.AddSqlDigestBlackListStmt;
+import com.starrocks.sql.ast.AddStorageVolumeChildClause;
 import com.starrocks.sql.ast.AdminAlterAutomatedSnapshotIntervalStmt;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
 import com.starrocks.sql.ast.AdminCheckTabletsStmt;
@@ -295,6 +296,7 @@ import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.RefreshTableStmt;
 import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.RemoveStorageVolumeChildClause;
 import com.starrocks.sql.ast.ReorderColumnsClause;
 import com.starrocks.sql.ast.ReplacePartitionClause;
 import com.starrocks.sql.ast.ReplacePartitionColumnClause;
@@ -4738,10 +4740,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         String storageType = ((Identifier) visit(context.typeDesc().identifier())).getValue();
 
-        List<com.starrocks.sql.parser.StarRocksParser.StringContext> locationList = context.locationsDesc().stringList().string();
         List<String> locations = new ArrayList<>();
-        for (com.starrocks.sql.parser.StarRocksParser.StringContext location : locationList) {
-            locations.add(((StringLiteral) visit(location)).getValue());
+        if (context.locationsDesc() != null) {
+            List<StarRocksParser.StringContext> locationList = context.locationsDesc().stringList().string();
+            for (StarRocksParser.StringContext location : locationList) {
+                locations.add(((StringLiteral) visit(location)).getValue());
+            }
         }
 
         return new CreateStorageVolumeStmt(context.IF() != null,
@@ -4774,17 +4778,42 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         List<AlterStorageVolumeClause> alterClauses = visit(context.alterStorageVolumeClause(),
                 AlterStorageVolumeClause.class);
 
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = null;
         String comment = null;
+        String addVolumeName = null;
+        String removeVolumeName = null;
         for (AlterStorageVolumeClause clause : alterClauses) {
             if (clause.getOpType().equals(AlterStorageVolumeClause.AlterOpType.ALTER_COMMENT)) {
+                if (comment != null) {
+                    throw new ParsingException("Multiple COMMENT clauses are not allowed in a single ALTER statement");
+                }
                 comment = ((AlterStorageVolumeCommentClause) clause).getNewComment();
             } else if (clause.getOpType().equals(AlterStorageVolumeClause.AlterOpType.MODIFY_PROPERTIES)) {
+                if (properties != null) {
+                    throw new ParsingException("Multiple SET clauses are not allowed in a single ALTER statement");
+                }
                 properties = ((ModifyStorageVolumePropertiesClause) clause).getProperties();
+            } else if (clause.getOpType().equals(AlterStorageVolumeClause.AlterOpType.ADD_VOLUME)) {
+                if (addVolumeName != null) {
+                    throw new ParsingException("Multiple ADD VOLUME clauses are not allowed in a single ALTER statement");
+                }
+                addVolumeName = ((AddStorageVolumeChildClause) clause).getChildVolumeName();
+            } else if (clause.getOpType().equals(AlterStorageVolumeClause.AlterOpType.REMOVE_VOLUME)) {
+                if (removeVolumeName != null) {
+                    throw new ParsingException("Multiple REMOVE VOLUME clauses are not allowed in a single ALTER statement");
+                }
+                removeVolumeName = ((RemoveStorageVolumeChildClause) clause).getChildVolumeName();
             }
         }
+        if (addVolumeName != null && removeVolumeName != null) {
+            throw new ParsingException("Cannot combine ADD VOLUME and REMOVE VOLUME in a single ALTER statement");
+        }
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
 
-        return new AlterStorageVolumeStmt(context.IF() != null, svName, properties, comment, pos);
+        return new AlterStorageVolumeStmt(context.IF() != null, svName, properties, comment,
+                addVolumeName, removeVolumeName, pos);
     }
 
     @Override
@@ -4822,6 +4851,20 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitModifyStorageVolumePropertiesClause(
             com.starrocks.sql.parser.StarRocksParser.ModifyStorageVolumePropertiesClauseContext context) {
         return new ModifyStorageVolumePropertiesClause(getCaseSensitivePropertyList(context.propertyList()), createPos(context));
+    }
+
+    @Override
+    public ParseNode visitAddStorageVolumeChildClause(
+            StarRocksParser.AddStorageVolumeChildClauseContext context) {
+        Identifier identifier = (Identifier) visit(context.identifierOrString());
+        return new AddStorageVolumeChildClause(identifier.getValue(), createPos(context));
+    }
+
+    @Override
+    public ParseNode visitRemoveStorageVolumeChildClause(
+            StarRocksParser.RemoveStorageVolumeChildClauseContext context) {
+        Identifier identifier = (Identifier) visit(context.identifierOrString());
+        return new RemoveStorageVolumeChildClause(identifier.getValue(), createPos(context));
     }
 
     // ----------------------------------------------- FailPoint Statement -----------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/CompositeStorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/CompositeStorageVolume.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.storagevolume;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.StorageVolumeMgr;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * CompositeStorageVolume represents a logical aggregation of multiple ordinary storage volumes.
+ * It enables cross-bucket tablet distribution for a single table.
+ *
+ * <p><b>Key design decisions:</b>
+ * <ul>
+ *   <li>Metadata is stored in StarOS FileStore(COMPOSITE).</li>
+ *   <li>Children are referenced by ID (stable across rename).</li>
+ *   <li>{@code membershipVersion} increments on every ADD/REMOVE for snapshot-based concurrency.</li>
+ *   <li>Resolution is strict (Fail-Fast): any invalid child immediately throws {@link DdlException}.</li>
+ * </ul>
+ *
+ * <p><b>Usage in partition creation:</b>
+ * Resolve child SVs at partition-creation time, then distribute partitions across children
+ * via round-robin (partitionId % N). All tablets within the same partition share one child SV path.
+ */
+public class CompositeStorageVolume implements Writable {
+
+    @SerializedName("id")
+    private final String id;
+
+    @SerializedName("name")
+    private String name;
+
+    /** Child SV IDs (stable across rename). */
+    @SerializedName("childIds")
+    private List<String> childVolumeIds;
+
+    /** Monotonically increasing; incremented on every ADD/REMOVE child operation. */
+    @SerializedName("version")
+    private long membershipVersion;
+
+    @SerializedName("enabled")
+    private boolean enabled;
+
+    @SerializedName("comment")
+    private String comment;
+
+    /** Full constructor used by serialization and programmatic creation. */
+    public CompositeStorageVolume(String id, String name, List<String> childVolumeIds,
+                                  boolean enabled, String comment) {
+        this.id = id;
+        this.name = name;
+        this.childVolumeIds = new ArrayList<>(childVolumeIds);
+        this.membershipVersion = 0L;
+        this.enabled = enabled;
+        this.comment = (comment == null) ? "" : comment;
+    }
+
+    /** Factory: create a new composite SV with an auto-generated UUID. */
+    public static CompositeStorageVolume create(String name, List<String> childVolumeIds,
+                                                boolean enabled, String comment) {
+        return new CompositeStorageVolume(
+                UUID.randomUUID().toString(), name, childVolumeIds, enabled, comment);
+    }
+
+    /**
+     * Strictly resolves child SVs from {@code mgr}.
+     * Throws {@link DdlException} immediately on any invalid child (no silent skip).
+     * The returned snapshot is immutable and safe to use across concurrent DDL operations.
+     *
+     * @throws DdlException if any child is missing, disabled, nested composite, or type-mismatched
+     */
+    public synchronized ChildVolumesSnapshot resolveChildVolumesStrict(StorageVolumeMgr mgr)
+            throws DdlException {
+        if (childVolumeIds.isEmpty()) {
+            throw new DdlException("[SV_COMPOSITE_EMPTY_CHILDREN] Composite SV '"
+                    + name + "' has no child volumes");
+        }
+        StorageVolume.StorageVolumeType expectedType = null;
+        List<StorageVolume> result = new ArrayList<>(childVolumeIds.size());
+        for (String childId : childVolumeIds) {
+            StorageVolume child = mgr.getStorageVolume(childId);
+            if (child == null) {
+                throw new DdlException("[SV_COMPOSITE_CHILD_NOT_FOUND] Child SV id=" + childId
+                        + " not found, referenced by Composite SV '" + name + "'");
+            }
+            if (child.isComposite()) {
+                throw new DdlException("[SV_COMPOSITE_NESTED] Nested Composite SV is not allowed,"
+                        + " child id=" + childId + " in Composite SV '" + name + "'");
+            }
+            if (!child.getEnabled()) {
+                throw new DdlException("[SV_COMPOSITE_CHILD_DISABLED] Child SV '"
+                        + child.getName() + "' (id=" + childId + ") is disabled"
+                        + " in Composite SV '" + name + "'");
+            }
+            StorageVolume.StorageVolumeType childType =
+                    StorageVolume.StorageVolumeType.valueOf(child.getType().toUpperCase());
+            if (expectedType == null) {
+                expectedType = childType;
+            } else if (expectedType != childType) {
+                throw new DdlException("[SV_COMPOSITE_CHILD_TYPE_MISMATCH] Child SV '"
+                        + child.getName() + "' type=" + childType
+                        + " differs from expected=" + expectedType
+                        + " in Composite SV '" + name + "'");
+            }
+            result.add(child);
+        }
+        return new ChildVolumesSnapshot(Collections.unmodifiableList(result), membershipVersion);
+    }
+
+    /**
+     * Returns a new {@link CompositeStorageVolume} with {@code childId} appended
+     * and {@code membershipVersion} incremented. This object is unchanged.
+     */
+    public CompositeStorageVolume withAddedChild(String childId) {
+        List<String> newIds = new ArrayList<>(childVolumeIds);
+        newIds.add(childId);
+        CompositeStorageVolume updated =
+                new CompositeStorageVolume(id, name, newIds, enabled, comment);
+        updated.membershipVersion = this.membershipVersion + 1;
+        return updated;
+    }
+
+    /**
+     * Returns a new {@link CompositeStorageVolume} with {@code childId} removed
+     * and {@code membershipVersion} incremented. This object is unchanged.
+     */
+    public CompositeStorageVolume withRemovedChild(String childId) {
+        List<String> newIds = new ArrayList<>(childVolumeIds);
+        newIds.remove(childId);
+        CompositeStorageVolume updated =
+                new CompositeStorageVolume(id, name, newIds, enabled, comment);
+        updated.membershipVersion = this.membershipVersion + 1;
+        return updated;
+    }
+
+    // ---- Getters / Setters ----
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getChildVolumeIds() {
+        return Collections.unmodifiableList(childVolumeIds);
+    }
+
+    public long getMembershipVersion() {
+        return membershipVersion;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    // ---- Serialization ----
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static CompositeStorageVolume read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), CompositeStorageVolume.class);
+    }
+
+    // ---- Inner classes ----
+
+    /**
+     * Immutable snapshot of resolved child SVs taken at a specific {@code membershipVersion}.
+     * Callers should retain this snapshot throughout the entire partition-creation operation
+     * to ensure consistent bucket-to-child-SV mapping even if DDL modifies the Composite SV concurrently.
+     */
+    public static class ChildVolumesSnapshot {
+        public final List<StorageVolume> childVolumes;
+        public final long membershipVersion;
+
+        public ChildVolumesSnapshot(List<StorageVolume> childVolumes, long membershipVersion) {
+            this.childVolumes = childVolumes;
+            this.membershipVersion = membershipVersion;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -58,7 +58,9 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         HDFS,
         AZBLOB,
         ADLS2,
-        GS
+        GS,
+        /** Composite SV: logical aggregation of multiple regular SVs, persisted in StarOS. */
+        COMPOSITE
     }
 
     // Without id, the scenario like "create storage volume 'a', drop storage volume 'a', create storage volume 'a'"
@@ -105,12 +107,59 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public static final String V_SHARD_GROUP_ID = "v_shard_group_id";
 
     public static String CREDENTIAL_MASK = "******";
+    public static final String COMPOSITE_CHILD_FS_KEYS = "child_fs_keys";
+    public static final int COMPOSITE_FS_TYPE_VALUE = 5;
+
+    /**
+     * Detect whether a FileStoreInfo is a Composite SV definition.
+     *
+     * <p>Relying on fsTypeValue alone is unsafe because StarOS enum values may overlap with
+     * regular types (for example GS). Composite SV definitions always carry
+     * {@link #COMPOSITE_CHILD_FS_KEYS} in properties, so we use it as an extra discriminator.
+     */
+    public static boolean isCompositeFileStoreInfo(FileStoreInfo fsInfo) {
+        return fsInfo != null
+                && fsInfo.getFsTypeValue() == COMPOSITE_FS_TYPE_VALUE
+                && fsInfo.getPropertiesMap().containsKey(COMPOSITE_CHILD_FS_KEYS);
+    }
 
     private String dumpMaskedParams(Map<String, String> params) {
         Gson gson = new Gson();
         Map<String, String> maskedParams = new HashMap<>(params);
         addMaskForCredential(maskedParams);
         return gson.toJson(maskedParams);
+    }
+
+    /** Private no-arg constructor used ONLY by {@link #createCompositeWrapper}. */
+    private StorageVolume() {
+        this.id = "";
+        this.name = "";
+        this.svt = StorageVolumeType.COMPOSITE;
+        this.locations = new ArrayList<>();
+        this.params = new HashMap<>();
+        this.comment = "";
+        this.enabled = true;
+        this.cloudConfiguration = null;
+    }
+
+    /**
+     * Create a lightweight wrapper StorageVolume for a {@link CompositeStorageVolume}.
+     * Skips cloud-config validation intentionally (composite has no bucket/credentials of its own).
+     */
+    public static StorageVolume createCompositeWrapper(String id, String name,
+                                                       boolean enabled, String comment) {
+        StorageVolume sv = new StorageVolume();
+        sv.id = id;
+        sv.name = name;
+        sv.svt = StorageVolumeType.COMPOSITE;
+        sv.enabled = enabled;
+        sv.comment = (comment == null) ? "" : comment;
+        return sv;
+    }
+
+    /** Returns true if this StorageVolume is of COMPOSITE type. */
+    public boolean isComposite() {
+        return svt == StorageVolumeType.COMPOSITE;
     }
 
     public StorageVolume(String id, String name, String svt, List<String> locations,
@@ -122,11 +171,15 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         this.comment = comment;
         this.enabled = enabled;
         this.params = new HashMap<>(params);
-        Map<String, String> configurationParams = new HashMap<>(params);
-        preprocessAuthenticationIfNeeded(configurationParams);
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
-        if (!isValidCloudConfiguration()) {
-            throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
+        if (this.svt != StorageVolumeType.COMPOSITE) {
+            Map<String, String> configurationParams = new HashMap<>(params);
+            preprocessAuthenticationIfNeeded(configurationParams);
+            this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
+            if (!isValidCloudConfiguration()) {
+                throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
+            }
+        } else {
+            this.cloudConfiguration = null;
         }
         validateStorageVolumeConstraints();
     }
@@ -140,8 +193,12 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         this.enabled = sv.enabled;
         this.vTabletId = sv.vTabletId;
         this.vTabletGroupId = sv.vTabletGroupId;
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(sv.params, true);
         this.params = new HashMap<>(sv.params);
+        if (this.svt != StorageVolumeType.COMPOSITE) {
+            this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(sv.params, true);
+        } else {
+            this.cloudConfiguration = null;
+        }
         validateStorageVolumeConstraints();
     }
 
@@ -249,6 +306,8 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                 return StorageVolumeType.ADLS2;
             case "gs":
                 return StorageVolumeType.GS;
+            case "composite":
+                return StorageVolumeType.COMPOSITE;
             default:
                 return StorageVolumeType.UNKNOWN;
         }
@@ -266,6 +325,9 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                 return cloudConfiguration.getCloudType() == CloudType.AZURE;
             case GS:
                 return cloudConfiguration.getCloudType() == CloudType.GCP;
+            case COMPOSITE:
+                // Composite SV has no cloud config of its own; always valid.
+                return true;
             default:
                 return false;
         }
@@ -303,6 +365,17 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     }
 
     public FileStoreInfo toFileStoreInfo() {
+        if (svt == StorageVolumeType.COMPOSITE) {
+            return FileStoreInfo.newBuilder()
+                    .setFsTypeValue(COMPOSITE_FS_TYPE_VALUE)
+                    .setFsKey(id)
+                    .setFsName(this.name)
+                    .setComment(this.comment)
+                    .setEnabled(this.enabled)
+                    .putAllProperties(params)
+                    .addAllLocations(locations)
+                    .build();
+        }
         Map<String, String> properties = new HashMap<>();
         if (vTabletId != -1L) {
             properties.put(V_SHARD_ID, String.valueOf(vTabletId));
@@ -321,7 +394,9 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     }
 
     public static StorageVolume fromFileStoreInfo(FileStoreInfo fsInfo) throws DdlException {
-        String svt = fsInfo.getFsType().toString();
+        String svt = (isCompositeFileStoreInfo(fsInfo))
+                ? StorageVolumeType.COMPOSITE.name()
+                : fsInfo.getFsType().toString();
         Map<String, String> params = getParamsFromFileStoreInfo(fsInfo);
         StorageVolume storageVolume = new StorageVolume(fsInfo.getFsKey(), fsInfo.getFsName(), svt,
                 fsInfo.getLocationsList(), params, fsInfo.getEnabled(), fsInfo.getComment());
@@ -357,6 +432,10 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     public static Map<String, String> getParamsFromFileStoreInfo(FileStoreInfo fsInfo) {
         Map<String, String> params = new HashMap<>();
+        if (isCompositeFileStoreInfo(fsInfo)) {
+            params.putAll(fsInfo.getPropertiesMap());
+            return params;
+        }
         switch (fsInfo.getFsType()) {
             case S3:
                 S3FileStoreInfo s3FileStoreInfo = fsInfo.getS3FsInfo();
@@ -490,6 +569,10 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(params);
+        if (svt == StorageVolumeType.COMPOSITE) {
+            cloudConfiguration = null;
+        } else {
+            cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(params);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeAnalysisTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeAnalysisTest.java
@@ -95,12 +95,24 @@ public class StorageVolumeAnalysisTest {
         Assertions.assertTrue(stmt instanceof CreateStorageVolumeStmt);
         Assertions.assertEquals("CREATE STORAGE VOLUME hdfsvolume TYPE = HDFS " +
                 "LOCATIONS = ('hdfs://abc')", AstToStringBuilder.toString(stmt));
+
+        sql = "CREATE STORAGE VOLUME comp_volume TYPE = COMPOSITE " +
+                "PROPERTIES (\"child_volumes\"=\"sv_a,sv_b\")";
+        stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertTrue(stmt instanceof CreateStorageVolumeStmt);
+        Assertions.assertEquals("CREATE STORAGE VOLUME comp_volume TYPE = COMPOSITE " +
+                "PROPERTIES (\"child_volumes\" = \"sv_a,sv_b\")", stmt.toSql());
+
+        sql = "CREATE STORAGE VOLUME comp_volume_missing TYPE = COMPOSITE";
+        AnalyzeTestUtil.analyzeFail(sql,
+                "'child_volumes' property is required to create COMPOSITE storage volume");
     }
 
     @Test
     public void testAlterStorageVolumeParserAndAnalyzer() {
         String sql = "ALTER STORAGE VOLUME storage_volume_1";
-        AnalyzeTestUtil.analyzeFail(sql, "Unexpected input '<EOF>', the most similar input is {'SET', 'COMMENT'}");
+        AnalyzeTestUtil.analyzeFail(sql,
+                "Unexpected input '<EOF>', the most similar input is {'REMOVE', 'SET', 'COMMENT', 'ADD'}");
 
         sql = "ALTER STORAGE VOLUME storage_volume_1 COMMENT = 'comment', " +
                 "SET (\"aws.s3.region\"=\"us-west-2\", \"enabled\"=\"false\")";
@@ -139,6 +151,30 @@ public class StorageVolumeAnalysisTest {
         Assertions.assertEquals("ALTER STORAGE VOLUME storage_volume_1 SET (\"aws.s3.access_key\" = \"***\", " +
                 "\"aws.s3.secret_key\" = \"***\", \"azure.blob.shared_key\" = \"***\", \"azure.blob.sas_token\" = \"***\")",
                 AstToStringBuilder.toString(stmt));
+    }
+
+    @Test
+    public void testAlterStorageVolumeDuplicateClausesFail() {
+        // Multiple ADD VOLUME
+        AnalyzeTestUtil.analyzeFail(
+                "ALTER STORAGE VOLUME sv ADD VOLUME a, ADD VOLUME b",
+                "Multiple ADD VOLUME clauses are not allowed");
+        // Multiple REMOVE VOLUME
+        AnalyzeTestUtil.analyzeFail(
+                "ALTER STORAGE VOLUME sv REMOVE VOLUME a, REMOVE VOLUME b",
+                "Multiple REMOVE VOLUME clauses are not allowed");
+        // ADD + REMOVE combined
+        AnalyzeTestUtil.analyzeFail(
+                "ALTER STORAGE VOLUME sv ADD VOLUME a, REMOVE VOLUME b",
+                "Cannot combine ADD VOLUME and REMOVE VOLUME");
+        // Multiple COMMENT
+        AnalyzeTestUtil.analyzeFail(
+                "ALTER STORAGE VOLUME sv COMMENT = 'c1', COMMENT = 'c2'",
+                "Multiple COMMENT clauses are not allowed");
+        // Multiple SET
+        AnalyzeTestUtil.analyzeFail(
+                "ALTER STORAGE VOLUME sv SET (\"enabled\"=\"true\"), SET (\"enabled\"=\"false\")",
+                "Multiple SET clauses are not allowed");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -53,6 +53,7 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.storagevolume.CompositeStorageVolume;
 import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.type.IntegerType;
@@ -77,6 +78,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -154,6 +156,11 @@ public class SharedDataStorageVolumeMgrTest {
             public void updateFileStore(FileStoreInfo fsInfo) {
                 FileStoreInfo fileStoreInfo = fileStores.get(fsInfo.getFsKey());
                 fileStores.put(fsInfo.getFsKey(), fsInfo);
+            }
+
+            @Mock
+            public List<FileStoreInfo> listFileStore() {
+                return new ArrayList<>(fileStores.values());
             }
         };
     }
@@ -1211,4 +1218,373 @@ public class SharedDataStorageVolumeMgrTest {
 
         svm.removeStorageVolume(storageVolumeName);
     }
+
+    // ========== Composite Storage Volume Tests ==========
+    // These tests verify that Composite SV definitions are persisted solely in StarOS FileStore
+    // (via the mocked StarOSAgent) and that FE has no local cache for them.
+
+    /**
+     * Helper: create two child SVs and return their keys. Shared setup for composite SV tests.
+     */
+    private String[] createChildSVs(StorageVolumeMgr svm) throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put(AWS_S3_REGION, "region");
+        params.put(AWS_S3_ENDPOINT, "endpoint");
+        params.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+        String child1Key = svm.createStorageVolume("child1", "S3",
+                Arrays.asList("s3://bucket1"), params, Optional.of(true), "child 1");
+        String child2Key = svm.createStorageVolume("child2", "S3",
+                Arrays.asList("s3://bucket2"), params, Optional.of(true), "child 2");
+        return new String[] {child1Key, child2Key};
+    }
+
+    @Test
+    public void testCreateCompositeStorageVolumeViaTypeRoute() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("child_volumes", "child1,child2");
+        String csvId = svm.createStorageVolume("comp_by_type", "COMPOSITE", Collections.emptyList(),
+                properties, Optional.of(true), "created via generic route");
+        Assertions.assertNotNull(csvId);
+
+        CompositeStorageVolume csv = svm.getCompositeStorageVolumeByName("comp_by_type");
+        Assertions.assertNotNull(csv);
+        Assertions.assertEquals(2, csv.getChildVolumeIds().size());
+
+        Map<String, String> missingChildProps = new HashMap<>();
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.createStorageVolume("comp_missing_child", "COMPOSITE", Collections.emptyList(),
+                        missingChildProps, Optional.of(true), ""));
+    }
+
+    @Test
+    public void testCompositeStorageVolumeAddChildValidation() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+
+        Map<String, String> hdfsParams = new HashMap<>();
+        svm.createStorageVolume("hdfs_child", "HDFS", Arrays.asList("hdfs://cluster/path"),
+                hdfsParams, Optional.of(true), "hdfs child");
+
+        svm.createCompositeStorageVolume("comp_add_validation", Arrays.asList("child1"), true, "");
+
+        // Composite not found
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.addChildToCompositeStorageVolume("not_exists_comp", "child2"));
+        // Child not found
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.addChildToCompositeStorageVolume("comp_add_validation", "not_exists_child"));
+        // Nested composite is not allowed
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.addChildToCompositeStorageVolume("comp_add_validation", "comp_add_validation"));
+        // Type mismatch with existing children is not allowed
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.addChildToCompositeStorageVolume("comp_add_validation", "hdfs_child"));
+    }
+
+    @Test
+    public void testCompositeStorageVolumeRemoveChildValidation() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+        Map<String, String> params = new HashMap<>();
+        params.put(AWS_S3_REGION, "region");
+        params.put(AWS_S3_ENDPOINT, "endpoint");
+        params.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+        svm.createStorageVolume("child3", "S3", Arrays.asList("s3://bucket3"), params, Optional.of(true), "");
+        svm.createCompositeStorageVolume("comp_remove_validation", Arrays.asList("child1", "child2"), true, "");
+
+        // Composite not found
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("not_exists_comp", "child1"));
+        // Child not found
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("comp_remove_validation", "not_exists_child"));
+        // Child not in composite
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("comp_remove_validation", "child3"));
+    }
+
+    @Test
+    public void testRemoveChildFromDefaultCompositeStorageVolume() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+        svm.createCompositeStorageVolume("comp_default", Arrays.asList("child1", "child2"), true, "");
+        svm.setDefaultStorageVolume("comp_default");
+
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("comp_default", "child2"));
+    }
+
+    @Test
+    public void testDropCompositeStorageVolumeWithBindings() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+        svm.createCompositeStorageVolume("comp_drop_bindings", Arrays.asList("child1", "child2"), true, "");
+
+        svm.bindTableToStorageVolume("comp_drop_bindings", 10001L, 10002L);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> svm.removeStorageVolume("comp_drop_bindings"));
+
+        svm.unbindTableToStorageVolume(10002L);
+        svm.removeStorageVolume("comp_drop_bindings");
+        Assertions.assertFalse(svm.exists("comp_drop_bindings"));
+    }
+
+    @Test
+    public void testGetStorageVolumeCompositeWrapperById() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+        String csvId = svm.createCompositeStorageVolume("comp_wrapper", Arrays.asList("child1", "child2"), true, "");
+
+        StorageVolume wrapper = svm.getStorageVolume(csvId);
+        Assertions.assertNotNull(wrapper);
+        Assertions.assertTrue(wrapper.isComposite());
+        Assertions.assertEquals("comp_wrapper", wrapper.getName());
+    }
+
+    @Test
+    public void testCompositeStorageVolumeCRUD() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+
+        // CREATE composite SV
+        String csvId = svm.createCompositeStorageVolume("comp1",
+                Arrays.asList("child1", "child2"), true, "my composite");
+        Assertions.assertNotNull(csvId);
+        Assertions.assertTrue(svm.exists("comp1"));
+
+        // GET by name
+        CompositeStorageVolume csv = svm.getCompositeStorageVolumeByName("comp1");
+        Assertions.assertNotNull(csv);
+        Assertions.assertEquals("comp1", csv.getName());
+        Assertions.assertEquals(2, csv.getChildVolumeIds().size());
+        Assertions.assertTrue(csv.isEnabled());
+        Assertions.assertEquals("my composite", csv.getComment());
+
+        // GET by id
+        CompositeStorageVolume csvById = svm.getCompositeStorageVolume(csvId);
+        Assertions.assertNotNull(csvById);
+        Assertions.assertEquals(csv.getName(), csvById.getName());
+        Assertions.assertEquals(csv.getChildVolumeIds(), csvById.getChildVolumeIds());
+
+        // UPDATE: change comment and disable
+        svm.updateStorageVolume("comp1", "", Collections.emptyList(),
+                new HashMap<>(), Optional.of(false), "updated comment");
+        csv = svm.getCompositeStorageVolumeByName("comp1");
+        Assertions.assertFalse(csv.isEnabled());
+        Assertions.assertEquals("updated comment", csv.getComment());
+
+        // UPDATE: reject cloud config params on composite SV
+        Map<String, String> invalidParams = new HashMap<>();
+        invalidParams.put(AWS_S3_REGION, "us-east-1");
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.updateStorageVolume("comp1", "", Collections.emptyList(),
+                        invalidParams, Optional.empty(), ""));
+
+        // REMOVE composite SV
+        svm.removeStorageVolume("comp1");
+        Assertions.assertFalse(svm.exists("comp1"));
+        Assertions.assertNull(svm.getCompositeStorageVolumeByName("comp1"));
+    }
+
+    @Test
+    public void testCompositeStorageVolumeCreateValidation() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm);
+
+        // Cannot create with empty children
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.createCompositeStorageVolume("comp_empty",
+                        Collections.emptyList(), true, ""));
+
+        // Cannot create with non-existent child
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.createCompositeStorageVolume("comp_bad",
+                        Arrays.asList("child1", "nonexistent"), true, ""));
+
+        // Create a composite, then cannot create another with the same name
+        svm.createCompositeStorageVolume("comp1",
+                Arrays.asList("child1", "child2"), true, "");
+        Assertions.assertThrows(AlreadyExistsException.class,
+                () -> svm.createCompositeStorageVolume("comp1",
+                        Arrays.asList("child1"), true, ""));
+
+        // Cannot create a regular SV with the same name as an existing composite SV
+        Map<String, String> params = new HashMap<>();
+        params.put(AWS_S3_REGION, "region");
+        params.put(AWS_S3_ENDPOINT, "endpoint");
+        params.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+        Assertions.assertThrows(AlreadyExistsException.class,
+                () -> svm.createStorageVolume("comp1", "S3",
+                        Arrays.asList("s3://bucket3"), params, Optional.of(true), ""));
+    }
+
+    @Test
+    public void testCompositeStorageVolumeAddRemoveChild() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        String[] childKeys = createChildSVs(svm);
+
+        // Create composite with only child1
+        String csvId = svm.createCompositeStorageVolume("comp1",
+                Arrays.asList("child1"), true, "");
+
+        CompositeStorageVolume csv = svm.getCompositeStorageVolumeByName("comp1");
+        Assertions.assertEquals(1, csv.getChildVolumeIds().size());
+
+        // ADD child2
+        svm.addChildToCompositeStorageVolume("comp1", "child2");
+        csv = svm.getCompositeStorageVolumeByName("comp1");
+        Assertions.assertEquals(2, csv.getChildVolumeIds().size());
+
+        // ADD duplicate child — should fail
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.addChildToCompositeStorageVolume("comp1", "child2"));
+
+        // REMOVE child2 — should succeed (no bound tables)
+        svm.removeChildFromCompositeStorageVolume("comp1", "child2");
+        csv = svm.getCompositeStorageVolumeByName("comp1");
+        Assertions.assertEquals(1, csv.getChildVolumeIds().size());
+        Assertions.assertEquals(childKeys[0], csv.getChildVolumeIds().get(0));
+
+        // REMOVE child that is not in composite — should fail
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("comp1", "child2"));
+
+        // Bind a table to the composite SV, then REMOVE should fail
+        svm.storageVolumeToTables.computeIfAbsent(csvId, k -> new HashSet<>()).add(100L);
+        svm.addChildToCompositeStorageVolume("comp1", "child2");
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.removeChildFromCompositeStorageVolume("comp1", "child2"));
+
+        // Clean up binding
+        svm.storageVolumeToTables.get(csvId).clear();
+    }
+
+    @Test
+    public void testCheckNotReferencedAsChildSv() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        String[] childKeys = createChildSVs(svm);
+
+        // Before creating composite, dropping child should succeed (no composite references it)
+        svm.checkNotReferencedAsChildSv(childKeys[0], "child1");
+
+        // Create composite SV referencing both children
+        svm.createCompositeStorageVolume("comp1",
+                Arrays.asList("child1", "child2"), true, "");
+
+        // Now dropping child1 should be blocked
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.checkNotReferencedAsChildSv(childKeys[0], "child1"));
+
+        // Dropping child2 should also be blocked
+        Assertions.assertThrows(DdlException.class,
+                () -> svm.checkNotReferencedAsChildSv(childKeys[1], "child2"));
+
+        // Remove the composite SV
+        svm.removeStorageVolume("comp1");
+
+        // Now dropping children should succeed
+        svm.checkNotReferencedAsChildSv(childKeys[0], "child1");
+        svm.checkNotReferencedAsChildSv(childKeys[1], "child2");
+    }
+
+    @Test
+    public void testCompositePartitionRoundRobin() throws Exception {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        String[] childKeys = createChildSVs(svm);
+
+        // Create composite SV with 2 children
+        String csvId = svm.createCompositeStorageVolume("comp_rr",
+                Arrays.asList("child1", "child2"), true, "round-robin test");
+
+        // Bind table 1000 to the composite SV
+        long tableId = 1000L;
+        svm.bindTableToStorageVolume("comp_rr", 100L, tableId);
+
+        StorageVolume child1 = svm.getStorageVolumeByName("child1");
+        StorageVolume child2 = svm.getStorageVolumeByName("child2");
+
+        // Build distinguishable FilePathInfo for each child SV
+        FilePathInfo pathInfoChild1 = FilePathInfo.newBuilder()
+                .setFullPath("s3://bucket1/path").build();
+        FilePathInfo pathInfoChild2 = FilePathInfo.newBuilder()
+                .setFullPath("s3://bucket2/path").build();
+
+        new Expectations() {
+            {
+                starOSAgent.allocatePartitionFilePathInfoForChildSv(child1.getId(), 100L, tableId, anyLong);
+                result = pathInfoChild1;
+                minTimes = 0;
+
+                starOSAgent.allocatePartitionFilePathInfoForChildSv(child2.getId(), 100L, tableId, anyLong);
+                result = pathInfoChild2;
+                minTimes = 0;
+            }
+        };
+
+        // Verify round-robin: partitionId % 2 determines child selection
+        // Even partitionId → child[0] (child1), Odd partitionId → child[1] (child2)
+        FilePathInfo result0 = svm.resolveCompositePartitionFilePathInfo(
+                createMockOlapTable(tableId), 100L, 0L, 100L);
+        Assertions.assertNotNull(result0);
+        Assertions.assertEquals("s3://bucket1/path", result0.getFullPath());
+
+        FilePathInfo result1 = svm.resolveCompositePartitionFilePathInfo(
+                createMockOlapTable(tableId), 100L, 1L, 101L);
+        Assertions.assertNotNull(result1);
+        Assertions.assertEquals("s3://bucket2/path", result1.getFullPath());
+
+        FilePathInfo result2 = svm.resolveCompositePartitionFilePathInfo(
+                createMockOlapTable(tableId), 100L, 2L, 102L);
+        Assertions.assertNotNull(result2);
+        Assertions.assertEquals("s3://bucket1/path", result2.getFullPath());
+
+        FilePathInfo result3 = svm.resolveCompositePartitionFilePathInfo(
+                createMockOlapTable(tableId), 100L, 3L, 103L);
+        Assertions.assertNotNull(result3);
+        Assertions.assertEquals("s3://bucket2/path", result3.getFullPath());
+
+        // Verify non-composite table returns null
+        long regularTableId = 2000L;
+        FilePathInfo resultNonComposite = svm.resolveCompositePartitionFilePathInfo(
+                createMockOlapTable(regularTableId), 100L, 0L, 200L);
+        Assertions.assertNull(resultNonComposite);
+    }
+
+    /**
+     * Helper: create a mock OlapTable with the given table ID for testing.
+     */
+    private com.starrocks.catalog.OlapTable createMockOlapTable(long tableId) {
+        com.starrocks.catalog.OlapTable table = new com.starrocks.catalog.OlapTable();
+        table.setId(tableId);
+        return table;
+    }
+
+    @Test
+    public void testCompositeStorageVolumeNoLocalCache() throws Exception {
+        // Verifies that Composite SV state is read from StarOS (mocked), not from FE memory.
+        // After creating a Composite SV with one StorageVolumeMgr instance and creating a
+        // fresh instance, the new instance should still find the Composite SV because the
+        // StarOS mock (fileStores map) is shared across instances.
+        StorageVolumeMgr svm1 = new SharedDataStorageVolumeMgr();
+        createChildSVs(svm1);
+
+        String csvId = svm1.createCompositeStorageVolume("comp_persist",
+                Arrays.asList("child1", "child2"), true, "persistent");
+
+        // "Simulate FE failover" — create a brand-new StorageVolumeMgr instance.
+        // Since composite SV definitions are in StarOS (mocked via static MockUp), the new
+        // instance should see the composite SV without any EditLog replay or cache transfer.
+        StorageVolumeMgr svm2 = new SharedDataStorageVolumeMgr();
+
+        Assertions.assertTrue(svm2.exists("comp_persist"));
+        CompositeStorageVolume csv = svm2.getCompositeStorageVolumeByName("comp_persist");
+        Assertions.assertNotNull(csv);
+        Assertions.assertEquals(csvId, csv.getId());
+        Assertions.assertEquals(2, csv.getChildVolumeIds().size());
+        Assertions.assertEquals("persistent", csv.getComment());
+    }
+
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -872,7 +872,7 @@ alterCatalogStatement
 // ---------------------------------------- Storage Volume Statement ---------------------------------------------------
 
 createStorageVolumeStatement
-    : CREATE STORAGE VOLUME (IF NOT EXISTS)? storageVolumeName=identifierOrString typeDesc locationsDesc
+    : CREATE STORAGE VOLUME (IF NOT EXISTS)? storageVolumeName=identifierOrString typeDesc locationsDesc?
           comment? properties?
     ;
 
@@ -899,6 +899,16 @@ alterStorageVolumeStatement
 alterStorageVolumeClause
     : modifyStorageVolumeCommentClause
     | modifyStorageVolumePropertiesClause
+    | addStorageVolumeChildClause
+    | removeStorageVolumeChildClause
+    ;
+
+addStorageVolumeChildClause
+    : ADD VOLUME identifierOrString
+    ;
+
+removeStorageVolumeChildClause
+    : REMOVE VOLUME identifierOrString
     ;
 
 modifyStorageVolumePropertiesClause

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AddStorageVolumeChildClause.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AddStorageVolumeChildClause.java
@@ -14,37 +14,22 @@
 
 package com.starrocks.sql.ast;
 
-import com.google.common.collect.Maps;
 import com.starrocks.sql.parser.NodePosition;
 
-import java.util.Map;
+public class AddStorageVolumeChildClause extends AlterStorageVolumeClause {
+    private final String childVolumeName;
 
-public abstract class AlterStorageVolumeClause implements ParseNode {
-    public enum AlterOpType {
-        ALTER_COMMENT,
-        MODIFY_PROPERTIES,
-        ADD_VOLUME,
-        REMOVE_VOLUME
-    }
-    protected AlterOpType opType;
-
-    protected final NodePosition pos;
-
-    protected AlterStorageVolumeClause(AlterOpType opType, NodePosition pos) {
-        this.pos = pos;
-        this.opType = opType;
+    public AddStorageVolumeChildClause(String childVolumeName, NodePosition pos) {
+        super(AlterOpType.ADD_VOLUME, pos);
+        this.childVolumeName = childVolumeName;
     }
 
-    public Map<String, String> getProperties() {
-        return Maps.newHashMap();
-    }
-
-    public AlterOpType getOpType() {
-        return opType;
+    public String getChildVolumeName() {
+        return childVolumeName;
     }
 
     @Override
-    public NodePosition getPos() {
-        return pos;
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAddStorageVolumeChildClause(this, context);
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterStorageVolumeStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterStorageVolumeStmt.java
@@ -24,11 +24,23 @@ public class AlterStorageVolumeStmt extends DdlStmt {
     private final String storageVolumeName;
     private final Map<String, String> properties;
     private final String comment;
+    private final String addVolumeName;
+    private final String removeVolumeName;
 
     public AlterStorageVolumeStmt(boolean ifExists,
                                   String storageVolumeName,
                                   Map<String, String> properties,
                                   String comment,
+                                  NodePosition pos) {
+        this(ifExists, storageVolumeName, properties, comment, null, null, pos);
+    }
+
+    public AlterStorageVolumeStmt(boolean ifExists,
+                                  String storageVolumeName,
+                                  Map<String, String> properties,
+                                  String comment,
+                                  String addVolumeName,
+                                  String removeVolumeName,
                                   NodePosition pos) {
         super(pos);
 
@@ -36,6 +48,8 @@ public class AlterStorageVolumeStmt extends DdlStmt {
         this.storageVolumeName = storageVolumeName;
         this.properties = properties;
         this.comment = Strings.nullToEmpty(comment);
+        this.addVolumeName = addVolumeName;
+        this.removeVolumeName = removeVolumeName;
     }
 
     public String getName() {
@@ -52,6 +66,22 @@ public class AlterStorageVolumeStmt extends DdlStmt {
 
     public boolean isSetIfExists() {
         return ifExists;
+    }
+
+    public String getAddVolumeName() {
+        return addVolumeName;
+    }
+
+    public String getRemoveVolumeName() {
+        return removeVolumeName;
+    }
+
+    public boolean isAddVolume() {
+        return addVolumeName != null;
+    }
+
+    public boolean isRemoveVolume() {
+        return removeVolumeName != null;
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -855,6 +855,14 @@ public interface AstVisitor<R, C> {
         return visitNode(clause, context);
     }
 
+    default R visitAddStorageVolumeChildClause(AddStorageVolumeChildClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
+    default R visitRemoveStorageVolumeChildClause(RemoveStorageVolumeChildClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
     default R visitAlterTableColumnClause(AlterTableColumnClause clause, C context) {
         return visitNode(clause, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RemoveStorageVolumeChildClause.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/RemoveStorageVolumeChildClause.java
@@ -14,37 +14,22 @@
 
 package com.starrocks.sql.ast;
 
-import com.google.common.collect.Maps;
 import com.starrocks.sql.parser.NodePosition;
 
-import java.util.Map;
+public class RemoveStorageVolumeChildClause extends AlterStorageVolumeClause {
+    private final String childVolumeName;
 
-public abstract class AlterStorageVolumeClause implements ParseNode {
-    public enum AlterOpType {
-        ALTER_COMMENT,
-        MODIFY_PROPERTIES,
-        ADD_VOLUME,
-        REMOVE_VOLUME
-    }
-    protected AlterOpType opType;
-
-    protected final NodePosition pos;
-
-    protected AlterStorageVolumeClause(AlterOpType opType, NodePosition pos) {
-        this.pos = pos;
-        this.opType = opType;
+    public RemoveStorageVolumeChildClause(String childVolumeName, NodePosition pos) {
+        super(AlterOpType.REMOVE_VOLUME, pos);
+        this.childVolumeName = childVolumeName;
     }
 
-    public Map<String, String> getProperties() {
-        return Maps.newHashMap();
-    }
-
-    public AlterOpType getOpType() {
-        return opType;
+    public String getChildVolumeName() {
+        return childVolumeName;
     }
 
     @Override
-    public NodePosition getPos() {
-        return pos;
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRemoveStorageVolumeChildClause(this, context);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When using StarRocks in shared-data mode with multiple cloud storage buckets, there is currently no way to distribute partitions across different storage volumes (buckets). Users need a mechanism to aggregate multiple storage volumes and have StarRocks automatically distribute data across them.

## What I'm doing:

Fix https://github.com/StarRocks/starrocks/issues/70042

Introduce a new **Composite Storage Volume** concept that aggregates multiple regular storage volumes into a logical group. This PR covers:

1. **Metadata Model**: `CompositeStorageVolume` class that wraps child volume IDs, with StarOS FileStore as the sole persistence layer (no FE EditLog needed for this new feature)

2. **DDL Support**:
   - `CREATE STORAGE VOLUME ... TYPE = COMPOSITE PROPERTIES ("child_volumes"="sv_a,sv_b")`  
   - `ALTER STORAGE VOLUME ... ADD VOLUME child_sv_name`
   - `ALTER STORAGE VOLUME ... REMOVE VOLUME child_sv_name`
   - Grammar changes in StarRocks.g4 to support COMPOSITE type and ADD/REMOVE VOLUME clauses

3. **Multi-root Path Infrastructure**:
   - `ChildVolumesSnapshot` for concurrent-safe resolution of child volumes
   - `StarOSAgent.allocateTabletFilePathInfo()` with retry across child volumes
   - `StarOSAgent.getShardInfoBatch()` for querying shards from multiple FileStores
   - `LakeTableCleaner` / `LakeTableHelper` adapted for multi-root-path tablet collection
   - `LakeTabletsProcDir` shows StorageVolume/StoragePath columns in SHOW TABLETS
   - BE `vacuum.cpp` groups tablets by root path for correct garbage collection

4. **Metadata Observability**: `StorageVolumeProcNode` shows composite SV details including child volumes

5. **Safety Guards**: Prevent dropping a child SV while it's referenced by a composite SV

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR