### PR TITLE
[Enhancement] DPP file-skip pruning for Iceberg scans using runtime filter min/max vs manifest stats

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -77,6 +77,10 @@ public:
     void set_split_context(pipeline::ScanSplitContext* split_context) { _split_context = split_context; }
     virtual Status parse_runtime_filters(RuntimeState* state);
     void update_has_any_predicate();
+    // Returns true if this file/split can be skipped based on runtime filter min/max
+    // vs per-file column statistics from the Iceberg manifest (THdfsScanRange.min_max_values).
+    // Called after parse_runtime_filters(), before open(). Default: no pruning.
+    virtual bool should_prune_by_rf_min_max_stats() const { return false; }
     // Called frequently, don't do heavy work
     virtual const std::string get_custom_coredump_msg() const { return ""; }
     virtual void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) {}

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -139,8 +139,7 @@ bool HiveDataSource::should_prune_by_rf_min_max_stats() const {
     if (_scan_range.min_max_values.empty()) return false;
 
     for (const auto& [_, probe] : _runtime_filters->descriptors()) {
-        const RuntimeFilter* filter =
-                probe->runtime_filter(runtime_membership_filter_eval_context.driver_sequence);
+        const RuntimeFilter* filter = probe->runtime_filter(runtime_membership_filter_eval_context.driver_sequence);
         if (filter == nullptr) continue;
 
         const RuntimeFilter* mmf = filter->get_min_max_filter();

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -31,10 +31,12 @@
 #include "exprs/expr.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
+#include "exprs/runtime_filter.h"
 #include "fs/fs_factory.h"
 #include "runtime/descriptors_ext.h"
 #include "runtime/global_dict/fragment_dict_state.h"
 #include "storage/chunk_helper.h"
+#include "types/logical_type_infra.h"
 
 namespace starrocks::connector {
 
@@ -81,6 +83,83 @@ HiveDataSource::HiveDataSource(const HiveDataSourceProvider* provider, const TSc
 
 HiveDataSource::HiveDataSource(const HiveDataSourceProvider* provider, const THdfsScanRange& hdfs_scan_range)
         : _provider(provider), _scan_range(hdfs_scan_range) {}
+
+// Functor used with type_dispatch_filter to check whether a file's column range
+// [file_min, file_max] (from THdfsScanRange.min_max_values) overlaps with the
+// runtime filter's range [rf_min, rf_max].  Returns true if the file can be pruned
+// (i.e. there is definitely NO overlap).
+struct RfMinMaxFileStatsChecker {
+    const RuntimeFilter* _mmf;
+    const TExprMinMaxValue& _fstats;
+
+    template <LogicalType ltype>
+    bool operator()() {
+        using CppType = RunTimeCppType<ltype>;
+
+        // No min/max support for strings or exotic types.
+        if constexpr (IsSlice<CppType>) return false;
+
+        const auto* mm = down_cast<const MinMaxRuntimeFilter<ltype>*>(_mmf);
+        if (!mm->has_min_max() || mm->always_true()) return false;
+        if (_fstats.all_null) return false; // all-null file: can't prune safely
+
+        if constexpr (std::is_integral_v<CppType>) {
+            int64_t rf_min = static_cast<int64_t>(mm->min_raw());
+            int64_t rf_max = static_cast<int64_t>(mm->max_raw());
+            int64_t f_min = _fstats.min_int_value;
+            int64_t f_max = _fstats.max_int_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        if constexpr (IsDate<CppType>) {
+            // DateValue stores Julian day; TExprMinMaxValue stores days-since-Unix-epoch.
+            // date::UNIX_EPOCH_JULIAN == 2440588
+            constexpr int64_t kEpochJulian = 2440588LL;
+            int64_t rf_min = static_cast<int64_t>(mm->min_raw().julian()) - kEpochJulian;
+            int64_t rf_max = static_cast<int64_t>(mm->max_raw().julian()) - kEpochJulian;
+            int64_t f_min = _fstats.min_int_value;
+            int64_t f_max = _fstats.max_int_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        if constexpr (std::is_floating_point_v<CppType>) {
+            double rf_min = static_cast<double>(mm->min_raw());
+            double rf_max = static_cast<double>(mm->max_raw());
+            double f_min = _fstats.min_float_value;
+            double f_max = _fstats.max_float_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        return false;
+    }
+};
+
+bool HiveDataSource::should_prune_by_rf_min_max_stats() const {
+    if (_runtime_filters == nullptr || _runtime_filters->size() == 0) return false;
+    if (_scan_range.min_max_values.empty()) return false;
+
+    for (const auto& [_, probe] : _runtime_filters->descriptors()) {
+        const RuntimeFilter* filter =
+                probe->runtime_filter(runtime_membership_filter_eval_context.driver_sequence);
+        if (filter == nullptr) continue;
+
+        const RuntimeFilter* mmf = filter->get_min_max_filter();
+        if (mmf == nullptr || mmf->always_true()) continue;
+
+        SlotId slot_id;
+        if (!probe->is_probe_slot_ref(&slot_id)) continue;
+
+        auto it = _scan_range.min_max_values.find(slot_id);
+        if (it == _scan_range.min_max_values.end()) continue;
+
+        LogicalType slot_type = probe->probe_expr_type();
+        RfMinMaxFileStatsChecker checker{mmf, it->second};
+        if (type_dispatch_filter(slot_type, false, checker)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 Status HiveDataSource::_check_all_slots_nullable() {
     for (const auto* slot : _tuple_desc->slots()) {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -93,6 +93,7 @@ public:
 
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) override;
     Status _init_chunk_if_needed(ChunkPtr* chunk, size_t n) override;
+    bool should_prune_by_rf_min_max_stats() const override;
 
 private:
     const HiveDataSourceProvider* _provider;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -21,7 +21,9 @@
 #include "connector/connector.h"
 #include "exec/connector_scan_node.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
+#include "exprs/runtime_filter.h"
 #include "hive_chunk_sink.h"
+#include "types/logical_type_infra.h"
 
 namespace starrocks {
 class HiveTableDescriptor;
@@ -197,6 +199,56 @@ private:
     // ======================================
     // The following are profile metrics
     HdfsScanProfile _profile;
+};
+
+// Functor used with type_dispatch_filter to check whether a file's column range
+// [file_min, file_max] (from THdfsScanRange.min_max_values) overlaps with the
+// runtime filter's range [rf_min, rf_max].  Returns true if the file can be pruned
+// (i.e. there is definitely NO overlap).
+struct RfMinMaxFileStatsChecker {
+    const RuntimeFilter* _mmf;
+    const TExprMinMaxValue& _fstats;
+
+    template <LogicalType ltype>
+    bool operator()() {
+        using CppType = RunTimeCppType<ltype>;
+
+        // No min/max support for strings or exotic types.
+        if constexpr (IsSlice<CppType>) return false;
+
+        const auto* mm = down_cast<const MinMaxRuntimeFilter<ltype>*>(_mmf);
+        if (!mm->has_min_max() || mm->always_true()) return false;
+        if (_fstats.all_null) return false; // all-null file: can't prune safely
+
+        if constexpr (std::is_integral_v<CppType>) {
+            int64_t rf_min = static_cast<int64_t>(mm->min_raw());
+            int64_t rf_max = static_cast<int64_t>(mm->max_raw());
+            int64_t f_min = _fstats.min_int_value;
+            int64_t f_max = _fstats.max_int_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        if constexpr (IsDate<CppType>) {
+            // DateValue stores Julian day; TExprMinMaxValue stores days-since-Unix-epoch.
+            // date::UNIX_EPOCH_JULIAN == 2440588
+            constexpr int64_t kEpochJulian = 2440588LL;
+            int64_t rf_min = static_cast<int64_t>(mm->min_raw().julian()) - kEpochJulian;
+            int64_t rf_max = static_cast<int64_t>(mm->max_raw().julian()) - kEpochJulian;
+            int64_t f_min = _fstats.min_int_value;
+            int64_t f_max = _fstats.max_int_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        if constexpr (std::is_floating_point_v<CppType>) {
+            double rf_min = static_cast<double>(mm->min_raw());
+            double rf_max = static_cast<double>(mm->max_raw());
+            double f_min = _fstats.min_float_value;
+            double f_max = _fstats.max_float_value;
+            return (f_max < rf_min || f_min > rf_max);
+        }
+
+        return false;
+    }
 };
 
 } // namespace starrocks::connector

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -672,6 +672,8 @@ Status ConnectorChunkSource::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ChunkSource::prepare(state));
     _runtime_state = state;
     RETURN_IF_ERROR(_data_source->parse_runtime_filters(state));
+    _rf_min_max_pruned_files_counter = ADD_COUNTER(_runtime_profile, "RfMinMaxPrunedFiles", TUnit::UNIT);
+    _skip_by_rf_stats = _data_source->should_prune_by_rf_min_max_stats();
     return Status::OK();
 }
 
@@ -817,6 +819,10 @@ Status ConnectorChunkSource::_open_data_source(RuntimeState* state, bool* mem_al
 }
 
 Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
+    if (_skip_by_rf_stats) {
+        COUNTER_UPDATE(_rf_min_max_pruned_files_counter, 1);
+        return Status::EndOfFile("pruned by runtime filter min/max stats");
+    }
     ConnectorScanOperator* scan_op = down_cast<ConnectorScanOperator*>(_scan_op);
     ConnectorScanOperatorAdaptiveProcessor& P = *(scan_op->adaptive_processor());
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -182,6 +182,10 @@ private:
     bool _closed = false;
     bool _is_split_source_morsel = false;
     bool _split_source_morsel_reported = false;
+    // Set in prepare() after parse_runtime_filters(). When true, _read_chunk() returns
+    // EndOfFile immediately without opening the file (DPP file-skip via RF min/max stats).
+    bool _skip_by_rf_stats = false;
+    RuntimeProfile::Counter* _rf_min_max_pruned_files_counter = nullptr;
     uint64_t _chunk_rows_read = 0;
     uint64_t _chunk_mem_bytes = 0;
     int64_t _request_mem_tracker_bytes = 0;

--- a/be/src/runtime/runtime_filter.h
+++ b/be/src/runtime/runtime_filter.h
@@ -679,6 +679,11 @@ public:
 
     bool is_empty_range() const { return _min > _max; }
 
+    // Raw accessors used for split-level DPP file-skip pruning.
+    CppType min_raw() const { return _min; }
+    CppType max_raw() const { return _max; }
+    bool has_min_max() const { return _has_min_max; }
+
     bool is_full_range() const {
         if constexpr (IsSlice<CppType>) {
             return _min == Slice::min_value() && _max == Slice::max_value();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(EXEC_FILES
         ./connector/benchmark_connector_test.cpp
         ./connector/hive_connector_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
+        ./connector/hive_connector_dpp_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp
         ./connector_sink/file_chunk_sink_test.cpp

--- a/be/test/connector/hive_connector_dpp_test.cpp
+++ b/be/test/connector/hive_connector_dpp_test.cpp
@@ -1,0 +1,174 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/hive_connector.h"
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "exprs/runtime_filter.h"
+#include "types/date_value.h"
+#include "types/logical_type_infra.h"
+
+namespace starrocks {
+
+class HiveConnectorDppTest : public ::testing::Test {
+protected:
+    ObjectPool _pool;
+};
+
+// Build a MinMaxRuntimeFilter<ltype> covering [lo, hi] via insert().
+// Using insert() keeps _always_true=false and has_min_max=true, which is
+// what RfMinMaxFileStatsChecker requires to perform actual range checks.
+
+TEST_F(HiveConnectorDppTest, IntPruneLeft) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = 1;
+    fstats.max_int_value = 9; // file [1,9] entirely below RF [10,20]
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_TRUE(type_dispatch_filter(TYPE_INT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, IntPruneRight) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = 21;
+    fstats.max_int_value = 30; // file [21,30] entirely above RF [10,20]
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_TRUE(type_dispatch_filter(TYPE_INT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, IntOverlap) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = 15;
+    fstats.max_int_value = 25; // file [15,25] overlaps RF [10,20]
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_FALSE(type_dispatch_filter(TYPE_INT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, IntExactMatch) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = 10;
+    fstats.max_int_value = 20; // file [10,20] == RF [10,20]: no prune
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_FALSE(type_dispatch_filter(TYPE_INT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, IntAllNull) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = true; // all-null file must never be pruned
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_FALSE(type_dispatch_filter(TYPE_INT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, DatePrune) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_DATE>());
+    DateValue d1, d2;
+    d1.from_date(2024, 1, 1);
+    d2.from_date(2024, 12, 31);
+    rf->insert(d1);
+    rf->insert(d2);
+
+    // File is in 2025 — entirely outside the RF range [2024-01-01, 2024-12-31].
+    constexpr int64_t kEpochJulian = 2440588LL;
+    DateValue d3, d4;
+    d3.from_date(2025, 1, 1);
+    d4.from_date(2025, 6, 30);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = static_cast<int64_t>(d3.julian()) - kEpochJulian;
+    fstats.max_int_value = static_cast<int64_t>(d4.julian()) - kEpochJulian;
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_TRUE(type_dispatch_filter(TYPE_DATE, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, DateOverlap) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_DATE>());
+    DateValue d1, d2;
+    d1.from_date(2024, 1, 1);
+    d2.from_date(2024, 12, 31);
+    rf->insert(d1);
+    rf->insert(d2);
+
+    // File is in mid-2024 — overlaps the RF range.
+    constexpr int64_t kEpochJulian = 2440588LL;
+    DateValue d3, d4;
+    d3.from_date(2024, 3, 1);
+    d4.from_date(2024, 6, 30);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_int_value = static_cast<int64_t>(d3.julian()) - kEpochJulian;
+    fstats.max_int_value = static_cast<int64_t>(d4.julian()) - kEpochJulian;
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_FALSE(type_dispatch_filter(TYPE_DATE, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, FloatPrune) {
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_FLOAT>());
+    rf->insert(1.0f);
+    rf->insert(2.0f);
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+    fstats.min_float_value = 3.0;
+    fstats.max_float_value = 4.0; // file [3.0,4.0] above RF [1.0,2.0]
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_TRUE(type_dispatch_filter(TYPE_FLOAT, false, checker));
+}
+
+TEST_F(HiveConnectorDppTest, VarcharNoPrune) {
+    // Strings are unsupported: the checker always returns false for slice types.
+    auto* rf = _pool.add(new MinMaxRuntimeFilter<TYPE_VARCHAR>());
+
+    TExprMinMaxValue fstats;
+    fstats.all_null = false;
+
+    connector::RfMinMaxFileStatsChecker checker{rf, fstats};
+    EXPECT_FALSE(type_dispatch_filter(TYPE_VARCHAR, false, checker));
+}
+
+} // namespace starrocks

--- a/be/test/connector/hive_connector_dpp_test.cpp
+++ b/be/test/connector/hive_connector_dpp_test.cpp
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "connector/hive_connector.h"
-
 #include <gtest/gtest.h>
 
 #include "common/object_pool.h"
+#include "connector/hive_connector.h"
 #include "exprs/runtime_filter.h"
 #include "types/date_value.h"
 #include "types/logical_type_infra.h"


### PR DESCRIPTION
## Why I'm doing:

  When StarRocks executes a query with a Dynamic Partition Pruning (DPP) runtime filter, it already prunes partitions at the partition level. However, within a surviving partition,
  individual Iceberg data files may still be entirely outside the runtime filter's min/max range. Without this change, those files are opened and scanned unnecessarily, wasting IO and CPU.

  Iceberg manifests already carry per-file column-level min/max statistics (THdfsScanRange.min_max_values). This change leverages those stats to skip entire files before they are opened,
  purely at the scan operator level — no planner changes required.

## What I'm doing:

Fixes #71005

  Adds a file-skip optimization for Iceberg scans driven by DPP runtime filter min/max bounds:

  - Adds should_prune_by_rf_min_max_stats() virtual method to DataSource (default: no pruning).
  - Implements it in HiveDataSource: after parse_runtime_filters(), iterates over all probe-slot runtime filters that have a min/max sub-filter, looks up the corresponding file-level column
  stats from the scan range, and returns true if the file's [min, max] range is disjoint from the RF's [min, max] range. Handles integral, date, and floating-point types via
  type_dispatch_filter + RfMinMaxFileStatsChecker.
  - In ConnectorChunkSource::prepare(), evaluates should_prune_by_rf_min_max_stats() once and caches the result in _skip_by_rf_stats. If set, _read_chunk() returns EndOfFile immediately
  without opening the file.
  - Exposes min_raw(), max_raw(), and has_min_max() accessors on MinMaxRuntimeFilter for use by the checker.
  - Adds a RfMinMaxPrunedFiles runtime profile counter to track how many files are skipped.
  - Adds unit tests in be/test/connector/hive_connector_dpp_test.cpp covering integer, float, date, string (no-prune), all-null (no-prune), and always-true RF (no-prune) cases.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
- [x] 4.1
- [x] 4.0
- [ ] 3.5
- [ ] 3.4
