### PR TITLE
[Tool]Add SLACK_BOT_TOKEN to CI report notification

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -600,6 +600,7 @@ jobs:
       WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
       FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
       FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       PR_NUMBER: ${{ needs.INFO.outputs.PR_NUMBER }}
     steps:
       - name: CLEAN


### PR DESCRIPTION
## Why I'm doing:

Enable Slack DM notifications for CI results alongside existing Feishu notifications.

## What I'm doing:

Pass SLACK_BOT_TOKEN secret to NOTIFICATION job env in ci-report.yml.
The actual notification logic is in ci-tool repo (already merged).
If the secret is not set, Slack notification is silently skipped (no impact on Feishu).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr