### PR TITLE
[Refactor] Rename CppTypeTraits to StorageTypeTraits

### DIFF
--- a/be/src/column/datum_convert.cpp
+++ b/be/src/column/datum_convert.cpp
@@ -26,7 +26,7 @@ using strings::Substitute;
 
 template <LogicalType TYPE>
 Status datum_from_string(TypeInfo* type_info, Datum* dst, const std::string& str) {
-    typename CppTypeTraits<TYPE>::CppType value;
+    StorageCppType<TYPE> value;
     RETURN_IF_ERROR(type_info->from_string(&value, str));
     dst->set(value);
     return Status::OK();
@@ -108,8 +108,8 @@ Status datum_from_string(TypeInfo* type_info, Datum* dst, const std::string& str
 
 template <LogicalType TYPE>
 std::string datum_to_string(TypeInfo* type_info, const Datum& datum) {
-    using CppType = typename CppTypeTraits<TYPE>::CppType;
-    auto value = datum.template get<CppType>();
+    using CppType = StorageCppType<TYPE>;
+    auto value = datum.get<CppType>();
     return type_info->to_string(&value);
 }
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -44,7 +44,7 @@ namespace starrocks {
 // Infer ColumnType from LogicalType
 template <LogicalType ftype>
 struct CppColumnTraits {
-    using CppType = typename StorageTypeTraits<ftype>::CppType;
+    using CppType = StorageCppType<ftype>;
     using ColumnType = typename ColumnTraits<CppType>::ColumnType;
 };
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -44,7 +44,7 @@ namespace starrocks {
 // Infer ColumnType from LogicalType
 template <LogicalType ftype>
 struct CppColumnTraits {
-    using CppType = typename CppTypeTraits<ftype>::CppType;
+    using CppType = typename StorageTypeTraits<ftype>::CppType;
     using ColumnType = typename ColumnTraits<CppType>::ColumnType;
 };
 

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -32,7 +32,7 @@ namespace starrocks {
 
 template <LogicalType field_type, typename ItemSet>
 class ColumnInPredicate final : public ColumnPredicate {
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     static_assert(std::is_same_v<ValueType, typename ItemSet::value_type>);
 
 public:
@@ -599,62 +599,62 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
     auto scale = type_info->scale();
     switch (type) {
     case TYPE_BOOLEAN: {
-        using SetType = Set<CppTypeTraits<TYPE_BOOLEAN>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_BOOLEAN>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_BOOLEAN>(strs);
         return new ColumnInPredicate<TYPE_BOOLEAN, SetType>(type_info, id, std::move(values));
     }
     case TYPE_TINYINT: {
-        using SetType = Set<CppTypeTraits<TYPE_TINYINT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_TINYINT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_TINYINT>(strs);
         return new ColumnInPredicate<TYPE_TINYINT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_SMALLINT: {
-        using SetType = Set<CppTypeTraits<TYPE_SMALLINT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_SMALLINT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_SMALLINT>(strs);
         return new ColumnInPredicate<TYPE_SMALLINT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_INT: {
-        using SetType = Set<CppTypeTraits<TYPE_INT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_INT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_INT>(strs);
         return new ColumnInPredicate<TYPE_INT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_BIGINT: {
-        using SetType = Set<CppTypeTraits<TYPE_BIGINT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_BIGINT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_BIGINT>(strs);
         return new ColumnInPredicate<TYPE_BIGINT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_LARGEINT: {
-        using SetType = Set<CppTypeTraits<TYPE_LARGEINT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_LARGEINT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_LARGEINT>(strs);
         return new ColumnInPredicate<TYPE_LARGEINT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMAL>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMAL>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DECIMAL>(strs);
         return new ColumnInPredicate<TYPE_DECIMAL, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMALV2: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMALV2>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMALV2>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DECIMALV2>(strs);
         return new ColumnInPredicate<TYPE_DECIMALV2, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL32: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMAL32>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMAL32>, (Args)...>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL32>(scale, strs);
         return new ColumnInPredicate<TYPE_DECIMAL32, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL64: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMAL64>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMAL64>, (Args)...>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL64>(scale, strs);
         return new ColumnInPredicate<TYPE_DECIMAL64, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL128: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMAL128>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMAL128>, (Args)...>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL128>(scale, strs);
         return new ColumnInPredicate<TYPE_DECIMAL128, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL256: {
-        using SetType = Set<CppTypeTraits<TYPE_DECIMAL256>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DECIMAL256>, (Args)...>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL256>(scale, strs);
         return new ColumnInPredicate<TYPE_DECIMAL256, SetType>(type_info, id, std::move(values));
     }
@@ -663,32 +663,32 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
     case TYPE_VARCHAR:
         return new BinaryColumnInPredicate<TYPE_VARCHAR>(type_info, id, strs);
     case TYPE_DATE_V1: {
-        using SetType = Set<CppTypeTraits<TYPE_DATE_V1>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DATE_V1>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DATE_V1>(strs);
         return new ColumnInPredicate<TYPE_DATE_V1, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DATE: {
-        using SetType = Set<CppTypeTraits<TYPE_DATE>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DATE>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DATE>(strs);
         return new ColumnInPredicate<TYPE_DATE, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DATETIME_V1: {
-        using SetType = Set<CppTypeTraits<TYPE_DATETIME_V1>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DATETIME_V1>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DATETIME_V1>(strs);
         return new ColumnInPredicate<TYPE_DATETIME_V1, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DATETIME: {
-        using SetType = Set<CppTypeTraits<TYPE_DATETIME>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DATETIME>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DATETIME>(strs);
         return new ColumnInPredicate<TYPE_DATETIME, SetType>(type_info, id, std::move(values));
     }
     case TYPE_FLOAT: {
-        using SetType = Set<CppTypeTraits<TYPE_FLOAT>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_FLOAT>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_FLOAT>(strs);
         return new ColumnInPredicate<TYPE_FLOAT, SetType>(type_info, id, std::move(values));
     }
     case TYPE_DOUBLE: {
-        using SetType = Set<CppTypeTraits<TYPE_DOUBLE>::CppType, (Args)...>;
+        using SetType = Set<StorageCppType<TYPE_DOUBLE>, (Args)...>;
         SetType values = predicate_internal::strings_to_set<TYPE_DOUBLE>(strs);
         return new ColumnInPredicate<TYPE_DOUBLE, SetType>(type_info, id, std::move(values));
     }
@@ -755,7 +755,7 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
                     }
                     return new BinaryColumnInPredicate<LT>(type_info, id, std::move(strings));
                 } else {
-                    using SetType = Set<typename CppTypeTraits<LT>::CppType, (Args)...>;
+                    using SetType = Set<StorageCppType<LT>, (Args)...>;
                     SetType value_set = predicate_internal::datums_to_set<LT>(operands);
                     return new ColumnInPredicate<LT, SetType>(type_info, id, std::move(value_set));
                 }

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -28,7 +28,7 @@ namespace starrocks {
 
 template <LogicalType field_type>
 class ColumnNotInPredicate final : public ColumnPredicate {
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
 
 public:
     ColumnNotInPredicate(const TypeInfoPtr& type_info, ColumnId id, const std::vector<std::string>& strs)
@@ -354,25 +354,25 @@ ColumnPredicate* new_column_not_in_predicate(const TypeInfoPtr& type_info, Colum
         return new ColumnNotInPredicate<TYPE_DECIMALV2>(type_info, id, strs);
     case TYPE_DECIMAL32: {
         const auto scale = type_info->scale();
-        using SetType = ItemHashSet<CppTypeTraits<TYPE_DECIMAL32>::CppType>;
+        using SetType = ItemHashSet<StorageCppType<TYPE_DECIMAL32>>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL32>(scale, strs);
         return new ColumnNotInPredicate<TYPE_DECIMAL32>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL64: {
         const auto scale = type_info->scale();
-        using SetType = ItemHashSet<CppTypeTraits<TYPE_DECIMAL64>::CppType>;
+        using SetType = ItemHashSet<StorageCppType<TYPE_DECIMAL64>>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL64>(scale, strs);
         return new ColumnNotInPredicate<TYPE_DECIMAL64>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL128: {
         const auto scale = type_info->scale();
-        using SetType = ItemHashSet<CppTypeTraits<TYPE_DECIMAL128>::CppType>;
+        using SetType = ItemHashSet<StorageCppType<TYPE_DECIMAL128>>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL128>(scale, strs);
         return new ColumnNotInPredicate<TYPE_DECIMAL128>(type_info, id, std::move(values));
     }
     case TYPE_DECIMAL256: {
         const auto scale = type_info->scale();
-        using SetType = ItemHashSet<CppTypeTraits<TYPE_DECIMAL256>::CppType>;
+        using SetType = ItemHashSet<StorageCppType<TYPE_DECIMAL256>>;
         SetType values = predicate_internal::strings_to_decimal_set<TYPE_DECIMAL256>(scale, strs);
         return new ColumnNotInPredicate<TYPE_DECIMAL256>(type_info, id, std::move(values));
     }
@@ -433,7 +433,7 @@ ColumnPredicate* new_column_not_in_predicate_from_datum(const TypeInfoPtr& type_
                     }
                     return new BinaryColumnNotInPredicate<LT>(type_info, id, std::move(strings));
                 } else {
-                    using SetType = ItemHashSet<typename CppTypeTraits<LT>::CppType>;
+                    using SetType = ItemHashSet<StorageCppType<LT>>;
                     SetType value_set = predicate_internal::datums_to_set<LT>(operands);
                     return new ColumnNotInPredicate<LT>(type_info, id, std::move(value_set));
                 }

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -54,7 +54,7 @@ namespace starrocks {
 
 template <LogicalType ftype>
 struct PredicateCmpTypeForField {
-    using ValueType = typename CppTypeTraits<ftype>::CppType;
+    using ValueType = StorageCppType<ftype>;
 };
 
 template <>

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -43,29 +43,28 @@ class BloomFilter;
 namespace starrocks {
 
 template <LogicalType field_type>
-using GeEval = std::greater_equal<typename CppTypeTraits<field_type>::CppType>;
+using GeEval = std::greater_equal<StorageCppType<field_type>>;
 
 template <LogicalType field_type>
-using GtEval = std::greater<typename CppTypeTraits<field_type>::CppType>;
+using GtEval = std::greater<StorageCppType<field_type>>;
 
 template <LogicalType field_type>
-using LeEval = std::less_equal<typename CppTypeTraits<field_type>::CppType>;
+using LeEval = std::less_equal<StorageCppType<field_type>>;
 
 template <LogicalType field_type>
-using LtEval = std::less<typename CppTypeTraits<field_type>::CppType>;
+using LtEval = std::less<StorageCppType<field_type>>;
 
 template <LogicalType field_type>
-using EqEval = std::equal_to<typename CppTypeTraits<field_type>::CppType>;
+using EqEval = std::equal_to<StorageCppType<field_type>>;
 
 template <LogicalType field_type>
-using NeEval = std::not_equal_to<typename CppTypeTraits<field_type>::CppType>;
+using NeEval = std::not_equal_to<StorageCppType<field_type>>;
 
 template <LogicalType field_type, template <LogicalType> typename Predicate, typename ColumnPredicateBuilder>
 static Status predicate_convert_to(Predicate<field_type> const& input_predicate,
-                                   typename CppTypeTraits<field_type>::CppType const& value,
+                                   StorageCppType<field_type> const& value,
                                    ColumnPredicateBuilder column_predicate_builder, const ColumnPredicate** output,
                                    const TypeInfoPtr& target_type_info, ObjectPool* obj_pool) {
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
     const auto to_type = target_type_info->type();
     if (to_type == field_type) {
         *output = &input_predicate;
@@ -200,10 +199,10 @@ static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, Colum
     const auto type = type_info->type();
     return field_type_dispatch_column_predicate(
             type, static_cast<ColumnPredicate*>(nullptr), [&]<LogicalType LT>() -> ColumnPredicate* {
-                using CppType = typename CppTypeTraits<LT>::CppType;
+                using CppType = StorageCppType<LT>;
                 // ColumnRangeBuilder treats TINYINT and BOOLEAN as INT.
                 constexpr auto MappingLogicalType = LT == TYPE_TINYINT || LT == TYPE_BOOLEAN ? TYPE_INT : LT;
-                using MappingCppType = typename CppTypeTraits<MappingLogicalType>::CppType;
+                using MappingCppType = StorageCppType<MappingLogicalType>;
 
                 if constexpr (lt_is_string<LT>) {
                     return new BinaryPredicate<LT>(type_info, id, operand.get_slice());
@@ -217,7 +216,7 @@ static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, Colum
 // Base class for column predicate
 template <LogicalType field_type, class Eval>
 class ColumnPredicateCmpBase : public ColumnPredicate {
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
 
 public:
     ColumnPredicateCmpBase(PredicateType predicate, const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -280,7 +279,7 @@ protected:
 template <LogicalType field_type>
 class ColumnGePredicate final : public ColumnPredicateCmpBase<field_type, GeEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, GeEval<field_type>>;
 
     ColumnGePredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -330,7 +329,7 @@ public:
 template <LogicalType field_type>
 class ColumnGtPredicate final : public ColumnPredicateCmpBase<field_type, GtEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, GtEval<field_type>>;
 
     ColumnGtPredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -380,7 +379,7 @@ public:
 template <LogicalType field_type>
 class ColumnLePredicate final : public ColumnPredicateCmpBase<field_type, LeEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, LeEval<field_type>>;
 
     ColumnLePredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -431,7 +430,7 @@ public:
 template <LogicalType field_type>
 class ColumnLtPredicate final : public ColumnPredicateCmpBase<field_type, LtEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, LtEval<field_type>>;
 
     ColumnLtPredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -482,7 +481,7 @@ public:
 template <LogicalType field_type>
 class ColumnEqPredicate final : public ColumnPredicateCmpBase<field_type, EqEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, EqEval<field_type>>;
 
     ColumnEqPredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)
@@ -545,7 +544,7 @@ public:
 template <LogicalType field_type>
 class ColumnNePredicate final : public ColumnPredicateCmpBase<field_type, NeEval<field_type>> {
 public:
-    using ValueType = typename CppTypeTraits<field_type>::CppType;
+    using ValueType = StorageCppType<field_type>;
     using Base = ColumnPredicateCmpBase<field_type, NeEval<field_type>>;
 
     ColumnNePredicate(const TypeInfoPtr& type_info, ColumnId id, ValueType value)

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -504,7 +504,7 @@ public:
 template <LogicalType int_type>
 class IntegerToDateV2TypeConverter : public TypeConverter {
 public:
-    using CppType = typename CppTypeTraits<int_type>::CppType;
+    using CppType = StorageCppType<int_type>;
 
     IntegerToDateV2TypeConverter() = default;
     ~IntegerToDateV2TypeConverter() override = default;
@@ -539,8 +539,8 @@ public:
 template <LogicalType SrcType, LogicalType DstType>
 class DecimalTypeConverter : public TypeConverter {
 public:
-    using SrcCppType = typename CppTypeTraits<SrcType>::CppType;
-    using DstCppType = typename CppTypeTraits<DstType>::CppType;
+    using SrcCppType = StorageCppType<SrcType>;
+    using DstCppType = StorageCppType<DstType>;
 
     DecimalTypeConverter() = default;
     ~DecimalTypeConverter() override = default;
@@ -566,8 +566,8 @@ public:
 template <LogicalType SrcType, LogicalType DstType>
 class DecimalV3TypeConverter : public TypeConverter {
 public:
-    using SrcCppType = typename CppTypeTraits<SrcType>::CppType;
-    using DstCppType = typename CppTypeTraits<DstType>::CppType;
+    using SrcCppType = StorageCppType<SrcType>;
+    using DstCppType = StorageCppType<DstType>;
 
     DecimalV3TypeConverter() = default;
     ~DecimalV3TypeConverter() override = default;
@@ -595,7 +595,7 @@ public:
 template <LogicalType Type>
 class StringToOtherTypeConverter : public TypeConverter {
 public:
-    using CppType = typename CppTypeTraits<Type>::CppType;
+    using CppType = StorageCppType<Type>;
 
     StringToOtherTypeConverter() = default;
     ~StringToOtherTypeConverter() override = default;
@@ -622,9 +622,9 @@ public:
 // Convert string to json
 // JSON needs dynamic memory allocation, which could not fit in TypeInfo::from_string
 template <>
-class StringToOtherTypeConverter<TYPE_JSON> : public TypeConverter {
+class StringToOtherTypeConverter<TYPE_JSON> final : public TypeConverter {
 public:
-    using CppType = typename CppTypeTraits<TYPE_JSON>::CppType;
+    using CppType = StorageCppType<TYPE_JSON>;
 
     StringToOtherTypeConverter() = default;
     ~StringToOtherTypeConverter() override = default;
@@ -657,9 +657,9 @@ public:
 };
 
 template <LogicalType Type>
-class OtherToStringTypeConverter : public TypeConverter {
+class OtherToStringTypeConverter final : public TypeConverter {
 public:
-    using CppType = typename CppTypeTraits<Type>::CppType;
+    using CppType = StorageCppType<Type>;
 
     OtherToStringTypeConverter() = default;
     ~OtherToStringTypeConverter() override = default;
@@ -674,7 +674,7 @@ public:
             dst->set_null();
             return Status::OK();
         }
-        auto value = src.template get<CppType>();
+        auto value = src.get<CppType>();
         std::string source = src_typeinfo->to_string(&value);
         Slice slice;
         slice.size = source.size();
@@ -696,7 +696,7 @@ public:
 template <>
 class OtherToStringTypeConverter<TYPE_JSON> : public TypeConverter {
 public:
-    using CppType = typename CppTypeTraits<TYPE_JSON>::CppType;
+    using CppType = StorageCppType<TYPE_JSON>;
 
     OtherToStringTypeConverter() = default;
     ~OtherToStringTypeConverter() override = default;
@@ -1075,7 +1075,7 @@ public:
 template <LogicalType SrcType>
 class DecimalToPercentileTypeConverter : public MaterializeTypeConverter {
 public:
-    using CppType = typename CppTypeTraits<SrcType>::CppType;
+    using CppType = StorageCppType<SrcType>;
     DecimalToPercentileTypeConverter() = default;
     ~DecimalToPercentileTypeConverter() override = default;
 

--- a/be/src/storage/in_predicate_utils.h
+++ b/be/src/storage/in_predicate_utils.h
@@ -116,8 +116,8 @@ private:
 };
 
 template <LogicalType field_type>
-inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_set(const std::vector<std::string>& strings) {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+inline Converter<StorageCppType<field_type>> strings_to_set(const std::vector<std::string>& strings) {
+    using CppType = StorageCppType<field_type>;
 
     TypeInfoPtr type_info = get_type_info(field_type);
     Converter<CppType> result;
@@ -131,9 +131,9 @@ inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_set(con
 }
 
 template <LogicalType field_type>
-inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_decimal_set(
-        int scale, const std::vector<std::string>& strings) {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+inline Converter<StorageCppType<field_type>> strings_to_decimal_set(int scale,
+                                                                    const std::vector<std::string>& strings) {
+    using CppType = StorageCppType<field_type>;
     Converter<CppType> result;
     for (const auto& s : strings) {
         CppType v;
@@ -145,12 +145,12 @@ inline Converter<typename CppTypeTraits<field_type>::CppType> strings_to_decimal
 }
 
 template <LogicalType field_type>
-inline Converter<typename CppTypeTraits<field_type>::CppType> datums_to_set(const std::vector<Datum>& values) {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+inline Converter<StorageCppType<field_type>> datums_to_set(const std::vector<Datum>& values) {
+    using CppType = StorageCppType<field_type>;
     // ColumnRangeBuilder treats TINYINT and BOOLEAN as INT.
     constexpr auto MappingLogicalType =
             field_type == TYPE_TINYINT || field_type == TYPE_BOOLEAN ? TYPE_INT : field_type;
-    using MappingCppType = typename CppTypeTraits<MappingLogicalType>::CppType;
+    using MappingCppType = StorageCppType<MappingLogicalType>;
 
     Converter<CppType> result;
     for (const auto& v : values) {
@@ -161,9 +161,8 @@ inline Converter<typename CppTypeTraits<field_type>::CppType> datums_to_set(cons
 }
 
 template <LogicalType field_type>
-inline ItemHashSet<typename CppTypeTraits<field_type>::CppType> strings_to_hashset(
-        const std::vector<std::string>& strings) {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+inline ItemHashSet<StorageCppType<field_type>> strings_to_hashset(const std::vector<std::string>& strings) {
+    using CppType = StorageCppType<field_type>;
 
     static TypeInfoPtr type_info = get_type_info(field_type);
     ItemHashSet<CppType> result;

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
@@ -37,7 +37,7 @@ namespace starrocks {
 template <LogicalType field_type>
 class BuiltinInvertedWriterImpl : public BuiltinInvertedWriter {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
 
     explicit BuiltinInvertedWriterImpl(std::unique_ptr<BitmapIndexWriter>& writer, const TabletIndex* inverted_index)
             : _builtin_writer(std::move(writer)) {

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
@@ -41,7 +41,7 @@ namespace starrocks {
 template <LogicalType field_type>
 class CLuceneInvertedWriterImpl : public CLuceneInvertedWriter {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
 
     explicit CLuceneInvertedWriterImpl(const std::string& field_name, std::string directory,
                                        const TabletIndex* inverted_index)

--- a/be/src/storage/key_coder.h
+++ b/be/src/storage/key_coder.h
@@ -97,14 +97,12 @@ template <LogicalType field_type, typename Enable = void>
 class KeyCoderTraits {};
 
 template <LogicalType field_type>
-class KeyCoderTraits<field_type,
-                     typename std::enable_if_t<std::is_integral_v<typename CppTypeTraits<field_type>::CppType> &&
-                                               field_type != TYPE_INT256>> {
+class KeyCoderTraits<field_type, typename std::enable_if_t<std::is_integral_v<StorageCppType<field_type>> &&
+                                                           field_type != TYPE_INT256>> {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
-    using UnsignedCppType = typename CppTypeTraits<field_type>::UnsignedCppType;
+    using CppType = StorageCppType<field_type>;
+    using UnsignedCppType = StorageUnsignedCppType<field_type>;
 
-public:
     static void full_encode_ascending(const void* value, std::string* buf) {
         UnsignedCppType unsigned_val;
         memcpy(&unsigned_val, value, sizeof(unsigned_val));
@@ -153,9 +151,8 @@ public:
 template <>
 class KeyCoderTraits<TYPE_BOOLEAN> {
 public:
-    using CppType = typename CppTypeTraits<TYPE_BOOLEAN>::CppType;
+    using CppType = StorageCppType<TYPE_BOOLEAN>;
 
-public:
     static void full_encode_ascending(const void* value, std::string* buf) {
         bool v = *reinterpret_cast<const bool*>(value);
         static_assert(!std::is_signed_v<bool>);
@@ -193,10 +190,9 @@ public:
 template <>
 class KeyCoderTraits<TYPE_DATE_V1> {
 public:
-    using CppType = typename CppTypeTraits<TYPE_DATE_V1>::CppType;
-    using UnsignedCppType = typename CppTypeTraits<TYPE_DATE_V1>::UnsignedCppType;
+    using CppType = StorageCppType<TYPE_DATE_V1>;
+    using UnsignedCppType = StorageUnsignedCppType<TYPE_DATE_V1>;
 
-public:
     static void full_encode_ascending(const void* value, std::string* buf) {
         UnsignedCppType unsigned_val;
         memcpy(&unsigned_val, value, sizeof(unsigned_val));

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1004,7 +1004,7 @@ std::unique_ptr<HashIndex> create_hash_index() {
     } else if constexpr (LT == TYPE_CHAR || LT == TYPE_VARCHAR) {
         return std::make_unique<ShardByLengthSliceHashIndex>();
     } else {
-        return std::make_unique<HashIndexImpl<typename CppTypeTraits<LT>::CppType>>();
+        return std::make_unique<HashIndexImpl<StorageCppType<LT>>>();
     }
 }
 

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -248,7 +248,7 @@ Status BinaryDictPageDecoder<Type>::next_batch(const SparseRange<>& range, Colum
 
     RETURN_IF_ERROR(_data_page_decoder->next_batch(range, _vec_code_buf.get()));
     size_t nread = _vec_code_buf->size();
-    using cast_type = CppTypeTraits<TYPE_INT>::CppType;
+    using cast_type = StorageCppType<TYPE_INT>;
     const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
 
     static_assert(sizeof(Slice) == sizeof(int128_t));
@@ -354,7 +354,7 @@ Status BinaryDictPageDecoder<Type>::next_batch_with_filter(
         return Status::OK();
     }
 
-    using cast_type = CppTypeTraits<TYPE_INT>::CppType;
+    using cast_type = StorageCppType<TYPE_INT>;
     const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
 
     // Step 3: Update selection based on dictionary selection and collect matching slices
@@ -407,7 +407,7 @@ Status BinaryDictPageDecoder<Type>::read_by_rowids(const ordinal_t first_ordinal
         *count = 0;
         return Status::OK();
     }
-    using cast_type = CppTypeTraits<TYPE_INT>::CppType;
+    using cast_type = StorageCppType<TYPE_INT>;
     const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
     auto slices_data = std::make_unique_for_overwrite<uint8_t[]>(read_count * sizeof(Slice));
     Slice* slices = reinterpret_cast<Slice*>(slices_data.get());

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -253,7 +253,7 @@ struct BitmapIndexTraits<Slice> {
 template <LogicalType field_type>
 class BitmapIndexWriterImpl : public BitmapIndexWriter {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
     using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
 
     explicit BitmapIndexWriterImpl(TypeInfoPtr type_info, int32_t gram_num)

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -227,7 +227,7 @@ private:
         return &_compressed_data;
     }
 
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
     uint8_t _reserved_head_size{0};
     uint32_t _max_count;
     uint32_t _count{0};
@@ -376,7 +376,7 @@ private:
         memcpy(data, get_data(_cur_index * SIZE_OF_TYPE), n * SIZE_OF_TYPE);
     }
 
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
 
     Slice _data;
     uint32_t _num_elements{0};

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -100,7 +100,7 @@ std::string bitshuffle_error_msg(int64_t err);
 //
 template <LogicalType Type>
 class BitshufflePageBuilder final : public PageBuilder {
-    typedef typename TypeTraits<Type>::CppType CppType;
+    using CppType = StorageCppType<Type>;
 
 public:
     explicit BitshufflePageBuilder(const PageBuilderOptions& options)
@@ -227,7 +227,7 @@ private:
         return &_compressed_data;
     }
 
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
     uint8_t _reserved_head_size{0};
     uint32_t _max_count;
     uint32_t _count{0};
@@ -240,7 +240,7 @@ private:
 
 template <LogicalType Type>
 class BitShufflePageDecoder final : public PageDecoder {
-    typedef typename TypeTraits<Type>::CppType CppType;
+    using CppType = StorageCppType<Type>;
 
 public:
     BitShufflePageDecoder(Slice data) : _data(data) {}
@@ -376,7 +376,7 @@ private:
         memcpy(data, get_data(_cur_index * SIZE_OF_TYPE), n * SIZE_OF_TYPE);
     }
 
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>)};
 
     Slice _data;
     uint32_t _num_elements{0};

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -376,7 +376,7 @@ private:
         memcpy(data, get_data(_cur_index * SIZE_OF_TYPE), n * SIZE_OF_TYPE);
     }
 
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>)};
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
 
     Slice _data;
     uint32_t _num_elements{0};

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -105,7 +105,7 @@ inline void update_bf(BloomFilter* bf, const StorageCppType<type>& v) {
 // high cardinality key columns and none-agg value columns for high selectivity and storage
 // efficiency.
 // This builder builds a bloom filter page by every data page, with a page id index.
-// Meanwhile, It adds an ordinal index to load bloom filter index according to requirement.
+// Meanwhile, it adds an ordinal index to load bloom filter index according to requirement.
 //
 template <LogicalType field_type>
 class OriginalBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -78,10 +78,9 @@ constexpr bool is_int128() {
 }
 
 template <LogicalType type>
-inline typename CppTypeTraits<type>::CppType get_value(const typename CppTypeTraits<type>::CppType* v,
-                                                       const TypeInfoPtr& type_info,
-                                                       const TypeInfoAllocator* allocator) {
-    using CppType = typename CppTypeTraits<type>::CppType;
+inline StorageCppType<type> get_value(const StorageCppType<type>* v, const TypeInfoPtr& type_info,
+                                      const TypeInfoAllocator* allocator) {
+    using CppType = StorageCppType<type>;
     if constexpr (is_slice_type<type>()) {
         CppType new_value;
         type_info->deep_copy(&new_value, v, allocator);
@@ -92,8 +91,8 @@ inline typename CppTypeTraits<type>::CppType get_value(const typename CppTypeTra
 }
 
 template <LogicalType type>
-inline void update_bf(BloomFilter* bf, const typename CppTypeTraits<type>::CppType& v) {
-    using CppType = typename CppTypeTraits<type>::CppType;
+inline void update_bf(BloomFilter* bf, const StorageCppType<type>& v) {
+    using CppType = StorageCppType<type>;
     if constexpr (is_slice_type<type>()) {
         const auto* s = reinterpret_cast<const Slice*>(&v);
         bf->add_bytes(s->data, s->size);
@@ -106,12 +105,12 @@ inline void update_bf(BloomFilter* bf, const typename CppTypeTraits<type>::CppTy
 // high cardinality key columns and none-agg value columns for high selectivity and storage
 // efficiency.
 // This builder builds a bloom filter page by every data page, with a page id index.
-// Meanswhile, It adds an ordinal index to load bloom filter index according to requirement.
+// Meanwhile, It adds an ordinal index to load bloom filter index according to requirement.
 //
 template <LogicalType field_type>
 class OriginalBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
     using ValueDict = typename BloomFilterTraits<CppType>::ValueDict;
 
     explicit OriginalBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
@@ -194,7 +193,7 @@ private:
 template <LogicalType field_type, typename Enable = void>
 class NgramBloomFilterIndexWriterImpl : public OriginalBloomFilterIndexWriterImpl<field_type> {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
     using OriginalBloomFilterIndexWriterImpl<field_type>::_values;
 
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
@@ -207,7 +206,7 @@ template <LogicalType field_type>
 class NgramBloomFilterIndexWriterImpl<field_type, std::enable_if_t<is_slice_type<field_type>()>>
         : public OriginalBloomFilterIndexWriterImpl<field_type> {
 public:
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
     using OriginalBloomFilterIndexWriterImpl<field_type>::_values;
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
             : OriginalBloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -224,7 +224,7 @@ Status DictPageDecoder<Type>::next_batch(const SparseRange<>& range, Column* dst
 
     RETURN_IF_ERROR(_data_page_decoder->next_batch(range, _vec_code_buf.get()));
     size_t nread = _vec_code_buf->size();
-    using cast_type = typename CppTypeTraits<DataTypeTraits<Type>::type>::CppType;
+    using cast_type = StorageCppType<DataTypeTraits<Type>::type>;
     const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
     std::vector<ValueType> numbers;
     raw::stl_vector_resize_uninitialized(&numbers, nread);

--- a/be/src/storage/rowset/dict_page.h
+++ b/be/src/storage/rowset/dict_page.h
@@ -68,8 +68,8 @@ struct DataTypeTraits<TYPE_SMALLINT> {
 
 template <LogicalType Type>
 class DictPageBuilder final : public PageBuilder {
-    using ValueType = typename CppTypeTraits<Type>::CppType;
-    using ValueCodeType = typename CppTypeTraits<DataTypeTraits<Type>::type>::CppType;
+    using ValueType = StorageCppType<Type>;
+    using ValueCodeType = StorageCppType<DataTypeTraits<Type>::type>;
 
 public:
     explicit DictPageBuilder(const PageBuilderOptions& options);
@@ -100,7 +100,7 @@ public:
     bool all_dict_encoded() const override { return _encoding_type == DICT_ENCODING; }
 
 private:
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
 
     PageBuilderOptions _options;
     bool _finished{false};
@@ -124,7 +124,7 @@ private:
 // but rather the index of the data. In this case, you need to load the data from the dictionary.
 template <LogicalType Type>
 class DictPageDecoder final : public PageDecoder {
-    using ValueType = typename CppTypeTraits<Type>::CppType;
+    using ValueType = StorageCppType<Type>;
 
 public:
     DictPageDecoder(Slice data);
@@ -150,7 +150,7 @@ public:
     Status next_dict_codes(const SparseRange<>& range, Column* dst) override;
 
 private:
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
     Slice _data;
     std::unique_ptr<PageDecoder> _data_page_decoder;
     const BitShufflePageDecoder<Type>* _dict_decoder = nullptr;

--- a/be/src/storage/rowset/dict_page.h
+++ b/be/src/storage/rowset/dict_page.h
@@ -100,7 +100,7 @@ public:
     bool all_dict_encoded() const override { return _encoding_type == DICT_ENCODING; }
 
 private:
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
 
     PageBuilderOptions _options;
     bool _finished{false};
@@ -150,7 +150,7 @@ public:
     Status next_dict_codes(const SparseRange<>& range, Column* dst) override;
 
 private:
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
     Slice _data;
     std::unique_ptr<PageDecoder> _data_page_decoder;
     const BitShufflePageDecoder<Type>* _dict_decoder = nullptr;

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -139,7 +139,7 @@ struct TypeEncodingTraits<type, DICT_ENCODING, CppType> {
 };
 
 template <>
-struct TypeEncodingTraits<TYPE_DATE_V1, FOR_ENCODING, typename CppTypeTraits<TYPE_DATE_V1>::CppType> {
+struct TypeEncodingTraits<TYPE_DATE_V1, FOR_ENCODING, StorageCppType<TYPE_DATE_V1>> {
     static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
         *builder = new FrameOfReferencePageBuilder<TYPE_DATE_V1>(opts);
         return Status::OK();
@@ -176,7 +176,7 @@ struct TypeEncodingTraits<type, PREFIX_ENCODING, Slice> {
 };
 
 template <LogicalType field_type, EncodingTypePB encoding_type>
-struct EncodingTraits : TypeEncodingTraits<field_type, encoding_type, typename CppTypeTraits<field_type>::CppType> {
+struct EncodingTraits : TypeEncodingTraits<field_type, encoding_type, StorageCppType<field_type>> {
     static const LogicalType type = field_type;
     static const EncodingTypePB encoding = encoding_type;
 };

--- a/be/src/storage/rowset/frame_of_reference_page.h
+++ b/be/src/storage/rowset/frame_of_reference_page.h
@@ -102,7 +102,7 @@ public:
     }
 
 private:
-    typedef typename TypeTraits<Type>::CppType CppType;
+    using CppType = StorageCppType<Type>;
     PageBuilderOptions _options;
     uint32_t _count{0};
     bool _finished{false};
@@ -211,7 +211,7 @@ public:
     EncodingTypePB encoding_type() const override { return FOR_ENCODING; }
 
 private:
-    typedef typename TypeTraits<Type>::CppType CppType;
+    using CppType = StorageCppType<Type>;
 
     bool _parsed{false};
     Slice _data;

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -128,7 +128,7 @@ private:
     uint32_t _count;
     uint32_t _max_count;
     using CppType = StorageCppType<Type>;
-    enum { SIZE_OF_TYPE = sizeof(CppType) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
     faststring _first_value;
     faststring _last_value;
     uint8_t _reserved_head_size{0};
@@ -272,7 +272,7 @@ private:
     uint32_t _num_elems{0};
     uint32_t _cur_idx{0};
     using CppType = StorageCppType<Type>;
-    enum { SIZE_OF_TYPE = sizeof(CppType) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -128,7 +128,7 @@ private:
     uint32_t _count;
     uint32_t _max_count;
     using CppType = StorageCppType<Type>;
-    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
+    enum { SIZE_OF_TYPE = sizeof(CppType) };
     faststring _first_value;
     faststring _last_value;
     uint8_t _reserved_head_size{0};

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -127,8 +127,8 @@ private:
     PageBuilderOptions _options;
     uint32_t _count;
     uint32_t _max_count;
-    typedef typename TypeTraits<Type>::CppType CppType;
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    using CppType = StorageCppType<Type>;
+    enum { SIZE_OF_TYPE = sizeof(StorageCppType<Type>) };
     faststring _first_value;
     faststring _last_value;
     uint8_t _reserved_head_size{0};
@@ -137,7 +137,7 @@ private:
 
 template <LogicalType Type>
 class PlainPageDecoder : public PageDecoder {
-    using ValueType = typename CppTypeTraits<Type>::CppType;
+    using ValueType = StorageCppType<Type>;
 
 public:
     PlainPageDecoder(Slice data) : _data(data) {}
@@ -271,8 +271,8 @@ private:
     bool _parsed{false};
     uint32_t _num_elems{0};
     uint32_t _cur_idx{0};
-    typedef typename TypeTraits<Type>::CppType CppType;
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    using CppType = StorageCppType<Type>;
+    enum { SIZE_OF_TYPE = sizeof(CppType) };
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -151,7 +151,7 @@ public:
 
 private:
     using CppType = StorageCppType<Type>;
-    enum { SIZE_OF_TYPE = sizeof(CppType) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
 
     PageBuilderOptions _options;
     uint32_t _count{0};
@@ -254,7 +254,7 @@ public:
 
 private:
     using CppType = StorageCppType<Type>;
-    enum { SIZE_OF_TYPE = sizeof(CppType) };
+    enum { SIZE_OF_TYPE = StorageCppTypeSize<Type> };
 
     Slice _data;
     bool _parsed{false};

--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -150,8 +150,8 @@ public:
     }
 
 private:
-    typedef typename TypeTraits<Type>::CppType CppType;
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    using CppType = StorageCppType<Type>;
+    enum { SIZE_OF_TYPE = sizeof(CppType) };
 
     PageBuilderOptions _options;
     uint32_t _count{0};
@@ -253,8 +253,8 @@ public:
     EncodingTypePB encoding_type() const override { return RLE; }
 
 private:
-    typedef typename TypeTraits<Type>::CppType CppType;
-    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    using CppType = StorageCppType<Type>;
+    enum { SIZE_OF_TYPE = sizeof(CppType) };
 
     Slice _data;
     bool _parsed{false};

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2741,7 +2741,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
             cid = _schema.field(predicate_count)->id();
         }
 
-        static_assert(std::is_same_v<rowid_t, TypeTraits<TYPE_UNSIGNED_INT>::CppType>);
+        static_assert(std::is_same_v<rowid_t, StorageCppType<TYPE_UNSIGNED_INT>>);
         auto f = std::make_shared<Field>(cid, "ordinal", TYPE_UNSIGNED_INT, -1, -1, false);
         auto* iter = new RowIdColumnIterator();
         _obj_pool.add(iter);

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -56,7 +56,7 @@ namespace starrocks {
 
 template <LogicalType type>
 struct ZoneMapDatumBase {
-    using CppType = typename TypeTraits<type>::CppType;
+    using CppType = StorageCppType<type>;
     CppType value;
 
     virtual ~ZoneMapDatumBase() = default;
@@ -178,7 +178,7 @@ struct ZoneMap {
 
 template <LogicalType type>
 class ZoneMapIndexWriterImpl final : public ZoneMapIndexWriter {
-    using CppType = typename TypeTraits<type>::CppType;
+    using CppType = StorageCppType<type>;
 
 public:
     // TypeInfo is used for all kinds of types. It is used to change the content of datum of the max/min value.

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1255,7 +1255,7 @@ Status SegmentDump::_output_short_key_string(const std::vector<ColItem>& cols, s
 #define M(logical_type)                                                                                   \
     case logical_type: {                                                                                  \
         Datum data;                                                                                       \
-        data.set<TypeTraits<logical_type>::CppType>(*(TypeTraits<logical_type>::CppType*)(tmp_mem));      \
+        data.set<StorageCppType<logical_type>>(*(StorageCppType<logical_type>*)(tmp_mem));                \
         result->append(" key");                                                                           \
         result->append(std::to_string(idx));                                                              \
         result->append("(");                                                                              \

--- a/be/src/types/decimal_type_info.cpp
+++ b/be/src/types/decimal_type_info.cpp
@@ -29,7 +29,7 @@ class DecimalTypeInfo final : public TypeInfo {
 public:
     ~DecimalTypeInfo() override = default;
 
-    using CppType = typename CppTypeTraits<TYPE>::CppType;
+    using CppType = StorageCppType<TYPE>;
     DecimalTypeInfo(int precision, int scale)
             : _delegate(get_scalar_type_info(DelegateType<TYPE>)), _precision(precision), _scale(scale) {}
 

--- a/be/src/types/type_info.cpp
+++ b/be/src/types/type_info.cpp
@@ -173,7 +173,7 @@ private:
 // Base implementation for ScalarTypeInfo, use as default
 template <LogicalType field_type>
 struct ScalarTypeInfoImplBase {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
 
     static const LogicalType type = field_type;
     static const int32_t size = sizeof(CppType);
@@ -827,9 +827,9 @@ struct ScalarTypeInfoImpl<TYPE_CHAR> : public ScalarTypeInfoImplBase<TYPE_CHAR> 
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_VARCHAR> : public ScalarTypeInfoImpl<TYPE_CHAR> {
-    static const LogicalType type = TYPE_VARCHAR;
-    static const int32_t size = TypeTraits<TYPE_VARCHAR>::size;
+struct ScalarTypeInfoImpl<TYPE_VARCHAR> : ScalarTypeInfoImpl<TYPE_CHAR> {
+    static constexpr LogicalType type = TYPE_VARCHAR;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_VARCHAR>);
 
     static Status from_string(void* buf, const std::string& scan_key) {
         size_t value_len = scan_key.length();
@@ -860,33 +860,33 @@ struct ScalarTypeInfoImpl<TYPE_VARCHAR> : public ScalarTypeInfoImpl<TYPE_CHAR> {
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_HLL> : public ScalarTypeInfoImpl<TYPE_VARCHAR> {
-    static const LogicalType type = TYPE_HLL;
-    static const int32_t size = TypeTraits<TYPE_HLL>::size;
+struct ScalarTypeInfoImpl<TYPE_HLL> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
+    static constexpr LogicalType type = TYPE_HLL;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_HLL>);
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_OBJECT> : public ScalarTypeInfoImpl<TYPE_VARCHAR> {
-    static const LogicalType type = TYPE_OBJECT;
-    static const int32_t size = TypeTraits<TYPE_OBJECT>::size;
+struct ScalarTypeInfoImpl<TYPE_OBJECT> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
+    static constexpr LogicalType type = TYPE_OBJECT;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_OBJECT>);
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_PERCENTILE> : public ScalarTypeInfoImpl<TYPE_VARCHAR> {
-    static const LogicalType type = TYPE_PERCENTILE;
-    static const int32_t size = TypeTraits<TYPE_PERCENTILE>::size;
+struct ScalarTypeInfoImpl<TYPE_PERCENTILE> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
+    static constexpr LogicalType type = TYPE_PERCENTILE;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_PERCENTILE>);
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_JSON> : public ScalarTypeInfoImpl<TYPE_OBJECT> {
-    static const LogicalType type = TYPE_JSON;
-    static const int32_t size = TypeTraits<TYPE_JSON>::size;
+struct ScalarTypeInfoImpl<TYPE_JSON> : ScalarTypeInfoImpl<TYPE_OBJECT> {
+    static constexpr LogicalType type = TYPE_JSON;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_JSON>);
 };
 
 template <>
-struct ScalarTypeInfoImpl<TYPE_VARBINARY> : public ScalarTypeInfoImpl<TYPE_VARCHAR> {
-    static const LogicalType type = TYPE_VARBINARY;
-    static const int32_t size = TypeTraits<TYPE_VARBINARY>::size;
+struct ScalarTypeInfoImpl<TYPE_VARBINARY> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
+    static constexpr LogicalType type = TYPE_VARBINARY;
+    static constexpr int32_t size = sizeof(StorageCppType<TYPE_VARBINARY>);
 };
 
 void (*ScalarTypeInfoImpl<TYPE_CHAR>::set_to_max)(void*) = nullptr;

--- a/be/src/types/type_info.cpp
+++ b/be/src/types/type_info.cpp
@@ -829,7 +829,7 @@ struct ScalarTypeInfoImpl<TYPE_CHAR> : public ScalarTypeInfoImplBase<TYPE_CHAR> 
 template <>
 struct ScalarTypeInfoImpl<TYPE_VARCHAR> : ScalarTypeInfoImpl<TYPE_CHAR> {
     static constexpr LogicalType type = TYPE_VARCHAR;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_VARCHAR>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_VARCHAR>;
 
     static Status from_string(void* buf, const std::string& scan_key) {
         size_t value_len = scan_key.length();
@@ -862,31 +862,31 @@ struct ScalarTypeInfoImpl<TYPE_VARCHAR> : ScalarTypeInfoImpl<TYPE_CHAR> {
 template <>
 struct ScalarTypeInfoImpl<TYPE_HLL> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
     static constexpr LogicalType type = TYPE_HLL;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_HLL>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_HLL>;
 };
 
 template <>
 struct ScalarTypeInfoImpl<TYPE_OBJECT> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
     static constexpr LogicalType type = TYPE_OBJECT;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_OBJECT>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_OBJECT>;
 };
 
 template <>
 struct ScalarTypeInfoImpl<TYPE_PERCENTILE> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
     static constexpr LogicalType type = TYPE_PERCENTILE;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_PERCENTILE>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_PERCENTILE>;
 };
 
 template <>
 struct ScalarTypeInfoImpl<TYPE_JSON> : ScalarTypeInfoImpl<TYPE_OBJECT> {
     static constexpr LogicalType type = TYPE_JSON;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_JSON>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_JSON>;
 };
 
 template <>
 struct ScalarTypeInfoImpl<TYPE_VARBINARY> : ScalarTypeInfoImpl<TYPE_VARCHAR> {
     static constexpr LogicalType type = TYPE_VARBINARY;
-    static constexpr int32_t size = sizeof(StorageCppType<TYPE_VARBINARY>);
+    static constexpr int32_t size = StorageCppTypeSize<TYPE_VARBINARY>;
 };
 
 void (*ScalarTypeInfoImpl<TYPE_CHAR>::set_to_max)(void*) = nullptr;

--- a/be/src/types/type_traits.h
+++ b/be/src/types/type_traits.h
@@ -46,8 +46,8 @@
 
 namespace starrocks {
 
-// CppTypeTraits:
-// Infer on-disk type(CppType) from LogicalType
+// StorageTypeTraits:
+// Infer on-disk storage CppType from LogicalType
 template <LogicalType field_type>
 struct StorageTypeTraits {};
 

--- a/be/src/types/type_traits.h
+++ b/be/src/types/type_traits.h
@@ -221,4 +221,7 @@ using StorageCppType = typename StorageTypeTraits<Type>::CppType;
 template <LogicalType Type>
 using StorageUnsignedCppType = typename StorageTypeTraits<Type>::UnsignedCppType;
 
+template <LogicalType Type>
+constexpr int32_t StorageCppTypeSize = sizeof(StorageCppType<Type>);
+
 } // namespace starrocks

--- a/be/src/types/type_traits.h
+++ b/be/src/types/type_traits.h
@@ -49,179 +49,176 @@ namespace starrocks {
 // CppTypeTraits:
 // Infer on-disk type(CppType) from LogicalType
 template <LogicalType field_type>
-struct CppTypeTraits {};
+struct StorageTypeTraits {};
 
 template <>
-struct CppTypeTraits<TYPE_BOOLEAN> {
+struct StorageTypeTraits<TYPE_BOOLEAN> {
     using CppType = bool;
     using UnsignedCppType = bool;
 };
 
 template <>
-struct CppTypeTraits<TYPE_NONE> {
+struct StorageTypeTraits<TYPE_NONE> {
     using CppType = bool;
     using UnsignedCppType = bool;
 };
 
 template <>
-struct CppTypeTraits<TYPE_TINYINT> {
+struct StorageTypeTraits<TYPE_TINYINT> {
     using CppType = int8_t;
     using UnsignedCppType = uint8_t;
 };
 template <>
-struct CppTypeTraits<TYPE_UNSIGNED_TINYINT> {
+struct StorageTypeTraits<TYPE_UNSIGNED_TINYINT> {
     using CppType = uint8_t;
     using UnsignedCppType = uint8_t;
 };
 template <>
-struct CppTypeTraits<TYPE_SMALLINT> {
+struct StorageTypeTraits<TYPE_SMALLINT> {
     using CppType = int16_t;
     using UnsignedCppType = uint16_t;
 };
 template <>
-struct CppTypeTraits<TYPE_UNSIGNED_SMALLINT> {
+struct StorageTypeTraits<TYPE_UNSIGNED_SMALLINT> {
     using CppType = uint16_t;
     using UnsignedCppType = uint16_t;
 };
 template <>
-struct CppTypeTraits<TYPE_INT> {
+struct StorageTypeTraits<TYPE_INT> {
     using CppType = int32_t;
     using UnsignedCppType = uint32_t;
 };
 template <>
-struct CppTypeTraits<TYPE_UNSIGNED_INT> {
+struct StorageTypeTraits<TYPE_UNSIGNED_INT> {
     using CppType = uint32_t;
     using UnsignedCppType = uint32_t;
 };
 template <>
-struct CppTypeTraits<TYPE_BIGINT> {
+struct StorageTypeTraits<TYPE_BIGINT> {
     using CppType = int64_t;
     using UnsignedCppType = uint64_t;
 };
 template <>
-struct CppTypeTraits<TYPE_UNSIGNED_BIGINT> {
+struct StorageTypeTraits<TYPE_UNSIGNED_BIGINT> {
     using CppType = uint64_t;
     using UnsignedCppType = uint64_t;
 };
 template <>
-struct CppTypeTraits<TYPE_LARGEINT> {
+struct StorageTypeTraits<TYPE_LARGEINT> {
     using CppType = int128_t;
     using UnsignedCppType = uint128_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_INT256> {
+struct StorageTypeTraits<TYPE_INT256> {
     using CppType = int256_t;
     using UnsignedCppType = int256_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_FLOAT> {
+struct StorageTypeTraits<TYPE_FLOAT> {
     using CppType = float;
 };
 template <>
-struct CppTypeTraits<TYPE_DOUBLE> {
+struct StorageTypeTraits<TYPE_DOUBLE> {
     using CppType = double;
 };
 template <>
-struct CppTypeTraits<TYPE_DECIMAL> {
+struct StorageTypeTraits<TYPE_DECIMAL> {
     using CppType = decimal12_t;
     using UnsignedCppType = decimal12_t;
 };
 template <>
-struct CppTypeTraits<TYPE_DECIMALV2> {
+struct StorageTypeTraits<TYPE_DECIMALV2> {
     using CppType = DecimalV2Value;
     using UnsignedCppType = DecimalV2Value;
 };
 
 template <>
-struct CppTypeTraits<TYPE_DECIMAL32> {
+struct StorageTypeTraits<TYPE_DECIMAL32> {
     using CppType = int32_t;
     using UnsignedCppType = uint32_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_DECIMAL64> {
+struct StorageTypeTraits<TYPE_DECIMAL64> {
     using CppType = int64_t;
     using UnsignedCppType = uint64_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_DECIMAL128> {
+struct StorageTypeTraits<TYPE_DECIMAL128> {
     using CppType = int128_t;
     using UnsignedCppType = uint128_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_DECIMAL256> {
+struct StorageTypeTraits<TYPE_DECIMAL256> {
     using CppType = int256_t;
     using UnsignedCppType = int256_t;
 };
 
 template <>
-struct CppTypeTraits<TYPE_DATE_V1> {
+struct StorageTypeTraits<TYPE_DATE_V1> {
     using CppType = uint24_t;
     using UnsignedCppType = uint24_t;
 };
 template <>
-struct CppTypeTraits<TYPE_DATE> {
+struct StorageTypeTraits<TYPE_DATE> {
     using CppType = int32_t;
     using UnsignedCppType = uint32_t;
 };
 template <>
-struct CppTypeTraits<TYPE_DATETIME_V1> {
+struct StorageTypeTraits<TYPE_DATETIME_V1> {
     using CppType = int64_t;
     using UnsignedCppType = uint64_t;
 };
 template <>
-struct CppTypeTraits<TYPE_DATETIME> {
+struct StorageTypeTraits<TYPE_DATETIME> {
     using CppType = int64_t;
     using UnsignedCppType = uint64_t;
 };
 template <>
-struct CppTypeTraits<TYPE_CHAR> {
+struct StorageTypeTraits<TYPE_CHAR> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_VARCHAR> {
+struct StorageTypeTraits<TYPE_VARCHAR> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_HLL> {
+struct StorageTypeTraits<TYPE_HLL> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_OBJECT> {
+struct StorageTypeTraits<TYPE_OBJECT> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_PERCENTILE> {
+struct StorageTypeTraits<TYPE_PERCENTILE> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_JSON> {
+struct StorageTypeTraits<TYPE_JSON> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_VARIANT> {
+struct StorageTypeTraits<TYPE_VARIANT> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_VARBINARY> {
+struct StorageTypeTraits<TYPE_VARBINARY> {
     using CppType = Slice;
 };
 template <>
-struct CppTypeTraits<TYPE_ARRAY> {
+struct StorageTypeTraits<TYPE_ARRAY> {
     using CppType = Collection;
 };
 
-// Instantiate this template to get static access to the type traits.
-template <LogicalType field_type>
-struct TypeTraits {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+template <LogicalType Type>
+using StorageCppType = typename StorageTypeTraits<Type>::CppType;
 
-    static const LogicalType type = field_type;
-    static const int32_t size = sizeof(CppType);
-};
+template <LogicalType Type>
+using StorageUnsignedCppType = typename StorageTypeTraits<Type>::UnsignedCppType;
 
 } // namespace starrocks

--- a/be/test/storage/convert_helper_test.cpp
+++ b/be/test/storage/convert_helper_test.cpp
@@ -345,7 +345,7 @@ PARALLEL_TEST(ConvertHelperTest, testTimestampToDatetimeColumn) {
 
 template <LogicalType field_type>
 static void test_convert_same_numeric_types() {
-    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using CppType = StorageCppType<field_type>;
 
     auto conv = get_field_converter(field_type, field_type);
     CppType values[5] = {std::numeric_limits<CppType>::lowest(), -123, 0, 123, std::numeric_limits<CppType>::max()};

--- a/be/test/storage/key_coder_test.cpp
+++ b/be/test/storage/key_coder_test.cpp
@@ -55,7 +55,7 @@ private:
 
 template <LogicalType type>
 void test_integer_encode() {
-    using CppType = typename CppTypeTraits<type>::CppType;
+    using CppType = StorageCppType<type>;
 
     auto key_coder = get_key_coder(type);
 

--- a/be/test/storage/rowset/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/bitshuffle_page_test.cpp
@@ -56,17 +56,17 @@ public:
     ~BitShufflePageTest() override = default;
 
     template <LogicalType type, class PageDecoderType>
-    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
+    void copy_one(PageDecoderType* decoder, StorageCppType<type>* ret) {
         auto column = ChunkHelper::column_from_field_type(type, true);
         size_t n = 1;
         ASSERT_TRUE(decoder->next_batch(&n, column.get()).ok());
         ASSERT_EQ(1, n);
-        *ret = *reinterpret_cast<const typename TypeTraits<type>::CppType*>(column->raw_data());
+        *ret = *reinterpret_cast<const StorageCppType<type>*>(column->raw_data());
     }
 
     template <LogicalType Type, class PageBuilderType, class PageDecoderType, int ReserveHead = 0>
-    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    void test_encode_decode_page_template(StorageCppType<Type>* src, size_t size) {
+        using CppType = StorageCppType<Type>;
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
         PageBuilderType page_builder(options);
@@ -132,7 +132,7 @@ public:
 
     template <LogicalType Type, class PageBuilderType, class PageDecoderType>
     void test_encode_decode_page_vectorized() {
-        using CppType = typename CppTypeTraits<Type>::CppType;
+        using CppType = StorageCppType<Type>;
         auto src = ChunkHelper::column_from_field_type(Type, false);
         CppType value = 0;
         size_t count = 64 * 1024 / sizeof(CppType);
@@ -246,10 +246,10 @@ public:
 
     // The values inserted should be sorted.
     template <LogicalType Type, class PageBuilderType, class PageDecoderType>
-    void test_seek_at_or_after_value_template(typename TypeTraits<Type>::CppType* src, size_t size,
-                                              typename TypeTraits<Type>::CppType* small_than_smallest,
-                                              typename TypeTraits<Type>::CppType* bigger_than_biggest) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    void test_seek_at_or_after_value_template(StorageCppType<Type>* src, size_t size,
+                                              StorageCppType<Type>* small_than_smallest,
+                                              StorageCppType<Type>* bigger_than_biggest) {
+        using CppType = StorageCppType<Type>;
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
         PageBuilderType page_builder(options);

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -64,7 +64,7 @@ protected:
     void write_bloom_filter_index_file(const std::string& file_name, const void* values, size_t value_count,
                                        size_t null_count, ColumnIndexMetaPB* index_meta) {
         TypeInfoPtr type_info = get_type_info(type);
-        using CppType = typename CppTypeTraits<type>::CppType;
+        using CppType = StorageCppType<type>;
         std::string fname = kTestDir + "/" + file_name;
         {
             ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
@@ -104,12 +104,11 @@ protected:
     }
 
     template <LogicalType Type>
-    void test_bloom_filter_index_reader_writer_template(const std::string file_name,
-                                                        typename TypeTraits<Type>::CppType* val, size_t num,
-                                                        size_t null_num,
-                                                        typename TypeTraits<Type>::CppType* not_exist_value,
+    void test_bloom_filter_index_reader_writer_template(const std::string file_name, StorageCppType<Type>* val,
+                                                        size_t num, size_t null_num,
+                                                        StorageCppType<Type>* not_exist_value,
                                                         bool is_slice_type = false) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+        using CppType = StorageCppType<Type>;
         ColumnIndexMetaPB meta;
         write_bloom_filter_index_file<Type>(file_name, val, num, null_num, &meta);
         {

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -108,7 +108,6 @@ protected:
                             const std::string& null_ratio = "0") {
         config::set_config("null_encoding", null_encoding);
 
-        using Type = typename TypeTraits<type>::CppType;
         TypeInfoPtr type_info = get_type_info(type);
         int num_rows = src.size();
         ColumnMetaPB meta;
@@ -254,7 +253,7 @@ protected:
 
     template <LogicalType type>
     void test_read_default_value(string value, void* result) {
-        using Type = typename TypeTraits<type>::CppType;
+        using Type = StorageCppType<type>;
         TypeInfoPtr type_info = get_type_info(type);
         // read and check
         {
@@ -444,7 +443,7 @@ protected:
 
     template <LogicalType type>
     MutableColumnPtr numeric_data(int null_ratio) {
-        using CppType = typename CppTypeTraits<type>::CppType;
+        using CppType = StorageCppType<type>;
         auto col = ChunkHelper::column_from_field_type(type, true);
         CppType value = 0;
         size_t count = 2 * 1024 / sizeof(CppType);

--- a/be/test/storage/rowset/dict_page_test.cpp
+++ b/be/test/storage/rowset/dict_page_test.cpp
@@ -33,8 +33,8 @@ namespace starrocks {
 class DictPageTest : public testing::Test {
 public:
     template <LogicalType Type>
-    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* data, size_t base_size, size_t all_size) {
-        using CppType = typename TypeTraits<Type>::CppType;
+    void test_encode_decode_page_template(StorageCppType<Type>* data, size_t base_size, size_t all_size) {
+        using CppType = StorageCppType<Type>;
         // encode
         PageBuilderOptions options;
         // 64K
@@ -311,7 +311,7 @@ TEST_F(DictPageTest, TestLargeDataSize) {
     for (int i = 0; i < size; i++) {
         ints.get()[i] = i;
     }
-    using CppType = typename TypeTraits<TYPE_BIGINT>::CppType;
+    using CppType = StorageCppType<TYPE_BIGINT>;
     // encode
     PageBuilderOptions options;
     options.data_page_size = 1024 * 1024;

--- a/be/test/storage/rowset/frame_of_reference_page_test.cpp
+++ b/be/test/storage/rowset/frame_of_reference_page_test.cpp
@@ -56,7 +56,7 @@ namespace starrocks {
 class FrameOfReferencePageTest : public testing::Test {
 public:
     template <LogicalType type, class PageDecoderType>
-    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
+    void copy_one(PageDecoderType* decoder, StorageCppType<type>* ret) {
         LogicalType ltype = scalar_field_type_to_logical_type(type);
         TypeDescriptor index_type(ltype);
         // TODO(alvinz): To reuse this colum
@@ -64,13 +64,13 @@ public:
         size_t n = 1;
         ASSERT_TRUE(decoder->next_batch(&n, column.get()).ok());
         ASSERT_EQ(1, n);
-        *ret = *reinterpret_cast<const typename TypeTraits<type>::CppType*>(column->raw_data());
+        *ret = *reinterpret_cast<const StorageCppType<type>*>(column->raw_data());
     }
 
     template <LogicalType Type, class PageBuilderType = FrameOfReferencePageBuilder<Type>,
               class PageDecoderType = FrameOfReferencePageDecoder<Type>>
-    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    void test_encode_decode_page_template(StorageCppType<Type>* src, size_t size) {
+        using CppType = StorageCppType<Type>;
         PageBuilderOptions builder_options;
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType for_page_builder(builder_options);
@@ -111,8 +111,8 @@ public:
 
     template <LogicalType Type, class PageBuilderType = FrameOfReferencePageBuilder<Type>,
               class PageDecoderType = FrameOfReferencePageDecoder<Type>>
-    void test_encode_decode_page_vectorize(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    void test_encode_decode_page_vectorize(StorageCppType<Type>* src, size_t size) {
+        using CppType = StorageCppType<Type>;
         PageBuilderOptions builder_options;
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType for_page_builder(builder_options);

--- a/be/test/storage/rowset/plain_page_test.cpp
+++ b/be/test/storage/rowset/plain_page_test.cpp
@@ -48,6 +48,7 @@
 #include "storage/rowset/page_builder.h"
 #include "storage/rowset/page_decoder.h"
 #include "storage/types.h"
+#include "types/type_traits.h"
 
 namespace starrocks {
 
@@ -63,18 +64,17 @@ public:
         return ret;
     }
 
-    template <LogicalType type, class PageDecoderType>
-    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
+    template <LogicalType type, class PageDecoderType, class CppType = StorageCppType<type>>
+    void copy_one(PageDecoderType* decoder, CppType* ret) {
         auto column = ChunkHelper::column_from_field_type(type, false);
         size_t n = 1;
         decoder->next_batch(&n, column.get());
         ASSERT_EQ(1, n);
-        *ret = *reinterpret_cast<const typename TypeTraits<type>::CppType*>(column->raw_data());
+        *ret = *reinterpret_cast<const CppType*>(column->raw_data());
     }
 
-    template <LogicalType Type, class PageBuilderType, class PageDecoderType>
-    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    template <LogicalType Type, class PageBuilderType, class PageDecoderType, class CppType = StorageCppType<Type>>
+    void test_encode_decode_page_template(CppType* src, size_t size) {
 
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
@@ -150,11 +150,10 @@ public:
         }
     }
 
-    template <LogicalType Type, class PageBuilderType, class PageDecoderType>
-    void test_seek_at_or_after_value_template(typename TypeTraits<Type>::CppType* src, size_t size,
-                                              typename TypeTraits<Type>::CppType* small_than_smallest,
-                                              typename TypeTraits<Type>::CppType* bigger_than_biggest) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    template <LogicalType Type, class PageBuilderType, class PageDecoderType, class CppType = StorageCppType<Type>>
+    void test_seek_at_or_after_value_template(CppType* src, size_t size,
+                                              StorageCppType<Type>* small_than_smallest,
+                                              StorageCppType<Type>* bigger_than_biggest) {
 
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
@@ -202,15 +201,13 @@ public:
         }
     }
 
-    template <LogicalType Type, class PageBuilderType>
-    void test_multi_pages(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
-
+    template <LogicalType Type, class PageBuilderType, class CppType = StorageCppType<Type>>
+    void test_multi_pages(CppType* src, size_t size) {
         PageBuilderOptions options;
         options.data_page_size = 64 * 1024;
         PageBuilderType page_builder(options);
 
-        size_t element_size = TypeTraits<Type>::size;
+        size_t element_size = sizeof(CppType);
         size_t max_count = options.data_page_size / element_size;
         size_t max_round = size / max_count;
 
@@ -227,7 +224,7 @@ public:
             }
             added += num;
             round++;
-            pos += num * TypeTraits<TYPE_INT>::size;
+            pos += num * sizeof(StorageCppType<TYPE_INT>);
             page_builder.reset();
         } while (num > 0);
         EXPECT_EQ(size, added);

--- a/be/test/storage/rowset/plain_page_test.cpp
+++ b/be/test/storage/rowset/plain_page_test.cpp
@@ -75,7 +75,6 @@ public:
 
     template <LogicalType Type, class PageBuilderType, class PageDecoderType, class CppType = StorageCppType<Type>>
     void test_encode_decode_page_template(CppType* src, size_t size) {
-
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
         PageBuilderType page_builder(options);
@@ -151,10 +150,8 @@ public:
     }
 
     template <LogicalType Type, class PageBuilderType, class PageDecoderType, class CppType = StorageCppType<Type>>
-    void test_seek_at_or_after_value_template(CppType* src, size_t size,
-                                              StorageCppType<Type>* small_than_smallest,
+    void test_seek_at_or_after_value_template(CppType* src, size_t size, StorageCppType<Type>* small_than_smallest,
                                               StorageCppType<Type>* bigger_than_biggest) {
-
         PageBuilderOptions options;
         options.data_page_size = 256 * 1024;
         PageBuilderType page_builder(options);

--- a/be/test/storage/rowset/plain_page_test.cpp
+++ b/be/test/storage/rowset/plain_page_test.cpp
@@ -221,7 +221,7 @@ public:
             }
             added += num;
             round++;
-            pos += num * sizeof(StorageCppType<TYPE_INT>);
+            pos += num * StorageCppTypeSize<TYPE_INT>;
             page_builder.reset();
         } while (num > 0);
         EXPECT_EQ(size, added);

--- a/be/test/storage/rowset/rle_page_test.cpp
+++ b/be/test/storage/rowset/rle_page_test.cpp
@@ -46,6 +46,7 @@
 #include "storage/rowset/options.h"
 #include "storage/rowset/page_builder.h"
 #include "storage/rowset/page_decoder.h"
+#include "types/type_traits.h"
 #include "util/logging.h"
 
 using starrocks::PageBuilderOptions;
@@ -56,19 +57,19 @@ class RlePageTest : public testing::Test {
 public:
     ~RlePageTest() override = default;
 
-    template <LogicalType type, class PageDecoderType>
-    void copy_one(PageDecoderType* decoder, typename TypeTraits<type>::CppType* ret) {
+    template <LogicalType type, class PageDecoderType, class CppType = StorageCppType<type>>
+    void copy_one(PageDecoderType* decoder, CppType* ret) {
         auto column = ChunkHelper::column_from_field_type(type, false);
 
         size_t n = 1;
         ASSERT_TRUE(decoder->next_batch(&n, column.get()).ok());
         ASSERT_EQ(1, n);
-        *ret = *reinterpret_cast<const typename TypeTraits<type>::CppType*>(column->raw_data());
+        *ret = *reinterpret_cast<const CppType*>(column->raw_data());
     }
 
     template <LogicalType Type, class PageBuilderType = RlePageBuilder<Type>>
-    OwnedSlice rle_encode(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    OwnedSlice rle_encode(StorageCppType<Type>* src, size_t size) {
+        using CppType = StorageCppType<Type>;
         PageBuilderOptions builder_options;
         builder_options.data_page_size = 256 * 1024;
         PageBuilderType rle_page_builder(builder_options);
@@ -86,9 +87,8 @@ public:
         return s;
     }
 
-    template <LogicalType Type>
-    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    template <LogicalType Type, class CppType = StorageCppType<Type>>
+    void test_encode_decode_page_template(CppType* src, size_t size) {
         OwnedSlice s = rle_encode<Type>(src, size);
 
         RlePageDecoder<Type> rle_page_decoder(s.slice());
@@ -121,9 +121,8 @@ public:
         }
     }
 
-    template <LogicalType Type>
-    void test_encode_decode_page_vectorized(typename TypeTraits<Type>::CppType* src, size_t size) {
-        typedef typename TypeTraits<Type>::CppType CppType;
+    template <LogicalType Type, class CppType = StorageCppType<Type>>
+    void test_encode_decode_page_vectorized(CppType* src, size_t size) {
         OwnedSlice s = rle_encode<Type>(src, size);
 
         RlePageDecoder<Type> rle_page_decoder(s.slice());
@@ -173,7 +172,7 @@ TEST_F(RlePageTest, TestRleInt32BlockEncoderRandom) {
 
     // TYPE_INT
     {
-        using CppType = TypeTraits<TYPE_INT>::CppType;
+        using CppType = StorageCppType<TYPE_INT>;
         std::vector<CppType> ints(size, 0);
         std::generate(std::begin(ints), std::end(ints), []() -> CppType { return rand(); });
         test_encode_decode_page_template<TYPE_INT>(ints.data(), size);
@@ -181,7 +180,7 @@ TEST_F(RlePageTest, TestRleInt32BlockEncoderRandom) {
     }
     // TYPE_BIGINT
     {
-        using CppType = TypeTraits<TYPE_BIGINT>::CppType;
+        using CppType = StorageCppType<TYPE_BIGINT>;
         std::vector<CppType> ints(size, 0);
         std::generate(std::begin(ints), std::end(ints), []() -> CppType { return rand(); });
         test_encode_decode_page_template<TYPE_BIGINT>(ints.data(), size);

--- a/be/test/storage/vector_chunk_iterator.h
+++ b/be/test/storage/vector_chunk_iterator.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#pragma once
 
 #include <array>
 #include <initializer_list>
@@ -37,7 +38,7 @@ struct DatumBuilder {
         Datums datums;
         datums.resize(data.size());
         for (size_t i = 0; i < data.size(); i++) {
-            datums[i].set(static_cast<typename TypeTraits<Type>::CppType>(data[i]));
+            datums[i].set(static_cast<StorageCppType<Type>>(data[i]));
         }
         return datums;
     }

--- a/be/test/types/type_info_test.cpp
+++ b/be/test/types/type_info_test.cpp
@@ -64,8 +64,8 @@ private:
     std::vector<std::unique_ptr<uint8_t[]>> _buffers;
 };
 
-template <LogicalType field_type, class CppType = StorageCppType<field_type>>
-void common_test(CppType src_val) {
+template <LogicalType field_type>
+void common_test(StorageCppType<field_type> src_val) {
     TypeInfoPtr type = get_type_info(field_type);
 
     ASSERT_EQ(field_type, type->type());

--- a/be/test/types/type_info_test.cpp
+++ b/be/test/types/type_info_test.cpp
@@ -67,6 +67,7 @@ private:
 template <LogicalType field_type>
 void common_test(StorageCppType<field_type> src_val) {
     TypeInfoPtr type = get_type_info(field_type);
+    using CppType = StorageCppType<field_type>;
 
     ASSERT_EQ(field_type, type->type());
     ASSERT_EQ(sizeof(src_val), type->size());

--- a/be/test/types/type_info_test.cpp
+++ b/be/test/types/type_info_test.cpp
@@ -64,30 +64,30 @@ private:
     std::vector<std::unique_ptr<uint8_t[]>> _buffers;
 };
 
-template <LogicalType field_type>
-void common_test(typename TypeTraits<field_type>::CppType src_val) {
+template <LogicalType field_type, class CppType = StorageCppType<field_type>>
+void common_test(CppType src_val) {
     TypeInfoPtr type = get_type_info(field_type);
 
     ASSERT_EQ(field_type, type->type());
     ASSERT_EQ(sizeof(src_val), type->size());
     {
-        typename TypeTraits<field_type>::CppType dst_val;
+        CppType dst_val;
         LocalTypeInfoAllocator local_allocator;
         auto allocator = local_allocator.make_allocator();
         type->deep_copy((char*)&dst_val, (char*)&src_val, &allocator);
     }
     {
-        typename TypeTraits<field_type>::CppType dst_val;
+        CppType dst_val;
         type->direct_copy((char*)&dst_val, (char*)&src_val);
     }
     // test min
     {
-        typename TypeTraits<field_type>::CppType dst_val;
+        CppType dst_val;
         type->set_to_min((char*)&dst_val);
     }
     // test max
     {
-        typename TypeTraits<field_type>::CppType dst_val;
+        CppType dst_val;
         type->set_to_max((char*)&dst_val);
         // NOTE: bool input is true, this will return 0
     }
@@ -120,7 +120,6 @@ void test_char(Slice src_val) {
     // test max
     {
         char buf[64];
-        Slice dst_val(buf, sizeof(buf));
         memset(buf, 0xFF, 64);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

To distinguish it from RunTimeTypeTraits (used in the execution framework), rename CppTypeTraits to StorageTypeTraits (used for storage engine).

This is the 9st for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

Rename CppTypeTraits to StorageCppType

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
