### PR TITLE
[BugFix] Fix heap-buffer-overflow in MapExpr/ArrayExpr for mismatched child column types (backport #71199)

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -539,8 +539,7 @@ ColumnPtr ColumnHelper::normalize_column_type(const ColumnPtr& column, const Typ
     // ColumnPtr (nullptr) for types outside APPLY_FOR_ALL_SCALAR_TYPE, so we
     // never need a hand-maintained type whitelist.
     auto normalized = type_dispatch_predicate<ColumnPtr>(target_type.type, false, ScalarColumnTypeNormalizer(),
-                                                         column.get(),
-                                                         column->size());
+                                                         column.get(), column->size());
     if (normalized == nullptr) {
         return column;
     }

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -15,6 +15,7 @@
 #include "column/column_helper.h"
 
 #include <runtime/types.h>
+
 #include <type_traits>
 
 #ifdef __x86_64__

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -386,14 +386,14 @@ inline constexpr bool kIsNormalizableNumericType =
 // Returns nullptr when no conversion is needed (same width or non-numeric type).
 struct ScalarColumnTypeNormalizer {
     template <LogicalType LT>
-    ColumnPtr operator()(const Column& src_column, size_t count) const {
+    ColumnPtr operator()(const Column* src_column, size_t count) const {
         using TargetCppType = RunTimeCppType<LT>;
 
         if constexpr (!kIsNormalizableNumericType<TargetCppType>) {
             // Non-numeric types (VARCHAR, JSON, …) — no conversion needed.
             return nullptr;
         } else {
-            if (src_column.type_size() == sizeof(TargetCppType)) {
+            if (src_column->type_size() == sizeof(TargetCppType)) {
                 // Physical width already matches — no conversion needed.
                 return nullptr;
             }
@@ -410,8 +410,8 @@ struct ScalarColumnTypeNormalizer {
             // We use the *target* type to disambiguate: a floating-point target
             // implies the source is also in the float family (FE literal typing
             // guarantees same-family mismatches), so we reinterpret accordingly.
-            const auto* raw = src_column.raw_data();
-            switch (src_column.type_size()) {
+            const auto* raw = src_column->raw_data();
+            switch (src_column->type_size()) {
             case 1:
                 for (size_t i = 0; i < count; ++i) {
                     dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int8_t*>(raw)[i]);
@@ -538,7 +538,8 @@ ColumnPtr ColumnHelper::normalize_column_type(const ColumnPtr& column, const Typ
     // type_dispatch_predicate with assert=false returns a default-constructed
     // ColumnPtr (nullptr) for types outside APPLY_FOR_ALL_SCALAR_TYPE, so we
     // never need a hand-maintained type whitelist.
-    auto normalized = type_dispatch_predicate<ColumnPtr>(target_type.type, false, ScalarColumnTypeNormalizer(), *column,
+    auto normalized = type_dispatch_predicate<ColumnPtr>(target_type.type, false, ScalarColumnTypeNormalizer(),
+                                                         column.get(),
                                                          column->size());
     if (normalized == nullptr) {
         return column;

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -15,6 +15,7 @@
 #include "column/column_helper.h"
 
 #include <runtime/types.h>
+#include <type_traits>
 
 #ifdef __x86_64__
 #include <immintrin.h>
@@ -366,6 +367,182 @@ MutableColumnPtr ColumnHelper::align_return_type(MutableColumnPtr&& old_col, con
 MutableColumnPtr ColumnHelper::align_return_type(ColumnPtr&& old_col, const TypeDescriptor& type_desc, size_t num_rows,
                                                  bool is_nullable) {
     return align_return_type(Column::mutate(std::move(old_col)), type_desc, num_rows, is_nullable);
+}
+
+namespace {
+
+// True for C++ types that back numeric FixedLengthColumns and can be safely
+// converted via static_cast between different widths (int8→int16, int32→float, etc.).
+// Non-numeric column types (Slice for VARCHAR, JsonValue* for JSON, …) are excluded
+// because they use entirely different column representations and never hit the
+// size-mismatch problem that normalize_column_type is designed to fix.
+template <typename T>
+inline constexpr bool kIsNormalizableNumericType =
+        std::is_arithmetic_v<T> || std::is_same_v<T, int128_t> || std::is_same_v<T, int256_t>;
+
+// Functor used with type_dispatch_predicate to convert a source scalar column
+// into a properly typed target column when the physical element widths differ.
+// Returns nullptr when no conversion is needed (same width or non-numeric type).
+struct ScalarColumnTypeNormalizer {
+    template <LogicalType LT>
+    ColumnPtr operator()(const Column& src_column, size_t count) const {
+        using TargetCppType = RunTimeCppType<LT>;
+
+        if constexpr (!kIsNormalizableNumericType<TargetCppType>) {
+            // Non-numeric types (VARCHAR, JSON, …) — no conversion needed.
+            return nullptr;
+        } else {
+            if (src_column.type_size() == sizeof(TargetCppType)) {
+                // Physical width already matches — no conversion needed.
+                return nullptr;
+            }
+
+            auto target = RunTimeColumnType<LT>::create();
+            auto& dst_data = target->get_data();
+            raw::stl_vector_resize_uninitialized(&dst_data, count);
+
+            // Read source elements according to their actual physical width and
+            // widen/narrow via static_cast into the target type.
+            //
+            // For 4-byte and 8-byte sources, the raw bytes could represent either
+            // an integer (int32/int64) or a floating-point value (float/double).
+            // We use the *target* type to disambiguate: a floating-point target
+            // implies the source is also in the float family (FE literal typing
+            // guarantees same-family mismatches), so we reinterpret accordingly.
+            const auto* raw = src_column.raw_data();
+            switch (src_column.type_size()) {
+            case 1:
+                for (size_t i = 0; i < count; ++i) {
+                    dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int8_t*>(raw)[i]);
+                }
+                return target;
+            case 2:
+                for (size_t i = 0; i < count; ++i) {
+                    dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int16_t*>(raw)[i]);
+                }
+                return target;
+            case 4:
+                for (size_t i = 0; i < count; ++i) {
+                    if constexpr (std::is_floating_point_v<TargetCppType>) {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const float*>(raw)[i]);
+                    } else {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int32_t*>(raw)[i]);
+                    }
+                }
+                return target;
+            case 8:
+                for (size_t i = 0; i < count; ++i) {
+                    if constexpr (std::is_floating_point_v<TargetCppType>) {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const double*>(raw)[i]);
+                    } else {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int64_t*>(raw)[i]);
+                    }
+                }
+                return target;
+            case 16:
+                if constexpr (std::is_same_v<TargetCppType, int128_t> || std::is_same_v<TargetCppType, int256_t>) {
+                    for (size_t i = 0; i < count; ++i) {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int128_t*>(raw)[i]);
+                    }
+                    return target;
+                }
+                return nullptr;
+            case 32:
+                if constexpr (std::is_same_v<TargetCppType, int256_t>) {
+                    for (size_t i = 0; i < count; ++i) {
+                        dst_data[i] = static_cast<TargetCppType>(reinterpret_cast<const int256_t*>(raw)[i]);
+                    }
+                    return target;
+                }
+                return nullptr;
+            default:
+                return nullptr;
+            }
+        }
+    }
+};
+
+} // namespace
+
+ColumnPtr ColumnHelper::normalize_column_type(const ColumnPtr& column, const TypeDescriptor& target_type) {
+    if (column->only_null()) {
+        return column;
+    }
+
+    // Handle ConstColumn: unfold first, then normalize the inner column.
+    // unfold_const_column alone does NOT convert the physical type — it only
+    // replicates the inner data column to the required row count.
+    if (column->is_constant()) {
+        auto unfolded = ColumnHelper::unfold_const_column(target_type, column->size(), column);
+        return normalize_column_type(unfolded, target_type);
+    }
+
+    // NullableColumn: normalize the data column, keep the null bitmap as-is.
+    if (column->is_nullable()) {
+        const auto* nullable = down_cast<const NullableColumn*>(column.get());
+        auto normalized_data = normalize_column_type(nullable->data_column(), target_type);
+        if (normalized_data.get() == nullable->data_column().get()) {
+            return column; // data column unchanged — return original to avoid copy
+        }
+        return NullableColumn::create(std::move(normalized_data), nullable->null_column());
+    }
+
+    // Nested complex types: recurse into children.
+    switch (target_type.type) {
+    case TYPE_STRUCT: {
+        const auto* struct_column = down_cast<const StructColumn*>(column.get());
+        DCHECK_EQ(target_type.children.size(), struct_column->fields_size());
+        bool changed = false;
+        Columns fields;
+        fields.reserve(struct_column->fields_size());
+        for (size_t i = 0; i < struct_column->fields_size(); ++i) {
+            auto normalized_field = normalize_column_type(struct_column->get_column_by_idx(i), target_type.children[i]);
+            changed |= normalized_field.get() != struct_column->get_column_by_idx(i).get();
+            fields.emplace_back(std::move(normalized_field));
+        }
+        if (!changed) {
+            return column;
+        }
+        return StructColumn::create(fields, struct_column->field_names());
+    }
+    case TYPE_MAP: {
+        const auto* map_column = down_cast<const MapColumn*>(column.get());
+        auto normalized_keys = normalize_column_type(map_column->keys_column(), target_type.children[0]);
+        auto normalized_values = normalize_column_type(map_column->values_column(), target_type.children[1]);
+        if (normalized_keys.get() == map_column->keys_column().get() &&
+            normalized_values.get() == map_column->values_column().get()) {
+            return column;
+        }
+        return MapColumn::create(std::move(normalized_keys), std::move(normalized_values),
+                                 map_column->offsets_column());
+    }
+    case TYPE_ARRAY: {
+        const auto* array_column = down_cast<const ArrayColumn*>(column.get());
+        auto normalized_elements = normalize_column_type(array_column->elements_column(), target_type.children[0]);
+        if (normalized_elements.get() == array_column->elements_column().get()) {
+            return column;
+        }
+        return ArrayColumn::create(std::move(normalized_elements), array_column->offsets_column());
+    }
+    default:
+        break;
+    }
+
+    // Leaf scalar type: dispatch to ScalarColumnTypeNormalizer which compares
+    // source and target element widths and converts if they differ.
+    if (target_type.type == TYPE_UNKNOWN || target_type.type == TYPE_NULL || !is_scalar_field_type(target_type.type)) {
+        return column;
+    }
+
+    // type_dispatch_predicate with assert=false returns a default-constructed
+    // ColumnPtr (nullptr) for types outside APPLY_FOR_ALL_SCALAR_TYPE, so we
+    // never need a hand-maintained type whitelist.
+    auto normalized = type_dispatch_predicate<ColumnPtr>(target_type.type, false, ScalarColumnTypeNormalizer(), *column,
+                                                         column->size());
+    if (normalized == nullptr) {
+        return column;
+    }
+    return normalized;
 }
 
 MutableColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -287,6 +287,21 @@ public:
     static MutableColumnPtr align_return_type(MutableColumnPtr&& old_col, const TypeDescriptor& type_desc,
                                               size_t num_rows, const bool is_nullable);
 
+    // Recursively normalize a column's physical type to match |target_type|.
+    //
+    // When a MAP/ARRAY/STRUCT expression is evaluated as a default column expression,
+    // child expression columns may carry a narrower physical element type than declared
+    // (e.g., a TINYINT literal produces a 1-byte FixedLengthColumn<int8_t> but the MAP
+    // key type is SMALLINT which expects 2-byte FixedLengthColumn<int16_t>).
+    // Column::append does a raw memcpy that assumes identical element widths, so feeding
+    // a narrower source into a wider destination causes a heap-buffer-overflow.
+    //
+    // This function walks the column tree and, wherever it detects a physical size
+    // mismatch on a leaf FixedLengthColumn, creates a properly typed replacement with
+    // element-by-element conversion.  Pointer comparison is used at every level so the
+    // common case (types already match) incurs no copy at all.
+    static ColumnPtr normalize_column_type(const ColumnPtr& column, const TypeDescriptor& target_type);
+
     // Create a column with specified size, the column will be resized to size
     static MutableColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size,
                                           bool use_adaptive_nullable_column = false);

--- a/be/src/exprs/array_expr.cpp
+++ b/be/src/exprs/array_expr.cpp
@@ -53,6 +53,9 @@ public:
         for (size_t i = 0; i < num_elements; i++) {
             element_columns[i] =
                     ColumnHelper::unfold_const_column(element_type, cal_rows, std::move(element_columns[i]));
+            // Ensure the child column's physical element width matches the declared
+            // ARRAY element type.  See normalize_column_type() for details.
+            element_columns[i] = ColumnHelper::normalize_column_type(element_columns[i], element_type);
         }
 
         auto array_elements = ColumnHelper::create_column(element_type, true);

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -46,6 +46,10 @@ StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk
     for (size_t i = 0; i < num_pairs; i++) {
         pairs_columns[i] = ColumnHelper::cast_to_nullable_column(
                 ColumnHelper::unfold_const_column(_type.children[i % 2], num_rows, std::move(pairs_columns[i])));
+        // Ensure the child column's physical element width matches the declared MAP
+        // key/value type.  Without this, a TINYINT literal (1 byte) fed into a
+        // SMALLINT slot (2 bytes) causes heap-buffer-overflow in Column::append.
+        pairs_columns[i] = ColumnHelper::normalize_column_type(pairs_columns[i], _type.children[i % 2]);
     }
 
     auto key_col = ColumnHelper::create_column(_type.children[0], true);

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -447,26 +447,6 @@ TEST_F(ColumnHelperTest, normalize_column_type_struct_no_change) {
     ASSERT_EQ(result.get(), ptr.get());
 }
 
-TEST_F(ColumnHelperTest, normalize_column_type_const_nullable) {
-    auto data_col = Int8Column::create();
-    data_col->append(42);
-    auto null_col = NullColumn::create();
-    null_col->append(0);
-    auto nullable = NullableColumn::create(std::move(data_col), std::move(null_col));
-    auto const_col = ConstColumn::create(std::move(nullable), 2);
-    ColumnPtr ptr = const_col;
-
-    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
-    ASSERT_FALSE(result->is_constant());
-    ASSERT_TRUE(result->is_nullable());
-    ASSERT_EQ(result->size(), 2);
-
-    auto* result_nullable = down_cast<const NullableColumn*>(result.get());
-    auto* result_data = down_cast<const Int32Column*>(result_nullable->data_column().get());
-    EXPECT_EQ(result_data->get_data()[0], 42);
-    EXPECT_EQ(result_data->get_data()[1], 42);
-}
-
 TEST_F(ColumnHelperTest, normalize_column_type_tinyint_to_bigint) {
     auto col = Int8Column::create();
     col->append(-128);

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -14,8 +14,15 @@
 
 #include "column/column_helper.h"
 
+#include "column/array_column.h"
 #include "column/column_builder.h"
+#include "column/const_column.h"
+#include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "gtest/gtest.h"
+#include "testutil/column_test_helper.h"
 
 namespace starrocks {
 
@@ -96,6 +103,383 @@ TEST_F(ColumnHelperTest, get_null_column) {
     column = create_const_column();
     null_column = ColumnHelper::get_null_column(column.get());
     ASSERT_EQ(null_column->get_name(), "integral-1");
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_no_change) {
+    auto col = Int32Column::create();
+    col->append(1);
+    col->append(2);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_widen_tinyint_to_smallint) {
+    auto col = Int8Column::create();
+    col->append(1);
+    col->append(-5);
+    col->append(127);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_SMALLINT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 3);
+    ASSERT_EQ(result->type_size(), sizeof(int16_t));
+
+    auto* converted = down_cast<const Int16Column*>(result.get());
+    ASSERT_EQ(converted->get_data()[0], 1);
+    ASSERT_EQ(converted->get_data()[1], -5);
+    ASSERT_EQ(converted->get_data()[2], 127);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_nullable) {
+    auto data_col = Int8Column::create();
+    data_col->append(10);
+    data_col->append(20);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    null_col->append(1);
+    ColumnPtr ptr = NullableColumn::create(std::move(data_col), std::move(null_col));
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_SMALLINT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_TRUE(result->is_nullable());
+
+    auto* result_nullable = down_cast<const NullableColumn*>(result.get());
+    auto* result_data = down_cast<const Int16Column*>(result_nullable->data_column().get());
+    ASSERT_EQ(result_data->get_data()[0], 10);
+    ASSERT_EQ(result_data->get_data()[1], 20);
+    ASSERT_EQ(result_nullable->null_column()->get_data()[0], 0);
+    ASSERT_EQ(result_nullable->null_column()->get_data()[1], 1);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_struct_nested) {
+    auto field = Int8Column::create();
+    field->append(42);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    ColumnPtr nullable_field = NullableColumn::create(std::move(field), std::move(null_col));
+
+    Columns fields;
+    fields.emplace_back(std::move(nullable_field));
+    ColumnPtr ptr = StructColumn::create(fields, {"f1"});
+
+    TypeDescriptor type_struct;
+    type_struct.type = TYPE_STRUCT;
+    type_struct.children.emplace_back(TYPE_SMALLINT);
+    type_struct.field_names.emplace_back("f1");
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_struct);
+    ASSERT_NE(result.get(), ptr.get());
+
+    auto* result_struct = down_cast<const StructColumn*>(result.get());
+    auto* result_field = down_cast<const NullableColumn*>(result_struct->field_column_raw_ptr(0));
+    auto* result_data = down_cast<const Int16Column*>(result_field->data_column().get());
+    ASSERT_EQ(result_data->get_data()[0], 42);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_only_null) {
+    auto col = ColumnHelper::create_const_null_column(3);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_const_column) {
+    auto inner = Int8Column::create();
+    inner->append(7);
+    auto const_col = ConstColumn::create(std::move(inner), 3);
+    ColumnPtr ptr = const_col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_SMALLINT));
+    ASSERT_FALSE(result->is_constant());
+    ASSERT_EQ(result->size(), 3);
+    auto* converted = down_cast<const Int16Column*>(result.get());
+    EXPECT_EQ(converted->get_data()[0], 7);
+    EXPECT_EQ(converted->get_data()[1], 7);
+    EXPECT_EQ(converted->get_data()[2], 7);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_nullable_no_change) {
+    auto data_col = Int32Column::create();
+    data_col->append(100);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    ColumnPtr ptr = NullableColumn::create(std::move(data_col), std::move(null_col));
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_widen_smallint_to_int) {
+    auto col = Int16Column::create();
+    col->append(100);
+    col->append(-200);
+    col->append(32767);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 3);
+    auto* converted = down_cast<const Int32Column*>(result.get());
+    EXPECT_EQ(converted->get_data()[0], 100);
+    EXPECT_EQ(converted->get_data()[1], -200);
+    EXPECT_EQ(converted->get_data()[2], 32767);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_widen_int_to_bigint) {
+    auto col = Int32Column::create();
+    col->append(1000000);
+    col->append(-999);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_BIGINT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 2);
+    auto* converted = down_cast<const Int64Column*>(result.get());
+    EXPECT_EQ(converted->get_data()[0], 1000000);
+    EXPECT_EQ(converted->get_data()[1], -999);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_float_to_double) {
+    auto col = FloatColumn::create();
+    col->append(1.5f);
+    col->append(-3.25f);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_DOUBLE));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 2);
+    auto* converted = down_cast<const DoubleColumn*>(result.get());
+    EXPECT_FLOAT_EQ(converted->get_data()[0], 1.5);
+    EXPECT_FLOAT_EQ(converted->get_data()[1], -3.25);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_bigint_to_largeint) {
+    auto col = Int64Column::create();
+    col->append(123456789LL);
+    col->append(-1LL);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_LARGEINT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 2);
+    auto* converted = down_cast<const Int128Column*>(result.get());
+    EXPECT_EQ(converted->get_data()[0], static_cast<int128_t>(123456789LL));
+    EXPECT_EQ(converted->get_data()[1], static_cast<int128_t>(-1LL));
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_double_to_float) {
+    auto col = DoubleColumn::create();
+    col->append(2.5);
+    col->append(-7.75);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_FLOAT));
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_EQ(result->size(), 2);
+    auto* converted = down_cast<const FloatColumn*>(result.get());
+    EXPECT_FLOAT_EQ(converted->get_data()[0], 2.5f);
+    EXPECT_FLOAT_EQ(converted->get_data()[1], -7.75f);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_varchar_no_conversion) {
+    auto col = BinaryColumn::create();
+    col->append(Slice("hello"));
+    col->append(Slice("world"));
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_VARCHAR));
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_map) {
+    auto key_data = Int8Column::create();
+    key_data->append(1);
+    auto key_null = NullColumn::create();
+    key_null->append(0);
+    auto keys = NullableColumn::create(std::move(key_data), std::move(key_null));
+
+    auto val_data = Int8Column::create();
+    val_data->append(10);
+    auto val_null = NullColumn::create();
+    val_null->append(0);
+    auto values = NullableColumn::create(std::move(val_data), std::move(val_null));
+
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(1);
+
+    ColumnPtr ptr = MapColumn::create(std::move(keys), std::move(values), std::move(offsets));
+
+    TypeDescriptor type_map;
+    type_map.type = TYPE_MAP;
+    type_map.children.emplace_back(TYPE_SMALLINT);
+    type_map.children.emplace_back(TYPE_SMALLINT);
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_map);
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_TRUE(result->is_map());
+
+    auto* map_result = down_cast<const MapColumn*>(result.get());
+    auto* result_keys = down_cast<const NullableColumn*>(map_result->keys_column().get());
+    auto* result_key_data = down_cast<const Int16Column*>(result_keys->data_column().get());
+    EXPECT_EQ(result_key_data->get_data()[0], 1);
+
+    auto* result_values = down_cast<const NullableColumn*>(map_result->values_column().get());
+    auto* result_val_data = down_cast<const Int16Column*>(result_values->data_column().get());
+    EXPECT_EQ(result_val_data->get_data()[0], 10);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_map_no_change) {
+    auto keys = NullableColumn::create(Int16Column::create(), NullColumn::create());
+    auto values = NullableColumn::create(Int16Column::create(), NullColumn::create());
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(0);
+    ColumnPtr ptr = MapColumn::create(std::move(keys), std::move(values), std::move(offsets));
+
+    TypeDescriptor type_map;
+    type_map.type = TYPE_MAP;
+    type_map.children.emplace_back(TYPE_SMALLINT);
+    type_map.children.emplace_back(TYPE_SMALLINT);
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_map);
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_array) {
+    auto elem_data = Int8Column::create();
+    elem_data->append(5);
+    elem_data->append(6);
+    auto elem_null = NullColumn::create();
+    elem_null->append(0);
+    elem_null->append(0);
+    auto elements = NullableColumn::create(std::move(elem_data), std::move(elem_null));
+
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(2);
+
+    ColumnPtr ptr = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+    TypeDescriptor type_arr;
+    type_arr.type = TYPE_ARRAY;
+    type_arr.children.emplace_back(TYPE_SMALLINT);
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_arr);
+    ASSERT_NE(result.get(), ptr.get());
+    ASSERT_TRUE(result->is_array());
+
+    auto* arr_result = down_cast<const ArrayColumn*>(result.get());
+    auto* result_elements = down_cast<const NullableColumn*>(arr_result->elements_column().get());
+    auto* result_elem_data = down_cast<const Int16Column*>(result_elements->data_column().get());
+    EXPECT_EQ(result_elem_data->get_data()[0], 5);
+    EXPECT_EQ(result_elem_data->get_data()[1], 6);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_array_no_change) {
+    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(0);
+    ColumnPtr ptr = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+    TypeDescriptor type_arr;
+    type_arr.type = TYPE_ARRAY;
+    type_arr.children.emplace_back(TYPE_INT);
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_arr);
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_struct_multi_field_partial) {
+    auto f1_data = Int16Column::create();
+    f1_data->append(100);
+    auto f1_null = NullColumn::create();
+    f1_null->append(0);
+    ColumnPtr f1 = NullableColumn::create(std::move(f1_data), std::move(f1_null));
+
+    auto f2_data = Int8Column::create();
+    f2_data->append(42);
+    auto f2_null = NullColumn::create();
+    f2_null->append(0);
+    ColumnPtr f2 = NullableColumn::create(std::move(f2_data), std::move(f2_null));
+
+    Columns fields{f1, f2};
+    ColumnPtr ptr = StructColumn::create(fields, {"f1", "f2"});
+
+    TypeDescriptor type_struct;
+    type_struct.type = TYPE_STRUCT;
+    type_struct.children.emplace_back(TYPE_SMALLINT);
+    type_struct.field_names.emplace_back("f1");
+    type_struct.children.emplace_back(TYPE_INT);
+    type_struct.field_names.emplace_back("f2");
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_struct);
+    ASSERT_NE(result.get(), ptr.get());
+
+    auto* result_struct = down_cast<const StructColumn*>(result.get());
+    auto* rf1 = down_cast<const NullableColumn*>(result_struct->field_column_raw_ptr(0));
+    EXPECT_EQ(down_cast<const Int16Column*>(rf1->data_column().get())->get_data()[0], 100);
+    auto* rf2 = down_cast<const NullableColumn*>(result_struct->field_column_raw_ptr(1));
+    EXPECT_EQ(down_cast<const Int32Column*>(rf2->data_column().get())->get_data()[0], 42);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_struct_no_change) {
+    auto f1_data = Int32Column::create();
+    f1_data->append(99);
+    auto f1_null = NullColumn::create();
+    f1_null->append(0);
+    ColumnPtr f1 = NullableColumn::create(std::move(f1_data), std::move(f1_null));
+
+    Columns fields{f1};
+    ColumnPtr ptr = StructColumn::create(fields, {"f1"});
+
+    TypeDescriptor type_struct;
+    type_struct.type = TYPE_STRUCT;
+    type_struct.children.emplace_back(TYPE_INT);
+    type_struct.field_names.emplace_back("f1");
+
+    auto result = ColumnHelper::normalize_column_type(ptr, type_struct);
+    ASSERT_EQ(result.get(), ptr.get());
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_const_nullable) {
+    auto data_col = Int8Column::create();
+    data_col->append(42);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    auto nullable = NullableColumn::create(std::move(data_col), std::move(null_col));
+    auto const_col = ConstColumn::create(std::move(nullable), 2);
+    ColumnPtr ptr = const_col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_INT));
+    ASSERT_FALSE(result->is_constant());
+    ASSERT_TRUE(result->is_nullable());
+    ASSERT_EQ(result->size(), 2);
+
+    auto* result_nullable = down_cast<const NullableColumn*>(result.get());
+    auto* result_data = down_cast<const Int32Column*>(result_nullable->data_column().get());
+    EXPECT_EQ(result_data->get_data()[0], 42);
+    EXPECT_EQ(result_data->get_data()[1], 42);
+}
+
+TEST_F(ColumnHelperTest, normalize_column_type_tinyint_to_bigint) {
+    auto col = Int8Column::create();
+    col->append(-128);
+    col->append(0);
+    col->append(127);
+    ColumnPtr ptr = col;
+
+    auto result = ColumnHelper::normalize_column_type(ptr, TypeDescriptor(TYPE_BIGINT));
+    ASSERT_NE(result.get(), ptr.get());
+    auto* converted = down_cast<const Int64Column*>(result.get());
+    EXPECT_EQ(converted->get_data()[0], -128);
+    EXPECT_EQ(converted->get_data()[1], 0);
+    EXPECT_EQ(converted->get_data()[2], 127);
 }
 
 } // namespace starrocks

--- a/be/test/exprs/array_expr_test.cpp
+++ b/be/test/exprs/array_expr_test.cpp
@@ -21,6 +21,7 @@
 
 #include "column/column_helper.h"
 #include "column/const_column.h"
+#include "column/struct_column.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "gutil/casts.h"
 #include "testutil/column_test_helper.h"
@@ -188,6 +189,31 @@ TEST_F(ArrayExprTest, test_evaluate) {
         EXPECT_EQ(4, result->get(2).get_array()[1].get_int32());
         EXPECT_EQ(8, result->get(2).get_array()[2].get_int32());
     }
+}
+
+TEST_F(ArrayExprTest, test_nested_type_mismatch_no_overflow) {
+    TypeDescriptor type_struct_smallint;
+    type_struct_smallint.type = LogicalType::TYPE_STRUCT;
+    type_struct_smallint.children.emplace_back(LogicalType::TYPE_SMALLINT);
+    type_struct_smallint.field_names.emplace_back("f1");
+
+    TypeDescriptor type_arr_struct;
+    type_arr_struct.type = LogicalType::TYPE_ARRAY;
+    type_arr_struct.children.emplace_back(type_struct_smallint);
+
+    auto build_struct_column = [](std::initializer_list<int8_t> values) -> ColumnPtr {
+        Columns fields;
+        fields.emplace_back(ColumnTestHelper::build_column<int8_t>(values));
+        return StructColumn::create(fields, {"f1"});
+    };
+
+    std::unique_ptr<Expr> expr(ExprsTestHelper::create_array_expr(type_arr_struct));
+    expr->add_child(new_mock_expr(build_struct_column({1, 2, 3}), type_struct_smallint));
+    expr->add_child(new_mock_expr(build_struct_column({4, 5, 6}), type_struct_smallint));
+
+    auto result = expr->evaluate(nullptr, nullptr);
+    EXPECT_EQ(3, result->size());
+    EXPECT_TRUE(result->is_array());
 }
 
 } // namespace starrocks

--- a/be/test/exprs/map_expr_test.cpp
+++ b/be/test/exprs/map_expr_test.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "column/column_helper.h"
+#include "column/struct_column.h"
 #include "exprs/array_expr.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "testutil/column_test_helper.h"
@@ -155,6 +156,65 @@ TEST_F(MapExprTest, test_const_evaluate) {
         EXPECT_TRUE(result->is_map());
         ASSERT_EQ("{1:'a',4:'x'}", result->debug_string());
     }
+}
+
+TEST_F(MapExprTest, test_type_mismatch_no_overflow) {
+    TypeDescriptor type_map_smallint;
+    type_map_smallint.type = LogicalType::TYPE_MAP;
+    type_map_smallint.children.emplace_back();
+    type_map_smallint.children.back().type = LogicalType::TYPE_SMALLINT;
+    type_map_smallint.children.emplace_back();
+    type_map_smallint.children.back().type = LogicalType::TYPE_SMALLINT;
+
+    {
+        auto expr = ExprsTestHelper::create_map_expr(type_map_smallint);
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({1, 2, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({10, 20, 30}), LogicalType::TYPE_TINYINT));
+
+        auto result = expr->evaluate(nullptr, nullptr);
+        EXPECT_EQ(3, result->size());
+        EXPECT_TRUE(result->is_map());
+    }
+
+    {
+        auto expr = ExprsTestHelper::create_map_expr(type_map_smallint);
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({1, 2, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({10, 20, 30}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({4, 5, 3}), LogicalType::TYPE_TINYINT));
+        expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int8_t>({40, 50, 60}), LogicalType::TYPE_TINYINT));
+
+        auto result = expr->evaluate(nullptr, nullptr);
+        EXPECT_EQ(3, result->size());
+        EXPECT_TRUE(result->is_map());
+    }
+}
+
+TEST_F(MapExprTest, test_nested_type_mismatch_no_overflow) {
+    TypeDescriptor type_struct_smallint;
+    type_struct_smallint.type = LogicalType::TYPE_STRUCT;
+    type_struct_smallint.children.emplace_back(LogicalType::TYPE_SMALLINT);
+    type_struct_smallint.field_names.emplace_back("f1");
+
+    TypeDescriptor type_map_struct;
+    type_map_struct.type = LogicalType::TYPE_MAP;
+    type_map_struct.children.emplace_back(LogicalType::TYPE_SMALLINT);
+    type_map_struct.children.emplace_back(type_struct_smallint);
+
+    auto build_struct_column = [](std::initializer_list<int8_t> values) -> ColumnPtr {
+        Columns fields;
+        fields.emplace_back(ColumnTestHelper::build_column<int8_t>(values));
+        return StructColumn::create(fields, {"f1"});
+    };
+
+    auto expr = ExprsTestHelper::create_map_expr(type_map_struct);
+    expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int16_t>({1, 2, 3}), LogicalType::TYPE_SMALLINT));
+    expr->add_child(new_mock_expr(build_struct_column({10, 20, 30}), type_struct_smallint));
+    expr->add_child(new_mock_expr(ColumnTestHelper::build_column<int16_t>({4, 5, 3}), LogicalType::TYPE_SMALLINT));
+    expr->add_child(new_mock_expr(build_struct_column({40, 50, 60}), type_struct_smallint));
+
+    auto result = expr->evaluate(nullptr, nullptr);
+    EXPECT_EQ(3, result->size());
+    EXPECT_TRUE(result->is_map());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

In shared-data read path, evaluating complex default expressions (`MAP<..., STRUCT<...>>`) triggers a **heap-buffer-overflow** detected by ASan.

**Root cause**: `MapExpr::evaluate_checked` (and `ArrayExpr`) only performs top-level const unfolding (`unfold_const_column`) and nullable wrapping (`cast_to_nullable_column`) on child expression columns. Neither of these operations converts the physical column type. When FE does not insert CAST nodes — which happens in the `default_expr` to `default_value` BE-side evaluation path — child columns retain their original narrower types (e.g., a TINYINT literal produces a 1-byte `FixedLengthColumn<int8_t>`, but the MAP key type is SMALLINT which expects 2-byte `FixedLengthColumn<int16_t>`).

`Column::append` performs a raw `reinterpret_cast + memcpy` that assumes the source and destination element widths are identical. When `T = int16_t` (2 bytes) but the source buffer only holds `int8_t` (1 byte per element), this reads beyond the allocated buffer — **heap-buffer-overflow**.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11202

## What I'm doing:

Add `ColumnHelper::normalize_column_type(column, target_type)` that **recursively** ensures a column's physical type matches the target `TypeDescriptor` before any `append` operation:

- **NullableColumn**: normalizes inner data column, preserves null bitmap
- **StructColumn**: recursively normalizes each field
- **MapColumn**: recursively normalizes keys and values
- **ArrayColumn**: recursively normalizes elements
- **Scalar leaf columns**: detects `type_size()` mismatch via `ScalarColumnTypeNormalizer`, creates a properly typed column with element-by-element `static_cast` conversion
- **ConstColumn**: unfolds first, then normalizes the inner column

Uses pointer comparison at every level so the common case (types already match) incurs **zero copy overhead**.

Applied in both `MapExpr::evaluate_checked` and `ArrayExpr::evaluate_checked` after `unfold_const_column` / `cast_to_nullable_column`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
