### PR TITLE
[BugFix] Fix NaN row count estimation for MCV-only histograms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -133,10 +133,17 @@ public class BinaryPredicateStatisticCalculator {
             } else {
                 // The constant was not found in the column histogram.
                 Long mostCommonValuesCount = columnHist.getMCV().values().stream().reduce(Long::sum).orElse(0L);
-                double f = 1 / Math.max(columnStatistic.getDistinctValuesCount() - columnHist.getMCV().size(),
-                        columnHist.getBuckets().size());
-                double predicateFactor = (columnHist.getTotalRows() - mostCommonValuesCount) * f / columnHist.getTotalRows();
-                rows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction()) * predicateFactor;
+                double remainingDistinctValues =
+                        columnStatistic.getDistinctValuesCount() - columnHist.getMCV().size();
+                double remainingHistogramRows = columnHist.getTotalRows() - mostCommonValuesCount;
+                double denominator = Math.max(remainingDistinctValues, columnHist.getBuckets().size());
+                if (remainingHistogramRows <= 0 || denominator <= 0) {
+                    rows = 0;
+                } else {
+                    double f = 1 / denominator;
+                    double predicateFactor = remainingHistogramRows * f / columnHist.getTotalRows();
+                    rows = statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction()) * predicateFactor;
+                }
             }
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rows)
@@ -220,7 +227,8 @@ public class BinaryPredicateStatisticCalculator {
         } else {
             ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
             double rowCount = statistics.getOutputRowCount() -
-                    estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics).getOutputRowCount();
+                    estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics)
+                            .getOutputRowCount();
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                             .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -394,6 +394,36 @@ public class HistogramStatisticsTest {
         Assertions.assertEquals(500L, estimated.getOutputRowCount(), 0.001);
     }
 
+    @Test
+    public void testColumnNotEqualToOutOfDomainConstantWithMcvOnlyHistogram() {
+        Map<String, Long> mcv = Maps.newHashMap();
+        mcv.put("0", 1L);
+        mcv.put("1", 3L);
+        Histogram histogram = new Histogram(new ArrayList<>(), mcv);
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, BooleanType.BOOLEAN, "b1", true);
+        ColumnStatistic columnStatistic = new ColumnStatistic(0, 1, 0, 4, 2,
+                histogram, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(4);
+        builder.addColumnStatistic(columnRefOperator, columnStatistic);
+        Statistics statistics = builder.build();
+
+        BinaryPredicateOperator neOutOfDomain = new BinaryPredicateOperator(
+                BinaryType.NE,
+                columnRefOperator,
+                ConstantOperator.createBigint(2));
+        Statistics estimated = BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(
+                Optional.of(columnRefOperator),
+                columnStatistic,
+                neOutOfDomain,
+                Optional.of(ConstantOperator.createBigint(2)),
+                statistics);
+
+        Assertions.assertFalse(Double.isNaN(estimated.getOutputRowCount()));
+        Assertions.assertEquals(3L, estimated.getOutputRowCount(), 0.001);
+    }
+
 
     @Test
     public void testUpdateHistWithJoin() {


### PR DESCRIPTION
## Why I'm doing:
`IS NULL` predicate stats can build MCV-only histograms without residual buckets. When an equality comparison misses both MCV entries and buckets in that case, the fallback path may divide by zero and produce `NaN` row count estimates. The `NaN` then propagates into join reorder costing and can trigger planning failures such as `IllegalStateException` in `JoinReorderDP`.

## What I'm doing:
Guard the equality estimation fallback for MCV-only histograms so it does not produce `NaN` when no residual domain exists. Add a regression test covering an out-of-domain constant on an MCV-only histogram to verify the estimator returns a valid row count instead of `NaN`.

fix
```
 java.lang.IllegalStateException
        at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
        at com.starrocks.sql.optimizer.rule.join.JoinReorderDP.getBestExpr(JoinReorderDP.java:130)
        at com.starrocks.sql.optimizer.rule.join.JoinReorderDP.enumerate(JoinReorderDP.java:57)
        at com.starrocks.sql.optimizer.rule.join.JoinOrder.reorder(JoinOrder.java:231)
        at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.enumerate(ReorderJoinRule.java:96)
        at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.rewrite(ReorderJoinRule.java:201)
        at com.starrocks.sql.optimizer.QueryOptimizer.logicalJoinReorder(QueryOptimizer.java:900)
        at com.starrocks.sql.optimizer.QueryOptimizer.pushDownAggregation(QueryOptimizer.java:854)
        at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:694)
        at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:826)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:258)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:214)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:412)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:156)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:110)
        at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:763)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:926)
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:570)
        at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:464)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:401)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:781)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1167)
        at com.starrocks.mysql.nio.MySQLReadListener.handleRequest(MySQLReadListener.java:152)
        at com.starrocks.mysql.nio.MySQLReadListener.lambda$handleEvent$0(MySQLReadListener.java:92)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```
Fixes #issue
fix https://github.com/StarRocks/StarRocksTest/issues/11192

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
