### PR TITLE
[BugFix] Fix double-free crash in SystemMetrics due to concurrent getline access

### DIFF
--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -201,6 +201,13 @@ void SystemMetrics::install(MetricRegistry* registry, const std::set<std::string
 }
 
 void SystemMetrics::update() {
+    // Use try_lock to avoid blocking concurrent callers since metrics collection
+    // is best-effort and the data will be refreshed on the next collection cycle.
+    std::unique_lock lock(_update_mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return;
+    }
+
     update_memory_metrics();
 
     _update_cpu_metrics();

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 
 #include "base/metrics.h"
 
@@ -161,6 +162,7 @@ private:
     std::unique_ptr<SnmpMetrics> _snmp_metrics;
     std::vector<IOMetrics*> _io_metrics;
 
+    std::mutex _update_mutex;
     char* _line_ptr = nullptr;
     size_t _line_buf_size = 0;
     MetricRegistry* _registry = nullptr;

--- a/be/test/util/system_metrics_test.cpp
+++ b/be/test/util/system_metrics_test.cpp
@@ -37,6 +37,8 @@
 #include <gtest/gtest.h>
 #include <libgen.h>
 
+#include <thread>
+
 #include "base/concurrency/stopwatch.hpp"
 #include "base/metrics.h"
 #include "util/logging.h"
@@ -273,6 +275,53 @@ TEST_F(SystemMetricsTest, no_proc_file) {
         ASSERT_TRUE(bytes_read != nullptr);
         ASSERT_STREQ("0", bytes_read->to_string().c_str());
     }
+}
+
+TEST_F(SystemMetricsTest, concurrent_update) {
+    const std::string dir_path = "./be/test/util";
+    std::string stat_path(dir_path);
+    stat_path += "/test_data/stat_normal";
+    k_ut_stat_path = stat_path.c_str();
+    std::string diskstats_path(dir_path);
+    diskstats_path += "/test_data/diskstats_normal";
+    k_ut_diskstats_path = diskstats_path.c_str();
+    std::string net_dev_path(dir_path);
+    net_dev_path += "/test_data/net_dev_normal";
+    k_ut_net_dev_path = net_dev_path.c_str();
+    std::string fd_path(dir_path);
+    fd_path += "/test_data/fd_file_nr";
+    k_ut_fd_path = fd_path.c_str();
+    std::string net_snmp_path(dir_path);
+    net_snmp_path += "/test_data/net_snmp_normal";
+    k_ut_net_snmp_path = net_snmp_path.c_str();
+
+    MetricRegistry registry("test");
+    std::set<std::string> disk_devices;
+    disk_devices.emplace("sda");
+    std::vector<std::string> network_interfaces;
+    network_interfaces.emplace_back("xgbe0");
+
+    SystemMetrics metrics;
+    metrics.install(&registry, disk_devices, network_interfaces);
+
+    // Metrics should be zero before any update.
+    Metric* cpu_user = registry.get_metric("cpu", MetricLabels().add("mode", "user"));
+    ASSERT_TRUE(cpu_user != nullptr);
+    ASSERT_STREQ("0", cpu_user->to_string().c_str());
+
+    // Deterministically cover the try_lock early-return path:
+    // hold _update_mutex so that update() fails to acquire it and returns immediately.
+    {
+        std::lock_guard hold(metrics._update_mutex);
+        metrics.update(); // try_lock fails → early return
+    }
+
+    // Metrics should still be zero because update() returned early.
+    ASSERT_STREQ("0", cpu_user->to_string().c_str());
+
+    // After releasing the mutex, update() should succeed and populate metrics.
+    metrics.update();
+    ASSERT_STRNE("0", cpu_user->to_string().c_str());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`SystemMetrics::update()` uses shared member variables `_line_ptr` and `_line_buf_size` as `getline()` buffer. Since `MetricRegistry::collect()` acquires only a `shared_lock` on `_hooks_mutex`, multiple threads can invoke `update()` concurrently, causing concurrent `getline()` calls to race on the same buffer and trigger a double-free via `realloc`.

### Concrete trigger scenario

Two threads can race into `SystemMetrics::update()` simultaneously through the following paths:

**Thread A** — querying `SELECT * FROM information_schema.be_metrics`:
```
SchemaBeMetricsScanner::start()
  → MetricRegistry::collect()
    → shared_lock(_hooks_mutex)          // shared lock, doesn't block Thread B
      → unprotected_trigger_hook()
        → SystemMetrics::update()
          → _update_disk_metrics()
            → getline(&_line_ptr, ...)   // realloc frees old buffer
```

**Thread B** — `ADMIN SET FRONTEND CONFIG` updating `connector_scan_thread` count, which triggers a `write_be_configs_table` internally:
```
UpdateConfigAction::update_config()
  → write_be_configs_table()
    → SchemaBeMetricsScanner::start()
      → MetricRegistry::collect()
        → shared_lock(_hooks_mutex)      // shared lock, doesn't block Thread A
          → unprotected_trigger_hook()
            → SystemMetrics::update()
              → _update_disk_metrics()
                → getline(&_line_ptr, ...)   // double-free: old buffer already freed by Thread A
```

Both threads hold a `shared_lock` on `_hooks_mutex` concurrently, so they both enter `_update_disk_metrics()` and call `getline()` on the same `_line_ptr` buffer simultaneously, causing the double-free.

## What I'm doing:

Add a `std::mutex` with `try_lock` to `SystemMetrics::update()` so only one thread performs the update at a time. Concurrent callers skip the update rather than blocking, since metrics collection is best-effort and will be refreshed on the next collection cycle.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11187

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4