### PR TITLE
[BugFix] Fix incorrect shuffle distribution due to missing project node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -679,6 +679,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMultiDistinctRule());
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_EMPTY_OPERATOR_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new CTEProduceAddProjectionRule());
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_PROJECT_RULES);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2695,7 +2695,7 @@ public class JoinTest extends PlanTestBase {
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 11: N_NAME = 16: cast\n" +
-                "  |  equal join conjunct: 11: N_NAME = CAST(1: C_CUSTKEY AS VARCHAR(1048576))");
+                "  |  equal join conjunct: 11: N_NAME = 17: cast");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -238,13 +238,11 @@ public class SkewJoinTest extends PlanTestBase {
         sql = "select struct_tbl.c0, struct_tbl.c2.a, t0.v2 from default_catalog.test.struct_tbl " +
                 "join[skew|test.struct_tbl.c1.a(1,2)] test.t0 on t0.v1 = c1.a ";
         sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "HASH JOIN\n" +
-                        "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                        "  |  colocate: false, reason: \n" +
-                        "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
-                        "  |  equal join conjunct: 9: cast = 5: v1",
-                "<slot 10> : CASE WHEN 22: cast IS NULL THEN 24: round WHEN 22: cast IN (1, 2) THEN 24: round " +
-                        "ELSE 0 END");
+        assertCContains(sqlPlan, "  14:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
+                "  |  equal join conjunct: 9: cast = 5: v1");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

In multi-stage MV rewrite, JoinPredicatePushDown is disabled during the first stage, preventing PushDownJoinOnExpressionToChildProject from working correctly. 
After MV rewrite, although JoinPredicatePushDown is re-enabled and PUSH_DOWN_PREDICATE_RULES re-executed, there was no subsequent PushDownJoinOnExpressionToChildProject call, leaving join on-clause expressions unreplaced and causing incorrect shuffle keys.

Fix by adding PushDownJoinOnExpressionToChildProject after the second PUSH_DOWN_PREDICATE_RULES execution post MV rewrite. 

## What I'm doing:

Fixes #71058

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
