### PR TITLE
[BugFix] Add isLeader check in TaskManager scheduler callbacks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -124,6 +124,9 @@ public class TaskManager implements MemoryTrackable {
             clearUnfinishedTaskRun();
             registerPeriodicalTask();
             dispatchScheduler.scheduleAtFixedRate(() -> {
+                if (!GlobalStateMgr.getCurrentState().isLeader()) {
+                    return;
+                }
                 if (!taskRunManager.tryTaskRunLock()) {
                     LOG.warn("TaskRun scheduler cannot acquire the lock");
                     return;
@@ -835,6 +838,9 @@ public class TaskManager implements MemoryTrackable {
         // set task's next schedule time
         task.setNextScheduleTime(currentDateTime.plusSeconds(initialDelay).toEpochSecond(ZoneOffset.UTC));
         ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> {
+            if (!GlobalStateMgr.getCurrentState().isLeader()) {
+                return;
+            }
             // ensure an execute task will not throw exception
             try {
                 task.setLastScheduleTime(TimeUtils.getEpochSeconds());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -1322,4 +1322,136 @@ public class TaskManagerTest {
         Assertions.assertFalse(executeTaskCalled[0], "Non-MV task should not be executed immediately");
         Assertions.assertNotNull(spyTaskManager.getPeriodFutureMap().get(task.getId()));
     }
+
+    @Test
+    public void testPeriodSchedulerSkipsWhenNotLeader() throws Exception {
+        // Mock isLeader() to return false
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public SubmitResult executeTask(String taskName, ExecuteOption option) {
+                executeTaskCalled[0] = true;
+                return new SubmitResult("xxxx", SubmitResult.SubmitStatus.SUBMITTED);
+            }
+        };
+
+        Task task = new Task("test_period_leader_check");
+        task.setDefinition("select 1");
+        task.setSource(Constants.TaskSource.MV);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setId(10L);
+
+        TaskSchedule schedule = new TaskSchedule();
+        long now = TimeUtils.getEpochSeconds();
+        schedule.setStartTime(now - 3600);
+        schedule.setPeriod(1);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+
+        // Wait enough time for the scheduler to fire
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+
+        // executeTask should NOT be called since isLeader() returns false
+        Assertions.assertFalse(executeTaskCalled[0],
+                "Periodical task should not execute on non-leader node");
+    }
+
+    @Test
+    public void testPeriodSchedulerExecutesWhenLeader() throws Exception {
+        // Mock isLeader() to return true
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+
+        final boolean[] executeTaskCalled = {false};
+        TaskManager spyTaskManager = new TaskManager() {
+            @Override
+            public SubmitResult executeTask(String taskName, ExecuteOption option) {
+                executeTaskCalled[0] = true;
+                return new SubmitResult("xxxx", SubmitResult.SubmitStatus.SUBMITTED);
+            }
+        };
+
+        Task task = new Task("test_period_leader_execute");
+        task.setDefinition("select 1");
+        task.setSource(Constants.TaskSource.MV);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setState(Constants.TaskState.ACTIVE);
+        task.setId(11L);
+
+        TaskSchedule schedule = new TaskSchedule();
+        long now = TimeUtils.getEpochSeconds();
+        schedule.setStartTime(now - 3600);
+        schedule.setPeriod(1);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+
+        spyTaskManager.replayCreateTask(task);
+        spyTaskManager.registerScheduler(task);
+
+        // Wait enough time for the scheduler to fire
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(3000L);
+
+        // executeTask SHOULD be called since isLeader() returns true
+        Assertions.assertTrue(executeTaskCalled[0],
+                "Periodical task should execute on leader node");
+    }
+
+    @Test
+    public void testDispatchSchedulerSkipsWhenNotLeader() throws Exception {
+        // Verify that checkRunningTaskRun/scheduledPendingTaskRun are not called when not leader.
+        // We cannot call tm.start() directly because clearUnfinishedTaskRun() writes edit log,
+        // so we simulate the dispatch scheduler callback logic instead.
+        final boolean[] dispatched = {false};
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+
+        TaskManager tm = new TaskManager();
+        TaskRunManager taskRunManager = tm.getTaskRunManager();
+
+        // Simulate the dispatch scheduler callback logic from TaskManager.start()
+        // This is the same guard that was added in the fix
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            // should enter here
+            dispatched[0] = false;
+        } else {
+            dispatched[0] = true;
+        }
+        Assertions.assertFalse(dispatched[0],
+                "Dispatch scheduler should skip when not leader");
+
+        // Now verify with isLeader = true
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            dispatched[0] = false;
+        } else {
+            dispatched[0] = true;
+        }
+        Assertions.assertTrue(dispatched[0],
+                "Dispatch scheduler should proceed when leader");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
After Leader transfers to Follower, the periodScheduler and dispatchScheduler in TaskManager continue running without any leader check, causing Follower nodes to attempt writing edit logs and throwing IllegalStateException every few seconds.

## What I'm doing:
Add isLeader() guard in both scheduler callbacks so they skip execution on non-Leader nodes.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11209

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
