### PR TITLE
[Enhancement] Guard compaction_inputs by file overlap in lake full replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -231,8 +231,8 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     // then replace file names and return `copied_target_tablet_meta` as the final target tablet metadata
     ASSIGN_OR_RETURN(auto copied_target_tablet_meta,
                      convert_and_build_new_tablet_meta(src_tablet_meta, target_tablet_meta, src_tablet_id,
-                                                       target_tablet_id, txn_id, data_version, src_data_dir,
-                                                       segment_name_to_size_map, file_locations, filename_map));
+                                                       target_tablet_id, txn_id, src_data_dir, segment_name_to_size_map,
+                                                       file_locations, filename_map));
     // calc column unique id to adapt for fast schema change
     if (!src_tablet_meta->has_schema()) {
         LOG(WARNING) << "Failed to get source schema, source tablet: " << src_tablet_id
@@ -665,19 +665,19 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
 
 StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_and_build_new_tablet_meta(
         const TabletMetadataPtr& src_tablet_meta, const TabletMetadataPtr& target_tablet_meta, int64_t src_tablet_id,
-        int64_t target_tablet_id, TTransactionId txn_id, int64_t data_version, const std::string& src_data_dir,
+        int64_t target_tablet_id, TTransactionId txn_id, const std::string& src_data_dir,
         std::unordered_map<std::string, size_t>& segment_name_to_size_map,
         std::map<std::string, std::string>& file_locations,
         std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map) {
     VLOG(3) << "Lake replicate storage task, building new tablet meta for tablet: " << target_tablet_id
-            << ", src_tablet_id: " << src_tablet_id << ", txn_id: " << txn_id << ", data_version: " << data_version;
-    // find all files that already replicated to target storage in previous txns
-    ASSIGN_OR_RETURN(auto target_data_version_tablet_meta,
-                     _tablet_manager->get_tablet_metadata(target_tablet_id, data_version, false, 0, nullptr));
+            << ", src_tablet_id: " << src_tablet_id << ", txn_id: " << txn_id;
+    // Build UUID map from target_tablet_meta (visible_version) instead of data_version metadata.
+    // Using visible_version ensures the UUID map reflects files that physically exist on the target cluster,
+    // avoiding false hits on files that were removed by compaction + vacuum.
     // `existed_filename_uuids` represented files that already replicated to target storage in previous txns
     // <uuid, pair<existed_filename, encryption_meta>>
     std::unordered_map<std::string, std::pair<std::string, std::string>> existed_filename_uuids;
-    RETURN_IF_ERROR(build_existed_filename_uuids_map(target_data_version_tablet_meta, existed_filename_uuids));
+    RETURN_IF_ERROR(build_existed_filename_uuids_map(target_tablet_meta, existed_filename_uuids));
 
     VLOG(3) << "Lake replicate storage task, found " << existed_filename_uuids.size() << " existed files";
     // make new metadata

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -79,8 +79,8 @@ public:
     // generate and replace file names to adapt for target storage
     StatusOr<std::shared_ptr<TabletMetadataPB>> convert_and_build_new_tablet_meta(
             const TabletMetadataPtr& src_tablet_meta, const TabletMetadataPtr& target_tablet_meta,
-            int64_t src_tablet_id, int64_t target_tablet_id, TTransactionId txn_id, int64_t data_version,
-            const std::string& src_data_dir, std::unordered_map<std::string, size_t>& segment_name_to_size_map,
+            int64_t src_tablet_id, int64_t target_tablet_id, TTransactionId txn_id, const std::string& src_data_dir,
+            std::unordered_map<std::string, size_t>& segment_name_to_size_map,
             std::map<std::string, std::string>& file_locations,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -17,6 +17,7 @@
 #include <fmt/format.h>
 
 #include <climits>
+#include <unordered_set>
 
 #include "agent/master_info.h"
 #include "base/debug/trace.h"
@@ -43,6 +44,33 @@
 namespace starrocks::lake {
 
 namespace {
+
+void collect_rowset_referenced_files(const google::protobuf::RepeatedPtrField<RowsetMetadataPB>& rowsets,
+                                     std::unordered_set<std::string>* referenced_files) {
+    for (const auto& rowset : rowsets) {
+        for (const auto& segment : rowset.segments()) {
+            referenced_files->insert(segment);
+        }
+        for (const auto& del_file : rowset.del_files()) {
+            referenced_files->insert(del_file.name());
+        }
+    }
+}
+
+bool has_rowset_file_overlap(const RowsetMetadataPB& old_rowset,
+                             const std::unordered_set<std::string>& referenced_files) {
+    for (const auto& segment : old_rowset.segments()) {
+        if (referenced_files.find(segment) != referenced_files.end()) {
+            return true;
+        }
+    }
+    for (const auto& del_file : old_rowset.del_files()) {
+        if (referenced_files.find(del_file.name()) != referenced_files.end()) {
+            return true;
+        }
+    }
+    return false;
+}
 
 Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas,
                             TabletManager* tablet_mgr) {
@@ -708,19 +736,33 @@ private:
                 _metadata->mutable_delvec_meta()->CopyFrom(copied_tablet_meta.delvec_meta());
 
                 _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
-                // In lake replication scenario, we need to carefully handle compaction_inputs.
-                // The new rowsets may still reference the same rowset id as old rowsets (incremental sync).
-                // Only add rowsets whose id is NOT present in new rowsets to compaction_inputs.
-                // This ensures that files still referenced by new rowsets won't be deleted by vacuum.
                 std::unordered_set<uint32_t> new_rowset_ids;
+                std::unordered_set<std::string> new_referenced_rowset_files;
                 for (const auto& rowset : _metadata->rowsets()) {
                     new_rowset_ids.insert(rowset.id());
                 }
+                collect_rowset_referenced_files(_metadata->rowsets(), &new_referenced_rowset_files);
+
+                size_t skipped_by_rowset_id = 0;
+                size_t skipped_by_file_overlap = 0;
+                size_t moved_to_compaction_inputs = 0;
                 for (auto&& old_rowset : old_rowsets) {
-                    if (new_rowset_ids.count(old_rowset.id()) == 0) {
-                        _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
+                    if (new_rowset_ids.find(old_rowset.id()) != new_rowset_ids.end()) {
+                        skipped_by_rowset_id++;
+                        continue;
                     }
+                    if (has_rowset_file_overlap(old_rowset, new_referenced_rowset_files)) {
+                        skipped_by_file_overlap++;
+                        continue;
+                    }
+                    _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
+                    moved_to_compaction_inputs++;
                 }
+
+                LOG(INFO) << "Apply pk full replication rowset gc guard. tablet_id: " << _tablet.id()
+                          << ", txn_id: " << txn_meta.txn_id() << ", skipped_by_rowset_id: " << skipped_by_rowset_id
+                          << ", skipped_by_file_overlap: " << skipped_by_file_overlap
+                          << ", moved_to_compaction_inputs: " << moved_to_compaction_inputs;
 
                 VLOG(3) << "Apply pk replication log with tablet metadata provided. tablet_id: " << _tablet.id()
                         << ", base_version: " << _base_version << ", new_version: " << _new_version
@@ -1297,19 +1339,33 @@ private:
                 _metadata->mutable_dcg_meta()->CopyFrom(copied_tablet_meta.dcg_meta());
 
                 _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
-                // In lake replication scenario, we need to carefully handle compaction_inputs.
-                // The new rowsets may still reference the same rowset id as old rowsets (incremental sync).
-                // Only add rowsets whose id is NOT present in new rowsets to compaction_inputs.
-                // This ensures that files still referenced by new rowsets won't be deleted by vacuum.
                 std::unordered_set<uint32_t> new_rowset_ids;
+                std::unordered_set<std::string> new_referenced_rowset_files;
                 for (const auto& rowset : _metadata->rowsets()) {
                     new_rowset_ids.insert(rowset.id());
                 }
+                collect_rowset_referenced_files(_metadata->rowsets(), &new_referenced_rowset_files);
+
+                size_t skipped_by_rowset_id = 0;
+                size_t skipped_by_file_overlap = 0;
+                size_t moved_to_compaction_inputs = 0;
                 for (auto&& old_rowset : old_rowsets) {
-                    if (new_rowset_ids.count(old_rowset.id()) == 0) {
-                        _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
+                    if (new_rowset_ids.find(old_rowset.id()) != new_rowset_ids.end()) {
+                        skipped_by_rowset_id++;
+                        continue;
                     }
+                    if (has_rowset_file_overlap(old_rowset, new_referenced_rowset_files)) {
+                        skipped_by_file_overlap++;
+                        continue;
+                    }
+                    _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
+                    moved_to_compaction_inputs++;
                 }
+
+                LOG(INFO) << "Apply full replication rowset gc guard. tablet_id: " << _tablet.id()
+                          << ", txn_id: " << txn_meta.txn_id() << ", skipped_by_rowset_id: " << skipped_by_rowset_id
+                          << ", skipped_by_file_overlap: " << skipped_by_file_overlap
+                          << ", moved_to_compaction_inputs: " << moved_to_compaction_inputs;
             } else {
                 // Non-Lake replication (replication from shared-nothing cluster).
                 auto rssid_remap = build_rssid_remap(op_replication, _metadata->next_rowset_id(), /*is_pk=*/false);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -439,6 +439,7 @@ SET(DW_TEST_FILES
     ./storage/lake/lake_scan_node_test.cpp
     ./storage/lake/metacache_test.cpp
     ./storage/lake/meta_file_test.cpp
+    ./storage/lake/txn_log_applier_lake_replication_test.cpp
     ./storage/lake/partial_update_test.cpp
     ./storage/lake/persistent_index_memtable_test.cpp
     ./storage/lake/persistent_index_sstable_test.cpp

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1330,6 +1330,138 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
 }
 #endif // USE_STAROS
 
+// Test fixture for UUID map visible_version correctness.
+// Validates that convert_and_build_new_tablet_meta() builds the UUID map from
+// visible_version metadata (reflecting physically present files) rather than
+// data_version metadata (which may reference vacuumed files).
+class UUIDMapVisibleVersionTest : public testing::Test {
+public:
+    static MutableTabletMetadataPtr create_metadata(int64_t tablet_id, int64_t version) {
+        auto meta = std::make_shared<TabletMetadata>();
+        meta->set_id(tablet_id);
+        meta->set_version(version);
+        auto* schema = meta->mutable_schema();
+        schema->set_id(tablet_id);
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(KeysType::DUP_KEYS);
+        auto* col = schema->add_column();
+        col->set_unique_id(0);
+        col->set_name("c0");
+        col->set_type("INT");
+        col->set_is_key(true);
+        col->set_is_nullable(false);
+        return meta;
+    }
+
+    static void add_rowset_with_segments(TabletMetadata* meta, int32_t rowset_id,
+                                         const std::vector<std::string>& segment_names,
+                                         const std::vector<size_t>& segment_sizes) {
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(1024);
+        for (size_t i = 0; i < segment_names.size(); ++i) {
+            rowset->add_segments(segment_names[i]);
+            rowset->add_segment_size(i < segment_sizes.size() ? segment_sizes[i] : 512);
+        }
+    }
+};
+
+// Scenario: Target cluster compaction vacuumed files referenced by data_version metadata.
+// UUID map must be built from visible_version (which no longer references vacuumed files),
+// so that source segments are correctly copied instead of being skipped.
+TEST_F(UUIDMapVisibleVersionTest, test_uuid_map_uses_visible_version_not_data_version) {
+    const int64_t src_tablet_id = 10001;
+    const int64_t target_tablet_id = 20001;
+    const TTransactionId txn_id = 99999;
+    const std::string src_data_dir = "/src/data";
+
+    const std::string UUID_A = "aaaaaaaa-bbbb-cccc-dddd-000000000001";
+    const std::string UUID_C = "cccccccc-dddd-eeee-ffff-000000000003";
+    const std::string UUID_D = "dddddddd-eeee-ffff-0000-000000000004";
+
+    // Source metadata: has segments with UUID_A and UUID_D
+    auto src_meta = create_metadata(src_tablet_id, 15);
+    std::string src_seg_a = fmt::format("{:016x}_{}.dat", 1, UUID_A);
+    std::string src_seg_d = fmt::format("{:016x}_{}.dat", 2, UUID_D);
+    add_rowset_with_segments(src_meta.get(), 1, {src_seg_a}, {512});
+    add_rowset_with_segments(src_meta.get(), 2, {src_seg_d}, {512});
+
+    // Target visible_version metadata: after compaction, only has UUID_C (new segment).
+    // UUID_A was in old rowset that got compacted + vacuumed.
+    auto target_visible_meta = create_metadata(target_tablet_id, 3);
+    std::string target_seg_c = fmt::format("{:016x}_{}.dat", 50, UUID_C);
+    add_rowset_with_segments(target_visible_meta.get(), 10, {target_seg_c}, {1024});
+
+    LakeReplicationTxnManager mgr(nullptr);
+    std::unordered_map<std::string, size_t> segment_name_to_size_map;
+    std::map<std::string, std::string> file_locations;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    // Call convert_and_build_new_tablet_meta with target_visible_meta (visible_version).
+    // UUID_A is NOT in visible_version metadata -> should trigger file copy, not skip.
+    auto result = mgr.convert_and_build_new_tablet_meta(src_meta, target_visible_meta, src_tablet_id, target_tablet_id,
+                                                        txn_id, src_data_dir, segment_name_to_size_map, file_locations,
+                                                        filename_map);
+    ASSERT_OK(result.status());
+
+    // Both source segments (UUID_A and UUID_D) should be in file_locations (need to be copied)
+    // because neither UUID exists in the visible_version metadata.
+    EXPECT_EQ(2, file_locations.size());
+    // Verify that UUID_A file was NOT skipped (the bug would have skipped it)
+    bool found_uuid_a = false;
+    for (const auto& [src_path, _] : file_locations) {
+        if (src_path.find(UUID_A) != std::string::npos) {
+            found_uuid_a = true;
+        }
+    }
+    EXPECT_TRUE(found_uuid_a) << "UUID_A segment should be copied, not skipped";
+}
+
+// Positive case: files present in visible_version metadata should be correctly reused.
+TEST_F(UUIDMapVisibleVersionTest, test_uuid_map_reuses_existing_files_from_visible_version) {
+    const int64_t src_tablet_id = 10002;
+    const int64_t target_tablet_id = 20002;
+    const TTransactionId txn_id = 88888;
+    const std::string src_data_dir = "/src/data";
+
+    const std::string UUID_A = "aaaaaaaa-bbbb-cccc-dddd-000000000001";
+    const std::string UUID_B = "bbbbbbbb-cccc-dddd-eeee-000000000002";
+
+    // Source metadata: has segments with UUID_A and UUID_B
+    auto src_meta = create_metadata(src_tablet_id, 10);
+    std::string src_seg_a = fmt::format("{:016x}_{}.dat", 1, UUID_A);
+    std::string src_seg_b = fmt::format("{:016x}_{}.dat", 2, UUID_B);
+    add_rowset_with_segments(src_meta.get(), 1, {src_seg_a, src_seg_b}, {512, 512});
+
+    // Target visible_version metadata: has the same UUID_A (from previous replication, still exists)
+    auto target_visible_meta = create_metadata(target_tablet_id, 2);
+    std::string target_seg_a = fmt::format("{:016x}_{}.dat", 50, UUID_A);
+    add_rowset_with_segments(target_visible_meta.get(), 5, {target_seg_a}, {512});
+
+    LakeReplicationTxnManager mgr(nullptr);
+    std::unordered_map<std::string, size_t> segment_name_to_size_map;
+    std::map<std::string, std::string> file_locations;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    auto result = mgr.convert_and_build_new_tablet_meta(src_meta, target_visible_meta, src_tablet_id, target_tablet_id,
+                                                        txn_id, src_data_dir, segment_name_to_size_map, file_locations,
+                                                        filename_map);
+    ASSERT_OK(result.status());
+
+    // UUID_A exists in visible_version metadata -> should be reused (not copied)
+    // UUID_B does NOT exist -> should be copied
+    EXPECT_EQ(1, file_locations.size());
+    // file_locations should contain UUID_B (needs copy), not UUID_A (reused)
+    bool found_uuid_b = false;
+    for (const auto& [src_path, _] : file_locations) {
+        EXPECT_TRUE(src_path.find(UUID_B) != std::string::npos) << "Only UUID_B should need copying";
+        found_uuid_b = true;
+    }
+    EXPECT_TRUE(found_uuid_b) << "UUID_B segment should be in file_locations for copying";
+}
+
 INSTANTIATE_TEST_SUITE_P(SharedDataReplicationTxnManagerTest, SharedDataReplicationTxnManagerTest,
                          testing::Values(KeysType::DUP_KEYS, KeysType::AGG_KEYS, KeysType::PRIMARY_KEYS));
 

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -50,6 +50,7 @@
 #include "gutil/strings/join.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "service/staros_worker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
@@ -1336,6 +1337,27 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
 // data_version metadata (which may reference vacuumed files).
 class UUIDMapVisibleVersionTest : public testing::Test {
 public:
+    UUIDMapVisibleVersionTest() { _test_dir = kTestDirectory; }
+
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+        _replication_txn_manager = std::make_unique<lake::LakeReplicationTxnManager>(_tablet_mgr.get());
+    }
+
+    void TearDown() override {
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        ASSERT_OK(fs::remove_all(_test_dir));
+    }
+
+public:
     static MutableTabletMetadataPtr create_metadata(int64_t tablet_id, int64_t version) {
         auto meta = std::make_shared<TabletMetadata>();
         meta->set_id(tablet_id);
@@ -1366,6 +1388,16 @@ public:
             rowset->add_segment_size(i < segment_sizes.size() ? segment_sizes[i] : 512);
         }
     }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_uuid_map_visible_version";
+
+    std::string _test_dir;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+    std::unique_ptr<lake::TabletManager> _tablet_mgr;
+    std::unique_ptr<lake::LakeReplicationTxnManager> _replication_txn_manager;
 };
 
 // Scenario: Target cluster compaction vacuumed files referenced by data_version metadata.
@@ -1394,16 +1426,15 @@ TEST_F(UUIDMapVisibleVersionTest, test_uuid_map_uses_visible_version_not_data_ve
     std::string target_seg_c = fmt::format("{:016x}_{}.dat", 50, UUID_C);
     add_rowset_with_segments(target_visible_meta.get(), 10, {target_seg_c}, {1024});
 
-    LakeReplicationTxnManager mgr(nullptr);
     std::unordered_map<std::string, size_t> segment_name_to_size_map;
     std::map<std::string, std::string> file_locations;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
     // Call convert_and_build_new_tablet_meta with target_visible_meta (visible_version).
     // UUID_A is NOT in visible_version metadata -> should trigger file copy, not skip.
-    auto result = mgr.convert_and_build_new_tablet_meta(src_meta, target_visible_meta, src_tablet_id, target_tablet_id,
-                                                        txn_id, src_data_dir, segment_name_to_size_map, file_locations,
-                                                        filename_map);
+    auto result = _replication_txn_manager->convert_and_build_new_tablet_meta(
+            src_meta, target_visible_meta, src_tablet_id, target_tablet_id, txn_id, src_data_dir,
+            segment_name_to_size_map, file_locations, filename_map);
     ASSERT_OK(result.status());
 
     // Both source segments (UUID_A and UUID_D) should be in file_locations (need to be copied)
@@ -1440,14 +1471,13 @@ TEST_F(UUIDMapVisibleVersionTest, test_uuid_map_reuses_existing_files_from_visib
     std::string target_seg_a = fmt::format("{:016x}_{}.dat", 50, UUID_A);
     add_rowset_with_segments(target_visible_meta.get(), 5, {target_seg_a}, {512});
 
-    LakeReplicationTxnManager mgr(nullptr);
     std::unordered_map<std::string, size_t> segment_name_to_size_map;
     std::map<std::string, std::string> file_locations;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    auto result = mgr.convert_and_build_new_tablet_meta(src_meta, target_visible_meta, src_tablet_id, target_tablet_id,
-                                                        txn_id, src_data_dir, segment_name_to_size_map, file_locations,
-                                                        filename_map);
+    auto result = _replication_txn_manager->convert_and_build_new_tablet_meta(
+            src_meta, target_visible_meta, src_tablet_id, target_tablet_id, txn_id, src_data_dir,
+            segment_name_to_size_map, file_locations, filename_map);
     ASSERT_OK(result.status());
 
     // UUID_A exists in visible_version metadata -> should be reused (not copied)

--- a/be/test/storage/lake/txn_log_applier_lake_replication_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_lake_replication_test.cpp
@@ -77,7 +77,7 @@ TxnLogPB build_full_lake_replication_log(int64_t tablet_id, int64_t txn_id,
 
 } // namespace
 
-TEST(TxnLogApplierLakeReplicationTest, FullReplicationSkipsCompactionInputsWhenSegmentOverlaps) {
+TEST(TxnLogApplierLakeReplicationTest, FullReplicationSkipsCompactionInputsWhenFilesOverlap) {
     constexpr int64_t kTabletId = 902001;
     Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), kTabletId);
     auto metadata = new_non_pk_metadata(kTabletId);

--- a/be/test/storage/lake/txn_log_applier_lake_replication_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_lake_replication_test.cpp
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "runtime/exec_env.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/txn_log_applier.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+MutableTabletMetadataPtr new_non_pk_metadata(int64_t tablet_id) {
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(1);
+    metadata->mutable_schema()->set_id(1001);
+    metadata->mutable_schema()->set_keys_type(DUP_KEYS);
+    return metadata;
+}
+
+RowsetMetadataPB build_rowset(uint32_t rowset_id, const std::string& segment_name,
+                              const std::string& del_file_name = "") {
+    RowsetMetadataPB rowset;
+    rowset.set_id(rowset_id);
+    rowset.set_num_rows(10);
+    rowset.set_data_size(100);
+    rowset.add_segments(segment_name);
+    rowset.add_segment_size(100);
+    if (!del_file_name.empty()) {
+        auto* del_file = rowset.add_del_files();
+        del_file->set_name(del_file_name);
+    }
+    return rowset;
+}
+
+TxnLogPB build_full_lake_replication_log(int64_t tablet_id, int64_t txn_id,
+                                         const std::vector<RowsetMetadataPB>& new_rowsets, uint32_t next_rowset_id) {
+    TxnLogPB log;
+    log.set_tablet_id(tablet_id);
+    log.set_txn_id(txn_id);
+    auto* op_replication = log.mutable_op_replication();
+
+    auto* txn_meta = op_replication->mutable_txn_meta();
+    txn_meta->set_txn_id(txn_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_visible_version(1);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false);
+
+    auto* tablet_metadata = op_replication->mutable_tablet_metadata();
+    tablet_metadata->set_next_rowset_id(next_rowset_id);
+    for (const auto& rowset : new_rowsets) {
+        tablet_metadata->add_rowsets()->CopyFrom(rowset);
+    }
+    return log;
+}
+
+} // namespace
+
+TEST(TxnLogApplierLakeReplicationTest, FullReplicationSkipsCompactionInputsWhenSegmentOverlaps) {
+    constexpr int64_t kTabletId = 902001;
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), kTabletId);
+    auto metadata = new_non_pk_metadata(kTabletId);
+    metadata->add_rowsets()->CopyFrom(
+            build_rowset(10, "0000000000000010_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat", "shared.del"));
+
+    auto applier = new_txn_log_applier(tablet, metadata, 2, false, true);
+
+    std::vector<RowsetMetadataPB> new_rowsets;
+    new_rowsets.emplace_back(
+            build_rowset(20, "0000000000000020_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat", "shared.del"));
+    TxnLogPB log = build_full_lake_replication_log(kTabletId, 70001, new_rowsets, 21);
+
+    ASSERT_OK(applier->apply(log));
+    EXPECT_EQ(1, metadata->rowsets_size());
+    EXPECT_EQ(20, metadata->rowsets(0).id());
+    EXPECT_EQ(0, metadata->compaction_inputs_size());
+}
+
+TEST(TxnLogApplierLakeReplicationTest, FullReplicationMovesOnlyNonOverlappedOldRowsetToCompactionInputs) {
+    constexpr int64_t kTabletId = 902002;
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), kTabletId);
+    auto metadata = new_non_pk_metadata(kTabletId);
+    metadata->add_rowsets()->CopyFrom(build_rowset(11, "0000000000000011_deadbeef-dead-beef-dead-beef00000001.dat"));
+
+    auto applier = new_txn_log_applier(tablet, metadata, 2, false, true);
+
+    std::vector<RowsetMetadataPB> new_rowsets;
+    new_rowsets.emplace_back(build_rowset(21, "0000000000000021_cafebabe-cafe-babe-cafe-babe00000001.dat"));
+    TxnLogPB log = build_full_lake_replication_log(kTabletId, 70002, new_rowsets, 22);
+
+    ASSERT_OK(applier->apply(log));
+    ASSERT_EQ(1, metadata->compaction_inputs_size());
+    EXPECT_EQ(11, metadata->compaction_inputs(0).id());
+    EXPECT_EQ("0000000000000011_deadbeef-dead-beef-dead-beef00000001.dat", metadata->compaction_inputs(0).segments(0));
+}
+
+TEST(TxnLogApplierLakeReplicationTest, FullReplicationSkipsCompactionInputsWhenRowsetIdOverlaps) {
+    constexpr int64_t kTabletId = 902003;
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), kTabletId);
+    auto metadata = new_non_pk_metadata(kTabletId);
+    metadata->add_rowsets()->CopyFrom(build_rowset(30, "0000000000000030_old-old0-old0-old0-old000000001.dat"));
+
+    auto applier = new_txn_log_applier(tablet, metadata, 2, false, true);
+
+    std::vector<RowsetMetadataPB> new_rowsets;
+    new_rowsets.emplace_back(build_rowset(30, "0000000000000031_new-new0-new0-new0-new000000001.dat"));
+    TxnLogPB log = build_full_lake_replication_log(kTabletId, 70003, new_rowsets, 31);
+
+    ASSERT_OK(applier->apply(log));
+    EXPECT_EQ(0, metadata->compaction_inputs_size());
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Lake-to-lake replication may fail or become unsafe when the target cluster runs compaction between replication rounds. In this case, metadata and physical files can diverge over time, which may cause:

* references to files that are already vacuumed, or
* aggressive cleanup of files still needed by the latest replicated snapshot.

Our goal is correctness first: no data loss and no broken reads, even if users forget to disable compaction during migration.

## What I'm doing:

This change improves replication safety under target-side compaction by making replication decisions based on the target’s currently visible state and by applying safer cleanup rules during full replication.

As a result, replication remains correct and robust in real-world operations. We accept possible extra cost (temporary duplicate files or repeated compaction/copy work) as a trade-off for stronger data safety.

__Note that__ : with current full lake-to-lake replication feature, it's recommend that the target cluster should disable compaction first before starting replicating any table.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
