### PR TITLE
[Refactor] move jdbc sql concatenation from be to fe

### DIFF
--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -53,7 +53,7 @@ static std::string get_jdbc_sql(const Slice jdbc_url, const std::string& table, 
     std::ostringstream oss;
     oss << "SELECT";
     if (limit != -1 && jdbc_url.starts_with("jdbc:sqlserver")) {
-        oss << fmt::format(" TOP({}) ", limit);
+        oss << fmt::format(" TOP({})", limit);
         limit = -1;
     }
     for (size_t i = 0; i < columns.size(); i++) {
@@ -76,6 +76,14 @@ static std::string get_jdbc_sql(const Slice jdbc_url, const std::string& table, 
         }
     }
     return oss.str();
+}
+
+std::string resolve_jdbc_scan_sql(const TJDBCScanNode& jdbc_scan_node, const Slice& jdbc_url, int64_t read_limit) {
+    if (jdbc_scan_node.__isset.sql) {
+        return jdbc_scan_node.sql;
+    }
+    return get_jdbc_sql(jdbc_url, jdbc_scan_node.table_name, jdbc_scan_node.columns, jdbc_scan_node.filters,
+                        read_limit);
 }
 
 JDBCDataSource::JDBCDataSource(const JDBCDataSourceProvider* provider, const TScanRange& scan_range)
@@ -151,8 +159,7 @@ Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     scan_ctx.jdbc_url = jdbc_table->jdbc_url();
     scan_ctx.user = jdbc_table->jdbc_user();
     scan_ctx.passwd = jdbc_table->jdbc_passwd();
-    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_scan_node.table_name, jdbc_scan_node.columns,
-                                jdbc_scan_node.filters, _read_limit);
+    scan_ctx.sql = resolve_jdbc_scan_sql(jdbc_scan_node, scan_ctx.jdbc_url, _read_limit);
     _scanner = _pool->add(new JDBCScanner(scan_ctx, _tuple_desc, _runtime_profile));
 
     RETURN_IF_ERROR(_scanner->open(state));

--- a/be/src/connector/jdbc_connector.h
+++ b/be/src/connector/jdbc_connector.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/string/slice.h"
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
 #include "exec/jdbc_scanner.h"
@@ -22,6 +23,9 @@ namespace starrocks {
 class JDBCScanner;
 
 namespace connector {
+
+// When FE sends `TJDBCScanNode.sql`, use it; otherwise build SQL on BE (legacy path).
+std::string resolve_jdbc_scan_sql(const TJDBCScanNode& jdbc_scan_node, const Slice& jdbc_url, int64_t read_limit);
 
 class JDBCConnector final : public Connector {
 public:

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXEC_FILES
         ./common/uri_test.cpp
         ./connector/benchmark_connector_test.cpp
         ./connector/hive_connector_test.cpp
+        ./connector/jdbc_connector_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp

--- a/be/test/connector/jdbc_connector_test.cpp
+++ b/be/test/connector/jdbc_connector_test.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/jdbc_connector.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks::connector {
+
+TEST(JdbcConnectorTest, resolve_jdbc_scan_sql_prefers_fe_sql) {
+    TJDBCScanNode node;
+    node.__set_sql("SELECT c1, c2 FROM t1 WHERE c1 = 1 LIMIT 1");
+    Slice url("jdbc:mysql://localhost:3306");
+    EXPECT_EQ(resolve_jdbc_scan_sql(node, url, 99), "SELECT c1, c2 FROM t1 WHERE c1 = 1 LIMIT 1");
+}
+
+TEST(JdbcConnectorTest, resolve_jdbc_scan_sql_fallback_mysql_limit) {
+    TJDBCScanNode node;
+    node.__set_table_name("t");
+    node.__set_columns(std::vector<std::string>{"c1"});
+    Slice url("jdbc:mysql://localhost:3306");
+    EXPECT_EQ(resolve_jdbc_scan_sql(node, url, 5), "SELECT c1 FROM t LIMIT 5");
+}
+
+TEST(JdbcConnectorTest, resolve_jdbc_scan_sql_fallback_sqlserver_top) {
+    TJDBCScanNode node;
+    node.__set_table_name("t");
+    node.__set_columns(std::vector<std::string>{"c1"});
+    Slice url("jdbc:sqlserver://localhost:1433;");
+    EXPECT_EQ(resolve_jdbc_scan_sql(node, url, 10), "SELECT TOP(10) c1 FROM t");
+}
+
+TEST(JdbcConnectorTest, resolve_jdbc_scan_sql_fallback_oracle_rownum) {
+    TJDBCScanNode node;
+    node.__set_table_name("t");
+    node.__set_columns(std::vector<std::string>{"c1"});
+    Slice url("jdbc:oracle:thin:@localhost:1521:orcl");
+    EXPECT_EQ(resolve_jdbc_scan_sql(node, url, 3), "SELECT * FROM (SELECT c1 FROM t) WHERE ROWNUM <= 3");
+}
+
+} // namespace starrocks::connector

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -107,8 +107,16 @@ public class JDBCScanNode extends ScanNode {
         return output.toString();
     }
 
-    private String getJDBCQueryStr() {
+    private String buildJDBCQuerySQL(long queryLimit) {
+        String jdbcUri = getJdbcUri();
         StringBuilder sql = new StringBuilder("SELECT ");
+
+        // SQL Server uses TOP(N) instead of LIMIT
+        if (queryLimit != -1 && jdbcUri != null && jdbcUri.startsWith("jdbc:sqlserver")) {
+            sql.append("TOP(").append(queryLimit).append(") ");
+            queryLimit = -1;
+        }
+
         sql.append(Joiner.on(", ").join(columns));
         sql.append(" FROM ").append(tableName);
 
@@ -117,7 +125,20 @@ public class JDBCScanNode extends ScanNode {
             sql.append(Joiner.on(") AND (").join(filters));
             sql.append(")");
         }
+
+        if (queryLimit != -1) {
+            if (jdbcUri != null && jdbcUri.startsWith("jdbc:oracle")) {
+                // Oracle doesn't support LIMIT clause, use ROWNUM in a subquery
+                return "SELECT * FROM (" + sql + ") WHERE ROWNUM <= " + queryLimit;
+            } else {
+                sql.append(" LIMIT ").append(queryLimit);
+            }
+        }
         return sql.toString();
+    }
+
+    private String getJDBCQueryStr() {
+        return buildJDBCQuerySQL(-1);
     }
 
     private void createJDBCTableColumns() {
@@ -204,6 +225,7 @@ public class JDBCScanNode extends ScanNode {
         msg.jdbc_scan_node.setColumns(columns);
         msg.jdbc_scan_node.setFilters(filters);
         msg.jdbc_scan_node.setLimit(limit);
+        msg.jdbc_scan_node.setSql(buildJDBCQuerySQL(limit));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/planner/JdbcScanNodeSqlConcatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/JdbcScanNodeSqlConcatTest.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.planner;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.VarcharType;
+import com.starrocks.thrift.TJDBCScanNode;
+import com.starrocks.thrift.TPlanNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Verify {@link JDBCScanNode#toThrift} sets {@code TJDBCScanNode.sql} with correct dialect-specific
+ * limit handling (SQL Server TOP, Oracle ROWNUM subquery, generic LIMIT).
+ */
+public class JdbcScanNodeSqlConcatTest {
+
+    private JDBCScanNode createAndPrepareScanNode(String jdbcUri, long limit) throws DdlException {
+        JDBCTable table = createJdbcTable(jdbcUri);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(table);
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, table);
+
+        // Add a simple conjunct so the generated sql includes WHERE clause.
+        SlotRef slotRef = new SlotRef(
+                "col",
+                new SlotDescriptor(new SlotId(1), "col", VarcharType.VARCHAR, true));
+        Expr predicate = new BinaryPredicate(BinaryType.EQ, slotRef, StringLiteral.create("ABC"));
+        scanNode.getConjuncts().add(predicate);
+        scanNode.computeColumnsAndFilters();
+        scanNode.setLimit(limit);
+
+        return scanNode;
+    }
+
+    private JDBCTable createJdbcTable(String jdbcUri) throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        // JDBCScanNode's getJdbcUri() reads JDBCResource.URI from table connect info.
+        properties.put("jdbc_uri", jdbcUri);
+        // Unused by sql generation, but required by some table constructors.
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "driver_class");
+
+        return new JDBCTable(
+                1,
+                "jdbc_table",
+                Collections.singletonList(new Column("col", VarcharType.VARCHAR)),
+                properties);
+    }
+
+    @Test
+    public void testSqlServerTopWithLimit() throws Exception {
+        JDBCScanNode scanNode = createAndPrepareScanNode(
+                "jdbc:sqlserver://localhost:1433;databaseName=testdb", 5);
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        TJDBCScanNode jdbcScanNode = planNode.jdbc_scan_node;
+
+        String sql = jdbcScanNode.getSql();
+        Assertions.assertNotNull(sql);
+        Assertions.assertFalse(sql.contains(" LIMIT "));
+        Assertions.assertFalse(sql.contains("ROWNUM"));
+
+        // Must have whitespace between TOP(...) and select list.
+        Assertions.assertTrue(sql.matches("(?s).*SELECT\\s+TOP\\(5\\)\\s+.*FROM\\s+jdbc_table.*"));
+        Assertions.assertTrue(sql.contains("WHERE"));
+        Assertions.assertTrue(sql.contains("col = 'ABC'"));
+    }
+
+    @Test
+    public void testOracleRowNumWithLimit() throws Exception {
+        JDBCScanNode scanNode = createAndPrepareScanNode(
+                "jdbc:oracle:thin:@localhost:1521:orcl", 7);
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        TJDBCScanNode jdbcScanNode = planNode.jdbc_scan_node;
+
+        String sql = jdbcScanNode.getSql();
+        Assertions.assertNotNull(sql);
+        Assertions.assertFalse(sql.contains(" LIMIT "));
+
+        Assertions.assertTrue(sql.contains("SELECT * FROM ("));
+        Assertions.assertTrue(sql.contains(") WHERE ROWNUM <= 7"));
+        Assertions.assertTrue(sql.contains("col = 'ABC'"));
+    }
+
+    @Test
+    public void testGenericJdbcLimit() throws Exception {
+        JDBCScanNode scanNode = createAndPrepareScanNode(
+                "jdbc:mysql://localhost:3306", 3);
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        TJDBCScanNode jdbcScanNode = planNode.jdbc_scan_node;
+
+        String sql = jdbcScanNode.getSql();
+        Assertions.assertNotNull(sql);
+        Assertions.assertTrue(sql.contains(" LIMIT 3"));
+        Assertions.assertFalse(sql.contains("TOP("));
+        Assertions.assertFalse(sql.contains("ROWNUM"));
+        Assertions.assertTrue(sql.contains("`jdbc_table`"));
+        Assertions.assertTrue(sql.contains("`col` = 'ABC'"));
+    }
+
+    @Test
+    public void testPostgreSqlLimitWithDoubleQuotedIdentifiers() throws Exception {
+        JDBCScanNode scanNode = createAndPrepareScanNode(
+                "jdbc:postgresql://localhost:5432/db", 4);
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        String sql = planNode.jdbc_scan_node.getSql();
+
+        Assertions.assertNotNull(sql);
+        Assertions.assertTrue(sql.contains(" LIMIT 4"));
+        Assertions.assertFalse(sql.contains("TOP("));
+        Assertions.assertFalse(sql.contains("ROWNUM"));
+        Assertions.assertTrue(sql.contains("\"jdbc_table\""));
+        Assertions.assertTrue(sql.contains("\"col\" = 'ABC'"));
+    }
+
+    @Test
+    public void testWithoutLimitOmitsLimitTopAndRownum() throws Exception {
+        JDBCTable table = createJdbcTable("jdbc:mysql://localhost:3306");
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(table);
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, table);
+        SlotRef slotRef = new SlotRef(
+                "col",
+                new SlotDescriptor(new SlotId(1), "col", VarcharType.VARCHAR, true));
+        Expr predicate = new BinaryPredicate(BinaryType.EQ, slotRef, StringLiteral.create("ABC"));
+        scanNode.getConjuncts().add(predicate);
+        scanNode.computeColumnsAndFilters();
+
+        TPlanNode planNode = new TPlanNode();
+        scanNode.toThrift(planNode);
+        String sql = planNode.jdbc_scan_node.getSql();
+
+        Assertions.assertNotNull(sql);
+        Assertions.assertFalse(sql.contains(" LIMIT "));
+        Assertions.assertFalse(sql.contains("TOP("));
+        Assertions.assertFalse(sql.contains("ROWNUM"));
+        Assertions.assertTrue(sql.contains("`jdbc_table`"));
+        Assertions.assertTrue(sql.contains("`col` = 'ABC'"));
+    }
+}
+

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -674,6 +674,7 @@ struct TJDBCScanNode {
   3: optional list<string> columns
   4: optional list<string> filters
   5: optional i64 limit
+  6: optional string sql
 }
 
 // If you find yourself changing this struct, see also TOlapScanNode


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
