### PR TITLE
[Performance] Reduce lake_pk_compaction_max_input_rowsets from 500 to 200

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1326,7 +1326,7 @@ CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");
 CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -155,7 +155,7 @@ CONF_mInt64(lake_compaction_max_rowset_size, "4294967296");
 
 CONF_mBool(lake_enable_compaction_async_write, "false");
 
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 


### PR DESCRIPTION
## Summary

- Reduce `lake_pk_compaction_max_input_rowsets` default from 500 to 200 to limit delvec remote IO during compaction publish

## Bottleneck Analysis

**Problem:** In shared-data mode, when a primary key table compaction merges many input rowsets, the publish phase must load delvec (delete vector) data for each unique segment from remote storage (S3/OSS). With the default value of 500, compaction publish can take **3-10 seconds** due to delvec remote IO, directly causing extremely high write P99 latency.

**Evidence from realtime-benchmark (shared-data, 1 FE + 3 CN):**

| input_rowsets_size | compaction_delvec_loader_latency | Total publish cost |
|-------------------|----------------------------------|-------------------|
| 500 | 4.8s | 6.0s |
| 500 | 9.6s | ~10s |
| 500 | 3.1s | 4.0s |
| 84 | 0.18s | <1s |
| 64 | 0.05s | <1s |

Clear linear correlation: `input_rowsets_size=500` → seconds of delvec loading; `<100` → sub-200ms.

**Benchmark results (baseline):**
- Write P50: 2713ms (target: <1000ms)
- Write P99: 8438ms (target: <5000ms)
- Write throughput: ~26K rows/sec (target: >100K)

## What this PR does

Reduces `lake_pk_compaction_max_input_rowsets` from 500 to 200 in two files:
- `be/src/common/config.h`
- `be/src/common/config_compaction_fwd.h`

This limits worst-case delvec loading during compaction publish to ~1-3s while still allowing effective compaction. Compaction will run more frequently with smaller batches, which is a net positive for write latency in high-frequency write workloads.

## Expected Impact

- Write P99: ~8.4s → ~4-5s (reducing worst-case publish time)
- Write P50: modest improvement
- Read latency: no regression (compaction still effective, just smaller batches)
- Compaction frequency: slightly higher (more frequent, smaller compactions)

## Risk

- More frequent compactions may increase background IO, but each compaction is lighter
- The value is mutable (`CONF_mInt64`), so it can be tuned at runtime if needed
- Conservative reduction (500→200, not extreme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)