### PR TITLE
[BugFix] Fix MV rewriter false-positive on LEFT JOIN diff predicates with different constants

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
@@ -96,13 +96,23 @@ public class EquivalenceClasses implements Cloneable {
         return columnToEquivalenceClass.get(column);
     }
 
+    public Set<ColumnRefOperator> getEquivalenceClassByEquivalentColumn(ColumnRefOperator column) {
+        Set<ColumnRefOperator> direct = columnToEquivalenceClass.get(column);
+        if (direct != null) {
+            return direct;
+        }
+        Optional<ColumnRefOperator> opt = columnToEquivalenceClass.keySet()
+                .stream().filter(x -> ScalarOperator.isEquivalent(x, column)).findFirst();
+        return opt.map(columnToEquivalenceClass::get).orElse(null);
+    }
+
     public boolean containsKey(ColumnRefOperator column) {
         return columnToEquivalenceClass.containsKey(column);
     }
 
     public List<Set<ColumnRefOperator>> getEquivalenceClasses() {
         // Remove redundant equal classes, eg:
-        // a,b are equal calsses:
+        // a,b are equal classes:
         // cacheColumnToEquivalenceClass:
         // a -> set(a, b)
         // b -> set(a, b)
@@ -144,16 +154,6 @@ public class EquivalenceClasses implements Cloneable {
 
     public boolean containsRedundantKey(ColumnRefOperator column) {
         return redundantColumnToEquivalenceClass.containsKey(column);
-    }
-
-    public boolean containsEquivalentKey(ColumnRefOperator column) {
-        Optional<ColumnRefOperator> opt = redundantColumnToEquivalenceClass.keySet()
-                .stream().filter(x -> ScalarOperator.isEquivalent(x, column)).findFirst();
-        if (!opt.isPresent()) {
-            return false;
-        }
-        Set<ColumnRefOperator> refOperators = redundantColumnToEquivalenceClass.get(opt.get());
-        return refOperators.size() > 1;
     }
 
     public void deleteRedundantKey(ColumnRefOperator column) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -270,7 +270,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         }
 
         EquivalenceClasses queryEc = new EquivalenceClasses();
-        deduceEquivalenceClassesFromRangePredicates(predicates, queryEc, false);
+        deduceEquivalenceClassesFromRangePredicates(predicates, queryEc, true);
 
         for (ScalarOperator diffPredicate : diffPredicates) {
             BinaryPredicateOperator diffBinaryPredicate = (BinaryPredicateOperator) diffPredicate;
@@ -281,7 +281,8 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
             Preconditions.checkState(left.isColumnRef() && right.isColumnRef());
             ColumnRefOperator l = (ColumnRefOperator) left;
             ColumnRefOperator r = (ColumnRefOperator) right;
-            if (!queryEc.containsEquivalentKey(l) || !queryEc.containsEquivalentKey(r)) {
+            Set<ColumnRefOperator> leftEc = queryEc.getEquivalenceClassByEquivalentColumn(l);
+            if (leftEc == null || leftEc.stream().noneMatch(col -> ScalarOperator.isEquivalent(col, r))) {
                 return false;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriterTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.Sets;
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.MvRewriteContext;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class MaterializedViewRewriterTest {
+    @Test
+    public void testCheckJoinOnPredicateFromPredicatesUsesEquivalentColumns(@Mocked MvRewriteContext mvRewriteContext,
+                                                                            @Mocked MaterializationContext mvContext,
+                                                                            @Mocked OptimizerContext optimizerContext) {
+        QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
+        new Expectations() {
+            {
+                mvRewriteContext.getMaterializationContext();
+                result = mvContext;
+
+                mvContext.getOptimizerContext();
+                result = optimizerContext;
+
+                optimizerContext.getQueryMaterializationContext();
+                result = queryMaterializationContext;
+            }
+        };
+
+        MaterializedViewRewriter rewriter = new MaterializedViewRewriter(mvRewriteContext);
+
+        ColumnRefFactory predicateRefFactory = new ColumnRefFactory();
+        ColumnRefOperator leftFromPredicate = predicateRefFactory.create("left_col", IntegerType.INT, true);
+        ColumnRefOperator rightFromPredicate = predicateRefFactory.create("right_col", IntegerType.INT, true);
+        List<ScalarOperator> predicates = List.of(
+                BinaryPredicateOperator.eq(leftFromPredicate, ConstantOperator.createInt(1)),
+                BinaryPredicateOperator.eq(rightFromPredicate, ConstantOperator.createInt(1)));
+
+        ColumnRefFactory diffRefFactory = new ColumnRefFactory();
+        diffRefFactory.create("padding_col", IntegerType.INT, true);
+        ColumnRefOperator leftFromDiff = diffRefFactory.create("left_col", IntegerType.INT, true);
+        ColumnRefOperator rightFromDiff = diffRefFactory.create("right_col", IntegerType.INT, true);
+        Set<ScalarOperator> diffPredicates = Sets.newHashSet(BinaryPredicateOperator.eq(leftFromDiff, rightFromDiff));
+
+        Assertions.assertTrue(rewriter.checkJoinOnPredicateFromPredicates(predicates, diffPredicates));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteJoinTest.java
@@ -348,6 +348,56 @@ public class MvRewriteJoinTest extends MVTestBase {
         starRocksAssert.dropMaterializedView("test_mv2");
     }
 
+    // Regression test for https://github.com/StarRocks/starrocks/issues/70935
+    // When MV has extra join ON predicates (e.g., a.v1 = b.v1) that the query does not,
+    // these "diff predicates" must be provable from the query's WHERE clause.
+    // The old code only checked that each side of the diff predicate existed in SOME equivalence
+    // class, but did not verify they were in the SAME class (i.e., bound to the same constant).
+    @Test
+    public void testMVRewriteJoinDiffPredicateWithDifferentConstants() throws Exception {
+        // MV joins on TWO predicates: a.k1=b.k1 AND a.v1=b.v1
+        createAndRefreshMv("CREATE MATERIALIZED VIEW test_diff_pred_mv\n" +
+                "PARTITION BY k1\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
+                "REFRESH ASYNC\n" +
+                "AS SELECT a.k1, a.v1, a.v2, b.v1 as b_v1, b.v2 as b_v2\n" +
+                "FROM test_partition_tbl1 as a LEFT JOIN test_partition_tbl2 as b " +
+                "ON a.k1=b.k1 AND a.v1=b.v1;");
+
+        // Case 1: Query ON has only a.k1=b.k1, diff predicate is a.v1=b.v1.
+        // WHERE has a.v1=1 AND b.v1=2 — different constants, so a.v1=b.v1 is NOT provable.
+        // MV must NOT be used.
+        {
+            String query = "SELECT a.v2 FROM test_partition_tbl1 a " +
+                    "LEFT JOIN test_partition_tbl2 b ON a.k1=b.k1 " +
+                    "WHERE a.k1='2020-01-01' AND a.v1=1 AND b.v1=2;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_diff_pred_mv");
+        }
+
+        // Case 2: WHERE has a.v1=1 AND b.v1=1 — same constant, a.v1=b.v1 IS provable.
+        // MV SHOULD be used.
+        {
+            String query = "SELECT a.v2 FROM test_partition_tbl1 a " +
+                    "LEFT JOIN test_partition_tbl2 b ON a.k1=b.k1 " +
+                    "WHERE a.k1='2020-01-01' AND a.v1=1 AND b.v1=1;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_diff_pred_mv");
+        }
+
+        // Case 3: WHERE only has predicate on one side (a.v1=1, no b.v1 predicate).
+        // a.v1=b.v1 is NOT provable. MV must NOT be used.
+        {
+            String query = "SELECT a.v2 FROM test_partition_tbl1 a " +
+                    "LEFT JOIN test_partition_tbl2 b ON a.k1=b.k1 " +
+                    "WHERE a.k1='2020-01-01' AND a.v1=1;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_diff_pred_mv");
+        }
+
+        starRocksAssert.dropMaterializedView("test_diff_pred_mv");
+    }
+
     @Test
     public void testMVViewRewriteJoin() throws Exception {
         String view1 = "CREATE VIEW view1 as select * from test_partition_tbl1;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1806,6 +1806,29 @@ public class MvRewriteTest extends MVTestBase {
         starRocksAssert.dropMaterializedView("test_partition_tbl_mv3");
     }
 
+    @Test
+    public void testLeftJoinWithDifferentConstantEquivalenceClasses() throws Exception {
+        createAndRefreshMv("CREATE MATERIALIZED VIEW test_partition_tbl_mv3\n" +
+                "PARTITION BY a_k1\n" +
+                "DISTRIBUTED BY HASH(a_v1) BUCKETS 10\n" +
+                "REFRESH ASYNC\n" +
+                "AS SELECT a.k1 as a_k1, a.v1 as a_v1, a.v2 as a_v2, " +
+                "b.k1 as b_k1, b.v1 as b_v1, b.v2 as b_v2 \n" +
+                "FROM test_partition_tbl1 as a \n" +
+                "left join test_partition_tbl2 as b " +
+                "on a.v1=b.v1 and a.v2=b.v2 \n");
+        {
+            String query = "select a.k1, a.v1 " +
+                    "FROM test_partition_tbl1 as a left join test_partition_tbl2 as b " +
+                    "on a.v1=b.v1 " +
+                    "where a.v2=1 and b.v2=2 ;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_partition_tbl_mv3");
+        }
+
+        starRocksAssert.dropMaterializedView("test_partition_tbl_mv3");
+    }
+
     private List<MvPlanContext> getPlanContext(MaterializedView mv, boolean useCache) {
         boolean prev = connectContext.getSessionVariable().isEnableMaterializedViewPlanCache();
         connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(useCache);


### PR DESCRIPTION
## Why I'm doing:

When a materialized view has extra join ON predicates (diff predicates) not present in the query, `checkJoinOnPredicateFromPredicates` must verify these predicates are provable from the query's WHERE clause. The old code only checked that each column in the diff predicate existed in *some* equivalence class independently (`containsEquivalentKey(l) || containsEquivalentKey(r)`), but did not verify that both sides were bound to the **same** constant. This caused incorrect MV rewrite when columns were equal to different constants (e.g., `l.a=1 AND r.c=2` wrongly "proving" `l.a=r.c`), producing wrong query results.

## What I'm doing:

Replace the per-column equivalence class existence check with a direct column→constant mapping that verifies both sides of each diff predicate share the same constant value. Also added a unit test covering three scenarios: different constants (MV must not be used), same constants (MV should be used), and one-sided constant (MV must not be used).

Fixes #70935

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4