### PR TITLE
[Enhancement] Disable IVM support for Paimon tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -76,8 +76,7 @@ public class IVMAnalyzer {
 
     // table tables that supports IVM
     public static final Set<Table.TableType> SUPPORTED_TABLE_TYPES = Set.of(
-            Table.TableType.ICEBERG,
-            Table.TableType.PAIMON
+            Table.TableType.ICEBERG
     );
 
     // join operators that supports IVM


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Remove Table.TableType.PAIMON from IVMAnalyzer.SUPPORTED_TABLE_TYPES so that materialized views over Paimon base tables can no longer use the incremental (IVM) refresh path. Only Iceberg remains supported for IVM.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
