### PR TITLE
[BugFix] Fix missing partition predicate in short-circuit point lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1647,8 +1647,20 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         // must order in create table
         List<String> keyColumns = olapTable.getKeyColumnsInOrder().stream().map(Column::getName)
                 .collect(Collectors.toList());
-        Optional<List<List<LiteralExpr>>> points = RowStoreUtils.extractPointsLiteral(conjuncts, keyColumns);
 
+        // Some partition predicates may have been removed from conjuncts during partition pruning
+        // (e.g. when the partition column is not a distribution column), but are still required
+        // for short-circuit point lookup to identify the full primary key.
+        // Merge prunedPartitionPredicates into conjuncts, deduplicating by Expr equality.
+        List<Expr> mergedConjuncts = new ArrayList<>(conjuncts);
+        Set<Expr> conjunctSet = new HashSet<>(conjuncts);
+        for (Expr pred : prunedPartitionPredicates) {
+            if (conjunctSet.add(pred)) {
+                mergedConjuncts.add(pred);
+            }
+        }
+
+        Optional<List<List<LiteralExpr>>> points = RowStoreUtils.extractPointsLiteral(mergedConjuncts, keyColumns);
         if (points.isPresent()) {
             rowStoreKeyLiterals = points.get();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1651,11 +1651,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         // Some partition predicates may have been removed from conjuncts during partition pruning
         // (e.g. when the partition column is not a distribution column), but are still required
         // for short-circuit point lookup to identify the full primary key.
-        // Merge prunedPartitionPredicates into conjuncts, deduplicating by Expr equality.
+        // Merge prunedPartitionPredicates into conjuncts, using equals()-based linear scan for dedup
+        // to avoid relying on Expr.hashCode() which includes type while equals() does not.
         List<Expr> mergedConjuncts = new ArrayList<>(conjuncts);
-        Set<Expr> conjunctSet = new HashSet<>(conjuncts);
         for (Expr pred : prunedPartitionPredicates) {
-            if (conjunctSet.add(pred)) {
+            if (!conjuncts.contains(pred)) {
                 mergedConjuncts.add(pred);
             }
         }

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -85,3 +85,34 @@ set enable_profile=false;
 set sql_mode='ONLY_FULL_GROUP_BY';
 -- result:
 -- !result
+
+-- name: testShortCircuitPartitionPredicate @no_arrow_flight_sql
+set enable_short_circuit=true;
+-- result:
+-- !result
+CREATE TABLE t_short_circuit_part (
+  `k1` date NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL COMMENT ""
+)
+PRIMARY KEY(`k1`, `k2`)
+PARTITION BY RANGE(`k1`)
+(PARTITION p1 VALUES [("0000-01-01"), ("2026-04-02")),
+PARTITION p2 VALUES [("2026-04-02"), ("2026-04-03")))
+DISTRIBUTED BY HASH(`k2`);
+-- result:
+-- !result
+insert into t_short_circuit_part values("2026-04-01", 1, 1), ("2026-04-02", 2, 1);
+-- result:
+-- !result
+select * from t_short_circuit_part where k1 = "2026-04-01" and k2 = 1;
+-- result:
+2026-04-01	1	1
+-- !result
+select * from t_short_circuit_part where k1 = "2026-04-02" and k2 = 2;
+-- result:
+2026-04-02	2	1
+-- !result
+set enable_short_circuit=false;
+-- result:
+-- !result

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -53,3 +53,24 @@ select * from short_circuit_bool where k1 = 6 and k2=true;
 set enable_short_circuit=false;
 set enable_profile=false;
 set sql_mode='ONLY_FULL_GROUP_BY';
+
+-- name: testShortCircuitPartitionPredicate @no_arrow_flight_sql
+set enable_short_circuit=true;
+
+CREATE TABLE t_short_circuit_part (
+  `k1` date NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `k3` int(11) NULL COMMENT ""
+)
+PRIMARY KEY(`k1`, `k2`)
+PARTITION BY RANGE(`k1`)
+(PARTITION p1 VALUES [("0000-01-01"), ("2026-04-02")),
+PARTITION p2 VALUES [("2026-04-02"), ("2026-04-03")))
+DISTRIBUTED BY HASH(`k2`);
+
+insert into t_short_circuit_part values("2026-04-01", 1, 1), ("2026-04-02", 2, 1);
+
+select * from t_short_circuit_part where k1 = "2026-04-01" and k2 = 1;
+select * from t_short_circuit_part where k1 = "2026-04-02" and k2 = 2;
+
+set enable_short_circuit=false;


### PR DESCRIPTION
## Why I'm doing:

  When `enable_short_circuit=true`, partition pruning may remove a partition
  column predicate from conjuncts if the column is not a distribution column.
  This caused `computePointScanRangeLocations()` to miss the predicate when
  extracting primary key literals, resulting in an empty key list and an
  empty query result.

## What I'm doing:

  merge `prunedPartitionPredicates` into `conjuncts` before calling `extractPointsLiteral`, 
  so all key column predicates are visible to the point lookup path.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
