### PR TITLE
[Enhancement] Add snapshot_meta.json marker for cluster snapshot integrity check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
@@ -16,10 +16,22 @@ package com.starrocks.lake.snapshot;
 
 import com.starrocks.common.StarRocksException;
 import com.starrocks.fs.HdfsUtil;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.storagevolume.StorageVolume;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
 
 public class ClusterSnapshotUtils {
+    private static final Logger LOG = LogManager.getLogger(ClusterSnapshotUtils.class);
+
+    public static final String SNAPSHOT_META_FILE_NAME = "snapshot_meta.json";
+
     public static String getSnapshotImagePath(StorageVolume sv, String snapshotName) {
         return String.join("/", sv.getLocations().get(0),
                 GlobalStateMgr.getCurrentState().getStarOSAgent().getRawServiceId(), "meta/image", snapshotName);
@@ -36,6 +48,8 @@ public class ClusterSnapshotUtils {
         String localImagePath = GlobalStateMgr.getImageDirPath();
 
         HdfsUtil.copyFromLocal(localImagePath, snapshotImagePath, sv.getProperties());
+
+        writeSnapshotMetaFile(job, snapshotImagePath, sv.getProperties());
     }
 
     public static void clearClusterSnapshotFromRemote(ClusterSnapshotJob job) throws StarRocksException {
@@ -46,6 +60,62 @@ public class ClusterSnapshotUtils {
 
         StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getStorageVolumeBySnapshotJob(job);
         String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
+
+        // Delete meta file first to mark snapshot as incomplete immediately
+        deleteSnapshotMetaFile(snapshotImagePath, sv.getProperties());
+
         HdfsUtil.deletePath(snapshotImagePath, sv.getProperties());
+    }
+
+    public static String getSnapshotMetaFilePath(String snapshotImagePath) {
+        return snapshotImagePath + "/" + SNAPSHOT_META_FILE_NAME;
+    }
+
+    public static boolean checkSnapshotMetaFileExist(String snapshotImagePath,
+            Map<String, String> properties) throws StarRocksException {
+        return HdfsUtil.checkPathExist(getSnapshotMetaFilePath(snapshotImagePath), properties);
+    }
+
+    public static void deleteSnapshotMetaFile(String snapshotImagePath, Map<String, String> properties) {
+        String metaFilePath = getSnapshotMetaFilePath(snapshotImagePath);
+        try {
+            HdfsUtil.deletePath(metaFilePath, properties);
+        } catch (Exception e) {
+            LOG.warn("Failed to delete snapshot meta file: {}", metaFilePath, e);
+        }
+    }
+
+    public static ClusterSnapshot readLocalSnapshotMetaFile(String localImagePath) {
+        File localMetaFile = new File(localImagePath, SNAPSHOT_META_FILE_NAME);
+        if (!localMetaFile.exists()) {
+            return null;
+        }
+        try {
+            String json = new String(Files.readAllBytes(localMetaFile.toPath()), StandardCharsets.UTF_8);
+            ClusterSnapshot snapshot = GsonUtils.GSON.fromJson(json, ClusterSnapshot.class);
+            if (snapshot == null || snapshot.getSnapshotName() == null || snapshot.getSnapshotName().isEmpty()
+                    || snapshot.getFeJournalId() <= 0 || snapshot.getStarMgrJournalId() <= 0) {
+                LOG.warn("Invalid local snapshot meta file: {}", localMetaFile.getAbsolutePath());
+                return null;
+            }
+            return snapshot;
+        } catch (Exception e) {
+            LOG.warn("Failed to read local snapshot meta file: {}", localMetaFile.getAbsolutePath(), e);
+            return null;
+        }
+    }
+
+    public static void deleteLocalSnapshotMetaFile(String localImagePath) {
+        File localMetaFile = new File(localImagePath, SNAPSHOT_META_FILE_NAME);
+        if (localMetaFile.exists() && !localMetaFile.delete()) {
+            LOG.warn("Failed to delete local snapshot meta file: {}", localMetaFile.getAbsolutePath());
+        }
+    }
+
+    private static void writeSnapshotMetaFile(ClusterSnapshotJob job, String snapshotImagePath,
+            Map<String, String> properties) throws StarRocksException {
+        String metaFilePath = getSnapshotMetaFilePath(snapshotImagePath);
+        HdfsUtil.writeFile(GsonUtils.GSON.toJson(job.getSnapshot()).getBytes(StandardCharsets.UTF_8),
+                metaFilePath, properties);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -145,10 +145,30 @@ public class RestoreClusterSnapshotMgr {
             String pathPattern = snapshotImagePath + "/image/" + ClusterSnapshotMgr.AUTOMATED_NAME_PREFIX + '*';
             List<FileStatus> fileStatusList = HdfsUtil.listFileMeta(pathPattern,
                     clusterSnapshot.getStorageVolume().getProperties(), false);
-            if (fileStatusList.isEmpty() || fileStatusList.get(0).isFile()) {
+            if (fileStatusList.isEmpty()) {
                 throw new StarRocksException("No cluster snapshot found in path " + pathPattern);
             }
-            snapshotImagePath = fileStatusList.get(0).getPath().toString();
+
+            snapshotImagePath = null;
+
+            // Sort by name descending (name contains timestamp, larger = newer)
+            fileStatusList.sort((a, b) -> b.getPath().getName().compareTo(a.getPath().getName()));
+
+            // Find the newest snapshot that has a snapshot_meta.json (complete)
+            for (FileStatus fs : fileStatusList) {
+                String candidatePath = fs.getPath().toString();
+                if (ClusterSnapshotUtils.checkSnapshotMetaFileExist(candidatePath,
+                        clusterSnapshot.getStorageVolume().getProperties())) {
+                    snapshotImagePath = candidatePath;
+                    break;
+                }
+            }
+
+            // Fallback: no snapshot has meta file (old format), pick the newest
+            if (snapshotImagePath == null) {
+                LOG.warn("No snapshot with meta file found, fallback to first snapshot directory");
+                snapshotImagePath = fileStatusList.get(0).getPath().toString();
+            }
         }
 
         LOG.info("Download cluster snapshot {} to local dir {}", snapshotImagePath, localImagePath);
@@ -180,7 +200,16 @@ public class RestoreClusterSnapshotMgr {
     private RestoredSnapshotInfo buildRestoredSnapshotInfo(String snapshotName) throws StarRocksException {
         try {
             String localImagePath = GlobalStateMgr.getImageDirPath();
-            // Get image version, use image loader to support v2 image format
+
+            // Try to read snapshot info from snapshot_meta.json first, then delete it regardless
+            ClusterSnapshot snapshotMeta = ClusterSnapshotUtils.readLocalSnapshotMetaFile(localImagePath);
+            ClusterSnapshotUtils.deleteLocalSnapshotMetaFile(localImagePath);
+            if (snapshotMeta != null) {
+                return new RestoredSnapshotInfo(snapshotMeta.getSnapshotName(),
+                        snapshotMeta.getFeJournalId(), snapshotMeta.getStarMgrJournalId());
+            }
+
+            // Fallback: read image version from local image files (old format without meta file)
             long feImageJournalId = new ImageLoader(localImagePath).getImageJournalId();
             long starMgrImageJournalId = new Storage(localImagePath + StarMgrServer.IMAGE_SUBDIR).getImageJournalId();
             return new RestoredSnapshotInfo(snapshotName, feImageJournalId, starMgrImageJournalId);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -27,6 +27,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.fs.HdfsUtil;
 import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.journal.CheckpointException;
 import com.starrocks.journal.CheckpointWorker;
@@ -36,6 +37,7 @@ import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
 import com.starrocks.leader.CheckpointController;
 import com.starrocks.persist.ClusterSnapshotLog;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -49,6 +51,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.UnitIdentifier;
 import com.starrocks.sql.ast.expression.IntervalLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.thrift.TBrokerFD;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -56,6 +59,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -135,6 +143,21 @@ public class ClusterSnapshotTest {
             public void deletePath(String path, Map<String, String> loadProperties) {
                 return;
             } // IOException
+
+            @Mock
+            public TBrokerFD openWriter(String path, Map<String, String> loadProperties) {
+                return new TBrokerFD();
+            }
+
+            @Mock
+            public void pwrite(TBrokerFD fd, long offset, byte[] data) {
+                return;
+            }
+
+            @Mock
+            public void closeWriter(TBrokerFD fd) {
+                return;
+            }
         };
 
         setAutomatedSnapshotOff(false);
@@ -224,6 +247,146 @@ public class ClusterSnapshotTest {
         ExceptionChecker.expectThrowsNoException(
                 () -> ClusterSnapshotUtils.clearClusterSnapshotFromRemote(job));
         setAutomatedSnapshotOff(false);
+    }
+
+    @Test
+    public void testUploadWritesMetaFile() throws Exception {
+        setAutomatedSnapshotOn(false);
+        ClusterSnapshotJob job = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().createAutomatedSnapshotJob();
+        job.setState(ClusterSnapshotJobState.UPLOADING);
+
+        List<String> writeFilePaths = new ArrayList<>();
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void copyFromLocal(String srcPath, String destPath, Map<String, String> properties) {
+                return;
+            }
+
+            @Mock
+            public void writeFile(byte[] data, String destFilePath, Map<String, String> properties) {
+                writeFilePaths.add(destFilePath);
+            }
+        };
+
+        ClusterSnapshotUtils.uploadClusterSnapshotToRemote(job);
+
+        Assertions.assertEquals(1, writeFilePaths.size());
+        Assertions.assertTrue(writeFilePaths.get(0).endsWith(ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME));
+        setAutomatedSnapshotOff(false);
+    }
+
+    @Test
+    public void testClearDeletesMetaFileFirst() throws Exception {
+        setAutomatedSnapshotOn(false);
+        ClusterSnapshotJob job = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().createAutomatedSnapshotJob();
+        job.setState(ClusterSnapshotJobState.FINISHED);
+
+        List<String> deletedPaths = new ArrayList<>();
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void deletePath(String path, Map<String, String> loadProperties) {
+                deletedPaths.add(path);
+            }
+        };
+
+        ClusterSnapshotUtils.clearClusterSnapshotFromRemote(job);
+
+        Assertions.assertEquals(2, deletedPaths.size());
+        // First deletion should be the meta file
+        Assertions.assertTrue(deletedPaths.get(0).endsWith(ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME));
+        // Second deletion should be the snapshot directory
+        Assertions.assertFalse(deletedPaths.get(1).endsWith(ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME));
+        setAutomatedSnapshotOff(false);
+    }
+
+    @Test
+    public void testCheckSnapshotMetaFileExist() throws Exception {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public boolean checkPathExist(String remotePath, Map<String, String> properties) {
+                return remotePath.endsWith(ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME);
+            }
+        };
+
+        Assertions.assertTrue(ClusterSnapshotUtils.checkSnapshotMetaFileExist(
+                "s3://bucket/path/snapshot1", new HashMap<>()));
+        Assertions.assertEquals("s3://bucket/path/snapshot1/" + ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME,
+                ClusterSnapshotUtils.getSnapshotMetaFilePath("s3://bucket/path/snapshot1"));
+    }
+
+    @Test
+    public void testDeleteSnapshotMetaFileException() {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void deletePath(String path, Map<String, String> properties) throws StarRocksException {
+                throw new StarRocksException("delete failed");
+            }
+        };
+
+        // Should not throw, just log warning
+        ExceptionChecker.expectThrowsNoException(
+                () -> ClusterSnapshotUtils.deleteSnapshotMetaFile("s3://bucket/path/snapshot1", new HashMap<>()));
+    }
+
+    @Test
+    public void testReadLocalSnapshotMetaFile() throws Exception {
+        Path tempDir = Files.createTempDirectory("snapshot_read_test");
+        try {
+            // Case 1: file does not exist — returns null
+            Assertions.assertNull(ClusterSnapshotUtils.readLocalSnapshotMetaFile(tempDir.toString()));
+
+            // Case 2: valid meta file — returns ClusterSnapshot
+            ClusterSnapshot snapshot = new ClusterSnapshot(1L, "test_snapshot",
+                    ClusterSnapshot.ClusterSnapshotType.AUTOMATED, "sv", 1000L, 2000L, 100L, 200L);
+            File metaFile = new File(tempDir.toFile(), ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME);
+            Files.write(metaFile.toPath(),
+                    GsonUtils.GSON.toJson(snapshot).getBytes(StandardCharsets.UTF_8));
+
+            ClusterSnapshot result = ClusterSnapshotUtils.readLocalSnapshotMetaFile(tempDir.toString());
+            Assertions.assertNotNull(result);
+            Assertions.assertEquals("test_snapshot", result.getSnapshotName());
+            Assertions.assertEquals(100L, result.getFeJournalId());
+            Assertions.assertEquals(200L, result.getStarMgrJournalId());
+
+            // Case 3: corrupted file — returns null
+            Files.write(metaFile.toPath(), "invalid json".getBytes(StandardCharsets.UTF_8));
+            Assertions.assertNull(ClusterSnapshotUtils.readLocalSnapshotMetaFile(tempDir.toString()));
+
+            // Case 4: valid JSON but missing snapshotName — returns null
+            ClusterSnapshot incomplete = new ClusterSnapshot(1L, null,
+                    ClusterSnapshot.ClusterSnapshotType.AUTOMATED, "sv", 1000L, 2000L, 100L, 200L);
+            Files.write(metaFile.toPath(),
+                    GsonUtils.GSON.toJson(incomplete).getBytes(StandardCharsets.UTF_8));
+            Assertions.assertNull(ClusterSnapshotUtils.readLocalSnapshotMetaFile(tempDir.toString()));
+
+            // Case 5: valid JSON but zero journalId — returns null
+            ClusterSnapshot zeroJournal = new ClusterSnapshot(1L, "test",
+                    ClusterSnapshot.ClusterSnapshotType.AUTOMATED, "sv", 1000L, 2000L, 0L, 200L);
+            Files.write(metaFile.toPath(),
+                    GsonUtils.GSON.toJson(zeroJournal).getBytes(StandardCharsets.UTF_8));
+            Assertions.assertNull(ClusterSnapshotUtils.readLocalSnapshotMetaFile(tempDir.toString()));
+        } finally {
+            File metaFile = new File(tempDir.toFile(), ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME);
+            metaFile.delete();
+            tempDir.toFile().delete();
+        }
+    }
+
+    @Test
+    public void testDeleteLocalSnapshotMetaFile() throws Exception {
+        // Create a temp directory and a snapshot_meta.json file
+        Path tempDir = Files.createTempDirectory("snapshot_test");
+        File metaFile = new File(tempDir.toFile(), ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME);
+        Assertions.assertTrue(metaFile.createNewFile());
+        Assertions.assertTrue(metaFile.exists());
+
+        ClusterSnapshotUtils.deleteLocalSnapshotMetaFile(tempDir.toString());
+        Assertions.assertFalse(metaFile.exists());
+
+        // Call again on non-existing file — should be a no-op
+        ClusterSnapshotUtils.deleteLocalSnapshotMetaFile(tempDir.toString());
+
+        tempDir.toFile().delete();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
@@ -32,12 +32,16 @@ import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -195,6 +199,139 @@ public class RestoreClusterSnapshotMgrTest {
         Assertions.assertEquals(30L, restoredSnapshotInfo.getStarMgrJournalId());
 
         RestoreClusterSnapshotMgr.finishRestoring();
+        Assertions.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+    }
+
+    @Test
+    public void testAutoDiscoveryEmptySnapshotList() throws Exception {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public List<FileStatus> listFileMeta(String path, Map<String, String> properties, boolean skipDir)
+                    throws StarRocksException {
+                return new ArrayList<>();
+            }
+        };
+
+        Assertions.assertThrows(StarRocksException.class,
+                () -> RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot_auto.yaml", true));
+        Assertions.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+    }
+
+    @Test
+    public void testSelectSnapshotWithMetaFile() throws Exception {
+        // Three snapshot directories: snap_1 (oldest), snap_2 (middle, has meta), snap_3 (newest, no meta)
+        String basePath = "s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image";
+        String snap1 = basePath + "/automated_cluster_snapshot_1000000000000";
+        String snap2 = basePath + "/automated_cluster_snapshot_2000000000000";
+        String snap3 = basePath + "/automated_cluster_snapshot_3000000000000";
+
+        List<FileStatus> fileStatusList = new ArrayList<>();
+        // Unsorted order to verify sorting
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap1)));
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap3)));
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap2)));
+
+        List<String> copiedSrcPaths = new ArrayList<>();
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public List<FileStatus> listFileMeta(String path, Map<String, String> properties, boolean skipDir)
+                    throws StarRocksException {
+                return fileStatusList;
+            }
+
+            @Mock
+            public boolean checkPathExist(String remotePath, Map<String, String> properties) throws StarRocksException {
+                // Only snap2 has meta file
+                return remotePath.equals(snap2 + "/" + ClusterSnapshotUtils.SNAPSHOT_META_FILE_NAME);
+            }
+
+            @Mock
+            public void copyToLocal(String srcPath, String destPath, Map<String, String> properties)
+                    throws StarRocksException {
+                copiedSrcPaths.add(srcPath);
+            }
+        };
+
+        new MockUp<Storage>() {
+            @Mock
+            public long getImageJournalId() {
+                return 10L;
+            }
+        };
+
+        RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot_auto.yaml", true);
+        Assertions.assertTrue(RestoreClusterSnapshotMgr.isRestoring());
+
+        // Should have selected snap2 (newest with meta file), not snap3 (newest overall)
+        Assertions.assertEquals(1, copiedSrcPaths.size());
+        Assertions.assertTrue(copiedSrcPaths.get(0).contains("automated_cluster_snapshot_2000000000000"));
+
+        RestoredSnapshotInfo info = RestoreClusterSnapshotMgr.getRestoredSnapshotInfo();
+        Assertions.assertEquals("automated_cluster_snapshot_2000000000000", info.getSnapshotName());
+
+        try {
+            RestoreClusterSnapshotMgr.finishRestoring();
+        } catch (Exception e) {
+            // Storage volume update may fail in test environment; the singleton is still cleaned up
+        }
+        Assertions.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+    }
+
+    @Test
+    public void testSelectSnapshotFallbackNoMetaFile() throws Exception {
+        // Three snapshot directories, none has meta file
+        String basePath = "s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image";
+        String snap1 = basePath + "/automated_cluster_snapshot_1000000000000";
+        String snap2 = basePath + "/automated_cluster_snapshot_2000000000000";
+        String snap3 = basePath + "/automated_cluster_snapshot_3000000000000";
+
+        List<FileStatus> fileStatusList = new ArrayList<>();
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap1)));
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap3)));
+        fileStatusList.add(new FileStatus(0, true, 0, 0, 0, new Path(snap2)));
+
+        List<String> copiedSrcPaths = new ArrayList<>();
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public List<FileStatus> listFileMeta(String path, Map<String, String> properties, boolean skipDir)
+                    throws StarRocksException {
+                return fileStatusList;
+            }
+
+            @Mock
+            public boolean checkPathExist(String remotePath, Map<String, String> properties) throws StarRocksException {
+                return false; // No meta files exist
+            }
+
+            @Mock
+            public void copyToLocal(String srcPath, String destPath, Map<String, String> properties)
+                    throws StarRocksException {
+                copiedSrcPaths.add(srcPath);
+            }
+        };
+
+        new MockUp<Storage>() {
+            @Mock
+            public long getImageJournalId() {
+                return 10L;
+            }
+        };
+
+        RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot_auto.yaml", true);
+        Assertions.assertTrue(RestoreClusterSnapshotMgr.isRestoring());
+
+        // Should fallback to the first directory after sorting (snap3 is newest by name)
+        Assertions.assertEquals(1, copiedSrcPaths.size());
+        Assertions.assertTrue(copiedSrcPaths.get(0).contains("automated_cluster_snapshot_3000000000000"));
+
+        RestoredSnapshotInfo info = RestoreClusterSnapshotMgr.getRestoredSnapshotInfo();
+        Assertions.assertEquals("automated_cluster_snapshot_3000000000000", info.getSnapshotName());
+
+        try {
+            RestoreClusterSnapshotMgr.finishRestoring();
+        } catch (Exception e) {
+            // Storage volume update may fail in test environment; the singleton is still cleaned up
+        }
         Assertions.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
     }
 }

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot_auto.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot_auto.yaml
@@ -1,0 +1,30 @@
+--- # cluster_snapshot_auto.yaml
+
+# auto-discovery mode: path ends with /meta
+cluster_snapshot:
+    cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta
+    storage_volume_name: my_s3_volume
+
+frontends:
+  - host: 172.26.92.1
+    edit_log_port: 9010
+    type: follower
+
+compute_nodes:
+  - host: 172.26.92.11
+    heartbeat_service_port: 9050
+
+storage_volumes:
+  - name: my_s3_volume
+    type: S3
+    location: s3://defaultbucket/test/
+    comment: my s3 volume
+    properties:
+      - key: aws.s3.region
+        value: us-west-2
+      - key: aws.s3.endpoint
+        value: https://s3.us-west-2.amazonaws.com
+      - key: aws.s3.access_key
+        value: xxxxxxxxxx
+      - key: aws.s3.secret_key
+        value: yyyyyyyyyy


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                             
  In shared-data mode, the automated cluster snapshot upload (`HdfsUtil.copyFromLocal`) copies files one by one and is not atomic. If FE crashes during upload, incomplete snapshot directories remain on object storage. During restore,  `RestoreClusterSnapshotMgr.downloadSnapshot` lists directories via glob and picks the latest one, with no way to distinguish complete snapshots from incomplete ones.
                                                                                                                                                                                                                                                                             
## What I'm doing:                                                                                                                                                                                                                                                         

  Write a `snapshot_meta.json` marker file (serialized `ClusterSnapshot` JSON) after all image files are uploaded, and delete it before removing the snapshot directory. During restore, prefer the newest snapshot that has this marker file, falling back to the original behavior (pick the newest directory) when no snapshots have it, ensuring backward compatibility with old-format snapshots.

  ### ClusterSnapshotUtils

  - Upload: write `snapshot_meta.json` after `copyFromLocal` completes.
  - Delete: delete the remote marker file first to immediately mark the snapshot as incomplete, then delete the entire directory.
  - Extract `getSnapshotMetaFilePath`, `checkSnapshotMetaFileExist`, `deleteSnapshotMetaFile`, `deleteLocalSnapshotMetaFile`, and `readLocalSnapshotMetaFile` as public utility methods.

  ### RestoreClusterSnapshotMgr

  - In auto-discovery mode, sort snapshot candidates by name descending and select the newest one with `snapshot_meta.json`; fall back to the newest directory if none have it.
  - Refactor `buildRestoredSnapshotInfo`: try reading snapshot info (snapshotName, feJournalId, starMgrJournalId) from local `snapshot_meta.json` first; if the meta file does not exist (old format or manual restore), fall back to reading image version from local image files. Delete the local meta file after reading.
  - Remove the incorrect `isFile()` early-abort check on the first list entry.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
