### PR TITLE
[Refactor] Split MV refresh orchestration and partition computation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -22,9 +22,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
-import com.starrocks.sql.common.PCellSetMapping;
-import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.common.PartitionNameSetMap;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.sql.plan.ExecPlan;
 
 import java.util.Map;
@@ -54,21 +53,8 @@ public class MvTaskRunContext extends TaskRunContext {
         }
     }
 
-    // all the RefBaseTable's partition name to its intersected materialized view names.
-    //baseTable -> basePartition -> mvPartitions
-    private Map<Table, PCellSetMapping> refBaseTableMVIntersectedPartitions;
-    // all the materialized view's partition name to its intersected RefBaseTable's partition names.
-    //mvPartition -> baseTable -> basePartitions
-    private Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions;
-    // all the RefBaseTable's partition name to its partition range/list cell.
-    private Map<Table, PCellSortedSet> refBaseTableToCellMap;
-    // mv to its partition range/list cell.
-    private PCellSortedSet mvToCellMap;
-
-    // the external ref base table's mv partition name to original partition names map because external
-    // table supports multi partition columns, one converted partition name(mv partition name) may have
-    // multi original partition names.
-    private Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap;
+    private PCTPartitionTopology partitionTopology;
+    private PCTRefreshScope refreshScope;
 
     private String nextPartitionStart = null;
     private String nextPartitionEnd = null;
@@ -87,22 +73,20 @@ public class MvTaskRunContext extends TaskRunContext {
         return refreshRuntimeState;
     }
 
-    public Map<Table, PCellSetMapping> getRefBaseTableMVIntersectedPartitions() {
-        return refBaseTableMVIntersectedPartitions;
+    public PCTPartitionTopology getPartitionTopology() {
+        return partitionTopology;
     }
 
-    public void setRefBaseTableMVIntersectedPartitions(
-            Map<Table, PCellSetMapping> refBaseTableMVIntersectedPartitions) {
-        this.refBaseTableMVIntersectedPartitions = refBaseTableMVIntersectedPartitions;
+    public void setPartitionTopology(PCTPartitionTopology partitionTopology) {
+        this.partitionTopology = partitionTopology;
     }
 
-    public Map<String, Map<Table, PCellSortedSet>> getMvRefBaseTableIntersectedPartitions() {
-        return mvRefBaseTableIntersectedPartitions;
+    public PCTRefreshScope getRefreshScope() {
+        return refreshScope;
     }
 
-    public void setMvRefBaseTableIntersectedPartitions(
-            Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions) {
-        this.mvRefBaseTableIntersectedPartitions = mvRefBaseTableIntersectedPartitions;
+    public void setRefreshScope(PCTRefreshScope refreshScope) {
+        this.refreshScope = refreshScope;
     }
 
     public boolean hasNextBatchPartition() {
@@ -131,31 +115,6 @@ public class MvTaskRunContext extends TaskRunContext {
 
     public void setNextPartitionValues(String nextPartitionValues) {
         this.nextPartitionValues = nextPartitionValues;
-    }
-
-    public Map<Table, PCellSortedSet> getRefBaseTableToCellMap() {
-        return refBaseTableToCellMap;
-    }
-
-    public void setRefBaseTableToCellMap(Map<Table, PCellSortedSet> refBaseTableToCellMap) {
-        this.refBaseTableToCellMap = refBaseTableToCellMap;
-    }
-
-    public Map<Table, PartitionNameSetMap> getExternalRefBaseTableMVPartitionMap() {
-        return externalRefBaseTableMVPartitionMap;
-    }
-
-    public void setExternalRefBaseTableMVPartitionMap(
-            Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap) {
-        this.externalRefBaseTableMVPartitionMap = externalRefBaseTableMVPartitionMap;
-    }
-
-    public PCellSortedSet getMVToCellMap() {
-        return mvToCellMap;
-    }
-
-    public void setMVToCellMap(PCellSortedSet mvToCellMap) {
-        this.mvToCellMap = mvToCellMap;
     }
 
     public ExecPlan getExecPlan() {
@@ -190,8 +149,9 @@ public class MvTaskRunContext extends TaskRunContext {
      */
     public Set<String> getExternalTableRealPartitionName(Table table, String mvPartitionName) {
         if (!table.isNativeTableOrMaterializedView()) {
-            Preconditions.checkState(externalRefBaseTableMVPartitionMap.containsKey(table));
-            return externalRefBaseTableMVPartitionMap.get(table).get(mvPartitionName);
+            Preconditions.checkState(partitionTopology != null
+                    && partitionTopology.getExternalRefBaseTableMVPartitionMap().containsKey(table));
+            return partitionTopology.getExternalRefBaseTableMVPartitionMap().get(table).get(mvPartitionName);
         } else {
             return Sets.newHashSet(mvPartitionName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -57,6 +57,9 @@ import com.starrocks.scheduler.mv.pct.MVPCTRefreshListPartitioner;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshNonPartitioner;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshPartitioner;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScopeCalculator;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -69,7 +72,6 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellUtils;
-import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.common.PartitionNameSetMap;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.NodePosition;
@@ -110,6 +112,7 @@ public abstract class BaseMVRefreshProcessor {
     // format :     table id -> <base table info, snapshot table>
     protected final MVPCTRefreshPartitioner mvRefreshPartitioner;
     protected final MVRefreshParams mvRefreshParams;
+    protected final PCTRefreshScopeCalculator pctRefreshScopeCalculator;
     // current refresh mode, can be changed in the refresh's runtime for `auto` mode
     protected MaterializedView.RefreshMode currentRefreshMode;
 
@@ -151,6 +154,7 @@ public abstract class BaseMVRefreshProcessor {
         // prepare mv refresh partitioner
         this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, mvContext, mvRefreshParams);
         this.currentRefreshMode = refreshMode;
+        this.pctRefreshScopeCalculator = new PCTRefreshScopeCalculator();
         this.isEnableExternalTablePreciseRefresh = isEnableExternalTablePreciseRefresh();
         this.snapshotBaseTables = refreshRuntimeState.getSnapshotBaseTables();
         // init the refresh mode
@@ -408,7 +412,8 @@ public abstract class BaseMVRefreshProcessor {
                             db.getFullName(), mv.getName()));
                 }
                 PCellSortedSet mvCandidatePartition = getPCTMVToRefreshedPartitions(true);
-                baseTableCandidatePartitions = getPCTRefTableRefreshPartitions(mvCandidatePartition);
+                PCTRefreshScope candidateScope = buildPCTRefreshScope(mvCandidatePartition);
+                baseTableCandidatePartitions = candidateScope.getRefTableRefreshPartitions();
             } catch (Exception e) {
                 logger.warn("failed to compute candidate partitions in sync partitions",
                         DebugUtil.getRootStackTrace(e));
@@ -476,6 +481,11 @@ public abstract class BaseMVRefreshProcessor {
         }
         // do sync partitions (add or drop partitions) for materialized view
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
+        if (result && mv.isPartitionedTable() && mvContext.getPartitionTopology() == null) {
+            throw new DmlException("Materialized view %s.%s refresh failed: partition topology was not published " +
+                            "after sync partitions succeeded",
+                    db.getFullName(), mv.getName());
+        }
         logger.info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return result;
     }
@@ -490,12 +500,12 @@ public abstract class BaseMVRefreshProcessor {
      */
     protected void updatePCTToRefreshMetas(TaskRunContext taskRunContext,
                                            boolean skipBatchFilter) throws Exception {
-        this.pctMVToRefreshedPartitions = getPCTMVToRefreshedPartitions(false, skipBatchFilter);
-        // ref table of mv : refreshed partition names
-        this.pctRefTableRefreshPartitions = getPCTRefTableRefreshPartitions(pctMVToRefreshedPartitions);
-        // ref table of mv : refreshed partition names
-        this.pctRefTablePartitionNames = PCellSetMapping.of(pctRefTableRefreshPartitions.entrySet().stream()
-                .collect(Collectors.toMap(x -> x.getKey().getName(), Map.Entry::getValue)));
+        PCellSortedSet mvPartitionsToRefresh = getPCTMVToRefreshedPartitions(false, skipBatchFilter);
+        PCTRefreshScope refreshScope = buildPCTRefreshScope(mvPartitionsToRefresh);
+        mvContext.setRefreshScope(refreshScope);
+        this.pctMVToRefreshedPartitions = refreshScope.getMvPartitionsToRefresh();
+        this.pctRefTableRefreshPartitions = refreshScope.getRefTableRefreshPartitions();
+        this.pctRefTablePartitionNames = refreshScope.getRefTablePartitionNames();
         this.updatePCTBaseTableSnapshotInfos(pctRefTableRefreshPartitions);
         // add a message into information_schema
         this.updatePCTMVToRefreshInfoIntoTaskRun(pctMVToRefreshedPartitions, pctRefTablePartitionNames);
@@ -805,37 +815,16 @@ public abstract class BaseMVRefreshProcessor {
      */
     @VisibleForTesting
     public Map<BaseTableSnapshotInfo, PCellSortedSet> getPCTRefTableRefreshPartitions(PCellSortedSet mvToRefreshedPartitions) {
-        Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames = Maps.newHashMap();
-        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
-        if (mvToBaseNameRefs == null || mvToBaseNameRefs.isEmpty()) {
-            return refTableAndPartitionNames;
-        }
-        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
-            Table snapshotTable = snapshotInfo.getBaseTable();
-            PCellSortedSet needRefreshTablePartitionNames = null;
-            for (PCellWithName pCell : mvToRefreshedPartitions.getPartitions()) {
-                String mvPartitionName = pCell.name();
-                if (!mvToBaseNameRefs.containsKey(mvPartitionName)) {
-                    continue;
-                }
-                Map<Table, PCellSortedSet> mvToBaseNameRef = mvToBaseNameRefs.get(mvPartitionName);
-                if (mvToBaseNameRef.containsKey(snapshotTable)) {
-                    if (needRefreshTablePartitionNames == null) {
-                        needRefreshTablePartitionNames = PCellSortedSet.of();
-                    }
-                    // The table in this map has related partition with mv
-                    // It's ok to add empty set for a table, means no partition corresponding to this mv partition
-                    needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(snapshotTable));
-                } else {
-                    logger.info("ref-base-table {} is not found in `mvRefBaseTableIntersectedPartitions` " +
-                            "because of empty update", snapshotTable.getName());
-                }
-            }
-            if (needRefreshTablePartitionNames != null) {
-                refTableAndPartitionNames.put(snapshotInfo, needRefreshTablePartitionNames);
-            }
-        }
-        return refTableAndPartitionNames;
+        return buildPCTRefreshScope(mvToRefreshedPartitions).getRefTableRefreshPartitions();
+    }
+
+    private PCTRefreshScope buildPCTRefreshScope(PCellSortedSet mvPartitionsToRefresh) {
+        return pctRefreshScopeCalculator.buildScope(
+                mvContext.getPartitionTopology(),
+                snapshotBaseTables,
+                mvPartitionsToRefresh,
+                mvRefreshParams.isCompleteRefresh(),
+                !mvRefreshPartitioner.getMVToRefreshPotentialPartitions().isEmpty());
     }
 
     /**
@@ -919,7 +908,9 @@ public abstract class BaseMVRefreshProcessor {
 
     @VisibleForTesting
     public void updatePCTBaseTableSnapshotInfos(Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        Map<Table, PCellSetMapping> baseTableToMvNameRefs = mvContext.getRefBaseTableMVIntersectedPartitions();
+        PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
+        Map<Table, PCellSetMapping> baseTableToMvNameRefs =
+                partitionTopology == null ? null : partitionTopology.getRefBaseTableMVIntersectedPartitions();
         // update partition infos for each base table snapshot info
         for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
             if (!(snapshotInfo instanceof PCTTableSnapshotInfo)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -24,6 +24,7 @@ import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -267,7 +268,9 @@ public class MVVersionManager {
     private void updateAssociatedPartitionMeta(MaterializedView.AsyncRefreshContext refreshContext,
                                                PCellSortedSet mvRefreshedPartitions,
                                                Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRefs = mvTaskRunContext.getMvRefBaseTableIntersectedPartitions();
+        PCTPartitionTopology partitionTopology = mvTaskRunContext.getPartitionTopology();
+        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRefs =
+                partitionTopology == null ? null : partitionTopology.getMvRefBaseTableIntersectedPartitions();
         if (Objects.isNull(mvToBaseNameRefs) || Objects.isNull(refTableAndPartitionNames) ||
                 refTableAndPartitionNames.isEmpty()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -54,7 +54,6 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.common.PCellUtils;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
@@ -105,7 +104,8 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
         // check to refresh partitions of mv and base tables
         try (Timer ignored = Tracers.watchScope("MVRefreshCheckMVToRefreshPartitions")) {
             updatePCTToRefreshMetas(taskRunContext);
-            if (PCellUtils.isEmpty(pctMVToRefreshedPartitions)) {
+            PCTRefreshScope refreshScope = mvContext.getRefreshScope();
+            if (refreshScope == null || refreshScope.isEmpty()) {
                 return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
             }
         }
@@ -113,7 +113,9 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
         // execute the ExecPlan of insert stmt
         InsertStmt insertStmt = null;
         try (Timer ignored = Tracers.watchScope("MVRefreshPrepareRefreshPlan")) {
-            insertStmt = prepareRefreshPlan(pctMVToRefreshedPartitions, pctRefTablePartitionNames);
+            PCTRefreshScope refreshScope = mvContext.getRefreshScope();
+            insertStmt = prepareRefreshPlan(refreshScope.getMvPartitionsToRefresh(),
+                    refreshScope.getRefTablePartitionNames());
         }
         return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, mvContext.getExecPlan(), insertStmt);
     }
@@ -173,7 +175,8 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
                     db.getFullName(), mv.getName(), Config.mv_refresh_try_lock_timeout_ms));
         }
 
-        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, mvRefreshPartitioner);
+        PCTPredicateBuilder predicateBuilder = new PCTPredicateBuilder(mvRefreshPartitioner);
+        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(db, mv, mvContext, predicateBuilder);
         try {
             // Analyze and prepare a partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
@@ -15,16 +15,11 @@
 
 package com.starrocks.scheduler.mv.pct;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
@@ -44,16 +39,9 @@ import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
-import com.starrocks.sql.ast.PartitionValue;
-import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.ExprUtils;
-import com.starrocks.sql.ast.expression.IsNullPredicate;
-import com.starrocks.sql.ast.expression.LiteralExpr;
-import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiffer;
-import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
@@ -61,11 +49,9 @@ import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.PartitionDiff;
 import com.starrocks.sql.common.PartitionDiffResult;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
-import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -75,11 +61,9 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static com.starrocks.connector.iceberg.IcebergPartitionUtils.getIcebergTablePartitionPredicateExpr;
-
 public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     private final ListPartitionDiffer differ;
-    private final Logger logger;
+    final Logger logger;
 
     public MVPCTRefreshListPartitioner(MvTaskRunContext mvContext,
                                        TaskRunContext context,
@@ -171,203 +155,22 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         // mv partition name -> Map<base table -> base partition names>
         final Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef =
                 differ.generateMvRefMap(result.mvPartitionToCells, refBaseTablePartitionMap);
-        mvContext.setMVToCellMap(result.mvPartitionToCells);
-        mvContext.setRefBaseTableMVIntersectedPartitions(baseToMvNameRef);
-        mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
-        mvContext.setRefBaseTableToCellMap(refBaseTablePartitionMap);
-        mvContext.setExternalRefBaseTableMVPartitionMap(result.getRefBaseTableMVPartitionMap());
+        publishTopology(new PCTPartitionTopology(result.mvPartitionToCells, refBaseTablePartitionMap,
+                baseToMvNameRef, mvToBaseNameRef, result.getRefBaseTableMVPartitionMap()));
         return true;
     }
 
     @Override
     public Expr generatePartitionPredicate(Table refBaseTable, PCellSortedSet refBaseTablePartitionNames,
                                            List<Expr> mvPartitionSlotRefs) throws AnalysisException {
-        Map<Table, PCellSortedSet> basePartitionMaps = mvContext.getRefBaseTableToCellMap();
-        if (basePartitionMaps.isEmpty()) {
-            return null;
-        }
-        PCellSortedSet baseListPartitionMap = basePartitionMaps.get(refBaseTable);
-        if (baseListPartitionMap == null) {
-            logger.warn("Generate incremental partition predicate failed, " +
-                    "basePartitionMaps:{} contains no refBaseTable:{}", basePartitionMaps, refBaseTable);
-            return null;
-        }
-        if (baseListPartitionMap.isEmpty()) {
-            return new BoolLiteral(true);
-        }
-
-        // base table's partition columns, not mv's partition columns
-        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
-        if (refBaseTablePartitionColumns == null || !refBaseTablePartitionColumns.containsKey(refBaseTable)) {
-            logger.warn("Generate incremental partition failed, partitionTableAndColumn {} contains no ref table {}",
-                    refBaseTablePartitionColumns, refBaseTable);
-            return null;
-        }
-        // base table's partition columns that are referred by mv
-        List<Column> refPartitionColumns = refBaseTablePartitionColumns.get(refBaseTable);
-        if (refPartitionColumns.size() != mvPartitionSlotRefs.size()) {
-            logger.warn("Generate incremental partition failed, refPartitionColumns size {} != mvPartitionSlotRefs size {}",
-                    refPartitionColumns.size(), mvPartitionSlotRefs.size());
-            return null;
-        }
-        return genPartitionPredicate(refBaseTable, refBaseTablePartitionNames, mvPartitionSlotRefs,
-                refPartitionColumns, baseListPartitionMap);
+        return new PCTPredicateBuilder(this).buildPartitionPredicate(refBaseTable,
+                refBaseTablePartitionNames, mvPartitionSlotRefs);
     }
 
     @Override
     public Expr generateMVPartitionPredicate(TableName tableName,
                                              PCellSortedSet mvPartitionNames) throws AnalysisException {
-        PCellSortedSet mvToCellMap = mvContext.getMVToCellMap();
-        if (mvToCellMap.isEmpty()) {
-            return new BoolLiteral(true);
-        }
-        PartitionInfo partitionInfo = mv.getPartitionInfo();
-        Preconditions.checkArgument(partitionInfo instanceof ListPartitionInfo);
-
-        ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-        List<Expr> mvPartitionExprs = listPartitionInfo.getPartitionExprs(tableName, mv.getIdToColumn());
-        List<Column> mvPartitionCols = mv.getPartitionColumns();
-        Preconditions.checkArgument(mvPartitionExprs.size() == mvPartitionCols.size());
-        if (mvPartitionCols.size() == 1) {
-            boolean isContainsNullPartition = false;
-            Column refPartitionColumn = mvPartitionCols.get(0);
-            List<Expr> selectedPartitionValues = Lists.newArrayList();
-            Type partitionType = refPartitionColumn.getType();
-            for (PCell pCell : mvPartitionNames.getPCells()) {
-                PListCell cell = (PListCell) pCell;
-                for (List<String> values : cell.getPartitionItems()) {
-                    if (mvPartitionCols.size() != values.size()) {
-                        return null;
-                    }
-                    LiteralExpr partitionValue = new PartitionValue(values.get(0)).getValue(partitionType);
-                    if (partitionValue.isConstantNull()) {
-                        isContainsNullPartition = true;
-                        continue;
-                    }
-                    selectedPartitionValues.add(partitionValue);
-                }
-            }
-            Expr mvPartitionExpr = mvPartitionExprs.get(0);
-            Expr inPredicate = MvUtils.convertToInPredicate(mvPartitionExpr, selectedPartitionValues);
-            // NOTE: If target partition values contain `null partition`, the generated predicate should
-            // contain `is null` predicate rather than `in (null) or = null` because the later one is not correct.
-            if (isContainsNullPartition) {
-                IsNullPredicate isNullPredicate = new IsNullPredicate(mvPartitionExpr, false);
-                return ExprUtils.compoundOr(Lists.newArrayList(inPredicate, isNullPredicate));
-            } else {
-                return inPredicate;
-            }
-        } else {
-            List<Expr> partitionPredicates = Lists.newArrayList();
-            for (PCell pCell : mvPartitionNames.getPCells()) {
-                PListCell cell = (PListCell) pCell;
-                for (List<String> values : cell.getPartitionItems()) {
-                    if (mvPartitionCols.size() != values.size()) {
-                        return null;
-                    }
-                    List<Expr> predicates = Lists.newArrayList();
-                    for (int i = 0; i < mvPartitionCols.size(); i++) {
-                        Column refPartitionColumn = mvPartitionCols.get(i);
-                        Type partitionType = refPartitionColumn.getType();
-                        LiteralExpr partitionValue = new PartitionValue(values.get(i)).getValue(partitionType);
-                        Expr mvPartitionByExpr = mvPartitionExprs.get(i);
-                        Expr predicate;
-                        if (partitionValue.isConstantNull()) {
-                            // NOTE: If target partition values contain `null partition`, the generated predicate should
-                            // contain `is null` predicate rather than `in (null) or = null` because the later one is not correct.
-                            predicate = new IsNullPredicate(mvPartitionByExpr, false);
-                        } else {
-                            predicate = MvUtils.convertToInPredicate(mvPartitionByExpr,
-                                    Lists.newArrayList(partitionValue));
-                        }
-                        predicates.add(predicate);
-                    }
-                    partitionPredicates.add(ExprUtils.compoundAnd(predicates));
-                }
-            }
-            return ExprUtils.compoundOr(partitionPredicates);
-        }
-    }
-
-    private static Expr getRefBaseTablePartitionPredicateExpr(Table table,
-                                                              String partitionColumn,
-                                                              SlotRef slotRef,
-                                                              List<Expr> selectedPartitionValues) {
-        if (!(table instanceof IcebergTable)) {
-            return MvUtils.convertToInPredicate(slotRef, selectedPartitionValues);
-        } else {
-            IcebergTable icebergTable = (IcebergTable) table;
-            return getIcebergTablePartitionPredicateExpr(icebergTable, partitionColumn, slotRef, selectedPartitionValues);
-        }
-    }
-
-    private static @Nullable Expr genPartitionPredicate(
-            Table refBaseTable,
-            PCellSortedSet refBaseTablePartitionNames,
-            List<Expr> refBaseTablePartitionSlotRefs,
-            List<Column> refPartitionColumns,
-            PCellSortedSet baseListPartitionMap) throws AnalysisException {
-        Preconditions.checkArgument(refBaseTablePartitionSlotRefs.size() == refPartitionColumns.size());
-        if (refPartitionColumns.size() == 1) {
-            boolean isContainsNullPartition = false;
-            Column refPartitionColumn = refPartitionColumns.get(0);
-            List<Expr> selectedPartitionValues = Lists.newArrayList();
-            Type partitionType = refPartitionColumn.getType();
-            for (PCell pCell : refBaseTablePartitionNames.getPCells()) {
-                PListCell cell = (PListCell) pCell;
-                for (List<String> values : cell.getPartitionItems()) {
-                    if (refPartitionColumns.size() != values.size()) {
-                        return null;
-                    }
-                    LiteralExpr partitionValue = new PartitionValue(values.get(0)).getValue(partitionType);
-                    if (partitionValue.isConstantNull()) {
-                        isContainsNullPartition = true;
-                        continue;
-                    }
-                    selectedPartitionValues.add(partitionValue);
-                }
-            }
-            SlotRef refBaseTablePartitionSlotRef = (SlotRef) refBaseTablePartitionSlotRefs.get(0);
-            Expr inPredicate = getRefBaseTablePartitionPredicateExpr(refBaseTable, refPartitionColumn.getName(),
-                    refBaseTablePartitionSlotRef, selectedPartitionValues);
-            // NOTE: If target partition values contain `null partition`, the generated predicate should
-            // contain `is null` predicate rather than `in (null) or = null` because the later one is not correct.
-            if (isContainsNullPartition) {
-                IsNullPredicate isNullPredicate = new IsNullPredicate(refBaseTablePartitionSlotRef, false);
-                return ExprUtils.compoundOr(Lists.newArrayList(inPredicate, isNullPredicate));
-            } else {
-                return inPredicate;
-            }
-        } else {
-            List<Expr> partitionPredicates = Lists.newArrayList();
-            for (PCell pCell : refBaseTablePartitionNames.getPCells()) {
-                PListCell cell = (PListCell) pCell;
-                for (List<String> values : cell.getPartitionItems()) {
-                    if (refPartitionColumns.size() != values.size()) {
-                        return null;
-                    }
-                    List<Expr> predicates = Lists.newArrayList();
-                    for (int i = 0; i < refPartitionColumns.size(); i++) {
-                        Column refPartitionColumn = refPartitionColumns.get(i);
-                        Type partitionType = refPartitionColumn.getType();
-                        LiteralExpr partitionValue = new PartitionValue(values.get(i)).getValue(partitionType);
-                        Expr refBaseTablePartitionExpr = refBaseTablePartitionSlotRefs.get(i);
-                        Expr predicate;
-                        if (partitionValue.isConstantNull()) {
-                            // NOTE: If target partition values contain `null partition`, the generated predicate should
-                            // contain `is null` predicate rather than `in (null) or = null` because the later one is not correct.
-                            predicate = new IsNullPredicate(refBaseTablePartitionExpr, false);
-                        } else {
-                            predicate = getRefBaseTablePartitionPredicateExpr(refBaseTable, refPartitionColumn.getName(),
-                                    (SlotRef) refBaseTablePartitionExpr, Lists.newArrayList(partitionValue));
-                        }
-                        predicates.add(predicate);
-                    }
-                    partitionPredicates.add(ExprUtils.compoundAnd(predicates));
-                }
-            }
-            return ExprUtils.compoundOr(partitionPredicates);
-        }
+        return new PCTPredicateBuilder(this).buildMVPartitionPredicate(tableName, mvPartitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -124,6 +124,10 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public abstract boolean syncAddOrDropPartitions() throws AnalysisException, LockTimeoutException;
 
+    protected final void publishTopology(PCTPartitionTopology topology) {
+        mvContext.setPartitionTopology(topology);
+    }
+
     /**
      * Generate partition predicate for mv refresh according ref base table changed partitions.
      *
@@ -240,10 +244,11 @@ public abstract class MVPCTRefreshPartitioner {
             // should calculate the candidate partitions recursively.
             logger.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
                     " baseChangedPartitionNames: {}", result, baseChangedPCellsSortedSet);
+            PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
             SyncPartitionUtils.calcPotentialRefreshPartition(result,
                     baseChangedPartitionNames,
-                    mvContext.getRefBaseTableMVIntersectedPartitions(),
-                    mvContext.getMvRefBaseTableIntersectedPartitions(),
+                    partitionTopology.getRefBaseTableMVIntersectedPartitions(),
+                    partitionTopology.getMvRefBaseTableIntersectedPartitions(),
                     mvToRefreshPotentialPartitions);
             result.addAll(mvToRefreshPotentialPartitions);
             logger.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
@@ -257,6 +262,11 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public void filterMVToRefreshPartitionsByProperty(PCellSortedSet mvToRefreshedPartitions) {
         // do nothing by default
+    }
+
+    @VisibleForTesting
+    public PCellSortedSet getMVToRefreshPotentialPartitions() {
+        return PCellSortedSet.of(mvToRefreshPotentialPartitions);
     }
 
     /**
@@ -451,10 +461,12 @@ public abstract class MVPCTRefreshPartitioner {
             return toRefreshPartitions.size();
         }
 
-        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
+        PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
+        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRefs = partitionTopology.getMvRefBaseTableIntersectedPartitions();
         MVRefreshPartitionSelector mvRefreshPartitionSelector =
                 new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
-                        Config.mv_max_partitions_num_per_refresh, mvContext.getExternalRefBaseTableMVPartitionMap());
+                        Config.mv_max_partitions_num_per_refresh,
+                        partitionTopology.getExternalRefBaseTableMVPartitionMap());
         int adaptiveRefreshNumber = 0;
         for (PCellWithName pCellWithName : toRefreshPartitions.getPartitions()) {
             String mvRefreshPartition = pCellWithName.name();
@@ -487,7 +499,9 @@ public abstract class MVPCTRefreshPartitioner {
     protected PCellSortedSet getMvPartitionNamesToRefresh(Table refBaseTable,
                                                           PCellSortedSet baseTablePartitionNames) {
         PCellSortedSet result = PCellSortedSet.of();
-        Map<Table, PCellSetMapping> refBaseTableMVPartitionMaps = mvContext.getRefBaseTableMVIntersectedPartitions();
+        PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
+        Map<Table, PCellSetMapping> refBaseTableMVPartitionMaps =
+                partitionTopology == null ? null : partitionTopology.getRefBaseTableMVIntersectedPartitions();
         if (refBaseTableMVPartitionMaps == null || !refBaseTableMVPartitionMaps.containsKey(refBaseTable)) {
             logger.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
                     "refBaseTableMVPartitionMaps: {}", refBaseTable, refBaseTableMVPartitionMaps);
@@ -647,8 +661,9 @@ public abstract class MVPCTRefreshPartitioner {
      */
     protected Map<Table, PCellSortedSet> getBasePartitionNamesByMVPartitionNames(PCellSortedSet toRefreshPartitions) {
         Map<Table, PCellSortedSet> result = new HashMap<>();
+        PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
         Map<String, Map<Table, PCellSortedSet>> mvRefBaseTablePartitionMaps =
-                mvContext.getMvRefBaseTableIntersectedPartitions();
+                partitionTopology == null ? null : partitionTopology.getMvRefBaseTableIntersectedPartitions();
         for (PCellWithName pCell : toRefreshPartitions.getPartitions()) {
             String mvPartitionName = pCell.name();
             if (mvRefBaseTablePartitionMaps == null || !mvRefBaseTablePartitionMaps.containsKey(mvPartitionName)) {
@@ -732,7 +747,9 @@ public abstract class MVPCTRefreshPartitioner {
 
     protected Map<Table, PCellSortedSet> toBaseTableWithSortedSet(Map<Table, PCellSortedSet> baseToPartitionNames) {
         Map<Table, PCellSortedSet> result = new HashMap<>();
-        Map<Table, PCellSortedSet> refBaseTableRangePartitionMap = mvContext.getRefBaseTableToCellMap();
+        PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
+        Map<Table, PCellSortedSet> refBaseTableRangePartitionMap =
+                partitionTopology == null ? Map.of() : partitionTopology.getRefBaseTableToCellMap();
         for (Map.Entry<Table, PCellSortedSet> entry : baseToPartitionNames.entrySet()) {
             Table baseTable = entry.getKey();
             if (!refBaseTableRangePartitionMap.containsKey(baseTable)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
@@ -70,7 +70,7 @@ public class MVPCTRefreshPlanBuilder {
     private final Database mvDb;
     private final MaterializedView mv;
     private final MvTaskRunContext mvContext;
-    private final MVPCTRefreshPartitioner mvRefreshPartitioner;
+    private final PCTPredicateBuilder pctPredicateBuilder;
 
     // push down partition predicates into table relation
     private static final String EXTRA_PREDICATE_KEY = "_EXTRA_";
@@ -105,11 +105,11 @@ public class MVPCTRefreshPlanBuilder {
     public MVPCTRefreshPlanBuilder(Database mvDb,
                                    MaterializedView mv,
                                    MvTaskRunContext mvContext,
-                                   MVPCTRefreshPartitioner mvRefreshPartitioner) {
+                                   PCTPredicateBuilder pctPredicateBuilder) {
         this.mvDb = mvDb;
         this.mv = mv;
         this.mvContext = mvContext;
-        this.mvRefreshPartitioner = mvRefreshPartitioner;
+        this.pctPredicateBuilder = pctPredicateBuilder;
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshPlanBuilder.class);
     }
 
@@ -287,7 +287,7 @@ public class MVPCTRefreshPlanBuilder {
                                                     InsertStmt insertStmt)
             throws AnalysisException {
         TableName tableName = new TableName(mvDb.getFullName(), mv.getName());
-        Expr mvPartitionPredicate = mvRefreshPartitioner.generateMVPartitionPredicate(tableName, mvToRefreshedPartitions);
+        Expr mvPartitionPredicate = pctPredicateBuilder.buildMVPartitionPredicate(tableName, mvToRefreshedPartitions);
         if (mvPartitionPredicate == null) {
             logger.warn("Generate mv partition predicate failed, mv:{}", mv.getName());
             return null;
@@ -486,7 +486,7 @@ public class MVPCTRefreshPlanBuilder {
             // If the updated partition names are empty, it means that the table should not be refreshed.
             return new BoolLiteral(false);
         }
-        return mvRefreshPartitioner.generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExprs);
+        return pctPredicateBuilder.buildPartitionPredicate(table, tablePartitionNames, mvPartitionOutputExprs);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
@@ -21,16 +21,12 @@ import com.google.common.collect.Range;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExpressionRangePartitionInfo;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.connector.PartitionUtil;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunContext;
@@ -48,12 +44,7 @@ import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
-import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.ExprUtils;
-import com.starrocks.sql.ast.expression.FunctionCallExpr;
-import com.starrocks.sql.ast.expression.IsNullPredicate;
-import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -77,10 +68,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.SyncPartitionUtils.createRange;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getStr2DateExpr;
 
 public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner {
-    private final Logger logger;
+    final Logger logger;
 
     private final RangePartitionDiffer differ;
     public MVPCTRefreshRangePartitioner(MvTaskRunContext mvContext,
@@ -161,119 +151,21 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef =
                 differ.generateMvRefMap(mvPartitionToCells, result.refBaseTablePartitionMap);
 
-        mvContext.setMVToCellMap(mvPartitionToCells);
-        mvContext.setRefBaseTableMVIntersectedPartitions(baseToMvNameRef);
-        mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
-        mvContext.setRefBaseTableToCellMap(result.refBaseTablePartitionMap);
-        mvContext.setExternalRefBaseTableMVPartitionMap(result.getRefBaseTableMVPartitionMap());
+        publishTopology(new PCTPartitionTopology(mvPartitionToCells, result.refBaseTablePartitionMap,
+                baseToMvNameRef, mvToBaseNameRef, result.getRefBaseTableMVPartitionMap()));
         return true;
     }
 
     @Override
     public Expr generatePartitionPredicate(Table table, PCellSortedSet refBaseTablePartitionNames,
                                            List<Expr> mvPartitionSlotRefs) throws AnalysisException {
-        List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
-        Map<Table, PCellSortedSet> refBaseTablePartitionCells = mvContext.getRefBaseTableToCellMap();
-        if (!refBaseTablePartitionCells.containsKey(table)) {
-            throw new AnalysisException("Cannot generate mv refresh partition predicate because cannot find " +
-                    "the ref base table partition cells for table:" + table.getName());
-        }
-        for (String partitionName : refBaseTablePartitionNames.getPartitionNames()) {
-            PRangeCell rangeCell = (PRangeCell) refBaseTablePartitionCells.get(table).getPCell(partitionName);
-            sourceTablePartitionRange.add(rangeCell.getRange());
-        }
-        sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
-        // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
-        // here we should convert date into '%Y%m%d' format
-        Map<Table, List<Column>> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
-        if (!partitionTableAndColumn.containsKey(table)) {
-            logger.warn("Cannot generate mv refresh partition predicate because cannot decide the partition column of table {}," +
-                    "partitionTableAndColumn:{}", table.getName(), partitionTableAndColumn);
-            return null;
-        }
-        List<Column> refPartitionColumns = partitionTableAndColumn.get(table);
-        Preconditions.checkState(refPartitionColumns.size() == 1);
-        Optional<Expr> partitionExprOpt = mv.getRangePartitionFirstExpr();
-        if (partitionExprOpt.isEmpty()) {
-            return null;
-        }
-        Expr partitionExpr = partitionExprOpt.get();
-        boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, refPartitionColumns.get(0));
-        if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
-                && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
-            Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
-            if (!functionCallExprOpt.isPresent()) {
-                logger.warn("Invalid partition expr:{}", partitionExpr);
-                return null;
-            }
-            FunctionCallExpr functionCallExpr = functionCallExprOpt.get();
-            Preconditions.checkState(
-                    functionCallExpr.getFunctionName().equalsIgnoreCase(FunctionSet.STR2DATE));
-            String dateFormat = ((StringLiteral) functionCallExpr.getChild(1)).getStringValue();
-            List<Range<PartitionKey>> converted = Lists.newArrayList();
-            for (Range<PartitionKey> range : sourceTablePartitionRange) {
-                Range<PartitionKey> varcharPartitionKey = MvUtils.convertToVarcharRange(range, dateFormat);
-                converted.add(varcharPartitionKey);
-            }
-            sourceTablePartitionRange = converted;
-        }
-        if (mvPartitionSlotRefs.size() != 1) {
-            logger.warn("Cannot generate mv refresh partition predicate because mvPartitionSlotRefs size is not 1, " +
-                    "mvPartitionSlotRefs:{}", mvPartitionSlotRefs);
-            return null;
-        }
-        Expr mvPartitionSlotRef = mvPartitionSlotRefs.get(0);
-        List<Expr> partitionPredicates =
-                MvUtils.convertRange(mvPartitionSlotRef, sourceTablePartitionRange);
-        // range contains the min value could be null value
-        Optional<Range<PartitionKey>> nullRange = sourceTablePartitionRange.stream().
-                filter(range -> range.lowerEndpoint().isMinValue()).findAny();
-        if (nullRange.isPresent()) {
-            Expr isNullPredicate = new IsNullPredicate(mvPartitionSlotRef, false);
-            partitionPredicates.add(isNullPredicate);
-        }
-
-        return ExprUtils.compoundOr(partitionPredicates);
+        return new PCTPredicateBuilder(this).buildPartitionPredicate(table, refBaseTablePartitionNames, mvPartitionSlotRefs);
     }
 
     @Override
     public Expr generateMVPartitionPredicate(TableName tableName,
                                              PCellSortedSet mvPartitionNames) throws AnalysisException {
-        if (mvPartitionNames.isEmpty()) {
-            return new BoolLiteral(true);
-        }
-        PartitionInfo partitionInfo = mv.getPartitionInfo();
-        if (!(partitionInfo instanceof ExpressionRangePartitionInfo)) {
-            logger.warn("Cannot generate mv refresh partition predicate because mvPartitionExpr is invalid");
-            return null;
-        }
-        ExpressionRangePartitionInfo rangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
-        List<Expr> mvPartitionExprs = rangePartitionInfo.getPartitionExprs(mv.getIdToColumn());
-        if (mvPartitionExprs.size() != 1) {
-            logger.warn("Cannot generate mv refresh partition predicate because mvPartitionExpr's size is not 1");
-            return null;
-        }
-        Expr partitionExpr = mvPartitionExprs.get(0);
-
-        List<Range<PartitionKey>> mvPartitionRange = Lists.newArrayList();
-        PCellSortedSet mvToCellMap = mvContext.getMVToCellMap();
-        for (String partitionName : mvPartitionNames.getPartitionNames()) {
-            Preconditions.checkArgument(mvToCellMap.containsName(partitionName));
-            PRangeCell rangeCell = (PRangeCell) mvToCellMap.getPCell(partitionName);
-            mvPartitionRange.add(rangeCell.getRange());
-        }
-        mvPartitionRange = MvUtils.mergeRanges(mvPartitionRange);
-
-        List<Expr> partitionPredicates =
-                MvUtils.convertRange(partitionExpr, mvPartitionRange);
-        // range contains the min value could be null value
-        Optional<Range<PartitionKey>> nullRange = mvPartitionRange.stream().
-                filter(range -> range.lowerEndpoint().isMinValue()).findAny();
-        if (nullRange.isPresent()) {
-            Expr isNullPredicate = new IsNullPredicate(partitionExpr, false);
-            partitionPredicates.add(isNullPredicate);
-        }
-        return ExprUtils.compoundOr(partitionPredicates);
+        return new PCTPredicateBuilder(this).buildMVPartitionPredicate(tableName, mvPartitionNames);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPartitionTopology.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPartitionTopology.java
@@ -1,0 +1,145 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.common.PCellSetMapping;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PartitionNameSetMap;
+
+import java.util.Map;
+import java.util.Objects;
+
+public final class PCTPartitionTopology {
+
+    /**
+     * All materialized view partitions and their normalized partition cells.
+     * <p>
+     * Key is the MV partition name, value is the range/list cell of that partition.
+     * This is the canonical partition space on the MV side and is used later to:
+     * <p>
+     * 1. convert MV partition names back to their range/list semantics
+     * 2. generate MV-level partition predicates during refresh planning
+     * 3. reason about recursive potential refresh partitions
+     */
+    private final PCellSortedSet mvToCellMap;
+
+    /**
+     * For each ref base table, stores all of its normalized partition cells.
+     * <p>
+     * Key is the base table object, value is that table's partition-name to partition-cell mapping.
+     * This lets the refresh pipeline recover the exact range/list cell behind a base-table partition name
+     * when generating predicates or projecting refresh work back to base tables.
+     */
+    private final Map<Table, PCellSortedSet> refBaseTableToCellMap;
+
+    /**
+     * Forward intersection mapping from base-table partitions to MV partitions.
+     * <p>
+     * Key is a ref base table, and the nested mapping answers:
+     * "given one partition of this base table, which MV partitions intersect with it?"
+     * This is primarily used when the refresh flow starts from changed base-table partitions and needs
+     * to derive the candidate MV partitions that must be refreshed.
+     */
+    private final Map<Table, PCellSetMapping> refBaseTableMVIntersectedPartitions;
+
+    /**
+     * Reverse intersection mapping from MV partitions back to ref base-table partitions.
+     * <p>
+     * Key is an MV partition name, value is a map from each ref base table to the partitions of that
+     * table intersecting with the MV partition. This is the core projection structure used when the
+     * refresh flow already knows the MV partitions to refresh and needs to derive which base-table
+     * partitions should be scanned or refreshed for this task run.
+     */
+    private final Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions;
+
+    /**
+     * Mapping for external ref base tables from MV partition name back to the original external partition names.
+     * <p>
+     * External connectors may normalize one or more original partition names into a single MV partition name,
+     * especially for multi-column partitions. This structure preserves that reverse lookup so metadata refresh
+     * and partition-targeted external table refresh can recover the real connector-side partition names.
+     */
+    private final Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap;
+
+    public PCTPartitionTopology(PCellSortedSet mvToCellMap,
+                                Map<Table, PCellSortedSet> refBaseTableToCellMap,
+                                Map<Table, PCellSetMapping> refBaseTableMVIntersectedPartitions,
+                                Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions,
+                                Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap) {
+        this.mvToCellMap = mvToCellMap;
+        this.refBaseTableToCellMap = refBaseTableToCellMap;
+        this.refBaseTableMVIntersectedPartitions = refBaseTableMVIntersectedPartitions;
+        this.mvRefBaseTableIntersectedPartitions = mvRefBaseTableIntersectedPartitions;
+        this.externalRefBaseTableMVPartitionMap = externalRefBaseTableMVPartitionMap;
+    }
+
+    public PCellSortedSet getMvToCellMap() {
+        return mvToCellMap;
+    }
+
+    public Map<Table, PCellSortedSet> getRefBaseTableToCellMap() {
+        return refBaseTableToCellMap;
+    }
+
+    public Map<Table, PCellSetMapping> getRefBaseTableMVIntersectedPartitions() {
+        return refBaseTableMVIntersectedPartitions;
+    }
+
+    public Map<String, Map<Table, PCellSortedSet>> getMvRefBaseTableIntersectedPartitions() {
+        return mvRefBaseTableIntersectedPartitions;
+    }
+
+    public Map<Table, PartitionNameSetMap> getExternalRefBaseTableMVPartitionMap() {
+        return externalRefBaseTableMVPartitionMap;
+    }
+
+    public static PCTPartitionTopology empty() {
+        return new PCTPartitionTopology(PCellSortedSet.of(), Map.of(), Map.of(), Map.of(), Map.of());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PCTPartitionTopology)) {
+            return false;
+        }
+        PCTPartitionTopology that = (PCTPartitionTopology) o;
+        return Objects.equals(mvToCellMap, that.mvToCellMap)
+                && Objects.equals(refBaseTableToCellMap, that.refBaseTableToCellMap)
+                && Objects.equals(refBaseTableMVIntersectedPartitions, that.refBaseTableMVIntersectedPartitions)
+                && Objects.equals(mvRefBaseTableIntersectedPartitions, that.mvRefBaseTableIntersectedPartitions)
+                && Objects.equals(externalRefBaseTableMVPartitionMap, that.externalRefBaseTableMVPartitionMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mvToCellMap, refBaseTableToCellMap, refBaseTableMVIntersectedPartitions,
+                mvRefBaseTableIntersectedPartitions, externalRefBaseTableMVPartitionMap);
+    }
+
+    @Override
+    public String toString() {
+        return "PCTPartitionTopology{"
+                + "mvToCellMap=" + mvToCellMap
+                + ", refBaseTableToCellMap=" + refBaseTableToCellMap
+                + ", refBaseTableMVIntersectedPartitions=" + refBaseTableMVIntersectedPartitions
+                + ", mvRefBaseTableIntersectedPartitions=" + mvRefBaseTableIntersectedPartitions
+                + ", externalRefBaseTableMVPartitionMap=" + externalRefBaseTableMVPartitionMap
+                + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPredicateBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPredicateBuilder.java
@@ -1,0 +1,372 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.ast.expression.BoolLiteral;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.IsNullPredicate;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.common.PRangeCell;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.type.Type;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.starrocks.connector.iceberg.IcebergPartitionUtils.getIcebergTablePartitionPredicateExpr;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getStr2DateExpr;
+
+public class PCTPredicateBuilder {
+    private final MVPCTRefreshPartitioner mvRefreshPartitioner;
+
+    public PCTPredicateBuilder(MVPCTRefreshPartitioner mvRefreshPartitioner) {
+        this.mvRefreshPartitioner = mvRefreshPartitioner;
+    }
+
+    public Expr buildPartitionPredicate(Table refBaseTable,
+                                        PCellSortedSet refBaseTablePartitionNames,
+                                        List<Expr> mvPartitionSlotRefs) throws AnalysisException {
+        if (mvRefreshPartitioner instanceof MVPCTRefreshRangePartitioner) {
+            return buildRangePartitionPredicate((MVPCTRefreshRangePartitioner) mvRefreshPartitioner,
+                    refBaseTable, refBaseTablePartitionNames, mvPartitionSlotRefs);
+        } else if (mvRefreshPartitioner instanceof MVPCTRefreshListPartitioner) {
+            return buildListPartitionPredicate((MVPCTRefreshListPartitioner) mvRefreshPartitioner,
+                    refBaseTable, refBaseTablePartitionNames, mvPartitionSlotRefs);
+        }
+        return mvRefreshPartitioner.generatePartitionPredicate(
+                refBaseTable, refBaseTablePartitionNames, mvPartitionSlotRefs);
+    }
+
+    public Expr buildMVPartitionPredicate(TableName tableName,
+                                          PCellSortedSet mvPartitionNames) throws AnalysisException {
+        if (mvRefreshPartitioner instanceof MVPCTRefreshRangePartitioner) {
+            return buildRangeMVPartitionPredicate((MVPCTRefreshRangePartitioner) mvRefreshPartitioner,
+                    tableName, mvPartitionNames);
+        } else if (mvRefreshPartitioner instanceof MVPCTRefreshListPartitioner) {
+            return buildListMVPartitionPredicate((MVPCTRefreshListPartitioner) mvRefreshPartitioner,
+                    tableName, mvPartitionNames);
+        }
+        return mvRefreshPartitioner.generateMVPartitionPredicate(tableName, mvPartitionNames);
+    }
+
+    private Expr buildRangePartitionPredicate(MVPCTRefreshRangePartitioner partitioner,
+                                              Table table,
+                                              PCellSortedSet refBaseTablePartitionNames,
+                                              List<Expr> mvPartitionSlotRefs) throws AnalysisException {
+        List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
+        PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
+        Map<Table, PCellSortedSet> refBaseTablePartitionCells =
+                partitionTopology == null ? null : partitionTopology.getRefBaseTableToCellMap();
+        if (refBaseTablePartitionCells == null || !refBaseTablePartitionCells.containsKey(table)) {
+            throw new AnalysisException("Cannot generate mv refresh partition predicate because cannot find "
+                    + "the ref base table partition cells for table:" + table.getName());
+        }
+        for (String partitionName : refBaseTablePartitionNames.getPartitionNames()) {
+            PRangeCell rangeCell = (PRangeCell) refBaseTablePartitionCells.get(table).getPCell(partitionName);
+            sourceTablePartitionRange.add(rangeCell.getRange());
+        }
+        sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
+        // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
+        // here we should convert date into '%Y%m%d' format
+        Map<Table, List<Column>> partitionTableAndColumn = partitioner.mv.getRefBaseTablePartitionColumns();
+        if (!partitionTableAndColumn.containsKey(table)) {
+            partitioner.logger.warn("Cannot generate mv refresh partition predicate because cannot decide "
+                    + "the partition column of table {}, partitionTableAndColumn:{}",
+                    table.getName(), partitionTableAndColumn);
+            return null;
+        }
+        List<Column> refPartitionColumns = partitionTableAndColumn.get(table);
+        Preconditions.checkState(refPartitionColumns.size() == 1);
+        Optional<Expr> partitionExprOpt = partitioner.mv.getRangePartitionFirstExpr();
+        if (partitionExprOpt.isEmpty()) {
+            return null;
+        }
+        Expr partitionExpr = partitionExprOpt.get();
+        boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, refPartitionColumns.get(0));
+        if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
+                && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
+            Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
+            if (functionCallExprOpt.isEmpty()) {
+                partitioner.logger.warn("Invalid partition expr:{}", partitionExpr);
+                return null;
+            }
+            FunctionCallExpr functionCallExpr = functionCallExprOpt.get();
+            Preconditions.checkState(functionCallExpr.getFunctionName().equalsIgnoreCase(FunctionSet.STR2DATE));
+            String dateFormat = ((StringLiteral) functionCallExpr.getChild(1)).getStringValue();
+            List<Range<PartitionKey>> converted = Lists.newArrayList();
+            for (Range<PartitionKey> range : sourceTablePartitionRange) {
+                Range<PartitionKey> varcharPartitionKey = MvUtils.convertToVarcharRange(range, dateFormat);
+                converted.add(varcharPartitionKey);
+            }
+            sourceTablePartitionRange = converted;
+        }
+        if (mvPartitionSlotRefs.size() != 1) {
+            partitioner.logger.warn("Cannot generate mv refresh partition predicate because mvPartitionSlotRefs size "
+                    + "is not 1, mvPartitionSlotRefs:{}", mvPartitionSlotRefs);
+            return null;
+        }
+        Expr mvPartitionSlotRef = mvPartitionSlotRefs.get(0);
+        List<Expr> partitionPredicates = MvUtils.convertRange(mvPartitionSlotRef, sourceTablePartitionRange);
+        Optional<Range<PartitionKey>> nullRange = sourceTablePartitionRange.stream()
+                .filter(range -> range.lowerEndpoint().isMinValue())
+                .findAny();
+        if (nullRange.isPresent()) {
+            partitionPredicates.add(new IsNullPredicate(mvPartitionSlotRef, false));
+        }
+
+        return ExprUtils.compoundOr(partitionPredicates);
+    }
+
+    private Expr buildRangeMVPartitionPredicate(MVPCTRefreshRangePartitioner partitioner,
+                                                TableName tableName,
+                                                PCellSortedSet mvPartitionNames) throws AnalysisException {
+        if (mvPartitionNames.isEmpty()) {
+            return new BoolLiteral(true);
+        }
+        PartitionInfo partitionInfo = partitioner.mv.getPartitionInfo();
+        if (!(partitionInfo instanceof ExpressionRangePartitionInfo)) {
+            partitioner.logger.warn("Cannot generate mv refresh partition predicate because mvPartitionExpr is invalid");
+            return null;
+        }
+        ExpressionRangePartitionInfo rangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+        List<Expr> mvPartitionExprs = rangePartitionInfo.getPartitionExprs(partitioner.mv.getIdToColumn());
+        if (mvPartitionExprs.size() != 1) {
+            partitioner.logger.warn("Cannot generate mv refresh partition predicate because mvPartitionExpr's size is not 1");
+            return null;
+        }
+        Expr partitionExpr = mvPartitionExprs.get(0);
+
+        PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
+        PCellSortedSet mvToCellMap = partitionTopology == null ? PCellSortedSet.of() : partitionTopology.getMvToCellMap();
+        List<Range<PartitionKey>> mvPartitionRange = Lists.newArrayList();
+        for (String partitionName : mvPartitionNames.getPartitionNames()) {
+            Preconditions.checkArgument(mvToCellMap.containsName(partitionName));
+            PRangeCell rangeCell = (PRangeCell) mvToCellMap.getPCell(partitionName);
+            mvPartitionRange.add(rangeCell.getRange());
+        }
+        mvPartitionRange = MvUtils.mergeRanges(mvPartitionRange);
+
+        List<Expr> partitionPredicates = MvUtils.convertRange(partitionExpr, mvPartitionRange);
+        Optional<Range<PartitionKey>> nullRange = mvPartitionRange.stream()
+                .filter(range -> range.lowerEndpoint().isMinValue())
+                .findAny();
+        if (nullRange.isPresent()) {
+            partitionPredicates.add(new IsNullPredicate(partitionExpr, false));
+        }
+        return ExprUtils.compoundOr(partitionPredicates);
+    }
+
+    private Expr buildListPartitionPredicate(MVPCTRefreshListPartitioner partitioner,
+                                             Table refBaseTable,
+                                             PCellSortedSet refBaseTablePartitionNames,
+                                             List<Expr> mvPartitionSlotRefs) throws AnalysisException {
+        PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
+        Map<Table, PCellSortedSet> basePartitionMaps =
+                partitionTopology == null ? Map.of() : partitionTopology.getRefBaseTableToCellMap();
+        if (basePartitionMaps.isEmpty()) {
+            return null;
+        }
+        PCellSortedSet baseListPartitionMap = basePartitionMaps.get(refBaseTable);
+        if (baseListPartitionMap == null) {
+            partitioner.logger.warn("Generate incremental partition predicate failed, "
+                    + "basePartitionMaps:{} contains no refBaseTable:{}", basePartitionMaps, refBaseTable);
+            return null;
+        }
+        if (baseListPartitionMap.isEmpty()) {
+            return new BoolLiteral(true);
+        }
+
+        Map<Table, List<Column>> refBaseTablePartitionColumns = partitioner.mv.getRefBaseTablePartitionColumns();
+        if (refBaseTablePartitionColumns == null || !refBaseTablePartitionColumns.containsKey(refBaseTable)) {
+            partitioner.logger.warn("Generate incremental partition failed, partitionTableAndColumn {} contains no ref table {}",
+                    refBaseTablePartitionColumns, refBaseTable);
+            return null;
+        }
+        List<Column> refPartitionColumns = refBaseTablePartitionColumns.get(refBaseTable);
+        if (refPartitionColumns.size() != mvPartitionSlotRefs.size()) {
+            partitioner.logger.warn("Generate incremental partition failed, refPartitionColumns size {} != "
+                            + "mvPartitionSlotRefs size {}",
+                    refPartitionColumns.size(), mvPartitionSlotRefs.size());
+            return null;
+        }
+        return genPartitionPredicate(refBaseTable, refBaseTablePartitionNames, mvPartitionSlotRefs,
+                refPartitionColumns, baseListPartitionMap);
+    }
+
+    private Expr buildListMVPartitionPredicate(MVPCTRefreshListPartitioner partitioner,
+                                               TableName tableName,
+                                               PCellSortedSet mvPartitionNames) throws AnalysisException {
+        PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
+        PCellSortedSet mvToCellMap = partitionTopology == null ? PCellSortedSet.of() : partitionTopology.getMvToCellMap();
+        if (mvToCellMap.isEmpty()) {
+            return new BoolLiteral(true);
+        }
+        PartitionInfo partitionInfo = partitioner.mv.getPartitionInfo();
+        Preconditions.checkArgument(partitionInfo instanceof ListPartitionInfo);
+
+        ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+        List<Expr> mvPartitionExprs = listPartitionInfo.getPartitionExprs(tableName, partitioner.mv.getIdToColumn());
+        List<Column> mvPartitionCols = partitioner.mv.getPartitionColumns();
+        Preconditions.checkArgument(mvPartitionExprs.size() == mvPartitionCols.size());
+        if (mvPartitionCols.size() == 1) {
+            boolean isContainsNullPartition = false;
+            Column refPartitionColumn = mvPartitionCols.get(0);
+            List<Expr> selectedPartitionValues = Lists.newArrayList();
+            Type partitionType = refPartitionColumn.getType();
+            for (PCell pCell : mvPartitionNames.getPCells()) {
+                PListCell cell = (PListCell) pCell;
+                for (List<String> values : cell.getPartitionItems()) {
+                    if (mvPartitionCols.size() != values.size()) {
+                        return null;
+                    }
+                    LiteralExpr partitionValue = new PartitionValue(values.get(0)).getValue(partitionType);
+                    if (partitionValue.isConstantNull()) {
+                        isContainsNullPartition = true;
+                        continue;
+                    }
+                    selectedPartitionValues.add(partitionValue);
+                }
+            }
+            Expr mvPartitionExpr = mvPartitionExprs.get(0);
+            Expr inPredicate = MvUtils.convertToInPredicate(mvPartitionExpr, selectedPartitionValues);
+            if (isContainsNullPartition) {
+                return ExprUtils.compoundOr(Lists.newArrayList(inPredicate, new IsNullPredicate(mvPartitionExpr, false)));
+            } else {
+                return inPredicate;
+            }
+        } else {
+            List<Expr> partitionPredicates = Lists.newArrayList();
+            for (PCell pCell : mvPartitionNames.getPCells()) {
+                PListCell cell = (PListCell) pCell;
+                for (List<String> values : cell.getPartitionItems()) {
+                    if (mvPartitionCols.size() != values.size()) {
+                        return null;
+                    }
+                    List<Expr> predicates = Lists.newArrayList();
+                    for (int i = 0; i < mvPartitionCols.size(); i++) {
+                        Column refPartitionColumn = mvPartitionCols.get(i);
+                        Type partitionType = refPartitionColumn.getType();
+                        LiteralExpr partitionValue = new PartitionValue(values.get(i)).getValue(partitionType);
+                        Expr mvPartitionByExpr = mvPartitionExprs.get(i);
+                        Expr predicate = partitionValue.isConstantNull()
+                                ? new IsNullPredicate(mvPartitionByExpr, false)
+                                : MvUtils.convertToInPredicate(mvPartitionByExpr, Lists.newArrayList(partitionValue));
+                        predicates.add(predicate);
+                    }
+                    partitionPredicates.add(ExprUtils.compoundAnd(predicates));
+                }
+            }
+            return ExprUtils.compoundOr(partitionPredicates);
+        }
+    }
+
+    private static Expr getRefBaseTablePartitionPredicateExpr(Table table,
+                                                              String partitionColumn,
+                                                              SlotRef slotRef,
+                                                              List<Expr> selectedPartitionValues) {
+        if (!(table instanceof IcebergTable)) {
+            return MvUtils.convertToInPredicate(slotRef, selectedPartitionValues);
+        } else {
+            IcebergTable icebergTable = (IcebergTable) table;
+            return getIcebergTablePartitionPredicateExpr(icebergTable, partitionColumn, slotRef, selectedPartitionValues);
+        }
+    }
+
+    private static @Nullable Expr genPartitionPredicate(Table refBaseTable,
+                                                        PCellSortedSet refBaseTablePartitionNames,
+                                                        List<Expr> refBaseTablePartitionSlotRefs,
+                                                        List<Column> refPartitionColumns,
+                                                        PCellSortedSet baseListPartitionMap)
+            throws AnalysisException {
+        Preconditions.checkArgument(refBaseTablePartitionSlotRefs.size() == refPartitionColumns.size());
+        if (refPartitionColumns.size() == 1) {
+            boolean isContainsNullPartition = false;
+            Column refPartitionColumn = refPartitionColumns.get(0);
+            List<Expr> selectedPartitionValues = Lists.newArrayList();
+            Type partitionType = refPartitionColumn.getType();
+            for (PCell pCell : refBaseTablePartitionNames.getPCells()) {
+                PListCell cell = (PListCell) pCell;
+                for (List<String> values : cell.getPartitionItems()) {
+                    if (refPartitionColumns.size() != values.size()) {
+                        return null;
+                    }
+                    LiteralExpr partitionValue = new PartitionValue(values.get(0)).getValue(partitionType);
+                    if (partitionValue.isConstantNull()) {
+                        isContainsNullPartition = true;
+                        continue;
+                    }
+                    selectedPartitionValues.add(partitionValue);
+                }
+            }
+            SlotRef refBaseTablePartitionSlotRef = (SlotRef) refBaseTablePartitionSlotRefs.get(0);
+            Expr inPredicate = getRefBaseTablePartitionPredicateExpr(refBaseTable, refPartitionColumn.getName(),
+                    refBaseTablePartitionSlotRef, selectedPartitionValues);
+            if (isContainsNullPartition) {
+                IsNullPredicate isNullPredicate = new IsNullPredicate(refBaseTablePartitionSlotRef, false);
+                return ExprUtils.compoundOr(Lists.newArrayList(inPredicate, isNullPredicate));
+            } else {
+                return inPredicate;
+            }
+        } else {
+            List<Expr> partitionPredicates = Lists.newArrayList();
+            for (PCell pCell : refBaseTablePartitionNames.getPCells()) {
+                PListCell cell = (PListCell) pCell;
+                for (List<String> values : cell.getPartitionItems()) {
+                    if (refPartitionColumns.size() != values.size()) {
+                        return null;
+                    }
+                    List<Expr> predicates = Lists.newArrayList();
+                    for (int i = 0; i < refPartitionColumns.size(); i++) {
+                        Column refPartitionColumn = refPartitionColumns.get(i);
+                        Type partitionType = refPartitionColumn.getType();
+                        LiteralExpr partitionValue = new PartitionValue(values.get(i)).getValue(partitionType);
+                        Expr refBaseTablePartitionExpr = refBaseTablePartitionSlotRefs.get(i);
+                        Expr predicate = partitionValue.isConstantNull()
+                                ? new IsNullPredicate(refBaseTablePartitionExpr, false)
+                                : getRefBaseTablePartitionPredicateExpr(refBaseTable, refPartitionColumn.getName(),
+                                        (SlotRef) refBaseTablePartitionExpr, Lists.newArrayList(partitionValue));
+                        predicates.add(predicate);
+                    }
+                    partitionPredicates.add(ExprUtils.compoundAnd(predicates));
+                }
+            }
+            return ExprUtils.compoundOr(partitionPredicates);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScope.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScope.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.sql.common.PCellSetMapping;
+import com.starrocks.sql.common.PCellSortedSet;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class PCTRefreshScope {
+
+    /**
+     * The MV partitions selected for this task run after refresh-mode decisions and partition filtering.
+     * <p>
+     * This is the final MV-side refresh target used by planning and metadata update. It may be smaller than
+     * the initially detected partition-change set when batching, adaptive refresh, or user-specified partition
+     * ranges narrow the execution scope.
+     */
+    private final PCellSortedSet mvPartitionsToRefresh;
+
+    /**
+     * The base-table partitions that this task run should read or refresh, keyed by the snapshot table object.
+     * <p>
+     * This is the execution-oriented projection of {@link #mvPartitionsToRefresh}: once the MV partitions are
+     * fixed, the refresh flow maps them back to the precise partitions of each referenced base table that
+     * intersect with those MV partitions.
+     */
+    private final Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions;
+
+    /**
+     * A table-name keyed view of {@link #refTableRefreshPartitions} for components that do not need the full
+     * snapshot object and only require table-name to partition-name mapping.
+     * <p>
+     * This is the compact representation passed into refresh-plan building and task-run status reporting.
+     */
+    private final PCellSetMapping refTablePartitionNames;
+
+    /**
+     * Whether this task run semantically represents a complete refresh of the MV refresh scope.
+     * <p>
+     * This flag records the refresh decision made earlier in the pipeline, for example when force refresh or
+     * non-ref table changes require treating the current run as a full logical refresh rather than an
+     * incrementally reduced partition subset.
+     */
+    private final boolean completeRefresh;
+
+    /**
+     * Whether the refresh computation discovered additional potential MV partitions beyond the directly changed set.
+     * <p>
+     * This is used to preserve the fact that many-to-many partition relationships expanded the candidate scope,
+     * even if later batching or filtering narrowed the final execution set recorded in this object.
+     */
+    private final boolean hasPotentialPartitions;
+
+    public PCTRefreshScope(PCellSortedSet mvPartitionsToRefresh,
+                           Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions,
+                           PCellSetMapping refTablePartitionNames,
+                           boolean completeRefresh,
+                           boolean hasPotentialPartitions) {
+        this.mvPartitionsToRefresh = copyPartitions(mvPartitionsToRefresh);
+        this.refTableRefreshPartitions = copyRefTableRefreshPartitions(refTableRefreshPartitions);
+        this.refTablePartitionNames = copyRefTablePartitionNames(refTablePartitionNames);
+        this.completeRefresh = completeRefresh;
+        this.hasPotentialPartitions = hasPotentialPartitions;
+    }
+
+    public PCellSortedSet getMvPartitionsToRefresh() {
+        return copyPartitions(this.mvPartitionsToRefresh);
+    }
+
+    public Map<BaseTableSnapshotInfo, PCellSortedSet> getRefTableRefreshPartitions() {
+        return copyRefTableRefreshPartitions(this.refTableRefreshPartitions);
+    }
+
+    public PCellSetMapping getRefTablePartitionNames() {
+        return copyRefTablePartitionNames(this.refTablePartitionNames);
+    }
+
+    public boolean isCompleteRefresh() {
+        return completeRefresh;
+    }
+
+    public boolean hasPotentialPartitions() {
+        return hasPotentialPartitions;
+    }
+
+    public boolean isEmpty() {
+        return this.mvPartitionsToRefresh.isEmpty()
+                && this.refTableRefreshPartitions.isEmpty()
+                && this.refTablePartitionNames.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PCTRefreshScope)) {
+            return false;
+        }
+        PCTRefreshScope that = (PCTRefreshScope) o;
+        return completeRefresh == that.completeRefresh
+                && hasPotentialPartitions == that.hasPotentialPartitions
+                && Objects.equals(mvPartitionsToRefresh, that.mvPartitionsToRefresh)
+                && Objects.equals(refTableRefreshPartitions, that.refTableRefreshPartitions)
+                && Objects.equals(refTablePartitionNames, that.refTablePartitionNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mvPartitionsToRefresh, refTableRefreshPartitions, refTablePartitionNames,
+                completeRefresh, hasPotentialPartitions);
+    }
+
+    @Override
+    public String toString() {
+        return "PCTRefreshScope{"
+                + "mvPartitionsToRefresh=" + mvPartitionsToRefresh
+                + ", refTableRefreshPartitions=" + refTableRefreshPartitions
+                + ", refTablePartitionNames=" + refTablePartitionNames
+                + ", completeRefresh=" + completeRefresh
+                + ", hasPotentialPartitions=" + hasPotentialPartitions
+                + '}';
+    }
+
+    private static PCellSortedSet copyPartitions(PCellSortedSet partitions) {
+        return partitions == null ? PCellSortedSet.of() : PCellSortedSet.of(partitions);
+    }
+
+    private static Map<BaseTableSnapshotInfo, PCellSortedSet> copyRefTableRefreshPartitions(
+            Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions) {
+        Map<BaseTableSnapshotInfo, PCellSortedSet> copied = new LinkedHashMap<>();
+        if (refTableRefreshPartitions != null) {
+            refTableRefreshPartitions.forEach((snapshotInfo, partitions) ->
+                    copied.put(snapshotInfo, copyPartitions(partitions)));
+        }
+        return Map.copyOf(copied);
+    }
+
+    private static PCellSetMapping copyRefTablePartitionNames(PCellSetMapping refTablePartitionNames) {
+        PCellSetMapping copied = PCellSetMapping.of();
+        if (refTablePartitionNames != null) {
+            refTablePartitionNames.mapping().forEach((tableName, partitions) ->
+                    copied.mapping().put(tableName, copyPartitions(partitions)));
+        }
+        return copied;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculator.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.sql.common.PCellSetMapping;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PCTRefreshScopeCalculator {
+
+    public Map<BaseTableSnapshotInfo, PCellSortedSet> projectRefTableRefreshPartitions(
+            PCTPartitionTopology topology,
+            Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+            PCellSortedSet mvPartitionsToRefresh) {
+        Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions = new LinkedHashMap<>();
+        if (topology == null || snapshotBaseTables == null || mvPartitionsToRefresh == null || mvPartitionsToRefresh.isEmpty()) {
+            return refTableRefreshPartitions;
+        }
+
+        Map<String, Map<Table, PCellSortedSet>> mvToBasePartitions = topology.getMvRefBaseTableIntersectedPartitions();
+        if (mvToBasePartitions == null || mvToBasePartitions.isEmpty()) {
+            return refTableRefreshPartitions;
+        }
+
+        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
+            PCellSortedSet projectedPartitions = null;
+            for (PCellWithName mvPartition : mvPartitionsToRefresh.getPartitions()) {
+                Map<Table, PCellSortedSet> refTablePartitions = mvToBasePartitions.get(mvPartition.name());
+                if (refTablePartitions == null || !refTablePartitions.containsKey(snapshotTable)) {
+                    continue;
+                }
+                if (projectedPartitions == null) {
+                    projectedPartitions = PCellSortedSet.of();
+                }
+                PCellSortedSet intersectedPartitions = refTablePartitions.get(snapshotTable);
+                if (intersectedPartitions != null) {
+                    projectedPartitions.addAll(intersectedPartitions);
+                }
+            }
+            if (projectedPartitions != null) {
+                refTableRefreshPartitions.put(snapshotInfo, projectedPartitions);
+            }
+        }
+        return refTableRefreshPartitions;
+    }
+
+    public PCTRefreshScope buildScope(PCTPartitionTopology topology,
+                                      Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
+                                      PCellSortedSet mvPartitionsToRefresh,
+                                      boolean completeRefresh,
+                                      boolean hasPotentialPartitions) {
+        Map<BaseTableSnapshotInfo, PCellSortedSet> refTableRefreshPartitions = projectRefTableRefreshPartitions(
+                topology, snapshotBaseTables, mvPartitionsToRefresh);
+        PCellSetMapping refTablePartitionNames = PCellSetMapping.of(refTableRefreshPartitions.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().getName(),
+                        entry -> PCellSortedSet.of(entry.getValue()))));
+        return new PCTRefreshScope(
+                mvPartitionsToRefresh,
+                refTableRefreshPartitions,
+                refTablePartitionNames,
+                completeRefresh,
+                hasPotentialPartitions);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunContextTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Table;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
+import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellSetMapping;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
+import com.starrocks.sql.common.PartitionNameSetMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MvTaskRunContextTest {
+
+    @Test
+    public void testPartitionTopologyAndRefreshScopeDefaultToNullBeforeSet() {
+        MvTaskRunContext context = new MvTaskRunContext(new TaskRunContext());
+
+        Assertions.assertNull(context.getPartitionTopology());
+        Assertions.assertNull(context.getRefreshScope());
+    }
+
+    @Test
+    public void testSetPartitionTopologyStoresTopologyAndSupportsPartitionLookups() {
+        MvTaskRunContext context = new MvTaskRunContext(new TaskRunContext());
+
+        PCellSortedSet mvToCellMap = PCellSortedSet.of();
+        mvToCellMap.add(PCellWithName.of("mv_p1", new PCellNone()));
+
+        Table refBaseTable = Mockito.mock(Table.class);
+        Mockito.when(refBaseTable.isNativeTableOrMaterializedView()).thenReturn(false);
+
+        PCellSortedSet refBaseTableToCell = PCellSortedSet.of();
+        refBaseTableToCell.add(PCellWithName.of("base_p1", new PCellNone()));
+        Map<Table, PCellSortedSet> refBaseTableToCellMap = Maps.newHashMap();
+        refBaseTableToCellMap.put(refBaseTable, refBaseTableToCell);
+
+        PCellSetMapping refBaseTableMVIntersectedPartitions = PCellSetMapping.of();
+        refBaseTableMVIntersectedPartitions.put("base_p1", PCellWithName.of("mv_p1", new PCellNone()));
+        Map<Table, PCellSetMapping> baseToMvNameRef = Maps.newHashMap();
+        baseToMvNameRef.put(refBaseTable, refBaseTableMVIntersectedPartitions);
+
+        Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef = Maps.newHashMap();
+        mvToBaseNameRef.put("mv_p1", refBaseTableToCellMap);
+
+        PartitionNameSetMap externalRefBaseTableMVPartitionMap = PartitionNameSetMap.of();
+        externalRefBaseTableMVPartitionMap.put("mv_p1", "base_p1");
+        Map<Table, PartitionNameSetMap> externalMap = Maps.newHashMap();
+        externalMap.put(refBaseTable, externalRefBaseTableMVPartitionMap);
+
+        PCTPartitionTopology topology = new PCTPartitionTopology(mvToCellMap, refBaseTableToCellMap,
+                baseToMvNameRef, mvToBaseNameRef, externalMap);
+
+        context.setPartitionTopology(topology);
+
+        Assertions.assertSame(topology, context.getPartitionTopology());
+        Assertions.assertEquals(Set.of("base_p1"), context.getExternalTableRealPartitionName(refBaseTable, "mv_p1"));
+
+        Table nativeTable = Mockito.mock(Table.class);
+        Mockito.when(nativeTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        Assertions.assertEquals(Set.of("mv_p1"), context.getExternalTableRealPartitionName(nativeTable, "mv_p1"));
+    }
+
+    @Test
+    public void testSetRefreshScopeStoresScope() {
+        MvTaskRunContext context = new MvTaskRunContext(new TaskRunContext());
+
+        PCellSortedSet mvPartitionsToRefresh = PCellSortedSet.of();
+        mvPartitionsToRefresh.add(PCellWithName.of("mv_p1", new PCellNone()));
+
+        PCellSetMapping refTablePartitionNames = PCellSetMapping.of();
+        refTablePartitionNames.put("tbl1", PCellWithName.of("base_p1", new PCellNone()));
+
+        PCTRefreshScope refreshScope = new PCTRefreshScope(
+                mvPartitionsToRefresh,
+                Maps.newHashMap(),
+                refTablePartitionNames,
+                false,
+                false);
+
+        context.setRefreshScope(refreshScope);
+
+        Assertions.assertSame(refreshScope, context.getRefreshScope());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
@@ -205,6 +206,19 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
         ExecPlan execPlan = getExecPlan(taskRun);
         Assertions.assertTrue(execPlan != null);
         return execPlan;
+    }
+
+    private void assertRefreshScopeMatchesExtraMessage(MvTaskRunContext mvTaskRunContext, MVTaskRunExtraMessage message) {
+        PCTRefreshScope refreshScope = mvTaskRunContext.getRefreshScope();
+        Assertions.assertNotNull(refreshScope);
+        Assertions.assertEquals(message.getMvPartitionsToRefresh(),
+                refreshScope.getMvPartitionsToRefresh().getPartitionNames());
+        Assertions.assertEquals(message.getRefBasePartitionsToRefreshMap(),
+                refreshScope.getRefTablePartitionNames().getRefTablePartitionNames());
+
+        Map<String, Set<String>> refreshScopeRefPartitions = refreshScope.getRefTableRefreshPartitions().entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> entry.getValue().getPartitionNames()));
+        Assertions.assertEquals(message.getRefBasePartitionsToRefreshMap(), refreshScopeRefPartitions);
     }
 
     @Test
@@ -1084,6 +1098,8 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
                         Assertions.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
                         Assertions.assertEquals("p2", message.getMvPartitionsToRefreshString());
+                        Assertions.assertEquals(Map.of("s2", "p2"), message.getPlanBuilderMessage());
+                        assertRefreshScopeMatchesExtraMessage(mvTaskRunContext, message);
                         ExecPlan execPlan = mvTaskRunContext.getExecPlan();
                         Assertions.assertNotEquals(null, execPlan);
                         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -239,6 +240,9 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
+        Assertions.assertNotNull(mvContext.getPartitionTopology());
+        Assertions.assertNotNull(mvContext.getRefreshScope());
+        Assertions.assertTrue(Strings.isNullOrEmpty(taskRun.getStatus().getErrorMessage()));
         assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata =

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -197,6 +198,9 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
+        Assertions.assertNotNull(mvContext.getPartitionTopology());
+        Assertions.assertNotNull(mvContext.getRefreshScope());
+        Assertions.assertTrue(Strings.isNullOrEmpty(taskRun.getStatus().getErrorMessage()));
         assertPlanContains(execPlan, "3: date >= '2020-01-02', 3: date < '2020-01-03'");
 
         Map<String, Long> partitionVersionMap = new HashMap<>();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -45,6 +45,8 @@ import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshPartitioner;
+import com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner;
+import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -54,6 +56,7 @@ import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellNone;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
@@ -77,6 +80,8 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -272,6 +277,19 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             Assertions.assertTrue(StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected),
                     "expected is: " + expected + " but plan is \n" + explainString);
         }
+    }
+
+    private void assertRefreshScopeMatchesExtraMessage(MvTaskRunContext mvContext, MVTaskRunExtraMessage extraMessage) {
+        PCTRefreshScope refreshScope = mvContext.getRefreshScope();
+        Assertions.assertNotNull(refreshScope);
+        Assertions.assertEquals(extraMessage.getMvPartitionsToRefresh(),
+                refreshScope.getMvPartitionsToRefresh().getPartitionNames());
+        Assertions.assertEquals(extraMessage.getRefBasePartitionsToRefreshMap(),
+                refreshScope.getRefTablePartitionNames().getRefTablePartitionNames());
+
+        Map<String, Set<String>> refreshScopeRefPartitions = refreshScope.getRefTableRefreshPartitions().entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> entry.getValue().getPartitionNames()));
+        Assertions.assertEquals(extraMessage.getRefBasePartitionsToRefreshMap(), refreshScopeRefPartitions);
     }
 
     @Test
@@ -1029,9 +1047,37 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         partitioner.filterPartitionByRefreshNumber(getMVPCellWithNames(mv, mv.getPartitionNames()),
                 MaterializedView.PartitionRefreshStrategy.ADAPTIVE);
         MvTaskRunContext mvContext = processor.getMvContext();
+        Assertions.assertNotNull(mvContext.getPartitionTopology());
+        Assertions.assertNotNull(mvContext.getRefreshScope());
         Assertions.assertNull(mvContext.getNextPartitionStart());
         Assertions.assertNull(mvContext.getNextPartitionEnd());
         starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testSyncPartitionsFailsWhenTopologyIsNotPublished() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), "mv2"));
+        Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        initAndExecuteTaskRun(taskRun);
+
+        MVPCTBasedRefreshProcessor processor = createProcessor(taskRun, mv);
+        processor.getMvContext().setPartitionTopology(null);
+        new MockUp<MVPCTRefreshRangePartitioner>() {
+            @Mock
+            public boolean syncAddOrDropPartitions() {
+                return true;
+            }
+        };
+
+        Method syncPartitions = BaseMVRefreshProcessor.class.getDeclaredMethod("syncPartitions");
+        syncPartitions.setAccessible(true);
+        InvocationTargetException exception = Assertions.assertThrows(InvocationTargetException.class,
+                () -> syncPartitions.invoke(processor));
+        Assertions.assertInstanceOf(DmlException.class, exception.getCause());
+        Assertions.assertTrue(exception.getCause().getMessage().contains("partition topology was not published"));
     }
 
     @Test
@@ -1237,8 +1283,11 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
             MVPCTBasedRefreshProcessor processor = getPartitionBasedRefreshProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
+            MVTaskRunExtraMessage extraMessage = processor.getMVTaskRunExtraMessage();
             Assertions.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableSpill());
             Assertions.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableProfile());
+            Assertions.assertEquals(Map.of("tbl1", "(k1 >= '2022-03-01') AND (k1 < '2022-04-01')"),
+                    extraMessage.getPlanBuilderMessage());
 
             Config.enable_materialized_view_spill = true;
         }
@@ -1694,6 +1743,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p2"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+                        assertRefreshScopeMatchesExtraMessage(mvContext, processor.getMVTaskRunExtraMessage());
 
                         MaterializedView.AsyncRefreshContext asyncRefreshContext =
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();
@@ -1718,6 +1768,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                         logSysInfo(processor.getMVTaskRunExtraMessage());
                         Assertions.assertEquals(Sets.newHashSet("p1"),
                                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+                        assertRefreshScopeMatchesExtraMessage(mvContext, processor.getMVTaskRunExtraMessage());
 
                         MaterializedView.AsyncRefreshContext asyncRefreshContext =
                                 materializedView.getRefreshScheme().getAsyncRefreshContext();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -23,7 +23,9 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner;
+import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
 import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 import org.junit.jupiter.api.Assertions;
@@ -66,8 +68,12 @@ public class MVPCTRefreshRangePartitionerTest {
         mvToBaseNameRefs.put("mv_p1", ref1);
         mvToBaseNameRefs.put("mv_p2", ref2);
 
-        Mockito.when(mvContext.getMvRefBaseTableIntersectedPartitions()).thenReturn(mvToBaseNameRefs);
-        Mockito.when(mvContext.getExternalRefBaseTableMVPartitionMap()).thenReturn(new HashMap<>());
+        Mockito.when(mvContext.getPartitionTopology()).thenReturn(new PCTPartitionTopology(
+                PCellSortedSet.of(),
+                Maps.newHashMap(),
+                Maps.<Table, PCellSetMapping>newHashMap(),
+                mvToBaseNameRefs,
+                Maps.newHashMap()));
         // TODO: make range cells
         List<PCellWithName> partitions = Arrays.asList(PCellWithName.of("mv_p1", new PCellNone()),
                 PCellWithName.of("mv_p2", new PCellNone()));

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Table;
+import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class PCTRefreshScopeCalculatorTest {
+
+    private final PCTRefreshScopeCalculator calculator = new PCTRefreshScopeCalculator();
+
+    @Test
+    public void testProjectRefTableRefreshPartitionsUsesTopologyMappings() {
+        Table tableA = Mockito.mock(Table.class);
+        Table tableB = Mockito.mock(Table.class);
+        Table tableC = Mockito.mock(Table.class);
+
+        BaseTableSnapshotInfo snapshotInfoA = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfoA.getBaseTable()).thenReturn(tableA);
+        Mockito.when(snapshotInfoA.getName()).thenReturn("table_a");
+
+        BaseTableSnapshotInfo snapshotInfoB = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfoB.getBaseTable()).thenReturn(tableB);
+        Mockito.when(snapshotInfoB.getName()).thenReturn("table_b");
+
+        BaseTableSnapshotInfo snapshotInfoC = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfoC.getBaseTable()).thenReturn(tableC);
+        Mockito.when(snapshotInfoC.getName()).thenReturn("table_c");
+
+        PCellSortedSet mvPartitionsToRefresh = PCellSortedSet.of();
+        mvPartitionsToRefresh.add(PCellWithName.of("mv_p1", new PCellNone()));
+        mvPartitionsToRefresh.add(PCellWithName.of("mv_p2", new PCellNone()));
+
+        PCellSortedSet tableAPartitionsForMvP1 = PCellSortedSet.of();
+        tableAPartitionsForMvP1.add(PCellWithName.of("base_a_p1", new PCellNone()));
+        PCellSortedSet tableAPartitionsForMvP2 = PCellSortedSet.of();
+        tableAPartitionsForMvP2.add(PCellWithName.of("base_a_p2", new PCellNone()));
+
+        Map<String, Map<Table, PCellSortedSet>> mvToBasePartitions = Maps.newHashMap();
+        Map<Table, PCellSortedSet> mvP1Refs = Maps.newHashMap();
+        mvP1Refs.put(tableA, tableAPartitionsForMvP1);
+        mvP1Refs.put(tableB, PCellSortedSet.of());
+        mvToBasePartitions.put("mv_p1", mvP1Refs);
+
+        Map<Table, PCellSortedSet> mvP2Refs = Maps.newHashMap();
+        mvP2Refs.put(tableA, tableAPartitionsForMvP2);
+        mvToBasePartitions.put("mv_p2", mvP2Refs);
+
+        PCTPartitionTopology topology = new PCTPartitionTopology(
+                PCellSortedSet.of(),
+                Maps.newHashMap(),
+                Maps.newHashMap(),
+                mvToBasePartitions,
+                Maps.newHashMap());
+
+        Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = new LinkedHashMap<>();
+        snapshotBaseTables.put(1L, snapshotInfoA);
+        snapshotBaseTables.put(2L, snapshotInfoB);
+        snapshotBaseTables.put(3L, snapshotInfoC);
+
+        Map<BaseTableSnapshotInfo, PCellSortedSet> projected = calculator.projectRefTableRefreshPartitions(
+                topology, snapshotBaseTables, mvPartitionsToRefresh);
+
+        Assertions.assertEquals(2, projected.size());
+        Assertions.assertTrue(projected.get(snapshotInfoA).containsName("base_a_p1"));
+        Assertions.assertTrue(projected.get(snapshotInfoA).containsName("base_a_p2"));
+        Assertions.assertTrue(projected.containsKey(snapshotInfoB));
+        Assertions.assertTrue(projected.get(snapshotInfoB).isEmpty());
+        Assertions.assertFalse(projected.containsKey(snapshotInfoC));
+    }
+
+    @Test
+    public void testBuildScopePackagesProjectedState() {
+        Table table = Mockito.mock(Table.class);
+        BaseTableSnapshotInfo snapshotInfo = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfo.getBaseTable()).thenReturn(table);
+        Mockito.when(snapshotInfo.getName()).thenReturn("table_a");
+
+        PCellSortedSet mvPartitionsToRefresh = PCellSortedSet.of();
+        mvPartitionsToRefresh.add(PCellWithName.of("mv_p1", new PCellNone()));
+
+        PCellSortedSet refPartitions = PCellSortedSet.of();
+        refPartitions.add(PCellWithName.of("base_a_p1", new PCellNone()));
+
+        Map<String, Map<Table, PCellSortedSet>> mvToBasePartitions = Maps.newHashMap();
+        Map<Table, PCellSortedSet> mvP1Refs = Maps.newHashMap();
+        mvP1Refs.put(table, refPartitions);
+        mvToBasePartitions.put("mv_p1", mvP1Refs);
+
+        PCTPartitionTopology topology = new PCTPartitionTopology(
+                PCellSortedSet.of(),
+                Maps.newHashMap(),
+                Maps.newHashMap(),
+                mvToBasePartitions,
+                Maps.newHashMap());
+
+        Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Map.of(1L, snapshotInfo);
+
+        PCTRefreshScope scope = calculator.buildScope(topology, snapshotBaseTables, mvPartitionsToRefresh, true, true);
+
+        Assertions.assertFalse(scope.isEmpty());
+        Assertions.assertTrue(scope.isCompleteRefresh());
+        Assertions.assertTrue(scope.hasPotentialPartitions());
+        Assertions.assertEquals(mvPartitionsToRefresh.getPartitionNames(), scope.getMvPartitionsToRefresh().getPartitionNames());
+        Assertions.assertEquals(
+                Map.of("table_a", refPartitions.getPartitionNames()),
+                scope.getRefTablePartitionNames().getRefTablePartitionNames());
+        Assertions.assertEquals(refPartitions.getPartitionNames(),
+                scope.getRefTableRefreshPartitions().get(snapshotInfo).getPartitionNames());
+    }
+
+    @Test
+    public void testBuildScopeFailsWhenSnapshotTablesShareTheSameName() {
+        Table tableA = Mockito.mock(Table.class);
+        Table tableB = Mockito.mock(Table.class);
+
+        BaseTableSnapshotInfo snapshotInfoA = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfoA.getBaseTable()).thenReturn(tableA);
+        Mockito.when(snapshotInfoA.getName()).thenReturn("dup_table");
+
+        BaseTableSnapshotInfo snapshotInfoB = Mockito.mock(BaseTableSnapshotInfo.class);
+        Mockito.when(snapshotInfoB.getBaseTable()).thenReturn(tableB);
+        Mockito.when(snapshotInfoB.getName()).thenReturn("dup_table");
+
+        PCellSortedSet mvPartitionsToRefresh = PCellSortedSet.of();
+        mvPartitionsToRefresh.add(PCellWithName.of("mv_p1", new PCellNone()));
+
+        PCellSortedSet refPartitionsA = PCellSortedSet.of();
+        refPartitionsA.add(PCellWithName.of("base_a_p1", new PCellNone()));
+        PCellSortedSet refPartitionsB = PCellSortedSet.of();
+        refPartitionsB.add(PCellWithName.of("base_b_p1", new PCellNone()));
+
+        Map<String, Map<Table, PCellSortedSet>> mvToBasePartitions = Maps.newHashMap();
+        Map<Table, PCellSortedSet> mvP1Refs = Maps.newHashMap();
+        mvP1Refs.put(tableA, refPartitionsA);
+        mvP1Refs.put(tableB, refPartitionsB);
+        mvToBasePartitions.put("mv_p1", mvP1Refs);
+
+        PCTPartitionTopology topology = new PCTPartitionTopology(
+                PCellSortedSet.of(),
+                Maps.newHashMap(),
+                Maps.newHashMap(),
+                mvToBasePartitions,
+                Maps.newHashMap());
+
+        Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = new LinkedHashMap<>();
+        snapshotBaseTables.put(1L, snapshotInfoA);
+        snapshotBaseTables.put(2L, snapshotInfoB);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> calculator.buildScope(topology, snapshotBaseTables, mvPartitionsToRefresh, false, false));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request refactors and simplifies the management of partition and refresh metadata for materialized view (MV) refresh operations. The changes consolidate several partition-mapping fields and methods into new, higher-level abstractions (`PCTPartitionTopology` and `PCTRefreshScope`). This results in cleaner code, centralized logic, and improved maintainability. The most important changes are grouped below:

### Refactoring and Simplification of Partition Metadata

* Replaced multiple low-level partition mapping fields in `MvTaskRunContext` (such as `refBaseTableMVIntersectedPartitions`, `mvRefBaseTableIntersectedPartitions`, `refBaseTableToCellMap`, etc.) with two new fields: `partitionTopology` (`PCTPartitionTopology`) and `refreshScope` (`PCTRefreshScope`). Corresponding getter and setter methods were updated or removed accordingly. [[1]](diffhunk://#diff-aebc155dc33051d2326850346ce31f809e94ee3d4e3a5067d50315f0583b90fdL57-R57) [[2]](diffhunk://#diff-aebc155dc33051d2326850346ce31f809e94ee3d4e3a5067d50315f0583b90fdL90-R89) [[3]](diffhunk://#diff-aebc155dc33051d2326850346ce31f809e94ee3d4e3a5067d50315f0583b90fdL136-L160)
* Updated usages throughout the codebase to access partition mapping data via the new abstractions, including in `BaseMVRefreshProcessor`, `MVVersionManager`, and related classes. [[1]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L922-R913) [[2]](diffhunk://#diff-76844987e73e641349a2aad99f17b61f40b3f2d72e772e3bad8ce29af423f382L270-R273)

### Centralization of Refresh Scope Computation

* Introduced and utilized `PCTRefreshScopeCalculator` to compute the refresh scope, encapsulating logic for determining which partitions of the MV and base tables need to be refreshed. This replaces scattered logic for computing candidate partitions and refresh sets. [[1]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583R115) [[2]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583R157) [[3]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L808-R827)
* Refactored methods such as `updatePCTToRefreshMetas` and `getPCTRefTableRefreshPartitions` to use the new `PCTRefreshScope` abstraction, improving code clarity and reducing duplication. [[1]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L493-R508) [[2]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L808-R827) [[3]](diffhunk://#diff-eb3450d770525518e04448190dbd758f653b38f2b3458ade0cb4e9d0c0035583L411-R416)

### Improvements to Refresh Plan Preparation and Execution

* Updated refresh plan preparation to use the new refresh scope, passing partition information in a more structured way. This affects how insert statements for MV refresh are generated and how empty refreshes are detected. [[1]](diffhunk://#diff-430aa708a2938e6c5c53a81e04d1f7951a66077c318bd418244ce8f2c11568ddL108-R118) [[2]](diffhunk://#diff-430aa708a2938e6c5c53a81e04d1f7951a66077c318bd418244ce8f2c11568ddL176-R179)

### Robustness and Error Handling

* Added a check to ensure that the partition topology is published after partition synchronization, throwing an exception if not, to prevent inconsistent state during MV refresh.

These changes collectively modernize the partition and refresh metadata handling, making the codebase easier to maintain and extend.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
