### PR TITLE
[Enhancement] Implemneting suport for dictification for CTEConsume and CTEProduce operators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
@@ -35,14 +35,18 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
 
     private final Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap;
 
+    private final Map<Integer, ScalarOperator> globalDictsExpr;
+
     public PhysicalCTEConsumeOperator(int cteId, Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap,
-                                      long limit, ScalarOperator predicate, Projection projection) {
+                                      long limit, ScalarOperator predicate, Projection projection,
+                                      Map<Integer, ScalarOperator> globalDictExprs) {
         super(OperatorType.PHYSICAL_CTE_CONSUME);
         this.cteId = cteId;
         this.cteOutputColumnRefMap = cteOutputColumnRefMap;
         this.limit = limit;
         this.predicate = predicate;
         this.projection = projection;
+        this.globalDictsExpr = globalDictExprs;
     }
 
     public int getCteId() {
@@ -85,6 +89,10 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
         PhysicalCTEConsumeOperator that = (PhysicalCTEConsumeOperator) o;
         return Objects.equals(cteId, that.cteId) &&
                 Objects.equals(cteOutputColumnRefMap, that.cteOutputColumnRefMap);
+    }
+
+    public Map<Integer, ScalarOperator> getGlobalDictsExpr() {
+        return this.globalDictsExpr;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEConsumerReuseImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEConsumerReuseImplementationRule.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
+import java.util.Map;
 
 public class CTEConsumerReuseImplementationRule extends ImplementationRule {
     public CTEConsumerReuseImplementationRule() {
@@ -37,7 +38,7 @@ public class CTEConsumerReuseImplementationRule extends ImplementationRule {
         LogicalCTEConsumeOperator logical = (LogicalCTEConsumeOperator) input.getOp();
         PhysicalCTEConsumeOperator consume =
                 new PhysicalCTEConsumeOperator(logical.getCteId(), logical.getCteOutputColumnRefMap(),
-                        logical.getLimit(), logical.getPredicate(), logical.getProjection());
+                        logical.getLimit(), logical.getPredicate(), logical.getProjection(), Map.of());
         return Lists.newArrayList(OptExpression.create(consume));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -203,8 +203,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final ColumnRefSet scanColumnRefSet = new ColumnRefSet();
 
-    private final ColumnRefSet cteProduceOutputColumns = new ColumnRefSet();
-
     // check if there is a blocking node in plan
     private boolean canBlockingOutput = false;
 
@@ -348,10 +346,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 context.allStringColumns.add(cid);
                 continue;
             }
-            if (cteProduceOutputColumns.contains(cid)) {
-                context.allStringColumns.add(cid);
-                continue;
-            }
             List<ScalarOperator> dictExprList = stringExpressions.getOrDefault(cid, Collections.emptyList());
             long allExprNum = dictExprList.size();
             // only query original string-column
@@ -382,9 +376,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 return;
             }
             // Structs which pass checkDependOnExpr have at least one encoded field. We keep the structs encoded.
-            if (globalDicts.containsKey(cid) || cteProduceOutputColumns.contains(cid) ||
-                    expressionStringRefCounter.getOrDefault(cid, 0) != 0 ||
-                    defineExpr.getType().isStructType()) {
+            if (globalDicts.containsKey(cid) || expressionStringRefCounter.getOrDefault(cid, 0) != 0
+                    || defineExpr.getType().isStructType()) {
                 context.allStringColumns.add(cid);
             }
         });
@@ -531,12 +524,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         expressionStringRefCounter.put(col.getId(), counter);
     }
 
-    void maybeRecordCTEDecodeInfo(Operator operator, DecodeInfo decodeInfo) {
-        if (operator instanceof PhysicalCTEProduceOperator produce) {
-            cteDecodeInfo.put(produce.getCteId(), decodeInfo);
-        }
-    }
-
     private DecodeInfo collectImpl(OptExpression optExpression, OptExpression parent) {
         DecodeInfo context;
         if (optExpression.arity() == 1) {
@@ -546,7 +533,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             context = DecodeInfo.create();
             for (int i = 0; i < optExpression.arity(); ++i) {
                 OptExpression child = optExpression.inputAt(i);
-                context.addChildInfo(collectImpl(child, optExpression));
+                DecodeInfo info = collectImpl(child, optExpression);
+                if (child.getOp() instanceof PhysicalCTEProduceOperator produce) {
+                    cteDecodeInfo.put(produce.getCteId(), info);
+                } else {
+                    context.addChildInfo(info);
+                }
             }
         }
 
@@ -554,7 +546,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         DecodeInfo info = optExpression.getOp().accept(this, optExpression, context);
         if (info.isEmpty()) {
             collectProjection(optExpression.getOp(), info);
-            maybeRecordCTEDecodeInfo(optExpression.getOp(), info);
             return info;
         }
 
@@ -578,7 +569,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         allOperatorDecodeInfo.put(optExpression.getOp(), info);
         collectPredicate(optExpression.getOp(), info);
         collectProjection(optExpression.getOp(), info);
-        maybeRecordCTEDecodeInfo(optExpression.getOp(), info);
         return info;
     }
 
@@ -611,7 +601,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 setDefineExpr(consumerCol, producerCol, 1);
                 info.outputStringColumns.union(consumerCol);
                 info.usedStringColumns.union(producerCol);
-                cteProduceOutputColumns.union(producerCol);
             }
         }
         return info;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -45,6 +45,8 @@ import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
@@ -194,10 +196,14 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     private final UnionDictionaryManager unionDictionaryManager;
 
+    private final Map<Integer, DecodeInfo> cteDecodeInfo = Maps.newHashMap();
+
     // operators which are the children of Match operator
     private final ColumnRefSet matchChildren = new ColumnRefSet();
 
     private final ColumnRefSet scanColumnRefSet = new ColumnRefSet();
+
+    private final ColumnRefSet cteProduceOutputColumns = new ColumnRefSet();
 
     // check if there is a blocking node in plan
     private boolean canBlockingOutput = false;
@@ -342,6 +348,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 context.allStringColumns.add(cid);
                 continue;
             }
+            if (cteProduceOutputColumns.contains(cid)) {
+                context.allStringColumns.add(cid);
+                continue;
+            }
             List<ScalarOperator> dictExprList = stringExpressions.getOrDefault(cid, Collections.emptyList());
             long allExprNum = dictExprList.size();
             // only query original string-column
@@ -372,8 +382,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 return;
             }
             // Structs which pass checkDependOnExpr have at least one encoded field. We keep the structs encoded.
-            if (globalDicts.containsKey(cid) || expressionStringRefCounter.getOrDefault(cid, 0) != 0
-                    || defineExpr.getType().isStructType()) {
+            if (globalDicts.containsKey(cid) || cteProduceOutputColumns.contains(cid) ||
+                    expressionStringRefCounter.getOrDefault(cid, 0) != 0 ||
+                    defineExpr.getType().isStructType()) {
                 context.allStringColumns.add(cid);
             }
         });
@@ -520,6 +531,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         expressionStringRefCounter.put(col.getId(), counter);
     }
 
+    void maybeRecordCTEDecodeInfo(Operator operator, DecodeInfo decodeInfo) {
+        if (operator instanceof PhysicalCTEProduceOperator produce) {
+            cteDecodeInfo.put(produce.getCteId(), decodeInfo);
+        }
+    }
+
     private DecodeInfo collectImpl(OptExpression optExpression, OptExpression parent) {
         DecodeInfo context;
         if (optExpression.arity() == 1) {
@@ -537,6 +554,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         DecodeInfo info = optExpression.getOp().accept(this, optExpression, context);
         if (info.isEmpty()) {
             collectProjection(optExpression.getOp(), info);
+            maybeRecordCTEDecodeInfo(optExpression.getOp(), info);
             return info;
         }
 
@@ -560,12 +578,43 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         allOperatorDecodeInfo.put(optExpression.getOp(), info);
         collectPredicate(optExpression.getOp(), info);
         collectProjection(optExpression.getOp(), info);
+        maybeRecordCTEDecodeInfo(optExpression.getOp(), info);
         return info;
     }
 
     @Override
     public DecodeInfo visit(OptExpression optExpression, DecodeInfo context) {
         return context.createDecodeInfo();
+    }
+
+    @Override
+    public DecodeInfo visitPhysicalCTEProduce(OptExpression optExpression, DecodeInfo context) {
+        return context.createOutputInfo();
+    }
+
+    @Override
+    public DecodeInfo visitPhysicalCTEConsume(OptExpression optExpression, DecodeInfo context) {
+        PhysicalCTEConsumeOperator consume = optExpression.getOp().cast();
+        context = cteDecodeInfo.get(consume.getCteId());
+        Preconditions.checkNotNull(context);
+        if (context.outputStringColumns.isEmpty()) {
+            return DecodeInfo.empty();
+        }
+        DecodeInfo info = DecodeInfo.empty();
+        info.inputStringColumns.union(context.outputStringColumns);
+        // Map producer columns to consumer columns (like a projection)
+        for (var entry : consume.getCteOutputColumnRefMap().entrySet()) {
+            ColumnRefOperator consumerCol = entry.getKey();
+            ColumnRefOperator producerCol = entry.getValue();
+
+            if (info.inputStringColumns.contains(producerCol.getId())) {
+                setDefineExpr(consumerCol, producerCol, 1);
+                info.outputStringColumns.union(consumerCol);
+                info.usedStringColumns.union(producerCol);
+                cteProduceOutputColumns.union(producerCol);
+            }
+        }
+        return info;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDecodeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
@@ -704,6 +705,25 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         builder.setPredicate(rewritePredicate(scanOperator.getPredicate(), info.inputStringColumns));
         builder.setProjection(rewriteProjection(scanOperator.getProjection(), info.inputStringColumns));
         return rewriteOptExpression(optExpression, builder.build(), info.outputStringColumns);
+    }
+
+    @Override
+    public OptExpression visitPhysicalCTEConsume(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
+        PhysicalCTEConsumeOperator consume = optExpression.getOp().cast();
+        DecodeInfo info = context.operatorDecodeInfo.get(consume);
+        Map<ColumnRefOperator, ColumnRefOperator> newMap = consume.getCteOutputColumnRefMap().entrySet().stream().map(
+                        (e) -> new Pair<>(
+                                context.stringRefToDictRefMap.getOrDefault(e.getKey(), e.getKey()),
+                                context.stringRefToDictRefMap.getOrDefault(e.getValue(), e.getValue())))
+                .collect(Collectors.toMap(p -> p.first, p -> p.second));
+        PhysicalCTEConsumeOperator newOp = new PhysicalCTEConsumeOperator(
+                consume.getCteId(),
+                newMap,
+                consume.getLimit(),
+                rewritePredicate(consume.getPredicate(), info.outputStringColumns),
+                rewriteProjection(consume.getProjection(), info.outputStringColumns)
+        );
+        return rewriteOptExpression(optExpression, newOp, info.outputStringColumns);
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -721,7 +721,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 newMap,
                 consume.getLimit(),
                 rewritePredicate(consume.getPredicate(), info.outputStringColumns),
-                rewriteProjection(consume.getProjection(), info.outputStringColumns)
+                rewriteProjection(consume.getProjection(), info.outputStringColumns),
+                computeDictExpr(fragmentUseDictExprs)
         );
         return rewriteOptExpression(optExpression, newOp, info.outputStringColumns);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3816,7 +3816,7 @@ public class PlanFragmentBuilder {
             projectMap.putAll(consume.getCteOutputColumnRefMap());
             consumeFragment = buildProjectNode(optExpression, new Projection(projectMap), consumeFragment, context);
             consumeFragment.setQueryGlobalDicts(cteFragment.getQueryGlobalDicts());
-            consumeFragment.setQueryGlobalDictExprs(cteFragment.getQueryGlobalDictExprs());
+            consumeFragment.setQueryGlobalDictExprs(getGlobalDictsExprs(consume.getGlobalDictsExpr(), context));
             consumeFragment.setLoadGlobalDicts(cteFragment.getLoadGlobalDicts());
 
             // add filter node

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -192,7 +192,7 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         String sql = "with cte as (select * from supplier_nullable, unnest(S_ADDRESS)) " +
                 "select * from cte union all select * from cte";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "39: DictDefine(37: S_ADDRESS, [<place-holder>])");
+        assertContains(plan, "40: DictDefine(37: S_ADDRESS, [<place-holder>])");
         connectContext.getSessionVariable().setCboCteReuse(false);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1694,7 +1694,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setEnablePipelineEngine(false);
 
-        Assertions.assertTrue(
+        Assertions.assertFalse(
                 plan.contains("query_global_dicts:[TGlobalDict(columnId:28, strings:[6D 6F 63 6B], ids:[1]"));
     }
 
@@ -2853,6 +2853,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+<<<<<<< HEAD
     public void testPhysicalFilter() throws Exception {
         String sql = """
                   SELECT *
@@ -2867,6 +2868,36 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "  3:SELECT\n" +
                 "  |  predicates: DictDecode(15: max(2: c_user), [<place-holder> != 'abc'])\n" +
+                "  |  cardinality: 1", plan);
+    }
+
+    @Test
+    public void testCTEProduceAndConsume() throws Exception {
+        String sql = """
+                  WITH CTE AS (
+                    SELECT
+                      C_USER, C_DEPT
+                    FROM
+                      low_card_t1
+                  )
+                  SELECT /*+ SET_VAR(cbo_cte_reuse=true, cbo_cte_reuse_rate_v2=0) */
+                    UPPER(T1.C_USER) s1
+                  FROM
+                    CTE AS T1 JOIN CTE AS T2 USING (C_DEPT)
+                  """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  Global Dict Exprs:\n" +
+                "    36: DictDefine(35: c_user, [upper(<place-holder>)])\n" +
+                "\n" +
+                "  10:Decode\n" +
+                "  |  <dict id 35> : <string id 2>\n" +
+                "  |  <dict id 36> : <string id 34>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  9:Project\n" +
+                "  |  output columns:\n" +
+                "  |  36 <-> DictDefine([37: c_user, INT, true], [upper[(<place-holder>); args: VARCHAR; result: " +
+                "VARCHAR; args nullable: true; result nullable: true]])\n" +
                 "  |  cardinality: 1", plan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2823,7 +2823,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |      [29: c_user, INT, true] | [32: cast, INT, true] | [29: c_user, INT, true]\n" +
                 "  |      [35: expr, INT, true] | [34: expr, INT, false] | [36: expr, INT, true]", plan);
     }
-  
+
     @Test
     public void testLeadWindowFunctionLowCardinalityRewrite() throws Exception {
         String sql = "select S_SUPPKEY, S_ADDRESS, lead(S_ADDRESS, 1) over(order by S_SUPPKEY) from supplier";
@@ -2853,7 +2853,6 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
-<<<<<<< HEAD
     public void testPhysicalFilter() throws Exception {
         String sql = """
                   SELECT *
@@ -2888,9 +2887,9 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "  Global Dict Exprs:\n" +
                 "    36: DictDefine(35: c_user, [upper(<place-holder>)])\n" +
+                "    37: DictDefine(35: c_user, [<place-holder>])\n" +
                 "\n" +
                 "  10:Decode\n" +
-                "  |  <dict id 35> : <string id 2>\n" +
                 "  |  <dict id 36> : <string id 34>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +


### PR DESCRIPTION
## Why I'm doing:
Currently CTEConsume and CTEProduce are not being dictified.

## What I'm doing:
Implementing dictification for operators above. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
