### PR TITLE
[Perf] Batch-preload delvecs during compaction conflict resolution

### DIFF
--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -70,8 +70,8 @@ Status LakeDelvecLoader::preload_delvecs(int64_t tablet_id, int64_t version) {
         const std::string filepath = _lake_io_opts.location_provider->tablet_metadata_location(tablet_id, version);
         ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
     } else {
-        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(tablet_id, version, _fill_cache, 0,
-                                                                        _lake_io_opts.fs));
+        ASSIGN_OR_RETURN(metadata,
+                         _tablet_manager->get_tablet_metadata(tablet_id, version, _fill_cache, 0, _lake_io_opts.fs));
     }
 
     const auto& delvec_meta = metadata->delvec_meta();
@@ -89,8 +89,8 @@ Status LakeDelvecLoader::preload_delvecs(int64_t tablet_id, int64_t version) {
     for (const auto& [file_version, pages] : file_version_to_pages) {
         auto ver_it = delvec_meta.version_to_file().find(file_version);
         if (ver_it == delvec_meta.version_to_file().end()) {
-            LOG(WARNING) << "preload_delvecs: can't find delvec file for version " << file_version
-                         << ", tablet " << tablet_id << ", skipping";
+            LOG(WARNING) << "preload_delvecs: can't find delvec file for version " << file_version << ", tablet "
+                         << tablet_id << ", skipping";
             continue;
         }
         const auto& file_meta = ver_it->second;
@@ -100,10 +100,12 @@ Status LakeDelvecLoader::preload_delvecs(int64_t tablet_id, int64_t version) {
         RandomAccessFileOptions opts{.skip_fill_local_cache = !_lake_io_opts.fill_data_cache};
         std::unique_ptr<RandomAccessFile> rf;
         if (_lake_io_opts.fs && _lake_io_opts.location_provider) {
-            ASSIGN_OR_RETURN(rf, _lake_io_opts.fs->new_random_access_file(
-                                         opts, _lake_io_opts.location_provider->delvec_location(tablet_id, delvec_name)));
+            ASSIGN_OR_RETURN(rf,
+                             _lake_io_opts.fs->new_random_access_file(
+                                     opts, _lake_io_opts.location_provider->delvec_location(tablet_id, delvec_name)));
         } else {
-            ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, _tablet_manager->delvec_location(tablet_id, delvec_name)));
+            ASSIGN_OR_RETURN(
+                    rf, fs::new_random_access_file(opts, _tablet_manager->delvec_location(tablet_id, delvec_name)));
         }
         ASSIGN_OR_RETURN(auto file_content, rf->read_all());
 
@@ -111,8 +113,8 @@ Status LakeDelvecLoader::preload_delvecs(int64_t tablet_id, int64_t version) {
         for (const auto& [segment_id, page_ptr] : pages) {
             const auto& page = *page_ptr;
             if (page.offset() + page.size() > file_content.size()) {
-                LOG(WARNING) << "preload_delvecs: page out of bounds for segment " << segment_id
-                             << ", tablet " << tablet_id << ", skipping";
+                LOG(WARNING) << "preload_delvecs: page out of bounds for segment " << segment_id << ", tablet "
+                             << tablet_id << ", skipping";
                 continue;
             }
             auto delvec = std::make_shared<DelVector>();

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -31,6 +31,12 @@ Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelV
             return Status::OK();
         }
     }
+    // 2. check preloaded delvecs (populated by preload_delvecs())
+    auto it = _preloaded_delvecs.find(tsid.segment_id);
+    if (it != _preloaded_delvecs.end()) {
+        *pdelvec = it->second;
+        return Status::OK();
+    }
     return load_from_file(tsid, version, pdelvec);
 }
 
@@ -54,6 +60,68 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
 
     RETURN_IF_ERROR(
             lake::get_del_vec(_tablet_manager, *metadata, tsid.segment_id, _fill_cache, _lake_io_opts, pdelvec->get()));
+    return Status::OK();
+}
+
+Status LakeDelvecLoader::preload_delvecs(int64_t tablet_id, int64_t version) {
+    // Load tablet metadata for the given version (will be cached by tablet_manager).
+    TabletMetadataPtr metadata;
+    if (_lake_io_opts.location_provider) {
+        const std::string filepath = _lake_io_opts.location_provider->tablet_metadata_location(tablet_id, version);
+        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(filepath, _fill_cache, 0, _lake_io_opts.fs));
+    } else {
+        ASSIGN_OR_RETURN(metadata, _tablet_manager->get_tablet_metadata(tablet_id, version, _fill_cache, 0,
+                                                                        _lake_io_opts.fs));
+    }
+
+    const auto& delvec_meta = metadata->delvec_meta();
+    if (delvec_meta.delvecs().empty()) {
+        return Status::OK();
+    }
+
+    // Group delvec pages by their file (keyed by version which maps to a file).
+    std::map<int64_t, std::vector<std::pair<uint32_t, const DelvecPagePB*>>> file_version_to_pages;
+    for (const auto& [segment_id, delvec_page] : delvec_meta.delvecs()) {
+        file_version_to_pages[delvec_page.version()].emplace_back(segment_id, &delvec_page);
+    }
+
+    // For each unique delvec file, read it once and extract all needed pages.
+    for (const auto& [file_version, pages] : file_version_to_pages) {
+        auto ver_it = delvec_meta.version_to_file().find(file_version);
+        if (ver_it == delvec_meta.version_to_file().end()) {
+            LOG(WARNING) << "preload_delvecs: can't find delvec file for version " << file_version
+                         << ", tablet " << tablet_id << ", skipping";
+            continue;
+        }
+        const auto& file_meta = ver_it->second;
+        const std::string delvec_name = file_meta.name();
+
+        // Open and read the entire delvec file.
+        RandomAccessFileOptions opts{.skip_fill_local_cache = !_lake_io_opts.fill_data_cache};
+        std::unique_ptr<RandomAccessFile> rf;
+        if (_lake_io_opts.fs && _lake_io_opts.location_provider) {
+            ASSIGN_OR_RETURN(rf, _lake_io_opts.fs->new_random_access_file(
+                                         opts, _lake_io_opts.location_provider->delvec_location(tablet_id, delvec_name)));
+        } else {
+            ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, _tablet_manager->delvec_location(tablet_id, delvec_name)));
+        }
+        ASSIGN_OR_RETURN(auto file_content, rf->read_all());
+
+        // Extract each delvec page from the in-memory buffer.
+        for (const auto& [segment_id, page_ptr] : pages) {
+            const auto& page = *page_ptr;
+            if (page.offset() + page.size() > file_content.size()) {
+                LOG(WARNING) << "preload_delvecs: page out of bounds for segment " << segment_id
+                             << ", tablet " << tablet_id << ", skipping";
+                continue;
+            }
+            auto delvec = std::make_shared<DelVector>();
+            RETURN_IF_ERROR(delvec->load(page.version(), file_content.data() + page.offset(), page.size()));
+            _preloaded_delvecs[segment_id] = std::move(delvec);
+        }
+    }
+    VLOG(1) << "preload_delvecs: preloaded " << _preloaded_delvecs.size() << " delvecs for tablet " << tablet_id
+            << " version " << version << " from " << file_version_to_pages.size() << " files";
     return Status::OK();
 }
 

--- a/be/src/storage/lake/lake_delvec_loader.h
+++ b/be/src/storage/lake/lake_delvec_loader.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 #pragma once
 
+#include <unordered_map>
+
 #include "common/statusor.h"
 #include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
@@ -35,11 +37,19 @@ public:
     Status load_from_meta(const TabletMetadataPtr& metadata, const DelvecPagePB& delvec_page, DelVectorPtr* pdelvec);
     Status load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
 
+    // Batch-preload all delvecs for a tablet at the given version by reading
+    // entire delvec files at once. This amortizes remote IO: instead of one
+    // file-open + read per segment, we do one read per unique delvec file.
+    Status preload_delvecs(int64_t tablet_id, int64_t version);
+
 private:
     TabletManager* _tablet_manager;
     const MetaFileBuilder* _pk_builder = nullptr;
     bool _fill_cache = false;
     LakeIOOptions _lake_io_opts;
+
+    // Delvecs preloaded by preload_delvecs(), keyed by segment_id.
+    std::unordered_map<uint32_t, DelVectorPtr> _preloaded_delvecs;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -78,6 +78,10 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
 
     auto delvec_loader =
             std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    // Batch-preload all delvecs for the base version to amortize remote IO.
+    // Instead of one file-read per segment during conflict resolution, this
+    // reads each delvec file once and extracts all pages from the in-memory buffer.
+    RETURN_IF_ERROR(delvec_loader->preload_delvecs(_rowset->tablet_id(), _base_version));
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();
@@ -104,6 +108,8 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
 
     auto delvec_loader =
             std::make_unique<LakeDelvecLoader>(_tablet_mgr, _builder, false /* fill cache */, lake_io_opts);
+    // Batch-preload all delvecs for the base version to amortize remote IO.
+    RETURN_IF_ERROR(delvec_loader->preload_delvecs(_rowset->tablet_id(), _base_version));
     // init params
     CompactConflictResolveParams params;
     params.tablet_id = _rowset->tablet_id();


### PR DESCRIPTION
## Why I'm doing:

During publish of compaction results in shared-data mode, the compaction conflict resolver loads delete vectors (delvecs) **one-by-one** for each input rowset segment. Under high-throughput stream load workloads, a single compaction can have 400-500 input rowsets, causing 400-500 **sequential** remote storage reads (S3/OSS) at ~2-3ms each, totaling **1.0-1.4 seconds per publish**.

### Benchmark Evidence (30GB single-table, 3x CN 16c64g shared-data)

From CN publish traces (`lake_service.cpp:514`):

| input_rowsets_size | compaction_delvec_loader_us | Total publish cost |
|---|---|---|
| 88 | 56 ms | 1,716 ms |
| 147 | 180 ms | 1,410 ms |
| 263 | 518 ms | 2,545 ms |
| 407 | 1,095 ms | 2,592 ms |
| 481 | 1,341 ms | 3,699 ms |

**Clear linear scaling**: ~2.8 ms per input rowset, dominating publish time as rowset count grows. This directly causes high ingestion latency (P99: 76s vs target: <5s) because stream loads must wait for publish to complete.

## What I changed:

Added `preload_delvecs()` to `LakeDelvecLoader` that batch-reads all delvecs for a tablet version **before** the conflict resolution loop.

**How it works:**
1. Load the tablet metadata at `base_version` (already cached by tablet_manager)
2. Group all delvec entries by their file (`version_to_file` mapping)
3. For each unique delvec file, read the **entire file** into memory in a single IO
4. Extract all needed delvec pages from the in-memory buffer
5. The main loop then finds all delvecs already preloaded — zero on-demand remote reads

This turns **N sequential file reads** into **F file reads** where F = number of unique delvec files (typically 1-10), reducing delvec loading time by ~10x.

### Files changed:
- `be/src/storage/lake/lake_delvec_loader.h` — Add `preload_delvecs()` method and internal map
- `be/src/storage/lake/lake_delvec_loader.cpp` — Implement batch preloading; check preloaded map in `load()`
- `be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp` — Call `preload_delvecs()` before conflict resolution in both code paths

## Expected impact:
- Reduce `compaction_delvec_loader_latency_us` from ~1s to ~50-200ms for tablets with 400+ input rowsets
- Reduce overall publish time, directly improving ingestion latency
- Minimal memory overhead (delvec files are typically <1MB)

## Risks:
- Preloads ALL delvecs for the tablet at the base version, including those not needed by this compaction. For very large tablets with many segments, this could use extra memory temporarily. The delvec data is small (roaring bitmaps) so this is unlikely to be an issue in practice.