### PR TITLE
[Performance] Reduce lake_pk_compaction_max_input_rowsets from 500 to 200

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1326,7 +1326,7 @@ CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");
 CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -155,7 +155,7 @@ CONF_mInt64(lake_compaction_max_rowset_size, "4294967296");
 
 CONF_mBool(lake_enable_compaction_async_write, "false");
 
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 


### PR DESCRIPTION
## Why I'm doing:

The default value of `lake_pk_compaction_max_input_rowsets=500` causes excessive delvec remote IO during compaction publish in shared-data mode, leading to high write P99 latency.

## What I'm doing:

Reduce the default value from 500 to 200.

## Bottleneck Analysis

**Benchmark setup:** realtime-benchmark on shared-data cluster (1 FE 8c32g + 3 CN 16c64g), commit `87707ea` (main branch).

**Baseline metrics (steady state):**
| Metric | Value | Target |
|--------|-------|--------|
| Write P50 | 2713ms | < 1000ms |
| Write P99 | 8438ms | < 5000ms |
| Write throughput | ~26K rows/sec | > 100K rows/sec |

**Root cause:** During compaction publish, the `LakePrimaryKeyCompactionConflictResolver` loads delvecs for each unique segment from remote storage (S3/OSS). With 500 input rowsets, this causes 3-10 seconds of remote IO:

| input_rowsets_size | compaction_delvec_loader_latency | Total publish cost |
|-------------------|----------------------------------|-------------------|
| 500 | 4.8s - 9.6s | 4.0s - 6.0s |
| 64-84 | 54ms - 182ms | < 500ms |

**Code path:** `primary_key_compaction_conflict_resolver.cpp:86-88` → `lake_delvec_loader.cpp:43-58` performs sequential remote IO for each unique rssid.

## Expected Impact

- Write P99 should decrease by ~40-60% (capping worst-case publish time)
- Compaction runs more frequently with smaller batches — same throughput, lower latency
- No regression expected for read performance

## What type of PR is this:

- [x] Performance Improvement
- [ ] Bug Fix
- [ ] Feature
- [ ] Code Clean Up