### PR TITLE
[BugFix] Fix AUTO MV fallback checkpoint handoff for Iceberg IVM

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -160,6 +160,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         Preconditions.checkNotNull(mvRefreshProcessor);
 
         // get exec plan
+        mvTaskRunContext.getRefreshRuntimeState().reset();
         mvTaskRunContext.setIsExplain(true);
         BaseMVRefreshProcessor.ProcessExecPlan processExecPlan =
                 mvRefreshProcessor.getProcessExecPlan(mvTaskRunContext);
@@ -312,6 +313,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     public Constants.TaskRunState doProcessTaskRun(TaskRunContext taskRunContext,
                                                    MVRefreshExecutor executor) throws Exception {
         Stopwatch watch = Stopwatch.createStarted();
+        mvTaskRunContext.getRefreshRuntimeState().reset();
         final BaseMVRefreshProcessor.ProcessExecPlan processExecPlan = mvRefreshProcessor.getProcessExecPlan(taskRunContext);
         if (processExecPlan.state() == Constants.TaskRunState.SKIPPED) {
             logger.info("MV {} refresh task skipped, no partitions to refresh", mv.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -15,9 +15,13 @@
 package com.starrocks.scheduler;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PartitionNameSetMap;
@@ -27,6 +31,28 @@ import java.util.Map;
 import java.util.Set;
 
 public class MvTaskRunContext extends TaskRunContext {
+    public static class MVRefreshRuntimeState {
+        private final Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Maps.newHashMap();
+        private final Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap = Maps.newHashMap();
+
+        public Map<Long, BaseTableSnapshotInfo> getSnapshotBaseTables() {
+            return snapshotBaseTables;
+        }
+
+        public void replaceSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
+            this.snapshotBaseTables.clear();
+            this.snapshotBaseTables.putAll(snapshotBaseTables);
+        }
+
+        public Map<BaseTableInfo, TvrVersionRange> getPendingBaseTableTvrVersionRangeMap() {
+            return pendingBaseTableTvrVersionRangeMap;
+        }
+
+        public void reset() {
+            snapshotBaseTables.clear();
+            pendingBaseTableTvrVersionRangeMap.clear();
+        }
+    }
 
     // all the RefBaseTable's partition name to its intersected materialized view names.
     //baseTable -> basePartition -> mvPartitions
@@ -51,9 +77,14 @@ public class MvTaskRunContext extends TaskRunContext {
     private ExecPlan execPlan = null;
 
     private int partitionTTLNumber = TableProperty.INVALID;
+    private final MVRefreshRuntimeState refreshRuntimeState = new MVRefreshRuntimeState();
 
     public MvTaskRunContext(TaskRunContext context) {
         super(context);
+    }
+
+    public MVRefreshRuntimeState getRefreshRuntimeState() {
+        return refreshRuntimeState;
     }
 
     public Map<Table, PCellSetMapping> getRefBaseTableMVIntersectedPartitions() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -104,6 +104,7 @@ public abstract class BaseMVRefreshProcessor {
     protected final MaterializedView mv;
     protected final IMaterializedViewMetricsEntity mvEntity;
     protected final MvTaskRunContext mvContext;
+    protected final MvTaskRunContext.MVRefreshRuntimeState refreshRuntimeState;
     protected final Logger logger;
     // Collect all bases tables of the mv to be updated meta after mv refresh success.
     // format :     table id -> <base table info, snapshot table>
@@ -112,9 +113,8 @@ public abstract class BaseMVRefreshProcessor {
     // current refresh mode, can be changed in the refresh's runtime for `auto` mode
     protected MaterializedView.RefreshMode currentRefreshMode;
 
-    // Collect all base table snapshot infos for the mv which the snapshot infos are kept
-    // and used in the final update meta.
-    protected Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Maps.newHashMap();
+    // Per-task-run shared snapshot infos bound once from mvContext. Mutate the map contents only.
+    protected final Map<Long, BaseTableSnapshotInfo> snapshotBaseTables;
     // PCT related fields
     protected PCellSortedSet pctMVToRefreshedPartitions = null;
     protected PCellSetMapping pctRefTablePartitionNames = null;
@@ -144,6 +144,7 @@ public abstract class BaseMVRefreshProcessor {
         this.db = db;
         this.mv = mv;
         this.mvContext = mvContext;
+        this.refreshRuntimeState = mvContext.getRefreshRuntimeState();
         this.mvEntity = mvEntity;
         this.logger = MVTraceUtils.getLogger(mv, clazz);
         this.mvRefreshParams = new MVRefreshParams(mv, mvContext.getProperties());
@@ -151,6 +152,7 @@ public abstract class BaseMVRefreshProcessor {
         this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext, mvRefreshParams);
         this.currentRefreshMode = refreshMode;
         this.isEnableExternalTablePreciseRefresh = isEnableExternalTablePreciseRefresh();
+        this.snapshotBaseTables = refreshRuntimeState.getSnapshotBaseTables();
         // init the refresh mode
         updateTaskRunStatus(status -> {
             status.getMvTaskRunExtraMessage().setRefreshMode(currentRefreshMode.name());
@@ -244,6 +246,14 @@ public abstract class BaseMVRefreshProcessor {
      */
     public TaskRun getNextTaskRun() {
         return nextTaskRun;
+    }
+
+    protected void setSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
+        refreshRuntimeState.replaceSnapshotBaseTables(snapshotBaseTables);
+    }
+
+    protected Map<BaseTableInfo, TvrVersionRange> getPendingBaseTableTvrVersionRangeMap() {
+        return refreshRuntimeState.getPendingBaseTableTvrVersionRangeMap();
     }
 
     /**
@@ -424,7 +434,7 @@ public abstract class BaseMVRefreshProcessor {
     protected boolean syncPartitions() throws AnalysisException, LockTimeoutException {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         // collect base table snapshot infos
-        this.snapshotBaseTables = collectBaseTableSnapshotInfos();
+        setSnapshotBaseTables(collectBaseTableSnapshotInfos());
 
         if (!mvContext.isExplain() && mvRefreshParams.isNonTentativeForce()) {
             // drop existing partitions for force refresh

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
@@ -86,7 +87,11 @@ public class MVVersionManager {
             final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
                     refreshContext.getBaseTableInfoTvrVersionRangeMap();
             for (Map.Entry<BaseTableInfo, TvrVersionRange> entry : tempMvTvrVersionRangeMap.entrySet()) {
-                mvTvrVersionRangeMap.put(entry.getKey(), entry.getValue());
+                TvrVersionRange versionRange = entry.getValue();
+                if (versionRange == null || versionRange.isEmpty()) {
+                    continue;
+                }
+                mvTvrVersionRangeMap.put(entry.getKey(), TvrTableSnapshot.of(versionRange.to()));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -42,9 +42,6 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
     private final MVPCTBasedRefreshProcessor pctProcessor;
     private final MVIVMBasedRefreshProcessor ivmProcessor;
 
-    // This map is used to store the temporary tvr version range for each base table
-    private final Map<BaseTableInfo, TvrVersionRange> tempMvTvrVersionRangeMap = Maps.newConcurrentMap();
-
     public MVHybridBasedRefreshProcessor(Database db,
                                          MaterializedView mv,
                                          MvTaskRunContext mvContext,
@@ -108,19 +105,21 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         // If the refresh is transferred to pct, we need to refresh the changed partitions once
         // and cannot generate multi-task-runs.
         pctProcessor.getMvRefreshParams().setCanGenerateNextTaskRun(false);
+        final Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap =
+                getPendingBaseTableTvrVersionRangeMap();
 
         // try get the tvr version range map from ivm processor
         final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
                 mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
         for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
-            TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableChangedVersionRange(snapshotInfo,
-                    mvTvrVersionRangeMap, this.currentRefreshMode);
+            TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
+                    snapshotInfo, mvTvrVersionRangeMap);
             logger.info("Base table: {}, changed version range: {}",
                     snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
             // collect changed version range
             TvrTableSnapshotInfo tvrTableSnapshotInfo = new TvrTableSnapshotInfo(snapshotInfo.getBaseTableInfo(),
                     snapshotInfo.getBaseTable());
-            tempMvTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
+            pendingBaseTableTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
             // update the snapshot info with the changed version range
             tvrTableSnapshotInfo.setTvrSnapshot(changedVersionRange);
         }
@@ -163,8 +162,9 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
             if (mvContext.hasNextBatchPartition()) {
                 updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
             } else {
-                // if this is the last task run for a refresh job, update tempMvTvrVersionRangeMap instead.
-                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, tempMvTvrVersionRangeMap);
+                // if this is the last task run for a refresh job, update the pending tvr version ranges instead.
+                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions,
+                        getPendingBaseTableTvrVersionRangeMap());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -192,18 +192,7 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
                                                          MaterializedView.RefreshMode refreshMode) {
         final BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
         final Table snapshotTable = snapshotInfo.getBaseTable();
-
-        Optional<Table> optTable = MvUtils.getTableWithIdentifier(baseTableInfo);
-        if (optTable.isEmpty()) {
-            throw new SemanticException("Base table %s.%s does not exist",
-                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
-        }
-        if (!IVMAnalyzer.isTableTypeIVMSupported(snapshotTable.getType())) {
-            throw new SemanticException(String.format("Only support %s tables for MVIVMBasedRefreshProcessor, " +
-                    "but got: %s", Joiner.on(",").join(IVMAnalyzer.SUPPORTED_TABLE_TYPES),
-                    snapshotTable.getType()));
-        }
-        final TvrTableDelta maxTvrDelta = getMaxBaseTableChangedDelta(baseTableInfo, snapshotTable, mvTvrVersionRangeMap);
+        final TvrTableDelta maxTvrDelta = getBaseTableMaxChangedDelta(snapshotInfo, mvTvrVersionRangeMap);
         // if no change, return empty
         if (maxTvrDelta.isEmpty()) {
             return maxTvrDelta;
@@ -249,23 +238,24 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
         }
     }
 
-    public boolean isGenerateNextTaskRun() {
-        if (Config.mv_max_rows_per_refresh <= 0) {
-            return false;
+    public TvrTableDelta getBaseTableMaxChangedDelta(BaseTableSnapshotInfo snapshotInfo,
+                                                     Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap) {
+        Table snapshotTable = snapshotInfo.getBaseTable();
+        BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+        Optional<Table> optTable = MvUtils.getTableWithIdentifier(baseTableInfo);
+        if (optTable.isEmpty()) {
+            throw new SemanticException("Base table %s.%s does not exist",
+                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
         }
-        // for sync refresh, we always use the max changed delta
-        ExecuteOption executeOption = mvContext.getExecuteOption();
-        boolean isSyncRefresh = executeOption != null && executeOption.getIsSync();
-        return !isSyncRefresh;
-    }
-
-    private TvrTableDelta getMaxBaseTableChangedDelta(BaseTableInfo baseTableInfo,
-                                                      Table table,
-                                                      Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap) {
+        if (!IVMAnalyzer.isTableTypeIVMSupported(snapshotTable.getType())) {
+            throw new SemanticException(String.format("Only support %s tables for MVIVMBasedRefreshProcessor, " +
+                            "but got: %s", Joiner.on(",").join(IVMAnalyzer.SUPPORTED_TABLE_TYPES),
+                    snapshotTable.getType()));
+        }
         // For now, we always refresh the latest snapshot from the last refresh.
         // current tvr snapshot
         TvrVersionRange currentTvrSnapshot = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getCurrentTvrSnapshot(baseTableInfo.getDbName(), table);
+                .getCurrentTvrSnapshot(baseTableInfo.getDbName(), snapshotTable);
         if (currentTvrSnapshot == null || !(currentTvrSnapshot instanceof TvrTableSnapshot)) {
             logger.warn("Current tvr snapshot is null for base table: {}, db: {}",
                     baseTableInfo.getTableName(), baseTableInfo.getDbName());
@@ -300,6 +290,16 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
             return TvrTableDelta.of(beforeVersion, currentVersion);
         }
         return TvrTableDelta.of(beforeVersion, currentVersion);
+    }
+
+    public boolean isGenerateNextTaskRun() {
+        if (Config.mv_max_rows_per_refresh <= 0) {
+            return false;
+        }
+        // for sync refresh, we always use the max changed delta
+        ExecuteOption executeOption = mvContext.getExecuteOption();
+        boolean isSyncRefresh = executeOption != null && executeOption.getIsSync();
+        return !isSyncRefresh;
     }
 
     // TODO: We may introduce a smarter way to determine which incremental snapshot to refresh later.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -26,6 +26,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
@@ -313,6 +314,9 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
     public void updateVersionMeta(ExecPlan execPlan,
                                   PCellSortedSet mvRefreshedPartitions,
                                   Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
+        Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap =
+                getPendingBaseTableTvrVersionRangeMap();
+        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions,
+                pendingBaseTableTvrVersionRangeMap);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -14,8 +14,14 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.tvr.TvrDeltaStats;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableDeltaTrait;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
@@ -533,6 +539,45 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                     (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
             Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
         }
+    }
+
+    @Test
+    public void testAutoRefreshFallbackCanPersistCheckpointForNextIvm() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid1 =
+                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        MaterializedView refreshedMv = getMv("test_mv1");
+        TvrVersionRange checkpoint = refreshedMv.getRefreshScheme()
+                .getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap()
+                .values()
+                .iterator()
+                .next();
+        Assertions.assertTrue(checkpoint instanceof TvrTableSnapshot);
+        Assertions.assertEquals(2L, checkpoint.to().getVersion());
+
+        advanceTableVersionTo(3);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(2L, 3L),
+                        TvrDeltaStats.EMPTY)
+        ));
+
+        MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid2 =
+                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`AUTO` refresh for Iceberg MVs could fall back from IVM to PCT when the base table history contains retractable changes, but the fallback path did not hand the refresh checkpoint back to the next IVM run correctly.

In practice, this caused two problems:
1. the fallback path could miss the per-run snapshot state collected during the IVM attempt, and
2. even after a successful PCT fallback, the MV could fail to resume incremental refresh on the next append-only update because the checkpoint handoff was incomplete or persisted in an incompatible form.

As a result, an MV could keep behaving like a first refresh after fallback, or stay on the PCT path longer than expected.

## What I'm doing:
- Introduce a per-task-run refresh runtime state in `MvTaskRunContext` and bind `snapshotBaseTables` from that shared state so the hybrid, IVM, and PCT processors observe the same snapshot view during one refresh run.
- Make the shared `snapshotBaseTables` binding immutable in `BaseMVRefreshProcessor` to avoid accidental reassignment later in the flow.
- Fix the `AUTO -> PCT` fallback path to carry forward the pending base-table TVR checkpoint instead of dropping it.
- Use the max changed delta directly when switching from IVM to PCT, so the fallback path advances the checkpoint without re-entering the append-only validation logic that already triggered the fallback.
- Normalize persisted TVR checkpoints to `TvrTableSnapshot` before writing them into MV metadata, so the next IVM refresh can resume from the correct snapshot boundary.
- Add a regression test to verify that:
  - the first `AUTO` refresh falls back to PCT when retractable Iceberg changes are present,
  - the fallback persists a valid snapshot checkpoint, and
  - the next append-only refresh can switch back to IVM.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
