### PR TITLE
[BugFix] Clone nullable result null bitmaps in array/map functions (backport #71153)

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -60,7 +60,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
         if (arg0->has_null()) {
             // Copy null flags.
             return NullableColumn::create(std::move(col_result),
-                                          std::move(*(down_cast<const NullableColumn*>(arg0)->null_column())).mutate());
+                                          down_cast<const NullableColumn*>(arg0)->null_column()->clone());
         } else {
             return col_result;
         }
@@ -136,7 +136,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_append([[maybe_unused]] FunctionContex
     RETURN_IF_ERROR(result);
 
     if (nullable_array != nullptr) {
-        return NullableColumn::create(result.value(), nullable_array->null_column());
+        return NullableColumn::create(std::move(result.value()), nullable_array->null_column()->clone());
     }
     return result;
 }
@@ -372,7 +372,7 @@ private:
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
             ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
-            return NullableColumn::create(result, nullable->null_column());
+            return NullableColumn::create(std::move(result), nullable->null_column()->clone());
         }
 
         return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
@@ -1921,7 +1921,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     auto result = ArrayColumn::create(result_elements, result_offsets);
     if (src_nullable_column != nullptr) {
-        return NullableColumn::create(result, src_nullable_column->null_column());
+        return NullableColumn::create(std::move(result), src_nullable_column->null_column()->clone());
     }
     return result;
 }

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -59,8 +59,9 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
 
         if (arg0->has_null()) {
             // Copy null flags.
-            return NullableColumn::create(std::move(col_result),
-                                          down_cast<const NullableColumn*>(arg0)->null_column()->clone());
+            auto null_column = NullColumn::static_pointer_cast(
+                    Column::mutate(down_cast<const NullableColumn*>(arg0)->null_column()));
+            return NullableColumn::create(std::move(col_result), std::move(null_column));
         } else {
             return col_result;
         }
@@ -136,7 +137,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_append([[maybe_unused]] FunctionContex
     RETURN_IF_ERROR(result);
 
     if (nullable_array != nullptr) {
-        return NullableColumn::create(std::move(result.value()), nullable_array->null_column()->clone());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable_array->null_column()));
+        return NullableColumn::create(std::move(result.value()), std::move(null_column));
     }
     return result;
 }
@@ -372,7 +374,8 @@ private:
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
             ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
-            return NullableColumn::create(std::move(result), nullable->null_column()->clone());
+            auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable->null_column()));
+            return NullableColumn::create(std::move(result), std::move(null_column));
         }
 
         return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
@@ -1921,7 +1924,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     auto result = ArrayColumn::create(result_elements, result_offsets);
     if (src_nullable_column != nullptr) {
-        return NullableColumn::create(std::move(result), src_nullable_column->null_column()->clone());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(src_nullable_column->null_column()));
+        return NullableColumn::create(std::move(result), std::move(null_column));
     }
     return result;
 }

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -145,7 +145,7 @@ StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Colum
 
     if (arg0->has_null()) {
         return NullableColumn::create(std::move(col_result),
-                                      down_cast<const NullableColumn*>(arg0.get())->null_column());
+                                      down_cast<const NullableColumn*>(arg0.get())->null_column()->clone());
     } else {
         return col_result;
     }

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -144,8 +144,9 @@ StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Colum
     }
 
     if (arg0->has_null()) {
-        return NullableColumn::create(std::move(col_result),
-                                      down_cast<const NullableColumn*>(arg0.get())->null_column()->clone());
+        auto null_column = NullColumn::static_pointer_cast(
+                Column::mutate(down_cast<const NullableColumn*>(arg0.get())->null_column()));
+        return NullableColumn::create(std::move(col_result), std::move(null_column));
     } else {
         return col_result;
     }

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -54,6 +54,9 @@ protected:
     void _check_array_nullable(const Buffer<CppType>& check_values, const Buffer<uint8_t>& nulls,
                                const DatumArray& value);
 
+    void _assert_nullable_result_has_independent_null_column(const ColumnPtr& input, const ColumnPtr& result,
+                                                             const Filter& filter);
+
     FunctionContext _ctx;
 };
 
@@ -126,6 +129,25 @@ void ArrayFunctionsTest::_check_array_nullable(const Buffer<CppType>& check_valu
     } else {
         ASSERT_TRUE(false);
     }
+}
+
+void ArrayFunctionsTest::_assert_nullable_result_has_independent_null_column(const ColumnPtr& input,
+                                                                             const ColumnPtr& result,
+                                                                             const Filter& filter) {
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    EXPECT_NE(input_nullable->null_column().get(), result_nullable->null_column().get());
+
+    const size_t result_data_size = result_nullable->data_column()->size();
+    const size_t result_null_size = result_nullable->null_column()->size();
+
+    input->filter(filter);
+
+    EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
+    EXPECT_EQ(result_null_size, result_nullable->null_column()->size());
 }
 
 // NOLINTNEXTLINE
@@ -247,6 +269,68 @@ TEST_F(ArrayFunctionsTest, array_length) {
         EXPECT_EQ(3, result->size());
         EXPECT_EQ(4, result->get(1).get_int32());
     }
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_length_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)}));
+
+    auto result = ArrayFunctions::array_length(nullptr, {input}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0, 1});
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_append_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{}));
+    input->append_datum(Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)}));
+
+    MutableColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
+    target->append_datum(Datum((int32_t)9));
+
+    auto result = ArrayFunctions::array_append(nullptr, {input, target}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_remove_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum((int32_t)2)}));
+    input->append_datum(Datum(DatumArray{}));
+
+    MutableColumnPtr target = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+    target->append_datum(Datum((int32_t)2));
+
+    auto result = ArrayFunctions::array_remove(nullptr, {input, target}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
+}
+
+// NOLINTNEXTLINE
+TEST_F(ArrayFunctionsTest, array_flatten_result_should_not_share_null_column_with_input) {
+    MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)1)}),
+                                         Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
+    input->append_datum(Datum());
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{})}));
+    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)4)}), Datum(DatumArray{})}));
+
+    auto result = ArrayFunctions::array_flatten(nullptr, {input}).value();
+    _assert_nullable_result_has_independent_null_column(input, result, {1, 0, 1, 0});
 }
 
 // NOLINTNEXTLINE

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -144,7 +144,7 @@ void ArrayFunctionsTest::_assert_nullable_result_has_independent_null_column(con
     const size_t result_data_size = result_nullable->data_column()->size();
     const size_t result_null_size = result_nullable->null_column()->size();
 
-    input->filter(filter);
+    input->as_mutable_raw_ptr()->filter(filter);
 
     EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
     EXPECT_EQ(result_null_size, result_nullable->null_column()->size());

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -323,8 +323,8 @@ TEST_F(ArrayFunctionsTest, array_remove_result_should_not_share_null_column_with
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_flatten_result_should_not_share_null_column_with_input) {
     MutableColumnPtr input = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true);
-    input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)1)}),
-                                         Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
+    input->append_datum(Datum(
+            DatumArray{Datum(DatumArray{Datum((int32_t)1)}), Datum(DatumArray{Datum((int32_t)2), Datum((int32_t)3)})}));
     input->append_datum(Datum());
     input->append_datum(Datum(DatumArray{Datum(DatumArray{})}));
     input->append_datum(Datum(DatumArray{Datum(DatumArray{Datum((int32_t)4)}), Datum(DatumArray{})}));

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -23,6 +23,24 @@
 
 namespace starrocks {
 
+void _assert_nullable_result_has_independent_null_column(const ColumnPtr& input, const ColumnPtr& result,
+                                                         const Filter& filter) {
+    auto input_nullable = NullableColumn::dynamic_pointer_cast(input);
+    auto result_nullable = NullableColumn::dynamic_pointer_cast(result);
+
+    ASSERT_TRUE(input_nullable != nullptr);
+    ASSERT_TRUE(result_nullable != nullptr);
+    EXPECT_NE(input_nullable->null_column().get(), result_nullable->null_column().get());
+
+    const size_t result_data_size = result_nullable->data_column()->size();
+    const size_t result_null_size = result_nullable->null_column()->size();
+
+    input->as_mutable_raw_ptr()->filter(filter);
+
+    EXPECT_EQ(result_data_size, result_nullable->data_column()->size());
+    EXPECT_EQ(result_null_size, result_nullable->null_column()->size());
+}
+
 PARALLEL_TEST(MapFunctionsTest, test_map) {
     TypeDescriptor input_keys_type;
     input_keys_type.type = LogicalType::TYPE_ARRAY;
@@ -315,6 +333,27 @@ PARALLEL_TEST(MapFunctionsTest, test_map_function) {
     EXPECT_EQ(44, result_values->get(1).get_array()[0].get_int32());
     EXPECT_EQ(55, result_values->get(1).get_array()[1].get_int32());
     EXPECT_EQ(66, result_values->get(1).get_array()[2].get_int32());
+}
+
+PARALLEL_TEST(MapFunctionsTest, map_size_result_should_not_share_null_column_with_input) {
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
+    MutableColumnPtr column = ColumnHelper::create_column(type_map_int_int, true);
+
+    DatumMap map0;
+    map0[(int32_t)1] = (int32_t)11;
+    map0[(int32_t)2] = (int32_t)22;
+    column->append_datum(map0);
+
+    column->append_default();
+
+    DatumMap map2;
+    map2[(int32_t)3] = (int32_t)33;
+    column->append_datum(map2);
+
+    column->append_default();
+
+    auto result = MapFunctions::map_size(nullptr, {column}).value();
+    _assert_nullable_result_has_independent_null_column(column, result, {1, 0, 1, 0});
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {


### PR DESCRIPTION
## Why I'm doing:

Several array/map expression functions (`array_length`, `array_append`, `array_remove`, `array_flatten`, `map_size`) return a NullableColumn whose `null_column` shares the same pointer as the input's `null_column` (via `mutate()` or direct reference). When the result and input columns coexist in the same Chunk (e.g., via ProjectOperator), `Chunk::filter()` modifies the shared null bitmap through one column, corrupting the other and causing a `DCHECK` crash:

```
Check failed: _data_column->size() == _null_column->size() (3 vs. 2)
```

## What I'm doing:

- Changed `null_column().mutate()` back to `null_column()->clone()` in `array_length` to ensure exclusive ownership of the null bitmap
- Changed direct `null_column()` references to `null_column()->clone()` in `array_append`, `array_remove`, `array_flatten`, and `map_size`
- Added regression tests verifying that result NullableColumns have independent null bitmaps that are not corrupted by in-place filtering of the input

Fixes https://github.com/StarRocks/StarRocksTest/issues/11200

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4