### PR TITLE
[BugFix] Two different NullableColumns should not share the identical NullColumn

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -59,8 +59,9 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
 
         if (arg0->has_null()) {
             // Copy null flags.
-            return NullableColumn::create(std::move(col_result),
-                                          std::move(*(down_cast<const NullableColumn*>(arg0)->null_column())).mutate());
+            auto null_column = NullColumn::static_pointer_cast(
+                    Column::mutate(down_cast<const NullableColumn*>(arg0)->null_column()));
+            return NullableColumn::create(std::move(col_result), std::move(null_column));
         } else {
             return col_result;
         }

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -136,7 +136,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_append([[maybe_unused]] FunctionContex
     RETURN_IF_ERROR(result);
 
     if (nullable_array != nullptr) {
-        return NullableColumn::create(result.value(), nullable_array->null_column());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable_array->null_column()));
+        return NullableColumn::create(result.value(), std::move(null_column));
     }
     return result;
 }
@@ -372,7 +373,8 @@ private:
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
             ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
-            return NullableColumn::create(result, nullable->null_column());
+            auto null_column = NullColumn::static_pointer_cast(Column::mutate(nullable->null_column()));
+            return NullableColumn::create(result, std::move(null_column));
         }
 
         return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
@@ -1921,7 +1923,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     auto result = ArrayColumn::create(result_elements, result_offsets);
     if (src_nullable_column != nullptr) {
-        return NullableColumn::create(result, src_nullable_column->null_column());
+        auto null_column = NullColumn::static_pointer_cast(Column::mutate(src_nullable_column->null_column()));
+        return NullableColumn::create(result, std::move(null_column));
     }
     return result;
 }

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -256,7 +256,7 @@ public:
             NullColumn::MutablePtr null_flags;
             if (data->is_nullable()) {
                 auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(data);
-                null_flags = NullColumn::static_pointer_cast(std::move(*nullable_column->null_column()).mutate());
+                null_flags = NullColumn::static_pointer_cast(Column::mutate(nullable_column->null_column()));
             } else {
                 null_flags = RunTimeColumnType<TYPE_NULL>::create();
                 null_flags->resize(data->size());

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -144,8 +144,9 @@ StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Colum
     }
 
     if (arg0->has_null()) {
-        return NullableColumn::create(std::move(col_result),
-                                      down_cast<const NullableColumn*>(arg0.get())->null_column());
+        auto null_column = NullColumn::static_pointer_cast(
+                Column::mutate(down_cast<const NullableColumn*>(arg0.get())->null_column()));
+        return NullableColumn::create(std::move(col_result), std::move(null_column));
     } else {
         return col_result;
     }

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -180,7 +180,7 @@ private:
         StatusOr<ColumnPtr> lower;
         if (haystack_column->is_nullable()) {
             auto haystack_nullable = ColumnHelper::as_column<NullableColumn>(haystack_column);
-            res_null = haystack_nullable->null_column();
+            res_null = NullColumn::static_pointer_cast(Column::mutate(haystack_nullable->null_column()));
             haystackPtr = haystack_nullable->data_column();
         } else {
             haystackPtr = haystack_column;


### PR DESCRIPTION
## Why I'm doing:

Copy from https://github.com/StarRocks/starrocks/pull/70973

When creating a `NullableColumn` from an existing nullable column's null data, the code was directly sharing the `NullColumn` pointer. This can cause data corruption when one `NullableColumn` mutates the shared `NullColumn`, affecting the other. The fix uses `Column::mutate()` to create an independent copy of the null column.

## What I'm doing:

- `be/src/exprs/array_functions.cpp`: Fix 3 locations in `array_append`, `ArrayRemoveImpl`, and `array_flatten` where `NullableColumn::create` shared a `NullColumn` pointer.
- `be/src/exprs/binary_function.h`: Fix `CheckOutputBinaryFunction` to use `Column::mutate()` instead of `std::move(*...).mutate()`.
- `be/src/exprs/map_functions.cpp`: Fix `map_size` to create an independent null column copy.
- `be/src/exprs/ngram.cpp`: Fix `NgramFunctionImpl` to create an independent null column copy.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
