### PR TITLE
[BugFix] Fix NPE when analyzing generated columns in Stream Load/Broker Load if a referenced column is missing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -653,8 +653,7 @@ public class Load {
         }
 
         // 3. reanalyze all exprs using new type in vectorized load or using varchar in old load
-        analyzeMappingExprs(tbl, descriptorTable, srcTupleDesc, exprsByName, mvDefineExpr, slotDescByName,
-                useVectorizedLoad);
+        analyzeMappingExprs(tbl, descriptorTable, srcTupleDesc, exprsByName, mvDefineExpr, slotDescByName, useVectorizedLoad);
         LOG.debug("after init column, exprMap: {}", exprsByName);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -107,6 +107,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.DefaultExpr.isValidDefaultFunction;
 import static com.starrocks.common.ErrorCode.ERR_EXPR_REFERENCED_COLUMN_NOT_FOUND;
+import static com.starrocks.common.ErrorCode.ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN;
 import static com.starrocks.common.ErrorCode.ERR_MAPPING_EXPR_INVALID;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
@@ -652,7 +653,8 @@ public class Load {
         }
 
         // 3. reanalyze all exprs using new type in vectorized load or using varchar in old load
-        analyzeMappingExprs(tbl, descriptorTable, srcTupleDesc, exprsByName, mvDefineExpr, slotDescByName, useVectorizedLoad);
+        analyzeMappingExprs(tbl, descriptorTable, srcTupleDesc, exprsByName, mvDefineExpr, slotDescByName,
+                useVectorizedLoad);
         LOG.debug("after init column, exprMap: {}", exprsByName);
     }
 
@@ -758,6 +760,46 @@ public class Load {
         }
     }
 
+    private static Expr buildLoadDefaultExpr(Column column) throws StarRocksException {
+        Column.DefaultValueType defaultValueType = column.getDefaultValueType();
+        if (defaultValueType == Column.DefaultValueType.CONST) {
+            return new StringLiteral(column.calculatedDefaultValue());
+        } else if (defaultValueType == Column.DefaultValueType.VARY) {
+            if (isValidDefaultFunction(column.getDefaultExpr().getExpr())) {
+                return column.getDefaultExpr().obtainExpr();
+            }
+            throw new StarRocksException("Column(" + column + ") has unsupported default value:"
+                    + column.getDefaultExpr().getExpr());
+        } else if (defaultValueType == Column.DefaultValueType.NULL) {
+            if (column.isAllowNull()) {
+                return NullLiteral.create(column.getType());
+            }
+        }
+        return null;
+    }
+
+    private static Expr resolveGeneratedColumnRefExpr(Table tbl, SlotRef slot, Map<String, Expr> exprsByName,
+                                                      Map<String, SlotDescriptor> slotDescByName)
+            throws StarRocksException {
+        Expr replaceExpr = exprsByName.get(slot.getColumnName());
+        if (replaceExpr != null) {
+            return replaceExpr;
+        }
+
+        SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
+        if (slotDesc != null) {
+            SlotRef slotRef = new SlotRef(slotDesc);
+            slotRef.setColumnName(slot.getColumnName());
+            return slotRef;
+        }
+
+        Column refColumn = tbl.getColumn(slot.getColumnName());
+        if (refColumn == null) {
+            return null;
+        }
+        return buildLoadDefaultExpr(refColumn);
+    }
+
     private static void analyzeMappingExprs(Table tbl, DescriptorTable descriptorTable, TupleDescriptor srcTupleDesc,
                                             Map<String, Expr> exprsByName, Map<String, Expr> mvDefineExpr,
                                             Map<String, SlotDescriptor> slotDescByName, boolean useVectorizedLoad)
@@ -824,31 +866,17 @@ public class Load {
             List<SlotRef> slots = Lists.newArrayList();
             entry.getValue().collect(SlotRef.class, slots);
             for (SlotRef slot : slots) {
-                SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
-                // In this case, generated column ref some mapping column
-                // and the expression should be replace by mapping column expression.
-
-                // Notes that, if slotDesc != null and exprsByName.get(slot.getColumnName()) != null
-                // it means that the ref columns are both in column list and expression list.
-                // In this case, we should rewrite the generated column expression using
-                // the expression in expression list instead of column list.
-                if (slotDesc == null || exprsByName.get(slot.getColumnName()) != null) {
-                    Expr replaceExpr = exprsByName.get(slot.getColumnName());
-                    if (replaceExpr.getType().matchesType(VarcharType.VARCHAR) &&
-                            !replaceExpr.getType().matchesType(slot.getType())) {
-                        replaceExpr = ExprCastFunction.castTo(replaceExpr, slot.getType());
-                    }
-                    smap.put(slot, replaceExpr);
-                } else {
-                    SlotRef slotRef = new SlotRef(slotDesc);
-                    slotRef.setColumnName(slot.getColumnName());
-                    Expr replaceExpr = slotRef;
-                    if (replaceExpr.getType().matchesType(VarcharType.VARCHAR) &&
-                            !replaceExpr.getType().matchesType(slot.getType())) {
-                        replaceExpr = ExprCastFunction.castTo(replaceExpr, slot.getType());
-                    }
-                    smap.put(slot, replaceExpr);
+                // Generated columns should prefer the mapping expression when a referenced column
+                // exists in both the input column list and the expression list.
+                Expr replaceExpr = resolveGeneratedColumnRefExpr(tbl, slot, exprsByName, slotDescByName);
+                if (replaceExpr == null) {
+                    ErrorReport.reportAnalysisException(ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN, entry.getKey());
                 }
+                if (replaceExpr.getType().matchesType(VarcharType.VARCHAR) &&
+                        !replaceExpr.getType().matchesType(slot.getType())) {
+                    replaceExpr = ExprCastFunction.castTo(replaceExpr, slot.getType());
+                }
+                smap.put(slot, replaceExpr);
             }
             Expr expr = ExprSubstitutionVisitor.rewrite(entry.getValue(), smap);
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -107,8 +107,8 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.DefaultExpr.isValidDefaultFunction;
 import static com.starrocks.common.ErrorCode.ERR_EXPR_REFERENCED_COLUMN_NOT_FOUND;
-import static com.starrocks.common.ErrorCode.ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN;
 import static com.starrocks.common.ErrorCode.ERR_MAPPING_EXPR_INVALID;
+import static com.starrocks.common.ErrorCode.ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class Load {
@@ -759,9 +759,16 @@ public class Load {
         }
     }
 
-    private static Expr buildLoadDefaultExpr(Column column) throws StarRocksException {
+    static Expr buildLoadDefaultExpr(Column column) throws StarRocksException {
         Column.DefaultValueType defaultValueType = column.getDefaultValueType();
         if (defaultValueType == Column.DefaultValueType.CONST) {
+            if (column.getDefaultExpr() != null && column.getDefaultExpr().hasExprObject()) {
+                Expr expr = column.getDefaultExpr().obtainExpr();
+                if (expr == null) {
+                    throw new StarRocksException("Column(" + column + ") has invalid default expr object");
+                }
+                return expr;
+            }
             return new StringLiteral(column.calculatedDefaultValue());
         } else if (defaultValueType == Column.DefaultValueType.VARY) {
             if (isValidDefaultFunction(column.getDefaultExpr().getExpr())) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -32,6 +32,7 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.AggregateType;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.KeysType;
@@ -474,6 +475,33 @@ public class LoadTest {
     }
 
     @Test
+    public void testGeneratedColumnUsesSourceSlotWhenMappingExprMissing() throws StarRocksException {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", IntegerType.INT, true, null, true, null, "");
+        Column c3 = new Column("c3", IntegerType.INT, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema, new SlotRef(null, "c2")));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(
+                new ImportColumnDesc("c1"),
+                new ImportColumnDesc("c2"));
+
+        Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable, localSrcTupleDesc,
+                localSlotDescByName, new TBrokerScanRangeParams(), true, true, Lists.newArrayList());
+
+        Expr generatedExpr = localExprsByName.get("c3");
+        Assertions.assertNotNull(generatedExpr);
+        Assertions.assertInstanceOf(SlotRef.class, generatedExpr);
+        Assertions.assertEquals("c2", ((SlotRef) generatedExpr).getColumnName());
+    }
+
+    @Test
     public void testGeneratedColumnMissingDependencyUsesDefaultNull() throws StarRocksException {
         Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
         Column c2 = new Column("c2", IntegerType.INT, true, null, true, null, "");
@@ -497,6 +525,56 @@ public class LoadTest {
         Expr generatedExpr = localExprsByName.get("c3");
         Assertions.assertNotNull(generatedExpr);
         Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("NULL"));
+    }
+
+    @Test
+    public void testGeneratedColumnMissingDependencyUsesConstDefault() throws StarRocksException {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", IntegerType.INT, true, null, false,
+                new ColumnDef.DefaultValueDef(true, new com.starrocks.sql.ast.expression.StringLiteral("7")), "");
+        Column c3 = new Column("c3", IntegerType.INT, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema, new SlotRef(null, "c2")));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(new ImportColumnDesc("c1"));
+
+        Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable, localSrcTupleDesc,
+                localSlotDescByName, new TBrokerScanRangeParams(), true, true, Lists.newArrayList());
+
+        Expr generatedExpr = localExprsByName.get("c3");
+        Assertions.assertNotNull(generatedExpr);
+        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("7"));
+    }
+
+    @Test
+    public void testGeneratedColumnMissingDependencyUsesVaryDefault() throws StarRocksException {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", DateType.DATETIME, true, null, false,
+                new ColumnDef.DefaultValueDef(true, new FunctionCallExpr("now", Lists.newArrayList())), "");
+        Column c3 = new Column("c3", DateType.DATETIME, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema, new SlotRef(null, "c2")));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(new ImportColumnDesc("c1"));
+
+        Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable, localSrcTupleDesc,
+                localSlotDescByName, new TBrokerScanRangeParams(), true, true, Lists.newArrayList());
+
+        Expr generatedExpr = localExprsByName.get("c3");
+        Assertions.assertNotNull(generatedExpr);
+        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("now"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.ArrayExpr;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
@@ -45,6 +46,7 @@ import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.thrift.TBrokerScanRangeParams;
 import com.starrocks.thrift.TFileFormatType;
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.BitmapType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -550,6 +552,19 @@ public class LoadTest {
         Expr generatedExpr = localExprsByName.get("c3");
         Assertions.assertNotNull(generatedExpr);
         Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("7"));
+    }
+
+    @Test
+    public void testBuildLoadDefaultExprUsesExprObjectConstDefault() throws StarRocksException {
+        Column c2 = new Column("c2", new ArrayType(IntegerType.INT), false, null, false,
+                new ColumnDef.DefaultValueDef(true, new ArrayExpr(new ArrayType(IntegerType.INT),
+                        Lists.newArrayList(new IntLiteral(7, IntegerType.INT)))), "");
+
+        Expr defaultExpr = Load.buildLoadDefaultExpr(c2);
+        Assertions.assertNotNull(defaultExpr);
+        Assertions.assertInstanceOf(ArrayExpr.class, defaultExpr);
+        Assertions.assertTrue(defaultExpr.getType().isArrayType());
+        Assertions.assertTrue(ExprToSql.explain(defaultExpr).contains("7"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
 import com.starrocks.sql.ast.expression.ArrayExpr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
@@ -499,8 +500,9 @@ public class LoadTest {
 
         Expr generatedExpr = localExprsByName.get("c3");
         Assertions.assertNotNull(generatedExpr);
-        Assertions.assertInstanceOf(SlotRef.class, generatedExpr);
-        Assertions.assertEquals("c2", ((SlotRef) generatedExpr).getColumnName());
+        Assertions.assertInstanceOf(CastExpr.class, generatedExpr);
+        Assertions.assertInstanceOf(SlotRef.class, generatedExpr.getChild(0));
+        Assertions.assertEquals("c2", ((SlotRef) generatedExpr.getChild(0)).getColumnName());
     }
 
     @Test
@@ -570,9 +572,9 @@ public class LoadTest {
     @Test
     public void testGeneratedColumnMissingDependencyUsesVaryDefault() throws StarRocksException {
         Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
-        Column c2 = new Column("c2", DateType.DATETIME, true, null, false,
-                new ColumnDef.DefaultValueDef(true, new FunctionCallExpr("now", Lists.newArrayList())), "");
-        Column c3 = new Column("c3", DateType.DATETIME, true, null, true, null, "");
+        Column c2 = new Column("c2", VarcharType.VARCHAR, true, null, false,
+                new ColumnDef.DefaultValueDef(true, new FunctionCallExpr("uuid", Lists.newArrayList())), "");
+        Column c3 = new Column("c3", VarcharType.VARCHAR, true, null, true, null, "");
         List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
         c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema, new SlotRef(null, "c2")));
         Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
@@ -589,7 +591,7 @@ public class LoadTest {
 
         Expr generatedExpr = localExprsByName.get("c3");
         Assertions.assertNotNull(generatedExpr);
-        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("now"));
+        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("uuid"));
     }
 
     @Test
@@ -614,6 +616,6 @@ public class LoadTest {
                 "missing dependency column for generated column c3",
                 () -> Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable,
                         localSrcTupleDesc, localSlotDescByName, new TBrokerScanRangeParams(), true, true,
-                        Lists.newArrayList()));
+                        Lists.newArrayList(), false, true));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -22,9 +22,11 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.TupleDescriptor;
@@ -439,5 +441,86 @@ public class LoadTest {
         Assertions.assertNotNull(c2Expr);
         Assertions.assertEquals(
                 "now[(6); args: INT; result: DATETIME; args nullable: false; result nullable: false]", ExprToSql.explain(c2Expr));
+    }
+
+    @Test
+    public void testGeneratedColumnUsesMappingExprBeforeSourceSlot() throws StarRocksException {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", IntegerType.INT, true, null, true, null, "");
+        Column c3 = new Column("c3", IntegerType.INT, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema,
+                new ArithmeticExpr(ArithmeticExpr.Operator.ADD, new SlotRef(null, "c2"),
+                        new IntLiteral(1, IntegerType.INT))));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(
+                new ImportColumnDesc("c1"),
+                new ImportColumnDesc("c2"),
+                new ImportColumnDesc("c2", new ArithmeticExpr(ArithmeticExpr.Operator.ADD, new SlotRef(null, "c2"),
+                        new IntLiteral(2, IntegerType.INT))));
+
+        Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable, localSrcTupleDesc,
+                localSlotDescByName, new TBrokerScanRangeParams(), true, true, Lists.newArrayList());
+
+        Expr generatedExpr = localExprsByName.get("c3");
+        Assertions.assertNotNull(generatedExpr);
+        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("2"));
+    }
+
+    @Test
+    public void testGeneratedColumnMissingDependencyUsesDefaultNull() throws StarRocksException {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", IntegerType.INT, true, null, true, null, "");
+        Column c3 = new Column("c3", IntegerType.INT, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema,
+                new ArithmeticExpr(ArithmeticExpr.Operator.ADD, new SlotRef(null, "c2"),
+                        new IntLiteral(1, IntegerType.INT))));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(new ImportColumnDesc("c1"));
+
+        Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable, localSrcTupleDesc,
+                localSlotDescByName, new TBrokerScanRangeParams(), true, true, Lists.newArrayList());
+
+        Expr generatedExpr = localExprsByName.get("c3");
+        Assertions.assertNotNull(generatedExpr);
+        Assertions.assertTrue(ExprToSql.explain(generatedExpr).contains("NULL"));
+    }
+
+    @Test
+    public void testGeneratedColumnMissingDependencyFailsWhenNoDefault() {
+        Column c1 = new Column("c1", IntegerType.INT, true, null, true, null, "");
+        Column c2 = new Column("c2", IntegerType.INT, true, null, false, null, "");
+        Column c3 = new Column("c3", IntegerType.INT, true, null, true, null, "");
+        List<Column> fullSchema = Lists.newArrayList(c1, c2, c3);
+        c3.setGeneratedColumnExpr(ColumnIdExpr.create(fullSchema,
+                new ArithmeticExpr(ArithmeticExpr.Operator.ADD, new SlotRef(null, "c2"),
+                        new IntLiteral(1, IntegerType.INT))));
+        Table localTable = new Table(1L, "table0", Table.TableType.OLAP, fullSchema);
+
+        DescriptorTable localDescTable = new DescriptorTable();
+        TupleDescriptor localSrcTupleDesc = localDescTable.createTupleDescriptor();
+        localSrcTupleDesc.setTable(localTable);
+        Map<String, Expr> localExprsByName = Maps.newHashMap();
+        Map<String, SlotDescriptor> localSlotDescByName = Maps.newHashMap();
+        List<ImportColumnDesc> localColumnExprs = Lists.newArrayList(new ImportColumnDesc("c1"));
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "missing dependency column for generated column c3",
+                () -> Load.initColumns(localTable, localColumnExprs, null, localExprsByName, localDescTable,
+                        localSrcTupleDesc, localSlotDescByName, new TBrokerScanRangeParams(), true, true,
+                        Lists.newArrayList()));
     }
 }


### PR DESCRIPTION
## Why I'm doing
During Stream Load/Broker Load planning, FE may throw an NPE when analyzing a generated column if one of its referenced columns is missing from the load command.

## What I'm doing
Handle missing referenced columns in generated-column analysis using existing load semantics: prefer mapping expressions, then source slots, and fall back to default/NULL expressions when allowed. If no valid replacement exists, return a proper analysis error instead of throwing an NPE.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
