### PR TITLE
[BugFix] Input columns and result column of locate function should not share an identical NullColumn inside BinaryColumns

### DIFF
--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -68,13 +68,13 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
         auto start_pos_null = ColumnHelper::as_column<NullableColumn>(start_pos_expansion);
         start_pos = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(start_pos_null->data_column());
 
-        res_null = start_pos_null->null_column();
+        res_null = NullColumn::static_pointer_cast(start_pos_null->null_column()->clone());
     } else if (haystack_ptr->is_nullable() && !start_pos_expansion->is_nullable()) {
         auto haystack_null = ColumnHelper::as_column<NullableColumn>(haystack_ptr);
         haystack = ColumnHelper::as_raw_column<BinaryColumn>(haystack_null->data_column());
 
         start_pos = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(start_pos_expansion);
-        res_null = haystack_null->null_column();
+        res_null = NullColumn::static_pointer_cast(haystack_null->null_column()->clone());
     } else {
         haystack = ColumnHelper::as_raw_column<BinaryColumn>(haystack_ptr);
         start_pos = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(start_pos_expansion);

--- a/be/test/exprs/string_fn_locate_test.cpp
+++ b/be/test/exprs/string_fn_locate_test.cpp
@@ -557,4 +557,69 @@ TEST_F(StringFunctionLocateTest, locatePosChineseTest) {
     }
 }
 
+// Verify that the result NullableColumn does not share its NullColumn with any input column.
+// When haystack is nullable (needle is const), res_null must be a clone of haystack's null column.
+// When start_pos is nullable (needle is const), res_null must be a clone of start_pos's null column.
+TEST_F(StringFunctionLocateTest, locateNullColumnNotSharedTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    // Case 1: nullable haystack, const needle → result's null_column must differ from haystack's
+    {
+        auto haystack_data = BinaryColumn::create();
+        auto null_col = NullColumn::create();
+        auto needle = BinaryColumn::create();
+        auto start_pos = Int32Column::create();
+
+        for (int i = 0; i < 20; ++i) {
+            haystack_data->append("abcd");
+            null_col->append(i % 2);
+            start_pos->append(1);
+        }
+        needle->append("bc");
+
+        Columns columns;
+        columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+        columns.emplace_back(NullableColumn::create(std::move(haystack_data), std::move(null_col)));
+        columns.emplace_back(std::move(start_pos));
+
+        const NullableColumn* input_nullable = ColumnHelper::as_raw_column<NullableColumn>(columns[1]);
+
+        ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
+        ASSERT_TRUE(result->is_nullable());
+
+        const NullableColumn* result_nullable = ColumnHelper::as_raw_column<NullableColumn>(result);
+        ASSERT_NE(result_nullable->null_column().get(), input_nullable->null_column().get())
+                << "result must not share null_column with haystack input";
+    }
+
+    // Case 2: non-nullable haystack, nullable start_pos, const needle → result's null_column must differ from start_pos's
+    {
+        auto haystack_data = BinaryColumn::create();
+        auto start_pos_data = Int32Column::create();
+        auto start_pos_null = NullColumn::create();
+        auto needle = BinaryColumn::create();
+
+        for (int i = 0; i < 20; ++i) {
+            haystack_data->append("abcd");
+            start_pos_data->append(1);
+            start_pos_null->append(i % 2);
+        }
+        needle->append("bc");
+
+        Columns columns;
+        columns.emplace_back(ConstColumn::create(std::move(needle), 1));
+        columns.emplace_back(std::move(haystack_data));
+        columns.emplace_back(NullableColumn::create(std::move(start_pos_data), std::move(start_pos_null)));
+
+        const NullableColumn* input_start_pos_nullable = ColumnHelper::as_raw_column<NullableColumn>(columns[2]);
+
+        ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
+        ASSERT_TRUE(result->is_nullable());
+
+        const NullableColumn* result_nullable = ColumnHelper::as_raw_column<NullableColumn>(result);
+        ASSERT_NE(result_nullable->null_column().get(), input_start_pos_nullable->null_column().get())
+                << "result must not share null_column with start_pos input";
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
  Why I'm doing:                                                                                                                                                                              
                                                                                                                                                                                              
  In haystack_vector_and_needle_const (be/src/exprs/locate.cpp), when only one of the two inputs is nullable, the result NullableColumn was constructed by directly reusing the input's       
  NullColumn shared pointer:                                                                                                                                                                  
                                                                                                                                                                                            
  // haystack nullable, start_pos not nullable                                                                                                                                                
  res_null = haystack_null->null_column();          // shared — BUG                                                                                                                           
                                                                                                                                                                                              
  // start_pos nullable, haystack not nullable                                                                                                                                                
  res_null = start_pos_null->null_column();         // shared — BUG                                                                                                                           
                                                                                                                                                                                              
  This means the result column and the input column share the same NullColumn object. In the query plan that triggered this bug, the locate call sits inside a Project operator whose output  
  chunk is then fed into a PARTITION-TOP-N operator. When the number of distinct partition keys exceeds 512, PARTITION-TOP-N switches to passthrough mode and calls                           
  column->remove_first_n_values(i) in-place on every column in the chunk — including the shared NullColumn. Because both the locate result column and the  input column point to  
  the same NullColumn object, the in-place truncation corrupts the input column, leading to a crash.                                                                                        

  What I'm doing:

  Clone the NullColumn before assigning it to res_null in the two affected branches, so the result NullableColumn always owns an independent null bitmap:                                     
  
  res_null = NullColumn::static_pointer_cast(haystack_null->null_column()->clone());                                                                                                          
  res_null = NullColumn::static_pointer_cast(start_pos_null->null_column()->clone());                                                                                                         
                                                                                                                                                                                              
  The union_nullable_column branch (both inputs nullable) was already safe because it always allocates a new NullColumn.                                                                      
                                                                                                                                                                                              
  Also adds a unit test locateNullColumnNotSharedTest that explicitly asserts the result's null_column pointer is distinct from each input's null_column pointer for both affected branches. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
