### PR TITLE
[BugFix] skip safe deletion check for share nothing in alter handler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -46,6 +46,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.RemoveAlterJobV2OperationLog;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.CancelStmt;
 import com.starrocks.task.AlterReplicaTask;
@@ -128,8 +129,8 @@ public abstract class AlterHandler extends FrontendDaemon {
         Iterator<Map.Entry<Long, AlterJobV2>> iterator = alterJobsV2.entrySet().iterator();
         while (iterator.hasNext()) {
             AlterJobV2 alterJobV2 = iterator.next().getValue();
-            if (alterJobV2.isExpire() && GlobalStateMgr.getCurrentState()
-                    .getClusterSnapshotMgr().isDeletionSafeToExecute(alterJobV2.getFinishedTimeMs())) {
+            if (alterJobV2.isExpire() && (RunMode.isSharedNothingMode() || GlobalStateMgr.getCurrentState()
+                    .getClusterSnapshotMgr().isDeletionSafeToExecute(alterJobV2.getFinishedTimeMs()))) {
                 RemoveAlterJobV2OperationLog log =
                         new RemoveAlterJobV2OperationLog(alterJobV2.getJobId(), alterJobV2.getType());
                 GlobalStateMgr.getCurrentState().getEditLog().logRemoveExpiredAlterJobV2(log, wal -> {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
@@ -15,11 +15,17 @@
 package com.starrocks.alter;
 
 import com.starrocks.common.Config;
+import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.RemoveAlterJobV2OperationLog;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,10 +57,20 @@ public class AlterHandlerEditLogTest {
     }
 
     @Test
-    public void testClearExpireFinishedOrCancelledAlterJobsV2NormalCase() throws Exception {
+    public void testClearExpireFinishedOrCancelledAlterJobsV2NormalCase(@Mocked ClusterSnapshotMgr clusterSnapshotMgr)
+            throws Exception {
+        mockSharedNothingMode();
+        mockClusterSnapshotMgr(clusterSnapshotMgr);
+        new Expectations() {
+            {
+                clusterSnapshotMgr.isDeletionSafeToExecute(anyLong);
+                times = 0;
+            }
+        };
+
         // 1. Create expired finished alter job
         long oldFinishedTime = System.currentTimeMillis() - (Config.history_job_keep_max_second + 100) * 1000L;
-        MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE, 
+        MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE,
                 DB_ID, TABLE_ID, "test_table", 10000L);
         expiredJob.setJobState(AlterJobV2.JobState.FINISHED);
         expiredJob.setFinishedTimeMs(oldFinishedTime);
@@ -114,7 +130,29 @@ public class AlterHandlerEditLogTest {
     }
 
     @Test
+    public void testClearExpireFinishedOrCancelledAlterJobsV2SharedDataModeWaitsForSafeDeletion()
+            throws Exception {
+        ClusterSnapshotMgr clusterSnapshotMgr = mockClusterSnapshotMgr(false);
+        mockSharedDataMode();
+
+        long oldFinishedTime = System.currentTimeMillis() - (Config.history_job_keep_max_second + 100) * 1000L;
+        MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE,
+                DB_ID, TABLE_ID, "test_table", 10000L);
+        expiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        expiredJob.setFinishedTimeMs(oldFinishedTime);
+        schemaChangeHandler.addAlterJobV2(expiredJob);
+
+        schemaChangeHandler.clearExpireFinishedOrCancelledAlterJobsV2();
+
+        Assertions.assertEquals(1, schemaChangeHandler.getAlterJobsV2().size());
+        Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+        org.mockito.Mockito.verify(clusterSnapshotMgr).isDeletionSafeToExecute(oldFinishedTime);
+    }
+
+    @Test
     public void testClearExpireFinishedOrCancelledAlterJobsV2EditLogException() throws Exception {
+        mockSharedNothingMode();
+
         // 1. Create expired finished alter job
         long oldFinishedTime = System.currentTimeMillis() - (Config.history_job_keep_max_second + 100) * 1000L;
         MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE,
@@ -140,6 +178,51 @@ public class AlterHandlerEditLogTest {
         // 4. Verify job is still present (not removed due to exception)
         Assertions.assertEquals(1, schemaChangeHandler.getAlterJobsV2().size());
         Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+    }
+
+    private static void mockSharedNothingMode() {
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return false;
+            }
+
+            @Mock
+            public boolean isSharedNothingMode() {
+                return true;
+            }
+        };
+    }
+
+    private static void mockSharedDataMode() {
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return true;
+            }
+
+            @Mock
+            public boolean isSharedNothingMode() {
+                return false;
+            }
+        };
+    }
+
+    private static void mockClusterSnapshotMgr(ClusterSnapshotMgr clusterSnapshotMgr) {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public ClusterSnapshotMgr getClusterSnapshotMgr() {
+                return clusterSnapshotMgr;
+            }
+        };
+    }
+
+    private static ClusterSnapshotMgr mockClusterSnapshotMgr(boolean deletionSafe) {
+        ClusterSnapshotMgr clusterSnapshotMgr = spy(new ClusterSnapshotMgr());
+        org.mockito.Mockito.doReturn(deletionSafe).when(clusterSnapshotMgr)
+                .isDeletionSafeToExecute(org.mockito.ArgumentMatchers.anyLong());
+        mockClusterSnapshotMgr(clusterSnapshotMgr);
+        return clusterSnapshotMgr;
     }
 
     // Mock AlterJobV2 for testing
@@ -199,4 +282,3 @@ public class AlterHandlerEditLogTest {
         }
     }
 }
-


### PR DESCRIPTION
## Why I'm doing:
NPE for share nothing schema change if job is expired.

## What I'm doing:
Do not check for share nothing mode.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
