### PR TITLE
[Enhancement] Adopt Maven CI-friendly versioning for FE build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.pyc
+.flattened-pom.xml
 be/output
 be/build
 be/build_Release

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -214,14 +214,26 @@ mkdir -p ${meta_dir:-"$STARROCKS_HOME/meta"}
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-# Explicitly put fe-core-main.jar at the front of classpath to ensure StarRocks' 
-# customized classes (e.g., HiveMetaStoreClient) are loaded before the original 
+# Explicitly put fe-core jar at the front of classpath to ensure StarRocks'
+# customized classes (e.g., HiveMetaStoreClient) are loaded before the original
 # ones from third-party JARs (e.g., hive-apache-3.1.2-22.jar).
-# This prevents ClassLoader conflicts where the original HiveMetaStoreClient 
+# This prevents ClassLoader conflicts where the original HiveMetaStoreClient
 # (which uses old thrift paths like org.apache.thrift.transport.TFramedTransport)
 # might be loaded instead of StarRocks' version (which uses the correct new paths
 # like org.apache.thrift.transport.layered.TFramedTransport).
-export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-main.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
+# Support both fe-core-main.jar (default) and versioned jar names (e.g., fe-core-4.1.0.jar)
+FE_CORE_JAR=""
+if [ -f ${STARROCKS_HOME}/lib/fe-core-main.jar ]; then
+    FE_CORE_JAR=${STARROCKS_HOME}/lib/fe-core-main.jar
+else
+    # Find the first fe-core-*.jar file (sorted alphabetically)
+    FE_CORE_JAR=$(ls -1 ${STARROCKS_HOME}/lib/fe-core-*.jar 2>/dev/null | head -1)
+    if [ -z "$FE_CORE_JAR" ]; then
+        echo "Error: fe-core jar not found in ${STARROCKS_HOME}/lib/"
+        exit 1
+    fi
+fi
+export CLASSPATH=${FE_CORE_JAR}:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
 
 pidfile=$PID_DIR/fe.pid
 

--- a/build.sh
+++ b/build.sh
@@ -137,6 +137,9 @@ Usage: $0 <options>
      --without-avx2     build Backend without avx2(instruction)    
      --with-maven-batch-mode {ON|OFF}
                         build maven project in batch mode (default: $WITH_MAVEN_BATCH_MODE)
+     --fe-version VERSION
+                        set the FE artifact version via Maven CI-friendly property -Drevision=VERSION
+                        (also sets spark_dpp_version at build time). If not specified, defaults to 'main'.
      --output           specify the output directory (default: $STARROCKS_HOME/output)
      --disable-java-check-style
                         disable Java checkstyle checks during build (default: $DISABLE_JAVA_CHECK_STYLE)
@@ -149,6 +152,7 @@ Usage: $0 <options>
     $0 --fe --be --clean                         clean and build Frontend, Spark Dpp application and Backend
     $0 --spark-dpp                               build Spark DPP application alone
     $0 --hive-udf                                build Hive UDF
+    $0 --fe --fe-version 4.1.0                   build Frontend with version set to 4.1.0
     $0 --be --output PATH                        build Backend that outputs results to a specified path (relative paths are supported).
     BUILD_TYPE=build_type ./build.sh --be        build Backend is different mode (build_type could be Release, Debug, or Asan. Default value is Release. To build Backend in Debug mode, you can execute: BUILD_TYPE=Debug ./build.sh --be)
     DISABLE_JAVA_CHECK_STYLE=ON ./build.sh       build with Java checkstyle disabled
@@ -187,6 +191,7 @@ OPTS=$(${GETOPT_BIN} \
   -l 'with-source-file-relative-path:' \
   -l 'without-avx2' \
   -l 'with-maven-batch-mode:' \
+  -l 'fe-version:' \
   -l 'output:' \
   -l 'help' \
   -l 'disable-java-check-style' \
@@ -346,6 +351,7 @@ else
             --with-compress-debug-symbol) WITH_COMPRESS=$2 ; shift 2 ;;
             --with-source-file-relative-path) WITH_RELATIVE_SRC_PATH=$2 ; shift 2 ;;
             --with-maven-batch-mode) WITH_MAVEN_BATCH_MODE=$2 ; shift 2 ;;
+            --fe-version) FE_VERSION=$2 ; shift 2 ;;
             --output) STARROCKS_OUTPUT=$2 ; shift 2 ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
@@ -473,6 +479,10 @@ fi
 if [ "x$DISABLE_JAVA_CHECK_STYLE" = "xON" ] ; then
     # Add checkstyle.skip parameter to disable Java checkstyle
     addon_mvn_opts="${addon_mvn_opts} -Dcheckstyle.skip=true"
+fi
+
+if [ -n "$FE_VERSION" ] ; then
+    addon_mvn_opts="${addon_mvn_opts} -Drevision=${FE_VERSION}"
 fi
 
 # Clean and build Backend

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -982,6 +982,22 @@ under the License.
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>starrocks-version.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>starrocks-version.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <!-- fe proto precompile plugin-->
             <plugin>

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -41,10 +41,27 @@ import com.starrocks.qe.scheduler.slot.QueryQueueOptions;
 import com.starrocks.qe.scheduler.slot.SlotEstimatorFactory;
 import com.starrocks.statistic.sample.NDVEstimator;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 
 public class Config extends ConfigBase {
+
+    private static String loadVersionProperty(String key, String defaultValue) {
+        try (InputStream in = Config.class.getClassLoader()
+                .getResourceAsStream("starrocks-version.properties")) {
+            if (in != null) {
+                Properties props = new Properties();
+                props.load(in);
+                return props.getProperty(key, defaultValue);
+            }
+        } catch (IOException ignored) {
+        }
+        return defaultValue;
+    }
 
     /**
      *  STARROCKS_HOME is the root dir of starrocks installation.
@@ -1262,7 +1279,7 @@ public class Config extends ConfigBase {
      * Default spark dpp version
      */
     @ConfField
-    public static String spark_dpp_version = "main";
+    public static String spark_dpp_version = loadVersionProperty("spark_dpp_version", "main");
     /**
      * Default spark load timeout
      */

--- a/fe/fe-core/src/main/resources/starrocks-version.properties
+++ b/fe/fe-core/src/main/resources/starrocks-version.properties
@@ -1,0 +1,1 @@
+spark_dpp_version=${revision}

--- a/fe/fe-grammar/pom.xml
+++ b/fe/fe-grammar/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-parser/pom.xml
+++ b/fe/fe-parser/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-server/pom.xml
+++ b/fe/fe-server/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-spi/pom.xml
+++ b/fe/fe-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-testing/pom.xml
+++ b/fe/fe-testing/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-type/pom.xml
+++ b/fe/fe-type/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-utils/pom.xml
+++ b/fe/fe-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/plugin/hive-udf/pom.xml
+++ b/fe/plugin/hive-udf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fe/plugin/spark-dpp/pom.xml
+++ b/fe/plugin/spark-dpp/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>main</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-fe</artifactId>
-    <version>main</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -44,6 +44,7 @@ under the License.
     <name>starrocks-fe</name>
 
     <properties>
+        <revision>main</revision>
         <starrocks.home>${basedir}/../</starrocks.home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.8.2</junit.version>
@@ -1589,6 +1590,36 @@ under the License.
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <reporting>
         <plugins>


### PR DESCRIPTION
Follow-up to #63086. Previously, for each release we had to manually modify 12 source files to bump the version — 11 `pom.xml` files and `spark_dpp_version` in `Config.java` — like what was done in PR #71078.

Adopted Maven CI-Friendly Versioning for FE build, so release versions can now be set at build time — no source file changes needed:

./build.sh --fe --fe-version 4.1.0

- Use ${revision} property across all pom.xml files (default: main)
- Add flatten-maven-plugin to resolve CI-friendly placeholders
- Add resource filtering to propagate version to spark_dpp_version in Config.java
- Add --fe-version flag to build.sh

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
