### PR TITLE
[UT] Disable test_event_scheduler_with_grf in SQL tests

### DIFF
--- a/test/lib/skip.py
+++ b/test/lib/skip.py
@@ -67,5 +67,6 @@ skip_res_cmd = [
 
 skip_files = set([
     'test_window_skew_rewrite_with_mcv',
+    'test_event_schedule_with_grf',
     # 'test_parquet_dict_null_predicate'
 ])


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add test_event_schedule_with_grf to skip_files to disable this flaky event scheduler test case on branch-4.1.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

