### PR TITLE
[BugFix] Materialize default VARBINARY length only for explicit OLAP column definitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -111,6 +111,16 @@ public class ColumnDefAnalyzer {
             throw new AnalysisException("charset name " + charsetName + " is not supported yet in column definition");
         }
 
+        // Materialize the documented default 1MB length only for explicit SQL column
+        // definitions on OLAP tables. Derived columns (CTAS/MV/internal) and agg-state
+        // columns must keep their original VARBINARY semantics.
+        if (isOlap && columnDef.isExplicitSqlType() && aggStateDesc == null && typeDef.getType().isScalarType()) {
+            ScalarType scalarType = (ScalarType) typeDef.getType();
+            if (scalarType.getPrimitiveType() == PrimitiveType.VARBINARY && scalarType.getLength() < 0) {
+                typeDef.setType(TypeFactory.createVarbinary(TypeFactory.getOlapMaxVarcharLength()));
+            }
+        }
+
         if (aggregateType == AggregateType.SUM) {
             // For the decimal type we extend to decimal128 to avoid overflow
             typeDef.setType(extendedPrecision(typeDef.getType(), Config.enable_legacy_compatibility_for_replication));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -550,10 +550,7 @@ import com.starrocks.type.AnyMapType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
-import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
-import com.starrocks.type.TypeFactory;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
@@ -1192,14 +1189,6 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             columnType = TypeParser.getType(context.type());
         }
 
-        // Only plain column definitions should materialize the documented 1MB default
-        // length for VARBINARY. Agg-state columns must keep their opaque intermediate type.
-        if (aggStateDesc == null && columnType.isScalarType()) {
-            ScalarType scalarType = (ScalarType) columnType;
-            if (scalarType.getPrimitiveType() == PrimitiveType.VARBINARY && scalarType.getLength() < 0) {
-                columnType = TypeFactory.createVarbinary(TypeFactory.getOlapMaxVarcharLength());
-            }
-        }
         NodePosition pos = context.type() == null ? NodePosition.ZERO : createPos(context.type());
         TypeDef typeDef = new TypeDef(columnType, pos);
         String charsetName = context.charsetName() != null ?
@@ -1264,8 +1253,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
         String comment = context.comment() == null ? "" :
                 ((StringLiteral) visit(context.comment().string())).getStringValue();
-        return new ColumnDef(columnName, typeDef, charsetName, isKey, aggregateType, aggStateDesc, isAllowNull, defaultValueDef,
-                isAutoIncrement, expr, comment, createPos(context));
+        ColumnDef columnDef = new ColumnDef(columnName, typeDef, charsetName, isKey, aggregateType, aggStateDesc,
+                isAllowNull, defaultValueDef, isAutoIncrement, expr, comment, createPos(context));
+        columnDef.setExplicitSqlType(true);
+        return columnDef;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FileTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FileTableTest.java
@@ -195,4 +195,21 @@ public class FileTableTest {
         Assertions.assertEquals(tTableDescriptor.getFileTable().getHive_column_names(), "col1,col2,col3");
         Assertions.assertEquals(tTableDescriptor.getFileTable().getHive_column_types(), "int#int#string");
     }
+
+    @Test
+    public void testBinaryExternalTableKeepsHiveBinaryType() throws Exception {
+        String createTableSql =
+                "create external table if not exists db.file_tbl_binary (col1 int, col2 binary) engine=file properties " +
+                        "(\"path\"=\"hdfs://127.0.0.1:10000/hive/\", \"format\"=\"avro\")";
+        CreateTableStmt
+                createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableSql, connectContext);
+        com.starrocks.catalog.Table table = createTable(createTableStmt);
+
+        Assertions.assertTrue(table instanceof FileTable);
+        FileTable fileTable = (FileTable) table;
+        List<DescriptorTable.ReferencedPartitionInfo> partitions = new ArrayList<>();
+        TTableDescriptor tTableDescriptor = fileTable.toThrift(partitions);
+
+        Assertions.assertEquals("int#binary", tTableDescriptor.getFileTable().getHive_column_types());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -19,6 +19,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -30,6 +31,9 @@ import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
@@ -218,6 +222,18 @@ public class AnalyzeAlterTableStatementTest {
     public void testAlterWithTimeType() {
         analyzeFail("alter table t0 add column testcol TIME");
         analyzeFail("alter table t0 modify column v0 TIME");
+    }
+
+    @Test
+    public void testAlterAddVarbinaryWithoutLengthMaterializesDefaultLength() {
+        AlterTableStmt alterTableStmt = (AlterTableStmt) analyzeSuccess("alter table t0 add column testcol varbinary");
+        Assertions.assertEquals(1, alterTableStmt.getAlterClauseList().size());
+        Assertions.assertTrue(alterTableStmt.getAlterClauseList().get(0) instanceof AddColumnClause);
+
+        AddColumnClause clause = (AddColumnClause) alterTableStmt.getAlterClauseList().get(0);
+        ScalarType type = (ScalarType) clause.getColumnDef().getType();
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), type.getLength());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -84,6 +84,18 @@ public class AnalyzeCreateTableTest {
     }
 
     @Test
+    public void testExternalFileTableVarbinaryKeepsUnspecifiedLength() {
+        CreateTableStmt stmt = (CreateTableStmt) analyzeSuccess(
+                "create external table test.file_varbinary (col1 int, col2 varbinary) engine=file properties " +
+                        "(\"path\"=\"hdfs://127.0.0.1:10000/hive/\", \"format\"=\"parquet\")");
+        ScalarType type = (ScalarType) stmt.getColumnDefs().get(1).getType();
+
+        Assertions.assertEquals(PrimitiveType.VARBINARY, type.getPrimitiveType());
+        Assertions.assertEquals(-1, type.getLength());
+        Assertions.assertEquals("varbinary", type.toSql());
+    }
+
+    @Test
     public void testNoDb() {
         AnalyzeTestUtil.getConnectContext().setDatabase(null);
         String sql =

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -95,6 +95,9 @@ public class ColumnDef implements ParseNode {
     private DefaultValueDef defaultValueDef;
     private final String comment;
     private boolean isPartitionColumn = false;
+    // True only for columns defined directly by SQL column syntax. Derived ColumnDef instances
+    // created by CTAS/MV/internal builders should keep the default false value.
+    private boolean explicitSqlType = false;
 
     private final NodePosition pos;
 
@@ -233,6 +236,14 @@ public class ColumnDef implements ParseNode {
 
     public boolean isPartitionColumn() {
         return isPartitionColumn;
+    }
+
+    public boolean isExplicitSqlType() {
+        return explicitSqlType;
+    }
+
+    public void setExplicitSqlType(boolean explicitSqlType) {
+        this.explicitSqlType = explicitSqlType;
     }
 
     public TypeDef getTypeDef() {


### PR DESCRIPTION
## Why I'm doing:

`VARBINARY` without an explicit length should follow the documented default semantics on OLAP tables and behave as `VARBINARY(1M)`.

A previous fix moved this behavior too early into the parser layer and ended up affecting external table definitions as well. That caused regressions such as `ENGINE=FILE` external tables exposing `VARBINARY(1048576)` where external schema handling should keep the original unsized `VARBINARY` / `BINARY` semantics.

This PR narrows the behavior to the intended scope:
- explicit SQL column definitions
- OLAP table analysis
- non-agg-state columns

## What I'm doing:

- Add an `explicitSqlType` marker to `ColumnDef` so analyzer code can distinguish direct SQL column definitions from derived columns created by CTAS/MV/internal builders.
- Stop materializing the default `VARBINARY` length in `AstBuilder`; the parser now only marks explicit SQL column definitions.
- Materialize omitted `VARBINARY` length to `1MB` only in `ColumnDefAnalyzer`, and only when:
  - the target is an OLAP table
  - the column type comes from explicit SQL column syntax
  - the column is not an agg-state column
- Keep external table definitions and opaque agg-state `VARBINARY` semantics unchanged.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11186

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
