### PR TITLE
[Enhancement] Enabling dictification for physical filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -639,12 +639,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalFilter(OptExpression optExpression, DecodeInfo context) {
-        if (optExpression.getInputs().get(0).getOp() instanceof PhysicalOlapScanOperator) {
-            // PhysicalFilter->PhysicalOlapScan is a special pattern, the Filter's predicate is extracted from OlapScan,
-            // we should keep the DecodeInfo from it's input.
-            return context.createOutputInfo();
-        }
-        return context.createDecodeInfo();
+        return context.createOutputInfo();
     }
 
     private boolean tryHandleJoinEqPredicate(DecodeInfo decodeInfo,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1184,18 +1184,22 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "        union select 1,2\n" +
                 "    ) sys";
         plan = getFragmentPlan(sql);
-        assertContains(plan, plan, "  20:AGGREGATE (update serialize)\n"
-                + "  |  STREAMING\n"
-                + "  |  group by: 32: cast, 33: cast\n"
-                + "  |  \n"
-                + "  0:UNION\n"
-                + "  |  \n"
-                + "  |----19:EXCHANGE\n"
-                + "  |    \n"
-                + "  16:EXCHANGE");
+        assertContains(plan, plan, "  20:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 32: cast, 33: cast\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "  |  \n" +
+                "  |----19:EXCHANGE\n" +
+                "  |    \n" +
+                "  16:Decode\n" +
+                "  |  <dict id 38> : <string id 25>\n" +
+                "  |  <dict id 39> : <string id 26>\n" +
+                "  |  \n" +
+                "  15:EXCHANGE");
         assertContains(plan, plan, "Decode");
         plan = getThriftPlan(sql);
-        assertNotContains(plan.split("\n")[1], "query_global_dicts");
+        assertContains(plan.split("\n")[1], "query_global_dicts");
     }
 
     @Test
@@ -1296,9 +1300,6 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "select row_number() over( partition by L_COMMENT order by L_PARTKEY) as rm from lineitem" +
                 ") t where rm < 10";
         plan = getCostExplain(sql);
-        assertContains(plan, "  4:Decode\n" +
-                "  |  <dict id 20> : <string id 16>");
-
         assertContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, row_number[(); args: ; result: BIGINT; " +
                 "args nullable: false; result nullable: true], ]\n" +
@@ -1310,7 +1311,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select * from (select L_COMMENT,l_quantity, row_number() over " +
                 "(partition by L_COMMENT order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
-        assertContains(plan, "  4:Decode\n" +
+        assertContains(plan, "  5:Decode\n" +
                 "  |  <dict id 19> : <string id 16>");
         assertContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, row_number[(); args: ; result: BIGINT; " +
@@ -1323,7 +1324,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select * from (select L_COMMENT,l_quantity, rank() over " +
                 "(partition by L_COMMENT order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
-        assertContains(plan, "  4:Decode\n" +
+        assertContains(plan, "  5:Decode\n" +
                 "  |  <dict id 19> : <string id 16>");
         assertContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, rank[(); args: ; result: BIGINT; " +
@@ -1336,7 +1337,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select * from (select L_COMMENT,l_quantity, rank() over " +
                 "(partition by L_COMMENT, l_shipmode order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
-        assertContains(plan, "  4:Decode\n" +
+        assertContains(plan, "  6:Decode\n" +
                 "  |  <dict id 19> : <string id 16>");
         assertContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, rank[(); args: ; result: BIGINT; " +
@@ -1524,7 +1525,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String sql = "select t0.S_ADDRESS from (select S_ADDRESS, S_NATIONKEY from supplier_nullable limit 10) t0" +
                 " inner join supplier on t0.S_NATIONKEY = supplier.S_NATIONKEY;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  2:Decode\n" +
+        assertContains(plan, "  7:Decode\n" +
                 "  |  <dict id 17> : <string id 3>\n");
     }
 
@@ -1560,16 +1561,17 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select S_ADDRESS, S_COMMENT from (select S_ADDRESS, " +
                 "S_COMMENT from supplier_nullable order by S_COMMENT limit 10) tb where S_ADDRESS = 'SS' order by S_ADDRESS ";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  5:SORT\n" +
-                "  |  order by: <slot 3> 3: S_ADDRESS ASC\n" +
+        assertContains(plan, "  4:SORT\n" +
+                "  |  order by: <slot 9> 9: S_ADDRESS ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  4:SELECT\n" +
-                "  |  predicates: 3: S_ADDRESS = 'SS'\n" +
-                "  |  \n" +
-                "  3:Decode\n" +
+                "  3:SELECT\n" +
+                "  |  predicates: DictDecode(9: S_ADDRESS, [<place-holder> = 'SS'])");
+        assertContains(plan, "  6:Decode\n" +
                 "  |  <dict id 9> : <string id 3>\n" +
-                "  |  <dict id 10> : <string id 7>");
+                "  |  <dict id 10> : <string id 7>\n" +
+                "  |  \n" +
+                "  5:MERGING-EXCHANGE");
     }
 
     @Test
@@ -2167,7 +2169,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "where l1 = 'BJ'";
         String plan = getFragmentPlan(sql);
         // TODO: rewrite physical operator
-        assertContains(plan, "  9:Decode\n" +
+        assertContains(plan, "  10:Decode\n" +
                 "  |  <dict id 22> : <string id 12>");
     }
 
@@ -2351,19 +2353,19 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "WHERE\n" +
                 "    t.row_num = 1;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  7:Decode\n" +
-                "  |  <dict id 12> : <string id 3>\n" +
-                "  |  <dict id 13> : <string id 9>\n" +
-                "  |  <dict id 14> : <string id 11>\n" +
+        assertContains(plan, "  7:SELECT\n" +
+                "  |  predicates: 10: row_number() = 1\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  6:ANALYTIC\n" +
-                "  |  functions: [, row_number[(); args: ; result: BIGINT; " +
-                "args nullable: false; result nullable: true], ]\n" +
+                "  |  functions: [, row_number[(); args: ; result: BIGINT; args nullable: false; result nullable: true], ]\n" +
                 "  |  partition by: [12: S_ADDRESS, INT, false]\n" +
                 "  |  order by: [12: S_ADDRESS, INT, false] ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                 "  |  cardinality: 1");
+        assertContains(plan, "  9:Decode\n" +
+                "  |  <dict id 12> : <string id 3>\n" +
+                "  |  <dict id 13> : <string id 9>");
     }
 
     @Test
@@ -2848,5 +2850,23 @@ public class LowCardinalityTest2 extends PlanTestBase {
         Assertions.assertTrue(d2.getOutputStringColumns().isEmpty());
         Assertions.assertTrue(d2.getInputStringColumns().isEmpty());
         Assertions.assertTrue(d2.getDecodeStringColumns().isEmpty());
+    }
+
+    @Test
+    public void testPhysicalFilter() throws Exception {
+        String sql = """
+                  SELECT *
+                  FROM (
+                    SELECT
+                      MAX(C_USER) OVER (PARTITION BY C_DEPT) max_user
+                    FROM
+                      low_card_t1
+                  ) cte
+                  WHERE max_user != 'abc'
+                  """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  3:SELECT\n" +
+                "  |  predicates: DictDecode(15: max(2: c_user), [<place-holder> != 'abc'])\n" +
+                "  |  cardinality: 1", plan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -109,17 +109,22 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testSSB10() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/ssb10"), SV);
-        Assertions.assertTrue(replayPair.second.contains("  14:Project\n" +
-                "  |  output columns:\n" +
-                "  |  13 <-> [13: lo_revenue, INT, false]\n" +
-                "  |  22 <-> [22: d_year, INT, false]\n" +
-                "  |  38 <-> [38: c_city, VARCHAR, false]\n" +
-                "  |  46 <-> [46: s_city, VARCHAR, false]\n" +
-                "  |  cardinality: 28532"), replayPair.second);
-        Assertions.assertTrue(replayPair.second.contains("  |----7:EXCHANGE\n" +
-                "  |       distribution type: BROADCAST\n" +
-                "  |       cardinality: 30"), replayPair.second);
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/ssb10"), SV);
+            Assertions.assertTrue(replayPair.second.contains("  14:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  13 <-> [13: lo_revenue, INT, false]\n" +
+                    "  |  22 <-> [22: d_year, INT, false]\n" +
+                    "  |  51 <-> [51: s_city, INT, false]\n" +
+                    "  |  53 <-> [53: c_city, INT, false]\n" +
+                    "  |  cardinality: 28532"), replayPair.second);
+            Assertions.assertTrue(replayPair.second.contains("  |----7:EXCHANGE\n" +
+                    "  |       distribution type: BROADCAST\n" +
+                    "  |       cardinality: 30"), replayPair.second);
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = false;
+        }
     }
 
     @Test
@@ -291,15 +296,20 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testMultiCountDistinct() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/multi_count_distinct"), SV, TExplainLevel.NORMAL);
-        String plan = replayPair.second;
-        Assertions.assertTrue(plan.contains("AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: multi_distinct_count(6: order_id), multi_distinct_count(11: delivery_phone)," +
-                " multi_distinct_count(128: case), max(103: count)\n" +
-                "  |  group by: 40: city, 116: division_en, 104: department, 106: category, 126: concat, " +
-                "127: concat, 9: upc, 108: upc_desc"), plan);
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            Pair<QueryDumpInfo, String> replayPair =
+                    getPlanFragment(getDumpInfoFromFile("query_dump/multi_count_distinct"), SV, TExplainLevel.NORMAL);
+            String plan = replayPair.second;
+            Assertions.assertTrue(plan.contains("AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: multi_distinct_count(141: order_id), multi_distinct_count(143: delivery_phone)," +
+                    " multi_distinct_count(128: case), max(103: count)\n" +
+                    "  |  group by: 145: city, 150: division_en, 104: department, 106: category, 126: concat, " +
+                    "127: concat, 142: upc, 158: upc_desc"), plan);
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = false;
+        }
     }
 
     @Test
@@ -309,7 +319,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 getPlanFragment(getDumpInfoFromFile("query_dump/decode_limit_with_project"), SV,
                         TExplainLevel.NORMAL);
         String plan = replayPair.second;
-        Assertions.assertTrue(plan.contains(" 11:Decode\n" +
+        Assertions.assertTrue(plan.contains(" 10:Decode\n" +
                 "  |  <dict id 41> : <string id 18>\n" +
                 "  |  <dict id 42> : <string id 23>"), plan);
         FeConstants.USE_MOCK_DICT_MANAGER = false;
@@ -349,11 +359,16 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testLogicalAggWithOneTablet() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/local_agg_with_one_tablet"), SV,
-                        TExplainLevel.NORMAL);
-        Assertions.assertTrue(replayPair.second.contains("1:AGGREGATE (update finalize)\n" +
-                "  |  output: multi_distinct_count(4: t0d)"), replayPair.second);
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            Pair<QueryDumpInfo, String> replayPair =
+                    getPlanFragment(getDumpInfoFromFile("query_dump/local_agg_with_one_tablet"), SV,
+                            TExplainLevel.NORMAL);
+            Assertions.assertTrue(replayPair.second.contains("1:AGGREGATE (update finalize)\n" +
+                    "  |  output: multi_distinct_count(9: t0d)"), replayPair.second);
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = false;
+        }
     }
 
     @Test
@@ -798,16 +813,22 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testListPartitionPrunerWithNEExpr() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getCostPlanFragment(getDumpInfoFromFile("query_dump/list_partition_prune_dump"), SV);
-        // partitions should not be pruned
-        Assertions.assertTrue(!replayPair.second.contains("partitionsRatio=2/3, tabletsRatio=20/20"),
-                replayPair.second);
-        Assertions.assertTrue(replayPair.second.contains("0:OlapScanNode\n" +
-                "     table: partitions2_keys311, rollup: partitions2_keys311\n" +
-                "     preAggregation: on\n" +
-                "     Predicates: [7: undef_signed_not_null, VARCHAR, false] != 'j'\n" +
-                "     partitionsRatio=3/3, tabletsRatio=30/30"), replayPair.second);
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            Pair<QueryDumpInfo, String> replayPair =
+                    getCostPlanFragment(getDumpInfoFromFile("query_dump/list_partition_prune_dump"), SV);
+            // partitions should not be pruned
+            Assertions.assertTrue(!replayPair.second.contains("partitionsRatio=2/3, tabletsRatio=20/20"),
+                    replayPair.second);
+            Assertions.assertTrue(replayPair.second.contains("0:OlapScanNode\n" +
+                    "     table: partitions2_keys311, rollup: partitions2_keys311\n" +
+                    "     preAggregation: on\n" +
+                    "     Predicates: DictDecode([13: undef_signed_not_null, INT, false], [<place-holder> != 'j'])\n" +
+                    "     dict_col=undef_signed_not_null\n" +
+                    "     partitionsRatio=3/3, tabletsRatio=30/30"), replayPair.second);
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = false;
+        }
     }
 
     @Test
@@ -965,44 +986,49 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testEliminateConstantCTEAndNestLoopJoin() throws Exception {
-        String dumpString = getDumpInfoFromFile("query_dump/eliminate_nestloop_join");
-        QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpString);
-        Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
-                TExplainLevel.NORMAL);
-        Assertions.assertTrue(replayPair.second.contains("  29:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  \n" +
-                "  |----28:EXCHANGE\n" +
-                "  |    \n" +
-                "  18:Project\n" +
-                "  |  <slot 119> : 119: mock_189\n" +
-                "  |  \n" +
-                "  17:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 286: mock_278 = 67: mock_216\n" +
-                "  |  \n" +
-                "  |----16:EXCHANGE\n" +
-                "  |    \n" +
-                "  3:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 6\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: UNPARTITIONED\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 28\n" +
-                "    UNPARTITIONED\n" +
-                "\n" +
-                "  27:Project\n" +
-                "  |  <slot 603> : array_contains(601: array_agg, 'asdfasdfasdf')\n" +
-                "  |  \n" +
-                "  26:AGGREGATE (merge finalize)\n" +
-                "  |  output: array_agg(601: array_agg)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  25:EXCHANGE"), replayPair.second);
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            String dumpString = getDumpInfoFromFile("query_dump/eliminate_nestloop_join");
+            QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpString);
+            Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
+                    TExplainLevel.NORMAL);
+            Assertions.assertTrue(replayPair.second.contains("  29:NESTLOOP JOIN\n" +
+                    "  |  join op: CROSS JOIN\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  \n" +
+                    "  |----28:EXCHANGE\n" +
+                    "  |    \n" +
+                    "  18:Project\n" +
+                    "  |  <slot 621> : 621: mock_189\n" +
+                    "  |  \n" +
+                    "  17:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                    "  |  colocate: false, reason: \n" +
+                    "  |  equal join conjunct: 286: mock_278 = 67: mock_216\n" +
+                    "  |  \n" +
+                    "  |----16:EXCHANGE\n" +
+                    "  |    \n" +
+                    "  3:EXCHANGE\n" +
+                    "\n" +
+                    "PLAN FRAGMENT 6\n" +
+                    " OUTPUT EXPRS:\n" +
+                    "  PARTITION: UNPARTITIONED\n" +
+                    "\n" +
+                    "  STREAM DATA SINK\n" +
+                    "    EXCHANGE ID: 28\n" +
+                    "    UNPARTITIONED\n" +
+                    "\n" +
+                    "  27:Project\n" +
+                    "  |  <slot 603> : array_contains(DictDecode(625: array_agg, [<place-holder>]), 'asdfasdfasdf')\n" +
+                    "  |  \n" +
+                    "  26:AGGREGATE (merge finalize)\n" +
+                    "  |  output: array_agg(625: array_agg)\n" +
+                    "  |  group by: \n" +
+                    "  |  \n" +
+                    "  25:EXCHANGE"), replayPair.second);
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = false;
+        }
     }
 
     @Test
@@ -1115,11 +1141,11 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
             Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
                     TExplainLevel.NORMAL);
             String plan = replayPair.second;
-            Assertions.assertTrue(plan.contains("  30:Project\n"
+            Assertions.assertTrue(plan.contains("  28:Project\n"
                     + "  |  <slot 113> : 113: mock_field_111\n"
                     + "  |  <slot 268> : lower(142: jl_str)\n"
                     + "  |  \n"
-                    + "  29:TableValueFunction\n"
+                    + "  27:TableValueFunction\n"
                     + "  |  tableFunctionName: unnest\n"
                     + "  |  columns: [unnest]\n"
                     + "  |  returnTypes: [VARCHAR(65533)]"), plan);

--- a/test/sql/test_global_dict/R/dict_basic_query
+++ b/test/sql/test_global_dict/R/dict_basic_query
@@ -138,3 +138,7 @@ select v1, if(v1='a', null, 'b') from t4 order by 1;
 None	b
 a	None
 -- !result
+select * from (select max(v1) over (partition by v2) mv1 from t1) t where mv1 != '99' order by mv1 desc limit 1;
+-- result:
+98
+-- !result

--- a/test/sql/test_global_dict/T/dict_basic_query
+++ b/test/sql/test_global_dict/T/dict_basic_query
@@ -64,3 +64,5 @@ select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 fro
 select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
 
 select v1, if(v1='a', null, 'b') from t4 order by 1;
+
+select * from (select max(v1) over (partition by v2) mv1 from t1) t where mv1 != '99' order by mv1 desc limit 1;


### PR DESCRIPTION
## Why I'm doing:
Currently the check for dictification of physical filter is overly conservative. We can always dictify it. 

## What I'm doing:
Dictifying physical filter when there are dictified inputs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4