### PR TITLE
[BugFix] Two different NullableColumns should not share the identical NullColumn (backport #66037)

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -132,7 +132,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_append([[maybe_unused]] FunctionContex
     RETURN_IF_ERROR(result);
 
     if (nullable_array != nullptr) {
-        return NullableColumn::create(std::move(result.value()), nullable_array->null_column());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable_array->null_column()));
+        return NullableColumn::create(std::move(result.value()), std::move(null_column));
     }
     return result;
 }
@@ -366,7 +367,8 @@ private:
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
             ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
-            return NullableColumn::create(std::move(result), nullable->null_column());
+            auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable->null_column()));
+            return NullableColumn::create(std::move(result), std::move(null_column));
         }
 
         return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
@@ -1763,7 +1765,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     auto result = ArrayColumn::create(result_elements, result_offsets);
     if (src_nullable_column != nullptr) {
-        return NullableColumn::create(result, src_nullable_column->null_column());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(src_nullable_column->null_column()));
+        return NullableColumn::create(result, std::move(null_column));
     }
     return result;
 }

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -256,7 +256,8 @@ public:
 
             NullColumnPtr null_flags;
             if (data->is_nullable()) {
-                null_flags = ColumnHelper::as_raw_column<NullableColumn>(data)->null_column();
+                null_flags = NullColumn::static_pointer_cast(
+                        Column::mutate(ColumnHelper::as_raw_column<NullableColumn>(data)->null_column()));
             } else {
                 null_flags = RunTimeColumnType<TYPE_NULL>::create();
                 null_flags->resize(data->size());

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -143,7 +143,9 @@ StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Colum
     }
 
     if (arg0->has_null()) {
-        return NullableColumn::create(std::move(col_result), down_cast<NullableColumn*>(arg0.get())->null_column());
+        auto null_column =
+                NullColumn::static_pointer_cast(Column::mutate(down_cast<NullableColumn*>(arg0.get())->null_column()));
+        return NullableColumn::create(std::move(col_result), std::move(null_column));
     } else {
         return col_result;
     }

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -180,7 +180,7 @@ private:
         StatusOr<ColumnPtr> lower;
         if (haystack_column->is_nullable()) {
             auto haystack_nullable = ColumnHelper::as_column<NullableColumn>(haystack_column);
-            res_null = haystack_nullable->null_column();
+            res_null = NullColumn::static_pointer_cast(Column::mutate(haystack_nullable->null_column()));
             haystackPtr = haystack_nullable->data_column();
         } else {
             haystackPtr = haystack_column;

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -1839,7 +1839,8 @@ StatusOr<ColumnPtr> StringFunctions::append_trailing_char_if_absent(FunctionCont
             src = ColumnHelper::as_raw_column<BinaryColumn>(src_null->data_column());
 
             ColumnPtr data = RunTimeColumnType<TYPE_VARCHAR>::create();
-            dst = NullableColumn::create(data, src_null->null_column());
+            auto null_column = NullColumn::static_pointer_cast(Column::mutate(src_null->null_column()));
+            dst = NullableColumn::create(data, std::move(null_column));
             binary_dst = ColumnHelper::as_raw_column<BinaryColumn>(data);
         } else {
             src = ColumnHelper::as_raw_column<BinaryColumn>(columns[0]);


### PR DESCRIPTION
## Why I'm doing:

cp parts of https://github.com/StarRocks/starrocks/pull/66037

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
