### PR TITLE
[BugFix] Fix nullable aliasing in array/map functions

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -60,7 +60,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
         if (arg0->has_null()) {
             // Copy null flags.
             return NullableColumn::create(std::move(col_result),
-                                          std::move(*(down_cast<const NullableColumn*>(arg0)->null_column())).mutate());
+                                          down_cast<const NullableColumn*>(arg0)->null_column()->clone());
         } else {
             return col_result;
         }
@@ -136,7 +136,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_append([[maybe_unused]] FunctionContex
     RETURN_IF_ERROR(result);
 
     if (nullable_array != nullptr) {
-        return NullableColumn::create(std::move(result.value()), nullable_array->null_column());
+        return NullableColumn::create(std::move(result.value()), nullable_array->null_column()->clone());
     }
     return result;
 }
@@ -372,7 +372,7 @@ private:
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
             ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
-            return NullableColumn::create(std::move(result), nullable->null_column());
+            return NullableColumn::create(std::move(result), nullable->null_column()->clone());
         }
 
         return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
@@ -1921,7 +1921,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     auto result = ArrayColumn::create(result_elements, result_offsets);
     if (src_nullable_column != nullptr) {
-        return NullableColumn::create(result, src_nullable_column->null_column());
+        return NullableColumn::create(std::move(result), src_nullable_column->null_column()->clone());
     }
     return result;
 }

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -145,7 +145,7 @@ StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Colum
 
     if (arg0->has_null()) {
         return NullableColumn::create(std::move(col_result),
-                                      down_cast<const NullableColumn*>(arg0.get())->null_column());
+                                      down_cast<const NullableColumn*>(arg0.get())->null_column()->clone());
     } else {
         return col_result;
     }

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -262,6 +262,31 @@ TEST_F(ArrayFunctionsTest, array_length) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_length_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)}));
+
+    auto result = ArrayFunctions::array_length(nullptr, {input}).value();
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    ASSERT_EQ(5, result_nullable->data_column()->size());
+    ASSERT_EQ(5, result_nullable->null_column()->size());
+
+    Filter filter = {1, 0, 1, 0, 1};
+    input->filter(filter);
+
+    EXPECT_EQ(5, result_nullable->data_column()->size());
+    EXPECT_EQ(5, result_nullable->null_column()->size());
+}
+
+// NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_cum_sum) {
     // []
     // NULL

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -70,6 +70,9 @@ protected:
     void _check_array_nullable(const Buffer<CppType>& check_values, const Buffer<uint8_t>& nulls,
                                const DatumArray& value);
 
+    void _assert_nullable_result_has_independent_null_column(const ColumnPtr& input, const ColumnPtr& result,
+                                                             const Filter& filter);
+
     FunctionContext _ctx;
 };
 
@@ -142,6 +145,25 @@ void ArrayFunctionsTest::_check_array_nullable(const Buffer<CppType>& check_valu
     } else {
         ASSERT_TRUE(false);
     }
+}
+
+void ArrayFunctionsTest::_assert_nullable_result_has_independent_null_column(const ColumnPtr& input,
+                                                                             const ColumnPtr& result,
+                                                                             const Filter& filter) {
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    EXPECT_NE(input_nullable->null_column().get(), result_nullable->null_column().get());
+
+    const size_t result_data_size = result_nullable->data_column()->size();
+    const size_t result_null_size = result_nullable->null_column()->size();
+
+    input->filter(filter);
+
+    EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
+    EXPECT_EQ(result_null_size, result_nullable->null_column()->size());
 }
 
 // NOLINTNEXTLINE
@@ -271,19 +293,56 @@ TEST_F(ArrayFunctionsTest, array_length_result_should_not_share_null_column_with
     input->append_datum(Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)}));
 
     auto result = ArrayFunctions::array_length(nullptr, {input}).value();
-    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
-    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0, 1});
+}
 
-    ASSERT_TRUE(input_nullable != nullptr);
-    ASSERT_TRUE(result_nullable != nullptr);
-    ASSERT_EQ(5, result_nullable->data_column()->size());
-    ASSERT_EQ(5, result_nullable->null_column()->size());
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_append_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{}));
+    input->append_datum(Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)}));
 
-    Filter filter = {1, 0, 1, 0, 1};
-    input->filter(filter);
+    MutableColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
 
-    EXPECT_EQ(5, result_nullable->data_column()->size());
-    EXPECT_EQ(5, result_nullable->null_column()->size());
+    auto result = ArrayFunctions::array_append(nullptr, {input, target}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_remove_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)2)}));
+    input->append_datum(Datum(DatumArray{}));
+
+    MutableColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+
+    auto result = ArrayFunctions::array_remove(nullptr, {input, target}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_flatten_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)1)}),
+                                         Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{})}));
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)4)}), Datum(DatumArray{})}));
+
+    auto result = ArrayFunctions::array_flatten(nullptr, {input}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
 }
 
 // NOLINTNEXTLINE

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -335,8 +335,8 @@ TEST_F(ArrayFunctionsTest, array_remove_result_should_not_share_null_column_with
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_flatten_result_should_not_share_null_column_with_input) {
     MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
-    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)1)}),
-                                         Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
+    input->append_datum(Datum(
+            DatumArray{Datum(DatumArray{Datum((int32_t)1)}), Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
     input->append_datum(Datum());
     input->append_datum(Datum(DatumArray{Datum(DatumArray{})}));
     input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)4)}), Datum(DatumArray{})}));

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -160,7 +160,7 @@ void ArrayFunctionsTest::_assert_nullable_result_has_independent_null_column(con
     const size_t result_data_size = result_nullable->data_column()->size();
     const size_t result_null_size = result_nullable->null_column()->size();
 
-    input->filter(filter);
+    input->as_mutable_raw_ptr()->filter(filter);
 
     EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
     EXPECT_EQ(result_null_size, result_nullable->null_column()->size());

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -43,7 +43,7 @@ void _assert_nullable_result_has_independent_null_column(const ColumnPtr& input,
     const size_t result_data_size = result_nullable->data_column()->size();
     const size_t result_null_size = result_nullable->null_column()->size();
 
-    input->filter(filter);
+    input->as_mutable_raw_ptr()->filter(filter);
 
     EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
     EXPECT_EQ(result_null_size, result_nullable->null_column()->size());

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -31,6 +31,24 @@ TypeDescriptor map_type(LogicalType key, LogicalType value) {
     return type_creator;
 }
 
+void _assert_nullable_result_has_independent_null_column(const ColumnPtr& input, const ColumnPtr& result,
+                                                         const Filter& filter) {
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    EXPECT_NE(input_nullable->null_column().get(), result_nullable->null_column().get());
+
+    const size_t result_data_size = result_nullable->data_column()->size();
+    const size_t result_null_size = result_nullable->null_column()->size();
+
+    input->filter(filter);
+
+    EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
+    EXPECT_EQ(result_null_size, result_nullable->null_column()->size());
+}
+
 PARALLEL_TEST(MapFunctionsTest, test_map) {
     TypeDescriptor input_keys_type;
     input_keys_type.type = LogicalType::TYPE_ARRAY;
@@ -343,19 +361,7 @@ PARALLEL_TEST(MapFunctionsTest, map_size_result_should_not_share_null_column_wit
     column->append_default();
 
     auto result = MapFunctions::map_size(nullptr, {column}).value();
-    auto input_nullable = NullableColumn::dynamic_pointer_cast(column);
-    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
-
-    ASSERT_TRUE(input_nullable != nullptr);
-    ASSERT_TRUE(result_nullable != nullptr);
-    ASSERT_EQ(4, result_nullable->data_column()->size());
-    ASSERT_EQ(4, result_nullable->null_column()->size());
-
-    Filter filter = {1, 0, 1, 0};
-    column->filter(filter);
-
-    EXPECT_EQ(4, result_nullable->data_column()->size());
-    EXPECT_EQ(4, result_nullable->null_column()->size());
+    _assert_nullable_result_has_independent_null_column(column, result, {1, 0, 1, 0});
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -325,6 +325,39 @@ PARALLEL_TEST(MapFunctionsTest, test_map_function) {
     EXPECT_EQ(66, result_values->get(1).get_array()[2].get_int32());
 }
 
+PARALLEL_TEST(MapFunctionsTest, map_size_result_should_not_share_null_column_with_input) {
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
+    MutableColumnPtr column = ColumnHelper::create_column(type_map_int_int, true);
+
+    DatumMap map0;
+    map0[(int32_t)1] = (int32_t)11;
+    map0[(int32_t)2] = (int32_t)22;
+    column->append_datum(map0);
+
+    column->append_default();
+
+    DatumMap map2;
+    map2[(int32_t)3] = (int32_t)33;
+    column->append_datum(map2);
+
+    column->append_default();
+
+    auto result = MapFunctions::map_size(nullptr, {column}).value();
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(column);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    ASSERT_EQ(4, result_nullable->data_column()->size());
+    ASSERT_EQ(4, result_nullable->null_column()->size());
+
+    Filter filter = {1, 0, 1, 0};
+    column->filter(filter);
+
+    EXPECT_EQ(4, result_nullable->data_column()->size());
+    EXPECT_EQ(4, result_nullable->null_column()->size());
+}
+
 PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
     TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 


### PR DESCRIPTION
## Why I'm doing:

PR #66740 regressed several array/map expression functions by replacing safe `null_column()->clone()` calls with `mutate()`. When `mutate()` is called on a null column with `use_count() == 1`, it returns the same object instead of cloning, causing the result NullableColumn to share its null bitmap with the input column.

When both columns coexist in the same Chunk (e.g., via ProjectOperator placing `slot_ref(col)` and `array_length(col)` side-by-side), an in-place `Chunk::filter()` shrinks the shared null bitmap through the first column, leaving the second column with mismatched `_data_column` / `_null_column` sizes.

### Crash signature

```
Check failed: _data_column->size() == _null_column->size() (3 vs. 2)
```

### Regression chain

| Date | PR | array_length null_column handling | Safe? |
|------|----|-------------------------------------|-------|
| 2025-03-06 | #56287 (COW Part2) | ->as_mutable_ptr() | No |
| 2025-03-12 | #56810 (BugFix) | ->clone() | Yes, Fixed |
| **2025-12-24** | **#66740 (COW Follow-up)** | **.mutate()** | **No, Regressed** |

### Call path

```
SelectOperator::push_chunk
  -> eval_conjuncts_and_in_filters
    -> eager_prune_eval_conjuncts       (num_columns <= 5)
      -> Chunk::filter                  (in-place, column-by-column)
        -> NullableColumn::size()       -> DCHECK fails: data=3, null=2
```

## What I'm doing:

Replace `mutate()` / direct `null_column()` references with `null_column()->clone()` in the affected functions to ensure result columns always own an independent null bitmap:

- `ArrayFunctions::array_length` -- `mutate()` to `clone()`
- `ArrayFunctions::array_append` -- direct ref to `clone()`
- `ArrayRemoveImpl::_array_remove_generic` -- direct ref to `clone()`
- `ArrayFunctions::array_flatten` -- direct ref to `clone()`
- `MapFunctions::map_size` -- direct ref to `clone()`

Added regression tests for each function verifying that filtering the input column does not corrupt the result column's null/data sizes.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11200

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4