### PR TITLE
[BugFix] Fix a memory leak issue caused by shared_ptr cycle between `BatchUnit` and `FetchTaskContext` (backport #71126)

### DIFF
--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -47,47 +47,75 @@ Status FetchTask::submit(RuntimeState* state) {
 }
 
 Status FetchTask::_submit_local_task(RuntimeState* state) {
-    _ctx->callback = [ctx = _ctx](const Status& status) {
-        DeferOp defer([&]() { ctx->unit->finished_request_num++; });
+    auto self = shared_from_this();
+    _ctx->callback = [self, ctx = _ctx](const Status& status) {
+        auto unit = ctx->unit.lock();
+        auto processor = ctx->processor.lock();
+        DeferOp defer([&]() {
+            if (unit != nullptr) {
+                unit->finished_request_num++;
+            }
+            self->_is_done = true;
+        });
         if (!status.ok()) {
             LOG(WARNING) << "local fetch request failed, error: " << status.to_string();
-            ctx->processor->_set_io_task_status(status);
+            if (processor != nullptr) {
+                processor->_set_io_task_status(status);
+            }
             return;
         }
     };
+    auto processor = _ctx->processor.lock();
+    DCHECK(processor != nullptr);
     LookUpRequestContextPtr request = std::make_shared<LocalLookUpRequestContext>(_ctx);
-    return _ctx->processor->_local_dispatcher->add_request(std::move(request));
+    return processor->_local_dispatcher->add_request(std::move(request));
 }
 
 Status FetchTask::_submit_remote_task(RuntimeState* state) {
     const auto source_id = _ctx->source_node_id;
     const auto& request_chunk = _ctx->request_chunk;
 
-    auto* closure = new DisposableClosure<PLookUpResponse, FetchTaskContextPtr>(_ctx);
-    closure->addSuccessHandler([this, closure](const FetchTaskContextPtr& ctx, const PLookUpResponse& resp) noexcept {
-        DLOG(INFO) << "[GLM] receive a response, finished request num: " << ctx->unit->finished_request_num
-                   << ", total request num: " << ctx->unit->total_request_num << ", " << (void*)ctx->processor
-                   << ", latency: " << (MonotonicNanos() - ctx->send_ts) * 1.0 / 1000000 << "ms";
-        DeferOp defer([&]() {
-            if (++ctx->unit->finished_request_num == ctx->unit->total_request_num) {
-                VLOG_ROW << "[GLM] all request finished, notify fetch processor, total_request_num: "
-                         << ctx->unit->total_request_num << ", " << (void*)ctx->processor;
-            }
-            _is_done = true;
-        });
-        COUNTER_UPDATE(ctx->processor->_rpc_count, 1);
-        COUNTER_UPDATE(ctx->processor->_network_timer, MonotonicNanos() - ctx->send_ts);
-
-        if (resp.status().status_code() != TStatusCode::OK) {
-            auto msg = fmt::format("fetch request failed, error: {}", resp.status().DebugString());
-            LOG(WARNING) << msg;
-            ctx->processor->_set_io_task_status(Status::InternalError(msg));
+    auto closure = std::make_unique<DisposableClosure<PLookUpResponse, FetchTaskContextPtr>>(_ctx);
+    // The RPC callback can outlive queue ownership when the source finishes early.
+    auto self = shared_from_this();
+    auto processor = _ctx->processor.lock();
+    DCHECK(processor != nullptr);
+    const auto* node_info = processor->_nodes_info->find_node(source_id);
+    DCHECK(node_info != nullptr);
+    RETURN_IF(node_info == nullptr,
+              Status::InternalError(fmt::format("Failed to find node info for source_id: {}", source_id)));
+    closure->addSuccessHandler([self, done = closure.get(), host = node_info->host, port = node_info->brpc_port](
+                                       const FetchTaskContextPtr& ctx, const PLookUpResponse& resp) noexcept {
+        auto processor = ctx->processor.lock();
+        auto unit = ctx->unit.lock();
+        if (processor == nullptr || unit == nullptr) {
+            self->_is_done = true;
             return;
         }
-        DLOG(INFO) << "[GLM] receive a response, response size: " << closure->cntl.response_attachment().size();
-        if (closure->cntl.response_attachment().size() > 0) {
-            SCOPED_TIMER(ctx->processor->_deserialize_timer);
-            butil::IOBuf& io_buf = closure->cntl.response_attachment();
+        DLOG(INFO) << "[GLM] receive a response, finished request num: " << unit->finished_request_num
+                   << ", total request num: " << unit->total_request_num
+                   << ", latency: " << (MonotonicNanos() - ctx->send_ts) * 1.0 / 1000000 << "ms";
+        DeferOp defer([&]() {
+            if (++unit->finished_request_num == unit->total_request_num) {
+                VLOG_ROW << "[GLM] all request finished, notify fetch processor, total_request_num: "
+                         << unit->total_request_num;
+            }
+            self->_is_done = true;
+        });
+        COUNTER_UPDATE(processor->_rpc_count, 1);
+        COUNTER_UPDATE(processor->_network_timer, MonotonicNanos() - ctx->send_ts);
+
+        if (resp.status().status_code() != TStatusCode::OK) {
+            auto msg = fmt::format("fetch request failed, error: {}, host: {}, port: {}", resp.status().DebugString(),
+                                   host, port);
+            LOG(WARNING) << msg;
+            processor->_set_io_task_status(Status::InternalError(msg));
+            return;
+        }
+        DLOG(INFO) << "[GLM] receive a response, response size: " << done->cntl.response_attachment().size();
+        if (done->cntl.response_attachment().size() > 0) {
+            SCOPED_TIMER(processor->_deserialize_timer);
+            butil::IOBuf& io_buf = done->cntl.response_attachment();
             raw::RawString buffer;
 
             for (size_t i = 0; i < resp.columns_size(); i++) {
@@ -96,7 +124,7 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
                     auto msg = fmt::format("io_buf size {} is less than column data size {}", io_buf.size(),
                                            pcolumn.data_size());
                     LOG(WARNING) << msg;
-                    ctx->processor->_set_io_task_status(Status::InternalError(msg));
+                    processor->_set_io_task_status(Status::InternalError(msg));
                     return;
                 }
                 buffer.resize(pcolumn.data_size());
@@ -104,18 +132,18 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
                 if (UNLIKELY(size != pcolumn.data_size())) {
                     auto msg = fmt::format("iobuf read {} != expected {}", size, pcolumn.data_size());
                     LOG(WARNING) << msg;
-                    ctx->processor->_set_io_task_status(Status::InternalError(msg));
+                    processor->_set_io_task_status(Status::InternalError(msg));
                     return;
                 }
                 int32_t slot_id = pcolumn.slot_id();
-                const SlotDescriptor* slot_desc = ctx->processor->_slot_id_to_desc.at(slot_id);
+                const SlotDescriptor* slot_desc = processor->_slot_id_to_desc.at(slot_id);
                 auto column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
                 const uint8_t* buff = reinterpret_cast<const uint8_t*>(buffer.data());
                 auto ret = serde::ColumnArraySerde::deserialize(buff, buff + buffer.size(), column.get());
                 if (!ret.ok()) {
                     auto msg = fmt::format("deserialize column error, slot_id: {}", slot_id);
                     LOG(WARNING) << msg;
-                    ctx->processor->_set_io_task_status(Status::InternalError(msg));
+                    processor->_set_io_task_status(Status::InternalError(msg));
                     return;
                 }
                 DCHECK(!ctx->response_columns.contains(slot_id));
@@ -125,15 +153,21 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
         }
     });
 
-    closure->addFailureHandler([this](const FetchTaskContextPtr& ctx, std::string_view rpc_error_msg) noexcept {
+    closure->addFailureHandler([self](const FetchTaskContextPtr& ctx, std::string_view rpc_error_msg) noexcept {
+        auto processor = ctx->processor.lock();
+        auto unit = ctx->unit.lock();
+        if (processor == nullptr || unit == nullptr) {
+            self->_is_done = true;
+            return;
+        }
         DeferOp defer([&]() {
-            if (++ctx->unit->finished_request_num == ctx->unit->total_request_num) {
-                DLOG(INFO) << "all request finished, notify fetch processor, " << (void*)ctx->processor;
+            if (++unit->finished_request_num == unit->total_request_num) {
+                DLOG(INFO) << "all request finished, notify fetch processor, " << (void*)processor.get();
             }
-            _is_done = true;
+            self->_is_done = true;
         });
+        processor->_set_io_task_status(Status::InternalError(rpc_error_msg));
         LOG(WARNING) << "fetch request failed, error: " << rpc_error_msg;
-        ctx->processor->_set_io_task_status(Status::InternalError(rpc_error_msg));
     });
 
     closure->cntl.Reset();
@@ -144,19 +178,19 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     p_query_id.set_hi(state->query_id().hi);
     p_query_id.set_lo(state->query_id().lo);
     *request.mutable_query_id() = std::move(p_query_id);
-    request.set_lookup_node_id(_ctx->processor->_target_node_id);
+    request.set_lookup_node_id(processor->_target_node_id);
     request.set_request_tuple_id(_ctx->request_tuple_id);
     {
-        SCOPED_TIMER(_ctx->processor->_serialize_timer);
+        SCOPED_TIMER(processor->_serialize_timer);
         size_t max_serialize_size = 0;
         for (const auto& column : request_chunk->columns()) {
             max_serialize_size += serde::ColumnArraySerde::max_serialized_size(*column);
         }
 
-        _ctx->processor->_serialize_buffer.clear();
-        _ctx->processor->_serialize_buffer.resize(max_serialize_size);
+        processor->_serialize_buffer.clear();
+        processor->_serialize_buffer.resize(max_serialize_size);
 
-        uint8_t* buff = reinterpret_cast<uint8_t*>(_ctx->processor->_serialize_buffer.data());
+        uint8_t* buff = reinterpret_cast<uint8_t*>(processor->_serialize_buffer.data());
         uint8_t* begin = buff;
         for (const auto& [slot_id, idx] : request_chunk->get_slot_id_to_index_map()) {
             if (slot_id == FetchProcessor::kPositionColumnSlotId) {
@@ -171,14 +205,22 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
             p_column->set_data_size(buff - start);
         }
         size_t actual_serialize_size = buff - begin;
-        closure->cntl.request_attachment().append(_ctx->processor->_serialize_buffer.data(), actual_serialize_size);
+        closure->cntl.request_attachment().append(processor->_serialize_buffer.data(), actual_serialize_size);
     }
-    DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)_ctx->processor
-               << ", unit: " << _ctx->unit->debug_string();
+    auto unit = _ctx->unit.lock();
+    auto unit_debug_string = unit != nullptr ? unit->debug_string() : std::string("BatchUnit <expired>");
+    DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)processor.get()
+               << ", unit: " << unit_debug_string;
     _ctx->send_ts = MonotonicNanos();
-    const auto* node_info = _ctx->processor->_nodes_info->find_node(source_id);
     auto stub = state->exec_env()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
-    stub->lookup(&closure->cntl, &request, &closure->result, closure);
+    if (stub == nullptr) {
+        auto msg = fmt::format("Connect {}:{} failed.", node_info->host, node_info->brpc_port);
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
+
+    auto done = closure.release();
+    stub->lookup(&done->cntl, &request, &done->result, done);
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -47,46 +47,32 @@ Status FetchTask::submit(RuntimeState* state) {
 }
 
 Status FetchTask::_submit_local_task(RuntimeState* state) {
-    auto self = shared_from_this();
-    _ctx->callback = [self, ctx = _ctx](const Status& status) {
+    _ctx->callback = [ctx = _ctx](const Status& status) {
         auto unit = ctx->unit.lock();
-        auto processor = ctx->processor.lock();
         DeferOp defer([&]() {
             if (unit != nullptr) {
                 unit->finished_request_num++;
             }
-            self->_is_done = true;
         });
         if (!status.ok()) {
             LOG(WARNING) << "local fetch request failed, error: " << status.to_string();
-            if (processor != nullptr) {
-                processor->_set_io_task_status(status);
-            }
+            ctx->processor->_set_io_task_status(status);
             return;
         }
     };
-    auto processor = _ctx->processor.lock();
-    DCHECK(processor != nullptr);
     LookUpRequestContextPtr request = std::make_shared<LocalLookUpRequestContext>(_ctx);
-    return processor->_local_dispatcher->add_request(std::move(request));
+    return _ctx->processor->_local_dispatcher->add_request(std::move(request));
 }
 
 Status FetchTask::_submit_remote_task(RuntimeState* state) {
     const auto source_id = _ctx->source_node_id;
     const auto& request_chunk = _ctx->request_chunk;
 
-    auto closure = std::make_unique<DisposableClosure<PLookUpResponse, FetchTaskContextPtr>>(_ctx);
+    auto* closure = new DisposableClosure<PLookUpResponse, FetchTaskContextPtr>(_ctx);
     // The RPC callback can outlive queue ownership when the source finishes early.
     auto self = shared_from_this();
-    auto processor = _ctx->processor.lock();
-    DCHECK(processor != nullptr);
-    const auto* node_info = processor->_nodes_info->find_node(source_id);
-    DCHECK(node_info != nullptr);
-    RETURN_IF(node_info == nullptr,
-              Status::InternalError(fmt::format("Failed to find node info for source_id: {}", source_id)));
-    closure->addSuccessHandler([self, done = closure.get(), host = node_info->host, port = node_info->brpc_port](
-                                       const FetchTaskContextPtr& ctx, const PLookUpResponse& resp) noexcept {
-        auto processor = ctx->processor.lock();
+    closure->addSuccessHandler([self, closure](const FetchTaskContextPtr& ctx, const PLookUpResponse& resp) noexcept {
+        auto* processor = ctx->processor;
         auto unit = ctx->unit.lock();
         if (processor == nullptr || unit == nullptr) {
             self->_is_done = true;
@@ -106,16 +92,15 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
         COUNTER_UPDATE(processor->_network_timer, MonotonicNanos() - ctx->send_ts);
 
         if (resp.status().status_code() != TStatusCode::OK) {
-            auto msg = fmt::format("fetch request failed, error: {}, host: {}, port: {}", resp.status().DebugString(),
-                                   host, port);
+            auto msg = fmt::format("fetch request failed, error: {}", resp.status().DebugString());
             LOG(WARNING) << msg;
             processor->_set_io_task_status(Status::InternalError(msg));
             return;
         }
-        DLOG(INFO) << "[GLM] receive a response, response size: " << done->cntl.response_attachment().size();
-        if (done->cntl.response_attachment().size() > 0) {
+        DLOG(INFO) << "[GLM] receive a response, response size: " << closure->cntl.response_attachment().size();
+        if (closure->cntl.response_attachment().size() > 0) {
             SCOPED_TIMER(processor->_deserialize_timer);
-            butil::IOBuf& io_buf = done->cntl.response_attachment();
+            butil::IOBuf& io_buf = closure->cntl.response_attachment();
             raw::RawString buffer;
 
             for (size_t i = 0; i < resp.columns_size(); i++) {
@@ -154,7 +139,7 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     });
 
     closure->addFailureHandler([self](const FetchTaskContextPtr& ctx, std::string_view rpc_error_msg) noexcept {
-        auto processor = ctx->processor.lock();
+        auto* processor = ctx->processor;
         auto unit = ctx->unit.lock();
         if (processor == nullptr || unit == nullptr) {
             self->_is_done = true;
@@ -162,7 +147,7 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
         }
         DeferOp defer([&]() {
             if (++unit->finished_request_num == unit->total_request_num) {
-                DLOG(INFO) << "all request finished, notify fetch processor, " << (void*)processor.get();
+                DLOG(INFO) << "all request finished, notify fetch processor, " << (void*)processor;
             }
             self->_is_done = true;
         });
@@ -178,19 +163,19 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     p_query_id.set_hi(state->query_id().hi);
     p_query_id.set_lo(state->query_id().lo);
     *request.mutable_query_id() = std::move(p_query_id);
-    request.set_lookup_node_id(processor->_target_node_id);
+    request.set_lookup_node_id(_ctx->processor->_target_node_id);
     request.set_request_tuple_id(_ctx->request_tuple_id);
     {
-        SCOPED_TIMER(processor->_serialize_timer);
+        SCOPED_TIMER(_ctx->processor->_serialize_timer);
         size_t max_serialize_size = 0;
         for (const auto& column : request_chunk->columns()) {
             max_serialize_size += serde::ColumnArraySerde::max_serialized_size(*column);
         }
 
-        processor->_serialize_buffer.clear();
-        processor->_serialize_buffer.resize(max_serialize_size);
+        _ctx->processor->_serialize_buffer.clear();
+        _ctx->processor->_serialize_buffer.resize(max_serialize_size);
 
-        uint8_t* buff = reinterpret_cast<uint8_t*>(processor->_serialize_buffer.data());
+        uint8_t* buff = reinterpret_cast<uint8_t*>(_ctx->processor->_serialize_buffer.data());
         uint8_t* begin = buff;
         for (const auto& [slot_id, idx] : request_chunk->get_slot_id_to_index_map()) {
             if (slot_id == FetchProcessor::kPositionColumnSlotId) {
@@ -205,22 +190,16 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
             p_column->set_data_size(buff - start);
         }
         size_t actual_serialize_size = buff - begin;
-        closure->cntl.request_attachment().append(processor->_serialize_buffer.data(), actual_serialize_size);
+        closure->cntl.request_attachment().append(_ctx->processor->_serialize_buffer.data(), actual_serialize_size);
     }
     auto unit = _ctx->unit.lock();
     auto unit_debug_string = unit != nullptr ? unit->debug_string() : std::string("BatchUnit <expired>");
-    DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)processor.get()
+    DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)_ctx->processor
                << ", unit: " << unit_debug_string;
     _ctx->send_ts = MonotonicNanos();
+    const auto* node_info = _ctx->processor->_nodes_info->find_node(source_id);
     auto stub = state->exec_env()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
-    if (stub == nullptr) {
-        auto msg = fmt::format("Connect {}:{} failed.", node_info->host, node_info->brpc_port);
-        LOG(WARNING) << msg;
-        return Status::InternalError(msg);
-    }
-
-    auto done = closure.release();
-    stub->lookup(&done->cntl, &request, &done->result, done);
+    stub->lookup(&closure->cntl, &request, &closure->result, closure);
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fetch_task.h
+++ b/be/src/exec/pipeline/fetch_task.h
@@ -55,7 +55,7 @@ public:
     FetchTaskContext() = default;
     virtual ~FetchTaskContext() = default;
 
-    std::weak_ptr<FetchProcessor> processor;
+    FetchProcessor* processor = nullptr;
     // Keep the batch weak to avoid a BatchUnit -> FetchTask -> FetchTaskContext -> BatchUnit cycle.
     std::weak_ptr<BatchUnit> unit;
     TupleId request_tuple_id = 0;

--- a/be/src/exec/pipeline/fetch_task.h
+++ b/be/src/exec/pipeline/fetch_task.h
@@ -55,8 +55,9 @@ public:
     FetchTaskContext() = default;
     virtual ~FetchTaskContext() = default;
 
-    FetchProcessor* processor = nullptr;
-    BatchUnitPtr unit;
+    std::weak_ptr<FetchProcessor> processor;
+    // Keep the batch weak to avoid a BatchUnit -> FetchTask -> FetchTaskContext -> BatchUnit cycle.
+    std::weak_ptr<BatchUnit> unit;
     TupleId request_tuple_id = 0;
     int32_t source_node_id = 0;
     // request chunk, contains all request-related columns
@@ -67,7 +68,7 @@ public:
 };
 using FetchTaskContextPtr = std::shared_ptr<FetchTaskContext>;
 
-class FetchTask {
+class FetchTask : public std::enable_shared_from_this<FetchTask> {
 public:
     FetchTask(FetchTaskContextPtr ctx) : _ctx(std::move(ctx)) {}
     virtual ~FetchTask() = default;

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -61,7 +61,9 @@ StatusOr<size_t> LocalLookUpRequestContext::fill_response(const ChunkPtr& result
 }
 
 void LocalLookUpRequestContext::callback(const Status& status) {
-    fetch_ctx->unit->finished_request_num++;
+    if (auto unit = fetch_ctx->unit.lock(); unit != nullptr) {
+        unit->finished_request_num++;
+    }
 }
 
 // Deserialize remote request payload into a reusable chunk for processing.

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -77,6 +77,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/multi_cast_local_exchange_test.cpp
+        ./exec/pipeline/fetch_task_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -1,0 +1,252 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/fetch_task.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "base/utility/defer_op.h"
+#define private public
+#include "exec/pipeline/fetch_processor.h"
+#undef private
+#include "exec/pipeline/lookup_request.h"
+#include "exec/tablet_info.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gtest/gtest.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+namespace {
+
+constexpr int32_t kSourceNodeId = 1;
+
+int reserve_unused_local_port() {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    EXPECT_NE(fd, -1);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    EXPECT_EQ(bind(fd, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)), 0);
+    socklen_t len = sizeof(addr);
+    EXPECT_EQ(getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len), 0);
+    int port = ntohs(addr.sin_port);
+    EXPECT_EQ(close(fd), 0);
+    return port;
+}
+
+std::shared_ptr<StarRocksNodesInfo> create_nodes_info(int port) {
+    TNodesInfo t_nodes;
+    TNodeInfo node;
+    node.__set_id(kSourceNodeId);
+    node.__set_option(0);
+    node.__set_host("127.0.0.1");
+    node.__set_async_internal_port(port);
+    t_nodes.nodes.emplace_back(std::move(node));
+    return std::make_shared<StarRocksNodesInfo>(t_nodes);
+}
+
+std::shared_ptr<FetchProcessor> create_fetch_processor(const std::shared_ptr<StarRocksNodesInfo>& nodes_info) {
+    phmap::flat_hash_map<TupleId, RowPositionDescriptor*> row_pos_descs;
+    phmap::flat_hash_map<SlotId, SlotDescriptor*> slot_descs;
+    auto processor = std::make_shared<FetchProcessor>(100, row_pos_descs, slot_descs, nodes_info);
+
+    auto profile = std::make_shared<RuntimeProfile>("fetch_task_test");
+    processor->_rpc_count =
+            profile->add_counter("RpcCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    processor->_network_timer = profile->add_counter("NetworkTime", TUnit::TIME_NS,
+                                                     RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS));
+    return processor;
+}
+
+std::unique_ptr<RuntimeState> create_runtime_state(int query_timeout_s) {
+    TUniqueId fragment_instance_id;
+    fragment_instance_id.hi = 1;
+    fragment_instance_id.lo = 2;
+    TQueryOptions query_options;
+    query_options.__set_query_timeout(query_timeout_s);
+    TQueryGlobals query_globals;
+    return std::make_unique<RuntimeState>(fragment_instance_id, query_options, query_globals, ExecEnv::GetInstance());
+}
+
+bool wait_task_done(const FetchTaskPtr& task, int timeout_ms) {
+    constexpr int kCheckIntervalMs = 10;
+    int elapsed = 0;
+    while (elapsed < timeout_ms) {
+        if (task->is_done()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(kCheckIntervalMs));
+        elapsed += kCheckIntervalMs;
+    }
+    return task->is_done();
+}
+
+} // namespace
+
+// Verify the shared_ptr cycle between BatchUnit and FetchTaskContext is broken
+// after changing FetchTaskContext::unit to weak_ptr.
+TEST(FetchTaskTest, batch_unit_released_after_outer_refs_drop) {
+    std::weak_ptr<BatchUnit> weak_unit;
+
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        weak_unit = unit;
+
+        auto ctx = std::make_shared<FetchTaskContext>();
+        ctx->unit = unit;
+
+        auto task = std::make_shared<FetchTask>(ctx);
+        auto tasks = std::make_shared<std::vector<FetchTaskPtr>>();
+        tasks->emplace_back(task);
+        unit->fetch_tasks.emplace(1, tasks);
+
+        // Drop all external references; weak_ptr in ctx should not prevent release.
+        task.reset();
+        tasks.reset();
+        ctx.reset();
+        unit.reset();
+    }
+
+    EXPECT_TRUE(weak_unit.expired());
+}
+
+// Simulate the RPC closure holding FetchTask alive via shared_from_this()
+// even after the owning BatchUnit drops its reference.
+TEST(FetchTaskTest, shared_from_this_keeps_task_alive_after_batch_drops) {
+    std::weak_ptr<FetchTask> weak_task;
+
+    auto unit = std::make_shared<BatchUnit>();
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->unit = unit;
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    weak_task = task;
+
+    // Simulate what the RPC closure does: hold a shared_ptr copy.
+    auto closure_hold = task->shared_from_this();
+
+    // Store task in BatchUnit, then release all external refs except closure_hold.
+    auto tasks = std::make_shared<std::vector<FetchTaskPtr>>();
+    tasks->emplace_back(std::move(task));
+    unit->fetch_tasks.emplace(1, tasks);
+
+    tasks.reset();
+    unit.reset();
+    ctx.reset();
+
+    // FetchTask should still be alive because closure_hold keeps it.
+    EXPECT_FALSE(weak_task.expired());
+    EXPECT_FALSE(closure_hold->is_done());
+
+    // After closure finishes and releases, FetchTask is destroyed.
+    closure_hold.reset();
+    EXPECT_TRUE(weak_task.expired());
+}
+
+// LocalLookUpRequestContext::callback should safely increment finished_request_num
+// when the BatchUnit is still alive.
+TEST(FetchTaskTest, local_callback_increments_counter_when_unit_alive) {
+    auto unit = std::make_shared<BatchUnit>();
+    unit->total_request_num = 2;
+    unit->finished_request_num = 0;
+
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->unit = unit;
+
+    LocalLookUpRequestContext local_ctx(ctx);
+    local_ctx.callback(Status::OK());
+
+    EXPECT_EQ(unit->finished_request_num.load(), 1);
+
+    local_ctx.callback(Status::OK());
+    EXPECT_EQ(unit->finished_request_num.load(), 2);
+}
+
+// LocalLookUpRequestContext::callback should not crash when the BatchUnit
+// has already been released (weak_ptr expired).
+TEST(FetchTaskTest, local_callback_safe_when_unit_expired) {
+    auto ctx = std::make_shared<FetchTaskContext>();
+
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        unit->total_request_num = 1;
+        ctx->unit = unit;
+        // unit goes out of scope here, weak_ptr expires.
+    }
+
+    LocalLookUpRequestContext local_ctx(ctx);
+    // Should not crash or modify anything.
+    EXPECT_NO_FATAL_FAILURE(local_ctx.callback(Status::OK()));
+}
+
+TEST(FetchTaskTest, submit_remote_rpc_failure_marks_done_and_updates_status) {
+    ASSERT_NE(ExecEnv::GetInstance(), nullptr);
+    ASSERT_NE(ExecEnv::GetInstance()->brpc_stub_cache(), nullptr);
+
+    const int unused_port = reserve_unused_local_port();
+    auto processor = create_fetch_processor(create_nodes_info(unused_port));
+    auto unit = std::make_shared<BatchUnit>();
+    unit->total_request_num = 1;
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->processor = processor;
+    ctx->unit = unit;
+    ctx->source_node_id = kSourceNodeId;
+    ctx->request_tuple_id = 10;
+    ctx->request_chunk = std::make_shared<Chunk>();
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    auto state = create_runtime_state(1);
+    ASSERT_TRUE(task->submit(state.get()).ok());
+    ASSERT_TRUE(wait_task_done(task, 5000));
+
+    EXPECT_TRUE(task->is_done());
+    EXPECT_EQ(unit->finished_request_num.load(), 1);
+    EXPECT_FALSE(processor->_io_task_status.ok());
+}
+
+TEST(FetchTaskTest, submit_remote_rpc_failure_handles_expired_unit) {
+    ASSERT_NE(ExecEnv::GetInstance(), nullptr);
+    ASSERT_NE(ExecEnv::GetInstance()->brpc_stub_cache(), nullptr);
+
+    const int unused_port = reserve_unused_local_port();
+    auto processor = create_fetch_processor(create_nodes_info(unused_port));
+    auto ctx = std::make_shared<FetchTaskContext>();
+    ctx->processor = processor;
+    {
+        auto unit = std::make_shared<BatchUnit>();
+        ctx->unit = unit;
+    }
+    ctx->source_node_id = kSourceNodeId;
+    ctx->request_tuple_id = 11;
+    ctx->request_chunk = std::make_shared<Chunk>();
+
+    auto task = std::make_shared<FetchTask>(ctx);
+    auto state = create_runtime_state(1);
+    ASSERT_TRUE(task->submit(state.get()).ok());
+    ASSERT_TRUE(wait_task_done(task, 5000));
+
+    EXPECT_TRUE(task->is_done());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <vector>
 
-#include "base/utility/defer_op.h"
 #define private public
 #include "exec/pipeline/fetch_processor.h"
 #undef private
@@ -69,7 +68,7 @@ std::shared_ptr<StarRocksNodesInfo> create_nodes_info(int port) {
 std::shared_ptr<FetchProcessor> create_fetch_processor(const std::shared_ptr<StarRocksNodesInfo>& nodes_info) {
     phmap::flat_hash_map<TupleId, RowPositionDescriptor*> row_pos_descs;
     phmap::flat_hash_map<SlotId, SlotDescriptor*> slot_descs;
-    auto processor = std::make_shared<FetchProcessor>(100, row_pos_descs, slot_descs, nodes_info);
+    auto processor = std::make_shared<FetchProcessor>(100, row_pos_descs, slot_descs, nodes_info, nullptr);
 
     auto profile = std::make_shared<RuntimeProfile>("fetch_task_test");
     processor->_rpc_count =
@@ -209,7 +208,7 @@ TEST(FetchTaskTest, submit_remote_rpc_failure_marks_done_and_updates_status) {
     auto unit = std::make_shared<BatchUnit>();
     unit->total_request_num = 1;
     auto ctx = std::make_shared<FetchTaskContext>();
-    ctx->processor = processor;
+    ctx->processor = processor.get();
     ctx->unit = unit;
     ctx->source_node_id = kSourceNodeId;
     ctx->request_tuple_id = 10;
@@ -232,7 +231,7 @@ TEST(FetchTaskTest, submit_remote_rpc_failure_handles_expired_unit) {
     const int unused_port = reserve_unused_local_port();
     auto processor = create_fetch_processor(create_nodes_info(unused_port));
     auto ctx = std::make_shared<FetchTaskContext>();
-    ctx->processor = processor;
+    ctx->processor = processor.get();
     {
         auto unit = std::make_shared<BatchUnit>();
         ctx->unit = unit;


### PR DESCRIPTION
## Why I'm doing

The global lazy materialization feature (`FetchProcessor`) has a reference-count cycle that prevents `BatchUnit` objects from being freed when a query finishes normally or when a consumer finishes early (e.g. `LIMIT`).

The ownership cycle is:

```
BatchUnit                          (shared_ptr)
  └─ fetch_tasks map
       └─ shared_ptr<vector<FetchTaskPtr>>
            └─ shared_ptr<FetchTask>
                 └─ shared_ptr<FetchTaskContext>
                      └─ shared_ptr<BatchUnit>   ← back to start
```

Because every node in this ring holds a `shared_ptr` to the next, the reference count of `BatchUnit` never reaches zero even after all external owners (`_queue`, `_current_unit` in `FetchProcessor`) release their references. This causes a memory leak proportional to the number of batches processed during a query.

A secondary issue exists in the RPC callback closures: they capture the raw `this` pointer of `FetchTask`. Before this fix the `FetchTask` lifetime was accidentally sustained by the cycle itself. Once the cycle is broken, the `FetchTask` may be destroyed before an in-flight RPC callback returns, leading to a use-after-free on `_is_done`.

## What I'm doing

**Break the cycle by weakening one edge.** Change `FetchTaskContext::unit` from `shared_ptr<BatchUnit>` to `weak_ptr<BatchUnit>`. This is the natural weak edge because:
- `FetchTaskContext` does not own the `BatchUnit`; it only needs to read/update counters during RPC callbacks.
- The `BatchUnit` is strongly owned by `FetchProcessor::_queue` and `_current_unit` throughout its useful lifetime. As long as the batch is relevant, those strong references keep it alive.
- When the source finishes early (`set_source_finishing`), the queue is cleared, `BatchUnit` is released, and `is_finished()` short-circuits via `_is_source_finishing` — no downstream code ever checks `all_fetch_done()` after that point.

**Keep `FetchTask` alive through RPC callbacks via `shared_from_this()`.** `FetchTask` now inherits `enable_shared_from_this`. In `_submit_remote_task`, the success and failure closures capture `self = shared_from_this()` instead of raw `this`. This guarantees the `FetchTask` (and its `_is_done` flag) remains valid for the entire RPC round-trip, even if the owning `BatchUnit` and its `fetch_tasks` map are released before the callback fires.

**Guard all `unit` accesses in callbacks with `weak_ptr::lock()`.** Each callback locks the weak pointer and checks for expiry. If the `BatchUnit` is already gone (source finished early), the callback sets `_is_done = true` and returns without touching any batch state. This is correct because an expired `BatchUnit` means `FetchProcessor::is_finished()` already returns `true` (`fetch_processor.cpp:92-93`), so no one will poll `all_fetch_done()` or read batch counters again.

**Add a regression test** (`FetchTaskTest.batch_unit_cycle_is_released_after_outer_refs_drop`) that constructs the full cycle, drops all external references, and asserts the `BatchUnit` weak pointer expires — confirming the cycle is broken.

Fixes: https://github.com/StarRocks/StarRocksTest/issues/11201

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
