### PR TITLE
[Refactor] Eliminate unnecessary DescriptorTable usage and remove dead code

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -49,9 +49,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.Utils;
-import com.starrocks.planner.DescriptorTable;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
@@ -594,24 +591,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                     Map<Integer, TExpr> mcExprs = new HashMap<>();
                     TAlterTabletMaterializedColumnReq generatedColumnReq = null;
                     if (hasNewGeneratedColumn) {
-                        DescriptorTable descTbl = new DescriptorTable();
-                        TupleDescriptor tupleDesc = descTbl.createTupleDescriptor();
-                        Map<String, SlotDescriptor> slotDescByName = new HashMap<>();
-
-                        /*
-                         * The expression substitution is needed here, because all slotRefs in
-                         * GeneratedColumnExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
-                         * if it is init by SlotDescriptor. The slot information will be used by be to indentify
-                         * the column location in a chunk.
-                         */
-                        for (Column col : table.getFullSchema()) {
-                            SlotDescriptor slotDesc = descTbl.addSlotDescriptor(tupleDesc);
-                            slotDesc.setType(col.getType());
-                            slotDesc.setColumn(new Column(col));
-                            slotDesc.setIsMaterialized(true);
-                            slotDesc.setIsNullable(col.isAllowNull());
-
-                            slotDescByName.put(col.getName(), slotDesc);
+                        // Build slotId mapping from fullSchema (slot ids = positional index)
+                        Map<String, Integer> slotIdByName = new HashMap<>();
+                        for (int i = 0; i < table.getFullSchema().size(); i++) {
+                            slotIdByName.put(table.getFullSchema().get(i).getName(), i);
                         }
 
                         for (Column generatedColumn : diffGeneratedColumnSchema) {
@@ -619,16 +602,14 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             List<Expr> outputExprs = Lists.newArrayList();
 
                             for (Column col : table.getBaseSchema()) {
-                                SlotDescriptor slotDesc = slotDescByName.get(col.getName());
-
-                                if (slotDesc == null) {
-                                    throw new AlterCancelException("Expression for generated column can not find " +
-                                            "the ref column");
+                                Integer slotId = slotIdByName.get(col.getName());
+                                if (slotId == null) {
+                                    throw new AlterCancelException(
+                                            "Expression for generated column can not find the ref column: "
+                                                    + col.getName());
                                 }
-
-                                SlotRef slotRef = new SlotRef(slotDesc);
-                                slotRef.setColumnName(col.getName());
-                                outputExprs.add(slotRef);
+                                outputExprs.add(SlotRef.createAnalyzed(slotId,
+                                        col.getName(), col.getType(), col.isAllowNull()));
                             }
 
                             TableName tableName = new TableName(db.getFullName(), table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -72,9 +72,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.planner.DescriptorTable;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -663,24 +660,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     Map<Integer, TExpr> mcExprs = new HashMap<>();
                     TAlterTabletMaterializedColumnReq generatedColumnReq = new TAlterTabletMaterializedColumnReq();
                     if (hasNewGeneratedColumn) {
-                        DescriptorTable descTbl = new DescriptorTable();
-                        TupleDescriptor tupleDesc = descTbl.createTupleDescriptor();
-                        Map<String, SlotDescriptor> slotDescByName = new HashMap<>();
-
-                        /*
-                         * The expression substitution is needed here, because all slotRefs in
-                         * GeneratedColumnExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
-                         * if it is init by SlotDescriptor. The slot information will be used by be to indentify
-                         * the column location in a chunk.
-                         */
-                        for (Column col : tbl.getFullSchema()) {
-                            SlotDescriptor slotDesc = descTbl.addSlotDescriptor(tupleDesc);
-                            slotDesc.setType(col.getType());
-                            slotDesc.setColumn(new Column(col));
-                            slotDesc.setIsMaterialized(true);
-                            slotDesc.setIsNullable(col.isAllowNull());
-
-                            slotDescByName.put(col.getName(), slotDesc);
+                        // Build slotId mapping from fullSchema (slot ids = positional index)
+                        Map<String, Integer> slotIdByName = Maps.newHashMap();
+                        for (int i = 0; i < tbl.getFullSchema().size(); i++) {
+                            Column col = tbl.getFullSchema().get(i);
+                            slotIdByName.put(col.getName(), i);
                         }
 
                         for (Column generatedColumn : diffGeneratedColumnSchema) {
@@ -688,16 +672,14 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             List<Expr> outputExprs = Lists.newArrayList();
 
                             for (Column col : tbl.getBaseSchema()) {
-                                SlotDescriptor slotDesc = slotDescByName.get(col.getName());
-
-                                if (slotDesc == null) {
+                                Integer slotId = slotIdByName.get(col.getName());
+                                if (slotId == null) {
                                     throw new AlterCancelException("Expression for generated column can not find " +
                                             "the ref column");
                                 }
 
-                                SlotRef slotRef = new SlotRef(slotDesc);
-                                slotRef.setColumnName(col.getName());
-                                outputExprs.add(slotRef);
+                                outputExprs.add(SlotRef.createAnalyzed(slotId,
+                                        col.getName(), col.getType(), col.isAllowNull()));
                             }
 
                             TableName tableName = new TableName(db.getFullName(), tbl.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -55,8 +55,6 @@ import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.SlotId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.scheduler.Task;
@@ -1628,20 +1626,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (partitionInfo.isExprRangePartitioned()) {
             ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
             Expr partitionExpr = expressionRangePartitionInfo.getPartitionExprs(idToColumn).get(0);
-            // for Partition slot ref, the SlotDescriptor is not serialized, so should recover it here.
-            // the SlotDescriptor is used by toThrift, which influences the execution process.
+            // for Partition slot ref, type/nullable are not serialized, so should recover them here.
+            // The type and nullable information will be used by toThrift, which influences the execution process.
             List<SlotRef> slotRefs = Lists.newArrayList();
             partitionExpr.collect(SlotRef.class, slotRefs);
             Preconditions.checkState(slotRefs.size() == 1);
-            if (slotRefs.get(0).getSlotDescriptorWithoutCheck() == null) {
-                for (int i = 0; i < fullSchema.size(); i++) {
-                    Column column = fullSchema.get(i);
-                    if (column.getName().equalsIgnoreCase(slotRefs.get(0).getColumnName())) {
-                        SlotDescriptor slotDescriptor =
-                                new SlotDescriptor(new SlotId(i), column.getName(), column.getType(),
-                                        column.isAllowNull());
-                        slotRefs.get(0).setDesc(slotDescriptor);
-                    }
+            SlotRef slotRef = slotRefs.get(0);
+            // Recover type/nullable (not serialized in metadata).
+            for (Column column : fullSchema) {
+                if (column.getName().equalsIgnoreCase(slotRef.getColumnName())) {
+                    slotRef.setType(column.getType());
+                    slotRef.setNullable(column.isAllowNull());
+                    break;
                 }
             }
             TableName tableName =

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -85,8 +85,6 @@ import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.SlotId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -2778,20 +2776,19 @@ public class OlapTable extends Table {
         ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
         // currently, automatic partition only supports one expression
         Expr partitionExpr = expressionRangePartitionInfo.getPartitionExprs(idToColumn).get(0);
-        // for Partition slot ref, the SlotDescriptor is not serialized, so should
-        // recover it here.
-        // the SlotDescriptor is used by toThrift, which influences the execution
-        // process.
+        // for Partition slot ref, type/nullable are not serialized, so should recover them here.
+        // The type and nullable information will be used by toThrift, which influences the execution process.
         List<SlotRef> slotRefs = Lists.newArrayList();
         partitionExpr.collect(SlotRef.class, slotRefs);
         Preconditions.checkState(slotRefs.size() == 1);
-        // schema change should update slot id
-        for (int i = 0; i < fullSchema.size(); i++) {
-            Column column = fullSchema.get(i);
-            if (column.getName().equalsIgnoreCase(slotRefs.get(0).getColumnName())) {
-                SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(i), column.getName(),
-                        column.getType(), column.isAllowNull());
-                slotRefs.get(0).setDesc(slotDescriptor);
+        SlotRef slotRef = slotRefs.get(0);
+        // Recover type/nullable (not serialized in metadata).
+        // Schema change should update these.
+        for (Column column : fullSchema) {
+            if (column.getName().equalsIgnoreCase(slotRef.getColumnName())) {
+                slotRef.setType(column.getType());
+                slotRef.setNullable(column.isAllowNull());
+                break;
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -56,8 +56,6 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.mv.analyzer.MVPartitionSlotRefResolver;
-import com.starrocks.planner.SlotDescriptor;
-import com.starrocks.planner.SlotId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
@@ -1650,12 +1648,8 @@ public class MaterializedViewAnalyzer {
             throw new SemanticException("Materialized view partition exp column:"
                     + slotRef.getColumnName() + " is not found in query statement");
         }
-        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(columnId), slotRef.getColumnName(),
-                mvPartitionColumn.getType(), mvPartitionColumn.isAllowNull());
-        slotRef.setDesc(slotDescriptor);
         slotRef.setType(mvPartitionColumn.getType());
         slotRef.setNullable(mvPartitionColumn.isAllowNull());
-        slotRef.setType(mvPartitionColumn.getType());
         return mvPartitionColumn;
     }
 
@@ -1800,12 +1794,8 @@ public class MaterializedViewAnalyzer {
             LOG.warn("Materialized view partition exp column:" + slotRef.getColumnName() + " is not found in query statement");
             return;
         }
-        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(columnId), slotRef.getColumnName(),
-                mvPartitionColumn.getType(), mvPartitionColumn.isAllowNull());
-        slotRef.setDesc(slotDescriptor);
         slotRef.setType(mvPartitionColumn.getType());
         slotRef.setNullable(mvPartitionColumn.isAllowNull());
-        slotRef.setType(mvPartitionColumn.getType());
         slotRef.setColumnName(mvPartitionColumn.getName());
         // set it to null to avoid the slot ref referring to the original base table
         slotRef.setTblName(null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
@@ -36,9 +36,7 @@ package com.starrocks.sql.ast.expression;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.HintNode;
@@ -49,7 +47,6 @@ import org.apache.commons.collections.CollectionUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Representation of an analytic function call with OVER clause.
@@ -342,24 +339,4 @@ public class AnalyticExpr extends Expr {
                 useHashBasedPartition, isSkewed, skewColumn, skewValues);
     }
 
-    // aggregation function over unbounded window without sliding frame can convert into
-    // null-safe-eq join with aggregation
-    // for an example:
-    // Q1: select a, b, count(distinct c) over (partition by a,b) from t;
-    // equals to
-    // Q2: with cte as (select a,b, count(distinct c) cdc from t group by a,b)
-    //     select t.a,t.b,cte.cdc from t inner join cte on t.a <=> cte.a and t.b <= cte.b
-    public boolean isUnboundedWindowWithoutSlidingFrame() {
-        if (window != null && !window.getType().equals(AnalyticWindow.Type.RANGE)) {
-            return false;
-        }
-
-        final Set<String> supportFunctions = ImmutableSet.of(
-                FunctionSet.SUM,
-                FunctionSet.AVG,
-                FunctionSet.COUNT,
-                FunctionSet.ARRAY_AGG,
-                FunctionSet.ARRAY_AGG_DISTINCT);
-        return supportFunctions.contains(fnCall.getFunctionName());
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
@@ -168,6 +168,16 @@ public class SlotRef extends Expr {
         this(new SlotDescriptor(slotId, "", InvalidType.INVALID, false));
     }
 
+    /**
+     * Create an analyzed SlotRef with the given column metadata.
+     * Use this when a pre-analyzed SlotRef is needed but no DescriptorTable is required
+     * (e.g., DDL generated-column analysis, partition expression recovery).
+     */
+    public static SlotRef createAnalyzed(int slotId, String columnName, Type type, boolean nullable) {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(slotId), columnName, type, nullable);
+        return new SlotRef(slotDesc);
+    }
+
     public void setBackQuoted(boolean isBackQuoted) {
         this.isBackQuoted = isBackQuoted;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2736,9 +2736,8 @@ public class CreateMaterializedViewTest extends MVTestBase {
         Assertions.assertEquals(1, partitionExpr.size());
         Assertions.assertTrue(partitionExpr.get(0) instanceof SlotRef);
         SlotRef slotRef = (SlotRef) partitionExpr.get(0);
-        Assertions.assertNotNull(slotRef.getSlotDescriptorWithoutCheck());
-        SlotDescriptor slotDescriptor = slotRef.getSlotDescriptorWithoutCheck();
-        Assertions.assertEquals(1, slotDescriptor.getId().asInt());
+        Assertions.assertEquals("k1", slotRef.getColumnName());
+        Assertions.assertFalse(slotRef.getType().isInvalid());
     }
 
     @Test


### PR DESCRIPTION
Add SlotRef.createAnalyzed() factory method for creating pre-analyzed SlotRef without DescriptorTable infrastructure.

Eliminate DescriptorTable abuse in DDL/MV paths where descriptors were created but never serialized to BE:
- SchemaChangeJobV2, LakeTableSchemaChangeJob: remove throwaway DescriptorTable for generated column expression analysis
- MaterializedView, OlapTable: replace throwaway SlotDescriptor with direct setter calls for partition expression recovery
- MaterializedViewAnalyzer: same pattern for MV partition column resolution

Delete unused AnalyticExpr.isUnboundedWindowWithoutSlidingFrame() method (zero callers).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
