### PR TITLE
[BugFix] Fix NPE in visitDictionaryGetExpr when dictionary backing table is dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1971,7 +1971,7 @@ public class ExpressionAnalyzer {
             Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
                     session, dictionary.getCatalogName(), dictionary.getDbName(), dictionary.getQueryableObject());
             if (table == null) {
-                throw new SemanticException("dict table %s is not found", table.getName());
+                throw new SemanticException("dict table %s is not found", dictionary.getQueryableObject());
             }
 
             List<Column> schema = table.getFullSchema();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -14,10 +14,14 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Dictionary;
 import com.starrocks.catalog.Function;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.CollectionElementExpr;
+import com.starrocks.sql.ast.expression.DictionaryGetExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.IntLiteral;
@@ -39,6 +43,8 @@ import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class ExpressionAnalyzerTest extends PlanTestBase {
 
@@ -300,5 +306,48 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         String currentWarehouseName = connectContext.getCurrentWarehouseName();
         String plan = getFragmentPlan("select current_warehouse()");
         assertContains(plan, currentWarehouseName);
+    }
+
+    @Test
+    public void testVisitDictionaryGetExprThrowsSemanticExceptionWhenTableDropped() {
+        // Create a dictionary that references a non-existent table
+        String dictionaryName = "test_dict_dropped_table";
+        String nonExistentTable = "non_existent_table_12345";
+        List<String> keys = Lists.newArrayList("key_col");
+        List<String> values = Lists.newArrayList("value_col");
+        Dictionary dictionary = new Dictionary(
+                99999L, dictionaryName, nonExistentTable,
+                "default_catalog", "test", keys, values, null);
+        // Set state to FINISHED so we pass the state checks
+        dictionary.setFinished(System.currentTimeMillis(), 1L);
+
+        GlobalStateMgr.getCurrentState().getDictionaryMgr().addDictionary(dictionary);
+        try {
+            // Build a DictionaryGetExpr: dictionary_get("test_dict_dropped_table", key_value)
+            List<Expr> params = Lists.newArrayList();
+            params.add(new StringLiteral(dictionaryName));
+            params.add(new IntLiteral(1));
+            DictionaryGetExpr expr = new DictionaryGetExpr(params);
+            expr.setSkipStateCheck(true);
+
+            ExpressionAnalyzer.Visitor visitor =
+                    new ExpressionAnalyzer.Visitor(new AnalyzeState(), connectContext);
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+
+            // Before the fix, this would throw NullPointerException because the code called
+            // table.getName() when table was null. After the fix, it should throw
+            // SemanticException with a message containing the table name.
+            SemanticException ex = Assertions.assertThrows(SemanticException.class,
+                    () -> visitor.visitDictionaryGetExpr(expr, scope));
+            Assertions.assertTrue(ex.getMessage().contains(nonExistentTable),
+                    "Error message should contain the table name, but was: " + ex.getMessage());
+        } finally {
+            // Clean up the dictionary we added
+            try {
+                GlobalStateMgr.getCurrentState().getDictionaryMgr().dropDictionary(dictionaryName, true);
+            } catch (Exception e) {
+                // ignore cleanup errors
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When a dictionary's backing table is dropped, any query using `dictionary_get()` crashes with a `NullPointerException` instead of returning a clear error message. The null-check at `ExpressionAnalyzer.java:1974` correctly detects `table == null`, but the error message format string immediately dereferences `table.getName()` on the same null reference.

## What I'm doing:

Replace `table.getName()` with `dictionary.getQueryableObject()` in the SemanticException message. The `dictionary` object is already in scope and holds the table name string used for the lookup.

Fixes #70997
Fixes #71070

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4