### PR TITLE
[Enhancement] support per stmt audit log for multi stmts

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -119,6 +119,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of audit log files that can be retained within each retention period specified by the `audit_log_roll_interval` parameter.
 - Introduced in: -
 
+### `audit_stmt_before_execute`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether FE emits a `BEFORE_QUERY` audit event before each statement executes. When enabled, ConnectProcessor writes one audit record before statement execution and still writes the normal `AFTER_QUERY` audit record after the statement finishes. For multi-statement requests, this happens per executed statement: statements executed before a failure each emit a before/after pair, the failed statement also emits both records, and statements after the failure emit nothing because they are not executed. Parse failures are unchanged and still only produce the existing failed after-audit for the original SQL text. This is an FE-wide switch, so changing it affects all sessions on the FE.
+- Introduced in: v4.1
+
 ### `bdbje_log_level`
 
 - Default: INFO

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -119,6 +119,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 在 `audit_log_roll_interval` 参数指定的每个保留期内，可以保留的审计日志文件的最大数量。
 - 引入版本: -
 
+### `audit_stmt_before_execute`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 控制 FE 是否在每条语句真正执行前额外输出一条 `BEFORE_QUERY` 审计事件。启用后，ConnectProcessor 会在语句执行前记录一条审计日志，并在语句执行完成后继续记录原有的 `AFTER_QUERY` 审计日志。对于 multi-statement 请求，该行为按每条实际执行到的 stmt 生效：失败前成功执行的语句都会各自产生一对 before/after 审计，失败语句也会产生这两条审计，而失败后的语句因为不会执行，所以不会产生任何审计。parse 失败的行为不变，仍然只为原始 SQL 文本输出现有的失败 after-audit。这是一个 FE 级别的全局开关，因此修改后会影响该 FE 上的所有会话。
+- 引入版本: v4.1
+
 ### `bdbje_log_level`
 
 - 默认值: INFO

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -159,6 +159,8 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static boolean enable_audit_sql = true;
+    @ConfField(mutable = true, comment = "Whether to emit BEFORE_QUERY audit events before each statement executes.")
+    public static boolean audit_stmt_before_execute = false;
     @ConfField
     public static boolean enable_internal_sql = true;
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -63,6 +63,7 @@ public class DataCacheSelectExecutor {
             ConnectContext subContext = buildCacheSelectConnectContext(statement, connectContext, isFirstSubContext);
             try (var scope = subContext.bindScope()) {
                 subContext.setCurrentComputeResource(computeResource);
+                subContext.setMultiStmt(false);
                 StmtExecutor subStmtExecutor = StmtExecutor.newInternalExecutor(subContext, insertStmt);
                 isFirstSubContext = false;
                 // Register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
@@ -79,7 +79,6 @@ public class HttpConnectProcessor extends ConnectProcessor {
 
         // http sql doesn't support multi stmt
         ctx.setIsLastStmt(true);
-        ctx.setSingleStmt(true);
 
         //  for http protocal, if current FE can't read, just let client talk with leader
         if (executor.isForwardToLeader()) {
@@ -133,6 +132,7 @@ public class HttpConnectProcessor extends ConnectProcessor {
     public void processOnce() throws IOException {
         // set status of query to OK.
         ctx.getState().reset();
+        ctx.setMultiStmt(false);
         executor = null;
 
         // only handle query，so no need to dispatch

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -40,6 +40,8 @@ import com.starrocks.server.WarehouseManager;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 /*
@@ -203,6 +205,21 @@ public class AuditEvent {
         } else {
             return 0;
         }
+    }
+
+    public AuditEvent copy() {
+        AuditEvent copied = new AuditEvent();
+        try {
+            for (Field field : AuditEvent.class.getFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                field.set(copied, field.get(this));
+            }
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Failed to copy audit event", e);
+        }
+        return copied;
     }
 
     public static class AuditEventBuilder {
@@ -505,6 +522,10 @@ public class AuditEvent {
         public AuditEvent build() {
             this.auditEvent.calculateCacheHitRatio();
             return this.auditEvent;
+        }
+
+        public AuditEvent buildSnapshot() {
+            return build().copy();
         }
 
         // Copy execution statistics from another audit event

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -64,12 +64,6 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
             long queryTime = 0;
             boolean isAfterQuery = event.type == EventType.AFTER_QUERY;
 
-            if (Config.audit_log_json_format) {
-                logMap.put("EventType", event.type.name());
-            } else {
-                sb.append("|EventType=").append(event.type.name());
-            }
-
             // get each field with annotation "AuditField" in AuditEvent
             Field[] fields = event.getClass().getFields();
             for (Field f : fields) {
@@ -127,6 +121,14 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                     logMap.put(fieldName, value);
                 } else {
                     sb.append("|").append(af.value()).append("=").append(value);
+                }
+            }
+
+            if (Config.audit_stmt_before_execute) {
+                if (Config.audit_log_json_format) {
+                    logMap.put("EventType", event.type.name());
+                } else {
+                    sb.append("|EventType=").append(event.type.name());
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/AuditLogBuilder.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 
 // A builtin Audit plugin, registered when FE start.
-// it will receive "AFTER_QUERY" AuditEventy and print it as a log in fe.audit.log
+// it will receive query audit events and print them in fe.audit.log
 public class AuditLogBuilder extends Plugin implements AuditPlugin {
     private static final Logger LOG = LogManager.getLogger(AuditLogBuilder.class);
 
@@ -53,7 +53,7 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
 
     @Override
     public boolean eventFilter(EventType type) {
-        return type == EventType.AFTER_QUERY || type == EventType.CONNECTION;
+        return type == EventType.BEFORE_QUERY || type == EventType.AFTER_QUERY || type == EventType.CONNECTION;
     }
 
     @Override
@@ -62,6 +62,13 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
             Map<String, Object> logMap = new HashMap<>();
             StringBuilder sb = new StringBuilder();
             long queryTime = 0;
+            boolean isAfterQuery = event.type == EventType.AFTER_QUERY;
+
+            if (Config.audit_log_json_format) {
+                logMap.put("EventType", event.type.name());
+            } else {
+                sb.append("|EventType=").append(event.type.name());
+            }
 
             // get each field with annotation "AuditField" in AuditEvent
             Field[] fields = event.getClass().getFields();
@@ -133,7 +140,7 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                 }
 
             } else {
-                if (isBigQuery(event)) {
+                if (isAfterQuery && isBigQuery(event)) {
                     if (Config.audit_log_json_format) {
                         logMap.put("bigQueryLogCPUSecondThreshold", event.bigQueryLogCPUSecondThreshold);
                         logMap.put("bigQueryLogScanBytesThreshold", event.bigQueryLogScanBytesThreshold);
@@ -146,14 +153,14 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                         AuditLog.getBigQueryAudit().log(sb.toString());
                     }
                 }
-                if (Config.enable_qe_slow_log && queryTime > Config.qe_slow_log_ms) {
+                if (isAfterQuery && Config.enable_qe_slow_log && queryTime > Config.qe_slow_log_ms) {
                     if (Config.audit_log_json_format) {
                         AuditLog.getSlowAudit().log(objectMapper.writeValueAsString(logMap));
                     } else {
                         AuditLog.getSlowAudit().log(sb.toString());
                     }
                 }
-                if (Config.enable_plan_feature_collection && event.features != null) {
+                if (isAfterQuery && Config.enable_plan_feature_collection && event.features != null) {
                     StringBuilder execution = new StringBuilder();
                     execution.append("digest=").append(event.digest);
                     execution.append("|cpuCostNs=").append(event.cpuCostNs);
@@ -169,7 +176,6 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                     execution.append("|").append(event.features);
                     AuditLog.getFeaturesAudit().info(execution.toString());
                 }
-                event.features = null;
                 if (Config.audit_log_json_format) {
                     AuditLog.getQueryAudit().log(objectMapper.writeValueAsString(logMap));
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -210,7 +210,7 @@ public class ConnectContext {
     //    or current processing stmt is the last stmt for multi stmts
     // used to set mysql result package
     protected boolean isLastStmt = true;
-    protected boolean isSingleStmt = false;
+    protected boolean isMultiStmt = false;
     // set true when user dump query through HTTP
     protected boolean isHTTPQueryDump = false;
 
@@ -1913,11 +1913,11 @@ public class ConnectContext {
         listeners.clear();
     }
 
-    public boolean isSingleStmt() {
-        return isSingleStmt;
+    public boolean isMultiStmt() {
+        return isMultiStmt;
     }
 
-    public void setSingleStmt(boolean singleStmt) {
-        isSingleStmt = singleStmt;
+    public void setMultiStmt(boolean multiStmt) {
+        isMultiStmt = multiStmt;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -449,7 +449,7 @@ public class ConnectProcessor {
         auditAfterExec(auditSql, parsedStmt,
                 executor == null ? null : executor.getQueryStatisticsForAuditLog(),
                 getDigestFromLeader(executor));
-        if (ctx.getIsLastStmt() && executor != null) {
+        if (executor != null) {
             executor.addFinishedQueryDetail();
         }
     }
@@ -555,11 +555,7 @@ public class ConnectProcessor {
                 }
             }.visit(parsedStmt);
 
-            // Only add the last running stmt for multi statement,
-            // because query detail will be fixed in a later chunk.
-            if (ctx.getIsLastStmt()) {
-                executor.addRunningQueryDetail(parsedStmt);
-            }
+            executor.addRunningQueryDetail(parsedStmt);
             executor.execute();
         } catch (LargeInPredicateException e) {
             throw e;
@@ -796,6 +792,10 @@ public class ConnectProcessor {
         // null bitmap
         byte[] nullBitmap = new byte[(numParams + 7) / 8];
         packetBuf.get(nullBitmap);
+        boolean enableAudit = false;
+        String originStmt = null;
+        ExecuteStmt executeStmt = null;
+        boolean needAddFinishQueryDetail = false;
         try {
             ctx.setQueryId(UUIDUtil.genUUID());
             ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
@@ -818,10 +818,10 @@ public class ConnectProcessor {
                         prepareCtx.getStmt().getMysqlTypeCodes().get(i), packetBuf);
                 exprs.add(literal);
             }
-            ExecuteStmt executeStmt = new ExecuteStmt(String.valueOf(stmtId), exprs);
+            executeStmt = new ExecuteStmt(String.valueOf(stmtId), exprs);
             // audit will affect performance
-            boolean enableAudit = ctx.getSessionVariable().isAuditExecuteStmt();
-            String originStmt = AstToSQLBuilder.toSQL(executeStmt);
+            enableAudit = ctx.getSessionVariable().isAuditExecuteStmt();
+            originStmt = AstToSQLBuilder.toSQL(executeStmt);
             executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
             ctx.setIsLastStmt(true);
             ctx.setSingleStmt(true);
@@ -853,8 +853,10 @@ public class ConnectProcessor {
 
             if (enableAudit && isQuery) {
                 executor.addRunningQueryDetail(executeStmt);
+                needAddFinishQueryDetail = true;
                 executor.execute();
                 executor.addFinishedQueryDetail();
+                needAddFinishQueryDetail = false;
             } else {
                 // Clear query detail. Otherwise, after collecting the profile, it will be mistakenly added to ctx.queryDetail,
                 // which still belongs to the previous query.
@@ -863,21 +865,23 @@ public class ConnectProcessor {
             }
 
             if (enableAudit) {
-                String digestFromLeader = null;
-                if (executor.getIsForwardToLeaderOrInit(false) && executor.getLeaderOpExecutor() != null) {
-                    TMasterOpResult leaderResult = executor.getLeaderOpExecutor().getResult();
-                    if (leaderResult != null && leaderResult.isSetSql_digest()) {
-                        digestFromLeader = leaderResult.getSql_digest();
-                    }
-                }
                 auditAfterExec(originStmt, executor.getParsedStmt(),
-                              executor.getQueryStatisticsForAuditLog(), digestFromLeader);
+                              executor.getQueryStatisticsForAuditLog(), getDigestFromLeader(executor));
             }
         } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe palo bug.
             LOG.warn("Process one query failed because unknown reason: ", e);
-            ctx.getState().setError(e.getClass().getSimpleName() + ", msg: " + e.getMessage());
+            ctx.getState().setError(e.getMessage());
+            ctx.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
+            if (enableAudit && executeStmt != null) {
+                if (needAddFinishQueryDetail && executor != null) {
+                    executor.addFinishedQueryDetail();
+                }
+                auditAfterExec(originStmt, executor == null ? executeStmt : executor.getParsedStmt(),
+                        executor == null ? null : executor.getQueryStatisticsForAuditLog(),
+                         getDigestFromLeader(executor));
+            }
         }
     }
 
@@ -1274,9 +1278,7 @@ public class ConnectProcessor {
             executor = new StmtExecutor(ctx, statement);
         }
         ctx.setExecutor(executor);
-        if (ctx.getIsLastStmt()) {
-            executor.addRunningQueryDetail(statement);
-        }
+        executor.addRunningQueryDetail(statement);
         executor.setProxy();
         executor.execute();
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -572,7 +572,7 @@ public class ConnectProcessor {
         } catch (LargeInPredicateException e) {
             // we will retry this sql later, so don't audit here
             throw e;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             auditStmtFailure(e, parsedStmt, auditSql);
             throw e;
         }
@@ -591,7 +591,7 @@ public class ConnectProcessor {
             throws Exception {
         try {
             return prepareRetriedStmt(parsedStmt, originStmt, stmtCount);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // since this is the retry stmt, we have to audit
             auditStmtFailureForStmt(e, parsedStmt, originStmt);
             throw e;
@@ -699,7 +699,12 @@ public class ConnectProcessor {
         for (int i = 0; i < stmts.size(); ++i) {
             resetStmtExecutionContext(i > 0);
             StatementBase parsedStmt = stmts.get(i);
-            parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
+            try {
+                parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
+            } catch (Throwable e) {
+                auditStmtFailureForStmt(e, parsedStmt, originStmt);
+                throw e;
+            }
             if (!(parsedStmt instanceof SetStmt)) {
                 allStatementsAreSet = false;
             }
@@ -855,6 +860,7 @@ public class ConnectProcessor {
             executor = new StmtExecutor(ctx, executeStmt);
             ctx.setExecutor(executor);
             if (enableAudit) {
+                resetAuditEventBuilder();
                 auditBeforeExec(originStmt, executeStmt);
             }
 
@@ -1209,6 +1215,7 @@ public class ConnectProcessor {
             int idx = request.isSetStmtIdx() ? request.getStmtIdx() : 0;
 
             List<StatementBase> stmts = SqlParser.parse(request.getSql(), ctx.getSessionVariable());
+            ctx.setMultiStmt(stmts.size() > 1);
             StatementBase statement = stmts.get(idx);
             //Build View SQL without Policy Rewrite
             new AstTraverser<Void, Void>() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -823,6 +823,8 @@ public class ConnectProcessor {
             boolean enableAudit = ctx.getSessionVariable().isAuditExecuteStmt();
             String originStmt = AstToSQLBuilder.toSQL(executeStmt);
             executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
+            ctx.setIsLastStmt(true);
+            ctx.setSingleStmt(true);
 
             boolean isQuery = ctx.isQueryStmt(executeStmt);
             ctx.getState().setIsQuery(isQuery);
@@ -845,6 +847,9 @@ public class ConnectProcessor {
 
             executor = new StmtExecutor(ctx, executeStmt);
             ctx.setExecutor(executor);
+            if (enableAudit) {
+                auditBeforeExec(originStmt, executeStmt);
+            }
 
             if (enableAudit && isQuery) {
                 executor.addRunningQueryDetail(executeStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -449,7 +449,7 @@ public class ConnectProcessor {
         auditAfterExec(auditSql, parsedStmt,
                 executor == null ? null : executor.getQueryStatisticsForAuditLog(),
                 getDigestFromLeader(executor));
-        if (executor != null) {
+        if (ctx.getIsLastStmt() && executor != null) {
             executor.addFinishedQueryDetail();
         }
     }
@@ -555,7 +555,9 @@ public class ConnectProcessor {
                 }
             }.visit(parsedStmt);
 
-            executor.addRunningQueryDetail(parsedStmt);
+            if (ctx.getIsLastStmt()) {
+                executor.addRunningQueryDetail(parsedStmt);
+            }
             executor.execute();
         } catch (LargeInPredicateException e) {
             throw e;
@@ -604,8 +606,7 @@ public class ConnectProcessor {
                     auditStmtFailureForStmt(retryException, retriedStmt, originStmt);
                     throw retryException;
                 }
-            }
-            finally {
+            } finally {
                 ctx.getSessionVariable().setEnableLargeInPredicate(originalEnableLargeInPredicate);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -222,6 +222,30 @@ public class ConnectProcessor {
         auditAfterExec(origStmt, parsedStmt, statistics, null);
     }
 
+    public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+        if (!ctx.getSessionVariable().isAuditStmtBeforeExecute()) {
+            return;
+        }
+
+        ctx.getAuditEventBuilder().setEventType(EventType.BEFORE_QUERY)
+                .setState(ctx.getState().toString())
+                .setErrorCode(ctx.getNormalizedErrorCode())
+                .setReturnRows(ctx.getReturnRows())
+                .setStmtId(ctx.getStmtId())
+                .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString())
+                .setSessionId(ctx.getSessionId().toString())
+                .setCNGroup(ctx.getCurrentComputeResourceName())
+                .setQuerySource(ctx.getQuerySource().toString())
+                .setCommand(ctx.getCommandStr())
+                .setPreparedStmtId(null);
+
+        ctx.getAuditEventBuilder().setIsQuery(ctx.getState().isQuery());
+        ctx.getAuditEventBuilder().setFeIp(FrontendOptions.getLocalHostAddress());
+        ctx.getAuditEventBuilder().setStmt(formatStmt(origStmt, parsedStmt));
+        GlobalStateMgr.getCurrentState().getAuditEventProcessor().handleAuditEvent(
+                ctx.getAuditEventBuilder().buildSnapshot());
+    }
+
     public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
                                String digestFromLeader) {
         // slow query
@@ -672,6 +696,7 @@ public class ConnectProcessor {
                 allStatementsAreSet = false;
             }
             parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
+            auditBeforeExec(getAuditSql(parsedStmt, originStmt), parsedStmt);
             if (shouldTerminateBeforeStmtExecution(parsedStmt)) {
                 auditCurrentStmt(getAuditSql(parsedStmt, originStmt), parsedStmt);
                 return new QueryAttemptResult(allStatementsAreSet, true);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -411,7 +411,7 @@ public class ConnectProcessor {
         if (parsedStmt == null) {
             return originStmt;
         }
-        if (ctx.isSingleStmt()) {
+        if (!ctx.isMultiStmt()) {
             return originStmt;
         }
         return AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt);
@@ -449,7 +449,7 @@ public class ConnectProcessor {
         auditAfterExec(auditSql, parsedStmt,
                 executor == null ? null : executor.getQueryStatisticsForAuditLog(),
                 getDigestFromLeader(executor));
-        if (ctx.getIsLastStmt() && executor != null) {
+        if (executor != null) {
             executor.addFinishedQueryDetail();
         }
     }
@@ -474,6 +474,7 @@ public class ConnectProcessor {
     private void resetStmtExecutionContext(boolean refreshQueryId) {
         executor = null;
         ctx.setExecutor(null);
+        ctx.setQueryDetail(null);
         ctx.getState().reset();
         ctx.resetReturnRows();
         ctx.setStartTime();
@@ -487,6 +488,14 @@ public class ConnectProcessor {
             //    the current stmt's identity for the failure path and audit.
             ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         }
+    }
+
+    private void resetStmtRetryContext() {
+        executor = null;
+        ctx.setExecutor(null);
+        ctx.getState().reset();
+        ctx.resetReturnRows();
+        resetAuditEventBuilder();
     }
 
     private StatementBase prepareStmtForExecution(StatementBase parsedStmt, String originStmt,
@@ -506,7 +515,7 @@ public class ConnectProcessor {
         parsedStmt.setOrigStmt(new OriginStatement(originStmt, stmtIdx));
         Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
         ctx.setIsLastStmt(stmtIdx == stmtCount - 1);
-        ctx.setSingleStmt(stmtCount == 1);
+        ctx.setMultiStmt(stmtCount > 1);
         // auditAfterExec() reads ctx.getState().isQuery() even when the stmt fails before
         // StmtExecutor.execute(), so we must classify the stmt here as well.
         ctx.getState().setIsQuery(ctx.isQueryStmt(parsedStmt));
@@ -555,7 +564,7 @@ public class ConnectProcessor {
                 }
             }.visit(parsedStmt);
 
-            if (ctx.getIsLastStmt()) {
+            if (ctx.getQueryDetail() == null) {
                 executor.addRunningQueryDetail(parsedStmt);
             }
             executor.execute();
@@ -571,7 +580,7 @@ public class ConnectProcessor {
     private StatementBase prepareRetriedStmt(StatementBase parsedStmt, String originStmt, int stmtCount)
             throws AnalysisException {
         StatementBase retriedStmt = parseStatements(originStmt).get(parsedStmt.getOrigStmt().idx);
-        resetStmtExecutionContext(true);
+        resetStmtRetryContext();
         return prepareStmtForExecution(retriedStmt, originStmt, parsedStmt.getOrigStmt().idx, stmtCount);
     }
 
@@ -825,7 +834,6 @@ public class ConnectProcessor {
             originStmt = AstToSQLBuilder.toSQL(executeStmt);
             executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
             ctx.setIsLastStmt(true);
-            ctx.setSingleStmt(true);
 
             boolean isQuery = ctx.isQueryStmt(executeStmt);
             ctx.getState().setIsQuery(isQuery);
@@ -1055,6 +1063,7 @@ public class ConnectProcessor {
         ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
 
         ctx.getState().reset();
+        ctx.setMultiStmt(false);
         if (request.isSetResourceInfo()) {
             ctx.getSessionVariable().setResourceGroup(request.getResourceInfo().getGroup());
         }
@@ -1300,6 +1309,7 @@ public class ConnectProcessor {
     public void processOnce(RequestPackage req) throws Exception {
         // set status of query to OK.
         ctx.getState().reset();
+        ctx.setMultiStmt(false);
         executor = null;
 
         packetBuf = req.byteBuffer();
@@ -1320,6 +1330,7 @@ public class ConnectProcessor {
     public void processOnce() throws IOException {
         // set status of query to OK.
         ctx.getState().reset();
+        ctx.setMultiStmt(false);
         executor = null;
 
         // reset sequence id of MySQL protocol

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -223,7 +223,7 @@ public class ConnectProcessor {
     }
 
     public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-        if (!ctx.getSessionVariable().isAuditStmtBeforeExecute()) {
+        if (!Config.audit_stmt_before_execute) {
             return;
         }
 
@@ -522,7 +522,8 @@ public class ConnectProcessor {
         return parsedStmt;
     }
 
-    private boolean shouldTerminateBeforeStmtExecution(StatementBase parsedStmt, String originStmt) {
+    // return true if validate failed, which means it should terminate
+    private boolean validateStmtBeforeExecution(StatementBase parsedStmt, String originStmt) {
         try {
             if (ctx.getTxnId() != 0) {
                 ExplicitTxnStatementValidator.validate(parsedStmt, ctx);
@@ -569,6 +570,7 @@ public class ConnectProcessor {
             }
             executor.execute();
         } catch (LargeInPredicateException e) {
+            // we will retry this sql later, so don't audit here
             throw e;
         } catch (Exception e) {
             auditStmtFailure(e, parsedStmt, auditSql);
@@ -579,6 +581,7 @@ public class ConnectProcessor {
 
     private StatementBase prepareRetriedStmt(StatementBase parsedStmt, String originStmt, int stmtCount)
             throws AnalysisException {
+        // reparse the whole sql
         StatementBase retriedStmt = parseStatements(originStmt).get(parsedStmt.getOrigStmt().idx);
         resetStmtRetryContext();
         return prepareStmtForExecution(retriedStmt, originStmt, parsedStmt.getOrigStmt().idx, stmtCount);
@@ -589,6 +592,7 @@ public class ConnectProcessor {
         try {
             return prepareRetriedStmt(parsedStmt, originStmt, stmtCount);
         } catch (Exception e) {
+            // since this is the retry stmt, we have to audit
             auditStmtFailureForStmt(e, parsedStmt, originStmt);
             throw e;
         }
@@ -599,22 +603,14 @@ public class ConnectProcessor {
             executeStmtWithAudit(parsedStmt, getAuditSql(parsedStmt, originStmt));
         } catch (LargeInPredicateException e) {
             boolean originalEnableLargeInPredicate = ctx.getSessionVariable().enableLargeInPredicate();
-            if (!originalEnableLargeInPredicate) {
-                auditStmtFailureForStmt(e, parsedStmt, originStmt);
-                throw e;
-            }
             try {
                 ctx.getSessionVariable().setEnableLargeInPredicate(false);
                 LOG.warn("Retrying statement with enable_large_in_predicate=false, stmt idx: {}",
                         parsedStmt.getOrigStmt().idx);
                 Tracers.record(Tracers.Module.BASE, "retry_with_large_in_predicate_exception", "true");
                 StatementBase retriedStmt = prepareRetriedStmtWithAudit(parsedStmt, originStmt, stmtCount);
-                try {
-                    executeStmtWithAudit(retriedStmt, getAuditSql(retriedStmt, originStmt));
-                } catch (LargeInPredicateException retryException) {
-                    auditStmtFailureForStmt(retryException, retriedStmt, originStmt);
-                    throw retryException;
-                }
+                // retry this sql, and audit
+                executeStmtWithAudit(retriedStmt, getAuditSql(retriedStmt, originStmt));
             } finally {
                 ctx.getSessionVariable().setEnableLargeInPredicate(originalEnableLargeInPredicate);
             }
@@ -657,6 +653,7 @@ public class ConnectProcessor {
             }
             ctx.getState().setError(e.getMessage());
             ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            // if parse failed, audit stmts together once
             if (!parseSucceeded) {
                 auditAfterExec(originStmt, null, null, null);
             }
@@ -667,6 +664,7 @@ public class ConnectProcessor {
                     ", because unknown reason: ", e);
             ctx.getState().setError(e.getMessage());
             ctx.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
+            // for safety
             if (!parseSucceeded) {
                 auditAfterExec(originStmt, null, null, null);
             }
@@ -701,12 +699,12 @@ public class ConnectProcessor {
         for (int i = 0; i < stmts.size(); ++i) {
             resetStmtExecutionContext(i > 0);
             StatementBase parsedStmt = stmts.get(i);
+            parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
             if (!(parsedStmt instanceof SetStmt)) {
                 allStatementsAreSet = false;
             }
-            parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
             auditBeforeExec(getAuditSql(parsedStmt, originStmt), parsedStmt);
-            if (shouldTerminateBeforeStmtExecution(parsedStmt, originStmt)) {
+            if (validateStmtBeforeExecution(parsedStmt, originStmt)) {
                 auditCurrentStmt(getAuditSql(parsedStmt, originStmt), parsedStmt);
                 return new QueryAttemptResult(allStatementsAreSet, true);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -513,7 +513,7 @@ public class ConnectProcessor {
         return parsedStmt;
     }
 
-    private boolean shouldTerminateBeforeStmtExecution(StatementBase parsedStmt) {
+    private boolean shouldTerminateBeforeStmtExecution(StatementBase parsedStmt, String originStmt) {
         try {
             if (ctx.getTxnId() != 0) {
                 ExplicitTxnStatementValidator.validate(parsedStmt, ctx);
@@ -534,6 +534,9 @@ public class ConnectProcessor {
             }
             ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
             return true;
+        } catch (Throwable e) {
+            auditStmtFailureForStmt(e, parsedStmt, originStmt);
+            throw e;
         }
     }
 
@@ -697,7 +700,7 @@ public class ConnectProcessor {
             }
             parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
             auditBeforeExec(getAuditSql(parsedStmt, originStmt), parsedStmt);
-            if (shouldTerminateBeforeStmtExecution(parsedStmt)) {
+            if (shouldTerminateBeforeStmtExecution(parsedStmt, originStmt)) {
                 auditCurrentStmt(getAuditSql(parsedStmt, originStmt), parsedStmt);
                 return new QueryAttemptResult(allStatementsAreSet, true);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -430,6 +430,65 @@ public class ConnectProcessor {
         }
     }
 
+    private void auditStmtFailure(Throwable e, StatementBase parsedStmt, String auditSql) {
+        setStmtFailure(e, auditSql);
+        auditCurrentStmt(auditSql, parsedStmt);
+    }
+
+    private void auditStmtFailureForStmt(Throwable e, StatementBase parsedStmt, String originStmt) {
+        auditStmtFailure(e, parsedStmt, getAuditSql(parsedStmt, originStmt));
+    }
+
+    private List<StatementBase> parseStatements(String originStmt) throws AnalysisException {
+        try (Timer ignored = Tracers.watchScope(Tracers.Module.PARSER, "Parser")) {
+            return SqlParser.parse(originStmt, ctx.getSessionVariable());
+        } catch (ParsingException parsingException) {
+            throw new AnalysisException(parsingException.getMessage());
+        }
+    }
+
+    private void resetStmtExecutionContext(boolean refreshQueryId) {
+        executor = null;
+        ctx.setExecutor(null);
+        ctx.getState().reset();
+        ctx.resetReturnRows();
+        ctx.setStartTime();
+        ctx.setCurrentThreadAllocatedMemory(getThreadAllocatedBytes(Thread.currentThread().getId()));
+        resetAuditEventBuilder();
+        if (refreshQueryId) {
+            ctx.setQueryId(UUIDUtil.genUUID());
+            // Keep executionId aligned with the current stmt before StmtExecutor.execute():
+            // 1. StmtExecutor skips resetting executionId for cache-select.
+            // 2. A stmt can fail before entering StmtExecutor.execute(), but we still need
+            //    the current stmt's identity for the failure path and audit.
+            ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+        }
+    }
+
+    private StatementBase prepareStmtForExecution(StatementBase parsedStmt, String originStmt,
+                                                  int stmtIdx, int stmtCount) throws AnalysisException {
+        // from jdbc no params like that. COM_STMT_PREPARE + select 1
+        if (ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE && !(parsedStmt instanceof PrepareStmt)) {
+            parsedStmt = new PrepareStmt("", parsedStmt, new ArrayList<>());
+        }
+        // only for JDBC, COM_STMT_PREPARE bundled with jdbc
+        if (ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE && (parsedStmt instanceof PrepareStmt)) {
+            ((PrepareStmt) parsedStmt).setName(String.valueOf(ctx.getStmtId()));
+            if (!(((PrepareStmt) parsedStmt).getInnerStmt() instanceof QueryStatement)) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
+            }
+        }
+
+        parsedStmt.setOrigStmt(new OriginStatement(originStmt, stmtIdx));
+        Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
+        ctx.setIsLastStmt(stmtIdx == stmtCount - 1);
+        ctx.setSingleStmt(stmtCount == 1);
+        // auditAfterExec() reads ctx.getState().isQuery() even when the stmt fails before
+        // StmtExecutor.execute(), so we must classify the stmt here as well.
+        ctx.getState().setIsQuery(ctx.isQueryStmt(parsedStmt));
+        return parsedStmt;
+    }
+
     private boolean shouldTerminateBeforeStmtExecution(StatementBase parsedStmt) {
         try {
             if (ctx.getTxnId() != 0) {
@@ -454,6 +513,7 @@ public class ConnectProcessor {
         }
     }
 
+    // execute this sql and audit current sql unless throw LargeInPredicateException
     private void executeStmtWithAudit(StatementBase parsedStmt, String auditSql) throws Exception {
         try {
             executor = new StmtExecutor(ctx, parsedStmt);
@@ -477,11 +537,55 @@ public class ConnectProcessor {
         } catch (LargeInPredicateException e) {
             throw e;
         } catch (Exception e) {
-            setStmtFailure(e, auditSql);
-            auditCurrentStmt(auditSql, parsedStmt);
+            auditStmtFailure(e, parsedStmt, auditSql);
             throw e;
         }
         auditCurrentStmt(auditSql, parsedStmt);
+    }
+
+    private StatementBase prepareRetriedStmt(StatementBase parsedStmt, String originStmt, int stmtCount)
+            throws AnalysisException {
+        StatementBase retriedStmt = parseStatements(originStmt).get(parsedStmt.getOrigStmt().idx);
+        resetStmtExecutionContext(true);
+        return prepareStmtForExecution(retriedStmt, originStmt, parsedStmt.getOrigStmt().idx, stmtCount);
+    }
+
+    private StatementBase prepareRetriedStmtWithAudit(StatementBase parsedStmt, String originStmt, int stmtCount)
+            throws Exception {
+        try {
+            return prepareRetriedStmt(parsedStmt, originStmt, stmtCount);
+        } catch (Exception e) {
+            auditStmtFailureForStmt(e, parsedStmt, originStmt);
+            throw e;
+        }
+    }
+
+    private void runWithStmtParserStageRetry(StatementBase parsedStmt, String originStmt, int stmtCount) throws Exception {
+        try {
+            executeStmtWithAudit(parsedStmt, getAuditSql(parsedStmt, originStmt));
+        } catch (LargeInPredicateException e) {
+            boolean originalEnableLargeInPredicate = ctx.getSessionVariable().enableLargeInPredicate();
+            if (!originalEnableLargeInPredicate) {
+                auditStmtFailureForStmt(e, parsedStmt, originStmt);
+                throw e;
+            }
+            try {
+                ctx.getSessionVariable().setEnableLargeInPredicate(false);
+                LOG.warn("Retrying statement with enable_large_in_predicate=false, stmt idx: {}",
+                        parsedStmt.getOrigStmt().idx);
+                Tracers.record(Tracers.Module.BASE, "retry_with_large_in_predicate_exception", "true");
+                StatementBase retriedStmt = prepareRetriedStmtWithAudit(parsedStmt, originStmt, stmtCount);
+                try {
+                    executeStmtWithAudit(retriedStmt, getAuditSql(retriedStmt, originStmt));
+                } catch (LargeInPredicateException retryException) {
+                    auditStmtFailureForStmt(retryException, retriedStmt, originStmt);
+                    throw retryException;
+                }
+            }
+            finally {
+                ctx.getSessionVariable().setEnableLargeInPredicate(originalEnableLargeInPredicate);
+            }
+        }
     }
 
     // process COM_QUERY statement,
@@ -505,16 +609,24 @@ public class ConnectProcessor {
 
         // execute this query.
         boolean allStatementsAreSet = true;
+        boolean parseSucceeded = false;
         try {
-            QueryAttemptResult attemptResult = runWithParserStageRetry(originStmt);
+            List<StatementBase> stmts = parseStatements(originStmt);
+            parseSucceeded = true;
+            QueryAttemptResult attemptResult = executeQueryAttempt(originStmt, stmts);
             allStatementsAreSet = attemptResult.allStatementsAreSet;
             if (attemptResult.shouldTerminate) {
                 return;
             }
         } catch (AnalysisException e) {
-            LOG.warn("Failed to parse SQL: " + SqlCredentialRedactor.redact(originStmt) + ", because.", e);
+            if (!parseSucceeded) {
+                LOG.warn("Failed to parse SQL: " + SqlCredentialRedactor.redact(originStmt) + ", because.", e);
+            }
             ctx.getState().setError(e.getMessage());
             ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            if (!parseSucceeded) {
+                auditAfterExec(originStmt, null, null, null);
+            }
         } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe StarRocks bug.
@@ -522,43 +634,14 @@ public class ConnectProcessor {
                     ", because unknown reason: ", e);
             ctx.getState().setError(e.getMessage());
             ctx.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
+            if (!parseSucceeded) {
+                auditAfterExec(originStmt, null, null, null);
+            }
         } finally {
             Tracers.close();
             if (!allStatementsAreSet) {
                 // custom_query_id session is temporary, should be cleared after query finished
                 ctx.getSessionVariable().setCustomQueryId("");
-            }
-        }
-    }
-
-    /**
-     * Execute query with parser-stage retry support.
-     *
-     * This method provides a retry mechanism starting from the parser stage, which is necessary for
-     * certain optimizations that require different AST structures based on session variables or configs.
-     * Some scenarios that need parser-stage retry include:
-     * - LargeInPredicate optimization: When enable_large_in_predicate=true, the parser uses raw constant
-     *   values instead of expressions. If this optimization fails, we must re-parse with the flag disabled
-     *   to get a traditional expression-based AST. Additionally, mid-pipeline rewrites of expressions or
-     *   operators (e.g., during analyzer/optimizer phases) may bypass critical processing steps; therefore
-     *   a full re-parse is required to ensure all semantic checks and transformations are executed.
-     * - Other future optimizations that modify parsing behavior based on session/config settings.
-     *
-     * This is different from execution-level retries because it requires re-parsing the SQL to get
-     * a different AST structure, not just re-executing the same plan.
-     */
-    private QueryAttemptResult runWithParserStageRetry(String originStmt) throws Throwable {
-        try {
-            return executeQueryAttempt(originStmt);
-        } catch (LargeInPredicateException e) {
-            boolean originalEnableLargeInPredicate = ctx.getSessionVariable().enableLargeInPredicate();
-            try {
-                ctx.getSessionVariable().setEnableLargeInPredicate(false);
-                LOG.warn("Retrying query with enable_large_in_predicate=false");
-                Tracers.record(Tracers.Module.BASE, "retry_with_large_in_predicate_exception", "true");
-                return executeQueryAttempt(originStmt);
-            } finally {
-                ctx.getSessionVariable().setEnableLargeInPredicate(originalEnableLargeInPredicate);
             }
         }
     }
@@ -573,68 +656,28 @@ public class ConnectProcessor {
         }
     }
 
-    private QueryAttemptResult executeQueryAttempt(String originStmt) throws Throwable {
+    private QueryAttemptResult executeQueryAttempt(String originStmt, List<StatementBase> stmts) throws Throwable {
         boolean allStatementsAreSet = true;
 
         ctx.setQueryId(UUIDUtil.genUUID());
-        // Keep executionId aligned with the current stmt before StmtExecutor.execute():
-        // 1. StmtExecutor skips resetting executionId for cache-select.
-        // 2. A stmt can fail before entering StmtExecutor.execute(), but we still need
-        //    the current stmt's identity for the failure path and audit.
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: query, query id:{}, sql:{}", ctx.getQueryId(), originStmt);
         }
-        List<StatementBase> stmts;
-        try (Timer ignored = Tracers.watchScope(Tracers.Module.PARSER, "Parser")) {
-            stmts = com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable());
-        } catch (ParsingException parsingException) {
-            throw new AnalysisException(parsingException.getMessage());
-        }
 
         for (int i = 0; i < stmts.size(); ++i) {
-            executor = null;
-            ctx.setExecutor(null);
-            ctx.getState().reset();
-            ctx.resetReturnRows();
-            ctx.setStartTime();
-            ctx.setCurrentThreadAllocatedMemory(getThreadAllocatedBytes(Thread.currentThread().getId()));
-            resetAuditEventBuilder();
-            if (i > 0) {
-                ctx.setQueryId(UUIDUtil.genUUID());
-                // See the comment above: later stmts also need a fresh executionId even if
-                // StmtExecutor.execute() is never reached or cache-select is enabled.
-                ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-            }
+            resetStmtExecutionContext(i > 0);
             StatementBase parsedStmt = stmts.get(i);
-            // from jdbc no params like that. COM_STMT_PREPARE + select 1
-            if (ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE && !(parsedStmt instanceof PrepareStmt)) {
-                parsedStmt = new PrepareStmt("", parsedStmt, new ArrayList<>());
-            }
-            // only for JDBC, COM_STMT_PREPARE bundled with jdbc
-            if (ctx.getCommand() == MysqlCommand.COM_STMT_PREPARE && (parsedStmt instanceof PrepareStmt)) {
-                ((PrepareStmt) parsedStmt).setName(String.valueOf(ctx.getStmtId()));
-                if (!(((PrepareStmt) parsedStmt).getInnerStmt() instanceof QueryStatement)) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
-                }
-            }
             if (!(parsedStmt instanceof SetStmt)) {
                 allStatementsAreSet = false;
             }
-            parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
-            Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
-            ctx.setIsLastStmt(i == stmts.size() - 1);
-            ctx.setSingleStmt(stmts.size() == 1);
-            // auditAfterExec() reads ctx.getState().isQuery() even when the stmt fails before
-            // StmtExecutor.execute(), so we must classify the stmt here as well.
-            ctx.getState().setIsQuery(ctx.isQueryStmt(parsedStmt));
-            String auditSql = getAuditSql(parsedStmt, originStmt);
+            parsedStmt = prepareStmtForExecution(parsedStmt, originStmt, i, stmts.size());
             if (shouldTerminateBeforeStmtExecution(parsedStmt)) {
-                auditCurrentStmt(auditSql, parsedStmt);
+                auditCurrentStmt(getAuditSql(parsedStmt, originStmt), parsedStmt);
                 return new QueryAttemptResult(allStatementsAreSet, true);
             }
 
-            executeStmtWithAudit(parsedStmt, auditSql);
+            runWithStmtParserStageRetry(parsedStmt, originStmt, stmts.size());
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -47,6 +47,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -76,6 +77,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExecuteStmt;
@@ -91,6 +93,7 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.common.AuditEncryptionChecker;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.LargeInPredicateException;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.formatter.FormatOptions;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.parser.SqlParser;
@@ -311,7 +314,7 @@ public class ConnectProcessor {
 
         ctx.getAuditEventBuilder().setStmt(formatStmt(origStmt, parsedStmt));
 
-        AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
+        AuditEvent auditEvent = ctx.getAuditEventBuilder().buildSnapshot();
         if (ctx.getState().isQuery() && ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             // multiply LONG by 10 so in metric system we can have more accurate result
             MetricRepo.HISTO_CACHE_MISS_RATIO.update((long) (auditEvent.getCacheMissRatio() * 10));
@@ -364,6 +367,123 @@ public class ConnectProcessor {
         }
     }
 
+    private void resetAuditEventBuilder() {
+        ctx.getAuditEventBuilder().reset();
+        ctx.getAuditEventBuilder()
+                .setTimestamp(System.currentTimeMillis())
+                .setClientIp(ctx.getMysqlChannel().getRemoteHostPortString())
+                .setUser(ctx.getQualifiedUser())
+                .setAuthorizedUser(
+                        ctx.getCurrentUserIdentity() == null ? "null" : ctx.getCurrentUserIdentity().toString())
+                .setDb(ctx.getDatabase())
+                .setCatalog(ctx.getCurrentCatalog())
+                .setWarehouse(ctx.getCurrentWarehouseName())
+                .setCustomQueryId(ctx.getCustomQueryId())
+                .setCustomSessionName(ctx.getCustomSessionName())
+                .setCNGroup(ctx.getCurrentComputeResourceName());
+    }
+
+    private String getAuditSql(StatementBase parsedStmt, String originStmt) {
+        if (parsedStmt == null) {
+            return originStmt;
+        }
+        if (ctx.isSingleStmt()) {
+            return originStmt;
+        }
+        return AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt);
+    }
+
+    private String getDigestFromLeader(StmtExecutor stmtExecutor) {
+        if (stmtExecutor == null || !stmtExecutor.getIsForwardToLeaderOrInit(false)
+                || stmtExecutor.getLeaderOpExecutor() == null) {
+            return null;
+        }
+        TMasterOpResult leaderResult = stmtExecutor.getLeaderOpExecutor().getResult();
+        if (leaderResult != null && leaderResult.isSetSql_digest()) {
+            return leaderResult.getSql_digest();
+        }
+        return null;
+    }
+
+    private void setStmtFailure(Throwable e, String auditSql) {
+        if (e instanceof AnalysisException || e instanceof ErrorReportException
+                || e instanceof SemanticException
+                || (e instanceof StarRocksPlannerException
+                && ((StarRocksPlannerException) e).getType() == ErrorType.USER_ERROR)) {
+            LOG.info("Process one statement failed. SQL: {}, error: {}",
+                    SqlCredentialRedactor.redact(auditSql), e.getMessage());
+            ctx.getState().setError(e.getMessage());
+            ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            return;
+        }
+        LOG.warn("Process one statement failed. SQL: {}", SqlCredentialRedactor.redact(auditSql), e);
+        ctx.getState().setError(e.getMessage());
+        ctx.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
+    }
+
+    private void auditCurrentStmt(String auditSql, StatementBase parsedStmt) {
+        auditAfterExec(auditSql, parsedStmt,
+                executor == null ? null : executor.getQueryStatisticsForAuditLog(),
+                getDigestFromLeader(executor));
+        if (ctx.getIsLastStmt() && executor != null) {
+            executor.addFinishedQueryDetail();
+        }
+    }
+
+    private boolean shouldTerminateBeforeStmtExecution(StatementBase parsedStmt) {
+        try {
+            if (ctx.getTxnId() != 0) {
+                ExplicitTxnStatementValidator.validate(parsedStmt, ctx);
+            }
+            AuthenticationProvider authenticationProvider = ctx.getAuthenticationProvider();
+            if (authenticationProvider == null) {
+                ErrorReport.report("Unknown authentication method");
+                ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+                return true;
+            }
+            authenticationProvider.checkLoginSuccess(ctx.getConnectionId(), ctx.getAccessControlContext());
+            return false;
+        } catch (AuthenticationException authenticationException) {
+            if (authenticationException.getErrorCode() != null) {
+                ErrorReport.report(authenticationException.getErrorCode(), authenticationException.getMessage());
+            } else {
+                ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED, authenticationException.getMessage());
+            }
+            ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            return true;
+        }
+    }
+
+    private void executeStmtWithAudit(StatementBase parsedStmt, String auditSql) throws Exception {
+        try {
+            executor = new StmtExecutor(ctx, parsedStmt);
+            ctx.setExecutor(executor);
+
+            //Build View SQL without Policy Rewrite
+            new AstTraverser<Void, Void>() {
+                @Override
+                public Void visitRelation(Relation relation, Void context) {
+                    relation.setNeedRewrittenByPolicy(true);
+                    return null;
+                }
+            }.visit(parsedStmt);
+
+            // Only add the last running stmt for multi statement,
+            // because query detail will be fixed in a later chunk.
+            if (ctx.getIsLastStmt()) {
+                executor.addRunningQueryDetail(parsedStmt);
+            }
+            executor.execute();
+        } catch (LargeInPredicateException e) {
+            throw e;
+        } catch (Exception e) {
+            setStmtFailure(e, auditSql);
+            auditCurrentStmt(auditSql, parsedStmt);
+            throw e;
+        }
+        auditCurrentStmt(auditSql, parsedStmt);
+    }
+
     // process COM_QUERY statement,
     protected void handleQuery() {
         MetricRepo.COUNTER_REQUEST_ALL.increase(1L);
@@ -378,19 +498,7 @@ public class ConnectProcessor {
             ending--;
         }
         originStmt = new String(bytes, 1, ending, StandardCharsets.UTF_8);
-        ctx.getAuditEventBuilder().reset();
-        ctx.getAuditEventBuilder()
-                .setTimestamp(System.currentTimeMillis())
-                .setClientIp(ctx.getMysqlChannel().getRemoteHostPortString())
-                .setUser(ctx.getQualifiedUser())
-                .setAuthorizedUser(
-                        ctx.getCurrentUserIdentity() == null ? "null" : ctx.getCurrentUserIdentity().toString())
-                .setDb(ctx.getDatabase())
-                .setCatalog(ctx.getCurrentCatalog())
-                .setWarehouse(ctx.getCurrentWarehouseName())
-                .setCustomQueryId(ctx.getCustomQueryId())
-                .setCustomSessionName(ctx.getCustomSessionName())
-                .setCNGroup(ctx.getCurrentComputeResourceName());
+        resetAuditEventBuilder();
         Tracers.register(ctx);
         // set isQuery before `forwardToLeader` to make it right for audit log.
         ctx.getState().setIsQuery(true);
@@ -420,26 +528,6 @@ public class ConnectProcessor {
                 // custom_query_id session is temporary, should be cleared after query finished
                 ctx.getSessionVariable().setCustomQueryId("");
             }
-        }
-
-        // audit after exec
-        // replace '\n' to '\\n' to make string in one line
-        // TODO(cmy): when user send multi-statement, the executor is the last statement's executor.
-        // We may need to find some way to resolve this.
-        if (executor != null) {
-            String digestFromLeader = null;
-            if (executor.getIsForwardToLeaderOrInit(false) && executor.getLeaderOpExecutor() != null) {
-                TMasterOpResult leaderResult = executor.getLeaderOpExecutor().getResult();
-                if (leaderResult != null && leaderResult.isSetSql_digest()) {
-                    digestFromLeader = leaderResult.getSql_digest();
-                }
-            }
-            auditAfterExec(originStmt, executor.getParsedStmt(),
-                          executor.getQueryStatisticsForAuditLog(), digestFromLeader);
-            executor.addFinishedQueryDetail();
-        } else {
-            // executor can be null if we encounter analysis error.
-            auditAfterExec(originStmt, null, null, null);
         }
     }
 
@@ -489,6 +577,10 @@ public class ConnectProcessor {
         boolean allStatementsAreSet = true;
 
         ctx.setQueryId(UUIDUtil.genUUID());
+        // Keep executionId aligned with the current stmt before StmtExecutor.execute():
+        // 1. StmtExecutor skips resetting executionId for cache-select.
+        // 2. A stmt can fail before entering StmtExecutor.execute(), but we still need
+        //    the current stmt's identity for the failure path and audit.
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: query, query id:{}, sql:{}", ctx.getQueryId(), originStmt);
@@ -501,10 +593,18 @@ public class ConnectProcessor {
         }
 
         for (int i = 0; i < stmts.size(); ++i) {
+            executor = null;
+            ctx.setExecutor(null);
             ctx.getState().reset();
+            ctx.resetReturnRows();
+            ctx.setStartTime();
+            ctx.setCurrentThreadAllocatedMemory(getThreadAllocatedBytes(Thread.currentThread().getId()));
+            resetAuditEventBuilder();
             if (i > 0) {
-                ctx.resetReturnRows();
                 ctx.setQueryId(UUIDUtil.genUUID());
+                // See the comment above: later stmts also need a fresh executionId even if
+                // StmtExecutor.execute() is never reached or cache-select is enabled.
+                ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
             }
             StatementBase parsedStmt = stmts.get(i);
             // from jdbc no params like that. COM_STMT_PREPARE + select 1
@@ -523,53 +623,18 @@ public class ConnectProcessor {
             }
             parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
             Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
-
-            if (ctx.getTxnId() != 0) {
-                ExplicitTxnStatementValidator.validate(parsedStmt, ctx);
-            }
-
-            try {
-                AuthenticationProvider authenticationProvider = ctx.getAuthenticationProvider();
-                if (authenticationProvider == null) {
-                    ErrorReport.report("Unknown authentication method");
-                    ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
-                    return new QueryAttemptResult(allStatementsAreSet, true);
-                }
-
-                authenticationProvider.checkLoginSuccess(ctx.getConnectionId(), ctx.getAccessControlContext());
-            } catch (AuthenticationException authenticationException) {
-                if (authenticationException.getErrorCode() != null) {
-                    ErrorReport.report(authenticationException.getErrorCode(), authenticationException.getMessage());
-                } else {
-                    ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED, authenticationException.getMessage());
-                }
-                ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            ctx.setIsLastStmt(i == stmts.size() - 1);
+            ctx.setSingleStmt(stmts.size() == 1);
+            // auditAfterExec() reads ctx.getState().isQuery() even when the stmt fails before
+            // StmtExecutor.execute(), so we must classify the stmt here as well.
+            ctx.getState().setIsQuery(ctx.isQueryStmt(parsedStmt));
+            String auditSql = getAuditSql(parsedStmt, originStmt);
+            if (shouldTerminateBeforeStmtExecution(parsedStmt)) {
+                auditCurrentStmt(auditSql, parsedStmt);
                 return new QueryAttemptResult(allStatementsAreSet, true);
             }
 
-            executor = new StmtExecutor(ctx, parsedStmt);
-            ctx.setExecutor(executor);
-
-            ctx.setIsLastStmt(i == stmts.size() - 1);
-            ctx.setSingleStmt(stmts.size() == 1);
-
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(parsedStmt);
-
-            // Only add the last running stmt for multi statement,
-            // because the audit log will only show the last stmt.
-            if (ctx.getIsLastStmt()) {
-                executor.addRunningQueryDetail(parsedStmt);
-            }
-            executor.execute();
-
-            // do not execute following stmt when current stmt failed, this is consistent with mysql server
+            executeStmtWithAudit(parsedStmt, auditSql);
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -968,6 +968,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
+    public static final String AUDIT_STMT_BEFORE_EXECUTE = "audit_stmt_before_execute";
+
     public static final String CROSS_JOIN_COST_PENALTY = "cross_join_cost_penalty";
 
     public static final String CBO_DERIVE_RANGE_JOIN_PREDICATE = "cbo_derive_range_join_predicate";
@@ -2989,6 +2991,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
     private boolean auditExecuteStmt = true;
 
+    @VariableMgr.VarAttr(name = AUDIT_STMT_BEFORE_EXECUTE)
+    private boolean auditStmtBeforeExecute = false;
+
     @VariableMgr.VarAttr(name = ENABLE_SHORT_CIRCUIT)
     private boolean enableShortCircuit = false;
 
@@ -3446,6 +3451,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableLargeInPredicate(boolean enableLargeInPredicate) {
         this.enableLargeInPredicate = enableLargeInPredicate;
+    }
+
+    public boolean isAuditStmtBeforeExecute() {
+        return auditStmtBeforeExecute;
+    }
+
+    public void setAuditStmtBeforeExecute(boolean auditStmtBeforeExecute) {
+        this.auditStmtBeforeExecute = auditStmtBeforeExecute;
     }
 
     public int getLargeInPredicateThreshold() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -968,8 +968,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
-    public static final String AUDIT_STMT_BEFORE_EXECUTE = "audit_stmt_before_execute";
-
     public static final String CROSS_JOIN_COST_PENALTY = "cross_join_cost_penalty";
 
     public static final String CBO_DERIVE_RANGE_JOIN_PREDICATE = "cbo_derive_range_join_predicate";
@@ -2991,9 +2989,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
     private boolean auditExecuteStmt = true;
 
-    @VariableMgr.VarAttr(name = AUDIT_STMT_BEFORE_EXECUTE)
-    private boolean auditStmtBeforeExecute = false;
-
     @VariableMgr.VarAttr(name = ENABLE_SHORT_CIRCUIT)
     private boolean enableShortCircuit = false;
 
@@ -3451,14 +3446,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableLargeInPredicate(boolean enableLargeInPredicate) {
         this.enableLargeInPredicate = enableLargeInPredicate;
-    }
-
-    public boolean isAuditStmtBeforeExecute() {
-        return auditStmtBeforeExecute;
-    }
-
-    public void setAuditStmtBeforeExecute(boolean auditStmtBeforeExecute) {
-        this.auditStmtBeforeExecute = auditStmtBeforeExecute;
     }
 
     public int getLargeInPredicateThreshold() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3816,7 +3816,7 @@ public class StmtExecutor {
 
     private String getQueryDetailSql(StatementBase parsedStmt) {
         String originSql = parsedStmt.getOrigStmt().originStmt;
-        if (context.isSingleStmt()) {
+        if (context.isSingleStmt() || parsedStmt.getOrigStmt().idx == 0) {
             return originSql;
         }
         return AstToSQLBuilder.toSQLOrDefault(parsedStmt, originSql);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -419,7 +419,7 @@ public class StmtExecutor {
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
         // only print the sepecific sql in multi statement
-        String sql = context.isSingleStmt() ? originStmt.originStmt :
+        String sql = !context.isMultiStmt() ? originStmt.originStmt :
                 AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt);
         if (AuditEncryptionChecker.needEncrypt(parsedStmt)) {
             summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT,
@@ -3816,7 +3816,7 @@ public class StmtExecutor {
 
     private String getQueryDetailSql(StatementBase parsedStmt) {
         String originSql = parsedStmt.getOrigStmt().originStmt;
-        if (context.isSingleStmt() || parsedStmt.getOrigStmt().idx == 0) {
+        if (!context.isMultiStmt()) {
             return originSql;
         }
         return AstToSQLBuilder.toSQLOrDefault(parsedStmt, originSql);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3773,7 +3773,7 @@ public class StmtExecutor {
         }
 
         try {
-            String sql = parsedStmt.getOrigStmt().originStmt;
+            String sql = getQueryDetailSql(parsedStmt);
             boolean needEncrypt = AuditEncryptionChecker.needEncrypt(parsedStmt);
             if (needEncrypt || Config.enable_sql_desensitize_in_log) {
                 sql = AstToSQLBuilder.toSQL(parsedStmt, FormatOptions.allEnable()
@@ -3812,6 +3812,14 @@ public class StmtExecutor {
                 context.setCurrentComputeResource(computeResourceBackup);
             }
         }
+    }
+
+    private String getQueryDetailSql(StatementBase parsedStmt) {
+        String originSql = parsedStmt.getOrigStmt().originStmt;
+        if (context.isSingleStmt()) {
+            return originSql;
+        }
+        return AstToSQLBuilder.toSQLOrDefault(parsedStmt, originSql);
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -350,6 +350,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
             parentStmtExecutor.registerSubStmtExecutor(executor);
         }
         ctx.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
+        ctx.setMultiStmt(false);
         // Add running query detail for MV refresh
         ctx.setQuerySource(QueryDetail.QuerySource.MV);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -60,6 +60,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
 
             executor = StmtExecutor.newInternalExecutor(ctx, sqlStmt);
             ctx.setExecutor(executor);
+            ctx.setMultiStmt(false);
             ctx.setThreadLocalInfo();
             executor.addRunningQueryDetail(sqlStmt);
             executor.execute();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -290,7 +290,7 @@ public class TaskRun implements Comparable<TaskRun> {
         context.getState().reset();
         context.setQueryId(UUID.fromString(status.getQueryId()));
         context.setIsLastStmt(true);
-        context.setSingleStmt(true);
+        context.setMultiStmt(false);
         context.resetSessionVariable();
         // Preserve critical session variables from parent context if available
         // This ensures that settings like enableSingleNodeSchedule are inherited

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -142,6 +142,7 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
     public void processOnce() {
         // Set status of query to OK.
         ctx.getState().reset();
+        ctx.setMultiStmt(false);
         executor = null;
 
         // Only handle query，so no need to dispatch
@@ -310,7 +311,6 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
 
         executor = new StmtExecutor(ctx, parsedStmt, deploymentFinished);
         ctx.setIsLastStmt(true);
-        ctx.setSingleStmt(true);
         ctx.setExecutor(executor);
 
         executor.addRunningQueryDetail(parsedStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -1323,6 +1323,89 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    @Test
+    public void testHandleExecuteAuditBeforeAndAfter() throws Exception {
+        ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+        ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+
+        PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+        PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+        ctx.putPreparedStmt("1", prepareCtx);
+
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() throws Exception {
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:OK:SELECT 1 + 2"));
+    }
+
+    @Test
+    public void testHandleExecuteAuditBeforeAndAfterOnFailure() throws Exception {
+        ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+        ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+
+        PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+        PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+        ctx.putPreparedStmt("1", prepareCtx);
+
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() throws Exception {
+                throw new IOException("mock execute failure");
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:ERR:SELECT 1 + 2"));
+    }
+
     /**
      * Helper method to create a COM_STMT_EXECUTE packet
      */

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -61,6 +61,7 @@ import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.DDLTestBase;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.LargeInPredicateException;
@@ -68,6 +69,7 @@ import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.transaction.ExplicitTxnStatementValidator;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
@@ -728,6 +730,96 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
         Assertions.assertTrue(auditRecords.get(4).startsWith("BEFORE:2:"));
         Assertions.assertTrue(auditRecords.get(5).startsWith("AFTER:2:OK:"));
+    }
+
+    @Test
+    public void testMultiStatementPreExecutionFailureAuditsFailedStmt() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.setTxnId(1);
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<ExplicitTxnStatementValidator>() {
+            @Mock
+            public void validate(StatementBase statement, ConnectContext context) {
+                if (statement.getOrigStmt().idx == 1) {
+                    throw new SemanticException("mock pre execution failure");
+                }
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                executeCounts[stmtExecutor.getParsedStmt().getOrigStmt().idx]++;
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 0, 0}, executeCounts);
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
+    }
+
+    @Test
+    public void testMultiStatementPreExecutionFailureHasBeforeAndAfterAudit() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.setTxnId(1);
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<ExplicitTxnStatementValidator>() {
+            @Mock
+            public void validate(StatementBase statement, ConnectContext context) {
+                if (statement.getOrigStmt().idx == 1) {
+                    throw new SemanticException("mock pre execution failure");
+                }
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(4, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -601,135 +601,153 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @Test
     public void testMultiStatementAuditBeforeAndAfterPerStatement() throws Exception {
-        ByteBuffer packet = createQueryPacket("select 1; select 2;");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
-            }
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            List<String> auditRecords = new ArrayList<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
+                }
 
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() {
-            }
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString()
+                            + ":" + origStmt);
+                }
+            };
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
 
-        processor.processOnce();
-        Assertions.assertEquals(4, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
-        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
-        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
-        Assertions.assertFalse(auditRecords.get(0).contains(";"));
-        Assertions.assertFalse(auditRecords.get(1).contains(";"));
-        Assertions.assertFalse(auditRecords.get(2).contains(";"));
-        Assertions.assertFalse(auditRecords.get(3).contains(";"));
+            processor.processOnce();
+            Assertions.assertEquals(4, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+            Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+            Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
+            Assertions.assertFalse(auditRecords.get(0).contains(";"));
+            Assertions.assertFalse(auditRecords.get(1).contains(";"));
+            Assertions.assertFalse(auditRecords.get(2).contains(";"));
+            Assertions.assertFalse(auditRecords.get(3).contains(";"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     @Test
     public void testMultiStatementAuditBeforeAndAfterStopsAfterFailure() throws Exception {
-        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
-            }
-
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute(Invocation invocation) throws Exception {
-                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
-                if (stmtExecutor.getParsedStmt().getOrigStmt().idx == 1) {
-                    throw new IOException("mock stmt failure");
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            List<String> auditRecords = new ArrayList<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
                 }
-            }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString()
+                            + ":" + origStmt);
+                }
+            };
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute(Invocation invocation) throws Exception {
+                    StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                    if (stmtExecutor.getParsedStmt().getOrigStmt().idx == 1) {
+                        throw new IOException("mock stmt failure");
+                    }
+                }
 
-        processor.processOnce();
-        Assertions.assertEquals(4, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
-        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
-        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
-        Assertions.assertFalse(auditRecords.get(0).contains(";"));
-        Assertions.assertFalse(auditRecords.get(1).contains(";"));
-        Assertions.assertFalse(auditRecords.get(2).contains(";"));
-        Assertions.assertFalse(auditRecords.get(3).contains("; select 3"));
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+            Assertions.assertEquals(4, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+            Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+            Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
+            Assertions.assertFalse(auditRecords.get(0).contains(";"));
+            Assertions.assertFalse(auditRecords.get(1).contains(";"));
+            Assertions.assertFalse(auditRecords.get(2).contains(";"));
+            Assertions.assertFalse(auditRecords.get(3).contains("; select 3"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     @Test
     public void testMultiStatementAuditBeforeExecOnlyOnceWhenStmtRetries() throws Exception {
-        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
-        List<String> auditRecords = new ArrayList<>();
-        int[] executeCounts = new int[3];
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
-            }
-
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute(Invocation invocation) throws Exception {
-                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
-                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
-                executeCounts[stmtIdx]++;
-                if (stmtIdx == 1 && executeCounts[stmtIdx] == 1) {
-                    throw new LargeInPredicateException("mock large in predicate retry");
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            List<String> auditRecords = new ArrayList<>();
+            int[] executeCounts = new int[3];
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
                 }
-            }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString()
+                            + ":" + origStmt);
+                }
+            };
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute(Invocation invocation) throws Exception {
+                    StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                    int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                    executeCounts[stmtIdx]++;
+                    if (stmtIdx == 1 && executeCounts[stmtIdx] == 1) {
+                        throw new LargeInPredicateException("mock large in predicate retry");
+                    }
+                }
 
-        processor.processOnce();
-        Assertions.assertArrayEquals(new int[] {1, 2, 1}, executeCounts);
-        Assertions.assertEquals(6, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
-        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
-        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
-        Assertions.assertTrue(auditRecords.get(4).startsWith("BEFORE:2:"));
-        Assertions.assertTrue(auditRecords.get(5).startsWith("AFTER:2:OK:"));
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+            Assertions.assertArrayEquals(new int[] {1, 2, 1}, executeCounts);
+            Assertions.assertEquals(6, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+            Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+            Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
+            Assertions.assertTrue(auditRecords.get(4).startsWith("BEFORE:2:"));
+            Assertions.assertTrue(auditRecords.get(5).startsWith("AFTER:2:OK:"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     @Test
@@ -778,48 +796,54 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @Test
     public void testMultiStatementPreExecutionFailureHasBeforeAndAfterAudit() throws Exception {
-        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        ctx.setTxnId(1);
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
-            }
-
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<ExplicitTxnStatementValidator>() {
-            @Mock
-            public void validate(StatementBase statement, ConnectContext context) {
-                if (statement.getOrigStmt().idx == 1) {
-                    throw new SemanticException("mock pre execution failure");
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            ctx.setTxnId(1);
+            List<String> auditRecords = new ArrayList<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
                 }
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() {
-            }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString()
+                            + ":" + origStmt);
+                }
+            };
+            new MockUp<ExplicitTxnStatementValidator>() {
+                @Mock
+                public void validate(StatementBase statement, ConnectContext context) {
+                    if (statement.getOrigStmt().idx == 1) {
+                        throw new SemanticException("mock pre execution failure");
+                    }
+                }
+            };
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
 
-        processor.processOnce();
-        Assertions.assertEquals(4, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
-        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
-        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+            Assertions.assertEquals(4, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+            Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+            Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     @Test
@@ -1434,85 +1458,95 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @Test
     public void testHandleExecuteAuditBeforeAndAfter() throws Exception {
-        ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
-        ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+            ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
 
-        PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
-        PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
-        ctx.putPreparedStmt("1", prepareCtx);
+            PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+            PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+            ctx.putPreparedStmt("1", prepareCtx);
 
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + origStmt);
-            }
+            List<String> auditRecords = new ArrayList<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + origStmt);
+                }
 
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
+                }
+            };
 
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-            }
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() throws Exception {
+                }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
 
-        processor.processOnce();
-        Assertions.assertEquals(2, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:OK:SELECT 1 + 2"));
+            processor.processOnce();
+            Assertions.assertEquals(2, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:OK:SELECT 1 + 2"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     @Test
     public void testHandleExecuteAuditBeforeAndAfterOnFailure() throws Exception {
-        ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
-        ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+            ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
 
-        PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
-        PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
-        ctx.putPreparedStmt("1", prepareCtx);
+            PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+            PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+            ctx.putPreparedStmt("1", prepareCtx);
 
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
-                auditRecords.add("BEFORE:" + origStmt);
-            }
+            List<String> auditRecords = new ArrayList<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    auditRecords.add("BEFORE:" + origStmt);
+                }
 
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
-            }
-        };
+                @Override
+                public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                           String digestFromLeader) {
+                    auditRecords.add("AFTER:" + ctx.getState().toString() + ":" + origStmt);
+                }
+            };
 
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                throw new IOException("mock execute failure");
-            }
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() throws Exception {
+                    throw new IOException("mock execute failure");
+                }
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
 
-        processor.processOnce();
-        Assertions.assertEquals(2, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:ERR:SELECT 1 + 2"));
+            processor.processOnce();
+            Assertions.assertEquals(2, auditRecords.size());
+            Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:SELECT 1 + 2"));
+            Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:ERR:SELECT 1 + 2"));
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -598,6 +598,139 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     @Test
+    public void testMultiStatementAuditBeforeAndAfterPerStatement() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(4, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains(";"));
+        Assertions.assertFalse(auditRecords.get(2).contains(";"));
+        Assertions.assertFalse(auditRecords.get(3).contains(";"));
+    }
+
+    @Test
+    public void testMultiStatementAuditBeforeAndAfterStopsAfterFailure() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                if (stmtExecutor.getParsedStmt().getOrigStmt().idx == 1) {
+                    throw new IOException("mock stmt failure");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(4, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains(";"));
+        Assertions.assertFalse(auditRecords.get(2).contains(";"));
+        Assertions.assertFalse(auditRecords.get(3).contains("; select 3"));
+    }
+
+    @Test
+    public void testMultiStatementAuditBeforeExecOnlyOnceWhenStmtRetries() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setAuditStmtBeforeExecute(true);
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                auditRecords.add("BEFORE:" + parsedStmt.getOrigStmt().idx + ":" + origStmt);
+            }
+
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add("AFTER:" + parsedStmt.getOrigStmt().idx + ":" + ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                executeCounts[stmtIdx]++;
+                if (stmtIdx == 1 && executeCounts[stmtIdx] == 1) {
+                    throw new LargeInPredicateException("mock large in predicate retry");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 2, 1}, executeCounts);
+        Assertions.assertEquals(6, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("BEFORE:0:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("AFTER:0:OK:"));
+        Assertions.assertTrue(auditRecords.get(2).startsWith("BEFORE:1:"));
+        Assertions.assertTrue(auditRecords.get(3).startsWith("AFTER:1:OK:"));
+        Assertions.assertTrue(auditRecords.get(4).startsWith("BEFORE:2:"));
+        Assertions.assertTrue(auditRecords.get(5).startsWith("AFTER:2:OK:"));
+    }
+
+    @Test
     public void testQueryDetailForMultiStatement() throws Exception {
         boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
         Config.enable_collect_query_detail_info = true;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -70,6 +70,9 @@ import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -384,6 +387,71 @@ public class ConnectProcessorTest extends DDLTestBase {
             processor.processOnce();
             Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
         }
+    }
+
+    @Test
+    public void testMultiStatementAuditPerStatement() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditedSqls = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditedSqls.add(origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(2, auditedSqls.size());
+        Assertions.assertFalse(auditedSqls.get(0).contains(";"));
+        Assertions.assertFalse(auditedSqls.get(1).contains(";"));
+    }
+
+    @Test
+    public void testMultiStatementAuditStopsAfterFailure() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                if (stmtIdx == 1) {
+                    throw new IOException("mock stmt failure");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -564,47 +564,6 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
-    // Verify failed stmt is still audited when LargeInPredicate retry is disabled for the session.
-    @Test
-    public void testMultiStatementLargeInPredicateWithoutRetryStillAuditsFailedStmt() throws Exception {
-        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        ctx.getSessionVariable().setEnableLargeInPredicate(false);
-        List<String> auditRecords = new ArrayList<>();
-        int[] executeCounts = new int[3];
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute(Invocation invocation) throws Exception {
-                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
-                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
-                executeCounts[stmtIdx]++;
-                if (stmtIdx == 1) {
-                    throw new LargeInPredicateException("mock large in predicate without retry");
-                }
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertArrayEquals(new int[] {1, 1, 0}, executeCounts);
-        Assertions.assertEquals(2, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
-        Assertions.assertFalse(auditRecords.get(0).contains(";"));
-        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
-    }
-
     // Verify before/after audit hooks both fire once per stmt for successful multi-statement execution.
     @Test
     public void testMultiStatementAuditBeforeAndAfterPerStatement() throws Exception {
@@ -855,39 +814,6 @@ public class ConnectProcessorTest extends DDLTestBase {
         } finally {
             Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
         }
-    }
-
-    // Verify multi-statement COM_STMT_PREPARE still audits the failing stmt when prepare-stage validation fails.
-    @Test
-    public void testMultiStatementPrepareFailureStillAuditsFailedStmt() throws Exception {
-        ByteBuffer packet = createPreparePacket("select 1; set time_zone = 'Asia/Shanghai';");
-        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
-        List<String> auditRecords = new ArrayList<>();
-        ConnectProcessor processor = new ConnectProcessor(ctx) {
-            @Override
-            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
-                                       String digestFromLeader) {
-                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() {
-            }
-
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(2, auditRecords.size());
-        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
-        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
-        Assertions.assertFalse(auditRecords.get(0).contains(";"));
-        Assertions.assertTrue(auditRecords.get(1).toLowerCase().contains("set time_zone"));
-        Assertions.assertFalse(auditRecords.get(1).contains("; select"));
     }
 
     // Verify non-Exception Throwable from stmt execution still produces one failure audit for the current stmt.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -387,6 +387,82 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     @Test
+    public void testQueryDetailForMultiStatement() throws Exception {
+        boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        QueryDetailQueue.TOTAL_QUERIES.clear();
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+
+            List<QueryDetail> details = QueryDetailQueue.getQueryDetailsAfterTime(0);
+            int runningCount = 0;
+            int finishedCount = 0;
+            for (QueryDetail detail : details) {
+                if (detail.getState() == QueryDetail.QueryMemState.RUNNING) {
+                    runningCount++;
+                    Assertions.assertFalse(detail.getSql().contains(";"));
+                } else if (detail.getState() == QueryDetail.QueryMemState.FINISHED) {
+                    finishedCount++;
+                    Assertions.assertFalse(detail.getSql().contains(";"));
+                }
+            }
+            Assertions.assertEquals(2, details.size());
+            Assertions.assertEquals(1, runningCount);
+            Assertions.assertEquals(1, finishedCount);
+        } finally {
+            Config.enable_collect_query_detail_info = enableCollectQueryDetail;
+            QueryDetailQueue.TOTAL_QUERIES.clear();
+        }
+    }
+
+    @Test
+    public void testSingleStatementQueryDetailKeepsOriginalSql() throws Exception {
+        boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        QueryDetailQueue.TOTAL_QUERIES.clear();
+        try {
+            ByteBuffer packet = createQueryPacket("select 1 /*keep*/");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+
+            List<QueryDetail> details = QueryDetailQueue.getQueryDetailsAfterTime(0);
+            Assertions.assertFalse(details.isEmpty());
+            Assertions.assertTrue(details.get(0).getSql().contains("/*keep*/"));
+        } finally {
+            Config.enable_collect_query_detail_info = enableCollectQueryDetail;
+            QueryDetailQueue.TOTAL_QUERIES.clear();
+        }
+    }
+
+    @Test
     public void testQueryWithInlineWarehouse() throws Exception {
         Config.run_mode = RunMode.SHARED_DATA.getName();
         RunMode.detectRunMode();
@@ -842,6 +918,13 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
 
         return serializer.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private ByteBuffer createQueryPacket(String sql) {
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        serializer.writeInt1(3);
+        serializer.writeEofString(sql);
+        return serializer.toByteBuffer();
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -63,6 +63,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.LargeInPredicateException;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TUniqueId;
@@ -447,6 +448,148 @@ public class ConnectProcessorTest extends DDLTestBase {
         };
 
         processor.processOnce();
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
+    }
+
+    @Test
+    public void testParseFailureAuditsOriginalSql() throws Exception {
+        ByteBuffer packet = createQueryPacket("select from");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(1, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("ERR:"));
+        Assertions.assertEquals("ERR:select from", auditRecords.get(0));
+    }
+
+    @Test
+    public void testMultiStatementLargeInPredicateRetriesCurrentStmtOnly() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                executeCounts[stmtIdx]++;
+                if (stmtIdx == 1 && executeCounts[stmtIdx] == 1) {
+                    throw new LargeInPredicateException("mock large in predicate retry");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 2, 1}, executeCounts);
+        Assertions.assertEquals(3, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(2).startsWith("OK:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains(";"));
+        Assertions.assertFalse(auditRecords.get(2).contains(";"));
+    }
+
+    @Test
+    public void testMultiStatementLargeInPredicateRetryStopsAfterRetriedStmtFailure() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                executeCounts[stmtIdx]++;
+                if (stmtIdx == 1) {
+                    if (executeCounts[stmtIdx] == 1) {
+                        throw new LargeInPredicateException("mock large in predicate retry");
+                    }
+                    throw new IOException("mock stmt failure after retry");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 2, 0}, executeCounts);
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
+    }
+
+    @Test
+    public void testMultiStatementLargeInPredicateWithoutRetryStillAuditsFailedStmt() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        ctx.getSessionVariable().setEnableLargeInPredicate(false);
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) throws Exception {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                executeCounts[stmtIdx]++;
+                if (stmtIdx == 1) {
+                    throw new LargeInPredicateException("mock large in predicate without retry");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 1, 0}, executeCounts);
         Assertions.assertEquals(2, auditRecords.size());
         Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
         Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -392,6 +392,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify multi-statement query emits one after-audit per stmt when all stmts succeed.
     @Test
     public void testMultiStatementAuditPerStatement() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2;");
@@ -421,6 +422,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditedSqls.get(1).contains(";"));
     }
 
+    // Verify multi-statement query stops on the first failed stmt and only audits executed stmts.
     @Test
     public void testMultiStatementAuditStopsAfterFailure() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
@@ -457,6 +459,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
+    // Verify parse failure still records a single audit entry with the original raw SQL.
     @Test
     public void testParseFailureAuditsOriginalSql() throws Exception {
         ByteBuffer packet = createQueryPacket("select from");
@@ -476,6 +479,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertEquals("ERR:select from", auditRecords.get(0));
     }
 
+    // Verify LargeInPredicate retry is scoped to the failing stmt instead of replaying previous stmts.
     @Test
     public void testMultiStatementLargeInPredicateRetriesCurrentStmtOnly() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
@@ -517,6 +521,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(2).contains(";"));
     }
 
+    // Verify a stmt that still fails after LargeInPredicate retry is audited once and stops later stmts.
     @Test
     public void testMultiStatementLargeInPredicateRetryStopsAfterRetriedStmtFailure() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
@@ -559,6 +564,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
+    // Verify failed stmt is still audited when LargeInPredicate retry is disabled for the session.
     @Test
     public void testMultiStatementLargeInPredicateWithoutRetryStillAuditsFailedStmt() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
@@ -599,6 +605,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
+    // Verify before/after audit hooks both fire once per stmt for successful multi-statement execution.
     @Test
     public void testMultiStatementAuditBeforeAndAfterPerStatement() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -646,6 +653,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify before/after audit hooks stop after the first failing stmt in a multi-statement request.
     @Test
     public void testMultiStatementAuditBeforeAndAfterStopsAfterFailure() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -697,6 +705,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify stmt-level retry does not emit duplicated BEFORE audit entries for the retried stmt.
     @Test
     public void testMultiStatementAuditBeforeExecOnlyOnceWhenStmtRetries() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -750,6 +759,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify validation failure before executor.execute still audits the failing stmt.
     @Test
     public void testMultiStatementPreExecutionFailureAuditsFailedStmt() throws Exception {
         ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
@@ -794,6 +804,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
     }
 
+    // Verify validation failure before execution still gets both BEFORE and AFTER audit records.
     @Test
     public void testMultiStatementPreExecutionFailureHasBeforeAndAfterAudit() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -846,6 +857,80 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify multi-statement COM_STMT_PREPARE still audits the failing stmt when prepare-stage validation fails.
+    @Test
+    public void testMultiStatementPrepareFailureStillAuditsFailedStmt() throws Exception {
+        ByteBuffer packet = createPreparePacket("select 1; set time_zone = 'Asia/Shanghai';");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertTrue(auditRecords.get(1).toLowerCase().contains("set time_zone"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select"));
+    }
+
+    // Verify non-Exception Throwable from stmt execution still produces one failure audit for the current stmt.
+    @Test
+    public void testMultiStatementThrowableFailureStillAuditsFailedStmt() throws Exception {
+        ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        List<String> auditRecords = new ArrayList<>();
+        int[] executeCounts = new int[3];
+        ConnectProcessor processor = new ConnectProcessor(ctx) {
+            @Override
+            public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                                       String digestFromLeader) {
+                auditRecords.add(ctx.getState().toString() + ":" + origStmt);
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute(Invocation invocation) {
+                StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                executeCounts[stmtIdx]++;
+                if (stmtIdx == 1) {
+                    throw new AssertionError("mock throwable failure");
+                }
+            }
+
+            @Mock
+            public PQueryStatistics getQueryStatisticsForAuditLog() {
+                return null;
+            }
+        };
+
+        processor.processOnce();
+        Assertions.assertArrayEquals(new int[] {1, 1, 0}, executeCounts);
+        Assertions.assertEquals(2, auditRecords.size());
+        Assertions.assertTrue(auditRecords.get(0).startsWith("OK:"));
+        Assertions.assertTrue(auditRecords.get(1).startsWith("ERR:"));
+        Assertions.assertFalse(auditRecords.get(0).contains(";"));
+        Assertions.assertFalse(auditRecords.get(1).contains("; select 3"));
+    }
+
+    // Verify query detail records one running and one finished entry per stmt in successful multi-statement execution.
     @Test
     public void testQueryDetailForMultiStatement() throws Exception {
         boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
@@ -890,6 +975,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify query detail only contains executed stmts and marks the failed stmt as FAILED.
     @Test
     public void testQueryDetailForMultiStatementStopsAfterFailure() throws Exception {
         boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
@@ -942,6 +1028,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify stmt retry reuses the same stmt identity so query detail does not duplicate running entries.
     @Test
     public void testQueryDetailForMultiStatementRetryDoesNotDuplicateRunning() throws Exception {
         boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
@@ -999,6 +1086,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify single-statement query detail keeps the original SQL text instead of formatted stmt SQL.
     @Test
     public void testSingleStatementQueryDetailKeepsOriginalSql() throws Exception {
         boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
@@ -1372,6 +1460,61 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify leader-side proxy execution preserves multi-stmt context so query detail records the current stmt SQL.
+    // Verify leader-side proxy execution preserves multi-stmt context so query detail records the current stmt SQL.
+    @Test
+    public void testProxyExecuteMultiStmtUsesStmtScopedQueryDetail() throws Exception {
+        boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        QueryDetailQueue.TOTAL_QUERIES.clear();
+        try {
+            TMasterOpRequest request = new TMasterOpRequest();
+            request.setCatalog("default");
+            request.setDb("testDb1");
+            request.setUser("root");
+            request.setSql("select 1; select 2");
+            request.setStmtIdx(1);
+            request.setIsInternalStmt(true);
+            request.setCurrent_user_ident(new TUserIdentity().setUsername("root").setHost("127.0.0.1"));
+            request.setQueryId(UUIDUtil.genTUniqueId());
+            request.setSession_id(UUID.randomUUID().toString());
+            request.setIsLastStmt(true);
+
+            ConnectContext ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+            ctx.setCurrentCatalog("default");
+            ctx.setDatabase("testDb1");
+            ctx.setQualifiedUser("root");
+            ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+            ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+            ctx.setCurrentRoleIds(UserIdentity.ROOT);
+            ctx.setSessionId(UUID.randomUUID());
+            ctx.setThreadLocalInfo();
+
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            TMasterOpResult result = processor.proxyExecute(request, null);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(ctx.isMultiStmt());
+
+            List<QueryDetail> details = QueryDetailQueue.getQueryDetailsAfterTime(0);
+            Assertions.assertFalse(details.isEmpty());
+            Assertions.assertFalse(details.get(0).getSql().contains(";"));
+        } finally {
+            Config.enable_collect_query_detail_info = enableCollectQueryDetail;
+            QueryDetailQueue.TOTAL_QUERIES.clear();
+        }
+    }
+
     @Test
     public void testProxyExecuteUserIdentityIsNull() throws Exception {
         TMasterOpRequest request = new TMasterOpRequest();
@@ -1399,7 +1542,7 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     /**
-     * Test handleExecute method with tracing for query statements
+     * Verify COM_STMT_EXECUTE query path still registers and initializes tracing correctly.
      */
     @Test
     public void testHandleExecuteTracingForQuery() throws Exception {
@@ -1456,6 +1599,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify COM_STMT_EXECUTE emits both BEFORE and AFTER audit records on success.
     @Test
     public void testHandleExecuteAuditBeforeAndAfter() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -1502,6 +1646,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify COM_STMT_EXECUTE still emits AFTER audit when execution fails after BEFORE audit.
     @Test
     public void testHandleExecuteAuditBeforeAndAfterOnFailure() throws Exception {
         boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
@@ -1549,6 +1694,54 @@ public class ConnectProcessorTest extends DDLTestBase {
         }
     }
 
+    // Verify COM_STMT_EXECUTE before-audit starts from a reset builder instead of reusing stale base fields.
+    @Test
+    public void testHandleExecuteAuditBeforeUsesFreshBuilderBaseFields() throws Exception {
+        boolean oldAuditStmtBeforeExecute = Config.audit_stmt_before_execute;
+        Config.audit_stmt_before_execute = true;
+        try {
+            ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
+            ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
+            myContext.setDatabase("testDb1");
+
+            PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
+            PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
+            ctx.putPreparedStmt("1", prepareCtx);
+
+            ctx.getAuditEventBuilder().reset();
+            ctx.getAuditEventBuilder().setUser("stale-user").setDb("stale-db");
+
+            AtomicReference<String> beforeAuditUser = new AtomicReference<>();
+            AtomicReference<String> beforeAuditDb = new AtomicReference<>();
+            ConnectProcessor processor = new ConnectProcessor(ctx) {
+                @Override
+                public void auditBeforeExec(String origStmt, StatementBase parsedStmt) {
+                    AuditEvent snapshot = ctx.getAuditEventBuilder().buildSnapshot();
+                    beforeAuditUser.set(snapshot.user);
+                    beforeAuditDb.set(snapshot.db);
+                    super.auditBeforeExec(origStmt, parsedStmt);
+                }
+            };
+
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute() {
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+            Assertions.assertEquals("testCluster:user", beforeAuditUser.get());
+            Assertions.assertEquals("testDb1", beforeAuditDb.get());
+        } finally {
+            Config.audit_stmt_before_execute = oldAuditStmtBeforeExecute;
+        }
+    }
+
     /**
      * Helper method to create a COM_STMT_EXECUTE packet
      */
@@ -1585,6 +1778,13 @@ public class ConnectProcessorTest extends DDLTestBase {
     private ByteBuffer createQueryPacket(String sql) {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         serializer.writeInt1(3);
+        serializer.writeEofString(sql);
+        return serializer.toByteBuffer();
+    }
+
+    private ByteBuffer createPreparePacket(String sql) {
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        serializer.writeInt1(MysqlCommand.COM_STMT_PREPARE.getCommandCode());
         serializer.writeEofString(sql);
         return serializer.toByteBuffer();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -857,9 +857,118 @@ public class ConnectProcessorTest extends DDLTestBase {
                     Assertions.assertFalse(detail.getSql().contains(";"));
                 }
             }
-            Assertions.assertEquals(2, details.size());
-            Assertions.assertEquals(1, runningCount);
+            Assertions.assertEquals(4, details.size());
+            Assertions.assertEquals(2, runningCount);
+            Assertions.assertEquals(2, finishedCount);
+        } finally {
+            Config.enable_collect_query_detail_info = enableCollectQueryDetail;
+            QueryDetailQueue.TOTAL_QUERIES.clear();
+        }
+    }
+
+    @Test
+    public void testQueryDetailForMultiStatementStopsAfterFailure() throws Exception {
+        boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        QueryDetailQueue.TOTAL_QUERIES.clear();
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2; select 3;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute(Invocation invocation) throws Exception {
+                    StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                    if (stmtExecutor.getParsedStmt().getOrigStmt().idx == 1) {
+                        throw new IOException("mock stmt failure");
+                    }
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+
+            List<QueryDetail> details = QueryDetailQueue.getQueryDetailsAfterTime(0);
+            int runningCount = 0;
+            int finishedCount = 0;
+            int failedCount = 0;
+            for (QueryDetail detail : details) {
+                if (detail.getState() == QueryDetail.QueryMemState.RUNNING) {
+                    runningCount++;
+                } else if (detail.getState() == QueryDetail.QueryMemState.FINISHED) {
+                    finishedCount++;
+                } else if (detail.getState() == QueryDetail.QueryMemState.FAILED) {
+                    failedCount++;
+                }
+                Assertions.assertFalse(detail.getSql().contains(";"));
+                Assertions.assertFalse(detail.getSql().contains("select 3"));
+            }
+            Assertions.assertEquals(4, details.size());
+            Assertions.assertEquals(2, runningCount);
             Assertions.assertEquals(1, finishedCount);
+            Assertions.assertEquals(1, failedCount);
+        } finally {
+            Config.enable_collect_query_detail_info = enableCollectQueryDetail;
+            QueryDetailQueue.TOTAL_QUERIES.clear();
+        }
+    }
+
+    @Test
+    public void testQueryDetailForMultiStatementRetryDoesNotDuplicateRunning() throws Exception {
+        boolean enableCollectQueryDetail = Config.enable_collect_query_detail_info;
+        Config.enable_collect_query_detail_info = true;
+        QueryDetailQueue.TOTAL_QUERIES.clear();
+        try {
+            ByteBuffer packet = createQueryPacket("select 1; select 2;");
+            ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+            int[] executeCounts = new int[2];
+            List<String> retriedStmtQueryIds = new ArrayList<>();
+
+            new MockUp<StmtExecutor>() {
+                @Mock
+                public void execute(Invocation invocation) throws Exception {
+                    StmtExecutor stmtExecutor = (StmtExecutor) invocation.getInvokedInstance();
+                    int stmtIdx = stmtExecutor.getParsedStmt().getOrigStmt().idx;
+                    executeCounts[stmtIdx]++;
+                    if (stmtIdx == 1) {
+                        retriedStmtQueryIds.add(ctx.getQueryId().toString());
+                    }
+                    if (stmtIdx == 1 && executeCounts[stmtIdx] == 1) {
+                        throw new LargeInPredicateException("mock large in predicate retry");
+                    }
+                }
+
+                @Mock
+                public PQueryStatistics getQueryStatisticsForAuditLog() {
+                    return null;
+                }
+            };
+
+            processor.processOnce();
+
+            List<QueryDetail> details = QueryDetailQueue.getQueryDetailsAfterTime(0);
+            int runningCount = 0;
+            int finishedCount = 0;
+            for (QueryDetail detail : details) {
+                if (detail.getState() == QueryDetail.QueryMemState.RUNNING) {
+                    runningCount++;
+                } else if (detail.getState() == QueryDetail.QueryMemState.FINISHED) {
+                    finishedCount++;
+                }
+                Assertions.assertFalse(detail.getSql().contains(";"));
+            }
+            Assertions.assertArrayEquals(new int[] {1, 2}, executeCounts);
+            Assertions.assertEquals(2, retriedStmtQueryIds.size());
+            Assertions.assertEquals(retriedStmtQueryIds.get(0), retriedStmtQueryIds.get(1));
+            Assertions.assertEquals(4, details.size());
+            Assertions.assertEquals(2, runningCount);
+            Assertions.assertEquals(2, finishedCount);
         } finally {
             Config.enable_collect_query_detail_info = enableCollectQueryDetail;
             QueryDetailQueue.TOTAL_QUERIES.clear();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -116,6 +116,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
         String sql = "select * from test_running_detail";
         QueryStatement parsedStmt = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StmtExecutor executor = new StmtExecutor(connectContext, parsedStmt);
+        connectContext.setMultiStmt(false);
         long startTime = System.currentTimeMillis();
         executor.addRunningQueryDetail(parsedStmt);
         executor.execute();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This PR changes multi-statement handling from "audit once per command" to "audit once per executed statement", while keeping parsing unified for the original
  SQL text.

  Main changes:
  - Parse the original SQL text once up front in `handleQuery`.
  - If parsing fails, emit exactly one failed audit record with the original SQL text.
  - If parsing succeeds, execute statements one by one and audit each executed statement independently.
  - For multi-statement requests:
    - successful statements before a failure each produce one audit record
    - the failed statement also produces one audit record
    - statements after the failure are not executed and are not audited
  - Add the session variable `audit_stmt_before_execute`:
    - when disabled, behavior remains "after execution audit only"
    - when enabled, each executed statement emits one `BEFORE_QUERY` audit event before execution and one `AFTER_QUERY` audit event after execution
  - Keep exception handling consistent with the previous behavior by auditing first and then rethrowing execution exceptions.
  - Support `LargeInPredicateException` retry at statement granularity:
    - the request is still parsed as a whole first
    - if one statement throws `LargeInPredicateException` during execution, temporarily disable `enable_large_in_predicate`
    - reparse the original SQL text, rebuild the statement at the same index, and retry only that statement
    - other statements are not retried
  - Extend `handleExecute()` so prepared statement execution also covers the failure-audit path and the before/after audit hooks.
  - Upgrade `QueryDetail` to record multi-statement execution per statement instead of only recording the last statement.
  - Rename the context flag from `isSingleStmt` to `isMultiStmt` so the code matches the actual semantics more clearly: single-statement is the default, and only
  true multi-statement paths opt in.

  Behavior after this change:
  - parse failure: one failed audit record containing the full original SQL
  - `stmt1; stmt2; stmt3`, where `stmt2` fails:
    - `stmt1` is audited as success
    - `stmt2` is audited as failure
    - `stmt3` is not executed and is not audited
  - `LargeInPredicateException` retry only retries the current statement, not the whole request
  - QueryDetail is generated per executed statement

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
