### PR TITLE
[Enhancement] Parallelize segment reads during persistent index rebuild

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
+#include <future>
+
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "common/config_cache_fwd.h"
@@ -991,22 +993,37 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     const uint64_t rebuild_rss_rowid_point = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid();
     const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
     OlapReaderStatistics stats;
-    MutableColumnPtr pk_column;
-    if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
-        // more than one key column or big endian encoding
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type).ok()) {
-            CHECK(false) << "create column for primary key encoder failed";
-        }
-    }
-    vector<uint32_t> rowids;
-    rowids.reserve(4096);
-    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
-    auto chunk = chunk_shared_ptr.get();
     auto rowsets = Rowset::get_rowsets(tablet_mgr, metadata);
     int64_t get_next_cost_us = 0;
     int64_t pk_encode_cost_us = 0;
     int64_t build_values_cost_us = 0;
-    // Rowset whose version is between max_sstable_version and base_version should be recovered.
+
+    // Holds the pre-read PK data and index values for one chunk batch in a segment.
+    struct PKBatch {
+        ColumnPtr pk_col;       // encoded PK column (owned)
+        std::vector<IndexValue> values;
+        bool is_binary = false; // whether pk_col is binary type
+    };
+    // Holds all pre-read results for one segment.
+    struct SegmentReadResult {
+        Status status;
+        std::vector<PKBatch> batches;
+        int64_t get_next_cost_us = 0;
+        int64_t pk_encode_cost_us = 0;
+        int64_t build_values_cost_us = 0;
+        int64_t rebuild_index_num_rows = 0;
+    };
+
+    // Phase 1: Collect all segment tasks that need rebuild.
+    struct SegmentTask {
+        ChunkIteratorPtr itr;
+        uint32_t rssid;
+        int64_t rowset_version;
+    };
+    std::vector<SegmentTask> segment_tasks;
+    // Track rowsets with del files (processed after parallel reads).
+    std::vector<std::pair<RowsetPtr, int64_t>> rowsets_with_dels;
+
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_segment_cnt", rowset->num_segments());
         TRACE_COUNTER_INCREMENT("total_num_rows", rowset->num_rows());
@@ -1021,78 +1038,152 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         auto& itrs = res.value();
         CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
         for (size_t i = 0; i < itrs.size(); i++) {
-            TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_segment_cost_us");
-            auto itr = itrs[i].get();
-            if (itr == nullptr) {
+            if (itrs[i] == nullptr) {
                 continue;
             }
-            DeferOp close_iter([&] { itr->close(); });
             uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), static_cast<int32_t>(i));
             if (rssid < rebuild_rss_id) {
-                // lower than rebuild point, skip
-                // Notice: segment id that equal `rebuild_rss_id` can't be skip because
-                // there are maybe some rows need to rebuild.
+                itrs[i]->close();
                 continue;
             }
-            TRACE_COUNTER_INCREMENT("rebuild_index_segment_cnt", 1);
-            while (true) {
-                chunk->reset();
-                rowids.clear();
-                int64_t t1 = GetCurrentTimeMicros();
-                auto st = itr->get_next(chunk, &rowids);
-                get_next_cost_us += GetCurrentTimeMicros() - t1;
-                if (st.is_end_of_file()) {
-                    break;
-                } else if (!st.ok()) {
-                    return st;
-                } else {
-                    Column* pkc = nullptr;
-                    if (pk_column) {
-                        int64_t t2 = GetCurrentTimeMicros();
-                        pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
-                                                  pk_encoding_type);
-                        pk_encode_cost_us += GetCurrentTimeMicros() - t2;
-                        pkc = pk_column.get();
-                    } else {
-                        pkc = const_cast<Column*>(chunk->columns()[0].get());
-                    }
-                    int64_t t3 = GetCurrentTimeMicros();
-                    uint64_t base = ((uint64_t)rssid) << 32;
-                    std::vector<IndexValue> values;
-                    values.reserve(pkc->size());
-                    DCHECK(pkc->size() <= rowids.size());
-                    for (uint32_t i = 0; i < pkc->size(); i++) {
-                        values.emplace_back(base + rowids[i]);
-                    }
-                    build_values_cost_us += GetCurrentTimeMicros() - t3;
-                    if (values.back().get_value() <= rebuild_rss_rowid_point) {
-                        // lower AND equal than rebuild point, skip
-                        continue;
-                    }
-                    TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", pkc->size());
-                    if (pkc->is_binary()) {
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
-                                               values.data(), rowset_version));
-                    } else {
-                        std::vector<Slice> keys;
-                        keys.reserve(pkc->size());
-                        const auto* fkeys = pkc->continuous_data();
-                        for (size_t i = 0; i < pkc->size(); ++i) {
-                            keys.emplace_back(fkeys, _key_size);
-                            fkeys += _key_size;
-                        }
-                        RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), values.data(),
-                                               rowset_version));
-                    }
-                }
-            }
+            segment_tasks.push_back({std::move(itrs[i]), rssid, rowset_version});
         }
-        // Rebuild from del files
         if (rowset->metadata().del_files_size() > 0) {
-            RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+            rowsets_with_dels.emplace_back(rowset, rowset_version);
         }
     }
+
+    // Phase 2: Parallel read + encode PK for each segment.
+    // This overlaps remote IO across segments to reduce wall-clock time.
+    std::vector<SegmentReadResult> seg_results(segment_tasks.size());
+
+    auto read_segment = [&](size_t seg_idx) {
+        auto& task = segment_tasks[seg_idx];
+        auto& result = seg_results[seg_idx];
+
+        auto itr = task.itr.get();
+        DeferOp close_iter([&] { itr->close(); });
+
+        // Per-thread local buffers
+        auto local_chunk_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+        auto local_chunk = local_chunk_ptr.get();
+        MutableColumnPtr local_pk_column;
+        if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+            if (!PrimaryKeyEncoder::create_column(pkey_schema, &local_pk_column, pk_encoding_type).ok()) {
+                result.status = Status::InternalError("create column for primary key encoder failed");
+                return;
+            }
+        }
+        vector<uint32_t> local_rowids;
+        local_rowids.reserve(4096);
+
+        while (true) {
+            local_chunk->reset();
+            local_rowids.clear();
+            int64_t t1 = GetCurrentTimeMicros();
+            auto st = itr->get_next(local_chunk, &local_rowids);
+            result.get_next_cost_us += GetCurrentTimeMicros() - t1;
+            if (st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                result.status = st;
+                return;
+            }
+
+            PKBatch batch;
+            if (local_pk_column) {
+                int64_t t2 = GetCurrentTimeMicros();
+                local_pk_column->reset_column();
+                PrimaryKeyEncoder::encode(pkey_schema, *local_chunk, 0, local_chunk->num_rows(),
+                                          local_pk_column.get(), pk_encoding_type);
+                result.pk_encode_cost_us += GetCurrentTimeMicros() - t2;
+                // Clone the pk column data so it outlives this iteration
+                batch.pk_col = local_pk_column->clone_shared();
+                batch.is_binary = local_pk_column->is_binary();
+            } else {
+                batch.pk_col = local_chunk->columns()[0]->clone_shared();
+                batch.is_binary = local_chunk->columns()[0]->is_binary();
+            }
+
+            int64_t t3 = GetCurrentTimeMicros();
+            uint64_t base = ((uint64_t)task.rssid) << 32;
+            batch.values.reserve(batch.pk_col->size());
+            DCHECK(batch.pk_col->size() <= local_rowids.size());
+            for (uint32_t j = 0; j < batch.pk_col->size(); j++) {
+                batch.values.emplace_back(base + local_rowids[j]);
+            }
+            result.build_values_cost_us += GetCurrentTimeMicros() - t3;
+
+            if (batch.values.back().get_value() <= rebuild_rss_rowid_point) {
+                continue;
+            }
+            result.rebuild_index_num_rows += batch.pk_col->size();
+            result.batches.push_back(std::move(batch));
+        }
+        result.status = Status::OK();
+    };
+
+    if (segment_tasks.size() > 1) {
+        // Submit all but the last segment to thread pool, run the last one in current thread.
+        std::vector<std::future<void>> futures;
+        futures.reserve(segment_tasks.size() - 1);
+        for (size_t i = 0; i < segment_tasks.size() - 1; i++) {
+            auto task = std::make_shared<std::packaged_task<void()>>([&read_segment, i]() { read_segment(i); });
+            auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
+            if (!st.ok()) {
+                // Fallback: run serially if thread pool is full
+                read_segment(i);
+            } else {
+                futures.push_back(task->get_future());
+            }
+        }
+        // Run the last segment in current thread
+        read_segment(segment_tasks.size() - 1);
+        // Wait for all parallel tasks
+        for (auto& f : futures) {
+            f.get();
+        }
+    } else if (segment_tasks.size() == 1) {
+        read_segment(0);
+    }
+
+    // Phase 3: Sequential insert into persistent index (insert is not thread-safe).
+    for (size_t seg_idx = 0; seg_idx < seg_results.size(); seg_idx++) {
+        auto& result = seg_results[seg_idx];
+        RETURN_IF_ERROR(result.status);
+        get_next_cost_us += result.get_next_cost_us;
+        pk_encode_cost_us += result.pk_encode_cost_us;
+        build_values_cost_us += result.build_values_cost_us;
+        TRACE_COUNTER_INCREMENT("rebuild_index_segment_cnt", 1);
+        TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", result.rebuild_index_num_rows);
+
+        const int64_t rowset_version = segment_tasks[seg_idx].rowset_version;
+        for (auto& batch : result.batches) {
+            Column* pkc = batch.pk_col.get();
+            if (batch.is_binary) {
+                RETURN_IF_ERROR(
+                        insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
+                               batch.values.data(), rowset_version));
+            } else {
+                std::vector<Slice> keys;
+                keys.reserve(pkc->size());
+                const auto* fkeys = pkc->continuous_data();
+                for (size_t j = 0; j < pkc->size(); ++j) {
+                    keys.emplace_back(fkeys, _key_size);
+                    fkeys += _key_size;
+                }
+                RETURN_IF_ERROR(
+                        insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()),
+                               batch.values.data(), rowset_version));
+            }
+        }
+    }
+
+    // Process del files sequentially
+    for (auto& [rowset, rowset_version] : rowsets_with_dels) {
+        RETURN_IF_ERROR(load_dels(rowset, pkey_schema, rowset_version));
+    }
+
     TRACE_COUNTER_INCREMENT("rebuild_get_next_cost_us", get_next_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_pk_encode_cost_us", pk_encode_cost_us);
     TRACE_COUNTER_INCREMENT("rebuild_build_values_cost_us", build_values_cost_us);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1000,7 +1000,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
 
     // Holds the pre-read PK data and index values for one chunk batch in a segment.
     struct PKBatch {
-        ColumnPtr pk_col;       // encoded PK column (owned)
+        ColumnPtr pk_col; // encoded PK column (owned)
         std::vector<IndexValue> values;
         bool is_binary = false; // whether pk_col is binary type
     };
@@ -1094,8 +1094,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             if (local_pk_column) {
                 int64_t t2 = GetCurrentTimeMicros();
                 local_pk_column->reset_column();
-                PrimaryKeyEncoder::encode(pkey_schema, *local_chunk, 0, local_chunk->num_rows(),
-                                          local_pk_column.get(), pk_encoding_type);
+                PrimaryKeyEncoder::encode(pkey_schema, *local_chunk, 0, local_chunk->num_rows(), local_pk_column.get(),
+                                          pk_encoding_type);
                 result.pk_encode_cost_us += GetCurrentTimeMicros() - t2;
                 // Clone the pk column data so it outlives this iteration
                 batch.pk_col = local_pk_column->clone_shared();
@@ -1161,9 +1161,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         for (auto& batch : result.batches) {
             Column* pkc = batch.pk_col.get();
             if (batch.is_binary) {
-                RETURN_IF_ERROR(
-                        insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
-                               batch.values.data(), rowset_version));
+                RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()),
+                                       batch.values.data(), rowset_version));
             } else {
                 std::vector<Slice> keys;
                 keys.reserve(pkc->size());
@@ -1172,9 +1171,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                     keys.emplace_back(fkeys, _key_size);
                     fkeys += _key_size;
                 }
-                RETURN_IF_ERROR(
-                        insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()),
-                               batch.values.data(), rowset_version));
+                RETURN_IF_ERROR(insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), batch.values.data(),
+                                       rowset_version));
             }
         }
     }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2530,4 +2530,148 @@ TEST_P(LakePrimaryKeyPublishTest, test_preload_update_state_slow_log) {
     ASSERT_TRUE(read(tablet_id, 2).ok());
 }
 
+// Test that parallel segment reads during persistent index rebuild produce correct results.
+// This exercises the code path in LakePersistentIndex::load_from_lake_tablet where
+// multiple segments are read concurrently.
+TEST_P(LakePrimaryKeyPublishTest, test_parallel_rebuild_persistent_index_multi_segments) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Step 1: Write multiple chunks with small write_buffer_size to create multiple segments
+    // per rowset, ensuring rebuild will have multiple segments to read in parallel.
+    const int64_t old_write_buffer_size = config::write_buffer_size;
+    config::write_buffer_size = 1; // force flush per write -> multiple segments
+    const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10; // force sstable flush for cloud native index
+
+    // Write 3 rowsets, each with 3 segments (3 chunks per write)
+    for (int r = 0; r < 3; r++) {
+        auto [chunk0, indexes0] = gen_data_and_index(kChunkSize, r * 3, true, true);
+        auto [chunk1, indexes1] = gen_data_and_index(kChunkSize, r * 3 + 1, true, true);
+        auto [chunk2, indexes2] = gen_data_and_index(kChunkSize, r * 3 + 2, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes0.data(), indexes0.size()));
+        ASSERT_OK(delta_writer->write(*chunk1, indexes1.data(), indexes1.size()));
+        ASSERT_OK(delta_writer->write(*chunk2, indexes2.data(), indexes2.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    config::write_buffer_size = old_write_buffer_size;
+
+    // Verify initial data: 9 non-overlapping ranges, each kChunkSize rows
+    ASSERT_EQ(kChunkSize * 9, read_rows(tablet_id, version));
+
+    // Step 2: Remove persistent index to force rebuild on next publish
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+    // Step 3: Write more data, which triggers rebuild with multiple segments read in parallel
+    auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 9, true, true);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk_new, indexes_new.data(), indexes_new.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Step 4: Verify data correctness after parallel rebuild
+    ASSERT_EQ(kChunkSize * 10, read_rows(tablet_id, version));
+
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+}
+
+// Test parallel rebuild with overlapping data (upserts) to verify correctness
+// of insert ordering when segments are read in parallel.
+TEST_P(LakePrimaryKeyPublishTest, test_parallel_rebuild_persistent_index_with_upserts) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+
+    // Write 3 rowsets with overlapping keys (same shift=0 means same key range)
+    for (int r = 0; r < 3; r++) {
+        auto [chunk, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Should have kChunkSize rows (overlapping upserts)
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    // Remove persistent index to force rebuild
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+    // Write again with overlapping data to trigger rebuild + upsert
+    auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 0, true, true);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk_new, indexes_new.data(), indexes_new.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Still kChunkSize rows after upsert
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

During persistent index rebuild in publish, segment reads are performed sequentially.
When multiple segments need to be rebuilt, the remote IO latency accumulates linearly.
For example, with 3 segments and ~172 remote IO calls totaling 14.36s, the rebuild
takes 18s end-to-end. Parallelizing segment reads can reduce wall-clock time
proportional to the number of segments.

## What I'm doing:

Refactored `LakePersistentIndex::load_from_lake_tablet` into three phases:

1. **Collect**: Gather all segment iterators that need rebuild
2. **Parallel Read + Encode**: Submit segment read tasks to `load_rowset_thread_pool`,
   each with its own chunk/pk_column/rowids buffers. PK encoding is also done in parallel.
   Results (encoded PK columns + IndexValues) are stored in per-segment result structs.
3. **Sequential Insert**: Insert pre-read batches into the persistent index in original
   segment order (since `PersistentIndex::insert` is not thread-safe).

Key design points:
- Reuses existing `load_rowset_thread_pool` (same pattern as `tablet_reader.cpp`)
- Falls back to serial execution if thread pool submission fails
- Current thread runs the last segment to avoid wasting a thread
- Memory overhead is minimal: only buffered PK encoded data (typically small for rebuild)

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4