### PR TITLE
[BugFix] Fix batch publish blocked by incorrect transaction graph

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
@@ -131,10 +131,26 @@ public class TransactionGraph {
         }
         nodes.remove(txnId);
         nodesWithoutIns.remove(node);
+        // When removing the tail node for a table, update lastTableWriter to the nearest
+        // predecessor that also writes that table, instead of clearing it entirely.
+        // This ensures subsequent transactions for the same table can still find their dependency.
         for (long tableId : node.writeTableIds) {
             Node holder = lastTableWriter.get(tableId);
             if (holder == node) {
-                lastTableWriter.remove(tableId);
+                Node prevWriter = null;
+                if (node.ins != null) {
+                    for (Node dep : node.ins) {
+                        if (dep.writeTableIds.contains(tableId)) {
+                            prevWriter = dep;
+                            break;
+                        }
+                    }
+                }
+                if (prevWriter != null) {
+                    lastTableWriter.put(tableId, prevWriter);
+                } else {
+                    lastTableWriter.remove(tableId);
+                }
             }
         }
         if (node.outs == null) {
@@ -142,6 +158,14 @@ public class TransactionGraph {
         }
         for (Node next : node.outs) {
             next.ins.remove(node);
+            // Re-link predecessors directly to successors so that ordering is preserved
+            // even when an intermediate node is removed out of order.
+            if (node.ins != null && !node.ins.isEmpty()) {
+                for (Node prev : node.ins) {
+                    next.addIns(prev);
+                    prev.addOuts(next);
+                }
+            }
             if (next.ins.isEmpty()) {
                 nodesWithoutIns.add(next);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
@@ -29,6 +29,14 @@ import java.util.stream.Collectors;
 
 /**
  * store transactions' dependency relationships
+ *
+ * The dependency graph is modeled as the overlay of one doubly-linked writer
+ * chain per table: for every table T a node writes, the node stores its
+ * immediate predecessor (tablePrev[T]) and successor (tableNext[T]) on T's
+ * chain. Keeping the per-table chain explicit makes add/remove deterministic
+ * linked-list operations and avoids reverse-engineering chain membership from
+ * an unlabeled dependency set.
+ *
  * this class is used in DatabaseTransactionMgr and all methods are protected by mgr's lock
  * so this class does not require additional synchronization
  */
@@ -36,30 +44,22 @@ public class TransactionGraph {
     private static final Logger LOG = LogManager.getLogger(TransactionGraph.class);
 
     static class Node {
-        long txnId;
-        List<Long> writeTableIds;
-        // transactions this txn depends
-        Set<Node> ins;
-        // transactions depending on this txn
-        Set<Node> outs;
+        final long txnId;
+        final List<Long> writeTableIds;
+
+        // For every table this node writes, the immediate predecessor on that
+        // table's chain. An absent key means this node is the head of that
+        // table's chain (no predecessor for that table).
+        final Map<Long, Node> tablePrev;
+        // Symmetric: the immediate successor on each table's chain. An absent
+        // key means this node is the tail of that table's chain.
+        final Map<Long, Node> tableNext;
 
         Node(long txnId, List<Long> writeTableIds) {
             this.txnId = txnId;
             this.writeTableIds = writeTableIds;
-        }
-
-        void addIns(Node in) {
-            if (ins == null) {
-                ins = new HashSet<>();
-            }
-            ins.add(in);
-        }
-
-        void addOuts(Node out) {
-            if (outs == null) {
-                outs = new HashSet<>();
-            }
-            outs.add(out);
+            this.tablePrev = new HashMap<>(writeTableIds.size());
+            this.tableNext = new HashMap<>(writeTableIds.size());
         }
 
         @Override
@@ -88,7 +88,7 @@ public class TransactionGraph {
     private Map<Long, Node> nodes = new HashMap<>();
     private Set<Node> nodesWithoutIns = new HashSet<>();
 
-    // tableid -> txnId that lastly write this table
+    // tableId -> tail node of that table's writer chain
     private Map<Long, Node> lastTableWriter = new HashMap<>();
 
     public TransactionGraph() {
@@ -105,15 +105,15 @@ public class TransactionGraph {
         }
         Node node = new Node(txnId, writeTableIds);
         for (long tableId : writeTableIds) {
-            Node previous = lastTableWriter.put(tableId, node);
-            if (previous != null) {
-                Preconditions.checkState(previous != node, "duplicate node {}", txnId);
-                node.addIns(previous);
-                previous.addOuts(node);
+            Node prev = lastTableWriter.put(tableId, node);
+            if (prev != null) {
+                Preconditions.checkState(prev != node, "duplicate node {}", txnId);
+                node.tablePrev.put(tableId, prev);
+                prev.tableNext.put(tableId, node);
             }
         }
         nodes.put(txnId, node);
-        if (node.ins == null || node.ins.isEmpty()) {
+        if (node.tablePrev.isEmpty()) {
             nodesWithoutIns.add(node);
         }
     }
@@ -123,51 +123,46 @@ public class TransactionGraph {
         if (node == null) {
             return;
         }
-        if (node.ins != null && !node.ins.isEmpty()) {
-            LOG.warn("remove txn " + txnId + " with dependency: " + node.ins + " this may happen during FE upgrading");
-            for (Node dep : node.ins) {
-                dep.outs.remove(node);
-            }
+        if (!node.tablePrev.isEmpty()) {
+            LOG.warn("remove txn " + txnId + " with dependency: " + node.tablePrev.values()
+                    + " this may happen during FE upgrading");
         }
         nodes.remove(txnId);
         nodesWithoutIns.remove(node);
-        // When removing the tail node for a table, update lastTableWriter to the nearest
-        // predecessor that also writes that table, instead of clearing it entirely.
-        // This ensures subsequent transactions for the same table can still find their dependency.
+
+        // Splice node out of every table's chain it participated in. Per-table
+        // linked-list maintenance keeps predecessor/successor relationships
+        // exact and never creates cross-table edges.
         for (long tableId : node.writeTableIds) {
-            Node holder = lastTableWriter.get(tableId);
-            if (holder == node) {
-                Node prevWriter = null;
-                if (node.ins != null) {
-                    for (Node dep : node.ins) {
-                        if (dep.writeTableIds.contains(tableId)) {
-                            prevWriter = dep;
-                            break;
-                        }
+            Node prev = node.tablePrev.get(tableId);   // null => node is head of T
+            Node next = node.tableNext.get(tableId);   // null => node is tail of T
+
+            if (prev != null) {
+                if (next != null) {
+                    prev.tableNext.put(tableId, next);
+                } else {
+                    prev.tableNext.remove(tableId);
+                }
+            }
+            if (next != null) {
+                if (prev != null) {
+                    next.tablePrev.put(tableId, prev);
+                } else {
+                    next.tablePrev.remove(tableId);
+                    if (next.tablePrev.isEmpty()) {
+                        nodesWithoutIns.add(next);
                     }
                 }
-                if (prevWriter != null) {
-                    lastTableWriter.put(tableId, prevWriter);
+            }
+
+            // node was the tail of T iff next == null. In that case the new
+            // tail is prev (possibly null, meaning T has no writer left).
+            if (next == null) {
+                if (prev != null) {
+                    lastTableWriter.put(tableId, prev);
                 } else {
                     lastTableWriter.remove(tableId);
                 }
-            }
-        }
-        if (node.outs == null) {
-            return;
-        }
-        for (Node next : node.outs) {
-            next.ins.remove(node);
-            // Re-link predecessors directly to successors so that ordering is preserved
-            // even when an intermediate node is removed out of order.
-            if (node.ins != null && !node.ins.isEmpty()) {
-                for (Node prev : node.ins) {
-                    next.addIns(prev);
-                    prev.addOuts(next);
-                }
-            }
-            if (next.ins.isEmpty()) {
-                nodesWithoutIns.add(next);
             }
         }
     }
@@ -179,26 +174,21 @@ public class TransactionGraph {
     // The size of ins of node with txnId must be zero
     public List<Long> getTxnsWithTxnDependencyBatch(int minBatchSize, int maxBatchSize, long txnId) {
         List<Long> txns = new ArrayList<>();
-        if (nodes.containsKey(txnId)) {
-            Node node = nodes.get(txnId);
-            if (node.writeTableIds.size() > 1) {
-                txns.add(txnId);
-                return txns;
-            }
-            int count = 0;
-            // can not judge by ins.size()
-            // for the ins.size of the txn with multi table can be one
-            while (count < maxBatchSize && node != null && (node.writeTableIds.size() == 1)) {
-                count++;
-                txns.add(node.txnId);
-
-                // the node which size of write table is one, their size of outs can not be greater than two
-                if (node.outs != null) {
-                    node = node.outs.stream().findAny().orElse(null);
-                } else {
-                    node = null;
-                }
-            }
+        Node node = nodes.get(txnId);
+        if (node == null) {
+            return txns;
+        }
+        if (node.writeTableIds.size() > 1) {
+            txns.add(txnId);
+            return txns;
+        }
+        // Walk exactly the writer chain of the single table this node writes.
+        long tableId = node.writeTableIds.get(0);
+        int count = 0;
+        while (count < maxBatchSize && node != null && node.writeTableIds.size() == 1) {
+            count++;
+            txns.add(node.txnId);
+            node = node.tableNext.get(tableId);
         }
         return txns.size() >= minBatchSize ? txns : new ArrayList<>();
     }
@@ -219,12 +209,13 @@ public class TransactionGraph {
             return;
         }
         path.add(node.txnId);
-        if (node.outs == null) {
+        if (node.tableNext.isEmpty()) {
             print(path, builder);
             return;
         }
-
-        for (Node out : node.outs) {
+        // Distinct successor nodes across all tables this node writes.
+        Set<Node> outs = new HashSet<>(node.tableNext.values());
+        for (Node out : outs) {
             travelGraph(out, path, builder);
             path.remove(path.size() - 1);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.NoAliveBackendException;
@@ -554,6 +555,173 @@ public class LakePublishBatchTest {
         publishVersionDaemon.publishingTransactionIds.clear();
         awaitPublish(publishVersionDaemon, waiter6, waiter7);
     }
+
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTransactionGraphBySinglePublishRemoveLastNode(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+
+        List<TabletCommitInfo> transPartition1Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition2Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition3Tablets =  Lists.newArrayList();
+
+        int num = 0;
+        for (Partition partition : table.getPartitions()) {
+            MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+                for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
+                    TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
+                    if (num == 0) {
+                        transPartition1Tablets.add(tabletCommitInfo);
+                    } else if (num == 1) {
+                        transPartition2Tablets.add(tabletCommitInfo);
+                    } else if (num == 2) {
+                        transPartition3Tablets.add(tabletCommitInfo);
+                    }
+                }
+            }
+            num++;
+        }
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long transactionId5 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label5" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter5 = globalTransactionMgr.commitTransaction(db.getId(), transactionId5, transPartition1Tablets,
+                Lists.newArrayList(), null);
+
+
+        long transactionId6 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label6" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter6 = globalTransactionMgr.commitTransaction(db.getId(), transactionId6, transPartition2Tablets,
+                Lists.newArrayList(), null);
+
+        long transactionId7 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label7" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter7 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transPartition3Tablets,
+                Lists.newArrayList(), null);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public List<TransactionState> getReadyToPublishTransactions(boolean nodep) throws AnalysisException {
+                List<TransactionState> transactionStateList = Lists.newArrayList();
+                TransactionState state =  globalTransactionMgr.getDatabaseTransactionMgr(db.getId())
+                        .getTransactionState(transactionId7);
+                transactionStateList.add(state);
+                return transactionStateList;
+            }
+        };
+
+        Config.lake_enable_batch_publish_version = false;
+        PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
+        awaitPublish(publishVersionDaemon, waiter7);
+
+        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getReadyPublishTransactionsBatch();
+        Assertions.assertEquals(1, batch.size());
+
+        Config.lake_enable_batch_publish_version = true;
+        awaitPublish(publishVersionDaemon, waiter5);
+        awaitPublish(publishVersionDaemon, waiter6);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTransactionGraphRemoveMiddleNode(boolean enableAggregation) throws Exception {
+        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+
+        List<TabletCommitInfo> transPartition1Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition2Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition3Tablets =  Lists.newArrayList();
+
+        int num = 0;
+        for (Partition partition : table.getPartitions()) {
+            MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+                for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
+                    TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
+                    if (num == 0) {
+                        transPartition1Tablets.add(tabletCommitInfo);
+                    } else if (num == 1) {
+                        transPartition2Tablets.add(tabletCommitInfo);
+                    } else if (num == 2) {
+                        transPartition3Tablets.add(tabletCommitInfo);
+                    }
+                }
+            }
+            num++;
+        }
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long transactionId5 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label5" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter5 = globalTransactionMgr.commitTransaction(db.getId(), transactionId5, transPartition1Tablets,
+                Lists.newArrayList(), null);
+
+
+        long transactionId6 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label6" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter6 = globalTransactionMgr.commitTransaction(db.getId(), transactionId6, transPartition2Tablets,
+                Lists.newArrayList(), null);
+
+        long transactionId7 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label7" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter7 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transPartition3Tablets,
+                Lists.newArrayList(), null);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public List<TransactionState> getReadyToPublishTransactions(boolean nodep) throws AnalysisException {
+                List<TransactionState> transactionStateList = Lists.newArrayList();
+                TransactionState state =  globalTransactionMgr.getDatabaseTransactionMgr(db.getId())
+                        .getTransactionState(transactionId6);
+                transactionStateList.add(state);
+                return transactionStateList;
+            }
+        };
+
+        Config.lake_enable_batch_publish_version = false;
+        PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
+        awaitPublish(publishVersionDaemon, waiter6);
+
+        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().
+                getDatabaseTransactionMgr(db.getId()).getReadyToPublishTxnListBatch();
+        Assertions.assertEquals(1, batch.size());
+
+        Config.lake_enable_batch_publish_version = true;
+        awaitPublish(publishVersionDaemon, waiter5);
+        awaitPublish(publishVersionDaemon, waiter7);
+    }
+
+
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -722,7 +722,8 @@ public class LakePublishBatchTest {
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         awaitPublish(publishVersionDaemon, waiter7);
 
-        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getReadyPublishTransactionsBatch();
+        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState()
+                .getGlobalTransactionMgr().getReadyPublishTransactionsBatch();
         Assertions.assertEquals(1, batch.size());
 
         Config.lake_enable_batch_publish_version = true;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -82,6 +82,7 @@ public class LakePublishBatchTest {
     private static final String TABLE_AGG_ON = "table_for_test_agg_on";
     private static final String TABLE_AGG_OFF = "table_for_test_agg_off";
     private static final String TABLE_SCHEMA_CHANGE = "table_for_test_schema_change";
+    private static final String TABLE_GRAPH = "table_for_test_transaction_graph";
     private TransactionState.TxnCoordinator transactionSource =
             new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe");
 
@@ -213,6 +214,19 @@ public class LakePublishBatchTest {
                 " (pk int NOT NULL, v0 int not null) primary KEY (pk) " +
                 "DISTRIBUTED BY HASH(pk) BUCKETS 1;";
         starRocksAssert.withTable(sql3);
+
+        String sql4 = "create table " + TABLE_GRAPH +
+                " (dt date NOT NULL, pk bigint NOT NULL, v0 string not null) primary KEY (dt, pk) " +
+                "PARTITION BY RANGE(`dt`) (\n" +
+                "    PARTITION p20210820 VALUES [('2021-08-20'), ('2021-08-21')),\n" +
+                "    PARTITION p20210821 VALUES [('2021-08-21'), ('2021-08-22')),\n" +
+                "    PARTITION p20210929 VALUES [('2021-09-29'), ('2021-09-30')),\n" +
+                "    PARTITION p20210930 VALUES [('2021-09-30'), ('2021-10-01'))\n" +
+                ")" +
+                "DISTRIBUTED BY HASH(pk) BUCKETS 3" +
+                " PROPERTIES(\"replication_num\" = \"" + 3 +
+                "\", \"storage_medium\" = \"SSD\", \"file_bundling\" = \"false\")";
+        starRocksAssert.withTable(sql4);
     }
 
     @AfterAll
@@ -556,95 +570,10 @@ public class LakePublishBatchTest {
         awaitPublish(publishVersionDaemon, waiter6, waiter7);
     }
 
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testTransactionGraphBySinglePublishRemoveLastNode(boolean enableAggregation) throws Exception {
-        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
+    @Test
+    public void testTransactionGraphRemoveMiddleNode() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
-
-        List<TabletCommitInfo> transPartition1Tablets =  Lists.newArrayList();
-        List<TabletCommitInfo> transPartition2Tablets =  Lists.newArrayList();
-        List<TabletCommitInfo> transPartition3Tablets =  Lists.newArrayList();
-
-        int num = 0;
-        for (Partition partition : table.getPartitions()) {
-            MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
-                for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
-                    TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
-                    if (num == 0) {
-                        transPartition1Tablets.add(tabletCommitInfo);
-                    } else if (num == 1) {
-                        transPartition2Tablets.add(tabletCommitInfo);
-                    } else if (num == 2) {
-                        transPartition3Tablets.add(tabletCommitInfo);
-                    }
-                }
-            }
-            num++;
-        }
-
-        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        long transactionId5 = globalTransactionMgr.
-                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label5" + "_" + UUIDUtil.genUUID().toString(),
-                        transactionSource,
-                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-        // commit a transaction
-        VisibleStateWaiter waiter5 = globalTransactionMgr.commitTransaction(db.getId(), transactionId5, transPartition1Tablets,
-                Lists.newArrayList(), null);
-
-
-        long transactionId6 = globalTransactionMgr.
-                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label6" + "_" + UUIDUtil.genUUID().toString(),
-                        transactionSource,
-                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-        // commit a transaction
-        VisibleStateWaiter waiter6 = globalTransactionMgr.commitTransaction(db.getId(), transactionId6, transPartition2Tablets,
-                Lists.newArrayList(), null);
-
-        long transactionId7 = globalTransactionMgr.
-                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
-                        "label7" + "_" + UUIDUtil.genUUID().toString(),
-                        transactionSource,
-                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-        // commit a transaction
-        VisibleStateWaiter waiter7 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transPartition3Tablets,
-                Lists.newArrayList(), null);
-
-        new MockUp<GlobalTransactionMgr>() {
-            @Mock
-            public List<TransactionState> getReadyToPublishTransactions(boolean nodep) throws AnalysisException {
-                List<TransactionState> transactionStateList = Lists.newArrayList();
-                TransactionState state =  globalTransactionMgr.getDatabaseTransactionMgr(db.getId())
-                        .getTransactionState(transactionId7);
-                transactionStateList.add(state);
-                return transactionStateList;
-            }
-        };
-
-        Config.lake_enable_batch_publish_version = false;
-        PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
-        awaitPublish(publishVersionDaemon, waiter7);
-
-        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getReadyPublishTransactionsBatch();
-        Assertions.assertEquals(1, batch.size());
-
-        Config.lake_enable_batch_publish_version = true;
-        awaitPublish(publishVersionDaemon, waiter5);
-        awaitPublish(publishVersionDaemon, waiter6);
-    }
-
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testTransactionGraphRemoveMiddleNode(boolean enableAggregation) throws Exception {
-        String tableName = enableAggregation ? TABLE_AGG_ON : TABLE_AGG_OFF;
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE_GRAPH);
 
         List<TabletCommitInfo> transPartition1Tablets =  Lists.newArrayList();
         List<TabletCommitInfo> transPartition2Tablets =  Lists.newArrayList();
@@ -717,11 +646,88 @@ public class LakePublishBatchTest {
         Assertions.assertEquals(1, batch.size());
 
         Config.lake_enable_batch_publish_version = true;
-        awaitPublish(publishVersionDaemon, waiter5);
-        awaitPublish(publishVersionDaemon, waiter7);
+        awaitPublish(publishVersionDaemon, waiter5, waiter7);
     }
 
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTransactionGraphBySinglePublishRemoveLastNode(boolean enableAggregation) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE_GRAPH);
+
+        List<TabletCommitInfo> transPartition1Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition2Tablets =  Lists.newArrayList();
+        List<TabletCommitInfo> transPartition3Tablets =  Lists.newArrayList();
+
+        int num = 0;
+        for (Partition partition : table.getPartitions()) {
+            MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+                for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
+                    TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
+                    if (num == 0) {
+                        transPartition1Tablets.add(tabletCommitInfo);
+                    } else if (num == 1) {
+                        transPartition2Tablets.add(tabletCommitInfo);
+                    } else if (num == 2) {
+                        transPartition3Tablets.add(tabletCommitInfo);
+                    }
+                }
+            }
+            num++;
+        }
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long transactionId5 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label5" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter5 = globalTransactionMgr.commitTransaction(db.getId(), transactionId5, transPartition1Tablets,
+                Lists.newArrayList(), null);
+
+
+        long transactionId6 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label6" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter6 = globalTransactionMgr.commitTransaction(db.getId(), transactionId6, transPartition2Tablets,
+                Lists.newArrayList(), null);
+
+        long transactionId7 = globalTransactionMgr.
+                beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                        "label7" + "_" + UUIDUtil.genUUID().toString(),
+                        transactionSource,
+                        TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        // commit a transaction
+        VisibleStateWaiter waiter7 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transPartition3Tablets,
+                Lists.newArrayList(), null);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public List<TransactionState> getReadyToPublishTransactions(boolean nodep) throws AnalysisException {
+                List<TransactionState> transactionStateList = Lists.newArrayList();
+                TransactionState state =  globalTransactionMgr.getDatabaseTransactionMgr(db.getId())
+                        .getTransactionState(transactionId7);
+                transactionStateList.add(state);
+                return transactionStateList;
+            }
+        };
+
+        Config.lake_enable_batch_publish_version = false;
+        PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
+        awaitPublish(publishVersionDaemon, waiter7);
+
+        List<TransactionStateBatch> batch = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getReadyPublishTransactionsBatch();
+        Assertions.assertEquals(1, batch.size());
+
+        Config.lake_enable_batch_publish_version = true;
+        awaitPublish(publishVersionDaemon, waiter5, waiter6);
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
@@ -66,7 +66,12 @@ public class TransactionGraphTest {
         graph.remove(3);
         graph.remove(4);
         assertEquals(graph.size(), 4);
-        expectNextBatch(graph, Lists.newArrayList(1L, 2L, 5L, 6L));
+        // After removing txn3 (mid node of txn1->txn3->txn5) and txn4 (mid node of txn2->txn4->txn6),
+        // txn5 is re-linked to depend on txn1, txn6 is re-linked to depend on txn2.
+        // So only txn1 and txn2 are roots.
+        expectNextBatch(graph, Lists.newArrayList(1L, 2L));
+        assertEquals(graph.size(), 2);
+        expectNextBatch(graph, Lists.newArrayList(5L, 6L));
         assertEquals(graph.size(), 0);
         assertEquals(graph.getTxnsWithoutDependency().size(), 0);
     }
@@ -106,6 +111,7 @@ public class TransactionGraphTest {
                     if (writeTableIds.contains(tableId)) {
                         continue;
                     }
+                    writeTableIds.add(tableId);
                     break;
                 }
             }
@@ -193,13 +199,76 @@ public class TransactionGraphTest {
         assertEquals(txnIds.size(), 1);
         batchTxnIds = graph2.getTxnsWithTxnDependencyBatch(1, 5, 2);
         assertEquals(batchTxnIds.size(), 2);
-        graph.remove(2);
-        graph.remove(3);
+        graph2.remove(2);
+        graph2.remove(3);
 
         txnIds = graph2.getTxnsWithoutDependency();
         assertEquals(txnIds.size(), 1);
         batchTxnIds = graph2.getTxnsWithTxnDependencyBatch(1, 5, 4);
         assertEquals(batchTxnIds.size(), 1);
+    }
+
+    @Test
+    public void testRemoveTailBreaksLastTableWriter() {
+        // Verify that removing the lastTableWriter (tail node) for a table
+        // causes subsequent adds to lose dependency on remaining nodes.
+        //
+        // Setup chain: txn1 -> txn2 -> txn3, all write table1
+        // lastTableWriter[table1] = txn3
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(1L));
+        graph.add(3, Lists.newArrayList(1L));
+
+        // Only txn1 should be a root
+        List<Long> roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+        assertEquals(Lists.newArrayList(1L), roots);
+
+        // Remove txn3 (the tail / lastTableWriter for table1)
+        // txn1 and txn2 are still in the graph
+        graph.remove(3);
+        assertEquals(2, graph.size());
+
+        // Now add txn4 writing table1
+        // Expected: txn4 should depend on txn2 (the last remaining writer for table1)
+        // Actual (BUG): lastTableWriter[table1] was cleared when txn3 was removed,
+        //               so txn4 has NO dependency
+        graph.add(4, Lists.newArrayList(1L));
+
+        roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+
+        // If correct: roots should be {1} only (txn4 depends on txn2, which depends on txn1)
+        // If buggy:   roots will be {1, 4} because txn4 has no dependency
+        assertEquals(Lists.newArrayList(1L), roots,
+                "txn4 should depend on txn2 since both write table1, " +
+                        "but lastTableWriter was incorrectly cleared when txn3 was removed");
+    }
+
+    @Test
+    public void testRemoveMiddleNodeBreaksDependencyChain() {
+        // Verify that removing a middle node doesn't re-link predecessors to successors.
+        //
+        // Setup chain: txn1 -> txn2 -> txn3, all write table1
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(1L));
+        graph.add(3, Lists.newArrayList(1L));
+
+        // Remove txn2 (middle node)
+        graph.remove(2);
+        assertEquals(2, graph.size());
+
+        List<Long> roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+
+        // If correct: roots should be {1} only (txn3 should still depend on txn1
+        //             since they both write table1 and txn1 is not yet published)
+        // If buggy:   roots will be {1, 3} because the edge txn1->txn3 was never created
+        assertEquals(Lists.newArrayList(1L), roots,
+                "txn3 should still depend on txn1 after removing txn2, " +
+                        "since both write table1 and txn1 is still in the graph");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
@@ -272,6 +272,75 @@ public class TransactionGraphTest {
     }
 
     @Test
+    public void testMultiTableTxnPrevWriterAmbiguity() {
+        // Regression: when a multi-table txn's predecessor set contains both
+        // the immediate T-predecessor and a transitive T-ancestor, removing
+        // the tail must restore lastTableWriter[T] to the immediate one.
+        //
+        // Sequence: txn100 writes {T1,T2}; txn101 writes {T1}; txn102 writes {T1,T2}.
+        //   T1 chain: 100 -> 101 -> 102
+        //   T2 chain: 100 -> 102
+        // The (flat, unlabeled) predecessor set of 102 is {100, 101}, both
+        // writing T1. The immediate T1-predecessor of 102 is 101.
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(100, Lists.newArrayList(1L, 2L));
+        graph.add(101, Lists.newArrayList(1L));
+        graph.add(102, Lists.newArrayList(1L, 2L));
+
+        // Only txn100 is a root.
+        List<Long> roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+        assertEquals(Lists.newArrayList(100L), roots);
+
+        // Remove the T1 tail (102). lastTableWriter[T1] must retreat to 101,
+        // not to 100 (the transitive T1-ancestor).
+        graph.remove(102);
+
+        // Add 103 writing T1. It must depend on 101 (still in graph), hence
+        // NOT appear as a root. If lastTableWriter[T1] was wrongly restored
+        // to 100, then 103 would pick 100 as its predecessor while 101 stays
+        // orphaned of the chain tail -- leading to incorrect publish order.
+        graph.add(103, Lists.newArrayList(1L));
+        roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+        assertEquals(Lists.newArrayList(100L), roots);
+    }
+
+    @Test
+    public void testRemoveMiddleMultiTableNoCrossTableEdge() {
+        // Regression: removing a multi-table middle node must splice each
+        // table chain independently and must NOT create cross-table edges
+        // (e.g. linking a T1-only predecessor to a T2-only successor).
+        //
+        // Sequence: txn1 writes {T1}; txn2 writes {T2}; txn3 writes {T1,T2};
+        //           txn4 writes {T1}; txn5 writes {T2}.
+        //   T1 chain: 1 -> 3 -> 4
+        //   T2 chain: 2 -> 3 -> 5
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(2L));
+        graph.add(3, Lists.newArrayList(1L, 2L));
+        graph.add(4, Lists.newArrayList(1L));
+        graph.add(5, Lists.newArrayList(2L));
+
+        // Roots before removing 3: {1, 2}.
+        List<Long> roots = graph.getTxnsWithoutDependency();
+        Collections.sort(roots);
+        assertEquals(Lists.newArrayList(1L, 2L), roots);
+
+        // Remove the multi-table middle node. After splice the chains become
+        // T1: 1 -> 4 and T2: 2 -> 5, with no cross-table edges.
+        graph.remove(3);
+
+        // Drain: {1, 2} together, then {4, 5} together. If cross-table edges
+        // had been created (1->5 or 2->4) then 4 and 5 would not become
+        // roots at the same step.
+        expectNextBatch(graph, Lists.newArrayList(1L, 2L));
+        expectNextBatch(graph, Lists.newArrayList(4L, 5L));
+        assertEquals(0, graph.size());
+    }
+
+    @Test
     public void testPrintGraph() {
         TransactionGraph graph = new TransactionGraph();
         graph.add(1, Lists.newArrayList(1L));


### PR DESCRIPTION
## Why I'm doing:
`batch publish` relies on `TransactionGraph` to decide dependency-safe publish order. If the graph is maintained incorrectly after node removal, publish ordering can become invalid and publish can be blocked.

The issue is most likely to surface when switching from normal (single) publish to batch publish. In single publish, readiness is judged by partition version, so a transaction removed there may not be a zero in-degree node (a node with no incoming edges) in `TransactionGraph`. If `remove()` does not correctly preserve graph dependencies in this path, batch publish can later make wrong scheduling decisions.

### Root cause in `remove()`
`TransactionGraph.remove()` had two correctness gaps when removing a non-root node:

1. **`lastTableWriter` is cleared too aggressively**
   - Old logic: if removed node is current `lastTableWriter[tableId]`, it directly removes the mapping.
   - Problem: there may still be an earlier in-graph writer for the same table (a predecessor), but mapping is lost.
   - Impact: next `add()` for that table sees no previous writer and can become a zero in-degree node incorrectly.

2. **Predecessor/successor edges are not re-linked**
   - Old logic: for each successor, only `next.ins.remove(node)` is done.
   - Problem: happens-before relationship is dropped when removing a middle node (`prev -> node -> next`), because `prev -> next` is never restored.
   - Impact: successor can become zero in-degree too early and be considered publishable before predecessor chain is actually respected.

These two problems directly affect the dependency graph consumed by batch publish.

## What I'm doing:
- Keep `lastTableWriter` by falling back to the nearest predecessor that still writes the same table when removing a node.
- Re-link predecessors to successors when removing an intermediate node so dependency chains remain consistent.
- Add regression tests for tail-node removal and middle-node removal, and adjust existing assertions.

Fixes #N/A

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5