### PR TITLE
[Enhancement] Support appending BinaryColumn into LargeBinaryColumn

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -67,6 +67,7 @@ void BinaryColumnBase<T>::append(const Slice& str) {
 template <typename T>
 template <typename SrcOffset>
 void BinaryColumnBase<T>::_append_binary_impl(const BinaryColumnBase<SrcOffset>& src, size_t offset, size_t count) {
+    static_assert(sizeof(SrcOffset) <= sizeof(Offset));
     const auto& src_offsets = src.get_offset();
     const uint8_t* src_base = src.continuous_data();
     auto& dst_bytes = get_bytes();
@@ -116,7 +117,7 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
         }
     }
 
-    DCHECK(false) << "BinaryColumnBase::append: incompatible column type";
+    CHECK(false) << "BinaryColumnBase::append: incompatible column type";
 }
 
 template <typename T>

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -120,8 +120,7 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
     bool dst_is_large = std::is_same_v<T, uint64_t>;
     bool src_is_large_binary = src.is_large_binary();
     CHECK(false) << "BinaryColumnBase::append: incompatible column type"
-                 << " dst_is_large=" << dst_is_large
-                 << " src_is_large_binary=" << src_is_large_binary;
+                 << " dst_is_large=" << dst_is_large << " src_is_large_binary=" << src_is_large_binary;
 }
 
 template <typename T>

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -117,7 +117,11 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
         }
     }
 
-    CHECK(false) << "BinaryColumnBase::append: incompatible column type";
+    bool dst_is_large = std::is_same_v<T, uint64_t>;
+    bool src_is_large_binary = src.is_large_binary();
+    CHECK(false) << "BinaryColumnBase::append: incompatible column type"
+                 << " dst_is_large=" << dst_is_large
+                 << " src_is_large_binary=" << src_is_large_binary;
 }
 
 template <typename T>

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -65,33 +65,58 @@ void BinaryColumnBase<T>::append(const Slice& str) {
 }
 
 template <typename T>
-void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
-    DCHECK(offset + count <= src.size());
-    const auto& b = down_cast<const BinaryColumnBase<T>&>(src);
+template <typename SrcOffset>
+void BinaryColumnBase<T>::_append_binary_impl(const BinaryColumnBase<SrcOffset>& src, size_t offset, size_t count) {
+    const auto& src_offsets = src.get_offset();
+    const uint8_t* src_base = src.continuous_data();
+    auto& dst_bytes = get_bytes();
+    dst_bytes.insert(dst_bytes.end(), src_base + src_offsets[offset], src_base + src_offsets[offset + count]);
 
-    auto& bytes = get_bytes();
-    const uint8_t* src_base = b._data_base();
-    const uint8_t* p = src_base + b._offsets[offset];
-    const uint8_t* e = src_base + b._offsets[offset + count];
-    bytes.insert(bytes.end(), p, e);
-
-    // `new_offsets[i] = offsets[(num_prev_offsets + i - 1) + 1]` is the end offset of the new i-th string.
-    // new_offsets[i] = new_offsets[i - 1] + (b._offsets[offset + i + 1] - b._offsets[offset + i])
-    //    = b._offsets[offset + i + 1] + (new_offsets[i - 1] - b._offsets[offset + i])
-    //    = b._offsets[offset + i + 1] + delta
-    // where `delta` is always the difference between the start offset of the num_prev_offsets-th destination string
-    // and the start offset of the offset-th source string.
     const size_t num_prev_offsets = _offsets.size();
     _offsets.resize(num_prev_offsets + count);
     auto* new_offsets = _offsets.data() + num_prev_offsets;
-    strings::memcpy_inlined(new_offsets, b._offsets.data() + offset + 1, count * sizeof(Offset));
 
-    const auto delta = _offsets[num_prev_offsets - 1] - b._offsets[offset];
-    for (size_t i = 0; i < count; i++) {
-        new_offsets[i] += delta;
+    // new_offsets[i] = src_offsets[offset + i + 1] + delta
+    // where delta = dst_last_offset - src_offsets[offset]
+    if constexpr (std::is_same_v<T, SrcOffset>) {
+        // Same offset width: bulk-copy then adjust.
+        strings::memcpy_inlined(new_offsets, src_offsets.data() + offset + 1, count * sizeof(Offset));
+        const auto delta = _offsets[num_prev_offsets - 1] - src_offsets[offset];
+        for (size_t i = 0; i < count; i++) {
+            new_offsets[i] += delta;
+        }
+    } else {
+        // Different offset width (uint32_t -> uint64_t): convert element by element.
+        const auto delta =
+                static_cast<Offset>(_offsets[num_prev_offsets - 1]) - static_cast<Offset>(src_offsets[offset]);
+        for (size_t i = 0; i < count; i++) {
+            new_offsets[i] = static_cast<Offset>(src_offsets[offset + 1 + i]) + delta;
+        }
     }
 
     invalidate_slice_cache();
+}
+
+template <typename T>
+void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
+    DCHECK(offset + count <= src.size());
+
+    // Same offset type.
+    const bool src_is_same_type = std::is_same_v<T, uint32_t> ? src.is_binary() : src.is_large_binary();
+    if (src_is_same_type) {
+        _append_binary_impl(down_cast<const BinaryColumnBase<T>&>(src), offset, count);
+        return;
+    }
+
+    // Cross-type path: only LargeBinaryColumn can append from BinaryColumn, not the reverse.
+    if constexpr (std::is_same_v<T, uint64_t>) {
+        if (src.is_binary()) {
+            _append_binary_impl(down_cast<const BinaryColumn&>(src), offset, count);
+            return;
+        }
+    }
+
+    DCHECK(false) << "BinaryColumnBase::append: incompatible column type";
 }
 
 template <typename T>

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -413,6 +413,9 @@ public:
     void build_slices(Container& slices) const;
 
 private:
+    template <typename SrcOffset>
+    void _append_binary_impl(const BinaryColumnBase<SrcOffset>& src, size_t offset, size_t count);
+
     void _build_slices() const;
     void _build_german_strings() const;
     void _ensure_materialized();

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -748,7 +748,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_large_to_binary_unsupport
     src->append_string("hello");
     auto dst = BinaryColumn::create();
     dst->append_string("bar");
-    ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), ".*");
+    ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), "incompatible column type");
 }
 
 } // namespace starrocks

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -742,4 +742,13 @@ PARALLEL_TEST(BinaryColumnTest, test_append_zero_count) {
     EXPECT_EQ("['y']", dst->debug_string());
 }
 
+// Cross type (unsupported): LargeBinaryColumn -> BinaryColumn must be rejected.
+PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_large_to_binary_unsupported) {
+    auto src = LargeBinaryColumn::create();
+    src->append_string("hello");
+    auto dst = BinaryColumn::create();
+    dst->append_string("bar");
+    ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), ".*");
+}
+
 } // namespace starrocks

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -21,6 +21,7 @@
 #include "column/const_column.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
+#include "testutil/column_test_helper.h"
 
 namespace starrocks {
 
@@ -686,6 +687,59 @@ PARALLEL_TEST(BinaryColumnTest, test_immutable_bytes_size_large_binary_column) {
     col->append_string("foo"); // 3 bytes
     col->append_string("bar"); // 3 bytes
     EXPECT_EQ(col->immutable_data().immutable_bytes_size(), 6);
+}
+
+// ---- append(const Column& src, size_t offset, size_t count) ----
+
+// Same type: BinaryColumn -> BinaryColumn
+PARALLEL_TEST(BinaryColumnTest, test_append_same_type_binary) {
+    auto src = ColumnTestHelper::build_column<Slice>({"aa", "bb", "cc", "dd"});
+    auto dst = ColumnTestHelper::build_column<Slice>({"xx"});
+    dst->append(*src, 1, 2); // append "bb", "cc"
+
+    EXPECT_EQ("['xx', 'bb', 'cc']", dst->debug_string());
+}
+
+// Same type: LargeBinaryColumn -> LargeBinaryColumn
+PARALLEL_TEST(BinaryColumnTest, test_append_same_type_large_binary) {
+    auto src = LargeBinaryColumn::create();
+    src->append_string("aa");
+    src->append_string("bb");
+    src->append_string("cc");
+
+    auto dst = LargeBinaryColumn::create();
+    dst->append_string("xx");
+    dst->append(*src, 0, 2); // append "aa", "bb"
+
+    EXPECT_EQ("['xx', 'aa', 'bb']", dst->debug_string());
+}
+
+// Cross type: BinaryColumn -> LargeBinaryColumn
+PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_binary_to_large) {
+    auto src = ColumnTestHelper::build_column<Slice>({"hello", "world", "foo"});
+    auto dst = LargeBinaryColumn::create();
+    dst->append_string("bar");
+    dst->append(*src, 1, 2); // append "world", "foo"
+
+    EXPECT_EQ("['bar', 'world', 'foo']", dst->debug_string());
+}
+
+// Append from offset=0 into an empty dst
+PARALLEL_TEST(BinaryColumnTest, test_append_into_empty_dst) {
+    auto src = ColumnTestHelper::build_column<Slice>({"x", "y"});
+    auto dst = BinaryColumn::create();
+    dst->append(*src, 0, 2);
+
+    EXPECT_EQ("['x', 'y']", dst->debug_string());
+}
+
+// Append with count=0 is a no-op
+PARALLEL_TEST(BinaryColumnTest, test_append_zero_count) {
+    auto src = ColumnTestHelper::build_column<Slice>({"x"});
+    auto dst = ColumnTestHelper::build_column<Slice>({"y"});
+    dst->append(*src, 0, 0);
+
+    EXPECT_EQ("['y']", dst->debug_string());
 }
 
 } // namespace starrocks

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -86,12 +86,6 @@ ColumnPtr make_null_bigint_column() {
     return col;
 }
 
-// Metadata bytes from any VariantRowValue (all share the same root metadata).
-std::string get_metadata_raw(const VariantRowValue& rv) {
-    auto raw = rv.get_metadata().raw();
-    return std::string(raw.data(), raw.size());
-}
-
 } // namespace
 
 // ─── existing test ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why I'm doing:

This is the 8nd pr for https://github.com/StarRocks/starrocks/pull/69067, also fix the bug which introduced in the pr.

BinaryColumnBase::append previously only supported same-type appending (e.g., BinaryColumn → BinaryColumn). When a column is upgraded from BinaryColumn to LargeBinaryColumn at runtime (e.g., after exceeding 4GB), subsequent append operations from a BinaryColumn source would hit a DCHECK failure because the types no longer match.

## What I'm doing:

- Extend BinaryColumnBase::append to support appending a BinaryColumn (uint32_t offsets) into a LargeBinaryColumn (uint64_t offsets).
- Add a unified internal helper _append_binary_impl<SrcOffset> that handles both same-type (fast path via memcpy_inlined) and cross-type (element-wise static_cast for offset widening) cases with if constexpr.
- Cross-type appending is intentionally one-directional: BinaryColumn → LargeBinaryColumn only. Appending LargeBinaryColumn into BinaryColumn is not supported as it risks offset overflow.
- Add unit tests covering same-type binary, same-type large binary, cross-type, empty dst, and zero-count cases.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
