### PR TITLE
[Performance] Parallelize delvec loading during compaction conflict resolution

### DIFF
--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/primary_key_compaction_conflict_resolver.h"
 
+#include <future>
+
 #include "base/debug/trace.h"
 #include "common/config_exec_fwd.h"
 #include "runtime/current_thread.h"
@@ -25,6 +27,71 @@
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
+
+// Batch-load delvecs for a set of rssids in parallel.
+// This avoids sequential remote IO (S3/OSS) calls when many delvecs need to be loaded
+// during compaction conflict resolution.
+static Status batch_load_delvecs(const CompactConflictResolveParams& params,
+                                 const std::vector<uint32_t>& rssids_to_load,
+                                 std::map<uint32_t, DelVectorPtr>* rssid_to_delvec) {
+    if (rssids_to_load.empty()) {
+        return Status::OK();
+    }
+
+    // For small batches, load sequentially to avoid thread overhead
+    static constexpr size_t kParallelThreshold = 4;
+    if (rssids_to_load.size() <= kParallelThreshold) {
+        for (uint32_t rssid : rssids_to_load) {
+            DelVectorPtr delvec_ptr;
+            RETURN_IF_ERROR(params.delvec_loader->load({params.tablet_id, rssid}, params.base_version, &delvec_ptr));
+            (*rssid_to_delvec)[rssid] = std::move(delvec_ptr);
+        }
+        return Status::OK();
+    }
+
+    // Load delvecs in parallel using async tasks
+    struct LoadResult {
+        uint32_t rssid;
+        DelVectorPtr delvec;
+        Status status;
+    };
+
+    std::vector<std::future<LoadResult>> futures;
+    futures.reserve(rssids_to_load.size());
+
+    for (uint32_t rssid : rssids_to_load) {
+        futures.push_back(std::async(std::launch::async, [&params, rssid]() -> LoadResult {
+            LoadResult result;
+            result.rssid = rssid;
+            result.status = params.delvec_loader->load({params.tablet_id, rssid}, params.base_version, &result.delvec);
+            return result;
+        }));
+    }
+
+    // Collect results
+    for (auto& future : futures) {
+        auto result = future.get();
+        if (!result.status.ok()) {
+            return result.status;
+        }
+        (*rssid_to_delvec)[result.rssid] = std::move(result.delvec);
+    }
+
+    return Status::OK();
+}
+
+// Extract unique rssids from rssid_rowids that are not already in the cache.
+static std::vector<uint32_t> collect_missing_rssids(const std::vector<uint64_t>& rssid_rowids,
+                                                     const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
+    std::set<uint32_t> unique_rssids;
+    for (const auto& rssid_rowid : rssid_rowids) {
+        uint32_t rssid = rssid_rowid >> 32;
+        if (rssid_to_delvec.count(rssid) == 0) {
+            unique_rssids.insert(rssid);
+        }
+    }
+    return {unique_rssids.begin(), unique_rssids.end()};
+}
 
 Status PrimaryKeyCompactionConflictResolver::execute() {
     Schema pkey_schema = generate_pkey_schema();
@@ -76,19 +143,17 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                 std::vector<uint32_t> replace_indexes;
                                 RETURN_IF_ERROR(mapper_iter.next_values(chunk->num_rows(), &rssid_rowids));
                                 DCHECK(chunk->num_rows() == rssid_rowids.size());
+
+                                // Batch-prefetch delvecs for this chunk's unique rssids
+                                {
+                                    TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
+                                    auto missing = collect_missing_rssids(rssid_rowids, rssid_to_delvec);
+                                    RETURN_IF_ERROR(batch_load_delvecs(params, missing, &rssid_to_delvec));
+                                }
+
                                 for (int i = 0; i < rssid_rowids.size(); i++) {
                                     const uint32_t rssid = rssid_rowids[i] >> 32;
                                     const uint32_t rowid = rssid_rowids[i] & 0xffffffff;
-                                    if (rssid_to_delvec.count(rssid) == 0) {
-                                        // get delvec by loader
-                                        DelVectorPtr delvec_ptr;
-                                        {
-                                            TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
-                                            RETURN_IF_ERROR(params.delvec_loader->load(
-                                                    {params.tablet_id, rssid}, params.base_version, &delvec_ptr));
-                                        }
-                                        rssid_to_delvec[rssid] = delvec_ptr;
-                                    }
                                     if (!rssid_to_delvec[rssid]->empty() &&
                                         rssid_to_delvec[rssid]->roaring()->contains(rowid)) {
                                         // Input row had been deleted, so we need to delete it from output rowset
@@ -142,19 +207,19 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
                     std::vector<uint64_t> rssid_rowids;
                     RETURN_IF_ERROR(mapper_iter.next_values(segments[segment_id]->num_rows(), &rssid_rowids));
                     DCHECK(segments[segment_id]->num_rows() == rssid_rowids.size());
+
+                    // Batch-prefetch all delvecs for this segment's unique rssids in parallel.
+                    // This replaces sequential per-rssid loading which caused 3-10s latency
+                    // with 500 input rowsets due to remote IO (S3/OSS) per delvec.
+                    {
+                        TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
+                        auto missing = collect_missing_rssids(rssid_rowids, rssid_to_delvec);
+                        RETURN_IF_ERROR(batch_load_delvecs(params, missing, &rssid_to_delvec));
+                    }
+
                     for (int i = 0; i < rssid_rowids.size(); i++) {
                         const uint32_t rssid = rssid_rowids[i] >> 32;
                         const uint32_t rowid = rssid_rowids[i] & 0xffffffff;
-                        if (rssid_to_delvec.count(rssid) == 0) {
-                            // get delvec by loader
-                            DelVectorPtr delvec_ptr;
-                            {
-                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
-                                RETURN_IF_ERROR(params.delvec_loader->load({params.tablet_id, rssid},
-                                                                           params.base_version, &delvec_ptr));
-                            }
-                            rssid_to_delvec[rssid] = delvec_ptr;
-                        }
                         if (!rssid_to_delvec[rssid]->empty() && rssid_to_delvec[rssid]->roaring()->contains(rowid)) {
                             // Input row had been deleted, so we need to delete it from output rowset
                             tmp_deletes.push_back(i);

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -49,32 +49,44 @@ static Status batch_load_delvecs(const CompactConflictResolveParams& params,
         return Status::OK();
     }
 
-    // Load delvecs in parallel using async tasks
+    // Load delvecs in parallel using async tasks, capped at kMaxParallel
+    // to avoid unbounded thread creation under heavy compaction load.
     struct LoadResult {
         uint32_t rssid;
         DelVectorPtr delvec;
         Status status;
     };
 
-    std::vector<std::future<LoadResult>> futures;
-    futures.reserve(rssids_to_load.size());
+    static constexpr size_t kMaxParallel = 16;
+    auto* mem_tracker = tls_thread_status.mem_tracker();
 
-    for (uint32_t rssid : rssids_to_load) {
-        futures.push_back(std::async(std::launch::async, [&params, rssid]() -> LoadResult {
-            LoadResult result;
-            result.rssid = rssid;
-            result.status = params.delvec_loader->load({params.tablet_id, rssid}, params.base_version, &result.delvec);
-            return result;
-        }));
-    }
+    for (size_t start = 0; start < rssids_to_load.size(); start += kMaxParallel) {
+        size_t end = std::min(start + kMaxParallel, rssids_to_load.size());
+        std::vector<std::future<LoadResult>> futures;
+        futures.reserve(end - start);
 
-    // Collect results
-    for (auto& future : futures) {
-        auto result = future.get();
-        if (!result.status.ok()) {
-            return result.status;
+        for (size_t i = start; i < end; i++) {
+            futures.push_back(
+                    std::async(std::launch::async, [&params, rssid = rssids_to_load[i], mem_tracker]() -> LoadResult {
+                        // Attach parent thread's memory tracker so allocations inside
+                        // load() are properly accounted against compaction memory limits.
+                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
+                        LoadResult result;
+                        result.rssid = rssid;
+                        result.status = params.delvec_loader->load({params.tablet_id, rssid}, params.base_version,
+                                                                   &result.delvec);
+                        return result;
+                    }));
         }
-        (*rssid_to_delvec)[result.rssid] = std::move(result.delvec);
+
+        // Collect results for this batch before launching next batch
+        for (auto& future : futures) {
+            auto result = future.get();
+            if (!result.status.ok()) {
+                return result.status;
+            }
+            (*rssid_to_delvec)[result.rssid] = std::move(result.delvec);
+        }
     }
 
     return Status::OK();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -82,7 +82,7 @@ static Status batch_load_delvecs(const CompactConflictResolveParams& params,
 
 // Extract unique rssids from rssid_rowids that are not already in the cache.
 static std::vector<uint32_t> collect_missing_rssids(const std::vector<uint64_t>& rssid_rowids,
-                                                     const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
+                                                    const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
     std::set<uint32_t> unique_rssids;
     for (const auto& rssid_rowid : rssid_rowids) {
         uint32_t rssid = rssid_rowid >> 32;


### PR DESCRIPTION
## Summary

Parallelize delvec (delete vector) loading during compaction conflict resolution in the publish path for shared-data (lake) mode. This addresses the root cause of high write P99 latency without needing to reduce `lake_pk_compaction_max_input_rowsets`.

## Problem

During compaction publish, `PrimaryKeyCompactionConflictResolver` loads delvecs **sequentially** for each unique segment from remote storage (S3/OSS). With large compactions (500 input rowsets), this causes hundreds of sequential remote IO calls, leading to publish latencies of **3-10 seconds** that block the write path.

Evidence from realtime-benchmark CN publish traces:
| input_rowsets_size | compaction_delvec_loader_latency | Total publish cost |
|---|---|---|
| 500 | 9.6s | >6s |
| 500 | 4.8s | 6.0s |
| 64-84 | 54-182ms | <1s |

## Solution

- **Batch-collect** all unique rssids from the rows mapper data before processing
- **Parallel-load** delvecs using `std::async` when batch size exceeds 4
- Small batches (≤4) still load sequentially to avoid thread overhead
- Both `execute()` and `execute_without_update_index()` paths are optimized

## Why not just reduce max input rowsets?

PR #71024 tried reducing `lake_pk_compaction_max_input_rowsets` from 500 to 200. While this improved write P99 by 30%, it caused an **83% query QPS regression** because more frequent compaction cycles increased resource contention. This PR fixes the root cause (sequential remote IO) without changing compaction behavior.

## Expected Impact

- Write P99: ~8.4s → ~2-4s (parallel IO reduces wall-clock time by 3-5x for large batches)
- Write throughput: should improve proportionally
- Query performance: should NOT regress (compaction frequency unchanged)
- No config changes needed

## Test Plan

- [ ] Build and deploy to shared-data cluster
- [ ] Run realtime-benchmark with same parameters as baseline
- [ ] Verify `compaction_delvec_loader_latency_us` decreases in CN publish traces
- [ ] Verify query QPS does not regress vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)