### PR TITLE
[Enhancement] improve variant virtual column rewrite coverage and add tests

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
@@ -227,7 +227,15 @@ public class VariantPathRewriteRule extends TransformationRule {
                     mapping.put(entry.getKey(), rewriteScalar(entry.getValue(), context, rewriter));
                 }
                 builder.getProjection().getColumnRefMap().putAll(mapping);
+
+                Map<ColumnRefOperator, ScalarOperator> commonSubMapping = Maps.newHashMap();
+                for (var entry : scanOperator.getProjection().getCommonSubOperatorMap().entrySet()) {
+                    commonSubMapping.put(entry.getKey(), rewriteScalar(entry.getValue(), context, rewriter));
+                }
+                builder.getProjection().getCommonSubOperatorMap().putAll(commonSubMapping);
+
                 mapping.values().forEach(x -> requiredColumnSet.union(x.getUsedColumns()));
+                commonSubMapping.values().forEach(x -> requiredColumnSet.union(x.getUsedColumns()));
             } else {
                 scanOperator.getOutputColumns().forEach(requiredColumnSet::union);
             }
@@ -255,6 +263,7 @@ public class VariantPathRewriteRule extends TransformationRule {
             Operator newOp = builder.build();
             return OptExpression.builder().with(optExpr).setOp(newOp).build();
         }
+
     }
 
     private static ScalarOperator rewriteScalar(ScalarOperator scalar,
@@ -280,7 +289,7 @@ public class VariantPathRewriteRule extends TransformationRule {
 
         @Override
         public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext rewriteContext) {
-            if (isSupportedVariantFunction(call)) {
+            if (isRewriteCandidate(call)) {
                 return rewriteVariantFunction(call);
             }
             return call;
@@ -288,11 +297,10 @@ public class VariantPathRewriteRule extends TransformationRule {
 
         @Override
         public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
-            ScalarOperator child = operator.getChild(0);
-            if (!(child instanceof CallOperator call)) {
+            if (!(operator.getChild(0) instanceof CallOperator call)) {
                 return operator;
             }
-            if (!isSupportedVariantQuery(call)) {
+            if (!isRewriteCandidate(operator, call)) {
                 return operator;
             }
 
@@ -320,19 +328,19 @@ public class VariantPathRewriteRule extends TransformationRule {
             }
         }
 
-        private boolean isSupportedVariantFunction(CallOperator call) {
+        static boolean isSupportedVariantFunction(CallOperator call) {
             return SUPPORTED_VARIANT_FUNCTIONS.contains(call.getFnName())
                     && call.getArguments().size() == 2
                     && call.getChild(0).getType().isVariantType();
         }
 
-        private boolean isSupportedVariantQuery(CallOperator call) {
+        static boolean isSupportedVariantQuery(CallOperator call) {
             return FunctionSet.VARIANT_QUERY.equals(call.getFnName())
                     && call.getArguments().size() == 2
                     && call.getChild(0).getType().isVariantType();
         }
 
-        private boolean isSupportedCastTarget(Type type) {
+        static boolean isSupportedCastTarget(Type type) {
             return type.isBoolean()
                     || type.isIntegerType()
                     || type.isFloatingPointType()
@@ -340,6 +348,14 @@ public class VariantPathRewriteRule extends TransformationRule {
                     || type.isDate()
                     || type.isDatetime()
                     || type.isTime();
+        }
+
+        static boolean isRewriteCandidate(CallOperator call) {
+            return isSupportedVariantFunction(call);
+        }
+
+        static boolean isRewriteCandidate(CastOperator operator, CallOperator call) {
+            return isSupportedVariantQuery(call) && isSupportedCastTarget(operator.getType());
         }
 
         private ScalarOperator rewriteVariantFunction(CallOperator call) {
@@ -382,12 +398,12 @@ public class VariantPathRewriteRule extends TransformationRule {
             return columnResult.second;
         }
 
-        private static List<String> parseVariantPath(String path) {
+        static List<String> parseVariantPath(String path) {
             List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath(path);
             return result.isEmpty() ? null : result;
         }
 
-        private static boolean isValidVariantPath(List<String> variantPath) {
+        static boolean isValidVariantPath(List<String> variantPath) {
             if (CollectionUtils.isEmpty(variantPath)) {
                 return false;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -82,6 +82,8 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
     public static void beforeClass() throws Exception {
         Config.show_execution_groups = false;
         Config.enable_virtual_columns = false;
+        Config.proc_profile_cpu_enable = false;
+        Config.proc_profile_mem_enable = false;
         // disable checking tablets
         Config.tablet_sched_max_scheduling_tablets = -1;
         Config.alter_scheduler_interval_millisecond = 1;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
@@ -111,4 +111,93 @@ public class VariantPathRewriteTest extends ConnectorPlanTestBase {
         String verbose = getVerboseExplain(sql);
         assertContains(verbose, "ExtendedColumnAccessPath: [/v(bigint(20))/metrics(bigint(20))/views(bigint(20))]");
     }
+
+    @Test
+    public void testPrefixAndDescendantPathBothRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select cast(variant_query(v, '$.a.b') as bigint), get_variant_int(v, '$.a.b.c') from "
+                + VARIANT_TABLE;
+        String plan = getFragmentPlan(sql);
+        // Both paths are rewritten as virtual columns
+        assertContains(plan, "v.a.b");
+        assertContains(plan, "v.a.b.c");
+
+        String verbose = getVerboseExplain(sql);
+        // Both virtual columns appear in the extended access path list
+        assertContains(verbose, "/v(bigint(20))/a(bigint(20))/b(bigint(20))/c(bigint(20))");
+        assertContains(verbose, "/v(bigint(20))/a(bigint(20))/b(bigint(20))");
+    }
+
+    @Test
+    public void testSiblingLeafPathsRewriteIndependently() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select get_variant_int(v, '$.metrics.views'), get_variant_string(v, '$.profile.department') from "
+                + VARIANT_TABLE;
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "v.metrics.views");
+        assertContains(plan, "v.profile.department");
+
+        String verbose = getVerboseExplain(sql);
+        assertContains(verbose, "ColumnAccessPath:");
+        assertContains(verbose, "/v(bigint(20))/metrics(bigint(20))/views(bigint(20))");
+        assertContains(verbose, "/v(varchar)/profile(varchar)/department(varchar)");
+    }
+
+    @Test
+    public void testRootVariantAndVirtualColumnCoexist() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select v, get_variant_int(v, '$.id') from " + VARIANT_TABLE;
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "v.id");
+
+        String verbose = getVerboseExplain(sql);
+        assertContains(verbose, "ExtendedColumnAccessPath: [/v(bigint(20))/id(bigint(20))]");
+    }
+
+    @Test
+    public void testRootVariantAndVirtualPredicateCoexist() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select v from " + VARIANT_TABLE + " where get_variant_int(v, '$.id') = 1000";
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES:");
+        assertContains(plan, "v.id = 1000");
+
+        String verbose = getVerboseExplain(sql);
+        assertContains(verbose, "ExtendedColumnAccessPath: [/v(bigint(20))/id(bigint(20))]");
+    }
+
+    @Test
+    public void testCastRewriteRequiresDirectVariantQueryChild() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select cast(ifnull(variant_query(v, '$.a'), variant_query(v, '$.b')) as bigint) from "
+                + VARIANT_TABLE;
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(ifnull");
+        assertNotContains(plan, "v.a");
+        assertNotContains(plan, "v.b");
+
+        String verbose = getVerboseExplain(sql);
+        assertNotContains(verbose, "ExtendedColumnAccessPath:");
+    }
+
+    @Test
+    public void testNonRewritableCastDoesNotBlockSiblingLeafRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select cast(ifnull(variant_query(v, '$.a.b.c'), variant_query(v, '$.x')) as bigint), "
+                + "get_variant_int(v, '$.a.b') from " + VARIANT_TABLE;
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(ifnull");
+        assertContains(plan, "v.a.b");
+        assertNotContains(plan, "v.a.b.c");
+
+        String verbose = getVerboseExplain(sql);
+        assertContains(verbose, "ExtendedColumnAccessPath: [/v(bigint(20))/a(bigint(20))/b(bigint(20))]");
+        assertNotContains(verbose,
+                "ExtendedColumnAccessPath: [/v(bigint(20))/a(bigint(20))/b(bigint(20))/c(bigint(20))]");
+    }
 }

--- a/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
@@ -57,6 +57,72 @@ function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.p
 -- result:
 True
 -- !result
+select get_variant_int(data, '$.id') as id
+from test_variant_virtual_column
+order by id;
+-- result:
+1000
+1001
+1002
+1003
+1004
+-- !result
+select get_variant_string(data, '$.profile.department') as dept
+from test_variant_virtual_column
+order by dept;
+-- result:
+dept_0
+dept_1
+dept_2
+dept_3
+dept_4
+-- !result
+select get_variant_int(data, '$.id') as id,
+       get_variant_string(data, '$.profile.department') as dept
+from test_variant_virtual_column
+order by id;
+-- result:
+1000	dept_0
+1001	dept_1
+1002	dept_2
+1003	dept_3
+1004	dept_4
+-- !result
+select get_variant_int(data, '$.id') as id,
+       data
+from test_variant_virtual_column
+where get_variant_int(data, '$.id') = 1000
+order by id;
+-- result:
+1000	{"age":20,"city":"city_0","email":"user0@example.com","events":[{"count":1,"detail":"detail_view_0","type":"view"},{"count":2,"detail":"detail_click_0","type":"click"}],"groups":[{"name":"group_0","note":"note_0_0","scores":[10,20,30]},{"name":"group_1","note":"note_0_1","scores":[40,50,60]}],"id":1000,"name":"name_0","numbers":[1,2,3],"profile":{"department":"dept_0","metrics":{"ratio":0.10000000000000001,"views":100},"rank":1,"salary":50000.0},"score":80,"status":"active"}
+-- !result
+select cast(variant_query(data, '$.profile.rank') as bigint) as rank_val
+from test_variant_virtual_column
+order by rank_val;
+-- result:
+None
+None
+1
+3
+5
+-- !result
+select get_variant_string(data, '$.profile.department') as dept,
+       sum(get_variant_int(data, '$.profile.metrics.views')) as total_views
+from test_variant_virtual_column
+group by 1
+order by 1;
+-- result:
+dept_0	100
+dept_1	110
+dept_2	120
+dept_3	130
+dept_4	140
+-- !result
+select sum(get_variant_int(data, '$.profile.metrics.views'))
+from test_variant_virtual_column;
+-- result:
+600
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_variant_virtual_column_rewrite/${uuid0}/ > /dev/null
 -- result:
 0

--- a/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
@@ -57,6 +57,9 @@ function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.p
 -- result:
 True
 -- !result
+set cbo_variant_path_rewrite = false;
+-- result:
+-- !result
 select get_variant_int(data, '$.id') as id
 from test_variant_virtual_column
 order by id;

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -31,6 +31,8 @@ function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') 
 function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.rank') as bigint) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/rank(bigint(20))]")
 function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.profile.metrics.views')) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/metrics(bigint(20))/views(bigint(20))]")
 
+set cbo_variant_path_rewrite = false;
+
 select get_variant_int(data, '$.id') as id
 from test_variant_virtual_column
 order by id;

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -31,6 +31,38 @@ function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') 
 function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.rank') as bigint) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/rank(bigint(20))]")
 function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.profile.metrics.views')) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/metrics(bigint(20))/views(bigint(20))]")
 
+select get_variant_int(data, '$.id') as id
+from test_variant_virtual_column
+order by id;
+
+select get_variant_string(data, '$.profile.department') as dept
+from test_variant_virtual_column
+order by dept;
+
+select get_variant_int(data, '$.id') as id,
+       get_variant_string(data, '$.profile.department') as dept
+from test_variant_virtual_column
+order by id;
+
+select get_variant_int(data, '$.id') as id,
+       data
+from test_variant_virtual_column
+where get_variant_int(data, '$.id') = 1000
+order by id;
+
+select cast(variant_query(data, '$.profile.rank') as bigint) as rank_val
+from test_variant_virtual_column
+order by rank_val;
+
+select get_variant_string(data, '$.profile.department') as dept,
+       sum(get_variant_int(data, '$.profile.metrics.views')) as total_views
+from test_variant_virtual_column
+group by 1
+order by 1;
+
+select sum(get_variant_int(data, '$.profile.metrics.views'))
+from test_variant_virtual_column;
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_variant_virtual_column_rewrite/${uuid0}/ > /dev/null
 
 drop table test_variant_virtual_column force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR makes a small enhancement to variant virtual column rewrite in FE.

The main change is to improve rewrite coverage for more variant path access scenarios, including projection/common-sub-expression related paths, coexistence of root variant columns and rewritten virtual columns, and cases where rewritable and non-rewritable expressions appear together. The rewrite candidate check is also cleaned up to make the behavior more explicit and easier to validate.

In addition, this PR adds more FE unit tests and SQL integration tests for iceberg variant virtual column rewrite, covering both rewrite-enabled and rewrite-disabled cases to ensure plan stability and result correctness.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
