### PR TITLE
[BugFix] fix clang build failure in template parameter

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -219,7 +219,7 @@ struct ArrayAggWindowState final : ArrayAggAggregateState<PT, is_distinct, MyHas
     }
 };
 
-template <LogicalType LT, bool is_distinct, template <LogicalType, bool, typename> typename State,
+template <LogicalType LT, bool is_distinct, template <LogicalType, bool, typename...> typename State,
           typename MyHashSet = std::set<int>>
 class ArrayAggAggregateFunctionBase final
         : public AggregateFunctionBatchHelper<State<LT, is_distinct, MyHashSet>,


### PR DESCRIPTION
* Changed the template template parameter to template <LogicalType, bool, typename...> to accept ArrayAggAggregateState which now has 4 template parameters (the 4th being a guard with a default value) after the refactor in PR #70826

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
