### PR TITLE
[BugFix] Fix use-after-free in parallel segment/rowset loading on error path

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -18,6 +18,8 @@
 #include <unordered_set>
 
 #include "base/debug/trace.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/datum_convert.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
@@ -605,6 +607,16 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
         std::future<std::pair<StatusOr<SegmentPtr>, std::string>> future;
     };
     std::vector<SegmentLoadFuture> segment_futures;
+    // The parallel tasks capture |this| pointer. Must wait for all tasks
+    // to complete before returning, to prevent use-after-free if the
+    // Rowset is destroyed while tasks are still running.
+    DeferOp wait_futures([&segment_futures]() {
+        for (auto& f : segment_futures) {
+            if (f.future.valid()) {
+                f.future.wait();
+            }
+        }
+    });
 
     // Pre-allocate segments vector to maintain correct index mapping.
     // This is necessary because when parallel loading is enabled with skip_segment_idxs,
@@ -677,6 +689,13 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
         if (_parallel_load) {
             int captured_idx = current_idx;
             auto task = std::make_shared<std::packaged_task<std::pair<StatusOr<SegmentPtr>, std::string>()>>([=]() {
+#ifdef BE_TEST
+                Status injected_st;
+                TEST_SYNC_POINT_CALLBACK("Rowset::load_segments::parallel_load", &injected_st);
+                if (!injected_st.ok()) {
+                    return std::make_pair(StatusOr<SegmentPtr>(injected_st), seg_name);
+                }
+#endif
                 auto result = _tablet_mgr->load_segment(segment_info, segment_id, lake_io_opts,
                                                         lake_io_opts.fill_metadata_cache, _tablet_schema);
                 return std::make_pair(std::move(result), seg_name);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -17,6 +17,8 @@
 #include <future>
 #include <utility>
 
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/datum_convert.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_json_flat_fwd.h"
@@ -384,6 +386,16 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
 
     std::vector<std::future<StatusOr<std::vector<ChunkIteratorPtr>>>> futures;
+    // The parallel tasks capture local variables and |this| by reference.
+    // Must wait for all tasks to complete before returning, otherwise
+    // dangling references to |rs_opts| and |this| cause use-after-free.
+    DeferOp wait_futures([&futures]() {
+        for (auto& future : futures) {
+            if (future.valid()) {
+                future.wait();
+            }
+        }
+    });
     for (auto& rowset : _rowsets) {
         if (params.rowid_range_option != nullptr && !params.rowid_range_option->contains_rowset(rowset.get())) {
             continue;
@@ -391,7 +403,17 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
 
         if (config::enable_load_segment_parallel) {
             auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
-                    [&, rowset]() { return enhance_error_prompt(rowset->read(schema(), rs_opts)); });
+                    [&, rowset]() {
+#ifdef BE_TEST
+                        Status injected_st;
+                        TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read",
+                                                 &injected_st);
+                        if (!injected_st.ok()) {
+                            return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
+                        }
+#endif
+                        return enhance_error_prompt(rowset->read(schema(), rs_opts));
+                    });
 
             auto packaged_func = [task]() { (*task)(); };
             if (auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -402,18 +402,16 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
         }
 
         if (config::enable_load_segment_parallel) {
-            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
-                    [&, rowset]() {
+            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>([&, rowset]() {
 #ifdef BE_TEST
-                        Status injected_st;
-                        TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read",
-                                                 &injected_st);
-                        if (!injected_st.ok()) {
-                            return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
-                        }
+                Status injected_st;
+                TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);
+                if (!injected_st.ok()) {
+                    return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
+                }
 #endif
-                        return enhance_error_prompt(rowset->read(schema(), rs_opts));
-                    });
+                return enhance_error_prompt(rowset->read(schema(), rs_opts));
+            });
 
             auto packaged_func = [task]() { (*task)(); };
             if (auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -19,6 +19,8 @@
 
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
@@ -1214,6 +1216,46 @@ TEST_F(LakeRowsetTest, test_segment_range_mode_segment_ids) {
     // The segment ID is stored in the segment's metadata
     EXPECT_EQ(1, segments[0]->id());
     EXPECT_EQ(2, segments[1]->id());
+}
+
+// Verify that DeferOp in load_segments waits for all parallel tasks
+// before returning on error, preventing use-after-free of captured |this|.
+TEST_F(LakeRowsetTest, test_parallel_load_error_waits_all_futures) {
+    create_rowsets_for_testing();
+
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, true);
+
+    std::atomic<int> total_hits{0};
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([] {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->ClearTrace();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // First call injects error; subsequent calls succeed normally.
+    // total_hits >= 2 proves DeferOp waited for all tasks before returning.
+    SyncPoint::GetInstance()->SetCallBack(
+            "Rowset::load_segments::parallel_load",
+            [&](void* arg) {
+                if (total_hits.fetch_add(1) == 0) {
+                    *static_cast<Status*>(arg) = Status::IOError("injected");
+                }
+            });
+
+    // Create rowset after config is set (Rowset captures _parallel_load in constructor)
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+
+    RowsetReadOptions rs_opts;
+    OlapReaderStatistics stats;
+    rs_opts.stats = &stats;
+    rs_opts.tablet_schema = _tablet_schema;
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+    auto rs = rowset->read(input_schema, rs_opts);
+    ASSERT_FALSE(rs.ok());
+    ASSERT_GE(total_hits.load(), 2);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1236,13 +1236,11 @@ TEST_F(LakeRowsetTest, test_parallel_load_error_waits_all_futures) {
 
     // First call injects error; subsequent calls succeed normally.
     // total_hits >= 2 proves DeferOp waited for all tasks before returning.
-    SyncPoint::GetInstance()->SetCallBack(
-            "Rowset::load_segments::parallel_load",
-            [&](void* arg) {
-                if (total_hits.fetch_add(1) == 0) {
-                    *static_cast<Status*>(arg) = Status::IOError("injected");
-                }
-            });
+    SyncPoint::GetInstance()->SetCallBack("Rowset::load_segments::parallel_load", [&](void* arg) {
+        if (total_hits.fetch_add(1) == 0) {
+            *static_cast<Status*>(arg) = Status::IOError("injected");
+        }
+    });
 
     // Create rowset after config is set (Rowset captures _parallel_load in constructor)
     auto rowset =

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -1163,4 +1163,101 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_empty_tablet_with_split) {
     reader->close();
 }
 
+// Verify that DeferOp in get_segment_iterators waits for all parallel tasks
+// before returning on error, preventing use-after-free of captured references.
+TEST_F(LakeDuplicateTabletReaderTest, test_parallel_read_error_waits_all_futures) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+    Chunk chunk1({std::move(c2), std::move(c3)}, _schema);
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+
+    // Write rowset 1
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (const auto& file : writer->segments()) {
+            segs->Add()->assign(file.path);
+            segs_size->Add(file.size.value());
+        }
+        writer->close();
+    }
+
+    // Write rowset 2
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_id(2);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (const auto& file : writer->segments()) {
+            segs->Add()->assign(file.path);
+            segs_size->Add(file.size.value());
+        }
+        writer->close();
+    }
+
+    _tablet_metadata->set_version(3);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, true);
+
+    std::atomic<int> total_hits{0};
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([] {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->ClearTrace();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // First call injects error; subsequent calls succeed normally.
+    // total_hits >= 2 proves DeferOp waited for all tasks before returning.
+    SyncPoint::GetInstance()->SetCallBack(
+            "TabletReader::get_segment_iterators::parallel_read",
+            [&](void* arg) {
+                if (total_hits.fetch_add(1) == 0) {
+                    *static_cast<Status*>(arg) = Status::IOError("injected");
+                }
+            });
+
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    auto st = reader->open(params);
+    ASSERT_FALSE(st.ok());
+    ASSERT_GE(total_hits.load(), 2);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -1244,13 +1244,11 @@ TEST_F(LakeDuplicateTabletReaderTest, test_parallel_read_error_waits_all_futures
 
     // First call injects error; subsequent calls succeed normally.
     // total_hits >= 2 proves DeferOp waited for all tasks before returning.
-    SyncPoint::GetInstance()->SetCallBack(
-            "TabletReader::get_segment_iterators::parallel_read",
-            [&](void* arg) {
-                if (total_hits.fetch_add(1) == 0) {
-                    *static_cast<Status*>(arg) = Status::IOError("injected");
-                }
-            });
+    SyncPoint::GetInstance()->SetCallBack("TabletReader::get_segment_iterators::parallel_read", [&](void* arg) {
+        if (total_hits.fetch_add(1) == 0) {
+            *static_cast<Status*>(arg) = Status::IOError("injected");
+        }
+    });
 
     auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());


### PR DESCRIPTION
 ## Why I'm doing:
```
branch-4.1.0-f-0330 RELEASE (build e1112f9 distro ubuntu arch aarch64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1774947540 (unix time) try "date -d @1774947540" if you are using GNU date ***
PC: @          0xe62ad40 starrocks::TabletReaderParams::~TabletReaderParams()
*** SIGSEGV (@0x19) received by PID 331484 (TID 0xf664ebdafac0) LWP(332276) from PID 25; stack trace: ***
    @     0xf665745053dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @         0x1366a984 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xf66575bab8f8 ([vdso]+0x8f7)
    @          0xe62ad40 starrocks::TabletReaderParams::~TabletReaderParams()
    @          0xfa62300 starrocks::lake::TabletWarmupManager::do_warmup_tablet(std::shared_ptr<starrocks::lake::TabletWarmupManager::WarmupContext> const&)
    @         0x1014a764 starrocks::ThreadPool::dispatch_thread()
    @         0x10140d6c starrocks::Thread::supervise_thread(void*)
    @     0xf66574500398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xf66574569e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)

branch-4.1.0-f-0330 RELEASE (build e1112f9 distro ubuntu arch aarch64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1774947699 (unix time) try "date -d @1774947699" if you are using GNU date ***
PC: @          0xf9f1720 starrocks::lake::Rowset::read(starrocks::Schema const&, starrocks::RowsetReadOptions const&)
*** SIGSEGV (@0xa3) received by PID 332870 (TID 0xf9c9f71efac0) LWP(334250) from PID 163; stack trace: ***
    @     0xf9caee9853dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @         0x1366a984 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @          0xf9f1720 starrocks::lake::Rowset::read(starrocks::Schema const&, starrocks::RowsetReadOptions const&) ::_Result<starrocks::StatusOr<std::vector<std::shared_ptr<starrocks:<A0><C3>^^<F7><C9><F9>
    @          0xcee9dac std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)
    @     0xf9caee9853dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db) ator<std::shared_ptr<starrocks::ChunkIterator> > >*)::{lambda()#2}>:<A0><C3>^^<F7><C9><F9>
    @         0x10149f84 starrocks::ThreadPool::dispatch_thread()
    @         0x10140d6c starrocks::Thread::supervise_thread(void*)
    @     0xf9caee980398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xf9caee9e9e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

  CN crashes (SIGSEGV) in shared-data mode during warmup when `enable_load_segment_parallel=true`.
  The crash stacks point to `TabletReaderParams::~TabletReaderParams()` and `Rowset::read()`,
  both are typical null+offset dereferences caused by use-after-free.

  Root cause: when one parallel task returns an error, the function returns early **without waiting
  for remaining futures to complete**. Tasks still running in the thread pool then access dangling
  references to already-destroyed stack locals (`rs_opts`, `this`).

  Two defect sites:
  1. `TabletReader::get_segment_iterators` — parallel lambda captures `rs_opts` and `this` by reference via `[&, rowset]`. Early return on future error leaves pending tasks holding dangling references.
  2. `Rowset::load_segments` — parallel lambda captures `this` (Rowset*) via `[=]`. Early return lets `TabletReader::close()` destroy the Rowset while tasks are still running.

## What I'm doing:

  Add a `DeferOp` right after the futures container declaration in both functions. The `DeferOp`
  ensures all submitted futures are waited on before the function returns through **any** path
  (including `ASSIGN_OR_RETURN` serial-fallback failures and future error early-returns).

  This is the minimal fix — no change to lambda capture semantics, no change to control flow,
  just a scope guard that calls `future.wait()` on all valid futures at function exit.

  Also adds `BE_TEST`-only sync point hooks in the parallel lambdas and corresponding unit tests
  that inject errors to verify the DeferOp correctly waits for all tasks.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
