### PR TITLE
[BugFix] Fix duplicate column id error when querying MV after fast schema change ADD COLUMN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3291,6 +3291,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         materializedView.setIndexMeta(baseIndexMetaId, mvName, baseSchema, schemaVersion, schemaHash,
                 shortKeyColumnCount, baseIndexStorageType, stmt.getKeysType());
 
+        // Assign unique ids for columns after index meta is set up, so that getBaseSchema() returns
+        // the actual columns. The initUniqueId() call in the MV constructor is a no-op because it
+        // runs before setIndexMeta(), when getBaseSchema() returns an empty list.
+        materializedView.initUniqueId();
+
         // validate hint
         Map<String, String> optHints = Maps.newHashMap();
         if (stmt.isExistQueryScopeHint()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewTest.java
@@ -31,7 +31,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AlterMaterializedViewTest extends MVTestBase {
     @BeforeAll
@@ -465,5 +468,61 @@ public class AlterMaterializedViewTest extends MVTestBase {
         Assertions.assertEquals(3, mv.getColumns().size());
 
         alterMVDropColumn(dropStmt, true);
+    }
+
+    @Test
+    public void testMVColumnUniqueIdNoDuplicateAfterMultipleAddColumn() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl_uid\n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    v1 int, \n" +
+                "    v2 int, \n" +
+                "    v3 int \n" +
+                ")\n" +
+                "DUPLICATE KEY(`k1`)" +
+                "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_uid_test\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT k1, sum(v1) from base_tbl_uid group by k1;");
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable(db.getFullName(), "mv_uid_test");
+
+        // Verify initial columns have valid unique ids (not -1)
+        List<Column> initialColumns = mv.getBaseSchema();
+        Assertions.assertEquals(2, initialColumns.size());
+        for (Column col : initialColumns) {
+            Assertions.assertTrue(col.getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE,
+                    "Column " + col.getName() + " should have a valid unique id, but got " + col.getUniqueId());
+        }
+
+        // First ADD COLUMN
+        String addStmt1 = "alter materialized view mv_uid_test add column v2_col as v2";
+        alterMVAddColumn(addStmt1, false);
+        waitSchemaChangeJobDone(false, mv);
+        Assertions.assertEquals(3, mv.getColumns().size());
+
+        // Second ADD COLUMN
+        String addStmt2 = "alter materialized view mv_uid_test add column v3_col as v3";
+        alterMVAddColumn(addStmt2, false);
+        waitSchemaChangeJobDone(false, mv);
+        Assertions.assertEquals(4, mv.getColumns().size());
+
+        // Verify all column unique ids are valid and unique (no duplicates)
+        List<Column> allColumns = mv.getBaseSchema();
+        Set<Integer> uniqueIds = new HashSet<>();
+        for (Column col : allColumns) {
+            Assertions.assertTrue(col.getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE,
+                    "Column " + col.getName() + " should have a valid unique id, but got " + col.getUniqueId());
+            Assertions.assertTrue(uniqueIds.add(col.getUniqueId()),
+                    "Duplicate column unique id " + col.getUniqueId() + " found for column " + col.getName());
+        }
+        Assertions.assertEquals(4, uniqueIds.size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

In shared_data mode, querying a materialized view after two successive `ALTER MV ADD COLUMN` operations fails with `Duplicate column id` error.

**Root cause**: `initUniqueId()` in the `MaterializedView` constructor is called before `setIndexMeta()` in `LocalMetastore.createMaterializedView()`, so `getBaseSchema()` returns an empty list and all MV columns retain `uniqueId=-1`. When BE processes columns with `uniqueId=-1`, it falls back to ordinal-based IDs. After two ADD COLUMN operations, the ordinal-based fallback ID of the first new column collides with the explicitly assigned ID of the second new column.


Fixes https://github.com/StarRocks/StarRocksTest/issues/11197
Introduced by #67915.

## What I'm doing:

Call `initUniqueId()` after `setIndexMeta()` in `LocalMetastore`, where `getBaseSchema()` returns the actual columns. This ensures all MV columns get proper unique IDs at creation time, so subsequent ADD COLUMN operations assign non-colliding unique IDs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4