### PR TITLE
[BugFix] Fix delvec orphan entries caused by write-before-compaction in same publish batch

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1323,6 +1323,11 @@ CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
 CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
+// Enable cleanup of orphan delvec entries during compaction.
+// Orphan delvecs are leaked metadata entries from a historical bug that reference
+// non-existent segments and prevent delvec file garbage collection.
+// Turn this on after upgrade to clean up existing orphans, then turn it off once done.
+CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -825,7 +825,8 @@
         "lake_metadata_cache_limit",
         "lake_cache_select_in_physical_way",
         "lake_enable_publish_version_trace_log",
-        "lake_service_max_concurrency"
+        "lake_service_max_concurrency",
+        "lake_enable_orphan_delvec_cleanup_on_compaction"
       ]
     },
     {

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -82,6 +82,12 @@ CONF_mInt64(lake_max_garbage_version_distance, "100");
 
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 
+// Enable cleanup of orphan delvec entries during compaction.
+// Orphan delvecs are leaked metadata entries from a historical bug that reference
+// non-existent segments and prevent delvec file garbage collection.
+// Turn this on after upgrade to clean up existing orphans, then turn it off once done.
+CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
+
 // clear *.meta cache for lake table
 CONF_mBool(lake_clear_corrupted_cache_meta, "true");
 

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -529,8 +529,7 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
             }
         }
         if (orphan_cnt > 0) {
-            LOG(INFO) << fmt::format("Removed {} orphan delvec entries from tablet {}", orphan_cnt,
-                                     _tablet_meta->id());
+            LOG(INFO) << fmt::format("Removed {} orphan delvec entries from tablet {}", orphan_cnt, _tablet_meta->id());
         }
     }
 

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -600,6 +600,27 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         _cache_key_to_segment_id[delvec_cache_key(_tablet_meta->id(), each_delvec.second)] = each_delvec.first;
     }
 
+    // 2.5. Remove orphan delvec entries whose segment_id does not belong to any current rowset.
+    // Such orphans were created by a historical bug where _delvecs was not cleaned in
+    // apply_opcompaction, causing _finalize_delvec to re-insert entries for compacted segments.
+    // This step ensures existing orphans are cleaned up after upgrade.
+    {
+        std::unordered_set<uint32_t> valid_rssids;
+        for (const auto& rowset : _tablet_meta->rowsets()) {
+            collect_rowset_rssids(rowset, &valid_rssids);
+        }
+        auto* delvecs_map = _tablet_meta->mutable_delvec_meta()->mutable_delvecs();
+        for (auto it = delvecs_map->begin(); it != delvecs_map->end();) {
+            if (valid_rssids.count(it->first) == 0) {
+                VLOG(2) << "Remove orphan delvec entry, tablet_id: " << _tablet_meta->id()
+                        << ", segment_id: " << it->first << ", version: " << it->second.version();
+                it = delvecs_map->erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
     // 3. write to delvec file
     if (_buf.size() > 0) {
         TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec", &_buf);

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -511,9 +511,8 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
     // Clean up orphan delvec entries whose segment_id does not belong to any current rowset.
     // Such orphans were created by a historical bug where _delvecs was not cleaned in
     // apply_opcompaction, causing _finalize_delvec to re-insert entries for compacted segments.
-    // Doing this here (only during compaction) avoids per-publish overhead, and every tablet
-    // will eventually compact, so all historical orphans get cleaned up after upgrade.
-    {
+    // Gated by config: enable after upgrade to clean up existing orphans, disable once done.
+    if (config::lake_enable_orphan_delvec_cleanup_on_compaction) {
         std::unordered_set<uint32_t> valid_rssids;
         for (const auto& rowset : _tablet_meta->rowsets()) {
             collect_rowset_rssids(rowset, &valid_rssids);

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -428,6 +428,11 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
         _delvecs.erase(sid);
         _segmentid_to_delvec.erase(sid);
     }
+    // If all pending delvecs were for compacted segments, clear _buf to avoid
+    // writing an unnecessary delvec file during _finalize_delvec().
+    if (_delvecs.empty()) {
+        _buf.clear();
+    }
     // delete dcg by input rowsets
     auto dcgs = _tablet_meta->mutable_dcg_meta()->mutable_dcgs();
     using T_DCG = std::decay_t<decltype(*dcgs)>;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -420,6 +420,14 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
     using T_DELVEC = std::decay_t<decltype(*delvecs)>;
     int delvec_erase_cnt =
             delete_from_protobuf_map<T_DELVEC>(delvecs, delete_delvec_sids, [](const T_DELVEC& gc_map) {});
+    // Also clean up the builder's in-memory _delvecs buffer for compacted segments.
+    // Without this, _finalize_delvec() would re-insert these entries as "new" delvecs,
+    // creating orphan delvec entries that reference non-existent segments and prevent
+    // the corresponding delvec files from being garbage collected.
+    for (uint32_t sid : delete_delvec_sids) {
+        _delvecs.erase(sid);
+        _segmentid_to_delvec.erase(sid);
+    }
     // delete dcg by input rowsets
     auto dcgs = _tablet_meta->mutable_dcg_meta()->mutable_dcgs();
     using T_DCG = std::decay_t<decltype(*dcgs)>;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -508,6 +508,32 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
         }
     }
 
+    // Clean up orphan delvec entries whose segment_id does not belong to any current rowset.
+    // Such orphans were created by a historical bug where _delvecs was not cleaned in
+    // apply_opcompaction, causing _finalize_delvec to re-insert entries for compacted segments.
+    // Doing this here (only during compaction) avoids per-publish overhead, and every tablet
+    // will eventually compact, so all historical orphans get cleaned up after upgrade.
+    {
+        std::unordered_set<uint32_t> valid_rssids;
+        for (const auto& rowset : _tablet_meta->rowsets()) {
+            collect_rowset_rssids(rowset, &valid_rssids);
+        }
+        auto* remaining_delvecs = _tablet_meta->mutable_delvec_meta()->mutable_delvecs();
+        int orphan_cnt = 0;
+        for (auto it = remaining_delvecs->begin(); it != remaining_delvecs->end();) {
+            if (valid_rssids.count(it->first) == 0) {
+                it = remaining_delvecs->erase(it);
+                orphan_cnt++;
+            } else {
+                ++it;
+            }
+        }
+        if (orphan_cnt > 0) {
+            LOG(INFO) << fmt::format("Removed {} orphan delvec entries from tablet {}", orphan_cnt,
+                                     _tablet_meta->id());
+        }
+    }
+
     VLOG(2) << fmt::format(
             "MetaFileBuilder apply_opcompaction, id:{} input range:{} delvec del cnt:{} dcg del cnt:{} output:{}",
             _tablet_meta->id(), del_range_ss.str(), delvec_erase_cnt, dcg_erase_cnt,
@@ -603,27 +629,6 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         (*_tablet_meta->mutable_delvec_meta()->mutable_delvecs())[each_delvec.first] = each_delvec.second;
         // record from cache key to segment id, so we can fill up cache later
         _cache_key_to_segment_id[delvec_cache_key(_tablet_meta->id(), each_delvec.second)] = each_delvec.first;
-    }
-
-    // 2.5. Remove orphan delvec entries whose segment_id does not belong to any current rowset.
-    // Such orphans were created by a historical bug where _delvecs was not cleaned in
-    // apply_opcompaction, causing _finalize_delvec to re-insert entries for compacted segments.
-    // This step ensures existing orphans are cleaned up after upgrade.
-    {
-        std::unordered_set<uint32_t> valid_rssids;
-        for (const auto& rowset : _tablet_meta->rowsets()) {
-            collect_rowset_rssids(rowset, &valid_rssids);
-        }
-        auto* delvecs_map = _tablet_meta->mutable_delvec_meta()->mutable_delvecs();
-        for (auto it = delvecs_map->begin(); it != delvecs_map->end();) {
-            if (valid_rssids.count(it->first) == 0) {
-                VLOG(2) << "Remove orphan delvec entry, tablet_id: " << _tablet_meta->id()
-                        << ", segment_id: " << it->first << ", version: " << it->second.version();
-                it = delvecs_map->erase(it);
-            } else {
-                ++it;
-            }
-        }
     }
 
     // 3. write to delvec file

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1463,7 +1463,7 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
     file_meta.set_size(100);
     (*metadata->mutable_delvec_meta()->mutable_version_to_file())[5] = file_meta;
 
-    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size());  // 3 orphans + 1 valid
+    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size()); // 3 orphans + 1 valid
 
     // Compact rowset 300 — this triggers orphan cleanup in apply_opcompaction
     {
@@ -1491,8 +1491,7 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
 
         // The orphan version_to_file entry (version=5) should now be unreferenced and removed
         const auto& vtf = metadata->delvec_meta().version_to_file();
-        EXPECT_TRUE(vtf.find(5) == vtf.end())
-                << "version_to_file entry for orphan version 5 should be cleaned up";
+        EXPECT_TRUE(vtf.find(5) == vtf.end()) << "version_to_file entry for orphan version 5 should be cleaned up";
     }
 }
 

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1213,4 +1213,188 @@ TEST_F(MetaFileTest, test_remove_compacted_sst_no_reuse) {
     EXPECT_TRUE(orphan_names.count("b.sst") > 0);
 }
 
+// Test that append_delvec followed by apply_opcompaction in the same builder
+// does NOT create orphan delvec entries. This reproduces the bug where a write
+// txn generates a delvec for a segment that is then compacted away in the same
+// publish batch. Without the fix, _finalize_delvec would re-insert the deleted
+// delvec entry, creating an orphan that prevents delvec file GC.
+TEST_F(MetaFileTest, test_no_orphan_delvec_after_write_then_compaction) {
+    const int64_t tablet_id = 40001;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(100);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    // Create initial metadata on disk
+    {
+        MetaFileBuilder builder(*tablet, metadata);
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    // Add two rowsets: rowset 100 (segment "a.dat") and rowset 101 (segment "b.dat")
+    {
+        metadata->set_version(11);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("a.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+    {
+        metadata->set_version(12);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("b.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    // Now metadata has rowsets: id=100 (seg "a.dat"), id=101 (seg "b.dat")
+    ASSERT_EQ(2, metadata->rowsets_size());
+    ASSERT_EQ(100, metadata->rowsets(0).id());
+    ASSERT_EQ(101, metadata->rowsets(1).id());
+
+    // Simulate a publish batch where:
+    // 1) A write txn creates a delvec for segment 100 (belonging to rowset 100)
+    // 2) A compaction txn compacts rowset 100 away
+    // Both operations use the same MetaFileBuilder (batch publish).
+    {
+        metadata->set_version(13);
+        MetaFileBuilder builder(*tablet, metadata);
+
+        // Step 1: Write txn generates a delvec for segment 100
+        DelVector dv;
+        dv.set_empty();
+        std::shared_ptr<DelVector> ndv;
+        std::vector<uint32_t> dels = {1, 3, 5};
+        dv.add_dels_as_new_version(dels, 13, &ndv);
+        builder.append_delvec(ndv, 100);  // segment_id = 100, belongs to rowset 100
+
+        // Step 2: Compaction removes rowset 100
+        TxnLogPB_OpCompaction op_compaction;
+        op_compaction.add_input_rowsets(100);
+        RowsetMetadataPB output_rs;
+        output_rs.add_segments("compacted.dat");
+        op_compaction.mutable_output_rowset()->CopyFrom(output_rs);
+        ASSERT_OK(builder.apply_opcompaction(op_compaction, 100, 0));
+
+        // Step 3: Finalize - this is where the bug would manifest
+        ASSERT_OK(builder.finalize(next_id()));
+
+        // Verify: segment 100's delvec should NOT exist in metadata (it was compacted away)
+        const auto& delvecs_map = metadata->delvec_meta().delvecs();
+        EXPECT_TRUE(delvecs_map.find(100) == delvecs_map.end())
+                << "Orphan delvec entry found for compacted segment 100";
+
+        // Verify: rowset 100 should be gone, only rowset 101 and the new compaction output remain
+        EXPECT_EQ(2, metadata->rowsets_size());
+
+        // Verify: version_to_file should not hold unreferenced entries
+        for (const auto& [version, file_meta] : metadata->delvec_meta().version_to_file()) {
+            bool referenced = false;
+            for (const auto& [seg_id, page] : delvecs_map) {
+                if (page.version() == version) {
+                    referenced = true;
+                    break;
+                }
+            }
+            EXPECT_TRUE(referenced) << "version_to_file entry for version " << version
+                                    << " is not referenced by any delvec";
+        }
+    }
+}
+
+// Test the orphan delvec scenario with multiple segments in the compacted rowset.
+// The write txn creates delvecs for two segments of the input rowset, both should
+// be cleaned up when the rowset is compacted.
+TEST_F(MetaFileTest, test_no_orphan_delvec_multi_segment_compaction) {
+    const int64_t tablet_id = 40002;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(200);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    // Create initial metadata
+    {
+        MetaFileBuilder builder(*tablet, metadata);
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    // Add a rowset with 2 segments (rowset id=200, segments at rssid 200 and 201)
+    {
+        metadata->set_version(11);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("seg0.dat");
+        rs.add_segments("seg1.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    // Add a second rowset (rowset id=202)
+    {
+        metadata->set_version(12);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("other.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    ASSERT_EQ(2, metadata->rowsets_size());
+    ASSERT_EQ(200, metadata->rowsets(0).id());
+    ASSERT_EQ(202, metadata->rowsets(1).id());
+
+    // Simulate batch publish: write creates delvecs for both segments of rowset 200,
+    // then compaction removes rowset 200
+    {
+        metadata->set_version(13);
+        MetaFileBuilder builder(*tablet, metadata);
+
+        // Write creates delvecs for both segments
+        DelVector dv1;
+        dv1.set_empty();
+        std::shared_ptr<DelVector> ndv1;
+        std::vector<uint32_t> dels1 = {10, 20};
+        dv1.add_dels_as_new_version(dels1, 13, &ndv1);
+        builder.append_delvec(ndv1, 200);
+
+        DelVector dv2;
+        dv2.set_empty();
+        std::shared_ptr<DelVector> ndv2;
+        std::vector<uint32_t> dels2 = {30, 40};
+        dv2.add_dels_as_new_version(dels2, 13, &ndv2);
+        builder.append_delvec(ndv2, 201);
+
+        // Compaction removes rowset 200
+        TxnLogPB_OpCompaction op_compaction;
+        op_compaction.add_input_rowsets(200);
+        RowsetMetadataPB output_rs;
+        output_rs.add_segments("compacted.dat");
+        op_compaction.mutable_output_rowset()->CopyFrom(output_rs);
+        ASSERT_OK(builder.apply_opcompaction(op_compaction, 201, 0));
+
+        ASSERT_OK(builder.finalize(next_id()));
+
+        // Both delvec entries for compacted segments should be gone
+        const auto& delvecs_map = metadata->delvec_meta().delvecs();
+        EXPECT_TRUE(delvecs_map.find(200) == delvecs_map.end())
+                << "Orphan delvec for segment 200";
+        EXPECT_TRUE(delvecs_map.find(201) == delvecs_map.end())
+                << "Orphan delvec for segment 201";
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -20,9 +20,9 @@
 #include <set>
 
 #include "base/testutil/assert.h"
-#include "common/config.h"
 #include "base/testutil/id_generator.h"
 #include "base/uid_util.h"
+#include "common/config.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1274,7 +1274,7 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_after_write_then_compaction) {
         std::shared_ptr<DelVector> ndv;
         std::vector<uint32_t> dels = {1, 3, 5};
         dv.add_dels_as_new_version(dels, 13, &ndv);
-        builder.append_delvec(ndv, 100);  // segment_id = 100, belongs to rowset 100
+        builder.append_delvec(ndv, 100); // segment_id = 100, belongs to rowset 100
 
         // Step 2: Compaction removes rowset 100
         TxnLogPB_OpCompaction op_compaction;
@@ -1390,10 +1390,8 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_multi_segment_compaction) {
 
         // Both delvec entries for compacted segments should be gone
         const auto& delvecs_map = metadata->delvec_meta().delvecs();
-        EXPECT_TRUE(delvecs_map.find(200) == delvecs_map.end())
-                << "Orphan delvec for segment 200";
-        EXPECT_TRUE(delvecs_map.find(201) == delvecs_map.end())
-                << "Orphan delvec for segment 201";
+        EXPECT_TRUE(delvecs_map.find(200) == delvecs_map.end()) << "Orphan delvec for segment 200";
+        EXPECT_TRUE(delvecs_map.find(201) == delvecs_map.end()) << "Orphan delvec for segment 201";
     }
 }
 

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1395,4 +1395,86 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_multi_segment_compaction) {
     }
 }
 
+// Test that pre-existing orphan delvec entries in metadata are cleaned up
+// during finalize. This simulates the upgrade scenario where orphan entries
+// accumulated from the historical bug are present in the metadata.
+TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
+    const int64_t tablet_id = 40003;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(300);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    // Create initial metadata
+    {
+        MetaFileBuilder builder(*tablet, metadata);
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    // Add a rowset (id=300, segment rssid=300)
+    {
+        metadata->set_version(11);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("valid.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+
+    ASSERT_EQ(1, metadata->rowsets_size());
+    ASSERT_EQ(300, metadata->rowsets(0).id());
+
+    // Manually inject orphan delvec entries into metadata to simulate
+    // pre-existing orphans from the historical bug.
+    // Segment IDs 100, 200, 999 do not belong to any current rowset.
+    DelvecPagePB orphan_page;
+    orphan_page.set_version(5);
+    orphan_page.set_offset(0);
+    orphan_page.set_size(10);
+    (*metadata->mutable_delvec_meta()->mutable_delvecs())[100] = orphan_page;
+    (*metadata->mutable_delvec_meta()->mutable_delvecs())[200] = orphan_page;
+    (*metadata->mutable_delvec_meta()->mutable_delvecs())[999] = orphan_page;
+
+    // Also add a valid delvec for the existing segment 300
+    DelvecPagePB valid_page;
+    valid_page.set_version(11);
+    valid_page.set_offset(0);
+    valid_page.set_size(10);
+    (*metadata->mutable_delvec_meta()->mutable_delvecs())[300] = valid_page;
+
+    // Add version_to_file entries referenced by orphans
+    FileMetaPB file_meta;
+    file_meta.set_name("old_orphan.delvec");
+    file_meta.set_size(100);
+    (*metadata->mutable_delvec_meta()->mutable_version_to_file())[5] = file_meta;
+
+    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size());  // 3 orphans + 1 valid
+
+    // Now do a normal publish (no delvec changes) — the finalize should clean up orphans
+    {
+        metadata->set_version(12);
+        MetaFileBuilder builder(*tablet, metadata);
+        ASSERT_OK(builder.finalize(next_id()));
+
+        // Orphan entries should be removed
+        const auto& delvecs_map = metadata->delvec_meta().delvecs();
+        EXPECT_TRUE(delvecs_map.find(100) == delvecs_map.end()) << "Orphan segment 100 should be cleaned";
+        EXPECT_TRUE(delvecs_map.find(200) == delvecs_map.end()) << "Orphan segment 200 should be cleaned";
+        EXPECT_TRUE(delvecs_map.find(999) == delvecs_map.end()) << "Orphan segment 999 should be cleaned";
+
+        // Valid entry should remain
+        EXPECT_TRUE(delvecs_map.find(300) != delvecs_map.end()) << "Valid segment 300 should be kept";
+        EXPECT_EQ(1, delvecs_map.size());
+
+        // The orphan version_to_file entry (version=5) should now be unreferenced and removed
+        const auto& vtf = metadata->delvec_meta().version_to_file();
+        EXPECT_TRUE(vtf.find(5) == vtf.end())
+                << "version_to_file entry for orphan version 5 should be cleaned up";
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1296,15 +1296,15 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_after_write_then_compaction) {
         EXPECT_EQ(2, metadata->rowsets_size());
 
         // Verify: version_to_file should not hold unreferenced entries
-        for (const auto& [version, file_meta] : metadata->delvec_meta().version_to_file()) {
+        for (const auto& vtf_entry : metadata->delvec_meta().version_to_file()) {
             bool referenced = false;
-            for (const auto& [seg_id, page] : delvecs_map) {
-                if (page.version() == version) {
+            for (const auto& dv_entry : delvecs_map) {
+                if (dv_entry.second.version() == vtf_entry.first) {
                     referenced = true;
                     break;
                 }
             }
-            EXPECT_TRUE(referenced) << "version_to_file entry for version " << version
+            EXPECT_TRUE(referenced) << "version_to_file entry for version " << vtf_entry.first
                                     << " is not referenced by any delvec";
         }
     }
@@ -1384,7 +1384,7 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_multi_segment_compaction) {
         RowsetMetadataPB output_rs;
         output_rs.add_segments("compacted.dat");
         op_compaction.mutable_output_rowset()->CopyFrom(output_rs);
-        ASSERT_OK(builder.apply_opcompaction(op_compaction, 201, 0));
+        ASSERT_OK(builder.apply_opcompaction(op_compaction, 200, 0));
 
         ASSERT_OK(builder.finalize(next_id()));
 

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -20,6 +20,7 @@
 #include <set>
 
 #include "base/testutil/assert.h"
+#include "common/config.h"
 #include "base/testutil/id_generator.h"
 #include "base/uid_util.h"
 #include "fs/fs.h"
@@ -1465,6 +1466,9 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
 
     EXPECT_EQ(4, metadata->delvec_meta().delvecs().size()); // 3 orphans + 1 valid
 
+    // Enable orphan cleanup config for this test
+    config::lake_enable_orphan_delvec_cleanup_on_compaction = true;
+
     // Compact rowset 300 — this triggers orphan cleanup in apply_opcompaction
     {
         metadata->set_version(13);
@@ -1493,6 +1497,8 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
         const auto& vtf = metadata->delvec_meta().version_to_file();
         EXPECT_TRUE(vtf.find(5) == vtf.end()) << "version_to_file entry for orphan version 5 should be cleaned up";
     }
+
+    config::lake_enable_orphan_delvec_cleanup_on_compaction = false;
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1452,7 +1452,7 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
     file_meta.set_size(100);
     (*metadata->mutable_delvec_meta()->mutable_version_to_file())[5] = file_meta;
 
-    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size());  // 3 orphans + 1 valid
+    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size()); // 3 orphans + 1 valid
 
     // Now do a normal publish (no delvec changes) — the finalize should clean up orphans
     {
@@ -1472,8 +1472,7 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
 
         // The orphan version_to_file entry (version=5) should now be unreferenced and removed
         const auto& vtf = metadata->delvec_meta().version_to_file();
-        EXPECT_TRUE(vtf.find(5) == vtf.end())
-                << "version_to_file entry for orphan version 5 should be cleaned up";
+        EXPECT_TRUE(vtf.find(5) == vtf.end()) << "version_to_file entry for orphan version 5 should be cleaned up";
     }
 }
 

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1396,9 +1396,9 @@ TEST_F(MetaFileTest, test_no_orphan_delvec_multi_segment_compaction) {
 }
 
 // Test that pre-existing orphan delvec entries in metadata are cleaned up
-// during finalize. This simulates the upgrade scenario where orphan entries
+// during compaction. This simulates the upgrade scenario where orphan entries
 // accumulated from the historical bug are present in the metadata.
-TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
+TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
     const int64_t tablet_id = 40003;
     auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
     auto metadata = std::make_shared<TabletMetadata>();
@@ -1413,20 +1413,31 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
         ASSERT_OK(builder.finalize(next_id()));
     }
 
-    // Add a rowset (id=300, segment rssid=300)
+    // Add two rowsets: id=300 ("a.dat") and id=301 ("b.dat")
     {
         metadata->set_version(11);
         MetaFileBuilder builder(*tablet, metadata);
         RowsetMetadataPB rs;
-        rs.add_segments("valid.dat");
+        rs.add_segments("a.dat");
+        TxnLogPB_OpWrite op_write;
+        op_write.mutable_rowset()->CopyFrom(rs);
+        builder.apply_opwrite(op_write, {}, {});
+        ASSERT_OK(builder.finalize(next_id()));
+    }
+    {
+        metadata->set_version(12);
+        MetaFileBuilder builder(*tablet, metadata);
+        RowsetMetadataPB rs;
+        rs.add_segments("b.dat");
         TxnLogPB_OpWrite op_write;
         op_write.mutable_rowset()->CopyFrom(rs);
         builder.apply_opwrite(op_write, {}, {});
         ASSERT_OK(builder.finalize(next_id()));
     }
 
-    ASSERT_EQ(1, metadata->rowsets_size());
+    ASSERT_EQ(2, metadata->rowsets_size());
     ASSERT_EQ(300, metadata->rowsets(0).id());
+    ASSERT_EQ(301, metadata->rowsets(1).id());
 
     // Manually inject orphan delvec entries into metadata to simulate
     // pre-existing orphans from the historical bug.
@@ -1439,12 +1450,12 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
     (*metadata->mutable_delvec_meta()->mutable_delvecs())[200] = orphan_page;
     (*metadata->mutable_delvec_meta()->mutable_delvecs())[999] = orphan_page;
 
-    // Also add a valid delvec for the existing segment 300
+    // Also add a valid delvec for existing segment 301
     DelvecPagePB valid_page;
-    valid_page.set_version(11);
+    valid_page.set_version(12);
     valid_page.set_offset(0);
     valid_page.set_size(10);
-    (*metadata->mutable_delvec_meta()->mutable_delvecs())[300] = valid_page;
+    (*metadata->mutable_delvec_meta()->mutable_delvecs())[301] = valid_page;
 
     // Add version_to_file entries referenced by orphans
     FileMetaPB file_meta;
@@ -1452,27 +1463,36 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs) {
     file_meta.set_size(100);
     (*metadata->mutable_delvec_meta()->mutable_version_to_file())[5] = file_meta;
 
-    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size()); // 3 orphans + 1 valid
+    EXPECT_EQ(4, metadata->delvec_meta().delvecs().size());  // 3 orphans + 1 valid
 
-    // Now do a normal publish (no delvec changes) — the finalize should clean up orphans
+    // Compact rowset 300 — this triggers orphan cleanup in apply_opcompaction
     {
-        metadata->set_version(12);
+        metadata->set_version(13);
         MetaFileBuilder builder(*tablet, metadata);
+        TxnLogPB_OpCompaction op_compaction;
+        op_compaction.add_input_rowsets(300);
+        RowsetMetadataPB output_rs;
+        output_rs.add_segments("compacted.dat");
+        op_compaction.mutable_output_rowset()->CopyFrom(output_rs);
+        ASSERT_OK(builder.apply_opcompaction(op_compaction, 300, 0));
         ASSERT_OK(builder.finalize(next_id()));
 
-        // Orphan entries should be removed
+        // All orphan entries should be removed by the compaction cleanup
         const auto& delvecs_map = metadata->delvec_meta().delvecs();
         EXPECT_TRUE(delvecs_map.find(100) == delvecs_map.end()) << "Orphan segment 100 should be cleaned";
         EXPECT_TRUE(delvecs_map.find(200) == delvecs_map.end()) << "Orphan segment 200 should be cleaned";
         EXPECT_TRUE(delvecs_map.find(999) == delvecs_map.end()) << "Orphan segment 999 should be cleaned";
+        // Segment 300's delvec was also removed (rowset 300 was compacted, had no delvec anyway)
+        EXPECT_TRUE(delvecs_map.find(300) == delvecs_map.end());
 
-        // Valid entry should remain
-        EXPECT_TRUE(delvecs_map.find(300) != delvecs_map.end()) << "Valid segment 300 should be kept";
+        // Valid entry for segment 301 (non-compacted rowset) should remain
+        EXPECT_TRUE(delvecs_map.find(301) != delvecs_map.end()) << "Valid segment 301 should be kept";
         EXPECT_EQ(1, delvecs_map.size());
 
         // The orphan version_to_file entry (version=5) should now be unreferenced and removed
         const auto& vtf = metadata->delvec_meta().version_to_file();
-        EXPECT_TRUE(vtf.find(5) == vtf.end()) << "version_to_file entry for orphan version 5 should be cleaned up";
+        EXPECT_TRUE(vtf.find(5) == vtf.end())
+                << "version_to_file entry for orphan version 5 should be cleaned up";
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
When a write txn and a compaction txn are applied in the same publish batch, the write txn may generate delvecs for segments that the compaction txn then removes. The compaction's apply_opcompaction() correctly deletes delvec entries from the protobuf metadata, but fails to clean the builder's in-memory _delvecs buffer. During _finalize_delvec(), these leftover entries are re-inserted into the metadata as "new" entries, creating orphan delvec records that reference non-existent segments. These orphans prevent delvec files from being garbage collected, causing unbounded storage growth

## What I'm doing:
The fix synchronizes _delvecs and _segmentid_to_delvec cleanup with the protobuf metadata deletion in apply_opcompaction().

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
