### PR TITLE
[BugFix] Deduplicate repeated Apply attachment for scalar-subquery pl…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceSubqueryRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceSubqueryRewriteRule.java
@@ -22,7 +22,9 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.sql.optimizer.transformer.OptExprBuilder;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The processing flow of the subquery is as follows:
@@ -35,6 +37,7 @@ import java.util.Map;
 public class ReplaceSubqueryRewriteRule extends TopDownScalarOperatorRewriteRule {
 
     private final Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders;
+    private final Set<Integer> attachedApplyOutputIds = new HashSet<>();
     private OptExprBuilder builder;
 
     public ReplaceSubqueryRewriteRule(Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders,
@@ -59,8 +62,11 @@ public class ReplaceSubqueryRewriteRule extends TopDownScalarOperatorRewriteRule
         SubqueryOperator subqueryOperator = Utils.getValueIfExists(subqueryPlaceholders, scalarOperator);
         if (subqueryOperator != null) {
             LogicalApplyOperator applyOperator = subqueryOperator.getApplyOperator();
-            builder = new OptExprBuilder(applyOperator, Arrays.asList(builder, subqueryOperator.getRootBuilder()),
-                    builder.getExpressionMapping());
+            int outputId = applyOperator.getOutput().getId();
+            if (attachedApplyOutputIds.add(outputId)) {
+                builder = new OptExprBuilder(applyOperator, Arrays.asList(builder, subqueryOperator.getRootBuilder()),
+                        builder.getExpressionMapping());
+            }
         }
 
         return scalarOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -18,11 +18,13 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.SemanticException;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -111,6 +113,14 @@ public class SubqueryTest extends PlanTestBase {
                 + "\n"
                 + "  14:AGGREGATE (update finalize)\n"
                 + "  |  output: avg(5: v8)\n");
+    }
+
+    @Test
+    public void testBetweenScalarSubqueryAttachApplyOnlyOnce() throws Exception {
+        String sql = "with table_dt as (select if(v4 > 10, 10, v4) as v_date from t1) " +
+                "select v1 from t0 where (select v_date from table_dt) between 1 and 2";
+        String plan = getFragmentPlan(sql);
+        assertEquals(1, StringUtils.countMatches(plan, "ASSERT NUMBER OF ROWS"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Predicate normalization can make the same scalar-subquery placeholder appear multiple times in one rewrite pass.  
`ReplaceSubqueryRewriteRule` currently attaches an `Apply` node on every hit, which introduces duplicate subquery branches, extra `CROSS JOIN` / `ASSERT NUMBER OF ROWS`, and unstable downstream planning behavior.

## What I'm doing:
I only changed `ReplaceSubqueryRewriteRule` to deduplicate `Apply` attachment for scalar-subquery placeholders within the same rewrite pass:
- Track attached subqueries by `applyOperator.getOutput().getId()`.
- Attach `Apply` only on the first hit of a given output id.
- Skip repeated hits of the same placeholder/output id.

For the repro SQL:
```sql
with table_dt as (select if(v4 > 10, 10, v4) as v_date from t1)
select v1 from t0 where (select v_date from table_dt) between 1 and 2
```

## Plan comparison (before vs after):
- Total plan fragments: `5 -> 3`
- `ASSERT NUMBER OF ROWS` count: `2 -> 1`
- Root join chain: duplicate outer `CROSS JOIN` branch removed
- Predicate semantics unchanged: still `7: if >= 1, 7: if <= 2`

### Before (contains duplicated subquery branch)
```text
15:Project
14:NESTLOOP JOIN (CROSS JOIN)
  |----13:EXCHANGE
  8:Project
  7:NESTLOOP JOIN (CROSS JOIN)
...
12:ASSERT NUMBER OF ROWS
...
4:ASSERT NUMBER OF ROWS
```

### After (single subquery branch)
```text
8:Project
7:NESTLOOP JOIN (CROSS JOIN)
...
4:ASSERT NUMBER OF ROWS
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
