### PR TITLE
[BugFix] Remove threadlocal Info for ConnectContext when leader forward is finished to prevent context pollution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1089,6 +1089,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             final TMasterOpResult result = new TMasterOpResult();
             result.setErrorMsg(e.getMessage());
             return result;
+        } finally {
+            ConnectContext.remove();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
@@ -121,6 +121,49 @@ public class ForwardTest extends SchedulerTestBase {
     }
 
     @Test
+    public void testForwardRemoveConnectContextAfterSuccess() throws Exception {
+        final FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
+        final TMasterOpRequest request = makeRequest();
+
+        try {
+            new MockUp<ConnectProcessor>() {
+                @Mock
+                public TMasterOpResult proxyExecute(TMasterOpRequest request, Frontend requestFE) {
+                    new ConnectContext().setThreadLocalInfo();
+                    return new TMasterOpResult();
+                }
+            };
+
+            service.forward(request);
+            Assertions.assertNull(ConnectContext.get());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testForwardRemoveConnectContextAfterException() throws Exception {
+        final FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
+        final TMasterOpRequest request = makeRequest();
+
+        try {
+            new MockUp<ConnectProcessor>() {
+                @Mock
+                public TMasterOpResult proxyExecute(TMasterOpRequest request, Frontend requestFE) {
+                    new ConnectContext().setThreadLocalInfo();
+                    throw new RuntimeException("unknown exception");
+                }
+            };
+
+            final TMasterOpResult result = service.forward(request);
+            Assertions.assertEquals("unknown exception", result.errorMsg);
+            Assertions.assertNull(ConnectContext.get());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
     public void testArrowFlightSQL() throws Exception {
         PQueryStatistics statistics = new PQueryStatistics();
         statistics.scanBytes = 1L;


### PR DESCRIPTION
## Why I'm doing:
follower -> leader::forard will pollute the ConnectContext for thrift worker which cause incorrect timestamp generation when other request reuse this thrift worker thread

## What I'm doing:
Remove thread local when the leader::forard is finished

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
