### PR TITLE
[BugFix] Fix inverted GROUP BY subquery validation when ONLY_FULL_GROUP_BY is disabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -330,9 +330,7 @@ public class AggregationAnalyzer {
                     if (!SqlModeHelper.check(session.getSessionVariable().getSqlMode(),
                             SqlModeHelper.MODE_ONLY_FULL_GROUP_BY)) {
                         if (!analyzeState.getColumnNotInGroupBy().contains(expr)) {
-                            throw new SemanticException(
-                                    PARSER_ERROR_MSG.unsupportedNoGroupBySubquery(ExprToSql.toSql(expr), ExprToSql.toSql(node)),
-                                    expr.getPos());
+                            analyzeState.getColumnNotInGroupBy().add(expr);
                         }
                     } else {
                         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
@@ -496,6 +497,20 @@ public class QueryTransformer {
             // the output key -> value pair must use the original aggregate expr as key, because
             // the top node may ref the original aggregate expr
             groupingTranslations.put(aggregates.get(i), colRef);
+
+            // For any_value() wrapping a non-GROUP-BY column (generated when ONLY_FULL_GROUP_BY is off),
+            // also map the underlying column's field to the any_value output. This allows correlated
+            // subqueries to resolve outer non-GROUP-BY column references through the aggregate.
+            if (FunctionSet.ANY_VALUE.equals(aggOperator.getFnName())
+                    && aggregates.get(i).getChildren().size() == 1
+                    && aggregates.get(i).getChild(0) instanceof SlotRef) {
+                SlotRef childSlot = (SlotRef) aggregates.get(i).getChild(0);
+                ScalarOperator childOp = SqlToScalarOperatorTranslator.translate(
+                        childSlot, subOpt.getExpressionMapping(), columnRefFactory);
+                if (childOp instanceof ColumnRefOperator && !groupByColumnRefs.contains(childOp)) {
+                    groupingTranslations.put(childSlot, colRef);
+                }
+            }
         }
 
         //Add repeatOperator to support grouping sets

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -1886,14 +1887,73 @@ public class SubqueryTest extends PlanTestBase {
     //    }
 
     @Test
-    public void testHavingSubqueryNoGroupMode() {
+    public void testHavingSubqueryNoGroupMode() throws Exception {
+        // When ONLY_FULL_GROUP_BY is disabled (sql_mode=0), correlated subqueries in HAVING
+        // referencing non-GROUP-BY outer columns should be allowed.
+        // The non-GROUP-BY column is implicitly wrapped with any_value().
         String sql = "select v3 from t0 group by v2 having 1 > (select v4 from t1 where t0.v1 = t1.v5)";
         long sqlMode = connectContext.getSessionVariable().getSqlMode();
         try {
             connectContext.getSessionVariable().setSqlMode(0);
-            Assertions.assertThrows(SemanticException.class,
-                    () -> getFragmentPlan(sql),
-                    "must be an aggregate expression or appear in GROUP BY clause");
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "any_value");
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(sqlMode);
+        }
+    }
+
+    @Test
+    public void testCorrelatedSubqueryNonGroupByColumnNoFullGroupBy() throws Exception {
+        // Issue #70996: When ONLY_FULL_GROUP_BY is disabled, correlated subqueries in SELECT
+        // referencing non-GROUP-BY outer columns should be allowed.
+        long sqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(0);
+
+            // Basic case: single non-GROUP-BY column in subquery correlation
+            {
+                String sql = "SELECT v1, MAX(v2), " +
+                        "(SELECT COUNT(*) FROM t1 WHERE t1.v4 = t0.v1 AND t1.v5 = t0.v3) AS cnt " +
+                        "FROM t0 GROUP BY v1";
+                String plan = getFragmentPlan(sql);
+                // v3 is not in GROUP BY, should be projected through aggregate via any_value
+                assertContains(plan, "any_value");
+            }
+
+            // Multiple non-GROUP-BY columns in subquery correlation
+            {
+                String sql = "SELECT v1, MAX(v2), " +
+                        "(SELECT COUNT(*) FROM t1 WHERE t1.v4 = t0.v2 AND t1.v5 = t0.v3) AS cnt " +
+                        "FROM t0 GROUP BY v1";
+                String plan = getFragmentPlan(sql);
+                assertContains(plan, "any_value");
+            }
+
+            // GROUP-BY column + non-GROUP-BY column in same subquery correlation
+            {
+                String sql = "SELECT v1, SUM(v2), " +
+                        "(SELECT COUNT(*) FROM t1 WHERE t1.v4 = t0.v1 AND t1.v5 = t0.v3) AS cnt " +
+                        "FROM t0 GROUP BY v1";
+                String plan = getFragmentPlan(sql);
+                // v1 is in GROUP BY (no wrapping needed), v3 is not (needs any_value)
+                assertContains(plan, "any_value");
+            }
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(sqlMode);
+        }
+    }
+
+    @Test
+    public void testCorrelatedSubqueryNonGroupByColumnFullGroupByRejects() {
+        // When ONLY_FULL_GROUP_BY is ON (default), correlated subqueries referencing
+        // non-GROUP-BY outer columns should still be rejected.
+        long sqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(SqlModeHelper.MODE_ONLY_FULL_GROUP_BY);
+            String sql = "SELECT v1, MAX(v2), " +
+                    "(SELECT COUNT(*) FROM t1 WHERE t1.v4 = t0.v1 AND t1.v5 = t0.v3) AS cnt " +
+                    "FROM t0 GROUP BY v1";
+            assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
         } finally {
             connectContext.getSessionVariable().setSqlMode(sqlMode);
         }

--- a/test/sql/test_sql_mode_errors/R/test_no_full_group_by_subquery.result
+++ b/test/sql/test_sql_mode_errors/R/test_no_full_group_by_subquery.result
@@ -1,0 +1,57 @@
+-- name: test_no_full_group_by_correlated_subquery
+-- Test Point: correlated subquery referencing non-GROUP-BY outer columns should
+-- succeed when ONLY_FULL_GROUP_BY is disabled, and be rejected when enabled (issue #70996)
+create database test_db_${uuid0};
+-- result:
+-- !result
+use test_db_${uuid0};
+-- result:
+-- !result
+create table orders (
+  order_id INT,
+  customer_id INT,
+  amount DECIMAL(10,2),
+  status VARCHAR(20)
+) ENGINE=OLAP
+DUPLICATE KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into orders values (1, 101, 100.00, 'complete'), (2, 101, 200.00, 'pending'), (3, 102, 300.00, 'complete'), (4, 102, 150.00, 'pending');
+-- result:
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) as cnt from orders o group by customer_id order by customer_id;
+-- result:
+101	200.00	1
+102	300.00	1
+-- !result
+set sql_mode = 'ONLY_FULL_GROUP_BY';
+-- result:
+-- !result
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) as cnt from orders o group by customer_id order by customer_id;
+-- result:
+[REGEX].*must be an aggregate expression or appear in GROUP BY clause.*
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status and o2.amount = o.amount) as cnt from orders o group by customer_id order by customer_id;
+-- result:
+101	200.00	1
+102	300.00	1
+-- !result
+set sql_mode = '';
+-- result:
+-- !result
+select customer_id, max(amount) from orders o group by customer_id having max(amount) > (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) order by customer_id;
+-- result:
+101	200.00
+102	300.00
+-- !result
+drop database test_db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_sql_mode_errors/T/test_no_full_group_by_subquery.sql
+++ b/test/sql/test_sql_mode_errors/T/test_no_full_group_by_subquery.sql
@@ -1,0 +1,34 @@
+-- name: test_no_full_group_by_correlated_subquery
+-- Test Point: correlated subquery referencing non-GROUP-BY outer columns should
+-- succeed when ONLY_FULL_GROUP_BY is disabled, and be rejected when enabled (issue #70996)
+create database test_db_${uuid0};
+use test_db_${uuid0};
+create table orders (
+  order_id INT,
+  customer_id INT,
+  amount DECIMAL(10,2),
+  status VARCHAR(20)
+) ENGINE=OLAP
+DUPLICATE KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES('replication_num'='1');
+insert into orders values (1, 101, 100.00, 'complete'), (2, 101, 200.00, 'pending'), (3, 102, 300.00, 'complete'), (4, 102, 150.00, 'pending');
+
+-- With ONLY_FULL_GROUP_BY disabled, correlated subquery referencing
+-- non-GROUP-BY outer column should succeed and return correct results.
+set sql_mode = '';
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) as cnt from orders o group by customer_id order by customer_id;
+
+-- With ONLY_FULL_GROUP_BY enabled, the same query should be rejected.
+set sql_mode = 'ONLY_FULL_GROUP_BY';
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) as cnt from orders o group by customer_id order by customer_id;
+
+-- Additional: multiple non-GROUP-BY columns in subquery correlation
+set sql_mode = '';
+select customer_id, max(amount), (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status and o2.amount = o.amount) as cnt from orders o group by customer_id order by customer_id;
+
+-- Correlated subquery in HAVING with non-GROUP-BY outer column
+set sql_mode = '';
+select customer_id, max(amount) from orders o group by customer_id having max(amount) > (select count(*) from orders o2 where o2.customer_id = o.customer_id and o2.status = o.status) order by customer_id;
+
+drop database test_db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

When `ONLY_FULL_GROUP_BY` is disabled (`sql_mode=''`), correlated subqueries referencing non-GROUP-BY outer columns are incorrectly rejected with `SemanticException`. The guard logic in `AggregationAnalyzer.visitSubqueryExpr` is inverted — it throws in permissive mode instead of allowing the reference.

## What I'm doing:

Two fixes:

1. **AggregationAnalyzer.visitSubqueryExpr**: Replace `throw SemanticException` with `columnNotInGroupBy.add(expr)` to match `isGroupingKey`'s permissive behavior — the non-GROUP-BY column gets implicitly wrapped with `any_value()`.

2. **QueryTransformer.aggregate()**: For `any_value()` aggregates wrapping non-GROUP-BY columns, also update `fieldMappings` so the optimizer can resolve correlated subquery column references through the aggregate node. Without this, the optimizer throws a missing statistics error because the pre-aggregate column ref is no longer available after aggregation.

Fixes #70996

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4