### PR TITLE
[BugFix] Allow IVM→PCT fallback to respect partition_refresh_number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -17,10 +17,8 @@ package com.starrocks.scheduler;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
-import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -33,7 +31,6 @@ import java.util.Set;
 public class MvTaskRunContext extends TaskRunContext {
     public static class MVRefreshRuntimeState {
         private final Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Maps.newHashMap();
-        private final Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap = Maps.newHashMap();
 
         public Map<Long, BaseTableSnapshotInfo> getSnapshotBaseTables() {
             return snapshotBaseTables;
@@ -44,13 +41,8 @@ public class MvTaskRunContext extends TaskRunContext {
             this.snapshotBaseTables.putAll(snapshotBaseTables);
         }
 
-        public Map<BaseTableInfo, TvrVersionRange> getPendingBaseTableTvrVersionRangeMap() {
-            return pendingBaseTableTvrVersionRangeMap;
-        }
-
         public void reset() {
             snapshotBaseTables.clear();
-            pendingBaseTableTvrVersionRangeMap.clear();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -202,9 +202,10 @@ public abstract class BaseMVRefreshProcessor {
      * @param mvRefreshedPartitions the refreshed partitions of the mv
      * @param refTableAndPartitionNames the refreshed partitions of the base tables
      */
-    public abstract void updateVersionMeta(ExecPlan execPlan,
-                                           PCellSortedSet mvRefreshedPartitions,
-                                           Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames);
+    public void updateVersionMeta(ExecPlan execPlan,
+                                   PCellSortedSet mvRefreshedPartitions,
+                                   Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
+    }
 
     public MVRefreshParams getMvRefreshParams() {
         return mvRefreshParams;
@@ -250,10 +251,6 @@ public abstract class BaseMVRefreshProcessor {
 
     protected void setSnapshotBaseTables(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         refreshRuntimeState.replaceSnapshotBaseTables(snapshotBaseTables);
-    }
-
-    protected Map<BaseTableInfo, TvrVersionRange> getPendingBaseTableTvrVersionRangeMap() {
-        return refreshRuntimeState.getPendingBaseTableTvrVersionRangeMap();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -15,7 +15,6 @@
 package com.starrocks.scheduler.mv.hybrid;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -31,10 +30,7 @@ import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
 import com.starrocks.scheduler.mv.MVRefreshExecutor;
 import com.starrocks.scheduler.mv.MVRefreshParams;
 import com.starrocks.scheduler.mv.ivm.MVIVMBasedRefreshProcessor;
-import com.starrocks.scheduler.mv.ivm.TvrTableSnapshotInfo;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
-import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.plan.ExecPlan;
 
 import java.util.Map;
 
@@ -102,26 +98,27 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         });
         // reset the task run id for pct
         this.mvContext.getCtx().setQueryId(UUIDUtil.genUUID());
-        // If the refresh is transferred to pct, we need to refresh the changed partitions once
-        // and cannot generate multi-task-runs.
-        pctProcessor.getMvRefreshParams().setCanGenerateNextTaskRun(false);
-        final Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap =
-                getPendingBaseTableTvrVersionRangeMap();
 
-        // try get the tvr version range map from ivm processor
-        final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
-                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoTvrVersionRangeMap();
-        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
-            TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
-                    snapshotInfo, mvTvrVersionRangeMap);
-            logger.info("Base table: {}, changed version range: {}",
-                    snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
-            // collect changed version range
-            TvrTableSnapshotInfo tvrTableSnapshotInfo = new TvrTableSnapshotInfo(snapshotInfo.getBaseTableInfo(),
-                    snapshotInfo.getBaseTable());
-            pendingBaseTableTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
-            // update the snapshot info with the changed version range
-            tvrTableSnapshotInfo.setTvrSnapshot(changedVersionRange);
+        // For complete refreshes (IVM fallback or force): collect TVR version ranges and write
+        // them into the persisted tempBaseTableInfoTvrDeltaMap so that subsequent batch task_runs
+        // can access the checkpoint via AsyncRefreshContext (serialized to editlog).
+        // For partial refreshes (subsequent batches): skip — the temp map was already populated
+        // by the first task_run and persisted via editlog.
+        if (mvRefreshParams.isCompleteRefresh()) {
+            MaterializedView.AsyncRefreshContext refreshContext =
+                    mv.getRefreshScheme().getAsyncRefreshContext();
+            refreshContext.clearTempBaseTableInfoTvrDeltaMap();
+            final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
+                    refreshContext.getBaseTableInfoTvrVersionRangeMap();
+            for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+                TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
+                        snapshotInfo, mvTvrVersionRangeMap);
+                logger.info("Base table: {}, changed version range: {}",
+                        snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
+                // persist to AsyncRefreshContext temp map (survives across task_runs via editlog)
+                refreshContext.getTempBaseTableInfoTvrDeltaMap().put(
+                        snapshotInfo.getBaseTableInfo(), changedVersionRange);
+            }
         }
         return pctProcessor.getProcessExecPlan(taskRunContext);
     }
@@ -152,20 +149,4 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         getCurrentProcessor().generateNextTaskRunIfNeeded();
     }
 
-    @Override
-    public void updateVersionMeta(ExecPlan execPlan,
-                                  PCellSortedSet mvRefreshedPartitions,
-                                  Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        if (this.currentRefreshMode == MaterializedView.RefreshMode.INCREMENTAL) {
-            ivmProcessor.updateVersionMeta(execPlan, mvRefreshedPartitions, refTableAndPartitionNames);
-        } else {
-            if (mvContext.hasNextBatchPartition()) {
-                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, Maps.newHashMap());
-            } else {
-                // if this is the last task run for a refresh job, update the pending tvr version ranges instead.
-                updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions,
-                        getPendingBaseTableTvrVersionRangeMap());
-            }
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -316,9 +316,20 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
     public void updateVersionMeta(ExecPlan execPlan,
                                   PCellSortedSet mvRefreshedPartitions,
                                   Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames) {
-        Map<BaseTableInfo, TvrVersionRange> pendingBaseTableTvrVersionRangeMap =
-                getPendingBaseTableTvrVersionRangeMap();
-        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions,
-                pendingBaseTableTvrVersionRangeMap);
+        // Only promote TVR checkpoint on the last batch. Intermediate batches pass empty map
+        // to avoid committing TVR before all partitions are refreshed.
+        Map<BaseTableInfo, TvrVersionRange> tvrMap;
+        if (mvContext.hasNextBatchPartition()) {
+            tvrMap = Maps.newHashMap();
+        } else {
+            tvrMap = mv.getRefreshScheme().getAsyncRefreshContext().getTempBaseTableInfoTvrDeltaMap();
+        }
+        updatePCTMeta(execPlan, pctMVToRefreshedPartitions, pctRefTableRefreshPartitions, tvrMap);
+        // Clear temp map after the last batch promotes TVR, preventing stale data from being
+        // reused by subsequent unrelated refreshes (e.g., user-initiated partial refresh or
+        // explain-time planning that populates the temp map without executing).
+        if (!mvContext.hasNextBatchPartition()) {
+            mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaMap();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler.mv.ivm;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
@@ -26,6 +27,7 @@ import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.mv.BaseMVRefreshProcessor;
 import com.starrocks.scheduler.mv.hybrid.MVHybridBasedRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
@@ -609,15 +611,154 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
     }
 
     /**
+     * Verify that IVM→PCT fallback allows multi-batch splitting (respects partition_refresh_number)
+     * and correctly persists TVR checkpoint for the next IVM refresh.
+     *
+     * Before the fix: setCanGenerateNextTaskRun(false) forced all partitions into a single task_run,
+     * which could cause OOM on large tables.
+     *
+     * After the fix: TVR is persisted in tempBaseTableInfoTvrDeltaMap (via editlog) so that
+     * subsequent batch task_runs can access it, and partition_refresh_number is respected.
+     */
+    @Test
+    public void testAutoRefreshFallbackAllowsMultiBatchAndPersistsTvr() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        // Run 1: IVM fails (retractable changes) → fallback to PCT
+        MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid1 =
+                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
+        // Verify fallback to PCT
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        // Verify canGenerateNextTaskRun is NOT blocked (the core fix)
+        MVPCTBasedRefreshProcessor pctProcessor =
+                (MVPCTBasedRefreshProcessor) hybrid1.getCurrentProcessor();
+        Assertions.assertTrue(pctProcessor.getMvRefreshParams().isCanGenerateNextTaskRun(),
+                "IVM→PCT fallback should allow multi-batch splitting (canGenerateNextTaskRun=true)");
+
+        // Verify TVR checkpoint is persisted to baseTableInfoTvrVersionRangeMap
+        MaterializedView refreshedMv = getMv("test_mv1");
+        TvrVersionRange checkpoint = refreshedMv.getRefreshScheme()
+                .getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap()
+                .values()
+                .iterator()
+                .next();
+        Assertions.assertTrue(checkpoint instanceof TvrTableSnapshot);
+        Assertions.assertEquals(2L, checkpoint.to().getVersion());
+
+        // Run 2: append-only changes → IVM should recover from checkpoint
+        advanceTableVersionTo(3);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(2L, 3L),
+                        TvrDeltaStats.EMPTY)
+        ));
+
+        MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid2 =
+                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
+        // Should switch back to IVM since delta[2,3] is append-only
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor,
+                "After PCT fallback persists checkpoint, next IVM refresh should recover");
+    }
+
+    /**
+     * Verify IVM→PCT fallback with partition_refresh_number=1 produces multi-batch task_runs
+     * and only promotes TVR checkpoint on the last batch.
+     *
+     * Uses partitioned Iceberg table t1 (4 partitions). With partition_refresh_number=1,
+     * the PCT fallback should split into multiple batches. Intermediate batches should NOT
+     * promote TVR to baseTableInfoTvrVersionRangeMap; only the last batch should.
+     */
+    @Test
+    public void testAutoRefreshFallbackMultiBatchTvrPromoteOnlyOnLastBatch() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
+                "`date`", Map.of("partition_refresh_number", "1"));
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+
+        // First task_run: IVM fails (retractable changes) → fallback to PCT, batch 1
+        TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid =
+                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        // Verify fallback to PCT
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        // Verify canGenerateNextTaskRun is allowed
+        MVPCTBasedRefreshProcessor pctProcessor =
+                (MVPCTBasedRefreshProcessor) hybrid.getCurrentProcessor();
+        Assertions.assertTrue(pctProcessor.getMvRefreshParams().isCanGenerateNextTaskRun(),
+                "IVM→PCT fallback should allow multi-batch splitting");
+
+        // Check if there are more batches (partition_refresh_number=1, 4 partitions → should have next)
+        TaskRun nextTaskRun = pctProcessor.getNextTaskRun();
+        if (nextTaskRun != null) {
+            // Intermediate batch: TVR should NOT be promoted to baseTableInfoTvrVersionRangeMap yet
+            MaterializedView intermediateMv = getMv("test_mv1");
+            Map<BaseTableInfo, TvrVersionRange> intermediateCheckpoint = intermediateMv.getRefreshScheme()
+                    .getAsyncRefreshContext()
+                    .getBaseTableInfoTvrVersionRangeMap();
+            // baseTableInfoTvrVersionRangeMap should be empty (first refresh, no previous IVM success)
+            // TVR should only be promoted on the last batch
+            Assertions.assertTrue(intermediateCheckpoint.isEmpty(),
+                    "TVR should not be promoted to baseTableInfoTvrVersionRangeMap on intermediate batches, " +
+                            "but got: " + intermediateCheckpoint);
+
+            // tempBaseTableInfoTvrDeltaMap should have the pending TVR
+            Map<BaseTableInfo, TvrVersionRange> tempTvr = intermediateMv.getRefreshScheme()
+                    .getAsyncRefreshContext()
+                    .getTempBaseTableInfoTvrDeltaMap();
+            Assertions.assertFalse(tempTvr.isEmpty(),
+                    "tempBaseTableInfoTvrDeltaMap should contain pending TVR for subsequent batches");
+
+            // Execute remaining batches
+            while (nextTaskRun != null) {
+                initAndExecuteTaskRun(nextTaskRun);
+                MVTaskRunProcessor nextProcessor = getMVTaskRunProcessor(nextTaskRun);
+                BaseMVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
+                if (refreshProcessor instanceof MVHybridBasedRefreshProcessor) {
+                    MVHybridBasedRefreshProcessor nextHybrid =
+                            (MVHybridBasedRefreshProcessor) refreshProcessor;
+                    nextTaskRun = nextHybrid.getCurrentProcessor().getNextTaskRun();
+                } else if (refreshProcessor instanceof MVPCTBasedRefreshProcessor) {
+                    nextTaskRun = ((MVPCTBasedRefreshProcessor) refreshProcessor).getNextTaskRun();
+                } else {
+                    nextTaskRun = null;
+                }
+            }
+        }
+
+        // After all batches complete: TVR checkpoint should be promoted
+        MaterializedView finalMv = getMv("test_mv1");
+        Map<BaseTableInfo, TvrVersionRange> finalCheckpoint = finalMv.getRefreshScheme()
+                .getAsyncRefreshContext()
+                .getBaseTableInfoTvrVersionRangeMap();
+        Assertions.assertFalse(finalCheckpoint.isEmpty(),
+                "TVR checkpoint should be promoted to baseTableInfoTvrVersionRangeMap after all batches complete");
+        TvrVersionRange checkpoint = finalCheckpoint.values().iterator().next();
+        Assertions.assertTrue(checkpoint instanceof TvrTableSnapshot);
+        Assertions.assertEquals(2L, checkpoint.to().getVersion(),
+                "TVR checkpoint should point to version 2");
+    }
+
+    /**
      * Test that IVM refresh records complete PCT metadata without batch truncation.
-     *
-     * Before the fix, updatePCTToRefreshMetas in IVM path went through filterPartitionByRefreshNumber,
-     * which truncated the partition list based on partition_refresh_number (default 1).
-     * This caused incomplete visibleVersionMap updates — partitions that were actually refreshed by IVM
-     * (via TVR delta) would still appear stale in PCT metadata, breaking MV query rewrite.
-     *
-     * The fix passes skipBatchFilter=true so that detectMVPartitionsToRefresh is used instead of
-     * getMVToRefreshedPartitions, skipping all batch filtering.
      */
     @Test
     public void testIVMPCTMetadataNotTruncatedByPartitionRefreshNumber() throws Exception {


### PR DESCRIPTION
## Why I'm doing:
Fixes #69558
## What I'm doing:
When AUTO refresh mode falls back from IVM to PCT, the previous code set canGenerateNextTaskRun=false, forcing all partitions into a single task_run. This caused OOM/timeout on large tables with many partitions.

Root cause: TVR version ranges were stored in the in-memory-only pendingBaseTableTvrVersionRangeMap, which could not survive across task_runs. Splitting into multiple batches would lose the TVR checkpoint.

Fix: Replace pendingBaseTableTvrVersionRangeMap with the already-persisted tempBaseTableInfoTvrDeltaMap in AsyncRefreshContext (serialized to editlog). This allows multi-batch splitting while preserving TVR across task_runs.

Key changes:
- Remove setCanGenerateNextTaskRun(false) in switchToPCTRefresh
- Write TVR to tempBaseTableInfoTvrDeltaMap (persisted) instead of pendingBaseTableTvrVersionRangeMap (in-memory only)
- PCT updateVersionMeta reads from tempBaseTableInfoTvrDeltaMap, promoting TVR only on the last batch (hasNextBatchPartition check)
- Guard TVR collection with isCompleteRefresh() so subsequent batch task_runs don't clear the temp map written by the first task_run
- Remove pendingBaseTableTvrVersionRangeMap and dead code in MVHybridBasedRefreshProcessor.updateVersionMeta()
- Change BaseMVRefreshProcessor.updateVersionMeta() from abstract to default empty implementation


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
