### PR TITLE
[Refactor] Remove the dead code of Analytor::_append_chunk

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -639,59 +639,6 @@ public:
         }
     }
 
-    template <typename ColumnPtrType>
-    static inline void ensure_large_binary_column(ColumnPtrType& column) {
-        Column* data_column = get_data_column(column->as_mutable_raw_ptr());
-        if (!data_column->is_binary()) {
-            return;
-        }
-        auto* binary_column = down_cast<BinaryColumn*>(data_column);
-        auto large_column = LargeBinaryColumn::create();
-        large_column->get_bytes().swap(binary_column->get_bytes());
-        auto& src_offsets = binary_column->get_offset();
-        auto& dst_offsets = large_column->get_offset();
-        dst_offsets.resize(src_offsets.size());
-        for (size_t i = 0; i < src_offsets.size(); ++i) {
-            dst_offsets[i] = src_offsets[i];
-        }
-        // Reset to valid empty state (offsets must have at least one element)
-        src_offsets.resize(1);
-        src_offsets[0] = 0;
-        if (column->is_nullable()) {
-            auto* nullable_column = down_cast<NullableColumn*>(column->as_mutable_raw_ptr());
-            nullable_column->data_column() = std::move(large_column);
-        } else if (column->is_constant()) {
-            auto* const_column = down_cast<ConstColumn*>(column->as_mutable_raw_ptr());
-            const_column->data_column() = std::move(large_column);
-        } else {
-            column = std::move(large_column);
-        }
-    }
-
-    template <typename Func>
-    static inline void with_binary_column_bytes(Column* column, Func&& func) {
-        if (column->is_large_binary()) {
-            auto* col = down_cast<LargeBinaryColumn*>(column);
-            func(col->get_bytes(), col->get_offset());
-        } else {
-            auto* col = down_cast<BinaryColumn*>(column);
-            func(col->get_bytes(), col->get_offset());
-        }
-    }
-
-    // Dispatch on the concrete binary column type once, then invoke the lambda
-    // with a typed pointer (const BinaryColumn* or const LargeBinaryColumn*).
-    // Use this to hoist the type check out of hot loops.
-    template <typename Func>
-    static inline void with_binary_data_column(const Column* column, Func&& func) {
-        const Column* data_column = get_data_column(column);
-        if (data_column->is_large_binary()) {
-            func(down_cast<const LargeBinaryColumn*>(data_column));
-        } else {
-            func(down_cast<const BinaryColumn*>(data_column));
-        }
-    }
-
     static bool is_all_const(const Columns& columns);
 
     // Returns

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -683,12 +683,10 @@ Status Analytor::_add_chunk(const ChunkPtr& chunk) {
         SCOPED_TIMER(_column_resize_timer);
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
+                // https://github.com/StarRocks/starrocks/pull/43065 will confirm _agg_expr_cts->evaluate
+                // will not generate one column large then 4GB.
                 ASSIGN_OR_RETURN(ColumnPtr column, _agg_expr_ctxs[i][j]->evaluate(chunk.get()));
 
-                // When chunk's column is const, maybe need to unpack it.
-                if (ColumnHelper::get_data_column(column.get())->is_large_binary()) {
-                    ColumnHelper::ensure_large_binary_column(_agg_intput_columns[i][j]);
-                }
                 TRY_CATCH_BAD_ALLOC(
                         _append_column(chunk_size, _agg_intput_columns[i][j]->as_mutable_raw_ptr(), column));
 
@@ -704,9 +702,6 @@ Status Analytor::_add_chunk(const ChunkPtr& chunk) {
 
         for (size_t i = 0; i < _partition_ctxs.size(); i++) {
             ASSIGN_OR_RETURN(ColumnPtr column, _partition_ctxs[i]->evaluate(chunk.get()));
-            if (ColumnHelper::get_data_column(column.get())->is_large_binary()) {
-                ColumnHelper::ensure_large_binary_column(_partition_columns[i]);
-            }
             TRY_CATCH_BAD_ALLOC(_append_column(chunk_size, _partition_columns[i].get(), column));
 
             // Upgrade BinaryColumn to LargeBinaryColumn if it exceeds 4GB
@@ -719,9 +714,6 @@ Status Analytor::_add_chunk(const ChunkPtr& chunk) {
 
         for (size_t i = 0; i < _order_ctxs.size(); i++) {
             ASSIGN_OR_RETURN(ColumnPtr column, _order_ctxs[i]->evaluate(chunk.get()));
-            if (ColumnHelper::get_data_column(column.get())->is_large_binary()) {
-                ColumnHelper::ensure_large_binary_column(_order_columns[i]);
-            }
             TRY_CATCH_BAD_ALLOC(_append_column(chunk_size, _order_columns[i].get(), column));
 
             // Upgrade BinaryColumn to LargeBinaryColumn if it exceeds 4GB

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -683,8 +683,8 @@ Status Analytor::_add_chunk(const ChunkPtr& chunk) {
         SCOPED_TIMER(_column_resize_timer);
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
-                // https://github.com/StarRocks/starrocks/pull/43065 will confirm _agg_expr_cts->evaluate
-                // will not generate one column large then 4GB.
+                // https://github.com/StarRocks/starrocks/pull/43065 confirms that _agg_expr_ctxs[i][j]->evaluate
+                // will not generate a single column larger than 4GB.
                 ASSIGN_OR_RETURN(ColumnPtr column, _agg_expr_ctxs[i][j]->evaluate(chunk.get()));
 
                 TRY_CATCH_BAD_ALLOC(


### PR DESCRIPTION
## Why I'm doing:

This is the 9nd pr for https://github.com/StarRocks/starrocks/pull/69067

PR #43065 confirmed that evaluate() will never produce a column exceeding 4 GB, so the evaluated column will never be of LargeBinary type. These guards are therefore unreachable dead code.

And the implement of ensure_large_binary_column also has bug, can't handle complex type such as Array<String> column, so i just remove it. 

Later i will and chunk split logic at  ExprContext::evaluate instead of report one error.

## What I'm doing:

Remove the dead code of Analytor::_append_chunk

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
