### PR TITLE
[BugFix] Fix CachingIcebergCatalog reload() to refresh vended credentials without bypassing cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -125,13 +125,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     @Override
                     public Table reload(IcebergTableName key, Table oldValue) {
                         try {
-                            BaseTable updateTable = 
+                            BaseTable updateTable =
                                     (BaseTable) delegate.getTable(new ConnectContext(), key.dbName, key.tableName);
-                            TableOperations newOps = updateTable.operations();
-                            TableOperations oldOps = ((BaseTable) oldValue).operations();
-                            if (oldOps.current().metadataFileLocation().equals(newOps.current().metadataFileLocation())) {
-                                return oldValue;
-                            }
                             return updateTable;
                         } catch (Exception e) {
                             LOG.warn("refresh table {}.{} failed", key.dbName, key.tableName, e);
@@ -234,17 +229,15 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public Table getTable(ConnectContext connectContext, String dbName, String tableName) throws StarRocksConnectorException {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
 
-        // do not cache if jwt or oauth2 is used AND it is a REST Catalog.
-        // do not cache if vended credentials are enabled, because credentials may expire before cache TTL.
-        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
-                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog)) &&
-                !delegate.isVendedCredentialsEnabled();
-        if (!cacheAllowed) {
-            return delegate.getTable(connectContext, dbName, tableName);
-        }
-
         if (ConnectContext.get() == null || ConnectContext.get().getCommand() == MysqlCommand.COM_QUERY) {
             tableLatestAccessTime.put(icebergTableName, System.currentTimeMillis());
+        }
+
+        // do not cache if jwt or oauth2 is used AND it is a REST Catalog.
+        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
+                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
+        if (!cacheAllowed) {
+            return delegate.getTable(connectContext, dbName, tableName);
         }
         try {
             if (shouldOnlyReadCache(connectContext)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -278,17 +278,6 @@ public interface IcebergCatalog extends MemoryTrackable {
         return new HashMap<>();
     }
 
-    /**
-     * Check if this catalog uses vended credentials for table access.
-     * When vended credentials are used, caching tables may cause issues
-     * because credentials expire before the cache TTL.
-     *
-     * @return true if vended credentials are enabled
-     */
-    default boolean isVendedCredentialsEnabled() {
-        return false;
-    }
-
     default String defaultTableLocation(ConnectContext context, Namespace ns, String tableName) {
         Map<String, String> properties = loadNamespaceMetadata(context, ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -87,7 +87,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
-    private final boolean enableVendedCredentials;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
@@ -105,7 +104,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         restCatalogProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        this.enableVendedCredentials =
+        boolean enableVendedCredentials =
                 Boolean.parseBoolean(restCatalogProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));
         if (enableVendedCredentials) {
             restCatalogProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
@@ -140,7 +139,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
         this.restCatalogProperties = Maps.newHashMap();
-        this.enableVendedCredentials = false;
     }
 
     @Override
@@ -468,8 +466,4 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                 context.getCurrentUserIdentity());
     }
 
-    @Override
-    public boolean isVendedCredentialsEnabled() {
-        return enableVendedCredentials;
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -459,63 +459,79 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testGetTableBypassCacheWhenVendedCredentialsEnabled(@Mocked IcebergRESTCatalog restCatalog) {
-        // When vended credentials is enabled, caching should be bypassed to avoid
-        // using expired credentials.
-        ConnectContext ctx = new ConnectContext();
-        Table nativeTable1 = createBaseTableWithManifests(1, 1);
-        Table nativeTable2 = createBaseTableWithManifests(1, 1);
+    public void testReloadAlwaysReturnsFreshTable(@Mocked IcebergCatalog delegate,
+                                                   @Mocked IcebergCatalogProperties props,
+                                                   @Mocked ConnectContext ctx) throws Exception {
+        // Two tables with SAME metadataFileLocation but different identity,
+        // simulating a REST catalog returning fresh vended credentials on each loadTable call.
+        Table oldTable = createBaseTableWithManifests(1, 1);
+        Table freshTable = createBaseTableWithManifests(1, 1);
+        String sharedMetadataLocation = "s3://bucket/metadata/v1.metadata.json";
+        Mockito.when(((BaseTable) oldTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+        Mockito.when(((BaseTable) freshTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+
+        AtomicLong callCount = new AtomicLong(0);
 
         new Expectations() {
             {
-                restCatalog.isVendedCredentialsEnabled();
+                props.isEnableIcebergMetadataCache();
                 result = true;
-                minTimes = 0;
+                props.isEnableIcebergTableCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheRefreshIntervalSec();
+                result = 1L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
 
-                restCatalog.getTable(ctx, "db4", "tbl4");
-                result = nativeTable1;
-                result = nativeTable2;
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table capture(ConnectContext c, String db, String tbl) {
+                        long idx = callCount.incrementAndGet();
+                        if (idx == 1) {
+                            return oldTable;
+                        }
+                        return freshTable;
+                    }
+                };
             }
         };
 
-        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
-                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+            IcebergTableName key = new IcebergTableName("db1", "t1");
 
-        Table result1 = cachingIcebergCatalog.getTable(ctx, "db4", "tbl4");
-        Table result2 = cachingIcebergCatalog.getTable(ctx, "db4", "tbl4");
+            // Initial load returns oldTable
+            Table cached = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(oldTable, cached, "initial load should return oldTable");
+            Assertions.assertEquals(1, callCount.get());
 
-        // Should return different instances (no caching)
-        Assertions.assertSame(nativeTable1, result1);
-        Assertions.assertSame(nativeTable2, result2);
-    }
+            // Wait for refresh interval to elapse, then trigger async reload
+            LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+            Thread.sleep(1100);
+            tableCache.get(key); // triggers async reload
+            Thread.sleep(300);   // allow async reload to complete
 
-    @Test
-    public void testGetTableWithCacheWhenVendedCredentialsDisabled(@Mocked IcebergRESTCatalog restCatalog) {
-        // When vended credentials is disabled, normal caching should work.
-        ConnectContext ctx = new ConnectContext();
-        Table nativeTable = createBaseTableWithManifests(1, 1);
-
-        new Expectations() {
-            {
-                restCatalog.isVendedCredentialsEnabled();
-                result = false;
-                minTimes = 0;
-
-                restCatalog.getTable(ctx, "db5", "tbl5");
-                result = nativeTable;
-            }
-        };
-
-        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
-                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
-
-        Table result1 = cachingIcebergCatalog.getTable(ctx, "db5", "tbl5");
-        Table result2 = cachingIcebergCatalog.getTable(ctx, "db5", "tbl5");
-
-        // Should return the same instance (cached)
-        Assertions.assertSame(nativeTable, result1);
-        Assertions.assertSame(nativeTable, result2);
-        Assertions.assertSame(result1, result2);
+            // After reload, cache must hold freshTable (not oldTable),
+            // even though metadataFileLocation is identical.
+            Assertions.assertEquals(2, callCount.get(), "delegate should have been called twice");
+            Table reloaded = tableCache.get(key);
+            Assertions.assertSame(freshTable, reloaded,
+                    "reload must return freshly loaded table even when metadata location is unchanged");
+            Assertions.assertNotSame(oldTable, reloaded,
+                    "reload must NOT return stale oldTable when metadata location is unchanged");
+        } finally {
+            es.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

PR #69434 introduced a cache bypass for Iceberg REST catalogs with vended credentials to prevent stale STS tokens from being served. While it solved the credential expiration issue, it caused **all `getTable()` calls to hit the REST catalog and Lake Formation directly**, bypassing the Caffeine cache entirely. Under real workloads this generates hundreds of Lake Formation `GetDataAccess` requests per minute, triggering AWS rate limiting (`Rate exceeded`) and causing query failures.

The root cause is a bug in `CachingIcebergCatalog.reload()`: it compares `metadataFileLocation` between the old cached Table and the freshly loaded one, and when they match (the common case), it **discards the fresh Table and returns the old one**. Since vended credentials (STS tokens with ~1h TTL) are embedded in the Table's FileIO, the cache keeps serving expired tokens.

## What I'm doing:

1. **Fix `reload()`**: Always return the freshly loaded Table from `delegate.getTable()`, ensuring vended credentials in the cache are always current. The `metadataFileLocation` comparison optimization is removed — it is unsafe for REST catalogs where the Table object carries short-lived credentials even when metadata hasn't changed.

2. **Revert cache bypass from PR #69434**: Remove the `!delegate.isVendedCredentialsEnabled()` condition from `getTable()`, restoring the Caffeine cache for vended-credential catalogs. The cache is essential for absorbing the request load from background processes (statistics manager, stats-cache-refresher, catalog refresh) and concurrent queries.

3. **Remove `isVendedCredentialsEnabled()`** from `IcebergCatalog` interface and `IcebergRESTCatalog` — no longer needed since the cache is not bypassed.

**Recommended configuration** for REST catalogs with vended credentials:
- `iceberg_meta_cache_ttl_sec` < credential TTL (e.g. `3400` for AWS LF 1-hour tokens)
- `iceberg_table_cache_refresh_interval_sec` = `600` (reduces reload frequency while keeping credentials fresh)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior change**: Iceberg REST catalogs with vended credentials will now use the Caffeine table cache (as they did before PR #69434). The cache `reload()` method now always returns fresh Table objects, ensuring credentials are refreshed on every reload cycle. This replaces the full cache bypass introduced by PR #69434.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4