### PR TITLE
[BugFix] Fix data loss after tablet split by skipping data file deletion for range distribution tablets

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -714,33 +714,23 @@ static StatusOr<BundleTabletMetaState> check_bundle_tablet_meta_state(
 }
 
 static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLogPB& log, bool contains_alive_tablets,
-                                        bool is_combined_log, AsyncFileDeleter& deleter,
-                                        const std::unordered_set<std::string>& retained_files) {
+                                        bool is_combined_log, AsyncFileDeleter& deleter) {
     if (log.has_op_write()) {
         const auto& op = log.op_write();
         // Shared segments can be deleted only when we know all tablets in a combined log are being deleted.
         for (int i = 0; i < op.rowset().segments_size(); ++i) {
-            if (retained_files.count(op.rowset().segments(i))) {
-                continue;
-            }
             if (!is_shared_segment(op.rowset(), i) || (is_combined_log && !contains_alive_tablets)) {
                 RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, op.rowset().segments(i))));
             }
         }
         // delete del files
         for (const auto& f : op.dels()) {
-            if (retained_files.count(f)) {
-                continue;
-            }
             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f)));
         }
     }
     if (log.has_op_compaction()) {
         const auto& op = log.op_compaction();
         for (int i = 0; i < op.output_rowset().segments_size(); ++i) {
-            if (retained_files.count(op.output_rowset().segments(i))) {
-                continue;
-            }
             if (!is_shared_segment(op.output_rowset(), i) || (is_combined_log && !contains_alive_tablets)) {
                 RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, op.output_rowset().segments(i))));
             }
@@ -750,9 +740,6 @@ static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLo
         const auto& op = log.op_schema_change();
         for (const auto& rowset : op.rowsets()) {
             for (int i = 0; i < rowset.segments_size(); ++i) {
-                if (retained_files.count(rowset.segments(i))) {
-                    continue;
-                }
                 if (!is_shared_segment(rowset, i) || (is_combined_log && !contains_alive_tablets)) {
                     RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, rowset.segments(i))));
                 }
@@ -815,12 +802,6 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     // Used to avoid deleting shared files that are shared by multiple tablets.
     AsyncSharedFileDeleter dummy_shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
 
-    // Process metadata BEFORE txn logs to collect retained shared files.
-    // After tablet split, txn logs written before split may not mark files as shared,
-    // while the latest metadata (updated after split) does. Processing metadata first
-    // ensures shared files are collected into retained_files and not accidentally deleted
-    // when processing txn logs.
-    std::unordered_set<std::string> retained_files;
     bool is_range_distribution = false;
 
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(meta_dir, [&](std::string_view name) {
@@ -920,60 +901,54 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             if (latest_metadata->has_range()) {
                 is_range_distribution = true;
             }
-            const bool allow_delete_shared_files =
-                    can_bundle_meta_file_to_be_deleted(versions_and_states[latest_metadata->version()]);
-            for (const auto& rowset : latest_metadata->rowsets()) {
-                for (int i = 0; i < rowset.segments_size(); ++i) {
-                    // If the segment file is not shared by other alive tablets, we can delete it directly.
-                    if (!is_shared_segment(rowset, i) || allow_delete_shared_files) {
-                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, rowset.segments(i))));
-                    } else {
-                        retained_files.insert(rowset.segments(i));
+            // For range distribution tablets, skip data file deletion entirely.
+            // After tablet split, data files in pre-split metadata may be shared with
+            // new tablets but not marked as shared (shared flag only exists in the
+            // split-version metadata which may have been vacuumed).
+            // Data files will be cleaned up by new tablets' regular vacuum.
+            if (!is_range_distribution) {
+                const bool allow_delete_shared_files =
+                        can_bundle_meta_file_to_be_deleted(versions_and_states[latest_metadata->version()]);
+                for (const auto& rowset : latest_metadata->rowsets()) {
+                    for (int i = 0; i < rowset.segments_size(); ++i) {
+                        if (!is_shared_segment(rowset, i) || allow_delete_shared_files) {
+                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, rowset.segments(i))));
+                        }
                     }
-                }
-                for (const auto& del_file : rowset.del_files()) {
-                    if (!del_file.shared() || allow_delete_shared_files) {
-                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
-                    } else {
-                        retained_files.insert(del_file.name());
-                    }
-                }
-            }
-            if (latest_metadata->has_delvec_meta()) {
-                for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {
-                    if (!f.shared() || allow_delete_shared_files) {
-                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f.name())));
-                    } else {
-                        retained_files.insert(f.name());
-                    }
-                }
-            }
-            if (latest_metadata->has_dcg_meta()) {
-                for (const auto& [_, dcg] : latest_metadata->dcg_meta().dcgs()) {
-                    for (int i = 0; i < dcg.column_files_size(); ++i) {
-                        const bool shared_file = i < dcg.shared_files_size() && dcg.shared_files(i);
-                        if (!shared_file || allow_delete_shared_files) {
-                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, dcg.column_files(i))));
-                        } else {
-                            retained_files.insert(dcg.column_files(i));
+                    for (const auto& del_file : rowset.del_files()) {
+                        if (!del_file.shared() || allow_delete_shared_files) {
+                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
                         }
                     }
                 }
-            }
-            if (latest_metadata->sstable_meta().sstables_size() > 0) {
-                for (const auto& sst : latest_metadata->sstable_meta().sstables()) {
-                    if (!sst.shared() || allow_delete_shared_files) {
-                        RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, sst.filename())));
-                    } else {
-                        retained_files.insert(sst.filename());
+                if (latest_metadata->has_delvec_meta()) {
+                    for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {
+                        if (!f.shared() || allow_delete_shared_files) {
+                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, f.name())));
+                        }
+                    }
+                }
+                if (latest_metadata->has_dcg_meta()) {
+                    for (const auto& [_, dcg] : latest_metadata->dcg_meta().dcgs()) {
+                        for (int i = 0; i < dcg.column_files_size(); ++i) {
+                            const bool shared_file = i < dcg.shared_files_size() && dcg.shared_files(i);
+                            if (!shared_file || allow_delete_shared_files) {
+                                RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, dcg.column_files(i))));
+                            }
+                        }
+                    }
+                }
+                if (latest_metadata->sstable_meta().sstables_size() > 0) {
+                    for (const auto& sst : latest_metadata->sstable_meta().sstables()) {
+                        if (!sst.shared() || allow_delete_shared_files) {
+                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, sst.filename())));
+                        }
                     }
                 }
             }
         }
     }
 
-    // Process txn logs AFTER metadata processing, so that retained_files collected from
-    // shared files in metadata are used to protect files from being accidentally deleted.
     for (const auto& log_name : txn_logs) {
         auto res = tablet_mgr->get_txn_log(join_path(log_dir, log_name), false);
         if (res.status().is_not_found()) {
@@ -985,7 +960,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             // For range distribution tablets, skip deleting data files referenced by txn logs
             // because they may have been applied to new tablets after tablet split.
             if (!is_range_distribution) {
-                RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, *log_ptr, false, false, deleter, retained_files));
+                RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, *log_ptr, false, false, deleter));
             }
             // delete txnlog
             RETURN_IF_ERROR(deleter.delete_file(join_path(log_dir, log_name)));
@@ -1013,8 +988,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             for (const auto& log : combine_log_ptr->txn_logs()) {
                 if (!is_range_distribution &&
                     std::binary_search(tablet_ids.begin(), tablet_ids.end(), log.tablet_id())) {
-                    RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter,
-                                                              retained_files));
+                    RETURN_IF_ERROR(delete_files_under_txnlog(data_dir, log, contains_alive_tablets, true, deleter));
                 }
             }
             // delete txnlog
@@ -1024,8 +998,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
         }
     }
 
-    // Delete metadata files last. This ensures that if txn log processing above fails,
-    // metadata files are still available on retry to reconstruct retained_files.
+    // Delete metadata files last.
     for (auto& [tablet_id, versions_and_states] : tablet_versions) {
         for (auto& [version, state] : versions_and_states) {
             if (state == BundleTabletMetaState::NOT_BUNDLE_TABLET_META) {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4227,24 +4227,23 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
 }
 
 // NOLINTNEXTLINE
-TEST_P(LakeVacuumTest, test_delete_tablets_txnlog_retains_shared_files_from_metadata) {
-    // Simulate a tablet split scenario:
-    // - Txn log was written BEFORE split, so the file is NOT marked as shared in the txn log.
-    // - Metadata was updated AFTER split, so the file IS marked as shared in the metadata.
-    // When deleting the old tablet, the shared file should be retained because it is still
-    // referenced by other tablets via the shared flag in metadata.
-    const std::string shared_segment = "0000000000f659e4_66666666-6666-6666-6666-6666666666f1.dat";
-    const std::string shared_delvec = "0000000000f659e4_66666666-6666-6666-6666-6666666666f2.delvec";
-    const std::string shared_sstable = "0000000000f659e4_66666666-6666-6666-6666-6666666666f3.sst";
-    const std::string shared_del_file = "0000000000f659e4_66666666-6666-6666-6666-6666666666f4.del";
-    const std::string private_segment = "0000000000f759e4_77777777-7777-7777-7777-7777777777g1.dat";
-    const std::string private_del_file = "0000000000f759e4_77777777-7777-7777-7777-7777777777g2.del";
-    create_data_file(shared_segment);
-    create_data_file(shared_delvec);
-    create_data_file(shared_sstable);
-    create_data_file(shared_del_file);
-    create_data_file(private_segment);
-    create_data_file(private_del_file);
+TEST_P(LakeVacuumTest, test_delete_range_distribution_tablets_skip_metadata_data_files) {
+    // Simulate deleting old range distribution tablets after tablet split.
+    // The latest metadata contains data files (segments, delvecs, sstables, del files, dcg files)
+    // that may be shared with new split tablets. All data files should be retained for range
+    // distribution tablets; they will be cleaned up by new tablets' regular vacuum.
+    const std::string segment1 = "0000000000f659e4_66666666-6666-6666-6666-6666666666f1.dat";
+    const std::string segment2 = "0000000000f759e4_77777777-7777-7777-7777-7777777777g1.dat";
+    const std::string delvec1 = "0000000000f659e4_66666666-6666-6666-6666-6666666666f2.delvec";
+    const std::string sstable1 = "0000000000f659e4_66666666-6666-6666-6666-6666666666f3.sst";
+    const std::string del_file1 = "0000000000f659e4_66666666-6666-6666-6666-6666666666f4.del";
+    const std::string del_file2 = "0000000000f759e4_77777777-7777-7777-7777-7777777777g2.del";
+    create_data_file(segment1);
+    create_data_file(segment2);
+    create_data_file(delvec1);
+    create_data_file(sstable1);
+    create_data_file(del_file1);
+    create_data_file(del_file2);
 
     // Txn log: file is NOT marked as shared (written before split).
     ASSERT_OK(_tablet_mgr->put_txn_log(*json_to_pb<TxnLogPB>(R"DEL(
@@ -4267,12 +4266,17 @@ TEST_P(LakeVacuumTest, test_delete_tablets_txnlog_retains_shared_files_from_meta
         }
         )DEL")));
 
-    // Metadata v2: file IS marked as shared (updated after split).
-    // Only tablet 5000 is being deleted, while the shared files are also used by other tablets.
+    // Metadata v2: range distribution tablet with data files.
+    // Some files are marked shared, some are not. After split, ALL data files should be
+    // retained regardless of shared flag.
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
         "id": 5000,
         "version": 2,
+        "range": {
+            "lower_bound_included": true,
+            "upper_bound_included": false
+        },
         "rowsets": [
             {
                 "segments": [
@@ -4317,8 +4321,6 @@ TEST_P(LakeVacuumTest, test_delete_tablets_txnlog_retains_shared_files_from_meta
         )DEL")));
 
     {
-        // Delete tablet 5000. Shared files in metadata should be retained
-        // even though they are not marked as shared in the txn log.
         DeleteTabletRequest request;
         DeleteTabletResponse response;
         request.add_tablet_ids(5000);
@@ -4326,17 +4328,17 @@ TEST_P(LakeVacuumTest, test_delete_tablets_txnlog_retains_shared_files_from_meta
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
 
-        // Shared files should be retained (protected by metadata's shared flag).
-        EXPECT_TRUE(file_exist(shared_segment));
-        EXPECT_TRUE(file_exist(shared_delvec));
-        EXPECT_TRUE(file_exist(shared_sstable));
-        EXPECT_TRUE(file_exist(shared_del_file));
+        // All data files should be retained for range distribution tablets.
+        // Both shared and private files are kept because after split, even "private"
+        // files in pre-split metadata may be referenced by new tablets.
+        EXPECT_TRUE(file_exist(segment1));
+        EXPECT_TRUE(file_exist(segment2));
+        EXPECT_TRUE(file_exist(delvec1));
+        EXPECT_TRUE(file_exist(sstable1));
+        EXPECT_TRUE(file_exist(del_file1));
+        EXPECT_TRUE(file_exist(del_file2));
 
-        // Private segment and del file should be deleted.
-        EXPECT_FALSE(file_exist(private_segment));
-        EXPECT_FALSE(file_exist(private_del_file));
-
-        // Txn log and metadata should be deleted.
+        // Txn log and metadata files should be deleted.
         EXPECT_FALSE(file_exist(txn_log_filename(5000, 9900)));
         EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
     }


### PR DESCRIPTION
## Why I'm doing:

  In shared-data mode, after a range distribution tablet split (or merge), the old tablet's
  data files may still be referenced by the new tablets. The `delete_tablets_impl` vacuum path
  deletes data files found in the old tablet's latest metadata, but after the split-version
  metadata has been vacuumed, there is no way to tell which files are shared with the new
  tablets. This causes referenced `.dat` files to be mistakenly deleted, leading to data loss
  (publish 404 errors).

  The previous `retained_files` mechanism attempted to protect shared files by collecting them
  from metadata before processing txn logs. However, it only protected the txn log deletion
  path and did not cover the metadata deletion path. Once the split-version metadata (which
  carries the shared flags) was vacuumed by regular vacuum, older metadata versions no longer
  had shared markers, and the files were deleted.

## What I'm doing:

  For range distribution tablets, skip all data file deletion in `delete_tablets_impl` entirely
  (both metadata path and txn log path). The data files will be cleaned up later by the new
  tablets' regular vacuum after compaction replaces them. This is consistent with the existing
  txn log protection (line 987) that was already in place.

  Since range distribution tablets now skip data file deletion in both paths, the
  `retained_files` mechanism no longer has any consumers and is removed entirely. For
  non-range distribution tablets, there is no tablet split scenario, so
  `delete_files_under_txnlog`'s own `is_shared_segment` check is sufficient to protect shared
  files.

  Specific changes:
  - `delete_files_under_txnlog`: remove `retained_files` parameter and all `retained_files.count()` checks
  - `delete_tablets_impl`: wrap metadata data file deletion in `if (!is_range_distribution)`, remove `retained_files` variable and all `retained_files.insert()` calls
  - Update txn log processing call sites to remove `retained_files` argument
  - Replace `test_delete_tablets_txnlog_retains_shared_files_from_metadata` with `test_delete_range_distribution_tablets_skip_metadata_data_files` to verify range distribution tablets skip data file deletion from the metadata path

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
