### PR TITLE
[BugFix] Fix a memory leak issue in `DefaultValueColumnIterator` for complex types (backport #71142)

### DIFF
--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -37,6 +37,8 @@
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/types.h"
+#include "types/datum.h"
 
 namespace starrocks {
 
@@ -58,6 +60,18 @@ public:
               _pool(),
               _num_rows(num_rows),
               _path(path) {}
+
+    ~DefaultValueColumnIterator() override {
+        // For complex types (ARRAY/MAP/STRUCT), a Datum is placement-new'd into _mem_value.
+        // MemPool only frees raw memory without calling destructors, so we must explicitly
+        // destroy the Datum to avoid leaking its internal heap-allocated containers.
+        if (_mem_value != nullptr && _type_info != nullptr && !_is_default_value_null) {
+            auto type = _type_info->type();
+            if (type == TYPE_ARRAY || type == TYPE_MAP || type == TYPE_STRUCT) {
+                reinterpret_cast<Datum*>(_mem_value)->~Datum();
+            }
+        }
+    }
 
     Status init(const ColumnIteratorOptions& opts) override;
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -38,7 +38,7 @@
 #include "runtime/mem_tracker.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/types.h"
-#include "types/datum.h"
+#include "column/datum.h"
 
 namespace starrocks {
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -34,11 +34,11 @@
 
 #pragma once
 
+#include "column/datum.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/types.h"
-#include "column/datum.h"
 
 namespace starrocks {
 

--- a/be/test/storage/rowset/default_value_column_iterator_test.cpp
+++ b/be/test/storage/rowset/default_value_column_iterator_test.cpp
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "storage/column_predicate.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/tablet_schema.h"
 #include "storage/types.h"
 
 namespace starrocks {
@@ -53,6 +54,146 @@ TEST_F(DefaultValueColumnIteratorTest, delete_after_column) {
     ASSERT_EQ(column->size(), 10);
     for (size_t i = 0; i < 10; i++) {
         ASSERT_TRUE(column->is_null(i));
+    }
+}
+
+// Test that DefaultValueColumnIterator properly destroys placement-new'd Datum
+// for complex types (ARRAY/MAP/STRUCT), preventing memory leaks.
+// This test is designed to be run under ASAN to detect leaks.
+TEST_F(DefaultValueColumnIteratorTest, no_leak_for_array_default_value) {
+    // Build an ARRAY<INT> TypeInfo via TabletColumn
+    TabletColumn array_col;
+    array_col.set_unique_id(0);
+    array_col.set_name("c_array");
+    array_col.set_type(TYPE_ARRAY);
+    array_col.set_is_nullable(true);
+    array_col.set_length(24);
+
+    TabletColumn int_col;
+    int_col.set_unique_id(1);
+    int_col.set_name("element");
+    int_col.set_type(TYPE_INT);
+    int_col.set_is_nullable(false);
+    int_col.set_length(4);
+    array_col.add_sub_column(int_col);
+
+    TypeInfoPtr type_info = get_type_info(array_col);
+    ASSERT_NE(type_info, nullptr);
+
+    // JSON representation of [1, 2, 3]
+    std::string default_value = "[1, 2, 3]";
+
+    {
+        // Scope the iterator so its destructor runs before test ends.
+        // Under ASAN, a missing Datum destructor call would be reported as a leak.
+        DefaultValueColumnIterator iter(true, default_value, true, type_info, 24, 10);
+
+        ColumnIteratorOptions opts;
+        ASSERT_TRUE(iter.init(opts).ok());
+
+        // Read a batch to ensure the default value is actually used
+        TypeDescriptor type_desc(LogicalType::TYPE_ARRAY);
+        type_desc.children.emplace_back(LogicalType::TYPE_INT);
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, true);
+
+        size_t num_rows = 5;
+        ASSERT_TRUE(iter.next_batch(&num_rows, column.get()).ok());
+        ASSERT_EQ(column->size(), 5);
+    }
+    // If the destructor doesn't call Datum::~Datum(), ASAN will report a leak here.
+}
+
+TEST_F(DefaultValueColumnIteratorTest, no_leak_for_map_default_value) {
+    TabletColumn map_col;
+    map_col.set_unique_id(0);
+    map_col.set_name("c_map");
+    map_col.set_type(TYPE_MAP);
+    map_col.set_is_nullable(true);
+    map_col.set_length(24);
+
+    TabletColumn key_col;
+    key_col.set_unique_id(1);
+    key_col.set_name("key");
+    key_col.set_type(TYPE_VARCHAR);
+    key_col.set_is_nullable(false);
+    key_col.set_length(128);
+    map_col.add_sub_column(key_col);
+
+    TabletColumn val_col;
+    val_col.set_unique_id(2);
+    val_col.set_name("value");
+    val_col.set_type(TYPE_INT);
+    val_col.set_is_nullable(true);
+    val_col.set_length(4);
+    map_col.add_sub_column(val_col);
+
+    TypeInfoPtr type_info = get_type_info(map_col);
+    ASSERT_NE(type_info, nullptr);
+
+    std::string default_value = R"({"a": 1, "b": 2})";
+
+    {
+        DefaultValueColumnIterator iter(true, default_value, true, type_info, 24, 10);
+        ColumnIteratorOptions opts;
+        ASSERT_TRUE(iter.init(opts).ok());
+
+        TypeDescriptor type_desc(LogicalType::TYPE_MAP);
+        type_desc.children.emplace_back(LogicalType::TYPE_VARCHAR);
+        type_desc.children.back().len = 128;
+        type_desc.children.emplace_back(LogicalType::TYPE_INT);
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, true);
+
+        size_t num_rows = 3;
+        ASSERT_TRUE(iter.next_batch(&num_rows, column.get()).ok());
+        ASSERT_EQ(column->size(), 3);
+    }
+}
+
+TEST_F(DefaultValueColumnIteratorTest, no_leak_for_struct_default_value) {
+    TabletColumn struct_col;
+    struct_col.set_unique_id(0);
+    struct_col.set_name("c_struct");
+    struct_col.set_type(TYPE_STRUCT);
+    struct_col.set_is_nullable(true);
+    struct_col.set_length(24);
+
+    TabletColumn field1;
+    field1.set_unique_id(1);
+    field1.set_name("f1");
+    field1.set_type(TYPE_INT);
+    field1.set_is_nullable(true);
+    field1.set_length(4);
+    struct_col.add_sub_column(field1);
+
+    TabletColumn field2;
+    field2.set_unique_id(2);
+    field2.set_name("f2");
+    field2.set_type(TYPE_VARCHAR);
+    field2.set_is_nullable(true);
+    field2.set_length(128);
+    struct_col.add_sub_column(field2);
+
+    TypeInfoPtr type_info = get_type_info(struct_col);
+    ASSERT_NE(type_info, nullptr);
+
+    std::string default_value = R"([42, "hello"])";
+
+    {
+        DefaultValueColumnIterator iter(true, default_value, true, type_info, 24, 10);
+        ColumnIteratorOptions opts;
+        ASSERT_TRUE(iter.init(opts).ok());
+
+        TypeDescriptor type_desc(LogicalType::TYPE_STRUCT);
+        type_desc.children.emplace_back(LogicalType::TYPE_INT);
+        type_desc.children.emplace_back(LogicalType::TYPE_VARCHAR);
+        type_desc.children.back().len = 128;
+        type_desc.field_names.emplace_back("f1");
+        type_desc.field_names.emplace_back("f2");
+        MutableColumnPtr column = ColumnHelper::create_column(type_desc, true);
+
+        size_t num_rows = 3;
+        ASSERT_TRUE(iter.next_batch(&num_rows, column.get()).ok());
+        ASSERT_EQ(column->size(), 3);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing

For ARRAY/MAP/STRUCT default values, `DefaultValueColumnIterator::init()` constructs a `Datum` via **placement new** into MemPool-allocated memory (`default_value_column_iterator.cpp`). However, `MemPool` only frees raw bytes without calling destructors, so the `Datum`'s internal heap-allocated containers (`std::vector<Datum>`, `std::map<DatumKey, Datum>`) were never destroyed, causing memory leaks.

## What I'm doing

- Add `~DefaultValueColumnIterator()` that explicitly calls `Datum::~Datum()` for ARRAY/MAP/STRUCT types before MemPool reclaims the raw memory
- Add unit tests covering ARRAY, MAP, and STRUCT default value iterator lifecycle to catch regressions under ASAN
- **Fix include path**: `types/datum.h` does not exist on `branch-4.1`, changed to `column/datum.h`

Fixes: https://github.com/StarRocks/StarRocksTest/issues/11198

Supersedes #71193 (which had a BE UT compilation failure due to wrong include path)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4