### PR TITLE
[Enhancement] Parallelize SSTable opening during persistent index init

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -14,8 +14,6 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
-#include <future>
-
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "common/config_cache_fwd.h"
@@ -68,8 +66,8 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         const TabletMetadataPtr& metadata) {
     const int num_sstables = sstable_meta.sstables_size();
     std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
-    std::vector<Status> statuses(num_sstables);
 
+    Status shared_status;
     auto open_one = [&](int idx) {
         auto& pb = sstable_meta.sstables(idx);
         auto res = PersistentIndexSstable::new_sstable(pb, tablet_mgr->sst_location(tablet_id, pb.filename()), cache,
@@ -77,33 +75,22 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         if (res.ok()) {
             sstables[idx] = std::move(res.value());
         } else {
-            statuses[idx] = res.status();
+            shared_status.update(res.status());
         }
     };
 
-    if (num_sstables > 1) {
-        std::vector<std::future<void>> futures;
-        futures.reserve(num_sstables - 1);
-        for (int i = 0; i < num_sstables - 1; i++) {
-            auto task = std::make_shared<std::packaged_task<void()>>([&open_one, i]() { open_one(i); });
-            auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
-            if (!st.ok()) {
-                open_one(i);
-            } else {
-                futures.push_back(task->get_future());
-            }
-        }
-        open_one(num_sstables - 1);
-        for (auto& f : futures) {
-            f.get();
-        }
-    } else if (num_sstables == 1) {
-        open_one(0);
-    }
-
+    auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+            ThreadPool::ExecutionMode::CONCURRENT);
     for (int i = 0; i < num_sstables; i++) {
-        RETURN_IF_ERROR(statuses[i]);
+        auto st = token->submit_func([&open_one, i]() { open_one(i); });
+        if (!st.ok()) {
+            // Fallback to inline execution if submit fails
+            open_one(i);
+        }
     }
+    token->wait();
+
+    RETURN_IF_ERROR(shared_status);
     return std::move(sstables);
 }
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -81,16 +81,24 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         }
     };
 
-    auto token =
-            ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    std::unique_ptr<ThreadPoolToken> token;
+    if (config::enable_pk_index_parallel_execution) {
+        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+    }
     for (int i = 0; i < num_sstables; i++) {
-        auto st = token->submit_func([&open_one, i]() { open_one(i); });
-        if (!st.ok()) {
-            // Fallback to inline execution if submit fails
+        if (token) {
+            auto st = token->submit_func([&open_one, i]() { open_one(i); });
+            if (!st.ok()) {
+                open_one(i);
+            }
+        } else {
             open_one(i);
         }
     }
-    token->wait();
+    if (token) {
+        token->wait();
+    }
 
     RETURN_IF_ERROR(shared_status);
     return std::move(sstables);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -67,6 +67,7 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
     const int num_sstables = sstable_meta.sstables_size();
     std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
 
+    std::mutex mutex;
     Status shared_status;
     auto open_one = [&](int idx) {
         auto& pb = sstable_meta.sstables(idx);
@@ -75,6 +76,7 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         if (res.ok()) {
             sstables[idx] = std::move(res.value());
         } else {
+            std::lock_guard<std::mutex> lock(mutex);
             shared_status.update(res.status());
         }
     };

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -121,8 +121,8 @@ Status LakePersistentIndex::init(const TabletMetadataPtr& metadata) {
     std::vector<PersistentIndexSstableUniquePtr> sstables;
     {
         int64_t t_open = GetCurrentTimeMicros();
-        ASSIGN_OR_RETURN(sstables,
-                         _open_sstables_parallel(sstable_meta, _tablet_mgr, _tablet_id, block_cache->cache(), metadata));
+        ASSIGN_OR_RETURN(sstables, _open_sstables_parallel(sstable_meta, _tablet_mgr, _tablet_id, block_cache->cache(),
+                                                           metadata));
         sst_open_us = GetCurrentTimeMicros() - t_open;
     }
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -79,8 +79,8 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         }
     };
 
-    auto token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
-            ThreadPool::ExecutionMode::CONCURRENT);
+    auto token =
+            ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     for (int i = 0; i < num_sstables; i++) {
         auto st = token->submit_func([&open_one, i]() { open_one(i); });
         if (!st.ok()) {

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
+#include <future>
+
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "common/config_cache_fwd.h"
@@ -68,29 +70,75 @@ Status LakePersistentIndex::init(const TabletMetadataPtr& metadata) {
         return Status::InternalError("Block cache is null.");
     }
     const PersistentIndexSstableMetaPB& sstable_meta = metadata->sstable_meta();
-    TRACE_COUNTER_INCREMENT("pindex_init_sst_cnt", sstable_meta.sstables_size());
-    int64_t total_sst_filesize = 0;
+    const int num_sstables = sstable_meta.sstables_size();
+    TRACE_COUNTER_INCREMENT("pindex_init_sst_cnt", num_sstables);
+
+    // Phase 1: Open all SSTables in parallel.
+    // Each new_sstable() involves IO (reading file footer, index block, filter block)
+    // and benefits from concurrency when there are many SSTable files.
+    std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
+    std::vector<Status> open_statuses(num_sstables);
+
+    auto open_sstable = [&](int idx) {
+        auto& sstable_pb = sstable_meta.sstables(idx);
+        auto res = PersistentIndexSstable::new_sstable(
+                sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()), block_cache->cache(),
+                true /* need filter */, nullptr, metadata, _tablet_mgr);
+        if (res.ok()) {
+            sstables[idx] = std::move(res.value());
+        } else {
+            open_statuses[idx] = res.status();
+        }
+    };
+
     int64_t sst_open_us = 0;
+    {
+        int64_t t_open = GetCurrentTimeMicros();
+        if (num_sstables > 1) {
+            std::vector<std::future<void>> futures;
+            futures.reserve(num_sstables - 1);
+            for (int i = 0; i < num_sstables - 1; i++) {
+                auto task =
+                        std::make_shared<std::packaged_task<void()>>([&open_sstable, i]() { open_sstable(i); });
+                auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
+                if (!st.ok()) {
+                    open_sstable(i);
+                } else {
+                    futures.push_back(task->get_future());
+                }
+            }
+            // Run the last SSTable in current thread
+            open_sstable(num_sstables - 1);
+            for (auto& f : futures) {
+                f.get();
+            }
+        } else if (num_sstables == 1) {
+            open_sstable(0);
+        }
+        sst_open_us = GetCurrentTimeMicros() - t_open;
+    }
+
+    for (int i = 0; i < num_sstables; i++) {
+        RETURN_IF_ERROR(open_statuses[i]);
+    }
+
+    // Phase 2: Group SSTables into filesets (sequential, preserves order).
+    int64_t total_sst_filesize = 0;
     uint64_t max_rss_rowid = 0;
     std::vector<std::unique_ptr<PersistentIndexSstable>> cur_fileset;
-    for (auto& sstable_pb : sstable_meta.sstables()) {
-        int64_t t_open = GetCurrentTimeMicros();
-        ASSIGN_OR_RETURN(auto sstable,
-                         PersistentIndexSstable::new_sstable(
-                                 sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()),
-                                 block_cache->cache(), true /* need filter */, nullptr, metadata, _tablet_mgr));
-        sst_open_us += GetCurrentTimeMicros() - t_open;
+    for (int i = 0; i < num_sstables; i++) {
+        auto& sstable_pb = sstable_meta.sstables(i);
         total_sst_filesize += sstable_pb.filesize();
         if (cur_fileset.empty() ||
             (cur_fileset.back()->sstable_pb().has_fileset_id() &&
              UniqueId(cur_fileset.back()->sstable_pb().fileset_id()) == UniqueId(sstable_pb.fileset_id()))) {
-            cur_fileset.emplace_back(std::move(sstable));
+            cur_fileset.emplace_back(std::move(sstables[i]));
         } else {
             auto fileset = std::make_unique<PersistentIndexSstableFileset>();
             RETURN_IF_ERROR(fileset->init(cur_fileset));
             _sstable_filesets.emplace_back(std::move(fileset));
             cur_fileset.clear();
-            cur_fileset.emplace_back(std::move(sstable));
+            cur_fileset.emplace_back(std::move(sstables[i]));
         }
         max_rss_rowid = std::max(max_rss_rowid, sstable_pb.max_rss_rowid());
     }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -98,8 +98,7 @@ Status LakePersistentIndex::init(const TabletMetadataPtr& metadata) {
             std::vector<std::future<void>> futures;
             futures.reserve(num_sstables - 1);
             for (int i = 0; i < num_sstables - 1; i++) {
-                auto task =
-                        std::make_shared<std::packaged_task<void()>>([&open_sstable, i]() { open_sstable(i); });
+                auto task = std::make_shared<std::packaged_task<void()>>([&open_sstable, i]() { open_sstable(i); });
                 auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
                 if (!st.ok()) {
                     open_sstable(i);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -63,6 +63,50 @@ LakePersistentIndex::~LakePersistentIndex() {
     _sstable_filesets.clear();
 }
 
+StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_open_sstables_parallel(
+        const PersistentIndexSstableMetaPB& sstable_meta, TabletManager* tablet_mgr, int64_t tablet_id, Cache* cache,
+        const TabletMetadataPtr& metadata) {
+    const int num_sstables = sstable_meta.sstables_size();
+    std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
+    std::vector<Status> statuses(num_sstables);
+
+    auto open_one = [&](int idx) {
+        auto& pb = sstable_meta.sstables(idx);
+        auto res = PersistentIndexSstable::new_sstable(pb, tablet_mgr->sst_location(tablet_id, pb.filename()), cache,
+                                                       true /* need filter */, nullptr, metadata, tablet_mgr);
+        if (res.ok()) {
+            sstables[idx] = std::move(res.value());
+        } else {
+            statuses[idx] = res.status();
+        }
+    };
+
+    if (num_sstables > 1) {
+        std::vector<std::future<void>> futures;
+        futures.reserve(num_sstables - 1);
+        for (int i = 0; i < num_sstables - 1; i++) {
+            auto task = std::make_shared<std::packaged_task<void()>>([&open_one, i]() { open_one(i); });
+            auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
+            if (!st.ok()) {
+                open_one(i);
+            } else {
+                futures.push_back(task->get_future());
+            }
+        }
+        open_one(num_sstables - 1);
+        for (auto& f : futures) {
+            f.get();
+        }
+    } else if (num_sstables == 1) {
+        open_one(0);
+    }
+
+    for (int i = 0; i < num_sstables; i++) {
+        RETURN_IF_ERROR(statuses[i]);
+    }
+    return std::move(sstables);
+}
+
 Status LakePersistentIndex::init(const TabletMetadataPtr& metadata) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pindex_init_us");
     auto* block_cache = _tablet_mgr->update_mgr()->block_cache();
@@ -73,55 +117,16 @@ Status LakePersistentIndex::init(const TabletMetadataPtr& metadata) {
     const int num_sstables = sstable_meta.sstables_size();
     TRACE_COUNTER_INCREMENT("pindex_init_sst_cnt", num_sstables);
 
-    // Phase 1: Open all SSTables in parallel.
-    // Each new_sstable() involves IO (reading file footer, index block, filter block)
-    // and benefits from concurrency when there are many SSTable files.
-    std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
-    std::vector<Status> open_statuses(num_sstables);
-
-    auto open_sstable = [&](int idx) {
-        auto& sstable_pb = sstable_meta.sstables(idx);
-        auto res = PersistentIndexSstable::new_sstable(
-                sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()), block_cache->cache(),
-                true /* need filter */, nullptr, metadata, _tablet_mgr);
-        if (res.ok()) {
-            sstables[idx] = std::move(res.value());
-        } else {
-            open_statuses[idx] = res.status();
-        }
-    };
-
     int64_t sst_open_us = 0;
+    std::vector<PersistentIndexSstableUniquePtr> sstables;
     {
         int64_t t_open = GetCurrentTimeMicros();
-        if (num_sstables > 1) {
-            std::vector<std::future<void>> futures;
-            futures.reserve(num_sstables - 1);
-            for (int i = 0; i < num_sstables - 1; i++) {
-                auto task = std::make_shared<std::packaged_task<void()>>([&open_sstable, i]() { open_sstable(i); });
-                auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func([task]() { (*task)(); });
-                if (!st.ok()) {
-                    open_sstable(i);
-                } else {
-                    futures.push_back(task->get_future());
-                }
-            }
-            // Run the last SSTable in current thread
-            open_sstable(num_sstables - 1);
-            for (auto& f : futures) {
-                f.get();
-            }
-        } else if (num_sstables == 1) {
-            open_sstable(0);
-        }
+        ASSIGN_OR_RETURN(sstables,
+                         _open_sstables_parallel(sstable_meta, _tablet_mgr, _tablet_id, block_cache->cache(), metadata));
         sst_open_us = GetCurrentTimeMicros() - t_open;
     }
 
-    for (int i = 0; i < num_sstables; i++) {
-        RETURN_IF_ERROR(open_statuses[i]);
-    }
-
-    // Phase 2: Group SSTables into filesets (sequential, preserves order).
+    // Group SSTables into filesets (sequential, preserves order).
     int64_t total_sst_filesize = 0;
     uint64_t max_rss_rowid = 0;
     std::vector<std::unique_ptr<PersistentIndexSstable>> cur_fileset;

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -158,6 +158,12 @@ public:
     int64_t publish_sst_flush_bytes() const { return _publish_sst_flush_bytes; }
 
 private:
+    // Open all SSTables in parallel using thread pool.
+    // Returns opened SSTables in the same order as sstable_meta.sstables().
+    static StatusOr<std::vector<PersistentIndexSstableUniquePtr>> _open_sstables_parallel(
+            const PersistentIndexSstableMetaPB& sstable_meta, TabletManager* tablet_mgr, int64_t tablet_id,
+            Cache* cache, const TabletMetadataPtr& metadata);
+
     bool is_memtable_full() const;
 
     bool too_many_rebuild_files() const;

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2531,9 +2531,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_preload_update_state_slow_log) {
 }
 
 // Test that persistent index rebuild skips rows already covered by SSTables.
-// This verifies the optimization where rebuild_rss_rowid_point is used to set
-// a rowid range on the segment iterator, avoiding unnecessary IO for rows
-// that are already in SSTables.
 TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_rows) {
     if (!GetParam().enable_persistent_index ||
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
@@ -2542,11 +2539,8 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
     const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
-    config::l0_max_mem_usage = 10; // force sstable flush
+    config::l0_max_mem_usage = 10;
 
-    // Step 1: Write multiple rowsets to build up SSTables.
-    // Each publish will flush to SSTable due to small l0_max_mem_usage.
-    // This creates a rebuild_rss_rowid_point that covers most existing rows.
     for (int r = 0; r < 3; r++) {
         auto [chunk, indexes] = gen_data_and_index(kChunkSize, r, true, true);
         int64_t txn_id = next_id();
@@ -2566,17 +2560,10 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
-
-    // Verify: 3 non-overlapping chunks
     ASSERT_EQ(kChunkSize * 3, read_rows(tablet_id, version));
 
-    // Step 2: Remove persistent index to force rebuild on next publish.
-    // The rebuild should use rowid range to skip rows covered by SSTables.
     _update_mgr->unload_and_remove_primary_index(tablet_id);
 
-    // Step 3: Write new data. This triggers rebuild where most existing rows
-    // should be skipped (covered by SSTables), only a few rows near the
-    // rebuild_rss_rowid_point boundary need to be read.
     auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 3, true, true);
     {
         int64_t txn_id = next_id();
@@ -2596,8 +2583,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
-
-    // Step 4: Verify correctness after rebuild with row skipping
     ASSERT_EQ(kChunkSize * 4, read_rows(tablet_id, version));
 
     config::l0_max_mem_usage = old_l0_max_mem_usage;
@@ -2615,7 +2600,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
     const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 10;
 
-    // Write 4 rowsets with overlapping keys (same key range, shift=0)
     for (int r = 0; r < 4; r++) {
         auto [chunk, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
         int64_t txn_id = next_id();
@@ -2635,14 +2619,10 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
-
-    // Should have kChunkSize rows (all upserts to same key range)
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
 
-    // Force rebuild
     _update_mgr->unload_and_remove_primary_index(tablet_id);
 
-    // Write again with overlapping keys
     auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 0, true, true);
     {
         int64_t txn_id = next_id();
@@ -2662,9 +2642,65 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
-
-    // Still kChunkSize rows
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+}
+
+// Test that persistent index init works correctly when SSTables are opened in parallel.
+TEST_P(LakePrimaryKeyPublishTest, test_parallel_sstable_open_on_index_init) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+
+    for (int r = 0; r < 5; r++) {
+        auto [chunk, indexes] = gen_data_and_index(kChunkSize, r, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 5, read_rows(tablet_id, version));
+
+    _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+    auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 5, true, true);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk_new, indexes_new.data(), indexes_new.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 6, read_rows(tablet_id, version));
 
     config::l0_max_mem_usage = old_l0_max_mem_usage;
 }


### PR DESCRIPTION
## Why I'm doing:

During `LakePersistentIndex::init()`, SSTable files are opened sequentially.
Each `PersistentIndexSstable::new_sstable()` involves IO (reading file footer,
index block, filter block from remote storage). With many SSTable files (e.g. 77
files, 5GB total), this takes ~1.2s and dominates the `primary_index_load_latency`.

Profiling with publish trace counters (PR #71053) shows:
```
pindex_init_sst_cnt:       77
pindex_init_sst_open_us:   1,167,992  (1.17s, 64% of primary_index_load)
pindex_init_sst_total_bytes: 5.18GB
```

## What I'm doing:

Open all SSTable files concurrently using `load_rowset_thread_pool` (same
pattern as `tablet_reader.cpp` parallel segment loading). The fileset grouping
phase remains sequential to preserve ordering semantics.

Two-phase approach:
1. **Parallel open**: Submit SSTable open tasks to thread pool. Each task
   independently opens a file and reads its metadata. Falls back to serial
   if thread pool is full.
2. **Sequential group**: Iterate opened SSTables in order to build filesets.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4