### PR TITLE
[BugFix] Fix PK tablet rowset meta loss caused by GC race during disk re-migration (A→B→A) (backport #70727)

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -42,7 +42,6 @@
 #include <memory>
 
 #include "common/config.h"
-#include "testutil/sync_point.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
@@ -63,6 +62,7 @@
 #include "storage/txn_manager.h"
 #include "storage/update_manager.h"
 #include "storage/utils.h"
+#include "testutil/sync_point.h"
 #include "util/path_util.h"
 #include "util/starrocks_metrics.h"
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -42,6 +42,7 @@
 #include <memory>
 
 #include "common/config.h"
+#include "testutil/sync_point.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
@@ -1175,6 +1176,8 @@ Status TabletManager::start_trash_sweep() {
         sweep_shutdown_tablet(info, finished_tablets_redundant);
     }
 
+    TEST_SYNC_POINT("TabletManager::start_trash_sweep:1");
+
     if (!finished_tablets.empty() || !finished_tablets_redundant.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
         for (const auto& tablet_info_finished : finished_tablets) {
@@ -1895,10 +1898,28 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
     auto iter = _shutdown_tablets.find(tablet_id);
     if (iter != _shutdown_tablets.end()) {
         if ((iter->second).tablet != nullptr) {
-            // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
-            auto st = _remove_tablet_meta((iter->second).tablet);
-            if (!st.ok()) {
-                LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+            // Re-check the on-disk meta before destructive cleanup. During rapid re-migration
+            // a stale shutdown entry may still exist after ownership has already moved to a
+            // newer tablet instance on the same path. For PK tablets, _remove_tablet_meta()
+            // can clear rowset meta by tablet_id, so running it from the stale entry would
+            // wipe the new tablet's metadata. When uid/state no longer matches, leave this
+            // entry to the normal shutdown queues instead of eagerly clearing meta here.
+            auto& tablet = (iter->second).tablet;
+            TabletMeta tablet_meta;
+            Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(),
+                                                           tablet->schema_hash(), &tablet_meta);
+            if (st.ok() &&
+                (tablet_meta.tablet_uid() != tablet->tablet_uid() || tablet_meta.tablet_state() != TABLET_SHUTDOWN)) {
+                LOG(INFO) << "Skip removing stale shutdown tablet meta due to "
+                          << (tablet_meta.tablet_uid() != tablet->tablet_uid() ? "uid mismatch" : "state mismatch")
+                          << ". tablet_id=" << tablet->tablet_id() << ", path=" << tablet->data_dir()->path()
+                          << ", state=" << tablet_meta.tablet_state();
+            } else {
+                // just try to remove the tablet meta. if failed, it will be removed in sweep_shutdown_tablet
+                st = _remove_tablet_meta(tablet);
+                if (!st.ok()) {
+                    LOG(WARNING) << "Fail to remove previous tablet meta, id: " << tablet_id << " status: " << st;
+                }
             }
         }
         auto drop_info_redundant = iter->second;

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -18,6 +18,8 @@
 
 #include "butil/file_util.h"
 #include "common/config.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
 #include "exec/pipeline/query_context.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
@@ -35,6 +37,7 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_meta_manager.h"
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
 #include "util/cpu_info.h"
@@ -608,6 +611,116 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
     tablet.reset();
     EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path, false);
     ASSERT_OK(migration_task.execute());
+}
+
+// Verifies that rapid PK tablet re-migration (disk A->B->A) preserves the
+// new tablet's rowset metadata when GC and migration race concurrently.
+//
+// Test flow:
+//   1. Create PK tablet with rowset on disk_a, migrate A->B.
+//   2. GC sweep phase 1 clears V1's meta from disk_a; a sync point callback
+//      runs migration B->A before phase 2 removes the stale queue entry.
+//   3. Verify V3's rowset metadata on disk_a is intact.
+TEST_F(EngineStorageMigrationTaskTest, test_pk_migration_gc_race_preserves_new_tablet_meta) {
+    // Migration's assign_new_rowset_id sets creation_time = UnixSeconds().
+    // _add_tablet_unlocked requires new_time > old_time for same-version replacement.
+    // Poll at 10ms until UnixSeconds() passes the reference time (max 30s).
+    auto wait_until_after = [](int64_t ref_time) {
+        for (int i = 0; i < 3000 && UnixSeconds() <= ref_time; i++) {
+            usleep(10000);
+        }
+        CHECK_GT(UnixSeconds(), ref_time);
+    };
+
+    int64_t tablet_id = 77777;
+    int32_t schema_hash = 7777;
+    TabletManager* tablet_manager = StorageEngine::instance()->tablet_manager();
+
+    ASSERT_OK(tablet_manager->start_trash_sweep());
+
+    // Step 1: Create PK tablet with one committed rowset.
+    TabletSharedPtr tablet = create_pk_tablet(tablet_id, schema_hash);
+    tablet->set_enable_persistent_index(false);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_OK(tablet->set_tablet_state(TABLET_RUNNING));
+    tablet->save_meta();
+
+    std::vector<int64_t> keys = {1, 2, 3, 4, 5};
+    auto rowset = create_pk_rowset(tablet, keys);
+    int64_t rowset_time = rowset->creation_time();
+    ASSERT_OK(tablet->rowset_commit(2, rowset));
+
+    DataDir* disk_a = tablet->data_dir();
+    DataDir* disk_b = nullptr;
+    for (auto* store : StorageEngine::instance()->get_stores()) {
+        if (store != disk_a) {
+            disk_b = store;
+            break;
+        }
+    }
+    ASSERT_TRUE(disk_b != nullptr);
+    tablet.reset();
+
+    // Step 2: Migrate A->B. Wait until clock passes rowset_time so migration1 wins.
+    wait_until_after(rowset_time);
+    ASSERT_OK(EngineStorageMigrationTask(tablet_id, schema_hash, disk_b, false).execute());
+
+    tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_EQ(tablet->data_dir(), disk_b);
+    int64_t v2_time = tablet->updates()->max_rowset_creation_time();
+    tablet.reset();
+
+    // Step 3: GC runs synchronously. A sync point callback injects migration B->A
+    // between phase 1 (sweep) and phase 2 (cleanup), reproducing the real race
+    // window where a stale V1 entry is still in _shutdown_tablets.
+    Status migration2_status;
+    SyncPoint::GetInstance()->SetCallBack("TabletManager::start_trash_sweep:1", [&](void*) {
+        wait_until_after(v2_time);
+        EngineStorageMigrationTask migration2(tablet_id, schema_hash, disk_a, false);
+        migration2_status = migration2.execute();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer_sync([&]() {
+        SyncPoint::GetInstance()->DisableProcessing();
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->ClearTrace();
+    });
+
+    ASSERT_OK(tablet_manager->start_trash_sweep());
+    ASSERT_OK(migration2_status);
+
+    // Step 4: Verify V3 on disk_a has its rowset metadata intact.
+    tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(tablet != nullptr);
+    ASSERT_EQ(tablet->data_dir(), disk_a);
+
+    int rowset_count = 0;
+    ASSERT_OK(TabletMetaManager::rowset_iterate(disk_a, tablet_id, [&](const RowsetMetaSharedPtr&) -> bool {
+        rowset_count++;
+        return true;
+    }));
+    ASSERT_GT(rowset_count, 0);
+
+    // Step 5: Verify restart-loading works — proves on-disk meta is complete.
+    tablet.reset();
+    ASSERT_OK(tablet_manager->drop_tablet(tablet_id, kKeepMetaAndFiles));
+
+    TabletMeta reloaded_meta;
+    ASSERT_OK(TabletMetaManager::get_tablet_meta(disk_a, tablet_id, schema_hash, &reloaded_meta));
+
+    std::string meta_binary;
+    ASSERT_OK(reloaded_meta.serialize(&meta_binary));
+    ASSERT_OK(tablet_manager->load_tablet_from_meta(disk_a, tablet_id, schema_hash, meta_binary, false, false, false,
+                                                    false));
+
+    TabletSharedPtr reloaded = tablet_manager->get_tablet(tablet_id);
+    ASSERT_TRUE(reloaded != nullptr);
+    ASSERT_EQ(reloaded->data_dir(), disk_a);
+    ASSERT_EQ(2, reloaded->updates()->max_version());
+
+    reloaded.reset();
+    ASSERT_OK(tablet_manager->start_trash_sweep());
 }
 
 } // namespace starrocks

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -18,8 +18,6 @@
 
 #include "butil/file_util.h"
 #include "common/config.h"
-#include "testutil/sync_point.h"
-#include "util/defer_op.h"
 #include "exec/pipeline/query_context.h"
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
@@ -40,7 +38,9 @@
 #include "storage/tablet_meta_manager.h"
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
+#include "testutil/sync_point.h"
 #include "util/cpu_info.h"
+#include "util/defer_op.h"
 #include "util/disk_info.h"
 #include "util/logging.h"
 #include "util/mem_info.h"


### PR DESCRIPTION
## Why I'm doing:
Backport #70727 to branch-4.1.

During rapid PK tablet re-migration (disk A→B→A), a race between GC sweep and the second migration can cause the stale shutdown entry's `_remove_tablet_meta()` to wipe the new tablet's rowset metadata. This leads to data loss on restart.

## What I'm doing:
Cherry-pick of commit 68d879914cd from main to branch-4.1, with include path adaptations for branch-4.1's header structure:
- `base/testutil/sync_point.h` → `testutil/sync_point.h`
- `base/utility/defer_op.h` → `util/defer_op.h`
- Keep `common/config.h` (not split on branch-4.1)
- Keep `butil/file_util.h` (not moved on branch-4.1)

The fix adds a uid/state check in `_add_shutdown_tablet_unlocked()` before clearing meta, plus a regression test reproducing the race via SyncPoint injection.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
