### PR TITLE
[BugFix] Fix heap-buffer-overflow in MapExpr when nested column types mismatch declared types

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -45,6 +45,7 @@
 #include "util/date_func.h"
 #include "util/int96.h"
 #include "util/phmap/phmap.h"
+#include "util/raw_container.h"
 
 namespace starrocks {
 Filter& ColumnHelper::merge_nullable_filter(Column* column) {
@@ -776,6 +777,131 @@ ChunkUniquePtr ChunkSliceTemplate<SegmentedChunkPtr>::cutoff(size_t required_row
 template struct ChunkSliceTemplate<ChunkPtr>;
 template struct ChunkSliceTemplate<ChunkUniquePtr>;
 template struct ChunkSliceTemplate<SegmentedChunkPtr>;
+
+// Convert a scalar column's physical type to match the target LogicalType.
+// This handles the case where a column has a narrower type (e.g., int8_t for TINYINT)
+// but needs to be treated as a wider type (e.g., int16_t for SMALLINT).
+template <typename T>
+constexpr bool is_numeric_column_type_v =
+        std::is_arithmetic_v<T> || std::is_same_v<T, int128_t> || std::is_same_v<T, int256_t>;
+
+struct ScalarColumnTypeConverter {
+    template <LogicalType target_ltype>
+    ColumnPtr operator()(const Column& src_column, size_t count) {
+        using TargetCppType = RunTimeCppType<target_ltype>;
+
+        // Only convert numeric fixed-length types. Non-numeric types (VARCHAR, JSON, etc.)
+        // use different column representations and won't have this size mismatch issue.
+        if constexpr (!is_numeric_column_type_v<TargetCppType>) {
+            return {};
+        } else {
+            constexpr size_t target_type_size = sizeof(TargetCppType);
+
+            if (src_column.type_size() == target_type_size) {
+                return {};
+            }
+
+            auto target = RunTimeColumnType<target_ltype>::create();
+            auto& dst_data = target->get_data();
+            raw::stl_vector_resize_uninitialized(&dst_data, count);
+
+            const auto* raw = src_column.raw_data();
+            size_t src_type_size = src_column.type_size();
+
+            for (size_t i = 0; i < count; i++) {
+                TargetCppType value{};
+                switch (src_type_size) {
+                case 1:
+                    value = static_cast<TargetCppType>(reinterpret_cast<const int8_t*>(raw)[i]);
+                    break;
+                case 2:
+                    value = static_cast<TargetCppType>(reinterpret_cast<const int16_t*>(raw)[i]);
+                    break;
+                case 4:
+                    value = static_cast<TargetCppType>(reinterpret_cast<const int32_t*>(raw)[i]);
+                    break;
+                case 8:
+                    value = static_cast<TargetCppType>(reinterpret_cast<const int64_t*>(raw)[i]);
+                    break;
+                case 16:
+                    value = static_cast<TargetCppType>(reinterpret_cast<const int128_t*>(raw)[i]);
+                    break;
+                default:
+                    return {};
+                }
+                dst_data[i] = value;
+            }
+            return target;
+        }
+    }
+};
+
+ColumnPtr ColumnHelper::normalize_column_type(const ColumnPtr& column, const TypeDescriptor& target_type) {
+    if (column->only_null()) {
+        return column;
+    }
+
+    if (column->is_nullable()) {
+        const auto* nullable = down_cast<const NullableColumn*>(column.get());
+        auto normalized_data = normalize_column_type(nullable->data_column(), target_type);
+        if (normalized_data.get() == nullable->data_column().get()) {
+            return column;
+        }
+        return NullableColumn::create(std::move(normalized_data), nullable->null_column());
+    }
+
+    switch (target_type.type) {
+    case TYPE_STRUCT: {
+        const auto* struct_col = down_cast<const StructColumn*>(column.get());
+        DCHECK_EQ(target_type.children.size(), struct_col->fields_size());
+        bool changed = false;
+        Columns new_fields;
+        new_fields.reserve(struct_col->fields_size());
+        for (size_t i = 0; i < struct_col->fields_size(); i++) {
+            auto normalized = normalize_column_type(struct_col->get_column_by_idx(i), target_type.children[i]);
+            if (normalized.get() != struct_col->get_column_by_idx(i).get()) {
+                changed = true;
+            }
+            new_fields.push_back(std::move(normalized));
+        }
+        if (!changed) return column;
+        return StructColumn::create(std::move(new_fields), struct_col->field_names());
+    }
+    case TYPE_MAP: {
+        const auto* map_col = down_cast<const MapColumn*>(column.get());
+        auto normalized_keys = normalize_column_type(map_col->keys_column(), target_type.children[0]);
+        auto normalized_values = normalize_column_type(map_col->values_column(), target_type.children[1]);
+        if (normalized_keys.get() == map_col->keys_column().get() &&
+            normalized_values.get() == map_col->values_column().get()) {
+            return column;
+        }
+        return MapColumn::create(std::move(normalized_keys), std::move(normalized_values),
+                                 map_col->offsets_column());
+    }
+    case TYPE_ARRAY: {
+        const auto* array_col = down_cast<const ArrayColumn*>(column.get());
+        auto normalized_elements = normalize_column_type(array_col->elements_column(), target_type.children[0]);
+        if (normalized_elements.get() == array_col->elements_column().get()) {
+            return column;
+        }
+        return ArrayColumn::create(std::move(normalized_elements), array_col->offsets_column());
+    }
+    default: {
+        // For scalar types, check if physical type size matches.
+        // If sizes match, the column is already compatible (no buffer overflow risk).
+        // If sizes differ, convert element by element.
+        if (!is_scalar_field_type(target_type.type)) {
+            return column;
+        }
+        size_t count = column->size();
+        auto converted = type_dispatch_column(target_type.type, ScalarColumnTypeConverter(), *column, count);
+        if (converted == nullptr) {
+            return column;
+        }
+        return converted;
+    }
+    }
+}
 
 // Explicit instantiation for t_filter_range
 #define INSTANTIATE_T_FILTER_RANGE(T)                                                                   \

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -875,8 +875,7 @@ ColumnPtr ColumnHelper::normalize_column_type(const ColumnPtr& column, const Typ
             normalized_values.get() == map_col->values_column().get()) {
             return column;
         }
-        return MapColumn::create(std::move(normalized_keys), std::move(normalized_values),
-                                 map_col->offsets_column());
+        return MapColumn::create(std::move(normalized_keys), std::move(normalized_values), map_col->offsets_column());
     }
     case TYPE_ARRAY: {
         const auto* array_col = down_cast<const ArrayColumn*>(column.get());

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -273,6 +273,12 @@ public:
         return update_column_nullable(dst_nullable, std::move(dst_column), num_rows);
     }
 
+    // Recursively normalize a column's physical type to match the target TypeDescriptor.
+    // This is needed when child expression columns have different physical types than declared
+    // (e.g., a TINYINT column used where SMALLINT is expected), which would cause buffer overflow
+    // in Column::append due to raw memcpy with mismatched element sizes.
+    static ColumnPtr normalize_column_type(const ColumnPtr& column, const TypeDescriptor& target_type);
+
     // Create an empty column
     static MutableColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 

--- a/be/src/exprs/array_expr.cpp
+++ b/be/src/exprs/array_expr.cpp
@@ -53,6 +53,9 @@ public:
         for (size_t i = 0; i < num_elements; i++) {
             element_columns[i] =
                     ColumnHelper::unfold_const_column(element_type, cal_rows, std::move(element_columns[i]));
+            // Ensure the column's physical type matches the declared type to prevent buffer overflow
+            // in Column::append when child expressions produce narrower types (e.g., TINYINT for SMALLINT).
+            element_columns[i] = ColumnHelper::normalize_column_type(std::move(element_columns[i]), element_type);
         }
 
         auto array_elements = ColumnHelper::create_column(element_type, true);

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -46,6 +46,10 @@ StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk
     for (size_t i = 0; i < num_pairs; i++) {
         pairs_columns[i] = ColumnHelper::cast_to_nullable_column(
                 ColumnHelper::unfold_const_column(_type.children[i % 2], num_rows, std::move(pairs_columns[i])));
+        // Ensure the column's physical type matches the declared type to prevent buffer overflow
+        // in Column::append when child expressions produce narrower types (e.g., TINYINT for SMALLINT).
+        pairs_columns[i] =
+                ColumnHelper::normalize_column_type(std::move(pairs_columns[i]), _type.children[i % 2]);
     }
 
     auto key_col = ColumnHelper::create_column(_type.children[0], true);

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -48,8 +48,7 @@ StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk
                 ColumnHelper::unfold_const_column(_type.children[i % 2], num_rows, std::move(pairs_columns[i])));
         // Ensure the column's physical type matches the declared type to prevent buffer overflow
         // in Column::append when child expressions produce narrower types (e.g., TINYINT for SMALLINT).
-        pairs_columns[i] =
-                ColumnHelper::normalize_column_type(std::move(pairs_columns[i]), _type.children[i % 2]);
+        pairs_columns[i] = ColumnHelper::normalize_column_type(std::move(pairs_columns[i]), _type.children[i % 2]);
     }
 
     auto key_col = ColumnHelper::create_column(_type.children[0], true);

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -15,6 +15,10 @@
 #include "column/column_helper.h"
 
 #include "column/column_builder.h"
+#include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "gtest/gtest.h"
 
 namespace starrocks {
@@ -96,6 +100,94 @@ TEST_F(ColumnHelperTest, get_null_column) {
     column = create_const_column();
     null_column = ColumnHelper::get_null_column(column.get());
     ASSERT_EQ(null_column->get_name(), "integral-1");
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_no_change) {
+    // Same type: no conversion needed
+    auto col = Int32Column::create();
+    col->append(1);
+    col->append(2);
+    ColumnPtr ptr = col;
+
+    TypeDescriptor type_int(TYPE_INT);
+    auto result = ColumnHelper::normalize_column_type(ptr, type_int);
+    // Should return the same pointer (no conversion)
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_widen_tinyint_to_smallint) {
+    // TINYINT (int8_t) -> SMALLINT (int16_t)
+    auto col = Int8Column::create();
+    col->append(1);
+    col->append(-5);
+    col->append(127);
+    ColumnPtr ptr = col;
+
+    TypeDescriptor type_smallint(TYPE_SMALLINT);
+    auto result = ColumnHelper::normalize_column_type(ptr, type_smallint);
+    // Should return a new column with correct type
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 3);
+    ASSERT_EQ(result->type_size(), sizeof(int16_t));
+
+    // Verify values are correctly converted
+    auto* converted = down_cast<const Int16Column*>(result.get());
+    ASSERT_EQ(converted->get_data()[0], 1);
+    ASSERT_EQ(converted->get_data()[1], -5);
+    ASSERT_EQ(converted->get_data()[2], 127);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_nullable) {
+    // Nullable TINYINT -> SMALLINT
+    auto data_col = Int8Column::create();
+    data_col->append(10);
+    data_col->append(20);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    null_col->append(1);
+    auto nullable = NullableColumn::create(std::move(data_col), std::move(null_col));
+    ColumnPtr ptr = nullable;
+
+    TypeDescriptor type_smallint(TYPE_SMALLINT);
+    auto result = ColumnHelper::normalize_column_type(ptr, type_smallint);
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_TRUE(result->is_nullable());
+
+    auto* result_nullable = down_cast<const NullableColumn*>(result.get());
+    auto* result_data = down_cast<const Int16Column*>(result_nullable->data_column().get());
+    ASSERT_EQ(result_data->get_data()[0], 10);
+    ASSERT_EQ(result_data->get_data()[1], 20);
+    // Null flags should be preserved
+    ASSERT_EQ(result_nullable->null_column()->get_data()[0], 0);
+    ASSERT_EQ(result_nullable->null_column()->get_data()[1], 1);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_struct_nested) {
+    // STRUCT with a mismatched inner field: STRUCT<TINYINT> -> STRUCT<SMALLINT>
+    auto field = Int8Column::create();
+    field->append(42);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    auto nullable_field = NullableColumn::create(std::move(field), std::move(null_col));
+
+    Columns fields;
+    fields.push_back(std::move(nullable_field));
+    std::vector<std::string> names = {"f1"};
+    auto struct_col = StructColumn::create(std::move(fields), names);
+    ColumnPtr ptr = struct_col;
+
+    TypeDescriptor type_struct;
+    type_struct.type = TYPE_STRUCT;
+    type_struct.children.emplace_back(TYPE_SMALLINT);
+    type_struct.field_names.push_back("f1");
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_struct);
+    ASSERT_NE(result.get(), ptr.get());
+
+    auto* result_struct = down_cast<const StructColumn*>(result.get());
+    auto* result_field = down_cast<const NullableColumn*>(result_struct->field_column_raw_ptr(0));
+    auto* result_data = down_cast<const Int16Column*>(result_field->data_column().get());
+    ASSERT_EQ(result_data->get_data()[0], 42);
 }
 
 } // namespace starrocks

--- a/be/test/exprs/map_expr_test.cpp
+++ b/be/test/exprs/map_expr_test.cpp
@@ -157,4 +157,41 @@ TEST_F(MapExprTest, test_const_evaluate) {
     }
 }
 
+// Test that MapExpr handles type mismatch between child expressions and declared MAP types.
+// This reproduces the heap-buffer-overflow bug where a TINYINT column is used as a SMALLINT key.
+TEST_F(MapExprTest, test_type_mismatch_no_overflow) {
+    // Declare MAP<SMALLINT, SMALLINT> but provide TINYINT children
+    TypeDescriptor type_map_smallint;
+    type_map_smallint.type = LogicalType::TYPE_MAP;
+    type_map_smallint.children.emplace_back();
+    type_map_smallint.children.back().type = LogicalType::TYPE_SMALLINT;
+    type_map_smallint.children.emplace_back();
+    type_map_smallint.children.back().type = LogicalType::TYPE_SMALLINT;
+
+    // Single pair: TINYINT column used where SMALLINT is expected
+    {
+        auto expr(ExprsTestHelper::create_map_expr(type_map_smallint));
+        // Provide TINYINT (int8_t) columns but MAP expects SMALLINT (int16_t)
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({1, 2, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({10, 20, 30}), LogicalType::TYPE_TINYINT));
+
+        auto result = expr->evaluate(nullptr, nullptr);
+        EXPECT_EQ(3, result->size());
+        EXPECT_TRUE(result->is_map());
+    }
+
+    // Multiple pairs with duplicated keys: exercises the row-by-row append path
+    {
+        auto expr(ExprsTestHelper::create_map_expr(type_map_smallint));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({1, 2, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({10, 20, 30}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({4, 5, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({40, 50, 60}), LogicalType::TYPE_TINYINT));
+
+        auto result = expr->evaluate(nullptr, nullptr);
+        EXPECT_EQ(3, result->size());
+        EXPECT_TRUE(result->is_map());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

In shared-data read path, evaluating complex default expressions (MAP/ARRAY containing nested STRUCT) triggers a heap-buffer-overflow. The crash occurs in `FixedLengthColumnBase<short>::append` when it performs `memcpy` reading 2 bytes from a 1-byte buffer.

**Root cause**: `MapExpr::evaluate_checked` (and `ArrayExpr`) only performs top-level const unfolding and nullable wrapping on child expression columns, but does not verify that the physical column types match the MAP/ARRAY's declared types. When FE does not insert CAST nodes (e.g., in the `default_expr` → `default_value` BE-side evaluation path), child columns retain their original narrower types (e.g., TINYINT/int8_t). The subsequent `Column::append` uses `reinterpret_cast` + raw `memcpy` assuming identical element sizes, reading beyond the allocated buffer.

**Call path**:
```
OlapChunkSource::_init_olap_reader
  → preprocess_default_expr_for_tcolumns
    → convert_default_expr_to_json_string
      → Expr::evaluate_const → MapExpr::evaluate_checked
        → NullableColumn::append → StructColumn::append
          → FixedLengthColumnBase<short>::append  // reads 2 bytes from 1-byte buffer
```

## What I'm doing:

Add `ColumnHelper::normalize_column_type(column, target_type)` that recursively ensures a column's physical type matches the target TypeDescriptor before append operations:

- **NullableColumn**: unwraps, normalizes inner data column, re-wraps with original null flags
- **StructColumn**: recursively normalizes each field
- **MapColumn**: recursively normalizes keys and values
- **ArrayColumn**: recursively normalizes elements
- **Scalar types**: detects `type_size()` mismatch, creates properly typed column with element-by-element `static_cast` conversion via `type_dispatch_column`

Uses pointer comparison to skip conversion when types already match (zero overhead in the common case).

Called in both `MapExpr::evaluate_checked` and `ArrayExpr::evaluate_checked` after `unfold_const_column` + `cast_to_nullable_column`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
