### PR TITLE
[BugFix] Fix IVM refresh recording incomplete PCT partition metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -480,8 +480,17 @@ public abstract class BaseMVRefreshProcessor {
         return result;
     }
 
-    protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext) throws Exception {
-        this.pctMVToRefreshedPartitions = getPCTMVToRefreshedPartitions(false);
+    /**
+     * Compute PCT partition metadata for the current refresh.
+     *
+     * @param skipBatchFilter if true, skip batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit)
+     *                        and record all detected changed partitions. This is used by IVM where all changed
+     *                        partitions are refreshed via TVR delta regardless of partition_refresh_number.
+     *                        if false, apply batch filtering as in normal PCT execution.
+     */
+    protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext,
+                                           boolean skipBatchFilter) throws Exception {
+        this.pctMVToRefreshedPartitions = getPCTMVToRefreshedPartitions(false, skipBatchFilter);
         // ref table of mv : refreshed partition names
         this.pctRefTableRefreshPartitions = getPCTRefTableRefreshPartitions(pctMVToRefreshedPartitions);
         // ref table of mv : refreshed partition names
@@ -492,6 +501,10 @@ public abstract class BaseMVRefreshProcessor {
         this.updatePCTMVToRefreshInfoIntoTaskRun(pctMVToRefreshedPartitions, pctRefTablePartitionNames);
         logger.info("mvToRefreshedPartitions:{}, refTableRefreshPartitions:{}",
                 pctMVToRefreshedPartitions, pctRefTableRefreshPartitions);
+    }
+
+    protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext) throws Exception {
+        updatePCTToRefreshMetas(taskRunContext, false);
     }
 
     /**
@@ -751,17 +764,26 @@ public abstract class BaseMVRefreshProcessor {
     }
 
     /**
-     * @param tentative: if true, it means this is called in the first phase to compute candidate partitions and not the
-     *                 standard phase to get final partitions to refresh.
+     * @param tentative if true, this is a tentative computation for candidate estimation
+     *                  (isForce() returns true to get all partitions, task run status is not updated).
+     *                  if false, this is the final computation for metadata recording.
+     * @param skipBatchFilter if true, skip batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit).
+     *                        This is used by IVM where all changed partitions are refreshed via TVR delta,
+     *                        so PCT metadata should reflect all of them.
      */
     @VisibleForTesting
-    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative) throws AnalysisException, LockTimeoutException {
-        // change mv refresh params if needed
+    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative,
+                                                        boolean skipBatchFilter)
+            throws AnalysisException, LockTimeoutException {
         mvRefreshParams.setIsTentative(tentative);
-
-        final PCellSortedSet mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(snapshotBaseTables);
+        final PCellSortedSet mvToRefreshedPartitions;
+        if (skipBatchFilter) {
+            mvToRefreshedPartitions = mvRefreshPartitioner.detectMVPartitionsToRefresh(snapshotBaseTables);
+        } else {
+            mvToRefreshedPartitions = mvRefreshPartitioner.getMVToRefreshedPartitions(snapshotBaseTables);
+        }
         // update mv extra message
-        if (!mvRefreshParams.isTentative()) {
+        if (!tentative) {
             updateTaskRunStatus(status -> {
                 MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
                 extraMessage.setForceRefresh(mvRefreshParams.isForce());
@@ -770,6 +792,12 @@ public abstract class BaseMVRefreshProcessor {
             });
         }
         return mvToRefreshedPartitions;
+    }
+
+    @VisibleForTesting
+    public PCellSortedSet getPCTMVToRefreshedPartitions(boolean tentative)
+            throws AnalysisException, LockTimeoutException {
+        return getPCTMVToRefreshedPartitions(tentative, false);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -133,11 +133,13 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
 
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckMVToRefreshPartitions")) {
             try {
-                updatePCTToRefreshMetas(taskRunContext);
+                // IVM refreshes all changed partitions via TVR delta (not limited by partition_refresh_number),
+                // so pass skipBatchFilter=true to record complete PCT metadata without truncation.
+                updatePCTToRefreshMetas(taskRunContext, /* skipBatchFilter */ true);
             } catch (Exception e) {
                 // if the check failed, we should not throw exception here
-                // because this check only affects mv refresh rather than mv refresh.
-                logger.warn("Failed to check PCT partitions for materialized view: {}, error: {}",
+                // because this check only affects pct-based refresh rather than ivm-based mv refresh.
+                logger.warn("Failed to collect PCT metadata for materialized view: {}, error: {}",
                         mv.getName(), e.getMessage(), e);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -273,43 +273,59 @@ public abstract class MVPCTRefreshPartitioner {
     }
 
     /**
-     * Compute the partitioned to be refreshed in this task, according to [start, end), ttl, and other context info
-     * If it's tentative, only return the result rather than modify any state
-     * IF it's not, it would modify the context state, like `NEXT_PARTITION_START`
+     * Detect all MV partitions that need refresh, including partition change detection and
+     * potential partition calculation, but without any batch filtering (no partition_refresh_number,
+     * no adaptive truncation, no refreshPartitionLimit).
+     *
+     * <p>This is used by IVM to record complete PCT metadata that reflects all actually refreshed partitions.
      */
-    public PCellSortedSet getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
+    public PCellSortedSet detectMVPartitionsToRefresh(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
             throws AnalysisException, LockTimeoutException {
         PCellSortedSet mvToRefreshedPartitions = null;
         Locker locker = new Locker();
         if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
                 LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            logger.warn("failed to lock database: {} in checkMvToRefreshedPartitions", db.getFullName());
+            logger.warn("failed to lock database: {} in detectMVPartitionsToRefresh", db.getFullName());
             throw new LockTimeoutException(String.format("Materialized view %s.%s refresh failed: " +
                     "failed to acquire read lock on database %s within %d ms " +
-                    "when computing partitions to refresh",
+                    "when detecting partitions to refresh",
                     db.getFullName(), mv.getName(), db.getFullName(), Config.mv_refresh_try_lock_timeout_ms));
         }
-
         try {
             mvToRefreshedPartitions = getMVPartitionsToRefresh(snapshotBaseTables);
             if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
                 logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;
             }
-            // calculate the associated potential partitions to refresh
             calcPotentialMVRefreshPartitions(mvToRefreshedPartitions);
-
-            // filter partitions to avoid refreshing too many partitions
-            filterMVToRefreshPartitions(mvToRefreshedPartitions);
-
-            int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-            logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
-                            "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
-                    partitionRefreshNumber, mvToRefreshedPartitions, mvToRefreshPotentialPartitions,
-                    mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextPartitionValues());
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
         }
+        return mvToRefreshedPartitions;
+    }
+
+    /**
+     * Compute the partitions to be refreshed in this task, according to [start, end), ttl, and other context info.
+     * This applies batch filtering (partition_refresh_number, adaptive, refreshPartitionLimit) on top of
+     * {@link #detectMVPartitionsToRefresh} results.
+     * If it's tentative, only return the result rather than modify any state.
+     * If it's not, it would modify the context state, like `NEXT_PARTITION_START`.
+     */
+    public PCellSortedSet getMVToRefreshedPartitions(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables)
+            throws AnalysisException, LockTimeoutException {
+        PCellSortedSet mvToRefreshedPartitions = detectMVPartitionsToRefresh(snapshotBaseTables);
+        if (mvToRefreshedPartitions == null || mvToRefreshedPartitions.isEmpty()) {
+            return mvToRefreshedPartitions;
+        }
+
+        // filter partitions to avoid refreshing too many partitions
+        filterMVToRefreshPartitions(mvToRefreshedPartitions);
+
+        int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
+        logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
+                        "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
+                partitionRefreshNumber, mvToRefreshedPartitions, mvToRefreshPotentialPartitions,
+                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextPartitionValues());
         return mvToRefreshedPartitions;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler.mv.ivm;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.tvr.TvrDeltaStats;
@@ -23,8 +24,12 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.MVTaskRunProcessor;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import org.junit.jupiter.api.Assertions;
@@ -32,6 +37,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+import java.util.Set;
 
 @TestMethodOrder(MethodName.class)
 public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase {
@@ -597,6 +605,55 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
             mockListTableDeltaTraits();
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
             Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVPCTBasedRefreshProcessor);
+        }
+    }
+
+    /**
+     * Test that IVM refresh records complete PCT metadata without batch truncation.
+     *
+     * Before the fix, updatePCTToRefreshMetas in IVM path went through filterPartitionByRefreshNumber,
+     * which truncated the partition list based on partition_refresh_number (default 1).
+     * This caused incomplete visibleVersionMap updates — partitions that were actually refreshed by IVM
+     * (via TVR delta) would still appear stale in PCT metadata, breaking MV query rewrite.
+     *
+     * The fix passes skipBatchFilter=true so that detectMVPartitionsToRefresh is used instead of
+     * getMVToRefreshedPartitions, skipping all batch filtering.
+     */
+    @Test
+    public void testIVMPCTMetadataNotTruncatedByPartitionRefreshNumber() throws Exception {
+        // Create a PARTITIONED MV on partitioned Iceberg table t1 (4 partitions: date=2020-01-01..04).
+        // partition_refresh_number=1 would truncate to 1 partition in the old code path.
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        // Initial refresh: all 4 partitions detected as new
+        {
+            advanceTableVersionTo(2);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+            TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+            MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+
+            // Verify IVM path was used (auto mode -> hybrid -> IVM)
+            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+            MVHybridBasedRefreshProcessor hybridProcessor =
+                    (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+            Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+
+            // Verify PCT metadata records ALL partitions, not truncated to 1.
+            // Before the fix, partition_refresh_number=1 would truncate mvPartitionsToRefresh to 1 partition.
+            // After the fix (skipBatchFilter=true), all detected partitions should be recorded.
+            MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
+            MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
+            Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
+            Assertions.assertNotNull(mvPartitionsToRefresh,
+                    "mvPartitionsToRefresh should not be null");
+            // t1 has 4 partitions -> MV should have 4 corresponding partitions, all recorded
+            Assertions.assertTrue(mvPartitionsToRefresh.size() > 1,
+                    "IVM should record all detected partitions in PCT metadata, " +
+                            "not truncated by partition_refresh_number. " +
+                            "Expected >1 but got: " + mvPartitionsToRefresh);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -868,13 +868,38 @@ public abstract class MVTestBase extends StarRocksTestBase {
 
     protected MaterializedView createMaterializedViewWithRefreshMode(String query,
                                                                      String refreshMode) throws Exception {
-        String ddl = String.format("CREATE MATERIALIZED VIEW `test_mv1` " +
-                "REFRESH DEFERRED MANUAL\n" +
-                "PROPERTIES (\n" +
-                "\"refresh_mode\" = \"%s\"" +
-                ")\n" +
-                "AS %s;", refreshMode, query);
-        starRocksAssert.withMaterializedView(ddl);
+        return createMaterializedViewWithRefreshMode(query, refreshMode, null, null);
+    }
+
+    /**
+     * Create a materialized view with the given refresh mode, optional partition clause, and extra properties.
+     *
+     * @param query          the AS query for the MV
+     * @param refreshMode    refresh mode: "incremental", "auto", "pct", etc.
+     * @param partitionBy    partition clause content, e.g. "`date`". null for non-partitioned MV.
+     * @param extraProperties extra properties map, e.g. {"partition_refresh_number": "1"}. null if none.
+     */
+    protected MaterializedView createMaterializedViewWithRefreshMode(
+            String query,
+            String refreshMode,
+            String partitionBy,
+            Map<String, String> extraProperties) throws Exception {
+        StringBuilder ddl = new StringBuilder();
+        ddl.append("CREATE MATERIALIZED VIEW `test_mv1` ");
+        if (partitionBy != null) {
+            ddl.append("PARTITION BY (").append(partitionBy).append(") ");
+        }
+        ddl.append("REFRESH DEFERRED MANUAL\n");
+        ddl.append("PROPERTIES (\n");
+        ddl.append("\"refresh_mode\" = \"").append(refreshMode).append("\"");
+        if (extraProperties != null) {
+            for (Map.Entry<String, String> entry : extraProperties.entrySet()) {
+                ddl.append(",\n\"").append(entry.getKey()).append("\" = \"").append(entry.getValue()).append("\"");
+            }
+        }
+        ddl.append("\n)\n");
+        ddl.append("AS ").append(query).append(";");
+        starRocksAssert.withMaterializedView(ddl.toString());
         return getMv("test_mv1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                           
                                                                                                                                                                                           
IVM (Incremental View Maintenance) refreshes all changed partitions via TVR delta, but the PCT metadata recording path (updatePCTToRefreshMetas) reuses the full PCT partition selection pipeline which includes filterPartitionByRefreshNumber. 

This truncates the partition list based on partition_refresh_number (default 1), causing visibleVersionMap to only record a subset of actually refreshed partitions.

As a result, MV query rewrite incorrectly treats some partitions as stale and refuses to rewrite queries involving those partitions. The truncated partition also persists across subsequent IVM refreshes — the missed partition can never catch up in PCT metadata.
                                                                                           
##What I'm doing:
                                         
  Separate partition detection from batch filtering in the PCT partition computation pipeline:                                                                                             
   
  1. Extract detectMVPartitionsToRefresh from getMVToRefreshedPartitions in MVPCTRefreshPartitioner — performs partition change detection and potential partition calculation without any  
  batch filtering (no partition_refresh_number, no adaptive truncation, no refreshPartitionLimit).
  2. Add skipBatchFilter parameter to getPCTMVToRefreshedPartitions and updatePCTToRefreshMetas in BaseMVRefreshProcessor — when true, calls detectMVPartitionsToRefresh instead of        
  getMVToRefreshedPartitions, so all detected partitions are recorded.                                                                                                                     
  3. IVM processor passes skipBatchFilter=true when calling updatePCTToRefreshMetas, ensuring PCT metadata reflects all partitions actually refreshed by IVM.
  4. Add testIVMPCTMetadataNotTruncatedByPartitionRefreshNumber test to verify that a partitioned IVM MV with partition_refresh_number=1 records all detected partitions in                
  mvPartitionsToRefresh, not just 1.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
