### PR TITLE
[BugFix] Fix a memory leak issue caused by shared_ptr cycle between `BatchUnit` and `FetchTaskContext`

### DIFF
--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -50,27 +50,31 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     const auto& request_chunk = _ctx->request_chunk;
 
     auto closure = std::make_unique<DisposableClosure<PLookUpResponse, FetchTaskContextPtr>>(_ctx);
+    // The RPC callback can outlive queue ownership when the source finishes early.
+    auto self = shared_from_this();
     auto processor = _ctx->processor.lock();
     DCHECK(processor != nullptr);
     const auto* node_info = processor->_nodes_info->find_node(source_id);
     DCHECK(node_info != nullptr);
     RETURN_IF(node_info == nullptr,
               Status::InternalError(fmt::format("Failed to find node info for source_id: {}", source_id)));
-    closure->addSuccessHandler([this, done = closure.get(), host = node_info->host, port = node_info->brpc_port](
+    closure->addSuccessHandler([self, done = closure.get(), host = node_info->host, port = node_info->brpc_port](
                                        const FetchTaskContextPtr& ctx, const PLookUpResponse& resp) noexcept {
         auto processor = ctx->processor.lock();
-        if (processor == nullptr) {
+        auto unit = ctx->unit.lock();
+        if (processor == nullptr || unit == nullptr) {
+            self->_is_done = true;
             return;
         }
-        DLOG(INFO) << "[GLM] receive a response, finished request num: " << ctx->unit->finished_request_num
-                   << ", total request num: " << ctx->unit->total_request_num
+        DLOG(INFO) << "[GLM] receive a response, finished request num: " << unit->finished_request_num
+                   << ", total request num: " << unit->total_request_num
                    << ", latency: " << (MonotonicNanos() - ctx->send_ts) * 1.0 / 1000000 << "ms";
         DeferOp defer([&]() {
-            if (++ctx->unit->finished_request_num == ctx->unit->total_request_num) {
+            if (++unit->finished_request_num == unit->total_request_num) {
                 VLOG_ROW << "[GLM] all request finished, notify fetch processor, total_request_num: "
-                         << ctx->unit->total_request_num;
+                         << unit->total_request_num;
             }
-            _is_done = true;
+            self->_is_done = true;
         });
         COUNTER_UPDATE(processor->_rpc_count, 1);
         COUNTER_UPDATE(processor->_network_timer, MonotonicNanos() - ctx->send_ts);
@@ -123,16 +127,18 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
         }
     });
 
-    closure->addFailureHandler([this](const FetchTaskContextPtr& ctx, std::string_view rpc_error_msg) noexcept {
+    closure->addFailureHandler([self](const FetchTaskContextPtr& ctx, std::string_view rpc_error_msg) noexcept {
         auto processor = ctx->processor.lock();
-        if (processor == nullptr) {
+        auto unit = ctx->unit.lock();
+        if (processor == nullptr || unit == nullptr) {
+            self->_is_done = true;
             return;
         }
         DeferOp defer([&]() {
-            if (++ctx->unit->finished_request_num == ctx->unit->total_request_num) {
+            if (++unit->finished_request_num == unit->total_request_num) {
                 DLOG(INFO) << "all request finished, notify fetch processor, " << (void*)processor.get();
             }
-            _is_done = true;
+            self->_is_done = true;
         });
         processor->_set_io_task_status(Status::InternalError(rpc_error_msg));
         LOG(WARNING) << "fetch request failed, error: " << rpc_error_msg;
@@ -175,8 +181,10 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
         size_t actual_serialize_size = buff - begin;
         closure->cntl.request_attachment().append(processor->_serialize_buffer.data(), actual_serialize_size);
     }
+    auto unit = _ctx->unit.lock();
+    auto unit_debug_string = unit != nullptr ? unit->debug_string() : std::string("BatchUnit <expired>");
     DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)processor.get()
-               << ", unit: " << _ctx->unit->debug_string();
+               << ", unit: " << unit_debug_string;
     _ctx->send_ts = MonotonicNanos();
     auto stub = state->exec_env()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
     if (stub == nullptr) {

--- a/be/src/exec/pipeline/fetch_task.h
+++ b/be/src/exec/pipeline/fetch_task.h
@@ -52,7 +52,8 @@ public:
     virtual ~FetchTaskContext() = default;
 
     std::weak_ptr<FetchProcessor> processor;
-    BatchUnitPtr unit;
+    // Keep the batch weak to avoid a BatchUnit -> FetchTask -> FetchTaskContext -> BatchUnit cycle.
+    std::weak_ptr<BatchUnit> unit;
     TupleId request_tuple_id = 0;
     // source_id , used to find the target BE/CN to send request
     int32_t source_node_id = 0;
@@ -65,7 +66,7 @@ public:
 };
 using FetchTaskContextPtr = std::shared_ptr<FetchTaskContext>;
 
-class FetchTask {
+class FetchTask : public std::enable_shared_from_this<FetchTask> {
 public:
     FetchTask(FetchTaskContextPtr ctx) : _ctx(std::move(ctx)) {}
     virtual ~FetchTask() = default;

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -72,7 +72,9 @@ StatusOr<size_t> LocalLookUpRequestContext::fill_response(const ChunkPtr& result
 }
 
 void LocalLookUpRequestContext::callback(const Status& status) {
-    fetch_ctx->unit->finished_request_num++;
+    if (auto unit = fetch_ctx->unit.lock(); unit != nullptr) {
+        unit->finished_request_num++;
+    }
 }
 
 // Deserialize remote request payload into a reusable chunk for processing.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/multi_cast_local_exchange_test.cpp
+        ./exec/pipeline/fetch_task_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/exchange_sink_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -1,0 +1,34 @@
+#include "exec/pipeline/fetch_task.h"
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace starrocks::pipeline {
+
+TEST(FetchTaskTest, batch_unit_cycle_is_released_after_outer_refs_drop) {
+    std::weak_ptr<BatchUnit> weak_unit;
+
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        weak_unit = unit;
+
+        auto ctx = std::make_shared<FetchTaskContext>();
+        ctx->unit = unit;
+
+        auto task = std::make_shared<FetchTask>(ctx);
+        auto tasks = std::make_shared<std::vector<FetchTaskPtr>>();
+        tasks->emplace_back(task);
+        unit->fetch_tasks.emplace(1, tasks);
+
+        task.reset();
+        tasks.reset();
+        ctx.reset();
+        unit.reset();
+    }
+
+    EXPECT_TRUE(weak_unit.expired());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -1,13 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "exec/pipeline/fetch_task.h"
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
 #include <memory>
+#include <thread>
 #include <vector>
 
+#include "base/utility/defer_op.h"
+#define private public
+#include "exec/pipeline/fetch_processor.h"
+#undef private
+#include "exec/pipeline/lookup_request.h"
+#include "exec/tablet_info.h"
+#include "gen_cpp/Descriptors_types.h"
 #include "gtest/gtest.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+namespace {
 
-TEST(FetchTaskTest, batch_unit_cycle_is_released_after_outer_refs_drop) {
+constexpr int32_t kSourceNodeId = 1;
+
+int reserve_unused_local_port() {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    EXPECT_NE(fd, -1);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    EXPECT_EQ(bind(fd, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)), 0);
+    socklen_t len = sizeof(addr);
+    EXPECT_EQ(getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len), 0);
+    int port = ntohs(addr.sin_port);
+    EXPECT_EQ(close(fd), 0);
+    return port;
+}
+
+std::shared_ptr<StarRocksNodesInfo> create_nodes_info(int port) {
+    TNodesInfo t_nodes;
+    TNodeInfo node;
+    node.__set_id(kSourceNodeId);
+    node.__set_option(0);
+    node.__set_host("127.0.0.1");
+    node.__set_async_internal_port(port);
+    t_nodes.nodes.emplace_back(std::move(node));
+    return std::make_shared<StarRocksNodesInfo>(t_nodes);
+}
+
+std::shared_ptr<FetchProcessor> create_fetch_processor(const std::shared_ptr<StarRocksNodesInfo>& nodes_info) {
+    phmap::flat_hash_map<TupleId, RowPositionDescriptor*> row_pos_descs;
+    phmap::flat_hash_map<SlotId, SlotDescriptor*> slot_descs;
+    auto processor = std::make_shared<FetchProcessor>(100, row_pos_descs, slot_descs, nodes_info);
+
+    auto profile = std::make_shared<RuntimeProfile>("fetch_task_test");
+    processor->_rpc_count =
+            profile->add_counter("RpcCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    processor->_network_timer = profile->add_counter("NetworkTime", TUnit::TIME_NS,
+                                                     RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS));
+    return processor;
+}
+
+std::unique_ptr<RuntimeState> create_runtime_state(int query_timeout_s) {
+    TUniqueId fragment_instance_id;
+    fragment_instance_id.hi = 1;
+    fragment_instance_id.lo = 2;
+    TQueryOptions query_options;
+    query_options.__set_query_timeout(query_timeout_s);
+    TQueryGlobals query_globals;
+    return std::make_unique<RuntimeState>(fragment_instance_id, query_options, query_globals, ExecEnv::GetInstance());
+}
+
+bool wait_task_done(const FetchTaskPtr& task, int timeout_ms) {
+    constexpr int kCheckIntervalMs = 10;
+    int elapsed = 0;
+    while (elapsed < timeout_ms) {
+        if (task->is_done()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(kCheckIntervalMs));
+        elapsed += kCheckIntervalMs;
+    }
+    return task->is_done();
+}
+
+} // namespace
+
+// Verify the shared_ptr cycle between BatchUnit and FetchTaskContext is broken
+// after changing FetchTaskContext::unit to weak_ptr.
+TEST(FetchTaskTest, batch_unit_released_after_outer_refs_drop) {
     std::weak_ptr<BatchUnit> weak_unit;
 
     {
@@ -22,6 +121,7 @@ TEST(FetchTaskTest, batch_unit_cycle_is_released_after_outer_refs_drop) {
         tasks->emplace_back(task);
         unit->fetch_tasks.emplace(1, tasks);
 
+        // Drop all external references; weak_ptr in ctx should not prevent release.
         task.reset();
         tasks.reset();
         ctx.reset();
@@ -29,6 +129,124 @@ TEST(FetchTaskTest, batch_unit_cycle_is_released_after_outer_refs_drop) {
     }
 
     EXPECT_TRUE(weak_unit.expired());
+}
+
+// Simulate the RPC closure holding FetchTask alive via shared_from_this()
+// even after the owning BatchUnit drops its reference.
+TEST(FetchTaskTest, shared_from_this_keeps_task_alive_after_batch_drops) {
+    std::weak_ptr<FetchTask> weak_task;
+
+    auto unit = std::make_shared<BatchUnit>();
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->unit = unit;
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    weak_task = task;
+
+    // Simulate what the RPC closure does: hold a shared_ptr copy.
+    auto closure_hold = task->shared_from_this();
+
+    // Store task in BatchUnit, then release all external refs except closure_hold.
+    auto tasks = std::make_shared<std::vector<FetchTaskPtr>>();
+    tasks->emplace_back(std::move(task));
+    unit->fetch_tasks.emplace(1, tasks);
+
+    tasks.reset();
+    unit.reset();
+    ctx.reset();
+
+    // FetchTask should still be alive because closure_hold keeps it.
+    EXPECT_FALSE(weak_task.expired());
+    EXPECT_FALSE(closure_hold->is_done());
+
+    // After closure finishes and releases, FetchTask is destroyed.
+    closure_hold.reset();
+    EXPECT_TRUE(weak_task.expired());
+}
+
+// LocalLookUpRequestContext::callback should safely increment finished_request_num
+// when the BatchUnit is still alive.
+TEST(FetchTaskTest, local_callback_increments_counter_when_unit_alive) {
+    auto unit = std::make_shared<BatchUnit>();
+    unit->total_request_num = 2;
+    unit->finished_request_num = 0;
+
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->unit = unit;
+
+    LocalLookUpRequestContext local_ctx(ctx);
+    local_ctx.callback(Status::OK());
+
+    EXPECT_EQ(unit->finished_request_num.load(), 1);
+
+    local_ctx.callback(Status::OK());
+    EXPECT_EQ(unit->finished_request_num.load(), 2);
+}
+
+// LocalLookUpRequestContext::callback should not crash when the BatchUnit
+// has already been released (weak_ptr expired).
+TEST(FetchTaskTest, local_callback_safe_when_unit_expired) {
+    auto ctx = std::make_shared<FetchTaskContext>();
+
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        unit->total_request_num = 1;
+        ctx->unit = unit;
+        // unit goes out of scope here, weak_ptr expires.
+    }
+
+    LocalLookUpRequestContext local_ctx(ctx);
+    // Should not crash or modify anything.
+    EXPECT_NO_FATAL_FAILURE(local_ctx.callback(Status::OK()));
+}
+
+TEST(FetchTaskTest, submit_remote_rpc_failure_marks_done_and_updates_status) {
+    ASSERT_NE(ExecEnv::GetInstance(), nullptr);
+    ASSERT_NE(ExecEnv::GetInstance()->brpc_stub_cache(), nullptr);
+
+    const int unused_port = reserve_unused_local_port();
+    auto processor = create_fetch_processor(create_nodes_info(unused_port));
+    auto unit = std::make_shared<BatchUnit>();
+    unit->total_request_num = 1;
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->processor = processor;
+    ctx->unit = unit;
+    ctx->source_node_id = kSourceNodeId;
+    ctx->request_tuple_id = 10;
+    ctx->request_chunk = std::make_shared<Chunk>();
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    auto state = create_runtime_state(1);
+    ASSERT_TRUE(task->submit(state.get()).ok());
+    ASSERT_TRUE(wait_task_done(task, 5000));
+
+    EXPECT_TRUE(task->is_done());
+    EXPECT_EQ(unit->finished_request_num.load(), 1);
+    EXPECT_FALSE(processor->_io_task_status.ok());
+}
+
+TEST(FetchTaskTest, submit_remote_rpc_failure_handles_expired_unit) {
+    ASSERT_NE(ExecEnv::GetInstance(), nullptr);
+    ASSERT_NE(ExecEnv::GetInstance()->brpc_stub_cache(), nullptr);
+
+    const int unused_port = reserve_unused_local_port();
+    auto processor = create_fetch_processor(create_nodes_info(unused_port));
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->processor = processor;
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        ctx->unit = unit;
+    }
+    ctx->source_node_id = kSourceNodeId;
+    ctx->request_tuple_id = 11;
+    ctx->request_chunk = std::make_shared<Chunk>();
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    auto state = create_runtime_state(1);
+    ASSERT_TRUE(task->submit(state.get()).ok());
+    ASSERT_TRUE(wait_task_done(task, 5000));
+
+    EXPECT_TRUE(task->is_done());
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing

The global lazy materialization feature (`FetchProcessor`) has a reference-count cycle that prevents `BatchUnit` objects from being freed when a query finishes normally or when a consumer finishes early (e.g. `LIMIT`).

The ownership cycle is:

```
BatchUnit                          (shared_ptr)
  └─ fetch_tasks map
       └─ shared_ptr<vector<FetchTaskPtr>>
            └─ shared_ptr<FetchTask>
                 └─ shared_ptr<FetchTaskContext>
                      └─ shared_ptr<BatchUnit>   ← back to start
```

Because every node in this ring holds a `shared_ptr` to the next, the reference count of `BatchUnit` never reaches zero even after all external owners (`_queue`, `_current_unit` in `FetchProcessor`) release their references. This causes a memory leak proportional to the number of batches processed during a query.

A secondary issue exists in the RPC callback closures: they capture the raw `this` pointer of `FetchTask`. Before this fix the `FetchTask` lifetime was accidentally sustained by the cycle itself. Once the cycle is broken, the `FetchTask` may be destroyed before an in-flight RPC callback returns, leading to a use-after-free on `_is_done`.

## What I'm doing

**Break the cycle by weakening one edge.** Change `FetchTaskContext::unit` from `shared_ptr<BatchUnit>` to `weak_ptr<BatchUnit>`. This is the natural weak edge because:
- `FetchTaskContext` does not own the `BatchUnit`; it only needs to read/update counters during RPC callbacks.
- The `BatchUnit` is strongly owned by `FetchProcessor::_queue` and `_current_unit` throughout its useful lifetime. As long as the batch is relevant, those strong references keep it alive.
- When the source finishes early (`set_source_finishing`), the queue is cleared, `BatchUnit` is released, and `is_finished()` short-circuits via `_is_source_finishing` — no downstream code ever checks `all_fetch_done()` after that point.

**Keep `FetchTask` alive through RPC callbacks via `shared_from_this()`.** `FetchTask` now inherits `enable_shared_from_this`. In `_submit_remote_task`, the success and failure closures capture `self = shared_from_this()` instead of raw `this`. This guarantees the `FetchTask` (and its `_is_done` flag) remains valid for the entire RPC round-trip, even if the owning `BatchUnit` and its `fetch_tasks` map are released before the callback fires.

**Guard all `unit` accesses in callbacks with `weak_ptr::lock()`.** Each callback locks the weak pointer and checks for expiry. If the `BatchUnit` is already gone (source finished early), the callback sets `_is_done = true` and returns without touching any batch state. This is correct because an expired `BatchUnit` means `FetchProcessor::is_finished()` already returns `true` (`fetch_processor.cpp:92-93`), so no one will poll `all_fetch_done()` or read batch counters again.

**Add a regression test** (`FetchTaskTest.batch_unit_cycle_is_released_after_outer_refs_drop`) that constructs the full cycle, drops all external references, and asserts the `BatchUnit` weak pointer expires — confirming the cycle is broken.

Fixes: https://github.com/StarRocks/StarRocksTest/issues/11201

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4