### PR TITLE
[BugFix] Fix cross-published txn log num_rows/data_size inflation during tablet split

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -238,9 +238,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                 // Splitting tablet
                 const auto& splitting_tablet_info = resharding_tablet_info.splitting_tablet_info();
                 task_num += splitting_tablet_info.new_tablet_ids_size();
+                int32_t split_count = splitting_tablet_info.new_tablet_ids_size();
+                int32_t split_index = 0;
                 for (auto new_tablet_id : splitting_tablet_info.new_tablet_ids()) {
                     publish_tablet_infos.emplace_back(lake::PublishTabletInfo::SPLITTING_TABLET,
-                                                      splitting_tablet_info.old_tablet_id(), new_tablet_id);
+                                                      splitting_tablet_info.old_tablet_id(), new_tablet_id,
+                                                      split_count, split_index);
+                    split_index++;
                 }
             } else if (resharding_tablet_info.has_merging_tablet_info()) {
                 // Merging tablets

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -242,8 +242,8 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                 int32_t split_index = 0;
                 for (auto new_tablet_id : splitting_tablet_info.new_tablet_ids()) {
                     publish_tablet_infos.emplace_back(lake::PublishTabletInfo::SPLITTING_TABLET,
-                                                      splitting_tablet_info.old_tablet_id(), new_tablet_id,
-                                                      split_count, split_index);
+                                                      splitting_tablet_info.old_tablet_id(), new_tablet_id, split_count,
+                                                      split_index);
                     split_index++;
                 }
             } else if (resharding_tablet_info.has_merging_tablet_info()) {

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -293,6 +293,8 @@ StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetada
     if (publish_tablet_info.get_publish_tablet_type() == PublishTabletInfo::SPLITTING_TABLET) {
         tablet_reshard_helper::set_all_data_files_shared(new_txn_log.get());
         RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(new_txn_log.get(), base_tablet_metadata->range()));
+        tablet_reshard_helper::update_txn_log_data_stats(new_txn_log.get(), publish_tablet_info.get_split_count(),
+                                                         publish_tablet_info.get_split_index());
     }
 
     return new_txn_log;

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -17,6 +17,7 @@
 #include <span>
 #include <vector>
 
+#include "common/logging.h"
 #include "common/statusor.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet_metadata.h"
@@ -43,10 +44,14 @@ public:
 
     // For publish cross transaction with only one txn log, including splitting tablet and identical tablet
     PublishTabletInfo(PublishTabletType publish_tablet_type, int64_t tablet_id_in_txn_log,
-                      int64_t tablet_id_in_metadata)
+                      int64_t tablet_id_in_metadata, int32_t split_count = 0, int32_t split_index = 0)
             : publish_tablet_type(publish_tablet_type),
               tablet_ids_in_txn_logs(1, tablet_id_in_txn_log),
-              tablet_id_in_metadata(tablet_id_in_metadata) {}
+              tablet_id_in_metadata(tablet_id_in_metadata),
+              split_count(split_count),
+              split_index(split_index) {
+        DCHECK(publish_tablet_type != SPLITTING_TABLET || (split_count > 1 && split_index >= 0 && split_index < split_count));
+    }
 
     // For cross publish merging tablet with multiple txn logs
     PublishTabletInfo(PublishTabletType publish_tablet_type, const std::span<const int64_t>& tablet_ids_in_txn_logs,
@@ -58,6 +63,8 @@ public:
     PublishTabletType get_publish_tablet_type() const { return publish_tablet_type; }
     const std::vector<int64_t>& get_tablet_ids_in_txn_logs() const { return tablet_ids_in_txn_logs; }
     int64_t get_tablet_id_in_metadata() const { return tablet_id_in_metadata; }
+    int32_t get_split_count() const { return split_count; }
+    int32_t get_split_index() const { return split_index; }
     // A txn log will be applied to multiple tablets in splitting tablet, so it cannot be deleted after applied.
     bool can_delete_txn_log() const { return publish_tablet_type != SPLITTING_TABLET; }
 
@@ -65,6 +72,8 @@ private:
     PublishTabletType publish_tablet_type;
     std::vector<int64_t> tablet_ids_in_txn_logs;
     int64_t tablet_id_in_metadata;
+    int32_t split_count = 0;
+    int32_t split_index = 0;
 };
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -50,7 +50,8 @@ public:
               tablet_id_in_metadata(tablet_id_in_metadata),
               split_count(split_count),
               split_index(split_index) {
-        DCHECK(publish_tablet_type != SPLITTING_TABLET || (split_count > 1 && split_index >= 0 && split_index < split_count));
+        DCHECK(publish_tablet_type != SPLITTING_TABLET ||
+               (split_count > 1 && split_index >= 0 && split_index < split_count));
     }
 
     // For cross publish merging tablet with multiple txn logs

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -175,4 +175,45 @@ Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range) {
     return Status::OK();
 }
 
+void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index) {
+    if (split_count <= 1) return;
+
+    if (rowset->has_num_rows()) {
+        int64_t num_rows = rowset->num_rows();
+        rowset->set_num_rows(num_rows / split_count + (split_index < num_rows % split_count ? 1 : 0));
+    }
+    if (rowset->has_data_size()) {
+        int64_t data_size = rowset->data_size();
+        rowset->set_data_size(data_size / split_count + (split_index < data_size % split_count ? 1 : 0));
+    }
+}
+
+void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index) {
+    if (txn_log->has_op_write() && txn_log->mutable_op_write()->has_rowset()) {
+        update_rowset_data_stats(txn_log->mutable_op_write()->mutable_rowset(), split_count, split_index);
+    }
+    if (txn_log->has_op_compaction() && txn_log->mutable_op_compaction()->has_output_rowset()) {
+        update_rowset_data_stats(txn_log->mutable_op_compaction()->mutable_output_rowset(), split_count, split_index);
+    }
+    if (txn_log->has_op_schema_change()) {
+        for (auto& rowset : *txn_log->mutable_op_schema_change()->mutable_rowsets()) {
+            update_rowset_data_stats(&rowset, split_count, split_index);
+        }
+    }
+    if (txn_log->has_op_replication()) {
+        for (auto& op_write : *txn_log->mutable_op_replication()->mutable_op_writes()) {
+            if (op_write.has_rowset()) {
+                update_rowset_data_stats(op_write.mutable_rowset(), split_count, split_index);
+            }
+        }
+    }
+    if (txn_log->has_op_parallel_compaction()) {
+        for (auto& subtask : *txn_log->mutable_op_parallel_compaction()->mutable_subtask_compactions()) {
+            if (subtask.has_output_rowset()) {
+                update_rowset_data_stats(subtask.mutable_output_rowset(), split_count, split_index);
+            }
+        }
+    }
+}
+
 } // namespace starrocks::lake::tablet_reshard_helper

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -30,4 +30,7 @@ StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRan
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range);
 Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range);
 
+void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index);
+void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index);
+
 } // namespace starrocks::lake::tablet_reshard_helper

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1445,7 +1445,7 @@ TEST_F(LakeTabletReshardTest, test_split_cross_publish_sets_rowset_range_in_txn_
 
     EXPECT_OK(_tablet_manager->put_txn_log(log));
 
-    lake::PublishTabletInfo tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, old_tablet_id, new_tablet_id);
+    lake::PublishTabletInfo tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, old_tablet_id, new_tablet_id, 2, 0);
     TxnInfoPB txn_info;
     txn_info.set_txn_id(100);
     txn_info.set_txn_type(TXN_NORMAL);
@@ -1526,7 +1526,7 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
     fill_sstable(op_parallel_compaction->add_output_sstables(), "op_parallel_compaction_1.sst");
 
     lake::PublishTabletInfo publish_tablet_info(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(),
-                                                next_id());
+                                                next_id(), 2, 0);
     ASSIGN_OR_ABORT(auto converted, convert_txn_log(txn_log, base_metadata, publish_tablet_info));
 
     EXPECT_EQ(publish_tablet_info.get_tablet_id_in_metadata(), converted->tablet_id());
@@ -3439,6 +3439,183 @@ TEST_F(LakeTabletReshardTest, test_union_range_unequal_bounds) {
     VariantTuple expected_upper;
     ASSERT_OK(expected_upper.from_proto(generate_sort_key(25)));
     EXPECT_EQ(0, upper.compare(expected_upper));
+}
+
+TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_basic) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(100);
+    rowset.set_data_size(1000);
+
+    // Split into 3, index 0: gets remainder
+    lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 3, 0);
+    EXPECT_EQ(34, rowset.num_rows());  // 100/3=33, 100%3=1, index 0 < 1 => +1
+    EXPECT_EQ(334, rowset.data_size()); // 1000/3=333, 1000%3=1, index 0 < 1 => +1
+}
+
+TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_remainder_distribution) {
+    // Verify that splitting 10 rows into 3 tablets gives 4+3+3 = 10
+    int64_t total_rows = 0;
+    int64_t total_size = 0;
+    for (int32_t i = 0; i < 3; i++) {
+        RowsetMetadataPB rowset;
+        rowset.set_num_rows(10);
+        rowset.set_data_size(100);
+        lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 3, i);
+        total_rows += rowset.num_rows();
+        total_size += rowset.data_size();
+    }
+    EXPECT_EQ(10, total_rows);
+    EXPECT_EQ(100, total_size);
+}
+
+TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_exact_division) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(9);
+    rowset.set_data_size(300);
+
+    lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 3, 0);
+    EXPECT_EQ(3, rowset.num_rows());
+    EXPECT_EQ(100, rowset.data_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_split_count_one) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(100);
+    rowset.set_data_size(1000);
+
+    lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 1, 0);
+    EXPECT_EQ(100, rowset.num_rows());
+    EXPECT_EQ(1000, rowset.data_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_split_count_zero) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(100);
+    rowset.set_data_size(1000);
+
+    lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 0, 0);
+    EXPECT_EQ(100, rowset.num_rows());
+    EXPECT_EQ(1000, rowset.data_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_update_txn_log_data_stats_all_op_types) {
+    TxnLogPB txn_log;
+    txn_log.set_tablet_id(1);
+    txn_log.set_txn_id(1000);
+
+    // op_write
+    auto* op_write_rowset = txn_log.mutable_op_write()->mutable_rowset();
+    op_write_rowset->set_num_rows(10);
+    op_write_rowset->set_data_size(100);
+
+    // op_compaction
+    auto* op_compaction_rowset = txn_log.mutable_op_compaction()->mutable_output_rowset();
+    op_compaction_rowset->set_num_rows(20);
+    op_compaction_rowset->set_data_size(200);
+
+    // op_schema_change
+    auto* schema_change_rowset = txn_log.mutable_op_schema_change()->add_rowsets();
+    schema_change_rowset->set_num_rows(30);
+    schema_change_rowset->set_data_size(300);
+
+    // op_replication
+    auto* repl_rowset = txn_log.mutable_op_replication()->add_op_writes()->mutable_rowset();
+    repl_rowset->set_num_rows(40);
+    repl_rowset->set_data_size(400);
+
+    // op_parallel_compaction
+    auto* parallel_rowset = txn_log.mutable_op_parallel_compaction()->add_subtask_compactions()->mutable_output_rowset();
+    parallel_rowset->set_num_rows(50);
+    parallel_rowset->set_data_size(500);
+
+    // split_count=3, split_index=0 (gets extra remainder)
+    lake::tablet_reshard_helper::update_txn_log_data_stats(&txn_log, 3, 0);
+
+    EXPECT_EQ(4, txn_log.op_write().rowset().num_rows());        // 10/3=3 + (0<1?1:0) = 4
+    EXPECT_EQ(34, txn_log.op_write().rowset().data_size());       // 100/3=33 + (0<1?1:0) = 34
+    EXPECT_EQ(7, txn_log.op_compaction().output_rowset().num_rows());  // 20/3=6 + (0<2?1:0) = 7
+    EXPECT_EQ(67, txn_log.op_compaction().output_rowset().data_size()); // 200/3=66 + (0<2?1:0) = 67
+    EXPECT_EQ(10, txn_log.op_schema_change().rowsets(0).num_rows());
+    EXPECT_EQ(100, txn_log.op_schema_change().rowsets(0).data_size());
+    EXPECT_EQ(14, txn_log.op_replication().op_writes(0).rowset().num_rows());  // 40/3=13 + (0<1?1:0) = 14
+    EXPECT_EQ(134, txn_log.op_replication().op_writes(0).rowset().data_size()); // 400/3=133 + (0<1?1:0) = 134
+    EXPECT_EQ(17, txn_log.op_parallel_compaction().subtask_compactions(0).output_rowset().num_rows()); // 50/3=16 + (0<2?1:0) = 17
+    EXPECT_EQ(167, txn_log.op_parallel_compaction().subtask_compactions(0).output_rowset().data_size()); // 500/3=166 + (0<2?1:0) = 167
+}
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_adjusts_data_stats_for_splitting) {
+    auto base_metadata = std::make_shared<TabletMetadataPB>();
+    base_metadata->set_id(next_id());
+    base_metadata->set_version(1);
+    base_metadata->set_next_rowset_id(1);
+    base_metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    base_metadata->mutable_range()->set_lower_bound_included(true);
+    base_metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    base_metadata->mutable_range()->set_upper_bound_included(false);
+
+    auto txn_log = std::make_shared<TxnLogPB>();
+    txn_log->set_tablet_id(base_metadata->id());
+    txn_log->set_txn_id(1000);
+
+    auto* rowset = txn_log->mutable_op_write()->mutable_rowset();
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+    rowset->add_segments("seg.dat");
+    rowset->add_segment_size(1000);
+    auto* range = rowset->mutable_range();
+    range->mutable_lower_bound()->CopyFrom(generate_sort_key(5));
+    range->set_lower_bound_included(true);
+    range->mutable_upper_bound()->CopyFrom(generate_sort_key(25));
+    range->set_upper_bound_included(false);
+
+    // Simulate 3-way split, this is tablet index 0
+    lake::PublishTabletInfo info0(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(), next_id(), 3, 0);
+    ASSIGN_OR_ABORT(auto converted0, lake::convert_txn_log(txn_log, base_metadata, info0));
+    EXPECT_EQ(34, converted0->op_write().rowset().num_rows());   // 100/3=33 + (0<1?1:0) = 34
+    EXPECT_EQ(334, converted0->op_write().rowset().data_size()); // 1000/3=333 + (0<1?1:0) = 334
+
+    // tablet index 1
+    lake::PublishTabletInfo info1(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(), next_id(), 3, 1);
+    ASSIGN_OR_ABORT(auto converted1, lake::convert_txn_log(txn_log, base_metadata, info1));
+    EXPECT_EQ(33, converted1->op_write().rowset().num_rows());
+    EXPECT_EQ(333, converted1->op_write().rowset().data_size());
+
+    // tablet index 2
+    lake::PublishTabletInfo info2(lake::PublishTabletInfo::SPLITTING_TABLET, txn_log->tablet_id(), next_id(), 3, 2);
+    ASSIGN_OR_ABORT(auto converted2, lake::convert_txn_log(txn_log, base_metadata, info2));
+    EXPECT_EQ(33, converted2->op_write().rowset().num_rows());
+    EXPECT_EQ(333, converted2->op_write().rowset().data_size());
+
+    // Verify total equals original
+    EXPECT_EQ(100, converted0->op_write().rowset().num_rows() + converted1->op_write().rowset().num_rows() +
+                           converted2->op_write().rowset().num_rows());
+    EXPECT_EQ(1000, converted0->op_write().rowset().data_size() + converted1->op_write().rowset().data_size() +
+                            converted2->op_write().rowset().data_size());
+
+    // Verify ranges are still adjusted (shared and intersected with base range)
+    ASSERT_TRUE(converted0->op_write().rowset().shared_segments_size() > 0);
+    EXPECT_TRUE(converted0->op_write().rowset().shared_segments(0));
+}
+
+TEST_F(LakeTabletReshardTest, test_convert_txn_log_normal_publish_no_stats_change) {
+    auto base_metadata = std::make_shared<TabletMetadataPB>();
+    base_metadata->set_id(next_id());
+    base_metadata->set_version(1);
+
+    auto txn_log = std::make_shared<TxnLogPB>();
+    txn_log->set_tablet_id(base_metadata->id());
+    txn_log->set_txn_id(1000);
+    txn_log->mutable_op_write()->mutable_rowset()->set_num_rows(100);
+    txn_log->mutable_op_write()->mutable_rowset()->set_data_size(1000);
+
+    lake::PublishTabletInfo info(base_metadata->id());
+    ASSIGN_OR_ABORT(auto converted, lake::convert_txn_log(txn_log, base_metadata, info));
+
+    // Normal publish returns the same txn_log pointer, no changes
+    EXPECT_EQ(txn_log.get(), converted.get());
+    EXPECT_EQ(100, converted->op_write().rowset().num_rows());
+    EXPECT_EQ(1000, converted->op_write().rowset().data_size());
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3448,7 +3448,7 @@ TEST_F(LakeTabletReshardTest, test_update_rowset_data_stats_basic) {
 
     // Split into 3, index 0: gets remainder
     lake::tablet_reshard_helper::update_rowset_data_stats(&rowset, 3, 0);
-    EXPECT_EQ(34, rowset.num_rows());  // 100/3=33, 100%3=1, index 0 < 1 => +1
+    EXPECT_EQ(34, rowset.num_rows());   // 100/3=33, 100%3=1, index 0 < 1 => +1
     EXPECT_EQ(334, rowset.data_size()); // 1000/3=333, 1000%3=1, index 0 < 1 => +1
 }
 
@@ -3524,23 +3524,30 @@ TEST_F(LakeTabletReshardTest, test_update_txn_log_data_stats_all_op_types) {
     repl_rowset->set_data_size(400);
 
     // op_parallel_compaction
-    auto* parallel_rowset = txn_log.mutable_op_parallel_compaction()->add_subtask_compactions()->mutable_output_rowset();
+    auto* parallel_rowset =
+            txn_log.mutable_op_parallel_compaction()->add_subtask_compactions()->mutable_output_rowset();
     parallel_rowset->set_num_rows(50);
     parallel_rowset->set_data_size(500);
 
     // split_count=3, split_index=0 (gets extra remainder)
     lake::tablet_reshard_helper::update_txn_log_data_stats(&txn_log, 3, 0);
 
-    EXPECT_EQ(4, txn_log.op_write().rowset().num_rows());        // 10/3=3 + (0<1?1:0) = 4
-    EXPECT_EQ(34, txn_log.op_write().rowset().data_size());       // 100/3=33 + (0<1?1:0) = 34
-    EXPECT_EQ(7, txn_log.op_compaction().output_rowset().num_rows());  // 20/3=6 + (0<2?1:0) = 7
+    EXPECT_EQ(4, txn_log.op_write().rowset().num_rows());               // 10/3=3 + (0<1?1:0) = 4
+    EXPECT_EQ(34, txn_log.op_write().rowset().data_size());             // 100/3=33 + (0<1?1:0) = 34
+    EXPECT_EQ(7, txn_log.op_compaction().output_rowset().num_rows());   // 20/3=6 + (0<2?1:0) = 7
     EXPECT_EQ(67, txn_log.op_compaction().output_rowset().data_size()); // 200/3=66 + (0<2?1:0) = 67
     EXPECT_EQ(10, txn_log.op_schema_change().rowsets(0).num_rows());
     EXPECT_EQ(100, txn_log.op_schema_change().rowsets(0).data_size());
-    EXPECT_EQ(14, txn_log.op_replication().op_writes(0).rowset().num_rows());  // 40/3=13 + (0<1?1:0) = 14
+    EXPECT_EQ(14, txn_log.op_replication().op_writes(0).rowset().num_rows());   // 40/3=13 + (0<1?1:0) = 14
     EXPECT_EQ(134, txn_log.op_replication().op_writes(0).rowset().data_size()); // 400/3=133 + (0<1?1:0) = 134
-    EXPECT_EQ(17, txn_log.op_parallel_compaction().subtask_compactions(0).output_rowset().num_rows()); // 50/3=16 + (0<2?1:0) = 17
-    EXPECT_EQ(167, txn_log.op_parallel_compaction().subtask_compactions(0).output_rowset().data_size()); // 500/3=166 + (0<2?1:0) = 167
+    EXPECT_EQ(17, txn_log.op_parallel_compaction()
+                          .subtask_compactions(0)
+                          .output_rowset()
+                          .num_rows()); // 50/3=16 + (0<2?1:0) = 17
+    EXPECT_EQ(167, txn_log.op_parallel_compaction()
+                           .subtask_compactions(0)
+                           .output_rowset()
+                           .data_size()); // 500/3=166 + (0<2?1:0) = 167
 }
 
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_adjusts_data_stats_for_splitting) {


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                                                                                                          
                                                                                                     
  In shared-data mode, when a tablet is split into N new tablets, transactions that started before the split are "cross-published" to all N split tablets. The `convert_txn_log` function copies the original txn log to each new tablet but does NOT adjust `num_rows` and  `data_size` in the rowsets. This means each of the N split tablets receives the **full** original values, causing N-fold inflation of these statistics. This affects compaction decisions, query planning estimates, and tablet metadata accuracy.

## What I'm doing:

  For all rowsets in cross-published txn logs, divide `num_rows` and `data_size` by `split_count`, using `split_index` to distribute remainders to the first few tablets. This ensures the total across all split tablets is exactly equal to the original value.

```
  base = value / split_count
  remainder = value % split_count
  adjusted = base + (split_index < remainder ? 1 : 0)
```

  This is consistent with the existing remainder distribution pattern in `tablet_splitter.cpp`.

  Specific changes:
  - Add `split_count` and `split_index` fields to `PublishTabletInfo`
  - Pass `split_count` and `split_index` when constructing `PublishTabletInfo` for `SPLITTING_TABLET` in `lake_service.cpp`
  - Add `update_rowset_data_stats` and `update_txn_log_data_stats` helper functions in `tablet_reshard_helper`
  - Call `update_txn_log_data_stats` in `convert_txn_log` after existing range updates
  - Add 8 unit tests covering basic division, remainder distribution, exact division, edge cases, all operation types, and end-to-end verification

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
