### PR TITLE
Avoid potential null pointer exception when finding best group info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
@@ -141,9 +141,11 @@ public class JoinReorderGreedy extends JoinOrder {
     }
 
     private GroupInfo getBestGroupInfo(List<GroupInfo> groupInfos) {
-        double bestCost = Double.MAX_VALUE;
-        GroupInfo bestExpr = null;
-        for (GroupInfo groupInfo : groupInfos) {
+        Preconditions.checkState(!groupInfos.isEmpty());
+        var bestExpr = groupInfos.get(0);
+        double bestCost = bestExpr.bestExprInfo.cost;
+        for (int i = 1; i < groupInfos.size(); i++) {
+            var groupInfo = groupInfos.get(i);
             if (groupInfo.bestExprInfo.cost < bestCost) {
                 bestExpr = groupInfo;
                 bestCost = groupInfo.bestExprInfo.cost;


### PR DESCRIPTION
## Why I'm doing:

If the best cost of every group info is `Double.MAX_VALUE`, this method returns null (`bestExpr`) which leads to a `NullPointerException` upstream.

## What I'm doing:
If there is no best cost, return the first entry.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

