### PR TITLE
[Enhancement] Pause routine load job on non-retryable errors like primary key size exceed (backport #71161)

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -49,6 +49,7 @@
 #include "runtime/fragment_mgr.h"
 #include "runtime/plan_fragment_executor.h"
 #include "runtime/stream_load/stream_load_context.h"
+#include "storage/non_retryable_load_errors.h"
 #include "testutil/sync_point.h"
 #include "util/defer_op.h"
 #include "util/starrocks_metrics.h"
@@ -468,6 +469,9 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         rl_attach.__set_receivedBytes(ctx->receive_bytes);
         rl_attach.__set_loadedBytes(ctx->loaded_bytes);
         rl_attach.__set_loadCostMs(ctx->load_cost_nanos / 1000 / 1000);
+        if (!ctx->status.ok() && is_non_retryable_load_error(ctx->status.message())) {
+            rl_attach.__set_nonRetryable(true);
+        }
 
         attach->rlTaskTxnCommitAttachment = rl_attach;
         attach->__isset.rlTaskTxnCommitAttachment = true;

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -26,6 +26,7 @@
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
 #include "storage/memtable_sink.h"
+#include "storage/non_retryable_load_errors.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/row_store_encoder.h"
 #include "storage/row_store_encoder_factory.h"
@@ -289,7 +290,7 @@ Status MemTable::finalize() {
                 _aggregator.reset();
                 _aggregator_memory_usage = 0;
                 _aggregator_bytes_usage = 0;
-                return Status::Cancelled("primary key size exceed the limit.");
+                return Status::Cancelled(kPrimaryKeySizeExceedError);
             }
             if (_has_op_slot) {
                 // TODO(cbl): mem_tracker

--- a/be/src/storage/non_retryable_load_errors.h
+++ b/be/src/storage/non_retryable_load_errors.h
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace starrocks {
+
+// Centralized registry of non-retryable load error messages.
+// When a routine load task encounters one of these errors, it will be paused
+// instead of retried, because retrying would produce the same failure.
+//
+// To add a new non-retryable error:
+//   1. Add a constant below (kXxxError)
+//   2. Add it to kNonRetryableLoadErrors
+//   3. Use the constant at the error source site
+
+inline constexpr std::string_view kPrimaryKeySizeExceedError = "primary key size exceed the limit.";
+
+inline constexpr std::array<std::string_view, 1> kNonRetryableLoadErrors = {
+        kPrimaryKeySizeExceedError,
+};
+
+inline bool is_non_retryable_load_error(std::string_view msg) {
+    for (const auto& pattern : kNonRetryableLoadErrors) {
+        if (msg.find(pattern) != std::string_view::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -399,6 +399,7 @@ set(EXEC_FILES
         ./storage/get_use_pk_index_test.cpp
         ./storage/persistent_index_consistency_test.cpp
         ./storage/meta_reader_test.cpp
+        ./storage/non_retryable_load_errors_test.cpp
         ./storage/olap_meta_reader_test.cpp
         ./storage/dictionary_cache_manager_test.cpp
         ./storage/column_or_predicate_test.cpp

--- a/be/test/storage/non_retryable_load_errors_test.cpp
+++ b/be/test/storage/non_retryable_load_errors_test.cpp
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/non_retryable_load_errors.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(NonRetryableLoadErrorsTest, testPrimaryKeySizeExceed) {
+    ASSERT_TRUE(is_non_retryable_load_error(kPrimaryKeySizeExceedError));
+    ASSERT_TRUE(is_non_retryable_load_error("primary key size exceed the limit."));
+    ASSERT_TRUE(is_non_retryable_load_error("some prefix: primary key size exceed the limit."));
+}
+
+TEST(NonRetryableLoadErrorsTest, testRetryableErrors) {
+    ASSERT_FALSE(is_non_retryable_load_error(""));
+    ASSERT_FALSE(is_non_retryable_load_error("timeout"));
+    ASSERT_FALSE(is_non_retryable_load_error("too many filtered rows"));
+    ASSERT_FALSE(is_non_retryable_load_error("Offset out of range"));
+    ASSERT_FALSE(is_non_retryable_load_error("some random error"));
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -65,6 +65,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     private RoutineLoadProgress timestampProgress;
     private String errorLogUrl;
     private long loadedBytes;
+    private boolean nonRetryable = false;
 
     public RLTaskTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK);
@@ -98,6 +99,9 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
         if (rlTaskTxnCommitAttachment.isSetErrorLogUrl()) {
             this.errorLogUrl = rlTaskTxnCommitAttachment.getErrorLogUrl();
+        }
+        if (rlTaskTxnCommitAttachment.isSetNonRetryable()) {
+            this.nonRetryable = rlTaskTxnCommitAttachment.isNonRetryable();
         }
     }
 
@@ -147,6 +151,10 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
     public String getErrorLogUrl() {
         return errorLogUrl;
+    }
+
+    public boolean isNonRetryable() {
+        return nonRetryable;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1221,6 +1221,17 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                     }
                     // TODO(ml): use previous be id depend on change reason
                 }
+
+                // check if BE explicitly marked this error as non-retryable
+                RLTaskTxnCommitAttachment rlAttachment =
+                        (RLTaskTxnCommitAttachment) txnState.getTxnCommitAttachment();
+                if (rlAttachment != null && rlAttachment.isNonRetryable()) {
+                    String msg = "be " + taskBeId + " abort task "
+                            + "with non-retryable reason: " + txnStatusChangeReasonString;
+                    updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg));
+                    return;
+                }
+
                 // step2: commit task , update progress, maybe create a new task
                 executeTaskOnTxnStatusChanged(routineLoadTaskInfo, txnState, TransactionStatus.ABORTED,
                         txnStatusChangeReasonString);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1228,7 +1228,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                 if (rlAttachment != null && rlAttachment.isNonRetryable()) {
                     String msg = "be " + taskBeId + " abort task "
                             + "with non-retryable reason: " + txnStatusChangeReasonString;
-                    updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg));
+                    updateState(JobState.PAUSED, new ErrorReason(InternalErrorCode.TASKS_ABORT_ERR, msg), false);
                     return;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -874,7 +874,7 @@ public class RoutineLoadJobTest {
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
-        routineLoadJob.afterAborted(transactionState, txnStatusChangeReasonString);
+        routineLoadJob.afterAborted(transactionState, true, txnStatusChangeReasonString);
 
         Assertions.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
     }
@@ -935,7 +935,7 @@ public class RoutineLoadJobTest {
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
         Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
         Deencapsulation.setField(routineLoadJob, "progress", currentProgress);
-        routineLoadJob.afterAborted(transactionState, txnStatusChangeReasonString);
+        routineLoadJob.afterAborted(transactionState, true, txnStatusChangeReasonString);
 
         Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -838,10 +838,10 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testAfterAbortedNonRetryableAttachment(@Injectable TransactionState transactionState,
-                                                        @Injectable RoutineLoadTaskInfo routineLoadTaskInfo)
+    public void testAfterAbortedNonRetryableAttachment(@Mocked GlobalStateMgr globalStateMgr,
+                                                       @Injectable TransactionState transactionState,
+                                                       @Injectable RoutineLoadTaskInfo routineLoadTaskInfo)
             throws StarRocksException {
-
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         long txnId = 1L;
@@ -869,6 +869,12 @@ public class RoutineLoadJobTest {
             }
         };
 
+        new MockUp<EditLog>() {
+            @Mock
+            public void logOpRoutineLoadJob(RoutineLoadOperation routineLoadOperation) {
+            }
+        };
+
         // non-retryable attachment should cause pause even with unrecognized reason
         String txnStatusChangeReasonString = "primary key size exceed the limit";
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
@@ -881,10 +887,9 @@ public class RoutineLoadJobTest {
 
     @Test
     public void testAfterAbortedRetryableAttachment(@Mocked RoutineLoadMgr routineLoadMgr,
-                                                     @Injectable TransactionState transactionState,
-                                                     @Injectable KafkaTaskInfo routineLoadTaskInfo)
+                                                    @Injectable TransactionState transactionState,
+                                                    @Injectable KafkaTaskInfo routineLoadTaskInfo)
             throws StarRocksException {
-
         Deencapsulation.setField(routineLoadTaskInfo, "routineLoadManager", routineLoadMgr);
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
@@ -917,7 +922,7 @@ public class RoutineLoadJobTest {
                 result = Lists.newArrayList();
                 routineLoadTaskInfo.getId();
                 minTimes = 0;
-                result = UUIDUtil.genUUID();
+                result = UUID.randomUUID();
                 routineLoadMgr.getJob(anyLong);
                 minTimes = 0;
                 result = routineLoadJob;

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -838,6 +838,109 @@ public class RoutineLoadJobTest {
     }
 
     @Test
+    public void testAfterAbortedNonRetryableAttachment(@Injectable TransactionState transactionState,
+                                                        @Injectable RoutineLoadTaskInfo routineLoadTaskInfo)
+            throws StarRocksException {
+
+        List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
+        routineLoadTaskInfoList.add(routineLoadTaskInfo);
+        long txnId = 1L;
+
+        RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
+        Deencapsulation.setField(attachment, "nonRetryable", true);
+
+        new Expectations() {
+            {
+                transactionState.getTransactionId();
+                minTimes = 0;
+                result = txnId;
+                routineLoadTaskInfo.getTxnId();
+                minTimes = 0;
+                result = txnId;
+                transactionState.getTxnCommitAttachment();
+                minTimes = 0;
+                result = attachment;
+            }
+        };
+
+        new MockUp<RoutineLoadJob>() {
+            @Mock
+            void writeUnlock() {
+            }
+        };
+
+        // non-retryable attachment should cause pause even with unrecognized reason
+        String txnStatusChangeReasonString = "primary key size exceed the limit";
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+        Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        routineLoadJob.afterAborted(transactionState, txnStatusChangeReasonString);
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+    }
+
+    @Test
+    public void testAfterAbortedRetryableAttachment(@Mocked RoutineLoadMgr routineLoadMgr,
+                                                     @Injectable TransactionState transactionState,
+                                                     @Injectable KafkaTaskInfo routineLoadTaskInfo)
+            throws StarRocksException {
+
+        Deencapsulation.setField(routineLoadTaskInfo, "routineLoadManager", routineLoadMgr);
+        List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
+        routineLoadTaskInfoList.add(routineLoadTaskInfo);
+        long txnId = 1L;
+
+        RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
+        Deencapsulation.setField(attachment, "nonRetryable", false);
+        TKafkaRLTaskProgress tKafkaRLTaskProgress = new TKafkaRLTaskProgress();
+        tKafkaRLTaskProgress.partitionCmtOffset = Maps.newHashMap();
+        KafkaProgress kafkaProgress = new KafkaProgress(tKafkaRLTaskProgress.getPartitionCmtOffset());
+        Deencapsulation.setField(attachment, "progress", kafkaProgress);
+
+        KafkaProgress currentProgress = new KafkaProgress(tKafkaRLTaskProgress.getPartitionCmtOffset());
+
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+        new Expectations() {
+            {
+                transactionState.getTransactionId();
+                minTimes = 0;
+                result = txnId;
+                routineLoadTaskInfo.getTxnId();
+                minTimes = 0;
+                result = txnId;
+                transactionState.getTxnCommitAttachment();
+                minTimes = 0;
+                result = attachment;
+                routineLoadTaskInfo.getPartitions();
+                minTimes = 0;
+                result = Lists.newArrayList();
+                routineLoadTaskInfo.getId();
+                minTimes = 0;
+                result = UUIDUtil.genUUID();
+                routineLoadMgr.getJob(anyLong);
+                minTimes = 0;
+                result = routineLoadJob;
+            }
+        };
+
+        new MockUp<RoutineLoadJob>() {
+            @Mock
+            void writeUnlock() {
+            }
+        };
+
+        // retryable attachment should keep job running
+        String txnStatusChangeReasonString = "some transient error";
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
+        Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
+        Deencapsulation.setField(routineLoadJob, "progress", currentProgress);
+        routineLoadJob.afterAborted(transactionState, txnStatusChangeReasonString);
+
+        Assertions.assertEquals(RoutineLoadJob.JobState.RUNNING, routineLoadJob.getState());
+    }
+
+    @Test
     public void testPauseOnFatalParseError(@Mocked GlobalStateMgr globalStateMgr, @Injectable TransactionState transactionState,
                                                        @Injectable RoutineLoadTaskInfo routineLoadTaskInfo)
             throws StarRocksException {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1032,6 +1032,8 @@ struct TRLTaskTxnCommitAttachment {
     10: optional TKafkaRLTaskProgress kafkaRLTaskProgress
     11: optional string errorLogUrl
     12: optional TPulsarRLTaskProgress pulsarRLTaskProgress
+    // If true, the error is non-retryable and routine load job should be paused
+    13: optional bool nonRetryable
 }
 
 struct TMiniLoadTxnCommitAttachment {


### PR DESCRIPTION
## Why I'm doing:

When a routine load task encounters a non-retryable error such as "primary key
size exceed the limit", the job previously kept retrying indefinitely because
the error was not recognized by FE's TxnStatusChangeReason.

## What I'm doing:

This adds a mechanism for BE to explicitly signal non-retryable errors to FE via a new
nonRetryable flag in TRLTaskTxnCommitAttachment, causing the job to pause
instead of retrying.

Non-retryable error messages are centrally registered in
be/src/storage/non_retryable_load_errors.h so that adding new ones only
requires a BE-side change.

https://github.com/StarRocks/starrocks/pull/71161

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4


