### PR TITLE
[Enhancement] Enable delvec metacache during compaction conflict resolution

### DIFF
--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -76,8 +76,7 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     // init delvec loader
     LakeIOOptions lake_io_opts{.fill_data_cache = true, .skip_disk_cache = false};
 
-    auto delvec_loader =
-            std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, true /* fill cache */, lake_io_opts);
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();
@@ -102,8 +101,7 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     // init delvec loader
     LakeIOOptions lake_io_opts{.fill_data_cache = true, .skip_disk_cache = false};
 
-    auto delvec_loader =
-            std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, true /* fill cache */, lake_io_opts);
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();


### PR DESCRIPTION
## Why I'm doing:

During primary key compaction publish in shared-data (lake) mode, delete vectors (delvecs) are loaded from remote storage (S3/OSS) for conflict resolution via `LakeDelvecLoader`. The loader was created with `fill_cache=false`, so delvecs fetched from remote storage were discarded after use and had to be re-fetched on subsequent compaction cycles.

### Bottleneck Evidence

Benchmark data from a shared-data cluster (1 FE + 3 CN, commit `a2afd38`):

| Metric | Value |
|--------|-------|
| `compaction_delvec_loader_latency_us` avg | 2.0s |
| `compaction_delvec_loader_latency_us` P99 | 6.7s |
| Total publish cost avg | 3.67s |
| **Delvec loader % of publish time** | **~55%** |
| Compaction publish RPC cost (FE-side) P99 | 5.8s |

The delvec loader dominates compaction publish time. Since compaction publishes hold `pk_index_shard_lock`, this also blocks concurrent write operations, contributing to high write P99 latency.

## What I'm doing:

Enable metacache (`fill_cache=true`) for delvecs loaded during compaction conflict resolution in `LakePrimaryKeyCompactionConflictResolver::segment_iterator()`. This allows delvecs to be cached and reused across compaction cycles, reducing redundant remote IO calls.

The change affects both overloads of `segment_iterator()` (ChunkIterator-based and Segment-based paths).

## What type of PR is this:

- [x] Improvement

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior
- [x] No, this PR will not result in a change in behavior

## If yes, please specify the type of change:

N/A — the metacache already has eviction policies, so enabling caching follows the existing memory management pattern.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature — *No new tests needed; this changes a boolean parameter. Existing compaction tests cover the code path.*
- [x] This PR does not change any public interface

Signed-off-by: luohaha <luo_haha@126.com>