### PR TITLE
[BugFix] Fix ORC file metric construction in AddFilesProcedure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
@@ -482,11 +482,11 @@ public class AddFilesProcedure extends IcebergTableProcedure {
                 ColumnStatistics[] columnStats = orcReader.getStatistics();
 
                 // Extract statistics for each column
-                for (int colId = 0; colId < columnStats.length; colId++) {
+                for (int colId = 1; colId < columnStats.length; colId++) {
                     ColumnStatistics stats = columnStats[colId];
 
                     // Map ORC column to Iceberg field
-                    String columnName = getColumnNameFromOrcSchema(orcSchema, colId);
+                    String columnName = getColumnNameFromOrcSchema(orcSchema, colId - 1);
                     if (columnName != null) {
                         Types.NestedField field = schema.findField(columnName);
                         if (field != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
@@ -40,6 +40,10 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -208,7 +212,7 @@ public class AddFilesProcedureTest {
                 () -> procedure.execute(context, args));
 
         // The exception should be about Hive table access, not "not implemented"
-        assertTrue(exception.getMessage().contains("Failed to access source table") || 
+        assertTrue(exception.getMessage().contains("Failed to access source table") ||
                    exception.getMessage().contains("not found") ||
                    exception.getMessage().contains("not a Hive table"));
     }
@@ -596,6 +600,95 @@ public class AddFilesProcedureTest {
         assertFalse(metrics.nullValueCounts().containsKey(2));
         assertTrue(metrics.lowerBounds().isEmpty());
         assertTrue(metrics.upperBounds().isEmpty());
+    }
+
+
+    @Test
+    public void testExtractOrcMetrics(@Mocked Table table,
+                                      @Mocked IcebergHiveCatalog catalog,
+                                      @Mocked Reader orcReader) throws Exception {
+        AddFilesProcedure procedure = AddFilesProcedure.getInstance();
+        IcebergTableProcedureContext context =
+                new IcebergTableProcedureContext(catalog, table, null, null, HDFS_ENVIRONMENT, null, null);
+
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get())
+        );
+
+        FileStatus fileStatus = new FileStatus(2048L, false, 1, 0L, 0L, new Path("/tmp/data.orc"));
+
+        TypeDescription orcSchema = TypeDescription.createStruct()
+                .addField("id", TypeDescription.createInt())
+                .addField("name", TypeDescription.createString());
+
+
+        long totalRows = 100L;
+
+        // index 0: root struct statistics (should not be mapped to any column)
+        ColumnStatistics rootStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(rootStats.getNumberOfValues()).thenReturn(totalRows);
+        Mockito.when(rootStats.hasNull()).thenReturn(false);
+
+        // index 1: "id" column statistics, 90 non-null values, has nulls
+        ColumnStatistics idStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(idStats.getNumberOfValues()).thenReturn(90L);
+        Mockito.when(idStats.hasNull()).thenReturn(true);
+
+        // index 2: "name" column statistics, 80 non-null values, has nulls
+        ColumnStatistics nameStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(nameStats.getNumberOfValues()).thenReturn(80L);
+        Mockito.when(nameStats.hasNull()).thenReturn(true);
+
+        ColumnStatistics[] allStats = new ColumnStatistics[] {rootStats, idStats, nameStats};
+
+        new Expectations() {
+            {
+                table.schema();
+                result = schema;
+
+                orcReader.getNumberOfRows();
+                result = totalRows;
+
+                orcReader.getSchema();
+                result = orcSchema;
+
+                orcReader.getStatistics();
+                result = allStats;
+            }
+        };
+
+        new MockUp<OrcFile>() {
+            @Mock
+            public Reader createReader(Path path, OrcFile.ReaderOptions opts) {
+                return orcReader;
+            }
+        };
+
+        java.lang.reflect.Method method = AddFilesProcedure.class.getDeclaredMethod("extractOrcMetrics",
+                IcebergTableProcedureContext.class, Table.class, FileStatus.class);
+        method.setAccessible(true);
+        Metrics metrics = (Metrics) method.invoke(procedure, context, table, fileStatus);
+
+        assertEquals(totalRows, metrics.recordCount());
+
+
+        assertNotNull(metrics.valueCounts());
+        assertTrue(metrics.valueCounts().containsKey(1));
+        assertEquals(90L, metrics.valueCounts().get(1));
+
+        assertTrue(metrics.valueCounts().containsKey(2));
+        assertEquals(80L, metrics.valueCounts().get(2));
+
+        assertNotNull(metrics.nullValueCounts());
+        assertTrue(metrics.nullValueCounts().containsKey(1));
+        assertEquals(10L, metrics.nullValueCounts().get(1));
+
+        assertTrue(metrics.nullValueCounts().containsKey(2));
+        assertEquals(20L, metrics.nullValueCounts().get(2));
+
+        // Only 2 columns should have valueCounts, rootStats should not be mapped to any column
+        assertEquals(2, metrics.valueCounts().size());
     }
 
     private IcebergTableProcedureContext createMockContext(@Mocked Table table, @Mocked IcebergHiveCatalog catalog) {


### PR DESCRIPTION
## Why I'm doing:

In AddFilesProcedure extractOrcMetrics, ORC's Reader.getStatistics() returns file-level stats at index 0, with actual column stats starting from index 1. The current code iterates from index 0, causing all column metrics to be shifted by one position.

## What I'm doing:

Fix the off-by-one bug by starting the loop from colId = 1 and passing colId - 1 to getColumnNameFromOrcSchem to create correct metric in orc

Fixes https://github.com/StarRocks/starrocks/issues/71222
Issue: https://github.com/StarRocks/starrocks/issues/71222

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4