### PR TITLE
[Perf] Inline small delvecs in tablet metadata to eliminate remote IO

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1338,6 +1338,10 @@ CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_mBool(enable_strict_delvec_crc_check, "true");
+// Maximum serialized size (bytes) of a delvec to store inline in tablet metadata.
+// Delvecs at or below this size are embedded directly in the DelvecPagePB, eliminating
+// remote IO during compaction conflict resolution. Set to 0 to disable inlining.
+CONF_mInt32(lake_delvec_inline_max_size, "4096");
 // When the ratio of cumulative level to base level is greater than this config, use base merge.
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -124,4 +124,7 @@ CONF_mBool(lake_enable_alter_struct, "true");
 // For table schema service: max retry attempts for fetching schema from FE.
 CONF_mInt32(table_schema_service_max_retries, "3");
 
+// Maximum serialized size (bytes) of a delvec to store inline in tablet metadata.
+CONF_mInt32(lake_delvec_inline_max_size, "4096");
+
 } // namespace starrocks::config

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -76,8 +76,11 @@ static std::string delvec_cache_key(int64_t tablet_id, const DelvecPagePB& page)
     DelvecCacheKeyPB cache_key_pb;
     cache_key_pb.set_id(tablet_id);
     cache_key_pb.mutable_delvec_page()->CopyFrom(page);
-    // Do not include crc32c_gen_version in cache key
+    // Do not include crc32c_gen_version or inline_data in cache key.
+    // inline_data can be KB-sized; including it makes keys huge and destroys
+    // cache performance (serialization, comparison, memory).
     cache_key_pb.mutable_delvec_page()->clear_crc32c_gen_version();
+    cache_key_pb.mutable_delvec_page()->clear_inline_data();
     return cache_key_pb.SerializeAsString();
 }
 

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -747,7 +747,8 @@ StatusOr<bool> MetaFileBuilder::find_delvec(const TabletSegmentId& tsid, DelVect
     auto data_iter = _delvec_data.find(tsid.segment_id);
     if (data_iter != _delvec_data.end()) {
         auto page_iter = _delvecs.find(tsid.segment_id);
-        int64_t ver = (page_iter != _delvecs.end() && page_iter->second.has_version()) ? page_iter->second.version() : 0;
+        int64_t ver =
+                (page_iter != _delvecs.end() && page_iter->second.has_version()) ? page_iter->second.version() : 0;
         (*pdelvec) = std::make_shared<DelVector>();
         RETURN_IF_ERROR((*pdelvec)->load(ver, data_iter->second.data(), data_iter->second.size()));
         return true;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -98,14 +98,11 @@ MetaFileBuilder::MetaFileBuilder(const Tablet& tablet, std::shared_ptr<TabletMet
 
 void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment_id) {
     if (delvec->cardinality() > 0) {
-        const uint64_t offset = _buf.size();
         std::string delvec_str;
         delvec->save_to(&delvec_str);
-        _buf.insert(_buf.end(), delvec_str.begin(), delvec_str.end());
-        const uint64_t size = _buf.size() - offset;
-        _delvecs[segment_id].set_offset(offset);
-        _delvecs[segment_id].set_size(size);
+        _delvecs[segment_id].set_size(delvec_str.size());
         _delvecs[segment_id].set_crc32c(crc32c::Mask(crc32c::Value(delvec_str.data(), delvec_str.size())));
+        _delvec_data[segment_id] = std::move(delvec_str);
         _segmentid_to_delvec[segment_id] = delvec;
     }
 }
@@ -605,6 +602,26 @@ Status MetaFileBuilder::update_num_del_stat(const std::map<uint32_t, size_t>& se
 Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
     if (!is_primary_key(_tablet_meta.get())) return Status::OK();
 
+    const int32_t inline_max_size = config::lake_delvec_inline_max_size;
+
+    // Build _buf from _delvec_data and assign file offsets.
+    // All delvecs go to the file for backward compatibility; small ones are
+    // additionally inlined into DelvecPagePB.inline_data.
+    _buf.clear();
+    for (auto& [seg_id, page_pb] : _delvecs) {
+        auto data_it = _delvec_data.find(seg_id);
+        if (data_it == _delvec_data.end()) continue;
+        const auto& data = data_it->second;
+        const uint64_t offset = _buf.size();
+        _buf.insert(_buf.end(), data.begin(), data.end());
+        page_pb.set_offset(offset);
+        page_pb.set_size(data.size());
+        // Inline small delvecs into metadata
+        if (inline_max_size > 0 && static_cast<int32_t>(data.size()) <= inline_max_size) {
+            page_pb.set_inline_data(data);
+        }
+    }
+
     // 1. update delvec page in meta
     for (auto&& each_delvec : *(_tablet_meta->mutable_delvec_meta()->mutable_delvecs())) {
         auto iter = _delvecs.find(each_delvec.first);
@@ -614,6 +631,9 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
             each_delvec.second.set_size(iter->second.size());
             each_delvec.second.set_crc32c(iter->second.crc32c());
             each_delvec.second.set_crc32c_gen_version(version);
+            if (iter->second.has_inline_data()) {
+                each_delvec.second.set_inline_data(iter->second.inline_data());
+            }
             // record from cache key to segment id, so we can fill up cache later
             _cache_key_to_segment_id[delvec_cache_key(_tablet_meta->id(), each_delvec.second)] = iter->first;
             _delvecs.erase(iter);
@@ -721,13 +741,12 @@ Status MetaFileBuilder::finalize(int64_t txn_id, bool skip_write_tablet_metadata
 }
 
 StatusOr<bool> MetaFileBuilder::find_delvec(const TabletSegmentId& tsid, DelVectorPtr* pdelvec) const {
-    auto iter = _delvecs.find(tsid.segment_id);
-    if (iter != _delvecs.end()) {
+    auto data_iter = _delvec_data.find(tsid.segment_id);
+    if (data_iter != _delvec_data.end()) {
+        auto page_iter = _delvecs.find(tsid.segment_id);
+        int64_t ver = (page_iter != _delvecs.end() && page_iter->second.has_version()) ? page_iter->second.version() : 0;
         (*pdelvec) = std::make_shared<DelVector>();
-        // read delvec from write buf
-        RETURN_IF_ERROR((*pdelvec)->load(iter->second.version(),
-                                         reinterpret_cast<const char*>(_buf.data()) + iter->second.offset(),
-                                         iter->second.size()));
+        RETURN_IF_ERROR((*pdelvec)->load(ver, data_iter->second.data(), data_iter->second.size()));
         return true;
     }
     return false;
@@ -751,6 +770,14 @@ void MetaFileBuilder::finalize_sstable_meta(const PersistentIndexSstableMetaPB& 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, const DelvecPagePB& delvec_page,
                    bool fill_cache, const LakeIOOptions& lake_io_opts, DelVector* delvec) {
     VLOG(2) << fmt::format("get_del_vec {} tabletid {}", delvec_page.ShortDebugString(), metadata.id());
+
+    // Fast path: use inline data if available (no remote IO needed)
+    if (delvec_page.has_inline_data() && !delvec_page.inline_data().empty()) {
+        RETURN_IF_ERROR(delvec->load(delvec_page.version(), delvec_page.inline_data().data(),
+                                     delvec_page.inline_data().size()));
+        return Status::OK();
+    }
+
     std::string buf;
     raw::stl_string_resize_uninitialized(&buf, delvec_page.size());
     // find in cache

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -133,6 +133,8 @@ private:
     UpdateManager* _update_mgr;
     Buffer<uint8_t> _buf;
     std::unordered_map<uint32_t, DelvecPagePB> _delvecs;
+    // Raw serialized delvec data per segment, used by _finalize_delvec to decide inlining
+    std::unordered_map<uint32_t, std::string> _delvec_data;
     // from segment id to delvec, used for fill cache in finalize stage.
     std::unordered_map<uint32_t, DelVectorPtr> _segmentid_to_delvec;
     // from cache key to segment id

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -36,6 +36,11 @@ message DelvecPagePB {
     optional uint32 crc32c = 4;
     // For upgrade compatibility.
     optional int64 crc32c_gen_version = 5;
+    // Small delvecs are stored inline in tablet metadata to avoid remote IO
+    // during compaction conflict resolution. When present, readers should use
+    // this data directly instead of reading from the delvec file.
+    // The file-based fields (offset/size) remain valid for backward compatibility.
+    optional bytes inline_data = 6;
 }
 
 message PersistentIndexSstableRangePB {


### PR DESCRIPTION
## Why I'm doing:

During publish of compaction results in shared-data mode, the compaction conflict resolver loads delete vectors (delvecs) **sequentially** for each input rowset segment. With 400-500 input rowsets (common in high-throughput stream load workloads), this causes 400-500 sequential remote storage reads (S3/OSS) at ~2-3ms each, totaling **1.0-1.4 seconds per publish**.

The previous batch-preload approach (#71146) amortized file opens but still read the same total data. This change takes a fundamentally different approach: **store the delvec data directly in tablet metadata**, so it's already in memory when needed.

### Benchmark Evidence (30GB single-table, 3x CN 16c64g shared-data)

From CN publish traces:

| input_rowsets_size | compaction_delvec_loader_us | Total publish cost |
|---|---|---|
| 88 | 56 ms | 1,716 ms |
| 263 | 518 ms | 2,545 ms |
| 481 | 1,341 ms | 3,699 ms |

Linear scaling at ~2.8 ms per input rowset. This dominates publish time and directly causes ingestion P99 of 76s (target: <5s).

## What I changed:

### Proto change
Added `optional bytes inline_data = 6` to `DelvecPagePB`. When present, readers use this data directly instead of reading from the delvec file.

### Write path (`MetaFileBuilder`)
- `append_delvec()`: Stores serialized delvec data in a per-segment map (`_delvec_data`) instead of directly in the file buffer
- `_finalize_delvec()`: For delvecs ≤ `lake_delvec_inline_max_size` (default 4KB), sets `inline_data` on the `DelvecPagePB`. Still writes all delvecs to the delvec file for **backward compatibility** (old BEs that don't understand `inline_data` can still read from file)
- `find_delvec()`: Updated to read from `_delvec_data` map instead of `_buf`

### Read path (`get_del_vec`)
Added fast path at the top of `get_del_vec()`: if `delvec_page.has_inline_data()`, load directly from inline data — **zero remote IO, zero cache lookup**.

### Configuration
- `lake_delvec_inline_max_size` (default: 4096 bytes) — controls the max delvec size to inline. Set to 0 to disable.

## How it works:

For typical stream load workloads, each delvec is a roaring bitmap of deleted row IDs from upsert operations. With batch sizes of 5000 rows and ~10-20% update rate, each delvec contains a few hundred entries and serializes to **100-500 bytes** — well under the 4KB threshold.

When tablet metadata is loaded (which is always cached by tablet_manager), all inline delvecs are immediately available. The conflict resolution loop finds every delvec in the `DelvecPagePB.inline_data` field and never hits remote storage.

## Expected impact:
- **Eliminate** `compaction_delvec_loader_latency_us` entirely (from ~1s to ~0) for tablets where all delvecs are ≤ 4KB
- Metadata size increase: ~200-400 bytes per segment with delvecs (acceptable — metadata is always in memory)
- No impact on non-PK tables or tables without deletes

## Backward compatibility:
- Old BEs ignore the new `inline_data` field and continue reading from delvec files (offset/size remain valid)
- New BEs prefer `inline_data` when available, fall back to file for old metadata without inline data
- Delvec files are still written for all delvecs, ensuring safe rolling upgrade/downgrade

## Files changed:
- `gensrc/proto/lake_types.proto` — Add `inline_data` field
- `be/src/common/config.h`, `config_lake_fwd.h` — Add `lake_delvec_inline_max_size` config
- `be/src/storage/lake/meta_file.h` — Add `_delvec_data` member
- `be/src/storage/lake/meta_file.cpp` — Write path (inline in finalize), read path (fast path in get_del_vec)