### PR TITLE
[Performance] Parallelize delvec loading and reduce max compaction input rowsets

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1326,7 +1326,7 @@ CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");
 CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -155,7 +155,7 @@ CONF_mInt64(lake_compaction_max_rowset_size, "4294967296");
 
 CONF_mBool(lake_enable_compaction_async_write, "false");
 
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "200");
 
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/primary_key_compaction_conflict_resolver.h"
 
+#include <future>
+
 #include "base/debug/trace.h"
 #include "common/config_exec_fwd.h"
 #include "runtime/current_thread.h"
@@ -25,6 +27,83 @@
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
+
+// Batch-load delvecs for a set of rssids in parallel.
+// This avoids sequential remote IO (S3/OSS) calls when many delvecs need to be loaded
+// during compaction conflict resolution.
+static Status batch_load_delvecs(const CompactConflictResolveParams& params,
+                                 const std::vector<uint32_t>& rssids_to_load,
+                                 std::map<uint32_t, DelVectorPtr>* rssid_to_delvec) {
+    if (rssids_to_load.empty()) {
+        return Status::OK();
+    }
+
+    // For small batches, load sequentially to avoid thread overhead
+    static constexpr size_t kParallelThreshold = 4;
+    if (rssids_to_load.size() <= kParallelThreshold) {
+        for (uint32_t rssid : rssids_to_load) {
+            DelVectorPtr delvec_ptr;
+            RETURN_IF_ERROR(params.delvec_loader->load({params.tablet_id, rssid}, params.base_version, &delvec_ptr));
+            (*rssid_to_delvec)[rssid] = std::move(delvec_ptr);
+        }
+        return Status::OK();
+    }
+
+    // Load delvecs in parallel using async tasks, capped at kMaxParallel
+    // to avoid unbounded thread creation under heavy compaction load.
+    struct LoadResult {
+        uint32_t rssid;
+        DelVectorPtr delvec;
+        Status status;
+    };
+
+    static constexpr size_t kMaxParallel = 16;
+    auto* mem_tracker = tls_thread_status.mem_tracker();
+
+    for (size_t start = 0; start < rssids_to_load.size(); start += kMaxParallel) {
+        size_t end = std::min(start + kMaxParallel, rssids_to_load.size());
+        std::vector<std::future<LoadResult>> futures;
+        futures.reserve(end - start);
+
+        for (size_t i = start; i < end; i++) {
+            futures.push_back(
+                    std::async(std::launch::async, [&params, rssid = rssids_to_load[i], mem_tracker]() -> LoadResult {
+                        // Attach parent thread's memory tracker so allocations inside
+                        // load() are properly accounted against compaction memory limits.
+                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
+                        LoadResult result;
+                        result.rssid = rssid;
+                        result.status = params.delvec_loader->load({params.tablet_id, rssid}, params.base_version,
+                                                                   &result.delvec);
+                        return result;
+                    }));
+        }
+
+        // Collect results for this batch before launching next batch
+        for (auto& future : futures) {
+            auto result = future.get();
+            if (!result.status.ok()) {
+                return result.status;
+            }
+            (*rssid_to_delvec)[result.rssid] = std::move(result.delvec);
+        }
+    }
+
+    return Status::OK();
+}
+
+// Extract unique rssids from rssid_rowids that are not already in the cache.
+static std::vector<uint32_t> collect_missing_rssids(const std::vector<uint64_t>& rssid_rowids,
+                                                     const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
+    std::set<uint32_t> unique_rssids;
+    for (const auto& rssid_rowid : rssid_rowids) {
+        uint32_t rssid = rssid_rowid >> 32;
+        if (rssid_to_delvec.count(rssid) == 0) {
+            unique_rssids.insert(rssid);
+        }
+    }
+    return {unique_rssids.begin(), unique_rssids.end()};
+}
 
 Status PrimaryKeyCompactionConflictResolver::execute() {
     Schema pkey_schema = generate_pkey_schema();
@@ -76,19 +155,17 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                 std::vector<uint32_t> replace_indexes;
                                 RETURN_IF_ERROR(mapper_iter.next_values(chunk->num_rows(), &rssid_rowids));
                                 DCHECK(chunk->num_rows() == rssid_rowids.size());
+
+                                // Batch-prefetch delvecs for this chunk's unique rssids
+                                {
+                                    TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
+                                    auto missing = collect_missing_rssids(rssid_rowids, rssid_to_delvec);
+                                    RETURN_IF_ERROR(batch_load_delvecs(params, missing, &rssid_to_delvec));
+                                }
+
                                 for (int i = 0; i < rssid_rowids.size(); i++) {
                                     const uint32_t rssid = rssid_rowids[i] >> 32;
                                     const uint32_t rowid = rssid_rowids[i] & 0xffffffff;
-                                    if (rssid_to_delvec.count(rssid) == 0) {
-                                        // get delvec by loader
-                                        DelVectorPtr delvec_ptr;
-                                        {
-                                            TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
-                                            RETURN_IF_ERROR(params.delvec_loader->load(
-                                                    {params.tablet_id, rssid}, params.base_version, &delvec_ptr));
-                                        }
-                                        rssid_to_delvec[rssid] = delvec_ptr;
-                                    }
                                     if (!rssid_to_delvec[rssid]->empty() &&
                                         rssid_to_delvec[rssid]->roaring()->contains(rowid)) {
                                         // Input row had been deleted, so we need to delete it from output rowset
@@ -142,19 +219,17 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
                     std::vector<uint64_t> rssid_rowids;
                     RETURN_IF_ERROR(mapper_iter.next_values(segments[segment_id]->num_rows(), &rssid_rowids));
                     DCHECK(segments[segment_id]->num_rows() == rssid_rowids.size());
+
+                    // Batch-prefetch all delvecs for this segment's unique rssids in parallel.
+                    {
+                        TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
+                        auto missing = collect_missing_rssids(rssid_rowids, rssid_to_delvec);
+                        RETURN_IF_ERROR(batch_load_delvecs(params, missing, &rssid_to_delvec));
+                    }
+
                     for (int i = 0; i < rssid_rowids.size(); i++) {
                         const uint32_t rssid = rssid_rowids[i] >> 32;
                         const uint32_t rowid = rssid_rowids[i] & 0xffffffff;
-                        if (rssid_to_delvec.count(rssid) == 0) {
-                            // get delvec by loader
-                            DelVectorPtr delvec_ptr;
-                            {
-                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
-                                RETURN_IF_ERROR(params.delvec_loader->load({params.tablet_id, rssid},
-                                                                           params.base_version, &delvec_ptr));
-                            }
-                            rssid_to_delvec[rssid] = delvec_ptr;
-                        }
                         if (!rssid_to_delvec[rssid]->empty() && rssid_to_delvec[rssid]->roaring()->contains(rowid)) {
                             // Input row had been deleted, so we need to delete it from output rowset
                             tmp_deletes.push_back(i);

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -94,7 +94,7 @@ static Status batch_load_delvecs(const CompactConflictResolveParams& params,
 
 // Extract unique rssids from rssid_rowids that are not already in the cache.
 static std::vector<uint32_t> collect_missing_rssids(const std::vector<uint64_t>& rssid_rowids,
-                                                     const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
+                                                    const std::map<uint32_t, DelVectorPtr>& rssid_to_delvec) {
     std::set<uint32_t> unique_rssids;
     for (const auto& rssid_rowid : rssid_rowids) {
         uint32_t rssid = rssid_rowid >> 32;


### PR DESCRIPTION
## Summary

Combined optimization for write latency in shared-data (lake) mode. This PR merges the approaches from PR #71038 (parallel delvec loading) and PR #71024 (reduced max input rowsets) into a single change.

## Problem

During compaction publish, delvecs are loaded **sequentially** from remote storage (S3/OSS). With 500 input rowsets, this causes 3-10s publish latency. Prior attempts:
- PR #71024 (config 500→200): Write P99 -30%, but **-83% query QPS** (too many compaction cycles)
- PR #71038 (parallel loading): Write P99 -70%, query QPS -79% (still regressed due to higher write volume)

## Solution

Combines both optimizations:

1. **Parallel delvec prefetching** (`primary_key_compaction_conflict_resolver.cpp`):
   - Pre-collect unique rssids, batch-load in parallel via `std::async` (capped at 16)
   - Memory tracking via `SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER`
   - Both `execute()` and `execute_without_update_index()` paths

2. **Reduced `lake_pk_compaction_max_input_rowsets`** (500→200):
   - Caps worst-case compaction size
   - With parallel loading, each compaction finishes faster, mitigating the resource contention that caused query regression with config-only

## Benchmark History

| Metric | Baseline | Config-only (#71024) | Parallel-only (#71038) | **Combined (this PR)** |
|--------|----------|---------------------|----------------------|----------------------|
| Write P99 | 8,438ms | 5,922ms (-30%) | 2,512ms (-70%) | Expected: <2,000ms |
| Write P50 | 2,713ms | 1,272ms (-53%) | 1,096ms (-60%) | Expected: <1,000ms |
| Throughput | 26K/s | 55K/s (+112%) | 68K/s (+161%) | Expected: >70K/s |
| Query QPS | 178 | 30 (-83%) | 38 (-79%) | Expected: >38 |

## Test Plan

- [ ] Build and deploy to shared-data cluster
- [ ] Run realtime-benchmark (same params as baseline)
- [ ] Verify write P50 < 1,000ms and P99 < 5,000ms
- [ ] Verify query QPS does not regress further vs parallel-only (#71038)
- [ ] Check `compaction_delvec_loader_latency_us` in CN traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)