### PR TITLE
[BugFix][Iceberg] Use manifest metadata to answer COUNT(*)/COUNT(1) queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -176,11 +176,14 @@ public class IcebergTable extends Table {
     }
 
     public boolean isAllPartitionColumnsAlwaysIdentity() {
-        // now we are sure we have never applied transformation,
-        // we check if all partition columns are identity.
-        for (PartitionField field : getNativeTable().spec().fields()) {
-            if (!field.transform().isIdentity()) {
-                return false;
+        // Check all historical specs — a table that evolved from e.g. day(ts) to identity(ts)
+        // still has old files under the non-identity spec, so we cannot guarantee that every
+        // partition value maps 1:1 to the source column value across the full table history.
+        for (PartitionSpec spec : getNativeTable().specs().values()) {
+            for (PartitionField field : spec.fields()) {
+                if (!field.transform().isVoid() && !field.transform().isIdentity()) {
+                    return false;
+                }
             }
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -31,6 +31,7 @@ public class GetRemoteFilesParams {
     private boolean useCache = true;
     private boolean checkPartitionExistence = true;
     private boolean enableColumnStats = false;
+    private boolean useManifestCountOpt = false;
 
     protected GetRemoteFilesParams(Builder builder) {
         this.partitionKeys = builder.partitionKeys;
@@ -43,6 +44,7 @@ public class GetRemoteFilesParams {
         this.useCache = builder.useCache;
         this.checkPartitionExistence = builder.checkPartitionExistence;
         this.enableColumnStats = builder.enableColumnStats;
+        this.useManifestCountOpt = builder.useManifestCountOpt;
     }
 
     public int getPartitionSize() {
@@ -67,6 +69,7 @@ public class GetRemoteFilesParams {
                 .setUseCache(useCache)
                 .setCheckPartitionExistence(checkPartitionExistence)
                 .setEnableColumnStats(enableColumnStats)
+                .setUseManifestCountOpt(useManifestCountOpt)
                 .build();
     }
 
@@ -134,6 +137,10 @@ public class GetRemoteFilesParams {
         return enableColumnStats;
     }
 
+    public boolean isUseManifestCountOpt() {
+        return useManifestCountOpt;
+    }
+
     public static class Builder {
         private List<PartitionKey> partitionKeys;
         private List<String> partitionNames;
@@ -145,6 +152,7 @@ public class GetRemoteFilesParams {
         private boolean useCache = true;
         private boolean checkPartitionExistence = true;
         private boolean enableColumnStats = false;
+        private boolean useManifestCountOpt = false;
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
             this.partitionKeys = partitionKeys;
@@ -193,6 +201,11 @@ public class GetRemoteFilesParams {
 
         public Builder setEnableColumnStats(boolean enableColumnStats) {
             this.enableColumnStats = enableColumnStats;
+            return this;
+        }
+
+        public Builder setUseManifestCountOpt(boolean useManifestCountOpt) {
+            this.useManifestCountOpt = useManifestCountOpt;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -90,6 +90,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ManifestFile;
@@ -141,10 +142,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -187,8 +190,15 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final Map<TableIdentifier, org.apache.iceberg.Table> tables = new ConcurrentHashMap<>();
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<PredicateSearchKey, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
-    private final Set<PredicateSearchKey> scannedTables = new HashSet<>();
+    private final Set<PredicateSearchKey> scannedTables = ConcurrentHashMap.newKeySet();
     private final Set<PredicateSearchKey> preparedTables = ConcurrentHashMap.newKeySet();
+    // Cache for manifest-level count optimization results (O(partitions) synthetic tasks).
+    // Kept separate from splitTasks so the full file list remains available for non-count queries.
+    private final Map<PredicateSearchKey, List<FileScanTask>> manifestCountCache = new ConcurrentHashMap<>();
+    // Keys for which aggregateTasksByPartition() previously returned null (e.g. mixed
+    // partitioned/unpartitioned files).  Avoids re-running the expensive planFiles() scan on
+    // every query when the optimization is known to be inapplicable for a given snapshot key.
+    private final Set<PredicateSearchKey> manifestCountOptFailedKeys = ConcurrentHashMap.newKeySet();
 
     private final Map<IcebergRemoteFileInfoSourceKey, RemoteFileInfoSource> remoteFileInfoSources = new ConcurrentHashMap<>();
 
@@ -546,7 +556,22 @@ public class IcebergMetadata implements ConnectorMetadata {
     public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
         TableVersionRange version = params.getTableVersionRange();
         long snapshotId = version.end().isPresent() ? version.end().get() : -1;
-        return getRemoteFiles((IcebergTable) table, snapshotId, params.getPredicate(), params.getLimit());
+        IcebergTable icebergTable = (IcebergTable) table;
+        String dbName = icebergTable.getCatalogDBName();
+        String tableName = icebergTable.getCatalogTableName();
+        if (params.isUseManifestCountOpt() && snapshotId != -1) {
+            List<RemoteFileInfo> result = tryGetRemoteFilesViaManifestCount(
+                    icebergTable, snapshotId, params.getPredicate());
+            if (result != null) {
+                LOG.info("getRemoteFiles [manifestCountOpt]: returning {} tasks for {}.{} snapshotId={}",
+                        result.size(), dbName, tableName, snapshotId);
+                return result;
+            }
+        }
+        List<RemoteFileInfo> result = getRemoteFiles(icebergTable, snapshotId, params.getPredicate(), params.getLimit());
+        LOG.info("getRemoteFiles [regular]: returning {} tasks for {}.{} snapshotId={} useManifestOpt={} limit={}",
+                result.size(), dbName, tableName, snapshotId, params.isUseManifestCountOpt(), params.getLimit());
+        return result;
     }
 
     private List<RemoteFileInfo> getRemoteFiles(IcebergTable table, long snapshotId,
@@ -564,6 +589,464 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         return icebergScanTasks.stream().map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Attempt to serve a getRemoteFiles request using manifest-level partition count aggregation.
+     * Instead of returning O(files) scan tasks, returns one synthetic task per distinct partition
+     * with a pre-aggregated record count. The BE honours the record_count in each scan range and
+     * skips all Parquet I/O when canUseCountOpt is set (see HdfsScanner::can_use_count_optimization).
+     *
+     * Returns null if the optimization cannot be applied (e.g. table has delete files), in which
+     * case the caller should fall back to the regular path.
+     */
+    private List<RemoteFileInfo> tryGetRemoteFilesViaManifestCount(IcebergTable table,
+            long snapshotId, ScalarOperator predicate) {
+        String dbName = table.getCatalogDBName();
+        String tableName = table.getCatalogTableName();
+        PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, snapshotId, predicate);
+
+        // Return already-computed manifest-count result
+        if (manifestCountCache.containsKey(key)) {
+            List<FileScanTask> cached = manifestCountCache.get(key);
+            LOG.info("tryGetRemoteFilesViaManifestCount: CACHE HIT for {}.{} snapshotId={} cachedSize={}",
+                    dbName, tableName, snapshotId, cached.size());
+            return cached.stream()
+                    .map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
+        }
+
+        // Short-circuit: a previous attempt for this snapshot key determined the optimization
+        // is inapplicable (e.g. files with unpartitioned specs mixed with partitioned ones).
+        // Skip the expensive planFiles() and return null immediately.
+        if (manifestCountOptFailedKeys.contains(key)) {
+            return null;
+        }
+
+        org.apache.iceberg.Table nativeTbl = table.getNativeTable();
+        Snapshot snapshot = nativeTbl.snapshot(snapshotId);
+        if (snapshot == null) {
+            return null;
+        }
+
+        // If the snapshot has any delete files the manifest record_count may not reflect
+        // actual live row counts; skip the optimization
+        if (!snapshot.deleteManifests(nativeTbl.io()).isEmpty()) {
+            return null;
+        }
+
+        // Convert the scan predicate to an Iceberg expression up front so we can:
+        //   (a) bail out early if the predicate cannot be expressed as a partition filter, and
+        //   (b) reuse the result in the cold-path planFiles() call below.
+        //
+        // ScalarOperatorToIcebergExpr returns Expressions.alwaysTrue() for any sub-expression
+        // it cannot convert (e.g. function calls like date_trunc, upper, etc.).  If the whole
+        // predicate collapses to alwaysTrue() but there WAS a predicate, Iceberg cannot prune
+        // any files.  In that case record_count would cover rows that do not satisfy the
+        // original filter, so we must not use the count optimisation.
+        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+        ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct());
+        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+
+        if (predicate != null && icebergPredicate.op() == Expression.Operation.TRUE) {
+            LOG.info("tryGetRemoteFilesViaManifestCount: predicate={} could not be converted to an " +
+                    "Iceberg partition expression for {}.{}, skipping count optimisation",
+                    predicate, dbName, tableName);
+            return null;
+        }
+
+        // Read the manifest list — opens only the small manifest-list Avro file, not any
+        // individual manifest or data file.  Cost is O(num_manifests), essentially free.
+        List<ManifestFile> dataManifests = snapshot.dataManifests(nativeTbl.io());
+        int currentSpecId = nativeTbl.spec().specId();
+
+        // === Optimization A: pre-check manifest spec IDs ===
+        // ManifestFile.partitionSpecId() is available from the manifest list with no extra IO.
+        // If any manifest's spec is null or unpartitioned while the current spec is partitioned,
+        // aggregateTasksByPartition() would bail out anyway — detect this cheaply and avoid
+        // triggering the expensive planFiles() call.
+        if (!nativeTbl.spec().isUnpartitioned()) {
+            for (ManifestFile manifest : dataManifests) {
+                if (manifest.partitionSpecId() != currentSpecId) {
+                    PartitionSpec mSpec = nativeTbl.specs().get(manifest.partitionSpecId());
+                    if (mSpec == null || mSpec.isUnpartitioned()) {
+                        LOG.info("tryGetRemoteFilesViaManifestCount: manifest specId={} maps to a {} spec " +
+                                "while current specId={} is partitioned for {}.{}, skipping",
+                                manifest.partitionSpecId(),
+                                mSpec == null ? "unknown" : "unpartitioned",
+                                currentSpecId, dbName, tableName);
+                        manifestCountOptFailedKeys.add(key);
+                        return null;
+                    }
+                }
+            }
+        }
+
+        // === Optimization B: aggregate from manifest row counts ===
+        // When every manifest covers exactly one distinct partition value (lowerBound == upperBound
+        // for all partition fields, no nulls), addedRowsCount + existingRowsCount in the manifest
+        // is the exact live row count for that partition.  No planFiles() needed at all.
+        // This is the common case for append-only daily-partitioned tables where each day's data
+        // is written in a separate transaction (one manifest per partition).
+        List<FileScanTask> manifestDerivedTasks =
+                tryAggregateFromManifestRowCounts(nativeTbl, dataManifests, icebergPredicate);
+        LOG.info("tryGetRemoteFilesViaManifestCount: pathB result={} numDataManifests={} for {}.{}",
+                manifestDerivedTasks == null ? "null" : manifestDerivedTasks.size(),
+                dataManifests.size(), dbName, tableName);
+        if (manifestDerivedTasks != null && (!manifestDerivedTasks.isEmpty() || dataManifests.isEmpty())) {
+            manifestCountCache.put(key, manifestDerivedTasks);
+            return manifestDerivedTasks.stream()
+                    .map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
+        }
+
+        // Build or reuse the file-level task list.
+        // When splitTasks already has the key we reuse those (possibly row-group-split) tasks for
+        // the aggregation attempt.  When we plan from scratch we materialise planFiles() into a
+        // list so the tasks remain available even after aggregateTasksByPartition consumes them.
+        List<FileScanTask> fileScanTaskList;
+        boolean fromFreshPlan;
+        if (splitTasks.containsKey(key)) {
+            // prepareMetadata already ran; reuse the in-memory list (avoid a second planFiles() call)
+            fileScanTaskList = splitTasks.get(key);
+            fromFreshPlan = false;
+            LOG.info("tryGetRemoteFilesViaManifestCount: warm path for {}.{} snapshotId={} splitTasksSize={}",
+                    dbName, tableName, snapshotId, fileScanTaskList.size());
+        } else {
+            // Cold path: plan files now without TableScanUtil.splitFiles — one task per file.
+            // Materialise into a List so the tasks survive a failed aggregateTasksByPartition call.
+            StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(
+                    catalogName, dbName, tableName, planMode(ConnectContext.get()), ConnectContext.get());
+            scanContext.setLocalParallelism(catalogProperties.getIcebergJobPlanningThreadNum());
+            scanContext.setLocalPlanningMaxSlotSize(catalogProperties.getLocalPlanningMaxSlotBytes());
+
+            TableScan scan = icebergCatalog.getTableScan(nativeTbl, scanContext)
+                    .useSnapshot(snapshotId)
+                    .metricsReporter(metricsReporter)
+                    .planWith(jobPlanningExecutor);
+            if (icebergPredicate.op() != Expression.Operation.TRUE) {
+                scan = scan.filter(icebergPredicate);
+            }
+            try (CloseableIterable<FileScanTask> ownedIterable = scan.planFiles()) {
+                fileScanTaskList = Lists.newArrayList(ownedIterable);
+            } catch (Exception e) {
+                LOG.warn("tryGetRemoteFilesViaManifestCount: planFiles failed for {}.{}: {}",
+                        dbName, tableName, e.getMessage());
+                manifestCountOptFailedKeys.add(key);
+                return null;
+            }
+            fromFreshPlan = true;
+        }
+
+        List<FileScanTask> syntheticTasks = null;
+        try {
+            syntheticTasks = aggregateTasksByPartition(fileScanTaskList, nativeTbl);
+        } catch (Exception e) {
+            LOG.warn("Failed to aggregate tasks by partition for manifest count optimization on {}.{}: {}",
+                    dbName, tableName, e.getMessage());
+        }
+
+        LOG.info("tryGetRemoteFilesViaManifestCount: aggregateTasksByPartition result={} for {}.{} " +
+                "fromFreshPlan={} fileScanTaskListSize={}",
+                syntheticTasks == null ? "null" : syntheticTasks.size(),
+                dbName, tableName, fromFreshPlan, fileScanTaskList.size());
+
+        if (syntheticTasks != null) {
+            manifestCountCache.put(key, syntheticTasks);
+            return syntheticTasks.stream().map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
+        }
+
+        // Partition aggregation failed.  When we planned from scratch (no splitFiles), the
+        // file-level list is still a valid fallback: 1 scan range per file instead of 1 per
+        // row group (~8x cheaper).  The BE count optimisation reads record_count from scan-range
+        // metadata and issues 0 bytes of S3 IO, so file-level granularity is perfectly correct.
+        // Cache the list in manifestCountCache so subsequent count-opt queries skip re-planning.
+        if (fromFreshPlan) {
+            manifestCountCache.put(key, fileScanTaskList);
+            return fileScanTaskList.stream().map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
+        }
+
+        // We reused cached split tasks and aggregation still failed — mark the key as permanently
+        // failed so subsequent queries bypass the planFiles() attempt entirely.
+        manifestCountOptFailedKeys.add(key);
+        return null;
+    }
+
+    /**
+     * Attempts to build per-partition synthetic FileScanTasks directly from the manifest list,
+     * avoiding planFiles() entirely.
+     *
+     * <p>Each ManifestFile in the manifest list carries per-partition-field summary bounds
+     * (lowerBound / upperBound) and aggregate row counts (addedRowsCount + existingRowsCount).
+     * When every manifest covers exactly one distinct partition value — i.e. lowerBound equals
+     * upperBound for every partition field and neither is null — the manifest row count is the
+     * exact live count for that partition.  Multiple manifests for the same partition are summed.
+     *
+     * <p>This is the common case for append-only daily-partitioned tables where each day's data
+     * is written in a separate Iceberg transaction (one manifest per partition).  planFiles()
+     * opens every manifest Avro file to iterate individual FileScanTask entries; this method
+     * only needs the manifest list, which is already in memory.
+     *
+     * <p>Returns null if any manifest fails the single-partition or row-count-available check,
+     * signalling the caller to fall back to planFiles().
+     */
+    private List<FileScanTask> tryAggregateFromManifestRowCounts(
+            org.apache.iceberg.Table nativeTbl,
+            List<ManifestFile> dataManifests,
+            Expression icebergPredicate) {
+
+        // Apply partition-level predicate pruning using PartitionFieldSummary bounds.
+        // For alwaysTrue() (no predicate) this returns all manifests unchanged.
+        // For a partition equality / range filter this eliminates manifests whose
+        // partition bounds provably cannot contain matching rows.
+        List<ManifestFile> filtered = IcebergApiConverter.filterManifests(
+                dataManifests, nativeTbl, icebergPredicate);
+
+        // filterManifests removes manifests where hasAddedFiles() and hasExistingFiles() are
+        // both false.  This can happen when manifest-list statistics (added_files_count,
+        // existing_files_count) are null — e.g. manifests written by older Iceberg writers or
+        // third-party engines that omit these optional fields.  If filtering removed all
+        // manifests but the input was non-empty, the counts would be zero (incorrect).
+        // Fall back to planFiles() which reads the actual manifest entries.
+        if (filtered.isEmpty() && !dataManifests.isEmpty()) {
+            LOG.info("tryAggregateFromManifestRowCounts: filterManifests removed all {} manifests " +
+                    "for table {}, falling back to planFiles()",
+                    dataManifests.size(), nativeTbl.location());
+            return null;
+        }
+
+        Map<String, Long> countByKey = new LinkedHashMap<>();
+        Map<String, StructLike> partitionByKey = new LinkedHashMap<>();
+        Map<String, Integer> specIdByKey = new LinkedHashMap<>();
+
+        for (ManifestFile manifest : filtered) {
+            // Row counts must be present — older Iceberg writers may omit them.
+            Long addedRows = manifest.addedRowsCount();
+            Long existingRows = manifest.existingRowsCount();
+            Long deletedRows = manifest.deletedRowsCount();
+            if (addedRows == null && existingRows == null) {
+                return null;
+            }
+            // If any file entries in this manifest have been superseded (REPLACE/OVERWRITE
+            // operations produce DELETED-status entries), deletedRowsCount() reflects rows in
+            // those deleted files.  addedRows + existingRows would overcount.
+            // Fall back to planFiles() which returns only live files.
+            if (deletedRows != null && deletedRows > 0) {
+                return null;
+            }
+            long rowCount = (addedRows != null ? addedRows : 0L)
+                    + (existingRows != null ? existingRows : 0L);
+
+            // Fetch the partition spec before checking summaries so we can special-case
+            // unpartitioned tables (empty summaries list).
+            int mSpecId = manifest.partitionSpecId();
+            PartitionSpec mSpec = nativeTbl.specs().get(mSpecId);
+            if (mSpec == null) {
+                return null;
+            }
+
+            List<ManifestFile.PartitionFieldSummary> summaries = manifest.partitions();
+
+            if (!mSpec.isUnpartitioned()) {
+                // For partitioned manifests every field must cover exactly one distinct value
+                // so we can derive an exact per-partition count from the manifest row count.
+                if (summaries == null || summaries.isEmpty() || mSpec.fields().size() != summaries.size()) {
+                    return null;
+                }
+                for (ManifestFile.PartitionFieldSummary summary : summaries) {
+                    if (summary.containsNull()
+                            || summary.lowerBound() == null || summary.upperBound() == null
+                            || !summary.lowerBound().equals(summary.upperBound())) {
+                        return null;
+                    }
+                }
+            }
+
+            // Decode the single partition value for each field from lowerBound.
+            // For unpartitioned tables summaries is empty; we produce an empty-key partition.
+            int numFields = summaries == null ? 0 : summaries.size();
+            Types.StructType partitionType = mSpec.partitionType();
+            PartitionData partitionData = new PartitionData(numFields);
+            for (int i = 0; i < numFields; i++) {
+                Type nestedType = partitionType.fields().get(i).type();
+                Object value = Conversions.fromByteBuffer(nestedType, summaries.get(i).lowerBound());
+                partitionData.set(i, value);
+            }
+
+            String pKey = makePartitionKey(mSpecId, mSpec, partitionData);
+            countByKey.merge(pKey, rowCount, Long::sum);
+            partitionByKey.putIfAbsent(pKey, partitionData);
+            specIdByKey.putIfAbsent(pKey, mSpecId);
+        }
+
+        // Build one synthetic FileScanTask per distinct (specId, partition) with the
+        // aggregated row count.  Empty result is valid (predicate matched no partitions).
+        String tableLocation = nativeTbl.location();
+        List<FileScanTask> result = new ArrayList<>(countByKey.size());
+        for (Map.Entry<String, Long> entry : countByKey.entrySet()) {
+            String pKey = entry.getKey();
+            long count = entry.getValue();
+            StructLike partData = partitionByKey.get(pKey);
+            int specId = specIdByKey.get(pKey);
+            PartitionSpec spec = nativeTbl.specs().get(specId);
+
+            DataFile syntheticFile = DataFiles.builder(spec)
+                    .withPath(tableLocation + "/count-opt-" + pKey)
+                    .withFileSizeInBytes(0)
+                    .withFormat(FileFormat.PARQUET)
+                    .withPartition(partData)
+                    .withRecordCount(count)
+                    .build();
+
+            result.add(new SyntheticCountFileScanTask(syntheticFile, spec));
+        }
+        return result;
+    }
+
+    /**
+     * Aggregates an iterable of file-level scan tasks into one synthetic task per distinct partition.
+     * Each synthetic task carries a pre-summed record_count and an empty deletes list so the BE
+     * can short-circuit with canUseCountOpt without reading any data files.
+     */
+    private List<FileScanTask> aggregateTasksByPartition(Iterable<FileScanTask> tasks,
+            org.apache.iceberg.Table nativeTbl) {
+        // specId + "|" + per-field values → aggregated count / representative partition StructLike
+        Map<String, Long> countByKey = new LinkedHashMap<>();
+        Map<String, StructLike> partitionByKey = new LinkedHashMap<>();
+        Map<String, Integer> specIdByKey = new LinkedHashMap<>();
+
+        int currentSpecId = nativeTbl.spec().specId();
+        boolean currentSpecIsPartitioned = !nativeTbl.spec().isUnpartitioned();
+
+        for (FileScanTask task : tasks) {
+            int specId = task.file().specId();
+
+            // If the file was written under a different spec than the current table spec, only
+            // bail out when the file's *own* spec is absent from the specs map or is unpartitioned.
+            // In the unpartitioned case task.file().partition() returns an empty struct, so every
+            // such file would land in the null-partition bucket — incorrect for a partitioned table.
+            //
+            // When the file's spec IS partitioned (different spec ID but still has partition fields,
+            // e.g. Hudi tables synced via XTable where spec IDs may differ across file batches),
+            // task.file().partition() still carries valid partition data under that spec's layout.
+            // We aggregate those files using their own spec's partition key; the resulting synthetic
+            // tasks are merged correctly by the BE's GROUP BY aggregation.
+            if (currentSpecIsPartitioned && specId != currentSpecId) {
+                PartitionSpec fileSpec = nativeTbl.specs().get(specId);
+                if (fileSpec == null || fileSpec.isUnpartitioned()) {
+                    LOG.info("aggregateTasksByPartition: file specId={} maps to a {} spec " +
+                            "while current specId={} is partitioned for table {}, " +
+                            "skipping manifest count optimization",
+                            specId, fileSpec == null ? "unknown" : "unpartitioned",
+                            currentSpecId, nativeTbl.location());
+                    return null;
+                }
+                // File spec is partitioned — partition data is valid, continue with its own spec.
+            }
+
+            PartitionSpec spec = nativeTbl.specs().get(specId);
+            if (spec == null) {
+                // Unknown spec — cannot build a reliable partition key.
+                LOG.warn("aggregateTasksByPartition: unknown specId={} for table {}, skipping optimization",
+                        specId, nativeTbl.location());
+                return null;
+            }
+            StructLike partition = task.file().partition();
+            String key = makePartitionKey(specId, spec, partition);
+            countByKey.merge(key, task.file().recordCount(), Long::sum);
+            partitionByKey.putIfAbsent(key, partition);
+            specIdByKey.putIfAbsent(key, specId);
+        }
+
+        String tableLocation = nativeTbl.location();
+        List<FileScanTask> result = new ArrayList<>(countByKey.size());
+        for (Map.Entry<String, Long> entry : countByKey.entrySet()) {
+            String key = entry.getKey();
+            long count = entry.getValue();
+            StructLike partitionData = partitionByKey.get(key);
+            int specId = specIdByKey.get(key);
+            PartitionSpec spec = nativeTbl.specs().get(specId);
+
+            DataFile syntheticFile = DataFiles.builder(spec)
+                    .withPath(tableLocation + "/count-opt-" + Math.abs(key.hashCode()))
+                    .withFileSizeInBytes(0)
+                    .withFormat(FileFormat.PARQUET)
+                    .withPartition(partitionData)
+                    .withRecordCount(count)
+                    .build();
+
+            result.add(new SyntheticCountFileScanTask(syntheticFile, spec));
+        }
+        return result;
+    }
+
+    /** Builds a stable, collision-free string key for a (specId, partition) pair.
+     *
+     * Uses length-prefixed encoding for each field value so that string partition
+     * columns containing the separator characters cannot produce false collisions.
+     * Format: {@code specId|len:value len:value ...}  where null fields use {@code -1:}.
+     */
+    private static String makePartitionKey(int specId, PartitionSpec spec, StructLike partition) {
+        StringBuilder sb = new StringBuilder().append(specId).append('|');
+        for (int i = 0; i < spec.fields().size(); i++) {
+            Object value = partition.get(i, Object.class);
+            if (value == null) {
+                sb.append("-1:");
+            } else {
+                String s = value.toString();
+                sb.append(s.length()).append(':').append(s);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * A minimal FileScanTask implementation representing an entire partition's record count.
+     * Has no delete files so the BE's can_use_file_record_count check passes, enabling the
+     * count optimization short-circuit in HdfsScanner::get_next().
+     */
+    private static final class SyntheticCountFileScanTask implements FileScanTask {
+        private final DataFile file;
+        private final PartitionSpec spec;
+
+        private SyntheticCountFileScanTask(DataFile file, PartitionSpec spec) {
+            this.file = file;
+            this.spec = spec;
+        }
+
+        @Override
+        public DataFile file() {
+            return file;
+        }
+
+        @Override
+        public List<DeleteFile> deletes() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public PartitionSpec spec() {
+            return spec;
+        }
+
+        @Override
+        public long start() {
+            return 0;
+        }
+
+        @Override
+        public long length() {
+            return 0;
+        }
+
+        @Override
+        public Expression residual() {
+            return Expressions.alwaysTrue();
+        }
+
+        @Override
+        public Iterable<FileScanTask> split(long splitSize) {
+            return Lists.newArrayList(this);
+        }
     }
 
     @Override
@@ -829,6 +1312,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         splitTasks.put(key, icebergScanTasks);
+        LOG.info("collectTableStatisticsAndCacheIcebergSplit: stored {} tasks for {}.{} snapshotId={}",
+                icebergScanTasks.size(), dbName, tableName, snapshotId);
         scannedTables.add(key);
     }
 
@@ -846,7 +1331,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         String tableName = table.getCatalogTableName();
         PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, snapshotId.get(), param.getPredicate());
         RemoteFileInfoSource baseSource;
-        if (splitTasks.containsKey(predicateSearchKey)) {
+        // Only reuse a cached file list when scannedTables confirms it was produced by a full
+        // (unlimited) scan.  A limited-query result in splitTasks is a truncated subset and must
+        // not be served here.
+        if (splitTasks.containsKey(predicateSearchKey) && scannedTables.contains(predicateSearchKey)) {
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey));
         } else {
             List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
@@ -1413,6 +1901,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         return PlanMode.fromName(connectContext.getSessionVariable().getPlanMode());
     }
 
+
     private boolean enableCollectColumnStatistics(ConnectContext connectContext) {
         if (connectContext == null) {
             return false;
@@ -1428,9 +1917,11 @@ public class IcebergMetadata implements ConnectorMetadata {
     @Override
     public void clear() {
         splitTasks.clear();
+        manifestCountCache.clear();
         databases.clear();
         tables.clear();
         scannedTables.clear();
+        manifestCountOptFailedKeys.clear();
         metricsReporter.clear();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -413,6 +413,9 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     private SessionCatalog.SessionContext buildContext(ConnectContext context) {
+        if (context == null) {
+            return SessionCatalog.SessionContext.createEmpty();
+        }
         String sessionId = format("%s-%s", context.getQualifiedUser(), context.getSessionId());
 
         Map<String, String> credentials;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
@@ -75,6 +75,12 @@ public abstract class MetadataCollectJob {
         this.context = buildConnectContext(sessionVariable);
     }
 
+    public void init(ConnectContext originContext) {
+        this.sql = buildCollectMetadataSQL();
+        this.context = buildConnectContext(originContext.getSessionVariable());
+        this.context.setAuthToken(originContext.getAuthToken());
+    }
+
     protected String getCatalogName() {
         return catalogName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -159,6 +159,7 @@ public class IcebergScanNode extends ScanNode {
                         .setTableVersionRange(TableVersionRange.withEnd(snapshotId))
                         .setPredicate(icebergJobPlanningPredicate)
                         .setEnableColumnStats(scanOptimizeOption.getCanUseMinMaxOpt())
+                        .setUseManifestCountOpt(scanOptimizeOption.getCanUseCountOpt())
                         .build();
 
         RemoteFileInfoSource remoteFileInfoSource;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -103,6 +103,9 @@ public class ConnectScheduler {
                     ArrayList<Long> connectionIds = new ArrayList<>(connectionMap.keySet());
                     for (Long connectId : connectionIds) {
                         ConnectContext connectContext = connectionMap.get(connectId);
+                        if (connectContext == null) {
+                            continue;
+                        }
                         try (var guard = connectContext.bindScope()) {
                             connectContext.checkTimeout(now);
                         }
@@ -113,6 +116,9 @@ public class ConnectScheduler {
                             new ArrayList<>(arrowFlightSqlConnectContextMap.keySet());
                     for (String token : arrowFlightSqlConnections) {
                         ConnectContext connectContext = arrowFlightSqlConnectContextMap.get(token);
+                        if (connectContext == null) {
+                            continue;
+                        }
                         try (var guard = connectContext.bindScope()) {
                             connectContext.checkTimeout(now);
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -22,10 +22,14 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
+import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.ScanOptimizeOption;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -35,6 +39,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.pattern.MultiOpPattern;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -42,12 +47,17 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -81,6 +91,7 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
 
     private OptExpression buildAggScanOperator(LogicalAggregationOperator aggregationOperator,
                                                LogicalScanOperator scanOperator,
+                                               LogicalProjectOperator projectOperator,
                                                OptimizerContext context) {
         ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
 
@@ -117,13 +128,14 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
 
         ColumnRefOperator sumOutputColumnRef =
                 columnRefFactory.create("sum_" + aggCall.getFnName(), aggCall.getType(), aggCall.isNullable());
+        ColumnRefOperator placeholderColumn;
         {
             // generate a placeholder column for scan node.
             // ___count___ must be the column name for backend code.
             String metaColumnName = "___" + aggCall.getFnName() + "___";
             Column c = new Column(metaColumnName, Type.NULL);
             c.setIsAllowNull(true);
-            ColumnRefOperator placeholderColumn =
+            placeholderColumn =
                     columnRefFactory.create(metaColumnName, aggCall.getType(), aggCall.isNullable());
             columnRefFactory.updateColumnToRelationIds(placeholderColumn.getId(), tableRelationId);
             columnRefFactory.updateColumnRefToColumns(placeholderColumn, c, scanOperator.getTable());
@@ -156,8 +168,9 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             LOG.warn("Unexpected scan operator: " + scanOperator);
             return null;
         }
-        newMetaScan.setScanOptimizeOption(scanOperator.getScanOptimizeOption());
-        newMetaScan.getScanOptimizeOption().setCanUseCountOpt(true);
+        ScanOptimizeOption newOpt = scanOperator.getScanOptimizeOption().copy();
+        newOpt.setCanUseCountOpt(true);
+        newMetaScan.setScanOptimizeOption(newOpt);
         try {
             newMetaScan.setScanOperatorPredicates(scanOperator.getScanOperatorPredicates());
         } catch (AnalysisException e) {
@@ -180,7 +193,35 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
         newProjectMap.put(aggColumnRef, ifNullCall);
         LogicalProjectOperator newProjectOperator = new LogicalProjectOperator(newProjectMap);
 
-        // project(ifnull) -> agg(sum(__count__)) -> scan
+        // For SCAN_AND_PROJECT: the AGG's grouping keys reference the original PROJECT's output
+        // column refs (e.g. v1 = date_trunc('day', ds)).  The new SCAN only emits the underlying
+        // partition column refs, so we insert a thin inner PROJECT that reconstructs the grouping
+        // key expressions from the partition columns so that the AGG can still group by them.
+        //   outer-project(ifnull) -> agg(sum(__count__)) -> inner-project(gk exprs) -> new-scan
+        if (projectOperator != null) {
+            Map<ColumnRefOperator, ScalarOperator> innerProjMap = Maps.newHashMap();
+            // Carry over grouping-key mappings from the original PROJECT
+            for (ColumnRefOperator gk : aggregationOperator.getGroupingKeys()) {
+                ScalarOperator expr = projectOperator.getColumnRefMap().get(gk);
+                if (expr != null) {
+                    innerProjMap.put(gk, expr);
+                }
+            }
+            // Pass through the ___count___ placeholder so the AGG's SUM can consume it
+            innerProjMap.put(placeholderColumn, placeholderColumn);
+            LogicalProjectOperator innerProjectOperator = new LogicalProjectOperator(innerProjMap);
+
+            // outer-project -> agg -> inner-project -> scan
+            OptExpression optExpression = OptExpression.create(newProjectOperator);
+            OptExpression aggExpression = OptExpression.create(newAggOperator);
+            OptExpression innerProjExpression = OptExpression.create(innerProjectOperator);
+            optExpression.getInputs().add(aggExpression);
+            aggExpression.getInputs().add(innerProjExpression);
+            innerProjExpression.getInputs().add(OptExpression.create(newMetaScan));
+            return optExpression;
+        }
+
+        // project(ifnull) -> agg(sum(__count__)) -> scan  (SCAN_NO_PROJECT path)
         OptExpression optExpression = OptExpression.create(newProjectOperator);
         OptExpression aggExpression = OptExpression.create(newAggOperator);
         optExpression.getInputs().add(aggExpression);
@@ -198,38 +239,120 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
         return scanOperator;
     }
 
+    private LogicalProjectOperator getProjectOperator(final OptExpression input) {
+        if (!hasProjectOperator) {
+            return null;
+        }
+        return (LogicalProjectOperator) input.getInputs().get(0).getOp();
+    }
+
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
         if (!context.getSessionVariable().isEnableRewriteSimpleAggToHdfsScan()) {
+            LOG.info("RewriteSimpleAggToHDFSScanRule [{}]: skipped - session variable disabled",
+                    hasProjectOperator ? "SCAN_AND_PROJECT" : "SCAN_NO_PROJECT");
             return false;
         }
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
         LogicalScanOperator scanOperator = getScanOperator(input);
 
-        // no limit
+        LOG.debug("RewriteSimpleAggToHDFSScanRule [{}]: checking table={}, partitionColumns={}, scanPredicate={}",
+                hasProjectOperator ? "SCAN_AND_PROJECT" : "SCAN_NO_PROJECT",
+                scanOperator.getTable().getName(),
+                scanOperator.getPartitionColumns(),
+                scanOperator.getPredicate());
+
+        // For Iceberg tables the optimization is only correct when every partition field in the
+        // current spec uses an identity transform.
+        //
+        // Non-identity transforms (day(ts), bucket(n,col), truncate(n,col), etc.) store a
+        // *derived* value in the partition metadata, not the raw column value.  Two problems arise:
+        //
+        //   1. GROUP BY correctness: getPartitionColumns() returns the *source* column (e.g. "ts"
+        //      for day(ts)), so the grouping-key check lets a "GROUP BY ts" query through.  The
+        //      synthetic task emits the epoch-day integer as the "ts" value, which is wrong.
+        //
+        //   2. Predicate correctness: a filter on the source column (e.g. WHERE ts >= '...') does
+        //      not select whole partitions; record_count reflects all rows in the file, not the
+        //      filtered subset.
+        //
+        // For identity-partitioned tables neither issue exists: the partition value equals the
+        // column value, and a predicate on the partition column selects whole partitions.
+        //
+        // Files written under old, unpartitioned specs are handled by aggregateTasksByPartition(),
+        // which returns null for such files, causing the optimisation to fall back gracefully.
+        if (scanOperator instanceof LogicalIcebergScanOperator) {
+            IcebergTable icebergTable = (IcebergTable) scanOperator.getTable();
+            if (!icebergTable.isAllPartitionColumnsAlwaysIdentity()) {
+                LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - table={} has non-identity partition " +
+                        "transforms, partition values would not match source column values",
+                        icebergTable.getName());
+                return false;
+            }
+        }
+
+        // scan must not have a pushed-down limit (DEFAULT_LIMIT = -1 means no limit)
         if (scanOperator.getLimit() != -1) {
+            LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - scan has limit={}", scanOperator.getLimit());
             return false;
         }
 
         // no materialized column in predicate of scan
         if (hasMaterializedColumnInPredicate(scanOperator, scanOperator.getPredicate())) {
+            LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - materialized column in scan predicate={}",
+                    scanOperator.getPredicate());
             return false;
         }
 
         // all group by keys are partition keys.
         List<ColumnRefOperator> groupingKeys = aggregationOperator.getGroupingKeys();
-        if (!scanOperator.getPartitionColumns()
-                .containsAll(groupingKeys.stream().map(x -> x.getName()).collect(Collectors.toList()))) {
-            return false;
+        LogicalProjectOperator projectOperator = getProjectOperator(input);
+        LOG.debug("RewriteSimpleAggToHDFSScanRule: groupingKeys={}, hasProjectOperator={}",
+                groupingKeys, hasProjectOperator);
+        if (projectOperator != null) {
+            // SCAN_AND_PROJECT: grouping keys reference PROJECT output column refs.
+            // Resolve each grouping key through the PROJECT and verify every referenced
+            // column used in the expression is a partition column of the scan.
+            Map<ColumnRefOperator, ScalarOperator> projMap = projectOperator.getColumnRefMap();
+            LOG.debug("RewriteSimpleAggToHDFSScanRule: projMap keys={}", projMap.keySet());
+            for (ColumnRefOperator gk : groupingKeys) {
+                ScalarOperator projExpr = projMap.get(gk);
+                if (projExpr == null) {
+                    LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - groupingKey={} not found in projMap={}",
+                            gk, projMap.keySet());
+                    return false;
+                }
+                LOG.debug("RewriteSimpleAggToHDFSScanRule: gk={} -> projExpr={} (columnRefs={})",
+                        gk, projExpr, projExpr.getColumnRefs());
+                // Every column ref in the projection expression must be a partition column
+                for (ColumnRefOperator ref : projExpr.getColumnRefs()) {
+                    if (!scanOperator.getPartitionColumns().contains(ref.getName())) {
+                        LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - ref={} not in partitionColumns={}",
+                                ref.getName(), scanOperator.getPartitionColumns());
+                        return false;
+                    }
+                }
+            }
+        } else {
+            // SCAN_NO_PROJECT: grouping keys must directly be partition column refs
+            List<String> gkNames = groupingKeys.stream().map(x -> x.getName()).collect(Collectors.toList());
+            if (!scanOperator.getPartitionColumns().containsAll(gkNames)) {
+                LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - groupingKey names={} not all in partitionColumns={}",
+                        gkNames, scanOperator.getPartitionColumns());
+                return false;
+            }
         }
 
         // no materialized column in predicate of aggregation
         if (hasMaterializedColumnInPredicate(scanOperator, aggregationOperator.getPredicate())) {
+            LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - materialized column in agg predicate={}",
+                    aggregationOperator.getPredicate());
             return false;
         }
 
         // not applicable if there is no aggregation functions, like `distinct x`.
         if (aggregationOperator.getAggregations().isEmpty()) {
+            LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - no aggregation functions");
             return false;
         }
 
@@ -238,6 +361,8 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                     AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();
                     String functionName = aggregateFunction.functionName();
                     ColumnRefSet usedColumns = aggregator.getUsedColumns();
+                    LOG.debug("RewriteSimpleAggToHDFSScanRule: agg fn={}, distinct={}, usedColumns={}, args={}",
+                            functionName, aggregator.isDistinct(), usedColumns, aggregator.getArguments());
 
                     if (functionName.equals(FunctionSet.COUNT) && !aggregator.isDistinct() && usedColumns.isEmpty()) {
                         List<ScalarOperator> arguments = aggregator.getArguments();
@@ -248,11 +373,15 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                             // count(non-null constant)
                             return true;
                         }
+                        LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - COUNT with unexpected args={}", arguments);
                         return false;
                     }
+                    LOG.info("RewriteSimpleAggToHDFSScanRule: skipped - unsupported agg fn={} distinct={} usedColumns={}",
+                            functionName, aggregator.isDistinct(), usedColumns);
                     return false;
                 }
         );
+        LOG.debug("RewriteSimpleAggToHDFSScanRule: check result={}", allValid);
         return allValid;
     }
 
@@ -270,11 +399,126 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
         return false;
     }
 
+    /**
+     * Try to compute COUNT(*) directly from Iceberg manifest metadata.
+     * This is O(manifests) with no file I/O — much faster than the full planFiles() pipeline.
+     * For no-predicate queries, uses snapshot summary (zero I/O) when available.
+     *
+     * Returns the total row count if all conditions are met, empty otherwise.
+     * Conditions: Iceberg table, snapshot exists, no delete manifests, row counts available
+     * in all data manifests, no deleted rows in any manifest.
+     */
+    private OptionalLong tryManifestCountShortCircuit(LogicalScanOperator scanOperator) {
+        IcebergTable icebergTable = (IcebergTable) scanOperator.getTable();
+        org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTable.currentSnapshot();
+
+        if (snapshot == null) {
+            LOG.info("Manifest count short-circuit: empty table (no snapshot), returning 0");
+            return OptionalLong.of(0L);
+        }
+
+        // Fast path: for no-predicate queries, read total-records from snapshot summary (zero I/O)
+        if (scanOperator.getPredicate() == null) {
+            Map<String, String> summary = snapshot.summary();
+            String totalDeleteFiles = summary.get("total-delete-files");
+            if ("0".equals(totalDeleteFiles) || totalDeleteFiles == null) {
+                String totalRecords = summary.get("total-records");
+                if (totalRecords != null) {
+                    try {
+                        long count = Long.parseLong(totalRecords);
+                        LOG.info("Manifest count short-circuit: count={} from snapshot summary", count);
+                        return OptionalLong.of(count);
+                    } catch (NumberFormatException e) {
+                        // fall through to manifest-based counting
+                    }
+                }
+            } else {
+                LOG.info("Manifest count short-circuit: skipped - snapshot has delete files");
+                return OptionalLong.empty();
+            }
+        }
+
+        org.apache.iceberg.io.FileIO io = nativeTable.io();
+
+        List<ManifestFile> deleteManifests = snapshot.deleteManifests(io);
+        if (!deleteManifests.isEmpty()) {
+            LOG.info("Manifest count short-circuit: skipped - {} delete manifests", deleteManifests.size());
+            return OptionalLong.empty();
+        }
+
+        List<ManifestFile> dataManifests = snapshot.dataManifests(io);
+
+        if (scanOperator.getPredicate() != null) {
+            ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+            ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                    new ScalarOperatorToIcebergExpr.IcebergContext(nativeTable.schema().asStruct());
+            Expression filterExpr = converter.convert(
+                    Lists.newArrayList(scanOperator.getPredicate()), icebergContext);
+
+            if (filterExpr == Expressions.alwaysTrue()) {
+                LOG.info("Manifest count short-circuit: skipped - predicate could not be converted");
+                return OptionalLong.empty();
+            }
+
+            int beforeCount = dataManifests.size();
+            dataManifests = IcebergApiConverter.filterManifests(dataManifests, nativeTable, filterExpr);
+
+            if (dataManifests.isEmpty() && beforeCount > 0) {
+                LOG.info("Manifest count short-circuit: skipped - filter removed all {} manifests", beforeCount);
+                return OptionalLong.empty();
+            }
+        }
+
+        long totalCount = 0;
+        for (ManifestFile manifest : dataManifests) {
+            Long addedRows = manifest.addedRowsCount();
+            Long existingRows = manifest.existingRowsCount();
+
+            if (addedRows == null || existingRows == null) {
+                LOG.info("Manifest count short-circuit: skipped - manifest missing row counts");
+                return OptionalLong.empty();
+            }
+
+            Long deletedRows = manifest.deletedRowsCount();
+            if (deletedRows != null && deletedRows > 0) {
+                LOG.info("Manifest count short-circuit: skipped - manifest has {} deleted rows", deletedRows);
+                return OptionalLong.empty();
+            }
+
+            totalCount += addedRows + existingRows;
+        }
+
+        LOG.info("Manifest count short-circuit: count={} from {} manifests", totalCount, dataManifests.size());
+        return OptionalLong.of(totalCount);
+    }
+
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
         LogicalScanOperator scanOperator = getScanOperator(input);
-        OptExpression result = buildAggScanOperator(aggregationOperator, scanOperator, context);
+        LogicalProjectOperator projectOperator = getProjectOperator(input);
+        LOG.debug("RewriteSimpleAggToHDFSScanRule: transform() scanOperator.limit={} scanOperator.predicate={}",
+                scanOperator.getLimit(), scanOperator.getPredicate());
+
+        // Try manifest count short-circuit (Iceberg only, no GROUP BY)
+        if (scanOperator instanceof LogicalIcebergScanOperator
+                && aggregationOperator.getGroupingKeys().isEmpty()) {
+            OptionalLong manifestCount = tryManifestCountShortCircuit(scanOperator);
+            if (manifestCount.isPresent()) {
+                ColumnRefOperator aggColumnRef =
+                        aggregationOperator.getAggregations().entrySet().iterator().next().getKey();
+                List<ScalarOperator> row = Lists.newArrayList(
+                        ConstantOperator.createBigint(manifestCount.getAsLong()));
+                List<List<ScalarOperator>> rows = Lists.newArrayList();
+                rows.add(row);
+                LogicalValuesOperator valuesOp = new LogicalValuesOperator(
+                        Lists.newArrayList(aggColumnRef), rows);
+                return Lists.newArrayList(OptExpression.create(valuesOp));
+            }
+        }
+
+        OptExpression result = buildAggScanOperator(aggregationOperator, scanOperator, projectOperator, context);
         if (result == null) {
             // Fail to rewrite
             return Lists.newArrayList(input);

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -159,7 +159,7 @@ public class StarRocksIcebergTableScan
         MetadataCollectJob metadataCollectJob = new IcebergMetadataCollectJob(
                 catalogName, dbName, tableName, TResultSinkType.METADATA_ICEBERG, snapshotId(), icebergSerializedPredicate);
 
-        metadataCollectJob.init(connectContext.getSessionVariable());
+        metadataCollectJob.init(connectContext);
 
         long currentTimestamp = System.currentTimeMillis();
         String threadNamePrefix = String.format("%s-%s-%s-%d", catalogName, dbName, tableName, currentTimestamp);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -137,15 +137,11 @@ public class HiveScanTest extends ConnectorPlanTestBase {
     @Test
     public void testIcebergRewriteSimpleAggToHdfsScan() throws Exception {
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(true);
-        // positive cases.
+        // positive cases with GROUP BY — these use the ___count___ BE scan optimization.
         {
             String[] sqlString = {
-                    "select count(*) + 1 from iceberg0.partitioned_db.t1",
-                    "select count(*) + 1 from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
                     "select count(*) + 1, date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
                             "group by date",
-                    "select count(*) from iceberg0.partitioned_db.t1",
-                    "select count(*) from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
                     "select count(*), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
                             "group by date",
                     "select count(*), date from iceberg0.partitioned_db.t1 group by date having date > '2020-01-01'",
@@ -155,6 +151,23 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 String plan = getFragmentPlan(sql);
                 assertContains(plan, "___count___");
                 assertContains(plan, "ifnull");
+            }
+        }
+        // positive cases without GROUP BY — the FE manifest short-circuit computes count(*) = 0
+        // directly from the mock Iceberg table (null snapshot = empty table), returning a constant.
+        {
+            String[] sqlString = {
+                    "select count(*) + 1 from iceberg0.partitioned_db.t1",
+                    "select count(*) + 1 from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
+                    "select count(*) from iceberg0.partitioned_db.t1",
+                    "select count(*) from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                // FE manifest short-circuit: empty mock table → constant result via UNION
+                assertContains(plan, "UNION");
+                assertNotContains(plan, "___count___");
             }
         }
         // negative cases.


### PR DESCRIPTION
Avoid full file planning for COUNT(*) and COUNT(1) by reading row counts directly from Iceberg manifest metadata.

Two optimization paths:

1. FE manifest short-circuit (no GROUP BY): Computes count directly from manifest addedRowsCount + existingRowsCount in the FE O(manifests), zero file I/O. Returns a constant via LogicalValuesOperator. Applies only when no delete manifests exist and all row counts are available.

2. BE scan-range optimization (with or without GROUP BY): Rewrites COUNT(*) to SUM(___count___) and sends scan ranges to BE. BE reads record_count from scan-range metadata without opening files. aggregateTasksByPartition groups FileScanTasks by partition and builds synthetic SyntheticCountFileScanTask entries with aggregated record counts.

Other changes:
- isAllPartitionColumnsAlwaysIdentity checks all historical partition specs to guard against non-identity transforms.
- scannedTables uses ConcurrentHashMap.newKeySet() for thread safety.
- makePartitionKey uses length-prefixed encoding to prevent key collisions.
- Handle unpartitioned tables correctly in tryAggregateFromManifestRowCounts.

## Why I'm doing:
When running count agg queries like below, StarRocks shows very bad performance (~5 minutes) while Trino uses around > 50 seconds to finish.

```
mysql> SELECT date_trunc('day', ds) AS day, count(*) AS row_count  FROM     icebergDB.tableA GROUP BY     date_trunc('day', ds) ORDER BY     row_count DESC LIMIT 20;
```
## What I'm doing:

Avoid full file planning for COUNT(*) and COUNT(1) by reading row counts directly from Iceberg manifest metadata.

Two optimization paths:

1. FE manifest short-circuit (no GROUP BY): Computes count directly from manifest addedRowsCount + existingRowsCount in the FE O(manifests), zero file I/O. Returns a constant via LogicalValuesOperator. Applies only when no delete manifests exist and all row counts are available.

2. BE scan-range optimization (with or without GROUP BY): Rewrites COUNT(*) to SUM(___count___) and sends scan ranges to BE. BE reads record_count from scan-range metadata without opening files. aggregateTasksByPartition groups FileScanTasks by partition and builds synthetic SyntheticCountFileScanTask entries with aggregated record counts.

Other changes:
- isAllPartitionColumnsAlwaysIdentity checks all historical partition specs to guard against non-identity transforms.
- scannedTables uses ConcurrentHashMap.newKeySet() for thread safety.
- makePartitionKey uses length-prefixed encoding to prevent key collisions.
- Handle unpartitioned tables correctly in tryAggregateFromManifestRowCounts.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

