### PR TITLE
[Enhancement] Enable delvec metacache during write publish

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -449,7 +449,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             tsid.tablet_id = tablet->id();
             tsid.segment_id = rssid;
             DelVectorPtr old_del_vec;
-            RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, false /* file cache */, &old_del_vec));
+            RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, true /* fill metacache */, &old_del_vec));
             new_del_vecs[idx].first = rssid;
             old_del_vec->add_dels_as_new_version(new_delete.second, metadata->version(), &(new_del_vecs[idx].second));
             size_t cur_old = old_del_vec->cardinality();
@@ -792,7 +792,7 @@ Status UpdateManager::_handle_delete_files(const TxnLogPB_OpWrite& op_write, int
         tsid.tablet_id = tablet->id();
         tsid.segment_id = rssid;
         DelVectorPtr old_delvec;
-        RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, false, &old_delvec));
+        RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, true /* fill metacache */, &old_delvec));
         DelVectorPtr dv_new;
         old_delvec->add_dels_as_new_version(del_ids, metadata->version(), &dv_new);
         new_del_vecs.emplace_back(rssid, dv_new);


### PR DESCRIPTION
## Why I'm doing:

During primary key write publish, delete vectors (delvecs) are loaded from remote storage (S3/OSS) with `fill_cache=false` in two locations:

1. `publish_primary_key_tablet()` step 4 — delvec generation for existing segments (update_manager.cpp:452)
2. `_handle_delete_files()` — delvec generation for delete file handling (update_manager.cpp:795)

This means delvecs fetched from remote storage are **not cached** in metacache, causing repeated remote IO for the same delvec data across publish cycles. This directly impacts write P99 latency.

### Benchmark Evidence

Using realtime-benchmark (30GB scale, shared-data mode, 1 FE + 3 CN):
- **Write P50:** 2,713ms (target: < 1,000ms)
- **Write P99:** 8,438ms (target: < 5,000ms)
- **Compaction publish delvec loading:** 3-10s for large compactions (500 input rowsets)

The same pattern was already fixed for **compaction** conflict resolution in commit 87707ea, where changing `fill_cache` from `false` to `true` in `LakeDelvecLoader` reduced compaction publish delvec IO. This PR applies the same fix to the **write publish** path.

## What I'm doing:

Enable metacache (`fill_cache=true`) for delvecs loaded during write publish in two locations:

1. `get_del_vec()` call in `publish_primary_key_tablet()` (delvec generation step)
2. `get_del_vec()` call in `_handle_delete_files()` (delete file handling)

This allows delvec data to be reused across publish cycles, reducing remote IO calls for workloads with frequent updates to the same primary key tablets.

## What type of PR is this:

- [x] Improvement

## Does this PR entail a change in behavior?

- [x] No

## If yes, please specify the type of change:

N/A

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This PR only changes one thing. Description above is accurate
- [x] I have documented any user-facing changes