### PR TITLE
[Enhancement] Skip already-covered rows during persistent index rebuild

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1032,10 +1032,15 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             for (int32_t si = 0; si < rowset->num_segments(); si++) {
                 uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), si);
                 if (rssid == rebuild_rss_id) {
-                    uint32_t start_rowid = (rebuild_rss_rowid_point & 0xFFFFFFFF) + 1;
-                    auto range = std::make_shared<SparseRange<>>();
-                    range->add(Range<>(start_rowid, std::numeric_limits<rowid_t>::max()));
-                    rowid_ranges[si] = std::move(range);
+                    uint32_t low_rowid = rebuild_rss_rowid_point & 0xFFFFFFFF;
+                    if (low_rowid < std::numeric_limits<uint32_t>::max()) {
+                        uint32_t start_rowid = low_rowid + 1;
+                        auto range = std::make_shared<SparseRange<>>();
+                        range->add(Range<>(start_rowid, std::numeric_limits<rowid_t>::max()));
+                        rowid_ranges[si] = std::move(range);
+                    }
+                    // If low_rowid == UINT32_MAX, the entire segment is covered,
+                    // and will be skipped by the rssid < rebuild_rss_id check below.
                     break;
                 }
             }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1025,10 +1025,26 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             continue;
         }
         const int64_t rowset_version = rowset->version() != 0 ? rowset->version() : base_version;
+        // Build per-segment rowid ranges to skip rows already covered by SSTables.
+        // For the segment containing rebuild_rss_rowid_point, only rows after that point need rebuild.
+        std::vector<SparseRangePtr> rowid_ranges(rowset->num_segments());
+        if (rebuild_rss_rowid_point > 0) {
+            for (int32_t si = 0; si < rowset->num_segments(); si++) {
+                uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), si);
+                if (rssid == rebuild_rss_id) {
+                    uint32_t start_rowid = (rebuild_rss_rowid_point & 0xFFFFFFFF) + 1;
+                    auto range = std::make_shared<SparseRange<>>();
+                    range->add(Range<>(start_rowid, std::numeric_limits<rowid_t>::max()));
+                    rowid_ranges[si] = std::move(range);
+                    break;
+                }
+            }
+        }
         StatusOr<std::vector<ChunkIteratorPtr>> res;
         {
             TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_get_segment_iterator_with_delvec_us");
-            res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+            res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats,
+                                                                &rowid_ranges);
         }
         if (!res.ok()) {
             return res.status();

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -475,10 +475,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     return seg_iterators;
 }
 
-StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_delvec(const Schema& schema,
-                                                                                      int64_t version,
-                                                                                      const MetaFileBuilder* builder,
-                                                                                      OlapReaderStatistics* stats) {
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_delvec(
+        const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats,
+        const std::vector<SparseRangePtr>* rowid_range_per_segment) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_iterator_with_delvec_us");
     std::vector<SegmentPtr> segments;
     RETURN_IF_ERROR(load_segments(&segments, false));
@@ -506,6 +505,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
+        }
+        // Apply per-segment rowid range if provided
+        if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
+            seg_options.rowid_range_option = (*rowid_range_per_segment)[i];
+        } else {
+            seg_options.rowid_range_option = nullptr;
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -22,6 +22,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
+#include "storage/range.h"
 #include "storage/options.h"
 #include "storage/rowset/base_rowset.h"
 #include "storage/seek_range.h"
@@ -91,9 +92,12 @@ public:
     // if the segment is empty, it wouln't add this iterator to iterator list
     // this function does not expect segment schema will be changed, so return error if record predicate exists
     // but does not match its chunk schema
-    StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(const Schema& schema, int64_t version,
-                                                                                  const MetaFileBuilder* builder,
-                                                                                  OlapReaderStatistics* stats);
+    // |rowid_range_per_segment|: if non-null, rowid_range_per_segment[i] specifies the row range
+    // to scan for the i-th segment. If the pointer at index i is null, the entire segment is scanned.
+    // The vector size must equal num_segments() if provided.
+    StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(
+            const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats,
+            const std::vector<SparseRangePtr>* rowid_range_per_segment = nullptr);
 
     [[nodiscard]] bool is_overlapped() const override { return metadata().overlapped(); }
 

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -22,8 +22,8 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
-#include "storage/range.h"
 #include "storage/options.h"
+#include "storage/range.h"
 #include "storage/rowset/base_rowset.h"
 #include "storage/seek_range.h"
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2530,4 +2530,143 @@ TEST_P(LakePrimaryKeyPublishTest, test_preload_update_state_slow_log) {
     ASSERT_TRUE(read(tablet_id, 2).ok());
 }
 
+// Test that persistent index rebuild skips rows already covered by SSTables.
+// This verifies the optimization where rebuild_rss_rowid_point is used to set
+// a rowid range on the segment iterator, avoiding unnecessary IO for rows
+// that are already in SSTables.
+TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_rows) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10; // force sstable flush
+
+    // Step 1: Write multiple rowsets to build up SSTables.
+    // Each publish will flush to SSTable due to small l0_max_mem_usage.
+    // This creates a rebuild_rss_rowid_point that covers most existing rows.
+    for (int r = 0; r < 3; r++) {
+        auto [chunk, indexes] = gen_data_and_index(kChunkSize, r, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Verify: 3 non-overlapping chunks
+    ASSERT_EQ(kChunkSize * 3, read_rows(tablet_id, version));
+
+    // Step 2: Remove persistent index to force rebuild on next publish.
+    // The rebuild should use rowid range to skip rows covered by SSTables.
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+    // Step 3: Write new data. This triggers rebuild where most existing rows
+    // should be skipped (covered by SSTables), only a few rows near the
+    // rebuild_rss_rowid_point boundary need to be read.
+    auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 3, true, true);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk_new, indexes_new.data(), indexes_new.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Step 4: Verify correctness after rebuild with row skipping
+    ASSERT_EQ(kChunkSize * 4, read_rows(tablet_id, version));
+
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+}
+
+// Test rebuild with overlapping upserts to verify correctness when
+// rowid range skipping is combined with upsert deduplication.
+TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_rows_with_upserts) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+
+    // Write 4 rowsets with overlapping keys (same key range, shift=0)
+    for (int r = 0; r < 4; r++) {
+        auto [chunk, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Should have kChunkSize rows (all upserts to same key range)
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    // Force rebuild
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+    // Write again with overlapping keys
+    auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 0, true, true);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk_new, indexes_new.data(), indexes_new.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Still kChunkSize rows
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

During persistent index rebuild in publish, the code reads ALL rows from segments
that need rebuilding, then discards rows already covered by SSTables via a post-read
check (`values.back().get_value() <= rebuild_rss_rowid_point`). This wastes significant
IO — in a real case, 5,494,290 rows were read but only 2,090 (~0.04%) actually needed
rebuilding, resulting in 172 unnecessary remote IO calls taking 14.36s.

## What I'm doing:

Use `rebuild_rss_rowid_point` to compute a rowid range for the boundary segment
(where `rssid == rebuild_rss_id`), and pass it to the segment iterator via
`SegmentReadOptions::rowid_range_option`. This makes the segment iterator skip
rows before `start_rowid` at the scan range level, avoiding IO for those rows
entirely.

Changes:
- `lake_persistent_index.cpp`: Build per-segment rowid ranges based on
  `rebuild_rss_rowid_point`. For the boundary segment, set range to
  `[start_rowid, MAX)` where `start_rowid = (rebuild_rss_rowid_point & 0xFFFFFFFF) + 1`.
- `rowset.h/cpp`: Add optional `rowid_range_per_segment` parameter to
  `get_each_segment_iterator_with_delvec()`, applied per-segment to
  `seg_options.rowid_range_option`.
- Added 2 test cases verifying correctness with non-overlapping and overlapping keys.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4