### PR TITLE
[Enhancement] Add StarOSAgent PACK shard group support and ColocateRangeUtils for range colocate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateRangeUtils.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility methods for range distribution colocate operations.
+ */
+public class ColocateRangeUtils {
+
+    /**
+     * Expands a colocate range (on colocate column prefix) to a full sort key range
+     * by appending NULL variant values for the remaining sort key columns.
+     *
+     * <p>Colocate ranges are always in [lower, upper) form (inclusive lower, exclusive upper),
+     * which is guaranteed by ColocateRangeMgr.splitColocateRange(). For this form, NULL
+     * variant (which sorts before all normal values) is the correct sentinel for both bounds.
+     *
+     * <p>For example, with sort key (k1, k2, k3), colocate columns (k1):
+     * <ul>
+     *   <li>[100, 200) -> [(100, NULL, NULL), (200, NULL, NULL))</li>
+     *   <li>[100, +inf) -> [(100, NULL, NULL), +inf)</li>
+     *   <li>(-inf, 200) -> (-inf, (200, NULL, NULL))</li>
+     * </ul>
+     *
+     * <p>For ALL range (initial state), returns ALL directly without expansion.
+     *
+     * @param colocateRange the colocate range to expand (must be [lower, upper) form)
+     * @param sortKeyColumns the full sort key columns
+     * @param colocateColumnCount the number of colocate columns (prefix of sort key)
+     * @return the expanded range covering the full sort key
+     */
+    public static Range<Tuple> expandToFullSortKey(Range<Tuple> colocateRange,
+                                                    List<Column> sortKeyColumns,
+                                                    int colocateColumnCount) {
+        Preconditions.checkArgument(colocateColumnCount >= 0
+                        && colocateColumnCount <= sortKeyColumns.size(),
+                "colocateColumnCount %s out of range [0, %s]",
+                colocateColumnCount, sortKeyColumns.size());
+        if (colocateRange.isAll()) {
+            return Range.all();
+        }
+        // Colocate ranges are always [lower, upper) form
+        Preconditions.checkArgument(colocateRange.isMinimum() || colocateRange.isLowerBoundIncluded(),
+                "Colocate range lower bound must be inclusive or infinite");
+        Preconditions.checkArgument(colocateRange.isMaximum() || !colocateRange.isUpperBoundIncluded(),
+                "Colocate range upper bound must be exclusive or infinite");
+
+        int remainingColumns = sortKeyColumns.size() - colocateColumnCount;
+        Tuple lowerBound = colocateRange.isMinimum() ? null
+                : extendTupleWithNull(colocateRange.getLowerBound(), sortKeyColumns,
+                        colocateColumnCount, remainingColumns);
+        Tuple upperBound = colocateRange.isMaximum() ? null
+                : extendTupleWithNull(colocateRange.getUpperBound(), sortKeyColumns,
+                        colocateColumnCount, remainingColumns);
+        return Range.of(lowerBound, upperBound,
+                colocateRange.isLowerBoundIncluded(),
+                colocateRange.isUpperBoundIncluded());
+    }
+
+    private static Tuple extendTupleWithNull(Tuple tuple, List<Column> sortKeyColumns,
+                                              int colocateColumnCount, int remainingColumns) {
+        List<Variant> values = new ArrayList<>(tuple.getValues());
+        for (int i = 0; i < remainingColumns; i++) {
+            values.add(Variant.nullVariant(sortKeyColumns.get(colocateColumnCount + i).getType()));
+        }
+        return new Tuple(values);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -493,12 +493,17 @@ public class StarOSAgent {
     }
 
     public long createShardGroup(long dbId, long tableId, long partitionId, long indexId) throws DdlException {
+        return createShardGroup(dbId, tableId, partitionId, indexId, PlacementPolicy.SPREAD);
+    }
+
+    public long createShardGroup(long dbId, long tableId, long partitionId, long indexId,
+                                  PlacementPolicy placementPolicy) throws DdlException {
         prepare();
         List<ShardGroupInfo> shardGroupInfos = null;
         try {
             List<CreateShardGroupInfo> createShardGroupInfos = new ArrayList<>();
             createShardGroupInfos.add(CreateShardGroupInfo.newBuilder()
-                    .setPolicy(PlacementPolicy.SPREAD)
+                    .setPolicy(placementPolicy)
                     .putLabels("dbId", String.valueOf(dbId))
                     .putLabels("tableId", String.valueOf(tableId))
                     .putLabels("partitionId", String.valueOf(partitionId))
@@ -568,6 +573,17 @@ public class StarOSAgent {
                                    @Nullable List<Long> matchShardIds, @NotNull Map<String, String> properties,
                                    ComputeResource computeResource)
         throws DdlException {
+        return createShards(numShards, pathInfo, cacheInfo, List.of(groupId), matchShardIds, properties,
+                computeResource);
+    }
+
+    public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
+                                   List<Long> groupIds, @Nullable List<Long> matchShardIds,
+                                   @NotNull Map<String, String> properties,
+                                   ComputeResource computeResource)
+        throws DdlException {
+        Preconditions.checkArgument(groupIds != null && !groupIds.isEmpty(),
+                "groupIds must not be null or empty");
         if (matchShardIds != null) {
             Preconditions.checkState(numShards == matchShardIds.size());
         }
@@ -579,7 +595,7 @@ public class StarOSAgent {
 
             CreateShardInfo.Builder builder = CreateShardInfo.newBuilder();
             builder.setReplicaCount(1)
-                    .addGroupIds(groupId)
+                    .addAllGroupIds(groupIds)
                     .setPathInfo(pathInfo)
                     .setCacheInfo(cacheInfo)
                     .putAllShardProperties(properties)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateRangeUtilsTest.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.Range;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ColocateRangeUtilsTest {
+
+    private static final List<Column> SORT_KEY_COLUMNS = Arrays.asList(
+            new Column("k1", IntegerType.INT),
+            new Column("k2", VarcharType.VARCHAR),
+            new Column("k3", IntegerType.BIGINT));
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @Test
+    public void testExpandAllRange() {
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                Range.all(), SORT_KEY_COLUMNS, 1);
+        Assertions.assertTrue(result.isAll());
+    }
+
+    @Test
+    public void testExpandAllRangeWithAllColocateColumns() {
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                Range.all(), SORT_KEY_COLUMNS, 3);
+        Assertions.assertTrue(result.isAll());
+    }
+
+    // [100, 200) -> [(100, NULL, NULL), (200, NULL, NULL))
+    @Test
+    public void testExpandBoundedRange() {
+        Range<Tuple> colocateRange = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                colocateRange, SORT_KEY_COLUMNS, 1);
+
+        Assertions.assertTrue(result.isLowerBoundIncluded());
+        Assertions.assertFalse(result.isUpperBoundIncluded());
+
+        Tuple lower = result.getLowerBound();
+        Assertions.assertEquals(3, lower.getValues().size());
+        Assertions.assertEquals("100", lower.getValues().get(0).getStringValue());
+        Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
+        Assertions.assertTrue(lower.getValues().get(2) instanceof NullVariant);
+
+        Tuple upper = result.getUpperBound();
+        Assertions.assertEquals(3, upper.getValues().size());
+        Assertions.assertEquals("200", upper.getValues().get(0).getStringValue());
+        Assertions.assertTrue(upper.getValues().get(1) instanceof NullVariant);
+        Assertions.assertTrue(upper.getValues().get(2) instanceof NullVariant);
+    }
+
+    // (-inf, 200) -> (-inf, (200, NULL, NULL))
+    @Test
+    public void testExpandLowerUnbounded() {
+        Range<Tuple> colocateRange = Range.lt(makeTuple(200));
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                colocateRange, SORT_KEY_COLUMNS, 1);
+
+        Assertions.assertTrue(result.isMinimum());
+        Assertions.assertNull(result.getLowerBound());
+        Assertions.assertFalse(result.isUpperBoundIncluded());
+
+        Tuple upper = result.getUpperBound();
+        Assertions.assertEquals(3, upper.getValues().size());
+        Assertions.assertTrue(upper.getValues().get(1) instanceof NullVariant);
+    }
+
+    // [100, +inf) -> [(100, NULL, NULL), +inf)
+    @Test
+    public void testExpandUpperUnbounded() {
+        Range<Tuple> colocateRange = Range.ge(makeTuple(100));
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                colocateRange, SORT_KEY_COLUMNS, 1);
+
+        Assertions.assertTrue(result.isMaximum());
+        Assertions.assertNull(result.getUpperBound());
+        Assertions.assertTrue(result.isLowerBoundIncluded());
+
+        Tuple lower = result.getLowerBound();
+        Assertions.assertEquals(3, lower.getValues().size());
+        Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
+    }
+
+    @Test
+    public void testExpandNoRemainingColumns() {
+        List<Column> singleColumnSortKey = Arrays.asList(new Column("k1", IntegerType.INT));
+        Range<Tuple> colocateRange = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> result = ColocateRangeUtils.expandToFullSortKey(
+                colocateRange, singleColumnSortKey, 1);
+
+        // No expansion, tuple size unchanged
+        Assertions.assertEquals(1, result.getLowerBound().getValues().size());
+        Assertions.assertEquals(1, result.getUpperBound().getValues().size());
+    }
+
+    // Invalid: exclusive lower bound should be rejected
+    @Test
+    public void testRejectExclusiveLowerBound() {
+        Range<Tuple> colocateRange = Range.gt(makeTuple(100));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.expandToFullSortKey(colocateRange, SORT_KEY_COLUMNS, 1));
+    }
+
+    // Invalid: inclusive upper bound should be rejected
+    @Test
+    public void testRejectInclusiveUpperBound() {
+        Range<Tuple> colocateRange = Range.le(makeTuple(200));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.expandToFullSortKey(colocateRange, SORT_KEY_COLUMNS, 1));
+    }
+
+    // Invalid: colocateColumnCount out of range
+    @Test
+    public void testRejectInvalidColocateColumnCount() {
+        Range<Tuple> colocateRange = Range.gelt(makeTuple(100), makeTuple(200));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.expandToFullSortKey(colocateRange, SORT_KEY_COLUMNS, -1));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ColocateRangeUtils.expandToFullSortKey(colocateRange, SORT_KEY_COLUMNS, 4));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                           
  Range distribution colocate requires PACK shard groups (for co-location) and the ability                                                                                                                                                                                   
  to create shards belonging to multiple shard groups simultaneously (SPREAD + PACK).          
  The existing StarOSAgent only supports SPREAD placement policy and single group ID.                                                                                                                                                                                        
  Additionally, a utility is needed to expand colocate column ranges to full sort key ranges                                                                                                                                                                                 
  for tablet range assignment.

## What I'm doing:

  1. Add `StarOSAgent.createShardGroup(PlacementPolicy)` overload to support creating
     shard groups with configurable placement policy (SPREAD or PACK). The existing
     method delegates to the new one with SPREAD as default.

  2. Add `StarOSAgent.createShards(List<Long> groupIds)` overload to support creating
     shards belonging to multiple shard groups simultaneously. The existing single-groupId
     method delegates to the new one with `List.of(groupId)`. Includes argument validation
     for non-null/non-empty groupIds.

  3. Add `ColocateRangeUtils` helper class with `expandToFullSortKey()` method that expands
     a colocate range (on colocate column prefix) to a full sort key range by appending
     `Variant.nullVariant()` values for the remaining sort key columns. Colocate ranges are
     constrained to `[lower, upper)` form (inclusive lower, exclusive upper), which is
     guaranteed by ColocateRangeMgr. For this form, NULL variant (which sorts before all
     normal values in real data) is the correct and BE-compatible sentinel for both bounds.
     Includes validation for colocateColumnCount range and bound inclusiveness.


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
