### PR TITLE
[BugFix] Remove query progress HTTP loopback from current_queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/QueryProgressUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/QueryProgressUtils.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.starrocks.sql.ExplainAnalyzer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public final class QueryProgressUtils {
+    private static final Logger LOG = LogManager.getLogger(QueryProgressUtils.class);
+
+    private QueryProgressUtils() {
+    }
+
+    public static String getProgressPercent(String queryId) {
+        ProfileManager.ProfileElement profileElement = ProfileManager.getInstance().getProfileElement(queryId);
+        if (profileElement == null) {
+            return "";
+        }
+
+        String queryProgress = getQueryProgress(queryId, profileElement);
+        if (queryProgress == null || queryProgress.isEmpty() || queryProgress.charAt(0) != '{') {
+            return "";
+        }
+
+        try {
+            JsonObject jsonObject = JsonParser.parseString(queryProgress).getAsJsonObject();
+            JsonObject progressInfo = jsonObject.getAsJsonObject("progress_info");
+            if (progressInfo == null || !progressInfo.has("progress_percent")) {
+                return "";
+            }
+            return progressInfo.get("progress_percent").getAsString();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            LOG.warn("failed to parse query progress, query_id: {}, msg: {}", queryId, queryProgress);
+            return "";
+        }
+    }
+
+    public static String getQueryProgress(String queryId) {
+        ProfileManager.ProfileElement profileElement = ProfileManager.getInstance().getProfileElement(queryId);
+        if (profileElement == null) {
+            return "query id " + queryId + " not found.";
+        }
+        return getQueryProgress(queryId, profileElement);
+    }
+
+    public static String getQueryProgress(String queryId, ProfileManager.ProfileElement profileElement) {
+        if (profileElement.plan == null &&
+                profileElement.infoStrings.get(ProfileManager.QUERY_TYPE) != null &&
+                !profileElement.infoStrings.get(ProfileManager.QUERY_TYPE).equals("Load")) {
+            return "short circuit point query doesn't suppot get query progress, "
+                    + "you can set it off by using set enable_short_circuit=false";
+        }
+
+        try {
+            return ExplainAnalyzer.analyze(profileElement.plan, profileElement.getRuntimeProfile());
+        } catch (Exception e) {
+            String result = "Failed to get query progress, query_id:" + queryId;
+            LOG.warn(result, e);
+            return result;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryProgressAction.java
@@ -35,23 +35,19 @@
 package com.starrocks.http.rest;
 
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.QueryProgressUtils;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
-import com.starrocks.sql.ExplainAnalyzer;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 // This class is a RESTFUL interface to get query progress.
 // It will be used in query monitor.
 // Usage:
 //   http://fe_host:fe_http_port/api/query/progress?query_id=123456
 public class QueryProgressAction extends RestBaseAction {
-
-    private static final Logger LOG = LogManager.getLogger(QueryProgressAction.class);
 
     public QueryProgressAction(ActionController controller) {
         super(controller);
@@ -72,23 +68,7 @@ public class QueryProgressAction extends RestBaseAction {
 
         ProfileManager.ProfileElement profileElement = ProfileManager.getInstance().getProfileElement(queryId);
         if (profileElement != null) {
-            String result = "";
-            //For short circuit query, 'ProfileElement#plan' is null
-            if (profileElement.plan == null &&
-                    profileElement.infoStrings.get(ProfileManager.QUERY_TYPE) != null &&
-                    !profileElement.infoStrings.get(ProfileManager.QUERY_TYPE).equals("Load")) {
-                result = "short circuit point query doesn't suppot get query progress, " +
-                        "you can set it off by using set enable_short_circuit=false";
-            } else {
-                try {
-                    result = ExplainAnalyzer.analyze(profileElement.plan,
-                            profileElement.getRuntimeProfile());
-                } catch (Exception e) {
-                    result = "Failed to get query progress, query_id:" + queryId;
-                    LOG.warn(result, e);
-                }
-            }
-            response.getContent().append(result);
+            response.getContent().append(QueryProgressUtils.getQueryProgress(queryId, profileElement));
             sendResult(request, response);
         } else {
             response.getContent().append("query id " + queryId + " not found.");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -35,26 +35,14 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.proc.CurrentQueryInfoProvider;
+import com.starrocks.common.util.QueryProgressUtils;
 import com.starrocks.common.util.QueryStatisticsFormatter;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.thrift.TQueryStatisticsInfo;
-import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +50,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class QueryStatisticsInfo {
-    private static final Logger LOG = LogManager.getLogger(QueryStatisticsInfo.class);
-
     private long queryStartTime;
     private String feIp;
     private String queryId;
@@ -384,7 +370,6 @@ public class QueryStatisticsInfo {
                 statistic.values().stream()
                         .sorted(Comparator.comparingLong(QueryStatisticsItem::getQueryStartTime))
                         .collect(Collectors.toList());
-        final HttpClient httpClient = HttpClient.newHttpClient();
         for (QueryStatisticsItem item : sorted) {
             final CurrentQueryInfoProvider.QueryStatistics statistics = statisticsMap.get(item.getQueryId());
 
@@ -396,8 +381,7 @@ public class QueryStatisticsInfo {
                     .withDb(item.getDb())
                     .withUser(item.getUser())
                     .withExecTime(item.getQueryExecTime())
-                    .withExecProgress(getExecProgress(FrontendOptions.getLocalHostAddress(), 
-                                                      item.getQueryId(), httpClient))
+                    .withExecProgress(getExecProgress(item.getQueryId()))
                     .withExecState(item.getExecState())
                     .withWareHouseName(item.getWarehouseName())
                     .withCustomQueryId(item.getCustomQueryId())
@@ -415,34 +399,7 @@ public class QueryStatisticsInfo {
         return sortedRowData;
     }
 
-    public static String getExecProgress(String feIp, String queryId, HttpClient httpClient) {
-        String result = "";
-        try {
-            String url = String.format("http://%s:%s/api/query/progress?query_id=%s",
-                    feIp, Config.http_port, queryId);
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .GET()
-                    .build();
-
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() == HttpStatus.SC_OK) {
-                try {
-                    JsonElement jsonElement = JsonParser.parseString(response.body());
-                    JsonObject jsonObject = jsonElement.getAsJsonObject();
-                    JsonObject progressInfo = jsonObject.getAsJsonObject("progress_info");
-                    result = progressInfo.get("progress_percent").getAsString();
-                } catch (JsonSyntaxException e) {
-                    LOG.warn("failed to get query progress, query_id: {}, msg: {}", queryId, response.body());
-                }
-            } else {
-                LOG.warn("failed to get query progress, query_id: {}, status code: {}, msg: {}",
-                        queryId, response.statusCode(), response.body());
-            }
-        } catch (IOException | InterruptedException e) {
-            LOG.warn("failed to get query progress, query_id: {}, msg: {}", queryId, e);
-        } finally {
-            return result;
-        }
+    public static String getExecProgress(String queryId) {
+        return QueryProgressUtils.getProgressPercent(queryId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/QueryProgressUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/QueryProgressUtilsTest.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.gson.JsonObject;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.sql.ExplainAnalyzer;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class QueryProgressUtilsTest {
+    private static final String QUERY_ID = "123";
+
+    @Test
+    public void testGetQueryProgressAndPercent() throws Exception {
+        ProfileManager manager = ProfileManager.getInstance();
+        manager.clearProfiles();
+
+        try {
+            new MockUp<ExplainAnalyzer>() {
+                @Mock
+                public String getQueryProgress() throws StarRocksException {
+                    JsonObject progressInfo = new JsonObject();
+                    progressInfo.addProperty("total_operator_num", 5);
+                    progressInfo.addProperty("finished_operator_num", 3);
+                    progressInfo.addProperty("progress_percent", "60.00%");
+
+                    JsonObject result = new JsonObject();
+                    result.addProperty("query_id", QUERY_ID);
+                    result.addProperty("state", "Running");
+                    result.add("progress_info", progressInfo);
+                    return result.toString();
+                }
+            };
+
+            manager.pushProfile(new ProfilingExecPlan(), createProfile(QUERY_ID, "Query", "Running"));
+            String queryProgress = QueryProgressUtils.getQueryProgress(QUERY_ID);
+
+            Assertions.assertTrue(queryProgress.contains("\"progress_percent\":\"60.00%\""));
+            Assertions.assertEquals("60.00%", QueryProgressUtils.getProgressPercent(QUERY_ID));
+        } finally {
+            manager.clearProfiles();
+        }
+    }
+
+    @Test
+    public void testGetQueryProgressNotFound() {
+        ProfileManager manager = ProfileManager.getInstance();
+        manager.clearProfiles();
+
+        Assertions.assertEquals("query id 123 not found.", QueryProgressUtils.getQueryProgress(QUERY_ID));
+        Assertions.assertEquals("", QueryProgressUtils.getProgressPercent(QUERY_ID));
+    }
+
+    @Test
+    public void testGetQueryProgressShortCircuit() {
+        ProfileManager manager = ProfileManager.getInstance();
+        manager.clearProfiles();
+
+        try {
+            manager.pushProfile(null, createProfile(QUERY_ID, "Query", "Running"));
+            Assertions.assertEquals("short circuit point query doesn't suppot get query progress, "
+                            + "you can set it off by using set enable_short_circuit=false",
+                    QueryProgressUtils.getQueryProgress(QUERY_ID));
+            Assertions.assertEquals("", QueryProgressUtils.getProgressPercent(QUERY_ID));
+        } finally {
+            manager.clearProfiles();
+        }
+    }
+
+    @Test
+    public void testGetProgressPercentHandlesInvalidPayloadAndAnalysisFailure() throws Exception {
+        ProfileManager manager = ProfileManager.getInstance();
+        manager.clearProfiles();
+
+        try {
+            manager.pushProfile(new ProfilingExecPlan(), createProfile(QUERY_ID, "Query", "Running"));
+
+            new MockUp<ExplainAnalyzer>() {
+                @Mock
+                public String getQueryProgress() throws StarRocksException {
+                    return "not-json";
+                }
+            };
+            Assertions.assertEquals("", QueryProgressUtils.getProgressPercent(QUERY_ID));
+
+            new MockUp<ExplainAnalyzer>() {
+                @Mock
+                public String getQueryProgress() throws StarRocksException {
+                    throw new StarRocksException("mock failure");
+                }
+            };
+            Assertions.assertEquals("Failed to get query progress, query_id:123",
+                    QueryProgressUtils.getQueryProgress(QUERY_ID));
+            Assertions.assertEquals("", QueryProgressUtils.getProgressPercent(QUERY_ID));
+        } finally {
+            manager.clearProfiles();
+        }
+    }
+
+    private RuntimeProfile createProfile(String queryId, String queryType, String queryState) {
+        RuntimeProfile profile = new RuntimeProfile("");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, queryId);
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, queryType);
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, queryState);
+        profile.addChild(summaryProfile);
+        return profile;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -14,16 +14,17 @@
 
 package com.starrocks.qe;
 
+import com.google.gson.JsonObject;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.ProfilingExecPlan;
+import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.sql.ExplainAnalyzer;
 import com.starrocks.thrift.TQueryStatisticsInfo;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 
 import static com.starrocks.common.proc.CurrentGlobalQueryStatisticsProcDirTest.QUERY_ONE_LOCAL;
 
@@ -64,43 +65,53 @@ public class QueryStatisticsInfoTest {
 
     @Test
     public void testGetExecProgress() throws Exception {
-        HttpClient mockHttpClient = Mockito.mock(HttpClient.class);
-        HttpResponse mockResponse = Mockito.mock(HttpResponse.class);
-        HttpRequest mockRequest = Mockito.mock(HttpRequest.class);
-        Mockito.when(mockRequest.uri()).thenReturn(URI.create("http://localhost:8030/api/query/progress?query_id=123"));
-        Mockito.when(mockHttpClient.send(Mockito.any(HttpRequest.class), Mockito.any())).thenReturn(mockResponse);
-        QueryStatisticsInfo info = new QueryStatisticsInfo();
+        ProfileManager manager = ProfileManager.getInstance();
+        manager.clearProfiles();
 
-        //1.check query progress result    
-        String response1 = "{\"query_id\":\"123\",\"state\":\"Running\",\"progress_info\"" +
-                ":{\"total_operator_num\":5,\"finished_operator_num\":3,\"progress_percent\":\"60.00%\"}}";
-        Mockito.when(mockResponse.statusCode()).thenReturn(200);
-        Mockito.when(mockResponse.body()).thenReturn(response1);
+        RuntimeProfile profile = new RuntimeProfile("");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, "123");
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, "Running");
+        profile.addChild(summaryProfile);
 
-        String result1 = info.getExecProgress("localhost", "123", mockHttpClient);
-        Assertions.assertEquals("60.00%", result1);
+        try {
+            new MockUp<ExplainAnalyzer>() {
+                @Mock
+                public String getQueryProgress() throws StarRocksException {
+                    JsonObject progressInfo = new JsonObject();
+                    progressInfo.addProperty("total_operator_num", 5);
+                    progressInfo.addProperty("finished_operator_num", 3);
+                    progressInfo.addProperty("progress_percent", "60.00%");
 
-        //2.check query id not found, like set enable_profile=false
-        String response2 = "query id 123 not found.";
-        Mockito.when(mockResponse.statusCode()).thenReturn(404);
-        Mockito.when(mockResponse.body()).thenReturn(response2);
+                    JsonObject result = new JsonObject();
+                    result.addProperty("query_id", "123");
+                    result.addProperty("state", "Running");
+                    result.add("progress_info", progressInfo);
+                    return result.toString();
+                }
+            };
 
-        String result2 = info.getExecProgress("localhost", "123", mockHttpClient);
-        Assertions.assertEquals(result2, "");
+            manager.pushProfile(new ProfilingExecPlan(), profile);
+            Assertions.assertEquals("60.00%", QueryStatisticsInfo.getExecProgress("123"));
 
-        //3.check short circuit query
-        String response3 = "short circuit point query doesn't suppot get query progress, " +
-                             "you can set it off by using set enable_short_circuit=false";
-        Mockito.when(mockResponse.statusCode()).thenReturn(200);
-        Mockito.when(mockResponse.body()).thenReturn(response3);
+            manager.clearProfiles();
+            Assertions.assertEquals("", QueryStatisticsInfo.getExecProgress("123"));
 
-        String result3 = info.getExecProgress("localhost", "123", mockHttpClient);
-        Assertions.assertEquals(result3, "");
+            manager.pushProfile(null, profile);
+            Assertions.assertEquals("", QueryStatisticsInfo.getExecProgress("123"));
 
-        //4.check special case, like fe_ip:http_port is unreachable
-        Mockito.doThrow(new IOException("Network is unreachable")).when(mockHttpClient)
-                               .send(Mockito.any(HttpRequest.class), Mockito.any());
-        String result4 = info.getExecProgress("localhost", "123", mockHttpClient);
-        Assertions.assertEquals(result4, "");
+            manager.clearProfiles();
+            manager.pushProfile(new ProfilingExecPlan(), profile);
+            new MockUp<ExplainAnalyzer>() {
+                @Mock
+                public String getQueryProgress() throws StarRocksException {
+                    throw new StarRocksException("mock failure");
+                }
+            };
+            Assertions.assertEquals("", QueryStatisticsInfo.getExecProgress("123"));
+        } finally {
+            manager.clearProfiles();
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`/api/show_proc?path=/current_queries` was computing `ExecProgress` by synchronously calling the local FE HTTP endpoint `/api/query/progress` for every query. When this path ran on HTTP worker threads, the loopback call could block the same 8030 server that was serving the original request, leading to worker starvation and causing unrelated endpoints such as `/api/transaction/*` to time out.

## What I'm doing:

Remove the HTTP loopback from `current_queries` by computing query progress in-process from the local profile data.

Introduce a shared utility for query progress calculation so both `current_queries` and `/api/query/progress` use the same in-memory logic.

Keep the existing `/api/query/progress` response behavior unchanged while making `QueryStatisticsInfo` fetch only the progress percent directly from the shared utility.

Update the `QueryStatisticsInfo` unit test to validate the new non-HTTP execution path and its fallback behavior.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
