### PR TITLE
[Perf] File-level delvec cache to reduce remote IO during compaction publish

### DIFF
--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -16,6 +16,7 @@
 
 #include "common/logging.h"
 #include "common/status.h"
+#include "fmt/format.h"
 #include "storage/lake/location_provider.h"
 
 namespace starrocks::lake {
@@ -52,9 +53,55 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
                                                                         _lake_io_opts.fs));
     }
 
-    RETURN_IF_ERROR(
-            lake::get_del_vec(_tablet_manager, *metadata, tsid.segment_id, _fill_cache, _lake_io_opts, pdelvec->get()));
+    // Look up delvec page for this segment
+    auto iter = metadata->delvec_meta().delvecs().find(tsid.segment_id);
+    if (iter == metadata->delvec_meta().delvecs().end()) {
+        return Status::OK(); // no delvec for this segment
+    }
+    const auto& delvec_page = iter->second;
+
+    // Try to read from file cache (avoids per-page remote IO)
+    ASSIGN_OR_RETURN(auto page_data, _read_delvec_page(metadata, delvec_page));
+    RETURN_IF_ERROR((*pdelvec)->load(delvec_page.version(), page_data.data(), page_data.size()));
     return Status::OK();
+}
+
+StatusOr<std::string> LakeDelvecLoader::_read_delvec_page(const TabletMetadataPtr& metadata,
+                                                           const DelvecPagePB& delvec_page) {
+    // Look up which file this delvec page belongs to
+    auto ver_it = metadata->delvec_meta().version_to_file().find(delvec_page.version());
+    if (ver_it == metadata->delvec_meta().version_to_file().end()) {
+        return Status::InternalError(
+                fmt::format("Can't find delvec file for tablet {}, version {}", metadata->id(), delvec_page.version()));
+    }
+    const std::string& delvec_name = ver_it->second.name();
+
+    // Check file-level cache
+    auto cache_it = _delvec_file_cache.find(delvec_name);
+    if (cache_it == _delvec_file_cache.end()) {
+        // Cache miss: read the entire delvec file into memory
+        RandomAccessFileOptions opts{.skip_fill_local_cache = !_lake_io_opts.fill_data_cache};
+        std::unique_ptr<RandomAccessFile> rf;
+        if (_lake_io_opts.fs && _lake_io_opts.location_provider) {
+            ASSIGN_OR_RETURN(
+                    rf, _lake_io_opts.fs->new_random_access_file(
+                                opts, _lake_io_opts.location_provider->delvec_location(metadata->id(), delvec_name)));
+        } else {
+            ASSIGN_OR_RETURN(
+                    rf, fs::new_random_access_file(opts, _tablet_manager->delvec_location(metadata->id(), delvec_name)));
+        }
+        ASSIGN_OR_RETURN(auto content, rf->read_all());
+        cache_it = _delvec_file_cache.emplace(delvec_name, std::move(content)).first;
+    }
+
+    // Extract the requested page from the cached file content
+    const auto& file_content = cache_it->second;
+    if (delvec_page.offset() + delvec_page.size() > file_content.size()) {
+        return Status::Corruption(
+                fmt::format("Delvec page out of bounds: offset={}, size={}, file_size={}, tablet={}, file={}",
+                            delvec_page.offset(), delvec_page.size(), file_content.size(), metadata->id(), delvec_name));
+    }
+    return file_content.substr(delvec_page.offset(), delvec_page.size());
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -67,7 +67,7 @@ Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t ver
 }
 
 StatusOr<std::string> LakeDelvecLoader::_read_delvec_page(const TabletMetadataPtr& metadata,
-                                                           const DelvecPagePB& delvec_page) {
+                                                          const DelvecPagePB& delvec_page) {
     // Look up which file this delvec page belongs to
     auto ver_it = metadata->delvec_meta().version_to_file().find(delvec_page.version());
     if (ver_it == metadata->delvec_meta().version_to_file().end()) {
@@ -87,8 +87,8 @@ StatusOr<std::string> LakeDelvecLoader::_read_delvec_page(const TabletMetadataPt
                     rf, _lake_io_opts.fs->new_random_access_file(
                                 opts, _lake_io_opts.location_provider->delvec_location(metadata->id(), delvec_name)));
         } else {
-            ASSIGN_OR_RETURN(
-                    rf, fs::new_random_access_file(opts, _tablet_manager->delvec_location(metadata->id(), delvec_name)));
+            ASSIGN_OR_RETURN(rf, fs::new_random_access_file(
+                                         opts, _tablet_manager->delvec_location(metadata->id(), delvec_name)));
         }
         ASSIGN_OR_RETURN(auto content, rf->read_all());
         cache_it = _delvec_file_cache.emplace(delvec_name, std::move(content)).first;
@@ -97,9 +97,9 @@ StatusOr<std::string> LakeDelvecLoader::_read_delvec_page(const TabletMetadataPt
     // Extract the requested page from the cached file content
     const auto& file_content = cache_it->second;
     if (delvec_page.offset() + delvec_page.size() > file_content.size()) {
-        return Status::Corruption(
-                fmt::format("Delvec page out of bounds: offset={}, size={}, file_size={}, tablet={}, file={}",
-                            delvec_page.offset(), delvec_page.size(), file_content.size(), metadata->id(), delvec_name));
+        return Status::Corruption(fmt::format(
+                "Delvec page out of bounds: offset={}, size={}, file_size={}, tablet={}, file={}", delvec_page.offset(),
+                delvec_page.size(), file_content.size(), metadata->id(), delvec_name));
     }
     return file_content.substr(delvec_page.offset(), delvec_page.size());
 }

--- a/be/src/storage/lake/lake_delvec_loader.h
+++ b/be/src/storage/lake/lake_delvec_loader.h
@@ -13,6 +13,9 @@
 // limitations under the License.
 #pragma once
 
+#include <string>
+#include <unordered_map>
+
 #include "common/statusor.h"
 #include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
@@ -36,10 +39,20 @@ public:
     Status load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec);
 
 private:
+    // Read a delvec page from a cached file buffer. If the file is not yet
+    // cached, reads the entire file into _delvec_file_cache so that subsequent
+    // pages from the same file avoid remote IO.
+    StatusOr<std::string> _read_delvec_page(const TabletMetadataPtr& metadata, const DelvecPagePB& delvec_page);
+
     TabletManager* _tablet_manager;
     const MetaFileBuilder* _pk_builder = nullptr;
     bool _fill_cache = false;
     LakeIOOptions _lake_io_opts;
+
+    // File-level cache: delvec_file_name -> entire file content.
+    // Populated on first access per file, avoids repeated remote IO for
+    // multiple delvec pages within the same file.
+    std::unordered_map<std::string, std::string> _delvec_file_cache;
 };
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

During compaction conflict resolution in shared-data mode, delvec pages are loaded one at a time from remote storage (S3/OSS). Many pages reside in the same delvec file, but each `load()` call opens the file and reads independently (~2-3ms per remote IO). With 400-500 input rowsets, this sequential IO totals **1-1.4s per publish**, dominating publish latency.

### Previous attempt (PR #71146) FAILED

The batch-preload approach read ALL delvecs from tablet metadata upfront. This caused a **5.6x regression** (1.3s → 7.5s) because the metadata has far more delvec entries than the compaction needs. Over-fetching made things worse, not better.

### This approach: demand-driven file-level cache

Instead of preloading everything, this adds a **file-level read cache** to `LakeDelvecLoader`:
- When the first delvec page from a file is needed, read the **entire file** into an in-memory cache
- Subsequent pages from the same file are served from cache (**zero remote IO**)
- Only files with at least one needed page get cached (no over-fetching)

## What I changed:

**`be/src/storage/lake/lake_delvec_loader.h`** — Add `_delvec_file_cache` (file name → content) and `_read_delvec_page()` helper.

**`be/src/storage/lake/lake_delvec_loader.cpp`** — Rewrote `load_from_file()` to:
1. Load metadata (cached by tablet_manager)
2. Look up delvec page in metadata
3. Call `_read_delvec_page()` which checks the file cache
4. On cache miss: `read_all()` the entire delvec file, cache it
5. Extract the page from the cached buffer

## Why this works:

In a typical compaction with 400-500 input rowsets, the delvec pages are spread across a small number of delvec files (one per version/transaction batch). If there are F unique files, this reduces 500 remote reads to F reads, where F << 500.

Key differences from PR #71146:
- **Demand-driven**: only caches files actually needed (vs. ALL delvecs from metadata)
- **No startup cost**: no pre-scanning or pre-loading before conflict resolution
- **Bounded cache**: only caches files touched during this conflict resolution

## Expected impact:
- Reduce `compaction_delvec_loader_latency_us` proportional to the ratio of pages-per-file
- If 500 pages come from 10 files: ~10 reads * ~50ms = 500ms instead of 500 * 2.8ms = 1.4s
- Minimal memory overhead (delvec files are typically small, KB-MB range)