### PR TITLE
[Enhancement] Rewrite lake tablet merge to handle shared rowset/delvec/dcg/sstable from split

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -827,8 +827,9 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
 
 Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFileInfo>& old_delvec_files,
                           int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
-                          std::vector<uint64_t>* offsets) {
+                          std::vector<uint64_t>* offsets, const Slice& extra_data, uint64_t* extra_data_offset) {
     if (old_delvec_files.empty()) {
+        DCHECK(extra_data.empty()) << "extra_data provided but no delvec files to merge";
         return Status::OK();
     }
 
@@ -867,6 +868,14 @@ Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFil
         ASSIGN_OR_RETURN(auto content, reader->read_all());
         RETURN_IF_ERROR(writer->append(Slice(content.data(), content.size())));
         total_size += content.size();
+    }
+
+    if (!extra_data.empty()) {
+        if (extra_data_offset != nullptr) {
+            *extra_data_offset = total_size;
+        }
+        RETURN_IF_ERROR(writer->append(extra_data));
+        total_size += extra_data.size;
     }
 
     RETURN_IF_ERROR(writer->close());

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -150,7 +150,8 @@ struct DelvecFileInfo {
 
 Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFileInfo>& old_delvec_files,
                           int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
-                          std::vector<uint64_t>* offsets);
+                          std::vector<uint64_t>* offsets, const Slice& extra_data = {},
+                          uint64_t* extra_data_offset = nullptr);
 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, const DelvecPagePB& delvec_page,
                    bool fill_cache, const LakeIOOptions& lake_io_opts, DelVector* delvec);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -16,39 +16,112 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include "base/hash/crc32c.h"
 #include "base/testutil/sync_point.h"
+#include "fs/fs_util.h"
+#include "storage/del_vector.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reshard_helper.h"
+#include "storage/options.h"
 
 namespace starrocks::lake {
 
 namespace {
 
-struct TabletMergeInfo {
-    TabletMetadataPtr metadata;
-    int64_t rssid_offset = 0;
+class TabletMergeContext {
+public:
+    explicit TabletMergeContext(TabletMetadataPtr metadata) : _metadata(std::move(metadata)) {}
+
+    const TabletMetadataPtr& metadata() const { return _metadata; }
+
+    int64_t rssid_offset() const { return _rssid_offset; }
+    void set_rssid_offset(int64_t offset) { _rssid_offset = offset; }
+
+    // Maps an original rssid to the final output rssid.
+    // If the rssid was deduped, returns the canonical rssid from shared_rssid_map;
+    // otherwise applies the default offset mapping with overflow check.
+    StatusOr<uint32_t> map_rssid(uint32_t rssid) const {
+        auto it = _shared_rssid_map.find(rssid);
+        if (it != _shared_rssid_map.end()) {
+            return it->second;
+        }
+        int64_t mapped = static_cast<int64_t>(rssid) + _rssid_offset;
+        if (mapped < 0 || mapped > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+            return Status::InvalidArgument("Segment id overflow during tablet merge");
+        }
+        return static_cast<uint32_t>(mapped);
+    }
+
+    bool has_shared_rssid_mapping() const { return !_shared_rssid_map.empty(); }
+
+    // Fills shared_rssid_map so that all rssids occupied by |rowset| map to
+    // the corresponding rssid in |canonical_rowset|.
+    void update_shared_rssid_map(const RowsetMetadataPB& rowset, const RowsetMetadataPB& canonical_rowset) {
+        uint32_t canonical_rssid = canonical_rowset.id();
+        _shared_rssid_map[rowset.id()] = canonical_rssid;
+        for (int seg_pos = 0; seg_pos < rowset.segments_size(); ++seg_pos) {
+            uint32_t rssid = get_rssid(rowset, seg_pos);
+            uint32_t seg_offset = rssid - rowset.id();
+            _shared_rssid_map[rssid] = canonical_rssid + seg_offset;
+        }
+    }
+
+    bool has_next_rowset() const { return _current_rowset_index < _metadata->rowsets_size(); }
+    const RowsetMetadataPB& current_rowset() const { return _metadata->rowsets(_current_rowset_index); }
+    void advance_rowset() { ++_current_rowset_index; }
+
+private:
+    TabletMetadataPtr _metadata;
+    int64_t _rssid_offset = 0;
+    int _current_rowset_index = 0;
+    // Dedup-produced rssid remap table.
+    // key: original rssid in this child metadata
+    // value: canonical rowset's actual rssid in the final output
+    // rssid not in this map uses the default offset mapping.
+    std::unordered_map<uint32_t, uint32_t> _shared_rssid_map;
 };
 
-struct RowsetGroup {
-    std::vector<size_t> data_rowset_indices;
-    size_t predicate_rowset_index = 0;
-    int64_t predicate_rowset_version = 0;
-
-    bool has_predicate() const { return predicate_rowset_version > 0; }
+struct DelvecSourceRef {
+    const TabletMergeContext* ctx;
+    DelvecPagePB page;
+    std::string file_name;
 };
 
-struct TabletGroupState {
-    int64_t tablet_id = 0;
-    std::vector<RowsetGroup> rowset_groups;
-    std::vector<size_t> predicate_rowset_group_indices;
-    std::vector<int64_t> predicate_rowset_versions;
-    size_t next_predicate_index = 0;
+struct UnionPageInfo {
+    uint64_t offset;
+    uint64_t size;
+    uint32_t masked_crc32c;
 };
+
+struct TargetDelvecState {
+    std::optional<DelvecSourceRef> single_source;
+    std::unique_ptr<DelVector> merged;
+    std::map<std::pair<std::string, uint64_t>, uint64_t> seen_sources;
+};
+
+// Union |source| into |target|. If |target| is empty, it becomes a copy of |source|.
+void union_delvec(DelVector* target, DelVector& source, int64_t version) {
+    Roaring merged_bitmap;
+    if (target->roaring()) {
+        merged_bitmap = *target->roaring();
+    }
+    if (source.roaring()) {
+        merged_bitmap |= *source.roaring();
+    }
+    std::vector<uint32_t> all_dels;
+    for (auto it = merged_bitmap.begin(); it != merged_bitmap.end(); ++it) {
+        all_dels.push_back(*it);
+    }
+    target->init(version, all_dels.data(), all_dels.size());
+}
 
 int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const TabletMetadataPB& append_metadata) {
     uint32_t min_id = std::numeric_limits<uint32_t>::max();
@@ -61,162 +134,236 @@ int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const Tablet
     return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id;
 }
 
-Status merge_rowsets(const TabletMetadataPB& old_metadata, int64_t rssid_offset, TabletMetadataPB* new_metadata) {
-    for (const auto& rowset : old_metadata.rowsets()) {
-        auto* new_rowset = new_metadata->add_rowsets();
-        new_rowset->CopyFrom(rowset);
-        RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(new_rowset, old_metadata.range()));
-        new_rowset->set_id(static_cast<uint32_t>(static_cast<int64_t>(rowset.id()) + rssid_offset));
-        if (rowset.has_max_compact_input_rowset_id()) {
-            new_rowset->set_max_compact_input_rowset_id(
-                    static_cast<uint32_t>(static_cast<int64_t>(rowset.max_compact_input_rowset_id()) + rssid_offset));
-        }
-        for (auto& del : *new_rowset->mutable_del_files()) {
-            del.set_origin_rowset_id(
-                    static_cast<uint32_t>(static_cast<int64_t>(del.origin_rowset_id()) + rssid_offset));
-        }
+bool is_duplicate_rowset(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
+    // Two predicates at the same version -> duplicate
+    if (a.has_delete_predicate() && b.has_delete_predicate()) {
+        return true;
+    }
+    // Has segments: compare first segment's file_name, bundle_file_offset, shared
+    if (a.segments_size() > 0 && b.segments_size() > 0) {
+        if (a.segments(0) != b.segments(0)) return false;
+        int64_t a_off = a.bundle_file_offsets_size() > 0 ? a.bundle_file_offsets(0) : 0;
+        int64_t b_off = b.bundle_file_offsets_size() > 0 ? b.bundle_file_offsets(0) : 0;
+        if (a_off != b_off) return false;
+        bool a_shared = a.shared_segments_size() > 0 && a.shared_segments(0);
+        bool b_shared = b.shared_segments_size() > 0 && b.shared_segments(0);
+        return a_shared && b_shared;
+    } else if (a.del_files_size() > 0 && b.del_files_size() > 0) {
+        // Delete-only: compare first del_file's name, shared
+        return a.del_files(0).name() == b.del_files(0).name() && a.del_files(0).shared() && b.del_files(0).shared();
+    }
+    return false;
+}
 
-        const auto& rowset_to_schema = old_metadata.rowset_to_schema();
-        const auto rowset_schema_it = rowset_to_schema.find(rowset.id());
-        if (rowset_schema_it != rowset_to_schema.end()) {
-            (*new_metadata->mutable_rowset_to_schema())[new_rowset->id()] = rowset_schema_it->second;
-        }
+Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, TabletMetadataPB* new_metadata) {
+    auto* new_rowset = new_metadata->add_rowsets();
+    new_rowset->CopyFrom(rowset);
+    // rssid mapping
+    ASSIGN_OR_RETURN(auto new_id, ctx.map_rssid(rowset.id()));
+    new_rowset->set_id(new_id);
+    if (rowset.has_max_compact_input_rowset_id()) {
+        ASSIGN_OR_RETURN(auto new_max_compact, ctx.map_rssid(rowset.max_compact_input_rowset_id()));
+        new_rowset->set_max_compact_input_rowset_id(new_max_compact);
+    }
+    for (auto& del : *new_rowset->mutable_del_files()) {
+        ASSIGN_OR_RETURN(auto new_origin, ctx.map_rssid(del.origin_rowset_id()));
+        del.set_origin_rowset_id(new_origin);
+    }
+    // range update
+    RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(new_rowset, ctx.metadata()->range()));
+    // schema mapping
+    const auto& rowset_to_schema = ctx.metadata()->rowset_to_schema();
+    auto schema_it = rowset_to_schema.find(rowset.id());
+    if (schema_it != rowset_to_schema.end()) {
+        (*new_metadata->mutable_rowset_to_schema())[new_rowset->id()] = schema_it->second;
     }
     return Status::OK();
 }
 
-Status merge_sstables(const TabletMetadataPB& old_metadata, int64_t rssid_offset, TabletMetadataPB* new_metadata) {
-    if (!old_metadata.has_sstable_meta()) {
-        return Status::OK();
+Status update_canonical(RowsetMetadataPB* canonical_rowset, const RowsetMetadataPB& duplicate_rowset) {
+    if (canonical_rowset->has_range() && duplicate_rowset.has_range()) {
+        ASSIGN_OR_RETURN(auto merged_range,
+                         tablet_reshard_helper::union_range(canonical_rowset->range(), duplicate_rowset.range()));
+        canonical_rowset->mutable_range()->CopyFrom(merged_range);
     }
-    auto* dest_sstables = new_metadata->mutable_sstable_meta()->mutable_sstables();
-    for (const auto& sstable : old_metadata.sstable_meta().sstables()) {
-        auto* new_sstable = dest_sstables->Add();
-        new_sstable->CopyFrom(sstable);
-        new_sstable->set_rssid_offset(static_cast<int32_t>(rssid_offset));
-        const uint64_t max_rss_rowid = sstable.max_rss_rowid();
-        const uint64_t low = max_rss_rowid & 0xffffffffULL;
-        const int64_t high = static_cast<int64_t>(max_rss_rowid >> 32);
-        new_sstable->set_max_rss_rowid((static_cast<uint64_t>(high + rssid_offset) << 32) | low);
-        new_sstable->clear_delvec();
-    }
+    canonical_rowset->set_num_rows(canonical_rowset->num_rows() + duplicate_rowset.num_rows());
+    canonical_rowset->set_data_size(canonical_rowset->data_size() + duplicate_rowset.data_size());
     return Status::OK();
 }
 
-Status build_rowset_groups(const TabletMetadataPB& metadata, size_t start_rowset_index, size_t end_rowset_index,
-                           TabletGroupState* state) {
-    RowsetGroup current_group;
-    int64_t last_predicate_version = -1;
-    for (size_t rowset_index = start_rowset_index; rowset_index < end_rowset_index; ++rowset_index) {
-        const auto& rowset = metadata.rowsets(static_cast<int>(rowset_index));
-        if (!rowset.has_delete_predicate()) {
-            current_group.data_rowset_indices.push_back(rowset_index);
-            continue;
-        }
+Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+    int version_start_index = 0;
+    int64_t current_version = -1;
 
-        const int64_t predicate_version = rowset.version();
-        if (predicate_version <= 0) {
-            return Status::InvalidArgument("Invalid delete predicate version");
-        }
-        if (last_predicate_version >= 0 && predicate_version <= last_predicate_version) {
-            return Status::InvalidArgument("Delete predicate version not increasing in one tablet");
-        }
-
-        current_group.predicate_rowset_index = rowset_index;
-        current_group.predicate_rowset_version = predicate_version;
-        state->rowset_groups.emplace_back(std::move(current_group));
-        state->predicate_rowset_group_indices.push_back(state->rowset_groups.size() - 1);
-        state->predicate_rowset_versions.push_back(predicate_version);
-        current_group = RowsetGroup();
-        last_predicate_version = predicate_version;
-    }
-
-    if (!current_group.data_rowset_indices.empty()) {
-        state->rowset_groups.emplace_back(std::move(current_group));
-    }
-
-    return Status::OK();
-}
-
-Status build_rowset_index_offsets(const std::vector<TabletMergeInfo>& merge_infos, const TabletMetadataPB& new_metadata,
-                                  std::vector<size_t>* rowset_index_offsets) {
-    rowset_index_offsets->reserve(merge_infos.size() + 1);
-    rowset_index_offsets->push_back(0);
-    for (const auto& info : merge_infos) {
-        rowset_index_offsets->push_back(rowset_index_offsets->back() + info.metadata->rowsets_size());
-    }
-    if (rowset_index_offsets->back() != static_cast<size_t>(new_metadata.rowsets_size())) {
-        return Status::Corruption("Rowset count mismatch during merge reorder");
-    }
-    return Status::OK();
-}
-
-Status build_tablet_group_states(const std::vector<TabletMergeInfo>& merge_infos, const TabletMetadataPB& new_metadata,
-                                 const std::vector<size_t>& rowset_index_offsets,
-                                 std::vector<TabletGroupState>* tablet_states,
-                                 std::vector<int64_t>* all_predicate_versions) {
-    tablet_states->reserve(merge_infos.size());
-    for (size_t i = 0; i < merge_infos.size(); ++i) {
-        TabletGroupState state;
-        state.tablet_id = merge_infos[i].metadata->id();
-        RETURN_IF_ERROR(
-                build_rowset_groups(new_metadata, rowset_index_offsets[i], rowset_index_offsets[i + 1], &state));
-
-        for (const auto& rowset_group : state.rowset_groups) {
-            if (rowset_group.has_predicate()) {
-                all_predicate_versions->push_back(rowset_group.predicate_rowset_version);
+    for (;;) {
+        // Find child with minimum (version, child_index).
+        // Forward iteration with strict < ensures the smallest child_index wins on ties.
+        int min_child_index = -1;
+        int64_t min_version = std::numeric_limits<int64_t>::max();
+        for (int i = 0; i < static_cast<int>(merge_contexts.size()); ++i) {
+            if (!merge_contexts[i].has_next_rowset()) continue;
+            int64_t version = merge_contexts[i].current_rowset().version();
+            if (version < min_version) {
+                min_version = version;
+                min_child_index = i;
             }
         }
-        tablet_states->emplace_back(std::move(state));
+        if (min_child_index < 0) break;
+
+        const auto& rowset = merge_contexts[min_child_index].current_rowset();
+
+        // Version change: update version_start_index
+        if (rowset.version() != current_version) {
+            current_version = rowset.version();
+            version_start_index = new_metadata->rowsets_size();
+        }
+
+        // Check for duplicate in [version_start_index, end)
+        int canonical_index = -1;
+        for (int i = version_start_index; i < new_metadata->rowsets_size(); ++i) {
+            if (is_duplicate_rowset(rowset, new_metadata->rowsets(i))) {
+                canonical_index = i;
+                break;
+            }
+        }
+
+        if (canonical_index >= 0) {
+            // Duplicate: skip output
+            const auto& canonical = new_metadata->rowsets(canonical_index);
+            DCHECK(rowset.segments_size() == canonical.segments_size() &&
+                   rowset.del_files_size() == canonical.del_files_size())
+                    << "Shared rowset dedup hit but payload shape differs: segments(" << rowset.segments_size()
+                    << " vs " << canonical.segments_size() << "), del_files(" << rowset.del_files_size() << " vs "
+                    << canonical.del_files_size() << ")";
+            if (!rowset.has_delete_predicate()) {
+                merge_contexts[min_child_index].update_shared_rssid_map(rowset, canonical);
+                RETURN_IF_ERROR(update_canonical(new_metadata->mutable_rowsets(canonical_index), rowset));
+            }
+            // predicate: just skip
+        } else {
+            // First occurrence: output
+            RETURN_IF_ERROR(add_rowset(merge_contexts[min_child_index], rowset, new_metadata));
+        }
+
+        merge_contexts[min_child_index].advance_rowset();
+    }
+
+    return Status::OK();
+}
+
+Status validate_dcg_shape(const DeltaColumnGroupVerPB& dcg) {
+    // Required fields must be equal length
+    if (dcg.unique_column_ids_size() != dcg.column_files_size() || dcg.versions_size() != dcg.column_files_size()) {
+        return Status::Corruption("DCG shape invalid: column_files/unique_column_ids/versions size mismatch");
+    }
+    // Optional fields must not exceed column_files length
+    if (dcg.encryption_metas_size() > dcg.column_files_size() || dcg.shared_files_size() > dcg.column_files_size()) {
+        return Status::Corruption("DCG shape invalid: optional fields exceed column_files size");
+    }
+    // No duplicate column UIDs across entries
+    std::unordered_set<uint32_t> all_cids;
+    for (int i = 0; i < dcg.unique_column_ids_size(); ++i) {
+        for (auto cid : dcg.unique_column_ids(i).column_ids()) {
+            if (!all_cids.insert(cid).second) {
+                return Status::Corruption("DCG contains duplicate column UID across entries");
+            }
+        }
     }
     return Status::OK();
 }
 
-Status build_reordered_rowsets(const std::vector<int64_t>& all_predicate_versions, const TabletMetadataPB& new_metadata,
-                               std::vector<TabletGroupState>* tablet_states,
-                               std::vector<RowsetMetadataPB>* reordered_rowsets) {
-    reordered_rowsets->reserve(new_metadata.rowsets_size());
-    for (int64_t version : all_predicate_versions) {
-        std::vector<size_t> predicate_rowset_indices;
-        for (auto& state : *tablet_states) {
-            if (state.next_predicate_index >= state.predicate_rowset_versions.size()) {
+void normalize_dcg_optional_fields(DeltaColumnGroupVerPB* dcg) {
+    while (dcg->encryption_metas_size() < dcg->column_files_size()) {
+        dcg->add_encryption_metas("");
+    }
+    while (dcg->shared_files_size() < dcg->column_files_size()) {
+        dcg->add_shared_files(false);
+    }
+}
+
+Status verify_dcg_entry_consistency(const DeltaColumnGroupVerPB& existing, int j, const DeltaColumnGroupVerPB& incoming,
+                                    int i) {
+    // unique_column_ids
+    const auto& e_ids = existing.unique_column_ids(j);
+    const auto& i_ids = incoming.unique_column_ids(i);
+    if (e_ids.column_ids_size() != i_ids.column_ids_size()) {
+        return Status::Corruption("DCG same column_file but unique_column_ids differ");
+    }
+    for (int k = 0; k < e_ids.column_ids_size(); ++k) {
+        if (e_ids.column_ids(k) != i_ids.column_ids(k)) {
+            return Status::Corruption("DCG same column_file but unique_column_ids differ");
+        }
+    }
+    // versions
+    if (existing.versions(j) != incoming.versions(i)) {
+        return Status::Corruption("DCG same column_file but versions differ");
+    }
+    // encryption_metas (normalized)
+    if (existing.encryption_metas(j) != incoming.encryption_metas(i)) {
+        return Status::Corruption("DCG same column_file but encryption_metas differ");
+    }
+    // shared_files (normalized)
+    if (existing.shared_files(j) != incoming.shared_files(i)) {
+        return Status::Corruption("DCG same column_file but shared_files differ");
+    }
+    return Status::OK();
+}
+
+Status merge_dcg_meta(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+    auto* new_dcgs = new_metadata->mutable_dcg_meta()->mutable_dcgs();
+
+    for (const auto& ctx : merge_contexts) {
+        if (!ctx.metadata()->has_dcg_meta()) continue;
+
+        for (const auto& [segment_id, dcg_value] : ctx.metadata()->dcg_meta().dcgs()) {
+            ASSIGN_OR_RETURN(uint32_t target, ctx.map_rssid(segment_id));
+
+            // Validate + normalize incoming (copy because dcg_value is const)
+            DeltaColumnGroupVerPB incoming = dcg_value;
+            RETURN_IF_ERROR(validate_dcg_shape(incoming));
+            normalize_dcg_optional_fields(&incoming);
+
+            auto it = new_dcgs->find(target);
+            if (it == new_dcgs->end()) {
+                (*new_dcgs)[target] = std::move(incoming);
                 continue;
             }
 
-            const int64_t next_version = state.predicate_rowset_versions[state.next_predicate_index];
-            if (next_version < version) {
-                return Status::Corruption("Delete predicate version order mismatch across tablets");
-            }
-            if (next_version == version) {
-                const size_t rowset_group_index = state.predicate_rowset_group_indices[state.next_predicate_index];
-                const auto& rowset_group = state.rowset_groups[rowset_group_index];
-                for (auto rowset_index : rowset_group.data_rowset_indices) {
-                    reordered_rowsets->emplace_back(new_metadata.rowsets(static_cast<int>(rowset_index)));
+            // Entry-level merge into existing DCG
+            auto& existing = it->second;
+
+            for (int i = 0; i < incoming.column_files_size(); ++i) {
+                const auto& new_file = incoming.column_files(i);
+
+                // Step 1: exact dedup — same .cols filename
+                bool found_dup = false;
+                for (int j = 0; j < existing.column_files_size(); ++j) {
+                    if (existing.column_files(j) == new_file) {
+                        RETURN_IF_ERROR(verify_dcg_entry_consistency(existing, j, incoming, i));
+                        found_dup = true;
+                        break;
+                    }
                 }
-                predicate_rowset_indices.push_back(rowset_group.predicate_rowset_index);
-                ++state.next_predicate_index;
-            }
-        }
+                if (found_dup) continue;
 
-        if (predicate_rowset_indices.empty()) {
-            return Status::Corruption("Delete predicate version not found during merge reorder");
-        }
-        reordered_rowsets->emplace_back(new_metadata.rowsets(static_cast<int>(predicate_rowset_indices.front())));
-    }
+                // Step 2: column overlap check
+                for (int j = 0; j < existing.unique_column_ids_size(); ++j) {
+                    for (auto e_cid : existing.unique_column_ids(j).column_ids()) {
+                        for (auto n_cid : incoming.unique_column_ids(i).column_ids()) {
+                            if (e_cid == n_cid) {
+                                return Status::NotSupported(
+                                        "DCG conflict: same column updated independently by different split children");
+                            }
+                        }
+                    }
+                }
 
-    for (auto& state : *tablet_states) {
-        size_t start_rowset_group_index = 0;
-        if (state.next_predicate_index > 0) {
-            start_rowset_group_index = state.predicate_rowset_group_indices[state.next_predicate_index - 1] + 1;
-        }
-        for (size_t rowset_group_index = start_rowset_group_index; rowset_group_index < state.rowset_groups.size();
-             ++rowset_group_index) {
-            const auto& rowset_group = state.rowset_groups[rowset_group_index];
-            if (rowset_group.has_predicate()) {
-                return Status::Corruption("Unprocessed delete predicate group during merge reorder");
-            }
-            for (auto rowset_index : rowset_group.data_rowset_indices) {
-                reordered_rowsets->emplace_back(new_metadata.rowsets(static_cast<int>(rowset_index)));
+                // Step 3: disjoint columns — append entry (all 5 fields)
+                existing.add_column_files(new_file);
+                existing.add_unique_column_ids()->CopyFrom(incoming.unique_column_ids(i));
+                existing.add_versions(incoming.versions(i));
+                existing.add_encryption_metas(incoming.encryption_metas(i));
+                existing.add_shared_files(incoming.shared_files(i));
             }
         }
     }
@@ -224,11 +371,270 @@ Status build_reordered_rowsets(const std::vector<int64_t>& all_predicate_version
     return Status::OK();
 }
 
-void cleanup_orphan_schema_mappings(TabletMetadataPB* new_metadata) {
-    if (new_metadata->rowset_to_schema().empty()) {
-        return;
+Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
+                     int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
+    // Phase 1: Collect unique delvec files across all children
+    std::vector<DelvecFileInfo> unique_delvec_files;
+    std::unordered_map<std::string, size_t> file_name_to_index;
+
+    for (const auto& ctx : merge_contexts) {
+        if (!ctx.metadata()->has_delvec_meta()) {
+            continue;
+        }
+        for (const auto& [ver, file] : ctx.metadata()->delvec_meta().version_to_file()) {
+            (void)ver;
+            auto [it, inserted] = file_name_to_index.emplace(file.name(), unique_delvec_files.size());
+            if (inserted) {
+                DelvecFileInfo file_info;
+                file_info.tablet_id = ctx.metadata()->id();
+                file_info.delvec_file = file;
+                unique_delvec_files.emplace_back(std::move(file_info));
+            } else {
+                // Consistency check: same file name must have same size, encryption_meta, shared
+                const auto& existing = unique_delvec_files[it->second].delvec_file;
+                if (existing.size() != file.size() || existing.encryption_meta() != file.encryption_meta() ||
+                    existing.shared() != file.shared()) {
+                    return Status::Corruption("Delvec file metadata mismatch for same file name");
+                }
+            }
+        }
     }
 
+    if (unique_delvec_files.empty()) {
+        return Status::OK();
+    }
+
+    // Phase 2: Scan pages, build TargetDelvecState for each target rssid.
+    // File name is resolved inline via each child's version_to_file map.
+    std::map<uint32_t, TargetDelvecState> target_states;
+
+    for (const auto& ctx : merge_contexts) {
+        if (!ctx.metadata()->has_delvec_meta()) {
+            continue;
+        }
+        for (const auto& [segment_id, page] : ctx.metadata()->delvec_meta().delvecs()) {
+            ASSIGN_OR_RETURN(uint32_t target, ctx.map_rssid(segment_id));
+
+            // Resolve file name from page version
+            auto file_it = ctx.metadata()->delvec_meta().version_to_file().find(page.version());
+            if (file_it == ctx.metadata()->delvec_meta().version_to_file().end()) {
+                return Status::InvalidArgument("Delvec file not found for page version");
+            }
+            const std::string& file_name = file_it->second.name();
+
+            auto& state = target_states[target];
+            auto source_key = std::make_pair(file_name, page.offset());
+
+            if (!state.single_source.has_value() && !state.merged) {
+                // Empty state: first encounter
+                state.single_source = DelvecSourceRef{&ctx, page, file_name};
+                state.seen_sources[source_key] = page.size();
+            } else if (state.single_source.has_value() && !state.merged) {
+                // single_source state
+                auto seen_it = state.seen_sources.find(source_key);
+                if (seen_it != state.seen_sources.end()) {
+                    // Dedup hit: same file_name + offset
+                    if (seen_it->second != page.size()) {
+                        return Status::Corruption("Delvec page size mismatch for same source");
+                    }
+                    // Skip (page-ref dedup)
+                    continue;
+                }
+                // Different source: load both and union
+                DelVector dv_prev;
+                {
+                    const auto& ref = *state.single_source;
+                    LakeIOOptions io_opts;
+                    RETURN_IF_ERROR(
+                            get_del_vec(tablet_manager, *ref.ctx->metadata(), ref.page, false, io_opts, &dv_prev));
+                }
+                DelVector dv_new;
+                {
+                    LakeIOOptions io_opts;
+                    RETURN_IF_ERROR(get_del_vec(tablet_manager, *ctx.metadata(), page, false, io_opts, &dv_new));
+                }
+                // Union
+                auto merged_dv = std::make_unique<DelVector>();
+                union_delvec(merged_dv.get(), dv_prev, new_version);
+                union_delvec(merged_dv.get(), dv_new, new_version);
+                state.merged = std::move(merged_dv);
+                state.single_source.reset();
+                state.seen_sources[source_key] = page.size();
+            } else {
+                // merged state
+                auto seen_it = state.seen_sources.find(source_key);
+                if (seen_it != state.seen_sources.end()) {
+                    if (seen_it->second != page.size()) {
+                        return Status::Corruption("Delvec page size mismatch for same source in merged state");
+                    }
+                    // Skip (already merged)
+                    continue;
+                }
+                // New source: load and union into merged
+                DelVector dv_new;
+                {
+                    LakeIOOptions io_opts;
+                    RETURN_IF_ERROR(get_del_vec(tablet_manager, *ctx.metadata(), page, false, io_opts, &dv_new));
+                }
+                union_delvec(state.merged.get(), dv_new, new_version);
+                state.seen_sources[source_key] = page.size();
+            }
+        }
+    }
+
+    // Phase 3: Serialize union results into union_buffer
+    std::string union_buffer;
+    std::map<uint32_t, UnionPageInfo> union_page_infos;
+
+    for (auto& [target, state] : target_states) {
+        if (state.merged) {
+            std::string data = state.merged->save();
+            uint32_t masked_crc = crc32c::Mask(crc32c::Value(data.data(), data.size()));
+            union_page_infos[target] = {static_cast<uint64_t>(union_buffer.size()), static_cast<uint64_t>(data.size()),
+                                        masked_crc};
+            union_buffer.append(data);
+        }
+    }
+
+    // Phase 4: Write one file (old files concatenated + union_buffer appended)
+    FileMetaPB new_delvec_file;
+    std::vector<uint64_t> offsets;
+    uint64_t union_base_offset = 0;
+    RETURN_IF_ERROR(merge_delvec_files(tablet_manager, unique_delvec_files, new_metadata->id(), txn_id,
+                                       &new_delvec_file, &offsets, Slice(union_buffer), &union_base_offset));
+
+    // Build base_offset_by_file_name
+    std::unordered_map<std::string, uint64_t> base_offset_by_file_name;
+    for (size_t i = 0; i < unique_delvec_files.size(); ++i) {
+        base_offset_by_file_name[unique_delvec_files[i].delvec_file.name()] = offsets[i];
+    }
+
+    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_apply_offsets", &base_offset_by_file_name);
+
+    // Phase 5: Build page entries in new_metadata
+    auto* delvec_meta = new_metadata->mutable_delvec_meta();
+    delvec_meta->Clear();
+
+    for (const auto& [target, state] : target_states) {
+        DelvecPagePB new_page;
+        new_page.set_version(new_version);
+        new_page.set_crc32c_gen_version(new_version);
+
+        if (state.single_source.has_value()) {
+            const auto& ref = *state.single_source;
+            auto base_it = base_offset_by_file_name.find(ref.file_name);
+            if (base_it == base_offset_by_file_name.end()) {
+                return Status::InvalidArgument("Delvec file not merged for page version");
+            }
+            new_page.set_offset(base_it->second + ref.page.offset());
+            new_page.set_size(ref.page.size());
+            // CRC decision: only reuse if old CRC is trustworthy
+            if (ref.page.has_crc32c() && ref.page.crc32c_gen_version() == ref.page.version()) {
+                new_page.set_crc32c(ref.page.crc32c());
+            }
+        } else if (state.merged) {
+            auto info_it = union_page_infos.find(target);
+            if (info_it == union_page_infos.end()) {
+                return Status::Corruption("Union page info not found for merged target");
+            }
+            new_page.set_offset(union_base_offset + info_it->second.offset);
+            new_page.set_size(info_it->second.size);
+            new_page.set_crc32c(info_it->second.masked_crc32c);
+        } else {
+            return Status::Corruption("Delvec target state has neither single_source nor merged");
+        }
+
+        (*delvec_meta->mutable_delvecs())[target] = std::move(new_page);
+    }
+
+    (*delvec_meta->mutable_version_to_file())[new_version] = std::move(new_delvec_file);
+    return Status::OK();
+}
+
+Status merge_sstables(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+    auto* dest = new_metadata->mutable_sstable_meta()->mutable_sstables();
+    // key: filename -> index in dest, for shared dedup + consistency check
+    std::unordered_map<std::string, int> shared_dedup;
+
+    for (const auto& ctx : merge_contexts) {
+        if (!ctx.metadata()->has_sstable_meta()) continue;
+
+        for (const auto& sst : ctx.metadata()->sstable_meta().sstables()) {
+            // Dedup: only shared sstables can be duplicates
+            if (sst.shared()) {
+                auto [it, inserted] = shared_dedup.emplace(sst.filename(), dest->size());
+                if (!inserted) {
+                    // Dedup hit: consistency check (only fields that are not projected)
+                    const auto& existing = dest->Get(it->second);
+                    if (existing.filesize() != sst.filesize() || existing.encryption_meta() != sst.encryption_meta() ||
+                        existing.range().start_key() != sst.range().start_key() ||
+                        existing.range().end_key() != sst.range().end_key() ||
+                        existing.fileset_id().hi() != sst.fileset_id().hi() ||
+                        existing.fileset_id().lo() != sst.fileset_id().lo()) {
+                        return Status::Corruption("Shared sstable metadata mismatch for same filename");
+                    }
+                    continue; // skip duplicate
+                }
+            }
+
+            // Projection: branch on has_shared_rssid, not on shared flag
+            auto* out = dest->Add();
+            out->CopyFrom(sst);
+
+            if (sst.has_shared_rssid()) {
+                // shared_rssid path: project rssid, clear offset, project delvec
+                ASSIGN_OR_RETURN(auto mapped_rssid, ctx.map_rssid(sst.shared_rssid()));
+                out->set_shared_rssid(mapped_rssid);
+                out->set_rssid_offset(0); // clear to avoid double-transform in read path
+
+                // max_rss_rowid: replace high part with mapped rssid
+                uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
+                out->set_max_rss_rowid((static_cast<uint64_t>(mapped_rssid) << 32) | low);
+
+                // delvec projection via new_metadata->delvec_meta()
+                if (sst.has_delvec() && sst.delvec().size() > 0) {
+                    auto dv_it = new_metadata->delvec_meta().delvecs().find(mapped_rssid);
+                    if (dv_it == new_metadata->delvec_meta().delvecs().end()) {
+                        return Status::Corruption("Delvec page not found for sstable after merge");
+                    }
+                    out->mutable_delvec()->CopyFrom(dv_it->second);
+                }
+            } else {
+                // No shared_rssid (legacy format): use rssid_offset
+                if (sst.has_delvec() && sst.delvec().size() > 0) {
+                    return Status::Corruption("Sstable has delvec but no shared_rssid, cannot project delvec");
+                }
+                out->set_rssid_offset(static_cast<int32_t>(ctx.rssid_offset()));
+                uint64_t low = sst.max_rss_rowid() & 0xffffffffULL;
+                int64_t high = static_cast<int64_t>(sst.max_rss_rowid() >> 32);
+                out->set_max_rss_rowid((static_cast<uint64_t>(high + ctx.rssid_offset()) << 32) | low);
+                out->clear_delvec();
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+void update_next_rowset_id(TabletMetadataPB* metadata) {
+    uint32_t max_end = 1; // invariant: next_rowset_id >= 1
+    for (const auto& rowset : metadata->rowsets()) {
+        max_end = std::max(max_end, rowset.id() + get_rowset_id_step(rowset));
+    }
+    metadata->set_next_rowset_id(max_end);
+}
+
+void merge_schemas(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+    // Step 1: Collect all historical_schemas from all children (union by schema_id)
+    auto* merged_schemas = new_metadata->mutable_historical_schemas();
+    merged_schemas->clear();
+    for (const auto& ctx : merge_contexts) {
+        for (const auto& [schema_id, schema] : ctx.metadata()->historical_schemas()) {
+            (*merged_schemas)[schema_id] = schema;
+        }
+    }
+
+    // Step 2: Prune rowset_to_schema entries for non-existent rowset_ids
     std::unordered_set<uint32_t> rowset_ids;
     rowset_ids.reserve(new_metadata->rowsets_size());
     for (const auto& rowset : new_metadata->rowsets()) {
@@ -244,128 +650,24 @@ void cleanup_orphan_schema_mappings(TabletMetadataPB* new_metadata) {
         }
     }
 
-    std::unordered_set<int64_t> schema_ids;
-    for (const auto& pair : *rowset_to_schema) {
-        schema_ids.insert(pair.second);
+    // Step 3: Prune historical_schemas not referenced by any rowset_to_schema
+    std::unordered_set<int64_t> referenced_schema_ids;
+    for (const auto& [rowset_id, schema_id] : *rowset_to_schema) {
+        referenced_schema_ids.insert(schema_id);
     }
 
-    for (auto it = new_metadata->mutable_historical_schemas()->begin();
-         it != new_metadata->mutable_historical_schemas()->end();) {
-        if (schema_ids.count(it->first) == 0) {
-            it = new_metadata->mutable_historical_schemas()->erase(it);
+    for (auto it = merged_schemas->begin(); it != merged_schemas->end();) {
+        if (referenced_schema_ids.count(it->first) == 0) {
+            it = merged_schemas->erase(it);
         } else {
             ++it;
         }
     }
 
-    if (new_metadata->historical_schemas().count(new_metadata->schema().id()) == 0) {
-        auto& item = (*new_metadata->mutable_historical_schemas())[new_metadata->schema().id()];
-        item.CopyFrom(new_metadata->schema());
+    // Step 4: Ensure current schema is present (may have been pruned in step 3)
+    if (new_metadata->schema().has_id() && merged_schemas->count(new_metadata->schema().id()) == 0) {
+        (*merged_schemas)[new_metadata->schema().id()] = new_metadata->schema();
     }
-}
-
-Status reorder_rowsets_by_delete_predicate(const std::vector<TabletMergeInfo>& merge_infos,
-                                           TabletMetadataPB* new_metadata) {
-    std::vector<size_t> rowset_index_offsets;
-    RETURN_IF_ERROR(build_rowset_index_offsets(merge_infos, *new_metadata, &rowset_index_offsets));
-
-    std::vector<TabletGroupState> tablet_states;
-    std::vector<int64_t> all_predicate_versions;
-    RETURN_IF_ERROR(build_tablet_group_states(merge_infos, *new_metadata, rowset_index_offsets, &tablet_states,
-                                              &all_predicate_versions));
-
-    if (all_predicate_versions.empty()) {
-        return Status::OK();
-    }
-
-    std::sort(all_predicate_versions.begin(), all_predicate_versions.end());
-    all_predicate_versions.erase(std::unique(all_predicate_versions.begin(), all_predicate_versions.end()),
-                                 all_predicate_versions.end());
-
-    std::vector<RowsetMetadataPB> reordered_rowsets;
-    RETURN_IF_ERROR(build_reordered_rowsets(all_predicate_versions, *new_metadata, &tablet_states, &reordered_rowsets));
-
-    new_metadata->mutable_rowsets()->Clear();
-    for (auto& rowset : reordered_rowsets) {
-        new_metadata->add_rowsets()->Swap(&rowset);
-    }
-
-    cleanup_orphan_schema_mappings(new_metadata);
-    return Status::OK();
-}
-
-Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeInfo>& merge_infos,
-                     int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
-    std::vector<DelvecFileInfo> old_delvec_files;
-    old_delvec_files.reserve(merge_infos.size());
-    std::unordered_map<int64_t, std::unordered_map<std::string, size_t>> file_index_by_tablet;
-
-    for (const auto& info : merge_infos) {
-        const auto& metadata = info.metadata;
-        if (!metadata->has_delvec_meta()) {
-            continue;
-        }
-        for (const auto& [ver, file] : metadata->delvec_meta().version_to_file()) {
-            (void)ver;
-            auto& file_index = file_index_by_tablet[metadata->id()];
-            if (file_index.emplace(file.name(), old_delvec_files.size()).second) {
-                DelvecFileInfo file_info;
-                file_info.tablet_id = metadata->id();
-                file_info.delvec_file = file;
-                old_delvec_files.emplace_back(std::move(file_info));
-            }
-        }
-    }
-
-    if (old_delvec_files.empty()) {
-        return Status::OK();
-    }
-
-    FileMetaPB new_delvec_file;
-    std::vector<uint64_t> offsets;
-    RETURN_IF_ERROR(merge_delvec_files(tablet_manager, old_delvec_files, new_metadata->id(), txn_id, &new_delvec_file,
-                                       &offsets));
-
-    std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>> base_offset_by_tablet;
-    for (size_t i = 0; i < old_delvec_files.size(); ++i) {
-        base_offset_by_tablet[old_delvec_files[i].tablet_id][old_delvec_files[i].delvec_file.name()] = offsets[i];
-    }
-    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_apply_offsets", &base_offset_by_tablet);
-
-    auto* delvec_meta = new_metadata->mutable_delvec_meta();
-    delvec_meta->Clear();
-    for (const auto& info : merge_infos) {
-        const auto& metadata = info.metadata;
-        if (!metadata->has_delvec_meta()) {
-            continue;
-        }
-        for (const auto& [segment_id, page] : metadata->delvec_meta().delvecs()) {
-            auto file_it = metadata->delvec_meta().version_to_file().find(page.version());
-            if (file_it == metadata->delvec_meta().version_to_file().end()) {
-                return Status::InvalidArgument("Delvec file not found for page version");
-            }
-            auto tablet_it = base_offset_by_tablet.find(metadata->id());
-            if (tablet_it == base_offset_by_tablet.end()) {
-                return Status::InvalidArgument("Delvec file not merged for page version");
-            }
-            auto offset_it = tablet_it->second.find(file_it->second.name());
-            if (offset_it == tablet_it->second.end()) {
-                return Status::InvalidArgument("Delvec file not merged for page version");
-            }
-            const int64_t new_segment_id = static_cast<int64_t>(segment_id) + info.rssid_offset;
-            if (new_segment_id < 0 || new_segment_id > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-                return Status::InvalidArgument("Segment id overflow during delvec merge");
-            }
-            DelvecPagePB new_page = page;
-            new_page.set_version(new_version);
-            new_page.set_crc32c_gen_version(new_version);
-            new_page.set_offset(offset_it->second + page.offset());
-            (*delvec_meta->mutable_delvecs())[static_cast<uint32_t>(new_segment_id)] = std::move(new_page);
-        }
-    }
-
-    (*delvec_meta->mutable_version_to_file())[new_version] = std::move(new_delvec_file);
-    return Status::OK();
 }
 
 } // namespace
@@ -378,16 +680,16 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
         return Status::InvalidArgument("No old tablet metadata to merge");
     }
 
-    std::vector<TabletMergeInfo> merge_infos;
-    merge_infos.reserve(old_tablet_metadatas.size());
+    std::vector<TabletMergeContext> merge_contexts;
+    merge_contexts.reserve(old_tablet_metadatas.size());
     for (const auto& old_tablet_metadata : old_tablet_metadatas) {
         if (old_tablet_metadata == nullptr) {
             return Status::InvalidArgument("old tablet metadata is null");
         }
-        merge_infos.push_back({old_tablet_metadata, 0});
+        merge_contexts.emplace_back(old_tablet_metadata);
     }
 
-    auto new_tablet_metadata = std::make_shared<TabletMetadataPB>(*merge_infos.front().metadata);
+    auto new_tablet_metadata = std::make_shared<TabletMetadataPB>(*merge_contexts.front().metadata());
     new_tablet_metadata->set_id(merging_tablet.new_tablet_id());
     new_tablet_metadata->set_version(new_version);
     new_tablet_metadata->set_commit_time(txn_info.commit_time());
@@ -402,70 +704,46 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     new_tablet_metadata->clear_prev_garbage_version();
     new_tablet_metadata->set_cumulative_point(0);
 
-    auto* merged_historical_schemas = new_tablet_metadata->mutable_historical_schemas();
-    merged_historical_schemas->clear();
-    for (const auto& info : merge_infos) {
-        for (const auto& [schema_id, schema] : info.metadata->historical_schemas()) {
-            (*merged_historical_schemas)[schema_id] = schema;
-        }
-    }
-    if (new_tablet_metadata->schema().has_id()) {
-        (*merged_historical_schemas)[new_tablet_metadata->schema().id()] = new_tablet_metadata->schema();
-    }
-
-    auto* merged_range = new_tablet_metadata->mutable_range();
-    const auto& first_range = merge_infos.front().metadata->range();
-    const auto& last_range = merge_infos.back().metadata->range();
-    merged_range->clear_lower_bound();
-    merged_range->clear_upper_bound();
-    if (first_range.has_lower_bound()) {
-        merged_range->mutable_lower_bound()->CopyFrom(first_range.lower_bound());
-    }
-    merged_range->set_lower_bound_included(first_range.lower_bound_included());
-    if (last_range.has_upper_bound()) {
-        merged_range->mutable_upper_bound()->CopyFrom(last_range.upper_bound());
-    }
-    merged_range->set_upper_bound_included(last_range.upper_bound_included());
-
-    uint32_t next_rowset_id = merge_infos.front().metadata->next_rowset_id();
-    merge_infos.front().rssid_offset = 0;
-    for (size_t i = 1; i < merge_infos.size(); ++i) {
-        new_tablet_metadata->set_next_rowset_id(next_rowset_id);
-        const int64_t offset = compute_rssid_offset(*new_tablet_metadata, *merge_infos[i].metadata);
-        merge_infos[i].rssid_offset = offset;
-
-        uint32_t max_end = 0;
-        for (const auto& rowset : merge_infos[i].metadata->rowsets()) {
-            max_end = std::max(max_end, rowset.id() + get_rowset_id_step(rowset));
-        }
-        if (max_end > 0) {
-            next_rowset_id = std::max(next_rowset_id, static_cast<uint32_t>(static_cast<int64_t>(max_end) + offset));
-        }
-    }
-
-    for (const auto& info : merge_infos) {
-        RETURN_IF_ERROR(merge_rowsets(*info.metadata, info.rssid_offset, new_tablet_metadata.get()));
-        if (info.metadata->has_dcg_meta()) {
-            for (const auto& [segment_id, dcg_ver] : info.metadata->dcg_meta().dcgs()) {
-                const int64_t new_segment_id = static_cast<int64_t>(segment_id) + info.rssid_offset;
-                if (new_segment_id < 0 || new_segment_id > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-                    return Status::InvalidArgument("Segment id overflow during tablet merge");
-                }
-                (*new_tablet_metadata->mutable_dcg_meta()->mutable_dcgs())[static_cast<uint32_t>(new_segment_id)] =
-                        dcg_ver;
+    // Phase 1: Prepare rssid offsets and merged range
+    for (size_t i = 1; i < merge_contexts.size(); ++i) {
+        // Temporarily set next_rowset_id for compute_rssid_offset
+        uint32_t temp_next = merge_contexts.front().metadata()->next_rowset_id();
+        for (size_t j = 0; j < i; ++j) {
+            for (const auto& rowset : merge_contexts[j].metadata()->rowsets()) {
+                uint32_t end = static_cast<uint32_t>(static_cast<int64_t>(rowset.id() + get_rowset_id_step(rowset)) +
+                                                     merge_contexts[j].rssid_offset());
+                temp_next = std::max(temp_next, end);
             }
         }
-        RETURN_IF_ERROR(merge_sstables(*info.metadata, info.rssid_offset, new_tablet_metadata.get()));
+        new_tablet_metadata->set_next_rowset_id(temp_next);
+        merge_contexts[i].set_rssid_offset(compute_rssid_offset(*new_tablet_metadata, *merge_contexts[i].metadata()));
     }
 
-    new_tablet_metadata->set_next_rowset_id(next_rowset_id);
+    // Merge tablet-level range via union_range
+    TabletRangePB merged_range = merge_contexts.front().metadata()->range();
+    for (size_t i = 1; i < merge_contexts.size(); ++i) {
+        ASSIGN_OR_RETURN(merged_range,
+                         tablet_reshard_helper::union_range(merged_range, merge_contexts[i].metadata()->range()));
+    }
+    new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
+
+    // Phase 2: Merge rowsets (version-driven k-way merge with dedup)
+    RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get()));
+
+    // Phase 3: Projections (map_rssid uses shared_rssid_map + rssid_offset)
+    RETURN_IF_ERROR(merge_dcg_meta(merge_contexts, new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
-        RETURN_IF_ERROR(
-                merge_delvecs(tablet_manager, merge_infos, new_version, txn_info.txn_id(), new_tablet_metadata.get()));
+        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, new_version, txn_info.txn_id(),
+                                      new_tablet_metadata.get()));
     }
 
-    RETURN_IF_ERROR(reorder_rowsets_by_delete_predicate(merge_infos, new_tablet_metadata.get()));
+    RETURN_IF_ERROR(merge_sstables(merge_contexts, new_tablet_metadata.get()));
+
+    // Phase 4: Finalize
+    merge_schemas(merge_contexts, new_tablet_metadata.get());
+    update_next_rowset_id(new_tablet_metadata.get());
+
     return new_tablet_metadata;
 }
 

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -123,6 +123,17 @@ StatusOr<TabletRangePB> intersect_range(const TabletRangePB& lhs_pb, const Table
     return result;
 }
 
+StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb) {
+    TabletRange lhs;
+    RETURN_IF_ERROR(lhs.from_proto(lhs_pb));
+    TabletRange rhs;
+    RETURN_IF_ERROR(rhs.from_proto(rhs_pb));
+    auto result = lhs.union_with(rhs);
+    TabletRangePB result_pb;
+    result.to_proto(&result_pb);
+    return result_pb;
+}
+
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range) {
     DCHECK(rowset != nullptr);
     if (!rowset->has_range()) {

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -26,6 +26,7 @@ void set_all_data_files_shared(TxnLogPB* txn_log);
 void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs = false);
 
 StatusOr<TabletRangePB> intersect_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
+StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range);
 Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range);
 

--- a/be/src/storage/tablet_range.h
+++ b/be/src/storage/tablet_range.h
@@ -61,6 +61,9 @@ public:
     // Return the intersection between this range and rhs.
     StatusOr<TabletRange> intersect(const TabletRange& rhs) const;
 
+    // Return the union between this range and rhs.
+    TabletRange union_with(const TabletRange& rhs) const;
+
     // Empty range such as [x, x) or any range where lower bound is larger than upper bound.
     bool is_empty() const;
 
@@ -176,6 +179,46 @@ inline StatusOr<TabletRange> TabletRange::intersect(const TabletRange& rhs) cons
             result._upper_bound = result._lower_bound;
             result._lower_bound_included = true;
             result._upper_bound_included = false;
+        }
+    }
+
+    return result;
+}
+
+inline TabletRange TabletRange::union_with(const TabletRange& rhs) const {
+    TabletRange result;
+
+    // Lower bound: take the wider (smaller) bound; unbounded is widest.
+    if (is_minimum() || rhs.is_minimum()) {
+        // result lower stays default (unbounded)
+    } else {
+        const int cmp = _lower_bound.compare(rhs._lower_bound);
+        if (cmp < 0) {
+            result._lower_bound = _lower_bound;
+            result._lower_bound_included = _lower_bound_included;
+        } else if (cmp > 0) {
+            result._lower_bound = rhs._lower_bound;
+            result._lower_bound_included = rhs._lower_bound_included;
+        } else {
+            result._lower_bound = _lower_bound;
+            result._lower_bound_included = _lower_bound_included || rhs._lower_bound_included;
+        }
+    }
+
+    // Upper bound: take the wider (larger) bound; unbounded is widest.
+    if (is_maximum() || rhs.is_maximum()) {
+        // result upper stays default (unbounded)
+    } else {
+        const int cmp = _upper_bound.compare(rhs._upper_bound);
+        if (cmp > 0) {
+            result._upper_bound = _upper_bound;
+            result._upper_bound_included = _upper_bound_included;
+        } else if (cmp < 0) {
+            result._upper_bound = rhs._upper_bound;
+            result._upper_bound_included = rhs._upper_bound_included;
+        } else {
+            result._upper_bound = _upper_bound;
+            result._upper_bound_included = _upper_bound_included || rhs._upper_bound_included;
         }
     }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -32,7 +32,9 @@
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/variant_tuple.h"
@@ -162,6 +164,18 @@ protected:
         DeltaColumnGroupVerPB dcg;
         dcg.add_column_files(file_name);
         metadata->mutable_dcg_meta()->mutable_dcgs()->insert({segment_id, dcg});
+    }
+
+    void add_dcg_with_columns(TabletMetadataPB* metadata, uint32_t segment_id, const std::string& file_name,
+                              const std::vector<uint32_t>& column_ids, int64_t version) {
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[segment_id];
+        dcg.add_column_files(file_name);
+        auto* cids = dcg.add_unique_column_ids();
+        for (auto cid : column_ids) {
+            cids->add_column_ids(cid);
+        }
+        dcg.add_versions(version);
+        dcg.add_shared_files(true);
     }
 
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
@@ -600,11 +614,13 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     EXPECT_EQ(2, predicate_count);
     // Predicate versions should be in order: v10, v20
     EXPECT_EQ((std::vector<int64_t>{10, 20}), predicate_versions);
-    // Expected order after grouping by predicate version:
-    // 1. Process v10: A's data before v10 (id=1), B's data before v10 (id=4), predicate v10 (id=2)
-    // 2. Process v20: B's data before v20 (id=6), predicate v20 (id=7)
-    // 3. Trailing: A's data after v10 (id=3), B's data after v20 (id=8)
-    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 6, 7, 3, 8}), rowset_ids);
+    // Version-driven k-way merge order:
+    // v1: A(id=1), B(id=4)
+    // v10: A predicate(id=2) output, B predicate dedup skip
+    // v11: A(id=3), B(id=6)
+    // v20: B predicate(id=7)
+    // v21: B(id=8)
+    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 3, 6, 7, 8}), rowset_ids);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
@@ -672,8 +688,9 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     }
 
     EXPECT_EQ(0, predicate_count);
-    // Original order: tablet_a rowsets (1,2,3) then tablet_b rowsets (4,5,6 with offset=3)
-    EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4, 5, 6}), rowset_ids);
+    // Version-driven k-way merge interleaves by (version, child_index):
+    // v1: A(id=1), B(id=4); v2: A(id=2), B(id=5); v3: A(id=3), B(id=6)
+    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 5, 3, 6}), rowset_ids);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
@@ -746,12 +763,10 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
     }
 
     EXPECT_EQ(1, predicate_count);
-    // Expected order:
-    // - A's data before predicate (id=1)
-    // - predicate v10 (id=2)
-    // - A's data after predicate (id=3)
-    // - B's all data (ids=4,5,6 with offset=3, since B has no predicate, all go to trailing)
-    EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4, 5, 6}), rowset_ids);
+    // Version-driven k-way merge order:
+    // v1: A(id=1), B(id=4); v2: B(id=5); v3: B(id=6);
+    // v10: A predicate(id=2); v11: A(id=3)
+    EXPECT_EQ((std::vector<uint32_t>{1, 4, 5, 6, 2, 3}), rowset_ids);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_all_predicates) {
@@ -845,7 +860,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     (*meta1->mutable_rowset_to_schema())[10] = 1001;
     add_delvec(meta1.get(), old_tablet_id_1, base_version, 10, "delvec-1", "aaaa");
     add_sstable(meta1.get(), "sst-1", (static_cast<uint64_t>(1) << 32) | 7, true);
-    add_dcg(meta1.get(), 10, "dcg-1");
+    add_dcg_with_columns(meta1.get(), 10, "dcg-1", {101, 102}, 1);
 
     auto meta2 = std::make_shared<TabletMetadataPB>();
     meta2->set_id(old_tablet_id_2);
@@ -857,7 +872,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     (*meta2->mutable_rowset_to_schema())[1] = 2002;
     add_delvec(meta2.get(), old_tablet_id_2, base_version, 1, "delvec-2", "bbbbbb");
     add_sstable(meta2.get(), "sst-2", (static_cast<uint64_t>(2) << 32) | 5, true);
-    add_dcg(meta2.get(), 1, "dcg-2");
+    add_dcg_with_columns(meta2.get(), 1, "dcg-2", {201, 202}, 1);
 
     EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
     EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
@@ -940,8 +955,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     ASSERT_EQ(1, dcg_it->second.column_files_size());
     EXPECT_EQ("dcg-2", dcg_it->second.column_files(0));
 
-    EXPECT_TRUE(merged->historical_schemas().find(5001) != merged->historical_schemas().end());
-    EXPECT_TRUE(merged->historical_schemas().find(5002) != merged->historical_schemas().end());
+    // Unreferenced historical schemas (5001, 5002) are pruned by merge_schemas().
+    // The current schema (1001) is always preserved.
+    EXPECT_TRUE(merged->historical_schemas().find(1001) != merged->historical_schemas().end());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
@@ -1130,10 +1146,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) 
     txn_info.set_gtid(1);
 
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [old_tablet_id_2](void* arg) {
-        auto* base_offset_by_tablet =
-                reinterpret_cast<std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>>*>(arg);
-        base_offset_by_tablet->erase(old_tablet_id_2);
+    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [](void* arg) {
+        auto* base_offset_by_file_name = reinterpret_cast<std::unordered_map<std::string, uint64_t>*>(arg);
+        base_offset_by_file_name->clear();
     });
 
     std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
@@ -1188,13 +1203,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
     txn_info.set_gtid(1);
 
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [old_tablet_id_2](void* arg) {
-        auto* base_offset_by_tablet =
-                reinterpret_cast<std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>>*>(arg);
-        auto tablet_it = base_offset_by_tablet->find(old_tablet_id_2);
-        if (tablet_it != base_offset_by_tablet->end()) {
-            tablet_it->second.erase("delvec-2");
-        }
+    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [](void* arg) {
+        auto* base_offset_by_file_name = reinterpret_cast<std::unordered_map<std::string, uint64_t>*>(arg);
+        base_offset_by_file_name->erase("delvec-2");
     });
 
     std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
@@ -1365,7 +1376,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_segment_overflow) {
     meta2->set_version(base_version);
     meta2->set_next_rowset_id(10);
     add_rowset(meta2.get(), 90, 90, 90);
-    add_dcg(meta2.get(), std::numeric_limits<uint32_t>::max() - 5, "dcg-overflow");
+    add_dcg_with_columns(meta2.get(), std::numeric_limits<uint32_t>::max() - 5, "dcg-overflow", {301}, 1);
 
     EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
     EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
@@ -1532,6 +1543,1902 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     EXPECT_TRUE(converted->op_parallel_compaction().output_sstable().shared());
     ASSERT_EQ(1, converted->op_parallel_compaction().output_sstables_size());
     EXPECT_TRUE(converted->op_parallel_compaction().output_sstables(0).shared());
+}
+
+// --- New tests for split-then-merge correctness ---
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
+    // Split produces two children with identical shared rowsets.
+    // Merging them should dedup shared rowsets and restore original rssid count.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Both children share the same rowset (version 1, segment "shared_seg.dat")
+    // and the same shared sstable (with shared_rssid=1)
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        // Add shared sstable with shared_rssid
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename("shared_sst.sst");
+        sst->set_filesize(512);
+        sst->set_shared(true);
+        sst->set_shared_rssid(1);
+        sst->set_shared_version(1);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    // Should have only 1 rowset (deduped)
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ("shared_seg.dat", merged->rowsets(0).segments(0));
+    // num_rows/data_size should be accumulated from both children
+    EXPECT_EQ(20, merged->rowsets(0).num_rows());
+    EXPECT_EQ(200, merged->rowsets(0).data_size());
+    // Shared sstable should be deduped to 1
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ("shared_sst.sst", out_sst.filename());
+    EXPECT_TRUE(out_sst.shared());
+    // shared_rssid should be projected to canonical rssid (rowset deduped, rssid stays 1)
+    EXPECT_EQ(merged->rowsets(0).id(), out_sst.shared_rssid());
+    // rssid_offset should be 0 (shared_rssid path)
+    EXPECT_EQ(0, out_sst.rssid_offset());
+    // max_rss_rowid high part should match projected shared_rssid
+    EXPECT_EQ((static_cast<uint64_t>(out_sst.shared_rssid()) << 32) | 99, out_sst.max_rss_rowid());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
+    // Split, then each child does independent upsert (new version).
+    // Shared rowset is deduped, new rowsets are kept.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(4);
+    set_primary_key_schema(meta_a.get(), 1001);
+    // Shared rowset (from split)
+    auto* shared_a = meta_a->add_rowsets();
+    shared_a->set_id(1);
+    shared_a->set_version(1);
+    shared_a->set_num_rows(10);
+    shared_a->set_data_size(100);
+    shared_a->add_segments("shared_seg.dat");
+    shared_a->add_segment_size(100);
+    shared_a->add_shared_segments(true);
+    // Local upsert (new data after split)
+    auto* local_a = meta_a->add_rowsets();
+    local_a->set_id(2);
+    local_a->set_version(2);
+    local_a->set_num_rows(5);
+    local_a->set_data_size(50);
+    local_a->add_segments("local_a_seg.dat");
+    local_a->add_segment_size(50);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(4);
+    set_primary_key_schema(meta_b.get(), 1001);
+    // Shared rowset (from split)
+    auto* shared_b = meta_b->add_rowsets();
+    shared_b->set_id(1);
+    shared_b->set_version(1);
+    shared_b->set_num_rows(10);
+    shared_b->set_data_size(100);
+    shared_b->add_segments("shared_seg.dat");
+    shared_b->add_segment_size(100);
+    shared_b->add_shared_segments(true);
+    // Local upsert (different new data)
+    auto* local_b = meta_b->add_rowsets();
+    local_b->set_id(2);
+    local_b->set_version(3);
+    local_b->set_num_rows(3);
+    local_b->set_data_size(30);
+    local_b->add_segments("local_b_seg.dat");
+    local_b->add_segment_size(30);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // 1 shared (deduped) + 2 local = 3 rowsets
+    ASSERT_EQ(3, merged->rowsets_size());
+
+    // First rowset should be the deduped shared one
+    EXPECT_EQ("shared_seg.dat", merged->rowsets(0).segments(0));
+    // Remaining two are the local ones
+    std::unordered_set<std::string> local_segments;
+    for (int i = 1; i < merged->rowsets_size(); ++i) {
+        local_segments.insert(merged->rowsets(i).segments(0));
+    }
+    EXPECT_TRUE(local_segments.count("local_a_seg.dat") > 0);
+    EXPECT_TRUE(local_segments.count("local_b_seg.dat") > 0);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_compaction) {
+    // Child A compacted the shared rowset (new rowset replaces it).
+    // Child B still has the shared rowset.
+    // The compacted rowset in A is local (not shared), so no dedup.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Child A: compacted - shared rowset replaced by local
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(5);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* compacted_a = meta_a->add_rowsets();
+    compacted_a->set_id(3);
+    compacted_a->set_version(2);
+    compacted_a->set_num_rows(10);
+    compacted_a->set_data_size(100);
+    compacted_a->add_segments("compacted_a.dat");
+    compacted_a->add_segment_size(100);
+    // not shared - this is the compaction output
+
+    // Child B: still has shared rowset
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* shared_b = meta_b->add_rowsets();
+    shared_b->set_id(1);
+    shared_b->set_version(1);
+    shared_b->set_num_rows(10);
+    shared_b->set_data_size(100);
+    shared_b->add_segments("shared_seg.dat");
+    shared_b->add_segment_size(100);
+    shared_b->add_shared_segments(true);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Both rowsets should be present (no dedup: different segments)
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_rowset_on_non_first_child) {
+    // Shared rowset only appears in non-first child (child_b), not in child_a.
+    // Child_a has a local rowset. No dedup should happen.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(5);
+    rowset_a->set_data_size(50);
+    rowset_a->add_segments("local_a.dat");
+    rowset_a->add_segment_size(50);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // No dedup: different segments
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_only_shared_rowset) {
+    // Shared rowset that has no segments, only shared del_files
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_del_only_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(0);
+        // No segments, only del_file
+        auto* del_file = rowset->add_del_files();
+        del_file->set_name("shared_del.dat");
+        del_file->set_shared(true);
+        del_file->set_origin_rowset_id(1);
+        return meta;
+    };
+
+    auto meta_a = make_del_only_child(child_a);
+    auto meta_b = make_del_only_child(child_b);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Delete-only shared rowset should be deduped
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_EQ(1, merged->rowsets(0).del_files_size());
+    EXPECT_EQ("shared_del.dat", merged->rowsets(0).del_files(0).name());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_different_split_families) {
+    // C (from family A) and D (from family E) merge.
+    // Different file names, no dedup expected.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_c = next_id();
+    const int64_t child_d = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(child_d);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_c = std::make_shared<TabletMetadataPB>();
+    meta_c->set_id(child_c);
+    meta_c->set_version(base_version);
+    meta_c->set_next_rowset_id(3);
+    auto* rowset_c = meta_c->add_rowsets();
+    rowset_c->set_id(1);
+    rowset_c->set_version(1);
+    rowset_c->set_num_rows(10);
+    rowset_c->set_data_size(100);
+    rowset_c->add_segments("family_a_seg.dat");
+    rowset_c->add_segment_size(100);
+    rowset_c->add_shared_segments(true);
+
+    auto meta_d = std::make_shared<TabletMetadataPB>();
+    meta_d->set_id(child_d);
+    meta_d->set_version(base_version);
+    meta_d->set_next_rowset_id(3);
+    auto* rowset_d = meta_d->add_rowsets();
+    rowset_d->set_id(1);
+    rowset_d->set_version(1);
+    rowset_d->set_num_rows(10);
+    rowset_d->set_data_size(100);
+    rowset_d->add_segments("family_e_seg.dat");
+    rowset_d->add_segment_size(100);
+    rowset_d->add_shared_segments(true);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_d));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.add_old_tablet_ids(child_d);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Different families: no dedup
+    ASSERT_EQ(2, merged->rowsets_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
+    // Cross-publish: same txn log applied to both children, producing same segment
+    // but different rowset.id(). Should be deduped by is_duplicate_rowset.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Both have same shared segment but different rowset IDs (cross-publish)
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(5);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("cross_pub.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(8);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(3); // Different ID from A's rowset
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("cross_pub.dat"); // Same segment
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Should be deduped to 1 rowset
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ("cross_pub.dat", merged->rowsets(0).segments(0));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
+    // Two children independently apply column-mode partial update on the same shared segment.
+    // DCG values differ -> should return error.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("shared_seg.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    // DCG from child A's independent partial update
+    add_dcg_with_columns(meta_a.get(), 1, "dcg_a.cols", {1}, 1);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // DCG from child B's different independent partial update
+    add_dcg_with_columns(meta_b.get(), 1, "dcg_b.cols", {1}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    // Should fail with NotSupported for DCG conflict
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_predicate_dedup) {
+    // Both children have the same predicate version from split.
+    // Only one should be kept in the output.
+    const int64_t base_version = 2;
+    const int64_t new_version = 3;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    TabletMetadataPB meta_a;
+    meta_a.set_id(child_a);
+    meta_a.set_version(base_version);
+    meta_a.set_next_rowset_id(3);
+    add_rowset_with_predicate(&meta_a, 1, 5, true);  // predicate v5
+    add_rowset_with_predicate(&meta_a, 2, 6, false); // data v6
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+
+    TabletMetadataPB meta_b;
+    meta_b.set_id(child_b);
+    meta_b.set_version(base_version);
+    meta_b.set_next_rowset_id(3);
+    add_rowset_with_predicate(&meta_b, 1, 5, true);  // same predicate v5
+    add_rowset_with_predicate(&meta_b, 2, 6, false); // data v6
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // 1 predicate (deduped) + 2 data = 3 rowsets
+    ASSERT_EQ(3, merged->rowsets_size());
+
+    int predicate_count = 0;
+    for (const auto& rowset : merged->rowsets()) {
+        if (rowset.has_delete_predicate()) {
+            predicate_count++;
+            EXPECT_EQ(5, rowset.version());
+        }
+    }
+    EXPECT_EQ(1, predicate_count);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_dcg_dedup) {
+    // Two children share the same DCG (from split). Should be deduped successfully.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child_with_dcg = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        // Same shared DCG on both children (inherited from split)
+        add_dcg_with_columns(meta.get(), 1, "shared_dcg.cols", {1, 2}, 1);
+        return meta;
+    };
+
+    auto meta_a = make_child_with_dcg(child_a);
+    auto meta_b = make_child_with_dcg(child_b);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Rowset deduped to 1
+    ASSERT_EQ(1, merged->rowsets_size());
+    // DCG deduped: only one entry for the canonical rssid
+    ASSERT_TRUE(merged->has_dcg_meta());
+    ASSERT_EQ(1, merged->dcg_meta().dcgs().size());
+    auto dcg_it = merged->dcg_meta().dcgs().find(merged->rowsets(0).id());
+    ASSERT_TRUE(dcg_it != merged->dcg_meta().dcgs().end());
+    ASSERT_EQ(1, dcg_it->second.column_files_size());
+    EXPECT_EQ("shared_dcg.cols", dcg_it->second.column_files(0));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
+    // Split, then each child independently deletes different rows on the shared segment.
+    // Delvec pages come from different source files -> roaring union path.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Create delvec data: child_a deletes row 0, child_b deletes row 1
+    DelVector dv_a;
+    const uint32_t dels_a[] = {0};
+    dv_a.init(1, dels_a, 1);
+    std::string dv_a_data = dv_a.save();
+
+    DelVector dv_b;
+    const uint32_t dels_b[] = {1};
+    dv_b.init(2, dels_b, 1);
+    std::string dv_b_data = dv_b.save();
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("shared_seg.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    // Delvec from child_a's independent delete
+    add_delvec(meta_a.get(), child_a, 1, 1, "delvec_a.dv", dv_a_data);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // Delvec from child_b's different independent delete
+    add_delvec(meta_b.get(), child_b, 2, 1, "delvec_b.dv", dv_b_data);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Rowset deduped to 1
+    ASSERT_EQ(1, merged->rowsets_size());
+    // Delvec should exist for the deduped segment with union of both deletes
+    ASSERT_TRUE(merged->has_delvec_meta());
+    uint32_t target_rssid = merged->rowsets(0).id();
+    auto dv_it = merged->delvec_meta().delvecs().find(target_rssid);
+    ASSERT_TRUE(dv_it != merged->delvec_meta().delvecs().end());
+    // The merged delvec page should have size > 0 (contains union of row 0 and row 1)
+    EXPECT_GT(dv_it->second.size(), 0u);
+    // Verify delvec content: should contain both row 0 and row 1
+    {
+        DelVector dv_result;
+        LakeIOOptions io_opts;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_opts, &dv_result));
+        EXPECT_EQ(2, dv_result.cardinality());
+        ASSERT_TRUE(dv_result.roaring() != nullptr);
+        EXPECT_TRUE(dv_result.roaring()->contains(0));
+        EXPECT_TRUE(dv_result.roaring()->contains(1));
+    }
+    // version_to_file should only have new_version (no new_version+1 or other entries)
+    EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
+    EXPECT_TRUE(merged->delvec_meta().version_to_file().find(new_version) !=
+                merged->delvec_meta().version_to_file().end());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
+    // 2 children share 2 segments (rssid 1 and rssid 2), each independently deletes different rows.
+    // Verifies: both target delvecs exist with size > 0; version_to_file has only new_version.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // child_a deletes row 0 in segment 1, row 10 in segment 2
+    DelVector dv_a1;
+    const uint32_t dels_a1[] = {0};
+    dv_a1.init(1, dels_a1, 1);
+    std::string dv_a1_data = dv_a1.save();
+
+    DelVector dv_a2;
+    const uint32_t dels_a2[] = {10};
+    dv_a2.init(1, dels_a2, 1);
+    std::string dv_a2_data = dv_a2.save();
+
+    // child_b deletes row 1 in segment 1, row 11 in segment 2
+    DelVector dv_b1;
+    const uint32_t dels_b1[] = {1};
+    dv_b1.init(2, dels_b1, 1);
+    std::string dv_b1_data = dv_b1.save();
+
+    DelVector dv_b2;
+    const uint32_t dels_b2[] = {11};
+    dv_b2.init(2, dels_b2, 1);
+    std::string dv_b2_data = dv_b2.save();
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(4);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("shared_seg1.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    rowset_a->add_segments("shared_seg2.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    // Delvec for segment 1 (rssid 1) and segment 2 (rssid 2) from child_a
+    // Write a combined delvec file for child_a with both pages
+    std::string combined_a = dv_a1_data + dv_a2_data;
+    {
+        FileMetaPB file_meta;
+        file_meta.set_name("delvec_a.dv");
+        file_meta.set_size(combined_a.size());
+        (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[1] = file_meta;
+
+        DelvecPagePB page1;
+        page1.set_version(1);
+        page1.set_offset(0);
+        page1.set_size(dv_a1_data.size());
+        (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1] = page1;
+
+        DelvecPagePB page2;
+        page2.set_version(1);
+        page2.set_offset(dv_a1_data.size());
+        page2.set_size(dv_a2_data.size());
+        (*meta_a->mutable_delvec_meta()->mutable_delvecs())[2] = page2;
+
+        write_file(_tablet_manager->delvec_location(child_a, "delvec_a.dv"), combined_a);
+    }
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(4);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg1.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    rowset_b->add_segments("shared_seg2.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // Delvec for segment 1 and 2 from child_b
+    std::string combined_b = dv_b1_data + dv_b2_data;
+    {
+        FileMetaPB file_meta;
+        file_meta.set_name("delvec_b.dv");
+        file_meta.set_size(combined_b.size());
+        (*meta_b->mutable_delvec_meta()->mutable_version_to_file())[2] = file_meta;
+
+        DelvecPagePB page1;
+        page1.set_version(2);
+        page1.set_offset(0);
+        page1.set_size(dv_b1_data.size());
+        (*meta_b->mutable_delvec_meta()->mutable_delvecs())[1] = page1;
+
+        DelvecPagePB page2;
+        page2.set_version(2);
+        page2.set_offset(dv_b1_data.size());
+        page2.set_size(dv_b2_data.size());
+        (*meta_b->mutable_delvec_meta()->mutable_delvecs())[2] = page2;
+
+        write_file(_tablet_manager->delvec_location(child_b, "delvec_b.dv"), combined_b);
+    }
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Rowset deduped to 1
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_TRUE(merged->has_delvec_meta());
+    uint32_t rssid = merged->rowsets(0).id();
+    // Both target delvecs should exist
+    auto dv_it1 = merged->delvec_meta().delvecs().find(rssid);
+    ASSERT_TRUE(dv_it1 != merged->delvec_meta().delvecs().end());
+    EXPECT_GT(dv_it1->second.size(), 0u);
+    auto dv_it2 = merged->delvec_meta().delvecs().find(rssid + 1);
+    ASSERT_TRUE(dv_it2 != merged->delvec_meta().delvecs().end());
+    EXPECT_GT(dv_it2->second.size(), 0u);
+    // Verify content: segment 1 should have rows {0, 1}, segment 2 should have rows {10, 11}
+    {
+        DelVector dv1;
+        LakeIOOptions io_opts;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, rssid, false, io_opts, &dv1));
+        EXPECT_EQ(2, dv1.cardinality());
+        ASSERT_TRUE(dv1.roaring() != nullptr);
+        EXPECT_TRUE(dv1.roaring()->contains(0));
+        EXPECT_TRUE(dv1.roaring()->contains(1));
+    }
+    {
+        DelVector dv2;
+        LakeIOOptions io_opts;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, rssid + 1, false, io_opts, &dv2));
+        EXPECT_EQ(2, dv2.cardinality());
+        ASSERT_TRUE(dv2.roaring() != nullptr);
+        EXPECT_TRUE(dv2.roaring()->contains(10));
+        EXPECT_TRUE(dv2.roaring()->contains(11));
+    }
+    // version_to_file should only have new_version
+    EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
+    EXPECT_TRUE(merged->delvec_meta().version_to_file().find(new_version) !=
+                merged->delvec_meta().version_to_file().end());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_three_way_union) {
+    // 3 children share 1 segment, each independently deletes a different row (0, 1, 2).
+    // Verifies: merge succeeds; delvec exists with size > 0.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t child_c = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(child_c);
+    prepare_tablet_dirs(merged_tablet);
+
+    DelVector dv_a;
+    const uint32_t dels_a[] = {0};
+    dv_a.init(1, dels_a, 1);
+    std::string dv_a_data = dv_a.save();
+
+    DelVector dv_b;
+    const uint32_t dels_b[] = {1};
+    dv_b.init(2, dels_b, 1);
+    std::string dv_b_data = dv_b.save();
+
+    DelVector dv_c;
+    const uint32_t dels_c[] = {2};
+    dv_c.init(3, dels_c, 1);
+    std::string dv_c_data = dv_c.save();
+
+    auto make_child_meta = [&](int64_t tablet_id, int64_t delvec_version, const std::string& delvec_file_name,
+                               const std::string& delvec_data) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        add_delvec(meta.get(), tablet_id, delvec_version, 1, delvec_file_name, delvec_data);
+        return meta;
+    };
+
+    auto meta_a = make_child_meta(child_a, 1, "delvec_a.dv", dv_a_data);
+    auto meta_b = make_child_meta(child_b, 2, "delvec_b.dv", dv_b_data);
+    auto meta_c = make_child_meta(child_c, 3, "delvec_c.dv", dv_c_data);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_c));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.add_old_tablet_ids(child_c);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_TRUE(merged->has_delvec_meta());
+    uint32_t target_rssid = merged->rowsets(0).id();
+    auto dv_it = merged->delvec_meta().delvecs().find(target_rssid);
+    ASSERT_TRUE(dv_it != merged->delvec_meta().delvecs().end());
+    EXPECT_GT(dv_it->second.size(), 0u);
+    // Verify content: should contain rows {0, 1, 2} from three children
+    {
+        DelVector dv_result;
+        LakeIOOptions io_opts;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_opts, &dv_result));
+        EXPECT_EQ(3, dv_result.cardinality());
+        ASSERT_TRUE(dv_result.roaring() != nullptr);
+        EXPECT_TRUE(dv_result.roaring()->contains(0));
+        EXPECT_TRUE(dv_result.roaring()->contains(1));
+        EXPECT_TRUE(dv_result.roaring()->contains(2));
+    }
+    // version_to_file should only have new_version
+    EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) {
+    // 2 children share 1 segment and the same delvec (same file name, same offset/size).
+    // Verifies: all goes through single_source path; version_to_file has only new_version.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // Same delvec data for both children (split scenario, no independent delete)
+    DelVector dv;
+    const uint32_t dels[] = {0, 1};
+    dv.init(1, dels, 2);
+    std::string dv_data = dv.save();
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("shared_seg.dat");
+    rowset_a->add_segment_size(100);
+    rowset_a->add_shared_segments(true);
+    // Both children reference the same delvec file (shared after split)
+    add_delvec(meta_a.get(), child_a, 1, 1, "shared_delvec.dv", dv_data);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // Same file name, same offset/size -> page-ref dedup
+    add_delvec(meta_b.get(), child_b, 1, 1, "shared_delvec.dv", dv_data);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_TRUE(merged->has_delvec_meta());
+    uint32_t target_rssid = merged->rowsets(0).id();
+    auto dv_it = merged->delvec_meta().delvecs().find(target_rssid);
+    ASSERT_TRUE(dv_it != merged->delvec_meta().delvecs().end());
+    EXPECT_GT(dv_it->second.size(), 0u);
+    EXPECT_EQ(new_version, dv_it->second.version());
+    // Verify content: should contain rows {0, 1} (original delvec preserved via dedup)
+    {
+        DelVector dv_result;
+        LakeIOOptions io_opts;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_opts, &dv_result));
+        EXPECT_EQ(2, dv_result.cardinality());
+        ASSERT_TRUE(dv_result.roaring() != nullptr);
+        EXPECT_TRUE(dv_result.roaring()->contains(0));
+        EXPECT_TRUE(dv_result.roaring()->contains(1));
+    }
+    // version_to_file should only have new_version (single_source path, no union file)
+    EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
+    EXPECT_TRUE(merged->delvec_meta().version_to_file().find(new_version) !=
+                merged->delvec_meta().version_to_file().end());
+}
+
+// --- DCG merge tests ---
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns) {
+    // child_a updates columns {1,2}, child_b updates columns {3,4} on the same shared segment.
+    // Disjoint columns -> merge succeeds, output has 2 entries.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    add_dcg_with_columns(meta_a.get(), 1, "a.cols", {1, 2}, 1);
+
+    auto meta_b = make_child(child_b);
+    add_dcg_with_columns(meta_b.get(), 1, "b.cols", {3, 4}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_TRUE(merged->has_dcg_meta());
+    auto dcg_it = merged->dcg_meta().dcgs().find(merged->rowsets(0).id());
+    ASSERT_TRUE(dcg_it != merged->dcg_meta().dcgs().end());
+    // 2 entries: a.cols and b.cols
+    ASSERT_EQ(2, dcg_it->second.column_files_size());
+    std::unordered_set<std::string> files;
+    for (int i = 0; i < dcg_it->second.column_files_size(); ++i) {
+        files.insert(dcg_it->second.column_files(i));
+    }
+    EXPECT_TRUE(files.count("a.cols") > 0);
+    EXPECT_TRUE(files.count("b.cols") > 0);
+    // All 5 fields should be aligned
+    EXPECT_EQ(2, dcg_it->second.unique_column_ids_size());
+    EXPECT_EQ(2, dcg_it->second.versions_size());
+    EXPECT_EQ(2, dcg_it->second.encryption_metas_size());
+    EXPECT_EQ(2, dcg_it->second.shared_files_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
+    // Both children have the same .cols file (inherited from split).
+    // Exact dedup should keep only one entry.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        add_dcg_with_columns(meta.get(), 1, "shared.cols", {1, 2}, 1);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    auto dcg_it = merged->dcg_meta().dcgs().find(merged->rowsets(0).id());
+    ASSERT_TRUE(dcg_it != merged->dcg_meta().dcgs().end());
+    ASSERT_EQ(1, dcg_it->second.column_files_size());
+    EXPECT_EQ("shared.cols", dcg_it->second.column_files(0));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_same_column_conflict) {
+    // child_a and child_b both update column {1} with different .cols files.
+    // Same column conflict -> NotSupported.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    add_dcg_with_columns(meta_a.get(), 1, "a.cols", {1}, 1);
+
+    auto meta_b = make_child(child_b);
+    add_dcg_with_columns(meta_b.get(), 1, "b.cols", {1}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_partial_overlap) {
+    // child_a updates columns {1,2}, child_b updates columns {2,3}.
+    // Column 2 overlaps -> NotSupported.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    add_dcg_with_columns(meta_a.get(), 1, "a.cols", {1, 2}, 1);
+
+    auto meta_b = make_child(child_b);
+    add_dcg_with_columns(meta_b.get(), 1, "b.cols", {2, 3}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_missing_shape) {
+    // DCG with column_files but missing unique_column_ids/versions (legacy add_dcg).
+    // validate_dcg_shape should catch this -> Corruption.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    auto* rowset = meta_a->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_version(1);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments("seg.dat");
+    rowset->add_segment_size(100);
+    // Use legacy add_dcg (no unique_column_ids/versions)
+    add_dcg(meta_a.get(), 1, "malformed.cols");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_corruption()) << st;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_duplicate_column_uid) {
+    // Single child DCG has two entries with overlapping column UIDs {1,2} and {2,3}.
+    // validate_dcg_shape should catch column 2 duplication -> Corruption.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    auto* rowset = meta_a->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_version(1);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments("seg.dat");
+    rowset->add_segment_size(100);
+    // Build a malformed DCG with overlapping column UIDs across entries
+    add_dcg_with_columns(meta_a.get(), 1, "first.cols", {1, 2}, 1);
+    add_dcg_with_columns(meta_a.get(), 1, "second.cols", {2, 3}, 1);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_corruption()) << st;
+}
+
+// --- sstable merge tests ---
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_without_shared_rssid) {
+    // Legacy shared sstable without shared_rssid: uses rssid_offset path.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->add_segments("shared_seg.dat");
+        rowset->add_segment_size(100);
+        rowset->add_shared_segments(true);
+        // Legacy shared sstable: no shared_rssid, no delvec
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename("legacy_sst.sst");
+        sst->set_filesize(256);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
+        return meta;
+    };
+
+    auto meta_a = make_child(child_a);
+    auto meta_b = make_child(child_b);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // Deduped to 1 sstable
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ("legacy_sst.sst", out_sst.filename());
+    // No shared_rssid: should use rssid_offset (first child offset = 0)
+    EXPECT_FALSE(out_sst.has_shared_rssid());
+    EXPECT_EQ(0, out_sst.rssid_offset());
+    EXPECT_FALSE(out_sst.has_delvec());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_mixed_shared_and_local) {
+    // Child A has shared + local sstable, child B has same shared sstable.
+    // Shared deduped, local preserved.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(4);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a1 = meta_a->add_rowsets();
+    rowset_a1->set_id(1);
+    rowset_a1->set_version(1);
+    rowset_a1->set_num_rows(10);
+    rowset_a1->set_data_size(100);
+    rowset_a1->add_segments("shared_seg.dat");
+    rowset_a1->add_segment_size(100);
+    rowset_a1->add_shared_segments(true);
+    auto* rowset_a2 = meta_a->add_rowsets();
+    rowset_a2->set_id(2);
+    rowset_a2->set_version(2);
+    rowset_a2->set_num_rows(5);
+    rowset_a2->set_data_size(50);
+    rowset_a2->add_segments("local_a.dat");
+    rowset_a2->add_segment_size(50);
+    // Shared sstable
+    auto* sst_shared_a = meta_a->mutable_sstable_meta()->add_sstables();
+    sst_shared_a->set_filename("shared_sst.sst");
+    sst_shared_a->set_filesize(512);
+    sst_shared_a->set_shared(true);
+    sst_shared_a->set_shared_rssid(1);
+    sst_shared_a->set_shared_version(1);
+    sst_shared_a->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
+    // Local sstable (non-shared)
+    auto* sst_local = meta_a->mutable_sstable_meta()->add_sstables();
+    sst_local->set_filename("local_a_sst.sst");
+    sst_local->set_filesize(128);
+    sst_local->set_shared_rssid(2);
+    sst_local->set_shared_version(2);
+    sst_local->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 50);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("shared_seg.dat");
+    rowset_b->add_segment_size(100);
+    rowset_b->add_shared_segments(true);
+    // Same shared sstable
+    auto* sst_shared_b = meta_b->mutable_sstable_meta()->add_sstables();
+    sst_shared_b->set_filename("shared_sst.sst");
+    sst_shared_b->set_filesize(512);
+    sst_shared_b->set_shared(true);
+    sst_shared_b->set_shared_rssid(1);
+    sst_shared_b->set_shared_version(1);
+    sst_shared_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // 1 shared (deduped) + 1 local = 2 sstables
+    ASSERT_EQ(2, merged->sstable_meta().sstables_size());
+    std::unordered_set<std::string> sst_filenames;
+    for (const auto& sst : merged->sstable_meta().sstables()) {
+        sst_filenames.insert(sst.filename());
+    }
+    EXPECT_TRUE(sst_filenames.count("shared_sst.sst") > 0);
+    EXPECT_TRUE(sst_filenames.count("local_a_sst.sst") > 0);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_no_dedup_different_filenames) {
+    // Two shared sstables with different filenames (different split families).
+    // No dedup should happen.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("seg_a.dat");
+    rowset_a->add_segment_size(100);
+    auto* sst_a = meta_a->mutable_sstable_meta()->add_sstables();
+    sst_a->set_filename("sst_family_a.sst");
+    sst_a->set_filesize(256);
+    sst_a->set_shared(true);
+    sst_a->set_shared_rssid(1);
+    sst_a->set_shared_version(1);
+    sst_a->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(1);
+    rowset_b->set_num_rows(10);
+    rowset_b->set_data_size(100);
+    rowset_b->add_segments("seg_b.dat");
+    rowset_b->add_segment_size(100);
+    auto* sst_b = meta_b->mutable_sstable_meta()->add_sstables();
+    sst_b->set_filename("sst_family_b.sst");
+    sst_b->set_filesize(256);
+    sst_b->set_shared(true);
+    sst_b->set_shared_rssid(1);
+    sst_b->set_shared_version(1);
+    sst_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 50);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // No dedup: different filenames -> 2 sstables
+    ASSERT_EQ(2, merged->sstable_meta().sstables_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_sstable_shared_rssid_projection) {
+    // Shared sstable with shared_rssid on non-first child (rssid_offset != 0).
+    // Verifies shared_rssid is correctly projected and rssid_offset is cleared.
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // child_a: local rowset (not shared)
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(5);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rowset_a = meta_a->add_rowsets();
+    rowset_a->set_id(1);
+    rowset_a->set_version(1);
+    rowset_a->set_num_rows(10);
+    rowset_a->set_data_size(100);
+    rowset_a->add_segments("local_seg.dat");
+    rowset_a->add_segment_size(100);
+
+    // child_b: has shared sstable with shared_rssid=1 referencing shared segment
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rowset_b = meta_b->add_rowsets();
+    rowset_b->set_id(1);
+    rowset_b->set_version(2);
+    rowset_b->set_num_rows(5);
+    rowset_b->set_data_size(50);
+    rowset_b->add_segments("seg_b.dat");
+    rowset_b->add_segment_size(50);
+    auto* sst_b = meta_b->mutable_sstable_meta()->add_sstables();
+    sst_b->set_filename("sst_b.sst");
+    sst_b->set_filesize(512);
+    sst_b->set_shared(true);
+    sst_b->set_shared_rssid(1);
+    sst_b->set_shared_version(2);
+    sst_b->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_a));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(2, merged->rowsets_size()); // no dedup: different segments
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_EQ("sst_b.sst", out_sst.filename());
+    // child_b gets rssid_offset from meta_a's next_rowset_id.
+    // shared_rssid should be projected: original 1 + offset
+    const int64_t expected_offset = static_cast<int64_t>(meta_a->next_rowset_id()) - 1;
+    EXPECT_EQ(static_cast<uint32_t>(1 + expected_offset), out_sst.shared_rssid());
+    // rssid_offset must be 0 (shared_rssid path)
+    EXPECT_EQ(0, out_sst.rssid_offset());
+    // max_rss_rowid high part should match projected shared_rssid
+    uint64_t expected_max = (static_cast<uint64_t>(out_sst.shared_rssid()) << 32) | 99;
+    EXPECT_EQ(expected_max, out_sst.max_rss_rowid());
+}
+
+// --- union_range unit tests ---
+
+TEST_F(LakeTabletReshardTest, test_union_range_equal_bound_included_excluded) {
+    TabletRangePB a;
+    a.mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    a.set_lower_bound_included(true);
+    a.mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    a.set_upper_bound_included(false);
+
+    TabletRangePB b;
+    b.mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    b.set_lower_bound_included(false);
+    b.mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    b.set_upper_bound_included(true);
+
+    ASSIGN_OR_ABORT(auto result, lake::tablet_reshard_helper::union_range(a, b));
+    // Lower: equal values, included = true || false = true
+    EXPECT_TRUE(result.lower_bound_included());
+    // Upper: equal values, included = false || true = true
+    EXPECT_TRUE(result.upper_bound_included());
+}
+
+TEST_F(LakeTabletReshardTest, test_union_range_one_side_unbounded) {
+    TabletRangePB a;
+    // a has no lower_bound (unbounded)
+    a.mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    a.set_upper_bound_included(false);
+
+    TabletRangePB b;
+    b.mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    b.set_lower_bound_included(true);
+    b.mutable_upper_bound()->CopyFrom(generate_sort_key(30));
+    b.set_upper_bound_included(true);
+
+    ASSIGN_OR_ABORT(auto result, lake::tablet_reshard_helper::union_range(a, b));
+    // Lower: a is unbounded -> result lower is unbounded
+    EXPECT_FALSE(result.has_lower_bound());
+    // Upper: a=20 exclusive, b=30 inclusive -> take larger = 30 inclusive
+    ASSERT_TRUE(result.has_upper_bound());
+    EXPECT_TRUE(result.upper_bound_included());
+}
+
+TEST_F(LakeTabletReshardTest, test_union_range_both_unbounded) {
+    TabletRangePB a; // fully unbounded
+    TabletRangePB b; // fully unbounded
+
+    ASSIGN_OR_ABORT(auto result, lake::tablet_reshard_helper::union_range(a, b));
+    EXPECT_FALSE(result.has_lower_bound());
+    EXPECT_FALSE(result.has_upper_bound());
+}
+
+TEST_F(LakeTabletReshardTest, test_union_range_unequal_bounds) {
+    TabletRangePB a;
+    a.mutable_lower_bound()->CopyFrom(generate_sort_key(5));
+    a.set_lower_bound_included(true);
+    a.mutable_upper_bound()->CopyFrom(generate_sort_key(15));
+    a.set_upper_bound_included(false);
+
+    TabletRangePB b;
+    b.mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    b.set_lower_bound_included(true);
+    b.mutable_upper_bound()->CopyFrom(generate_sort_key(25));
+    b.set_upper_bound_included(true);
+
+    ASSIGN_OR_ABORT(auto result, lake::tablet_reshard_helper::union_range(a, b));
+    // Lower: take smaller = 5, included from a = true
+    ASSERT_TRUE(result.has_lower_bound());
+    EXPECT_TRUE(result.lower_bound_included());
+    // Upper: take larger = 25, included from b = true
+    ASSERT_TRUE(result.has_upper_bound());
+    EXPECT_TRUE(result.upper_bound_included());
+
+    // Verify the values
+    VariantTuple lower;
+    ASSERT_OK(lower.from_proto(result.lower_bound()));
+    VariantTuple expected_lower;
+    ASSERT_OK(expected_lower.from_proto(generate_sort_key(5)));
+    EXPECT_EQ(0, lower.compare(expected_lower));
+
+    VariantTuple upper;
+    ASSERT_OK(upper.from_proto(result.upper_bound()));
+    VariantTuple expected_upper;
+    ASSERT_OK(expected_upper.from_proto(generate_sort_key(25)));
+    EXPECT_EQ(0, upper.compare(expected_upper));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

  After tablet split, all child tablets share the same physical files (segments, delvecs, DCGs, sstables) via shared_segments markers. The existing merge_tablet() does not recognize these shared duplicates and treats each copy as an independent rowset, causing:
  - Duplicate primary keys visible across multiple live rowsets → prepare_primary_index() failure
  - Unbounded rssid space growth, duplicated delvec/dcg/sstable metadata
  - Delvec union bugs: multiple targets overwrite the same version_to_file entry, third-round unions reference non-existent temporary files, and new_version + 1 breaks delvec version conventions

## What I'm doing:

  Rewrite merge_tablet() with a unified architecture: version-driven k-way rowset merge → rssid projection via shared_rssid_map → metadata-level dedup for delvec/dcg/sstable.

  Core changes (tablet_merger.cpp):

  1. TabletMergeContext replaces TabletMergeInfo: encapsulates shared_rssid_map (filled during rowset dedup) and map_rssid() with overflow check, used by all subsequent projection phases.
  2. merge_rowsets(): Version-driven k-way merge with is_duplicate_rowset(). Shared rowsets are deduped (canonical keeps accumulated num_rows/data_size and union range); delete predicates at the same version are deduplicated. Eliminates the old
  reorder_rowsets_by_delete_predicate() — version-ordered merge naturally produces correct predicate ordering.
  3. merge_dcg_meta(): Entry-level merge with validate_dcg_shape() (required field alignment + optional field bounds + column UID uniqueness), normalize_dcg_optional_fields(), and verify_dcg_entry_consistency(). Exact dedup for same .cols filename; disjoint columns
  append as new entries; overlapping columns return NotSupported.
  4. merge_delvecs(): 5-phase pipeline — collect unique files → scan pages with TargetDelvecState (single_source / merged) → serialize union results → write one file via extended merge_delvec_files() → build page entries. Produces exactly one
  version_to_file[new_version] entry. Fixes all three original bugs.
  5. merge_sstables(): Dedup/projection decoupled — dedup by shared() + filename; projection by has_shared_rssid() regardless of shared flag. shared_rssid path: map_rssid() + set_rssid_offset(0) + delvec projection from new_metadata->delvec_meta(). Legacy path:
  rssid_offset + Corruption guard on has_delvec. Non-shared sstables with has_shared_rssid (from local compaction) correctly project delvec.
  6. merge_schemas(): Union historical schemas → prune orphan rowset_to_schema → prune unreferenced schemas → ensure current schema present.

  Supporting changes:

  - meta_file.h/cpp: merge_delvec_files() extended with extra_data/extra_data_offset parameters to append union buffer in one write.
  - tablet_reshard_helper.h/cpp: Added union_range() for tablet-level range merge.
  - tablet_range.h: VariantTuple comparison support for union_range().


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
