### PR TITLE
[BugFix] Fix ClassCastException in visitDropMVColumnClause for non-SelectRelation MVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java
@@ -91,6 +91,9 @@ public class AlterMVClauseAnalyzerVisitor extends AlterTableClauseAnalyzer {
             throw new SemanticException("Materialized view definition is invalid");
         }
         QueryStatement queryStatement = (QueryStatement) astParseNode;
+        if (queryStatement.getQueryRelation() == null || !(queryStatement.getQueryRelation() instanceof SelectRelation)) {
+            throw new SemanticException("Materialized view definition is invalid: only support SELECT statement");
+        }
         SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
         if (!(selectRelation.getRelation() instanceof TableRelation)) {
             throw new SemanticException("Materialized view based on multiple tables is not supported");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
@@ -466,4 +466,41 @@ public class AlterMaterializedViewTest extends MVTestBase {
 
         alterMVDropColumn(dropStmt, true);
     }
+
+    @Test
+    public void testDropColumnOnUnionMV() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_t1_union\n" +
+                "(\n" +
+                "    id int,\n" +
+                "    a int,\n" +
+                "    b int\n" +
+                ")\n" +
+                "DUPLICATE KEY(`id`)" +
+                "DISTRIBUTED BY HASH (id) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');");
+        starRocksAssert.withTable("CREATE TABLE base_t2_union\n" +
+                "(\n" +
+                "    id int,\n" +
+                "    a int,\n" +
+                "    b int\n" +
+                ")\n" +
+                "DUPLICATE KEY(`id`)" +
+                "DISTRIBUTED BY HASH (id) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_union_test\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 3\n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT id, a, b FROM base_t1_union UNION ALL SELECT id, a, b FROM base_t2_union;");
+
+        // DROP COLUMN on a UNION MV should fail with a clear error, not ClassCastException
+        String dropStmt = "alter materialized view mv_union_test drop column b";
+        alterMVDropColumn(dropStmt, true);
+
+        // ADD COLUMN on a UNION MV should also fail with a clear error
+        String addStmt = "alter materialized view mv_union_test add column cnt as count(a)";
+        alterMVAddColumn(addStmt, true);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`visitDropMVColumnClause` directly casts `queryStatement.getQueryRelation()` to `SelectRelation` without null or `instanceof` check. When `ALTER MATERIALIZED VIEW ... DROP COLUMN` is executed on a UNION ALL MV, the query relation is `UnionRelation`, causing an unhandled `ClassCastException` that crashes the query. The sister method `visitAddMVColumnClause` already has the correct guard.

## What I'm doing:

Add null and `instanceof SelectRelation` guard before the cast in `visitDropMVColumnClause`, matching the existing pattern in `visitAddMVColumnClause`. Now returns a clear `SemanticException` instead of crashing.

Fixes #70995

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4