### PR TITLE
[BugFix] Fix stale project output columns after GLM split projection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
@@ -166,19 +166,22 @@ public class GlobalLateMaterializationRewriter {
                 // remove projection from the original operator and create a new one
                 PhysicalProjectOperator projectOperator = new PhysicalProjectOperator(
                         projection.getColumnRefMap(), projection.getCommonSubOperatorMap());
+                RowOutputInfo projectedRowOutputInfo = optExpression.getRowOutputInfo();
 
                 op.setProjection(null);
                 op.clearRowOutputInfo();
 
-                RowOutputInfo newRowOutputInfo = optExpression.getRowOutputInfo();
-                LogicalProperty newLogicalProperty = new LogicalProperty(optExpression.getLogicalProperty());
+                RowOutputInfo childRowOutputInfo = optExpression.getRowOutputInfo();
+                LogicalProperty childLogicalProperty = new LogicalProperty(optExpression.getLogicalProperty());
 
-                newLogicalProperty.setOutputColumns(newRowOutputInfo.getOutputColumnRefSet());
+                childLogicalProperty.setOutputColumns(childRowOutputInfo.getOutputColumnRefSet());
 
-                optExpression.setLogicalProperty(newLogicalProperty);
+                optExpression.setLogicalProperty(childLogicalProperty);
 
                 OptExpression result = OptExpression.create(projectOperator, optExpression);
-                result.setLogicalProperty(optExpression.getLogicalProperty());
+                LogicalProperty projectLogicalProperty = new LogicalProperty(childLogicalProperty);
+                projectLogicalProperty.setOutputColumns(projectedRowOutputInfo.getOutputColumnRefSet());
+                result.setLogicalProperty(projectLogicalProperty);
                 result.setStatistics(optExpression.getStatistics());
                 return result;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeNativeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeNativeTest.java
@@ -133,6 +133,43 @@ public class GlobalLateMaterializeNativeTest extends PlanTestBase {
                 PROPERTIES (
                 "replication_num" = "1"
                 );""");
+
+        starRocksAssert.withTable("""
+                CREATE TABLE glm_join_expr_t0 (
+                    k0 int(11) NULL,
+                    v1 date NULL,
+                    v2 datetime NULL,
+                    v3 char(20) NULL,
+                    v4 varchar(20) NULL,
+                    v5 boolean NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`k0`)
+                DISTRIBUTED BY HASH(`k0`) BUCKETS 3
+                PROPERTIES ("replication_num" = "1");""");
+        starRocksAssert.withTable("""
+                CREATE TABLE glm_join_expr_t1 (
+                    k0 int(11) NULL,
+                    v1 date NULL,
+                    v2 datetime NULL,
+                    v3 char(20) NULL,
+                    v4 varchar(20) NULL,
+                    v5 boolean NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`k0`)
+                DISTRIBUTED BY HASH(`k0`) BUCKETS 3
+                PROPERTIES ("replication_num" = "1");""");
+        starRocksAssert.withTable("""
+                CREATE TABLE glm_join_expr_t2 (
+                    k0 int(11) NULL,
+                    v1 date NULL,
+                    v2 datetime NULL,
+                    v3 char(20) NULL,
+                    v4 varchar(20) NULL,
+                    v5 boolean NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`k0`)
+                DISTRIBUTED BY HASH(`k0`) BUCKETS 3
+                PROPERTIES ("replication_num" = "1");""");
     }
 
     @AfterAll
@@ -695,6 +732,30 @@ public class GlobalLateMaterializeNativeTest extends PlanTestBase {
                 "map_apply((k,v)->(k+1,concat(v,'a')), b))=map{2:\"aba\",4:\"cdda\"} order by 1 limit 1;\n";
         final String plan = getFragmentPlan(sql);
         System.out.println("plan = " + plan);
+    }
+
+    @Test
+    public void testCostBasedGlmKeepsDerivedJoinKeyProjection() throws Exception {
+        final SessionVariable sv = connectContext.getSessionVariable();
+        try {
+            sv.setEnableGlobalLateMaterializationCostBased(true);
+            String plan = getFragmentPlan(
+                    "select * from glm_join_expr_t0 t0 " +
+                            "join glm_join_expr_t1 t1 " +
+                            "on t0.v1 = t1.v1 " +
+                            "and t0.v2 = (exists (select max(v2) from glm_join_expr_t2)) " +
+                            "order by 1");
+            assertContains(plan, "1:Project\n" +
+                    "  |  <slot 1> : 1: k0\n" +
+                    "  |  <slot 2> : 2: v1\n" +
+                    "  |  <slot 3> : 3: v2\n" +
+                    "  |  <slot 4> : 4: v3\n" +
+                    "  |  <slot 6> : 6: v5\n" +
+                    "  |  <slot 23> : CAST(3: v2 AS DOUBLE)\n" +
+                    "  |  <slot 27> : 27: v4");
+        } finally {
+            sv.setEnableGlobalLateMaterializationCostBased(false);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Fix a planner failure caused by stale output columns after GLM splits an embedded projection into a standalone `PhysicalProjectOperator`.

In some cost-based GLM cases, the new project node inherited the child logical property, so its `outputColumns` no longer matched the projection keys. This could make a valid eq-join condition invisible to `PlanFragmentBuilder` and trigger `must be eq-join`.

## What I'm doing:
Update `SplitProjectionRewriter.splitProjection()` to rebuild logical properties separately for the child and the new project node.

The child now keeps the output columns of the operator after removing its embedded projection, while the new `PhysicalProjectOperator` keeps the output columns of the original projected row output. 

fix: https://github.com/StarRocks/StarRocksTest/issues/11178

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
