### PR TITLE
[Enhancement] Add tablet reshard metrics for split and merge operations

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -14,10 +14,10 @@
 
 #include "storage/lake/tablet_reshard.h"
 
-#include <unordered_map>
-
-#include <bvar/bvar.h>
 #include <butil/time.h>
+#include <bvar/bvar.h>
+
+#include <unordered_map>
 
 #include "common/logging.h"
 #include "storage/lake/metacache.h"

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -16,12 +16,43 @@
 
 #include <unordered_map>
 
+#include <bvar/bvar.h>
+#include <butil/time.h>
+
 #include "common/logging.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_merger.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_splitter.h"
+
+// Layer 1: Reshard operation overall metrics
+bvar::Adder<int64_t> g_tablet_reshard_total("tablet_reshard_total");
+bvar::Adder<int64_t> g_tablet_reshard_failed("tablet_reshard_failed");
+bvar::LatencyRecorder g_tablet_reshard_latency("tablet_reshard");
+
+// Layer 2: Split metrics
+bvar::Adder<int64_t> g_tablet_reshard_split_total("tablet_reshard_split_total");
+bvar::Adder<int64_t> g_tablet_reshard_split_failed("tablet_reshard_split_failed");
+bvar::LatencyRecorder g_tablet_reshard_split_latency("tablet_reshard_split");
+bvar::Adder<int64_t> g_tablet_reshard_split_output_tablet_count("tablet_reshard_split_output_tablet_count");
+bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total("tablet_reshard_split_fallback_total");
+
+// Layer 2: Merge metrics
+bvar::Adder<int64_t> g_tablet_reshard_merge_total("tablet_reshard_merge_total");
+bvar::Adder<int64_t> g_tablet_reshard_merge_failed("tablet_reshard_merge_failed");
+bvar::LatencyRecorder g_tablet_reshard_merge_latency("tablet_reshard_merge");
+bvar::Adder<int64_t> g_tablet_reshard_merge_input_tablet_count("tablet_reshard_merge_input_tablet_count");
+
+// Layer 2: Identical metrics
+bvar::Adder<int64_t> g_tablet_reshard_identical_total("tablet_reshard_identical_total");
+bvar::Adder<int64_t> g_tablet_reshard_identical_failed("tablet_reshard_identical_failed");
+
+// Layer 3: Cross publish metrics
+bvar::Adder<int64_t> g_tablet_reshard_cross_publish_total("tablet_reshard_cross_publish_total");
+bvar::Adder<int64_t> g_tablet_reshard_cross_publish_splitting_total("tablet_reshard_cross_publish_splitting_total");
+bvar::Adder<int64_t> g_tablet_reshard_cross_publish_merging_total("tablet_reshard_cross_publish_merging_total");
+bvar::Adder<int64_t> g_tablet_reshard_cross_publish_identical_total("tablet_reshard_cross_publish_identical_total");
 
 namespace starrocks::lake {
 
@@ -70,12 +101,15 @@ Status handle_splitting_tablet(TabletManager* tablet_manager, const SplittingTab
     }
 
 CONTINUE_HANDLE_SPLITTING_TABLET:
+    g_tablet_reshard_split_total << 1;
+
     auto old_tablet_old_metadata_or =
             tablet_manager->get_tablet_metadata(splitting_tablet.old_tablet_id(), base_version, false);
     if (old_tablet_old_metadata_or.status().is_not_found()) {
         auto old_tablet_new_metadata_or =
                 tablet_manager->get_tablet_metadata(splitting_tablet.old_tablet_id(), new_version, txn_info.gtid());
         if (!old_tablet_new_metadata_or.ok()) {
+            g_tablet_reshard_split_failed << 1;
             return old_tablet_old_metadata_or.status();
         }
         new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(old_tablet_new_metadata_or.value()));
@@ -84,6 +118,7 @@ CONTINUE_HANDLE_SPLITTING_TABLET:
             auto new_tablet_new_metadata_or =
                     tablet_manager->get_tablet_metadata(new_tablet_id, new_version, txn_info.gtid());
             if (!new_tablet_new_metadata_or.ok()) {
+                g_tablet_reshard_split_failed << 1;
                 return old_tablet_old_metadata_or.status();
             }
             auto& new_tablet_new_metadata = new_tablet_new_metadata_or.value();
@@ -96,6 +131,7 @@ CONTINUE_HANDLE_SPLITTING_TABLET:
     if (!old_tablet_old_metadata_or.ok()) {
         LOG(WARNING) << "Failed to get tablet: " << splitting_tablet.old_tablet_id() << ", version: " << base_version
                      << ", txn_id: " << txn_info.txn_id() << ", status: " << old_tablet_old_metadata_or.status();
+        g_tablet_reshard_split_failed << 1;
         return old_tablet_old_metadata_or.status();
     }
 
@@ -108,8 +144,16 @@ CONTINUE_HANDLE_SPLITTING_TABLET:
     tablet_reshard_helper::set_all_data_files_shared(old_tablet_new_metadata.get());
     new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(old_tablet_new_metadata));
 
-    ASSIGN_OR_RETURN(auto split_new_metadatas,
-                     split_tablet(tablet_manager, old_tablet_old_metadata, splitting_tablet, new_version, txn_info));
+    auto split_start_ts = butil::gettimeofday_us();
+    auto split_new_metadatas_or =
+            split_tablet(tablet_manager, old_tablet_old_metadata, splitting_tablet, new_version, txn_info);
+    if (!split_new_metadatas_or.ok()) {
+        g_tablet_reshard_split_failed << 1;
+        return split_new_metadatas_or.status();
+    }
+    g_tablet_reshard_split_latency << (butil::gettimeofday_us() - split_start_ts);
+    auto split_new_metadatas = std::move(split_new_metadatas_or.value());
+    g_tablet_reshard_split_output_tablet_count << split_new_metadatas.size();
     for (auto& [tablet_id, tablet_metadata] : split_new_metadatas) {
         tablet_ranges.emplace(tablet_id, tablet_metadata->range());
         new_metadatas.emplace(tablet_id, std::move(tablet_metadata));
@@ -147,6 +191,9 @@ Status handle_merging_tablet(TabletManager* tablet_manager, const MergingTabletI
     }
 
 CONTINUE_HANDLE_MERGING_TABLET:
+    g_tablet_reshard_merge_total << 1;
+    g_tablet_reshard_merge_input_tablet_count << merging_tablet.old_tablet_ids_size();
+
     std::vector<TabletMetadataPtr> old_tablet_metadatas;
     old_tablet_metadatas.reserve(merging_tablet.old_tablet_ids_size());
     for (auto old_tablet_id : merging_tablet.old_tablet_ids()) {
@@ -157,6 +204,7 @@ CONTINUE_HANDLE_MERGING_TABLET:
                 auto old_tablet_new_metadata_or =
                         tablet_manager->get_tablet_metadata(retry_tablet_id, new_version, txn_info.gtid());
                 if (!old_tablet_new_metadata_or.ok()) {
+                    g_tablet_reshard_merge_failed << 1;
                     return old_tablet_old_metadata_or.status();
                 }
                 new_metadatas.emplace(retry_tablet_id, std::move(old_tablet_new_metadata_or.value()));
@@ -164,6 +212,7 @@ CONTINUE_HANDLE_MERGING_TABLET:
             auto new_tablet_new_metadata_or =
                     tablet_manager->get_tablet_metadata(merging_tablet.new_tablet_id(), new_version, txn_info.gtid());
             if (!new_tablet_new_metadata_or.ok()) {
+                g_tablet_reshard_merge_failed << 1;
                 return old_tablet_old_metadata_or.status();
             }
             auto& new_tablet_new_metadata = new_tablet_new_metadata_or.value();
@@ -174,6 +223,7 @@ CONTINUE_HANDLE_MERGING_TABLET:
         if (!old_tablet_old_metadata_or.ok()) {
             LOG(WARNING) << "Failed to get tablet: " << old_tablet_id << ", version: " << base_version
                          << ", txn_id: " << txn_info.txn_id() << ", status: " << old_tablet_old_metadata_or.status();
+            g_tablet_reshard_merge_failed << 1;
             return old_tablet_old_metadata_or.status();
         }
         old_tablet_metadatas.emplace_back(std::move(old_tablet_old_metadata_or.value()));
@@ -188,8 +238,15 @@ CONTINUE_HANDLE_MERGING_TABLET:
         new_metadatas.emplace(old_tablet_old_metadata->id(), std::move(old_tablet_new_metadata));
     }
 
-    ASSIGN_OR_RETURN(auto new_tablet_metadata,
-                     merge_tablet(tablet_manager, old_tablet_metadatas, merging_tablet, new_version, txn_info));
+    auto merge_start_ts = butil::gettimeofday_us();
+    auto new_tablet_metadata_or =
+            merge_tablet(tablet_manager, old_tablet_metadatas, merging_tablet, new_version, txn_info);
+    if (!new_tablet_metadata_or.ok()) {
+        g_tablet_reshard_merge_failed << 1;
+        return new_tablet_metadata_or.status();
+    }
+    g_tablet_reshard_merge_latency << (butil::gettimeofday_us() - merge_start_ts);
+    auto new_tablet_metadata = std::move(new_tablet_metadata_or.value());
 
     tablet_ranges.emplace(merging_tablet.new_tablet_id(), new_tablet_metadata->range());
     new_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(new_tablet_metadata));
@@ -224,12 +281,15 @@ Status handle_identical_tablet(TabletManager* tablet_manager, const IdenticalTab
     }
 
 CONTINUE_HANDLE_IDENTICAL_TABLET:
+    g_tablet_reshard_identical_total << 1;
+
     auto old_tablet_old_metadata_or =
             tablet_manager->get_tablet_metadata(identical_tablet.old_tablet_id(), base_version, false);
     if (old_tablet_old_metadata_or.status().is_not_found()) {
         auto old_tablet_new_metadata_or =
                 tablet_manager->get_tablet_metadata(identical_tablet.old_tablet_id(), new_version, txn_info.gtid());
         if (!old_tablet_new_metadata_or.ok()) {
+            g_tablet_reshard_identical_failed << 1;
             return old_tablet_old_metadata_or.status();
         }
         new_metadatas.emplace(identical_tablet.old_tablet_id(), std::move(old_tablet_new_metadata_or.value()));
@@ -237,6 +297,7 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
         auto new_tablet_new_metadata_or =
                 tablet_manager->get_tablet_metadata(identical_tablet.new_tablet_id(), new_version, txn_info.gtid());
         if (!new_tablet_new_metadata_or.ok()) {
+            g_tablet_reshard_identical_failed << 1;
             return old_tablet_old_metadata_or.status();
         }
         new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(new_tablet_new_metadata_or.value()));
@@ -246,6 +307,7 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
     if (!old_tablet_old_metadata_or.ok()) {
         LOG(WARNING) << "Failed to get tablet: " << identical_tablet.old_tablet_id() << ", version: " << base_version
                      << ", txn_id: " << txn_info.txn_id() << ", status: " << old_tablet_old_metadata_or.status();
+        g_tablet_reshard_identical_failed << 1;
         return old_tablet_old_metadata_or.status();
     }
 
@@ -287,6 +349,21 @@ StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetada
         return txn_log;
     }
 
+    g_tablet_reshard_cross_publish_total << 1;
+    switch (publish_tablet_info.get_publish_tablet_type()) {
+    case PublishTabletInfo::SPLITTING_TABLET:
+        g_tablet_reshard_cross_publish_splitting_total << 1;
+        break;
+    case PublishTabletInfo::MERGING_TABLET:
+        g_tablet_reshard_cross_publish_merging_total << 1;
+        break;
+    case PublishTabletInfo::IDENTICAL_TABLET:
+        g_tablet_reshard_cross_publish_identical_total << 1;
+        break;
+    default:
+        break;
+    }
+
     auto new_txn_log = std::make_shared<TxnLogPB>(*txn_log);
     new_txn_log->set_tablet_id(publish_tablet_info.get_tablet_id_in_metadata());
 
@@ -303,30 +380,49 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                  bool skip_write_tablet_metadata,
                                  std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
                                  std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
+    g_tablet_reshard_total << 1;
+    auto reshard_start_ts = butil::gettimeofday_us();
+
     LOG(INFO) << "Start publish resharding tablet"
               << ", resharding_tablet=" << resharding_tablet.DebugString() << ", txn_info=" << txn_info.DebugString()
               << ", base_version=" << base_version << ", new_version=" << new_version;
 
+    auto handle_status = Status::OK();
     if (resharding_tablet.has_splitting_tablet_info()) {
-        RETURN_IF_ERROR(handle_splitting_tablet(tablet_manager, resharding_tablet.splitting_tablet_info(), base_version,
-                                                new_version, txn_info, tablet_metadatas, tablet_ranges));
+        handle_status = handle_splitting_tablet(tablet_manager, resharding_tablet.splitting_tablet_info(), base_version,
+                                                new_version, txn_info, tablet_metadatas, tablet_ranges);
     } else if (resharding_tablet.has_merging_tablet_info()) {
-        RETURN_IF_ERROR(handle_merging_tablet(tablet_manager, resharding_tablet.merging_tablet_info(), base_version,
-                                              new_version, txn_info, tablet_metadatas, tablet_ranges));
+        handle_status = handle_merging_tablet(tablet_manager, resharding_tablet.merging_tablet_info(), base_version,
+                                              new_version, txn_info, tablet_metadatas, tablet_ranges);
     } else if (resharding_tablet.has_identical_tablet_info()) {
-        RETURN_IF_ERROR(handle_identical_tablet(tablet_manager, resharding_tablet.identical_tablet_info(), base_version,
-                                                new_version, txn_info, tablet_metadatas));
+        handle_status = handle_identical_tablet(tablet_manager, resharding_tablet.identical_tablet_info(), base_version,
+                                                new_version, txn_info, tablet_metadatas);
+    }
+
+    if (!handle_status.ok()) {
+        g_tablet_reshard_failed << 1;
+        return handle_status;
     }
 
     for (const auto& [tablet_id, new_metadata] : tablet_metadatas) {
         if (!skip_write_tablet_metadata) {
-            RETURN_IF_ERROR(tablet_manager->put_tablet_metadata(new_metadata));
+            auto st = tablet_manager->put_tablet_metadata(new_metadata);
+            if (!st.ok()) {
+                g_tablet_reshard_failed << 1;
+                return st;
+            }
         } else {
-            RETURN_IF_ERROR(tablet_manager->cache_tablet_metadata(new_metadata));
+            auto st = tablet_manager->cache_tablet_metadata(new_metadata);
+            if (!st.ok()) {
+                g_tablet_reshard_failed << 1;
+                return st;
+            }
             tablet_manager->metacache()->cache_aggregation_partition(
                     tablet_manager->tablet_metadata_root_location(tablet_id), true);
         }
     }
+
+    g_tablet_reshard_latency << (butil::gettimeofday_us() - reshard_start_ts);
 
     LOG(INFO) << "Finish publish resharding tablet"
               << ", resharding_tablet=" << resharding_tablet.DebugString() << ", txn_info=" << txn_info.DebugString()

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -14,12 +14,12 @@
 
 #include "storage/lake/tablet_splitter.h"
 
+#include <bvar/bvar.h>
+
 #include <algorithm>
 #include <set>
 #include <unordered_map>
 #include <vector>
-
-#include <bvar/bvar.h>
 
 #include "common/logging.h"
 #include "storage/lake/tablet_manager.h"

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -19,10 +19,14 @@
 #include <unordered_map>
 #include <vector>
 
+#include <bvar/bvar.h>
+
 #include "common/logging.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/tablet_range.h"
+
+extern bvar::Adder<int64_t> g_tablet_reshard_split_fallback_total;
 
 namespace starrocks::lake {
 
@@ -381,6 +385,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     std::vector<TabletRangeInfo> split_ranges;
     Status status = get_tablet_split_ranges(old_tablet_metadata, splitting_tablet.new_tablet_ids_size(), &split_ranges);
     if (!status.ok()) {
+        g_tablet_reshard_split_fallback_total << 1;
         LOG(WARNING) << "Failed to get tablet split ranges, will not split this tablet: " << old_tablet_metadata->id()
                      << ", version: " << old_tablet_metadata->version() << ", txn_id: " << txn_info.txn_id()
                      << ", status: " << status;

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -2241,3 +2241,143 @@ The following metrics are exposed on the BE Prometheus endpoint (`/metrics`):
 - Unit: Bytes
 - Type: Counter
 - Description: Cumulative bytes of block cache misses. For now, only the cache miss bytes for external table is being counted.
+
+### Tablet Reshard Metrics
+
+Tablet reshard metrics provide visibility into tablet split and merge operations in shared-data mode with range distribution tables.
+
+#### FE Metrics
+
+##### starrocks_fe_job{job="tablet_reshard"}
+
+- Unit: Count
+- Type: Gauge
+- Labels: `job=tablet_reshard`, `type=SPLIT_TABLET|MERGE_TABLET`, `state=PENDING|PREPARING|RUNNING|CLEANING|FINISHED|ABORTING|ABORTED`
+- Description: Number of tablet reshard jobs in each state.
+
+##### starrocks_fe_tablet_reshard_parallel_tablets
+
+- Unit: Count
+- Type: Gauge
+- Description: Total number of tablets currently being resharded across all active jobs.
+
+##### starrocks_fe_tablet_reshard_job_total
+
+- Unit: Count
+- Type: Counter
+- Labels: `type=split|merge`
+- Description: Cumulative number of tablet reshard jobs created.
+
+##### starrocks_fe_tablet_reshard_job_finished
+
+- Unit: Count
+- Type: Counter
+- Labels: `type=split|merge`
+- Description: Cumulative number of tablet reshard jobs that finished successfully.
+
+##### starrocks_fe_tablet_reshard_job_aborted
+
+- Unit: Count
+- Type: Counter
+- Labels: `type=split|merge`
+- Description: Cumulative number of tablet reshard jobs that were aborted.
+
+##### starrocks_fe_tablet_reshard_job_duration_ms
+
+- Unit: ms
+- Type: Histogram
+- Description: Duration distribution (in milliseconds) of completed tablet reshard jobs.
+
+#### BE Metrics (bvar)
+
+The following metrics are exposed on the BE `/vars` HTTP endpoint with the `tablet_reshard_` prefix.
+
+##### tablet_reshard_total
+
+- Type: Counter
+- Description: Total number of reshard operations executed (one per `publish_resharding_tablet` call).
+
+##### tablet_reshard_failed
+
+- Type: Counter
+- Description: Number of reshard operations that failed.
+
+##### tablet_reshard_latency
+
+- Type: LatencyRecorder (us)
+- Description: End-to-end latency of reshard operations in microseconds.
+
+##### tablet_reshard_split_total
+
+- Type: Counter
+- Description: Total number of tablet split operations.
+
+##### tablet_reshard_split_failed
+
+- Type: Counter
+- Description: Number of tablet split operations that failed.
+
+##### tablet_reshard_split_latency
+
+- Type: LatencyRecorder (us)
+- Description: Latency of the `split_tablet` computation in microseconds.
+
+##### tablet_reshard_split_output_tablet_count
+
+- Type: Counter
+- Description: Cumulative number of output tablets produced by split operations.
+
+##### tablet_reshard_split_fallback_total
+
+- Type: Counter
+- Description: Number of split operations that fell back to identical (copy) because split boundaries could not be computed.
+
+##### tablet_reshard_merge_total
+
+- Type: Counter
+- Description: Total number of tablet merge operations.
+
+##### tablet_reshard_merge_failed
+
+- Type: Counter
+- Description: Number of tablet merge operations that failed.
+
+##### tablet_reshard_merge_latency
+
+- Type: LatencyRecorder (us)
+- Description: Latency of the `merge_tablet` computation in microseconds.
+
+##### tablet_reshard_merge_input_tablet_count
+
+- Type: Counter
+- Description: Cumulative number of input tablets consumed by merge operations.
+
+##### tablet_reshard_identical_total
+
+- Type: Counter
+- Description: Total number of identical (metadata copy) operations.
+
+##### tablet_reshard_identical_failed
+
+- Type: Counter
+- Description: Number of identical operations that failed.
+
+##### tablet_reshard_cross_publish_total
+
+- Type: Counter
+- Description: Total number of cross-publish operations (txn log conversions during reshard).
+
+##### tablet_reshard_cross_publish_splitting_total
+
+- Type: Counter
+- Description: Number of cross-publish operations for splitting tablets (1 txn log applied to N tablets).
+
+##### tablet_reshard_cross_publish_merging_total
+
+- Type: Counter
+- Description: Number of cross-publish operations for merging tablets (N txn logs applied to 1 tablet).
+
+##### tablet_reshard_cross_publish_identical_total
+
+- Type: Counter
+- Description: Number of cross-publish operations for identical tablets (1 txn log applied to another tablet).

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -32,6 +32,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
@@ -288,7 +289,13 @@ public class MergeTabletJob extends TabletReshardJob {
         // 4. Set tablet state to NORMAL
         setTableState(OlapTable.OlapTableState.TABLET_RESHARD, OlapTable.OlapTableState.NORMAL);
 
-        // 5. Set job state to FINISHED
+        // 5. Update metrics
+        if (MetricRepo.hasInit) {
+            MetricRepo.COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED.increase(1L);
+            MetricRepo.HISTO_TABLET_RESHARD_JOB_DURATION.update(System.currentTimeMillis() - createdTimeMs);
+        }
+
+        // 6. Set job state to FINISHED
         setJobState(JobState.FINISHED);
     }
 
@@ -301,7 +308,8 @@ public class MergeTabletJob extends TabletReshardJob {
      * 1. Unregister resharding tablets
      * 2. Remove new tablets from inverted index
      * 3. Set table state to NORMAL
-     * 4. Set job state to ABORTED
+     * 4. Update metrics
+     * 5. Set job state to ABORTED
      */
     @Override
     protected void runAbortingJob() {
@@ -318,7 +326,12 @@ public class MergeTabletJob extends TabletReshardJob {
             LOG.warn("Ignore exception when aborting tablet reshard job. {}. ", this, e);
         }
 
-        // 4. Set job state to ABORTED
+        // 4. Update metrics
+        if (MetricRepo.hasInit) {
+            MetricRepo.COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED.increase(1L);
+        }
+
+        // 5. Set job state to ABORTED
         setJobState(JobState.ABORTED);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -32,6 +32,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
@@ -303,6 +304,12 @@ public class SplitTabletJob extends TabletReshardJob {
         // 4. Set tablet state to NORMAL
         setTableState(OlapTable.OlapTableState.TABLET_RESHARD, OlapTable.OlapTableState.NORMAL);
 
+        // 5. Update metrics
+        if (MetricRepo.hasInit) {
+            MetricRepo.COUNTER_TABLET_RESHARD_SPLIT_JOB_FINISHED.increase(1L);
+            MetricRepo.HISTO_TABLET_RESHARD_JOB_DURATION.update(System.currentTimeMillis() - createdTimeMs);
+        }
+
         // 6. Set job state to FINISHED
         setJobState(JobState.FINISHED);
     }
@@ -316,7 +323,8 @@ public class SplitTabletJob extends TabletReshardJob {
      * 1. Unregister resharding tablets
      * 2. Remove new tablets from inverted index
      * 3. Set table state to NORMAL
-     * 4. Set job state to ABORTED
+     * 4. Update metrics
+     * 5. Set job state to ABORTED
      */
     @Override
     protected void runAbortingJob() {
@@ -333,7 +341,12 @@ public class SplitTabletJob extends TabletReshardJob {
             LOG.warn("Ignore exception when aborting tablet reshard job. {}. ", this, e);
         }
 
-        // 4. Set job state to ABORTED
+        // 4. Update metrics
+        if (MetricRepo.hasInit) {
+            MetricRepo.COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED.increase(1L);
+        }
+
+        // 5. Set job state to ABORTED
         setJobState(JobState.ABORTED);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -100,6 +101,14 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         }
 
         GlobalStateMgr.getCurrentState().getEditLog().logUpdateTabletReshardJob(tabletReshardJob);
+
+        if (MetricRepo.hasInit) {
+            if (tabletReshardJob.getJobType() == TabletReshardJob.JobType.SPLIT_TABLET) {
+                MetricRepo.COUNTER_TABLET_RESHARD_SPLIT_JOB_TOTAL.increase(1L);
+            } else if (tabletReshardJob.getJobType() == TabletReshardJob.JobType.MERGE_TABLET) {
+                MetricRepo.COUNTER_TABLET_RESHARD_MERGE_JOB_TOTAL.increase(1L);
+            }
+        }
 
         LOG.info("Added tablet reshard job. {}", tabletReshardJob);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -42,6 +42,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.reshard.TabletReshardJob;
+import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.backup.AbstractJob;
 import com.starrocks.backup.BackupJob;
 import com.starrocks.backup.RestoreJob;
@@ -246,6 +248,14 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_VACUUM_FILES_NUMBER;
     public static LongCounterMetric COUNTER_VACUUM_FILES_BYTES;
 
+    // tablet reshard metrics
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_SPLIT_JOB_TOTAL;
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_MERGE_JOB_TOTAL;
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_SPLIT_JOB_FINISHED;
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED;
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED;
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED;
+
     public static Histogram HISTO_QUERY_LATENCY;
     public static Histogram HISTO_EDIT_LOG_WRITE_LATENCY;
     public static Histogram HISTO_JOURNAL_WRITE_LATENCY;
@@ -253,6 +263,7 @@ public final class MetricRepo {
     public static Histogram HISTO_JOURNAL_WRITE_BYTES;
     public static Histogram HISTO_SHORTCIRCUIT_RPC_LATENCY;
     public static Histogram HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY;
+    public static Histogram HISTO_TABLET_RESHARD_JOB_DURATION;
 
     // following metrics will be updated by metric calculator
     public static GaugeMetricImpl<Double> GAUGE_QUERY_PER_SECOND;
@@ -363,6 +374,41 @@ public final class MetricRepo {
                     .addLabel(new MetricLabel("type", jobType.name()))
                     .addLabel(new MetricLabel("state", "running"));
             STARROCKS_METRIC_REGISTER.addMetric(gauge);
+        }
+
+        // tablet reshard jobs
+        TabletReshardJobMgr tabletReshardJobMgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        if (tabletReshardJobMgr != null) {
+            for (TabletReshardJob.JobType reshardJobType : TabletReshardJob.JobType.values()) {
+                for (TabletReshardJob.JobState reshardJobState : TabletReshardJob.JobState.values()) {
+                    Metric<Long> gauge = new LeaderAwareGaugeMetricLong("job",
+                            MetricUnit.NOUNIT, "job statistics") {
+                        @Override
+                        public Long getValueLeader() {
+                            long count = 0;
+                            for (TabletReshardJob job : tabletReshardJobMgr.getTabletReshardJobs().values()) {
+                                if (job.getJobType() == reshardJobType && job.getJobState() == reshardJobState) {
+                                    count++;
+                                }
+                            }
+                            return count;
+                        }
+                    };
+                    gauge.addLabel(new MetricLabel("job", "tablet_reshard"))
+                            .addLabel(new MetricLabel("type", reshardJobType.name()))
+                            .addLabel(new MetricLabel("state", reshardJobState.name()));
+                    STARROCKS_METRIC_REGISTER.addMetric(gauge);
+                }
+            }
+
+            Metric<Long> parallelTabletsGauge = new LeaderAwareGaugeMetricLong("tablet_reshard_parallel_tablets",
+                    MetricUnit.NOUNIT, "number of tablets being resharded") {
+                @Override
+                public Long getValueLeader() {
+                    return tabletReshardJobMgr.getTotalParallelTablets();
+                }
+            };
+            STARROCKS_METRIC_REGISTER.addMetric(parallelTabletsGauge);
         }
 
         // capacity
@@ -717,6 +763,33 @@ public final class MetricRepo {
                 "total file bytes have been vacuumed");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_VACUUM_FILES_BYTES);
 
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_TOTAL = new LongCounterMetric("tablet_reshard_job_total",
+                MetricUnit.REQUESTS, "total tablet reshard split jobs created");
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_TOTAL.addLabel(new MetricLabel("type", "split"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_SPLIT_JOB_TOTAL);
+        COUNTER_TABLET_RESHARD_MERGE_JOB_TOTAL = new LongCounterMetric("tablet_reshard_job_total",
+                MetricUnit.REQUESTS, "total tablet reshard merge jobs created");
+        COUNTER_TABLET_RESHARD_MERGE_JOB_TOTAL.addLabel(new MetricLabel("type", "merge"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_MERGE_JOB_TOTAL);
+
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_FINISHED = new LongCounterMetric("tablet_reshard_job_finished",
+                MetricUnit.REQUESTS, "total tablet reshard split jobs finished");
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_FINISHED.addLabel(new MetricLabel("type", "split"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_SPLIT_JOB_FINISHED);
+        COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED = new LongCounterMetric("tablet_reshard_job_finished",
+                MetricUnit.REQUESTS, "total tablet reshard merge jobs finished");
+        COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED.addLabel(new MetricLabel("type", "merge"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED);
+
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED = new LongCounterMetric("tablet_reshard_job_aborted",
+                MetricUnit.REQUESTS, "total tablet reshard split jobs aborted");
+        COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED.addLabel(new MetricLabel("type", "split"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED);
+        COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED = new LongCounterMetric("tablet_reshard_job_aborted",
+                MetricUnit.REQUESTS, "total tablet reshard merge jobs aborted");
+        COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED.addLabel(new MetricLabel("type", "merge"));
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED);
+
         // 3. histogram
         HISTO_QUERY_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("query", "latency", "ms"));
         HISTO_EDIT_LOG_WRITE_LATENCY =
@@ -730,6 +803,8 @@ public final class MetricRepo {
         HISTO_SHORTCIRCUIT_RPC_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("shortcircuit", "latency", "ms"));
         HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY = METRIC_REGISTER.histogram(
                 MetricRegistry.name("deploy_plan_fragments", "latency", "ms"));
+        HISTO_TABLET_RESHARD_JOB_DURATION = METRIC_REGISTER.histogram(
+                MetricRegistry.name("tablet_reshard_job", "duration", "ms"));
 
         // init system metrics
         initSystemMetrics();


### PR DESCRIPTION
  ## Why I'm doing:

  Shared-data mode range distribution tables support tablet split and merge (reshard), but there are no metrics to reflect operation status. This makes it difficult to monitor, troubleshoot, and alert on reshard operations. This PR adds comprehensive metrics at both FE
   and BE layers.

  ## What I'm doing:

  ### FE Metrics

  - **Job state gauges**: `job{job="tablet_reshard", type, state}` — number of reshard jobs in each state (LeaderAwareGauge)
  - **Parallel tablets gauge**: `tablet_reshard_parallel_tablets` — total tablets currently being resharded
  - **Job counters**: `tablet_reshard_job_total`, `tablet_reshard_job_finished`, `tablet_reshard_job_aborted` with `type=split|merge` label
  - **Job duration histogram**: `tablet_reshard_job_duration_ms` — job end-to-end duration distribution

  ### BE Metrics (bvar)

  **Layer 1 — Reshard overall** (`publish_resharding_tablet`):
  - `tablet_reshard_total` / `tablet_reshard_failed` / `tablet_reshard_latency`

  **Layer 2 — Split / Merge / Identical**:
  - `tablet_reshard_split_total` / `_failed` / `_latency` / `_output_tablet_count` / `_fallback_total`
  - `tablet_reshard_merge_total` / `_failed` / `_latency` / `_input_tablet_count`
  - `tablet_reshard_identical_total` / `_failed`

  **Layer 3 — Cross publish** (`convert_txn_log`):
  - `tablet_reshard_cross_publish_total` / `_splitting_total` / `_merging_total` / `_identical_total`

  ### Key design points

  - FE counters are guarded by `MetricRepo.hasInit` and only incremented in `run*()` methods, not `replay*()` methods (avoid follower double-counting)
  - BE metrics use bvar (consistent with existing lake publish_version metrics), auto-exposed at `/vars`
  - `tablet_reshard_split_fallback_total` tracks when split degrades to identical copy — an important alert signal
  - Cross publish metrics help evaluate reshard impact on write latency


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4