### PR TITLE
[BugFix] Fix UpdateTabletSchemaTask signature collision across alter jobs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTask.java
@@ -60,8 +60,13 @@ public abstract class TabletMetadataUpdateAgentTask extends AgentTask {
 
     protected long txnId;
 
+    // The original signature computed at construction time (e.g., tablets.hashCode()).
+    // Kept immutable so that setTxnId() is idempotent.
+    private final long baseSignature;
+
     protected TabletMetadataUpdateAgentTask(long backendId, long signature) {
         super(null, backendId, TTaskType.UPDATE_TABLET_META_INFO, -1L, -1L, -1L, -1L, -1L, signature);
+        this.baseSignature = signature;
     }
 
     public void setLatch(MarkedCountDownLatch<Long, Set<Long>> latch) {
@@ -75,7 +80,7 @@ public abstract class TabletMetadataUpdateAgentTask extends AgentTask {
         // table/partition produce identical signatures, causing AgentTaskQueue to
         // reject the second task or FE to match BE's old task completion report
         // to the wrong job.
-        this.signature = Objects.hash(this.signature, txnId);
+        this.signature = Objects.hash(baseSignature, txnId);
     }
 
     public void countDownLatch(long backendId, Set<Long> tablets) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTask.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -69,6 +70,12 @@ public abstract class TabletMetadataUpdateAgentTask extends AgentTask {
 
     public void setTxnId(long txnId) {
         this.txnId = txnId;
+        // Include txnId in signature to prevent collision between different jobs
+        // operating on the same tablet set. Without this, two jobs altering the same
+        // table/partition produce identical signatures, causing AgentTaskQueue to
+        // reject the second task or FE to match BE's old task completion report
+        // to the wrong job.
+        this.signature = Objects.hash(this.signature, txnId);
     }
 
     public void countDownLatch(long backendId, Set<Long> tablets) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -358,6 +358,17 @@ public class TabletMetadataUpdateAgentTaskFactory {
         }
 
         @Override
+        public void setTxnId(long txnId) {
+            super.setTxnId(txnId);
+            // Include txnId in signature to prevent collision between different alter jobs
+            // operating on the same tablet set. Without this, two jobs altering the same
+            // table/partition produce identical signatures (tablets.hashCode()), causing
+            // AgentTaskQueue to reject the second task or FE to match BE's old task
+            // completion report to the wrong job.
+            this.signature = Objects.hash(tablets, txnId);
+        }
+
+        @Override
         public Set<Long> getTablets() {
             return new HashSet<>(tablets);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -358,17 +358,6 @@ public class TabletMetadataUpdateAgentTaskFactory {
         }
 
         @Override
-        public void setTxnId(long txnId) {
-            super.setTxnId(txnId);
-            // Include txnId in signature to prevent collision between different alter jobs
-            // operating on the same tablet set. Without this, two jobs altering the same
-            // table/partition produce identical signatures (tablets.hashCode()), causing
-            // AgentTaskQueue to reject the second task or FE to match BE's old task
-            // completion report to the wrong job.
-            this.signature = Objects.hash(tablets, txnId);
-        }
-
-        @Override
         public Set<Long> getTablets() {
             return new HashSet<>(tablets);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -185,7 +186,9 @@ public class AgentTaskQueueSignatureCollisionTest {
 
         // AgentTaskQueue correctly deduplicates retries
         assertTrue(AgentTaskQueue.addTask(task1));
-        // task2 has the same signature, so it should be rejected (correct dedup)
-        // This is intentional: if the same job retries, the old task must be removed first
+        assertFalse(AgentTaskQueue.addTask(task2),
+                "task2 with same signature should be rejected (correct dedup)");
+        assertSame(task1, AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, task1.getSignature()),
+                "Queue should still contain task1, not task2");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 3. When BE reported old task completion, FE matched it to the new task (wrong job)
  * 4. New job proceeded with wrong txnId -> publish failed with 404
  *
- * Fix: setTxnId() now updates signature to Objects.hash(tablets, txnId), ensuring
+ * Fix: setTxnId() now updates signature to Objects.hash(baseSignature, txnId), ensuring
  * different alter jobs produce different signatures even for the same tablet set.
  */
 public class AgentTaskQueueSignatureCollisionTest {

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskQueueSignatureCollisionTest.java
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.thrift.TTabletSchema;
+import com.starrocks.thrift.TTaskType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for UpdateTabletSchemaTask signature uniqueness.
+ *
+ * Background: UpdateTabletSchemaTask previously used tablets.hashCode() as signature.
+ * When two different alter jobs operate on the same tablet set (same table/partition),
+ * they produced identical signatures, causing:
+ * 1. AgentTaskQueue rejected the new task while old task was still queued
+ * 2. After old task was removed, new task entered queue with same signature
+ * 3. When BE reported old task completion, FE matched it to the new task (wrong job)
+ * 4. New job proceeded with wrong txnId -> publish failed with 404
+ *
+ * Fix: setTxnId() now updates signature to Objects.hash(tablets, txnId), ensuring
+ * different alter jobs produce different signatures even for the same tablet set.
+ */
+public class AgentTaskQueueSignatureCollisionTest {
+
+    private static final long BACKEND_ID = 10001L;
+    private static final List<Long> TABLETS = Arrays.asList(24947932L, 24947929L);
+    private static final TTaskType TASK_TYPE = TTaskType.UPDATE_TABLET_META_INFO;
+
+    @BeforeEach
+    public void setUp() {
+        AgentTaskQueue.clearAllTasks();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        AgentTaskQueue.clearAllTasks();
+    }
+
+    /**
+     * Before setTxnId(), tasks with the same tablet list share an initial signature
+     * (tablets.hashCode()). After setTxnId() with different txnIds, signatures diverge.
+     */
+    @Test
+    public void testSignatureDivergesAfterSetTxnId() {
+        TabletMetadataUpdateAgentTask task1 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        TabletMetadataUpdateAgentTask task2 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+
+        // Before setTxnId: same initial signature (tablets.hashCode())
+        assertEquals(task1.getSignature(), task2.getSignature(),
+                "Before setTxnId, signatures should be the same (both = tablets.hashCode())");
+
+        // After setTxnId with different txnIds: signatures diverge
+        task1.setTxnId(1000L);
+        task2.setTxnId(2000L);
+        assertNotEquals(task1.getSignature(), task2.getSignature(),
+                "After setTxnId with different txnIds, signatures should differ");
+    }
+
+    /**
+     * With the fix, two tasks for different alter jobs (different txnIds) on the same
+     * tablet set can coexist in AgentTaskQueue without collision.
+     */
+    @Test
+    public void testDifferentTxnIdTasksCanCoexistInQueue() {
+        TabletMetadataUpdateAgentTask task1 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task1.setTxnId(1000L);
+
+        TabletMetadataUpdateAgentTask task2 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task2.setTxnId(2000L);
+
+        // Both tasks can be added (no signature collision)
+        assertTrue(AgentTaskQueue.addTask(task1), "First task should be added");
+        assertTrue(AgentTaskQueue.addTask(task2), "Second task should also be added (different signature)");
+
+        // Each task is retrievable by its own signature
+        AgentTask retrieved1 = AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, task1.getSignature());
+        AgentTask retrieved2 = AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, task2.getSignature());
+        assertSame(task1, retrieved1);
+        assertSame(task2, retrieved2);
+    }
+
+    /**
+     * Verifies that the race condition (old task completion matched to new job's task)
+     * is no longer possible after the fix.
+     *
+     * Scenario:
+     * 1. Job A creates task1 (txnId=1000) and adds to queue
+     * 2. Job A times out, task1 removed from FE queue (but BE still executing)
+     * 3. Job B creates task2 (txnId=2000), adds to queue (succeeds: different signature)
+     * 4. BE finishes old task (txnId=1000), reports with task1's signature
+     * 5. FE looks up by task1's signature -> finds nothing (task1 already removed)
+     * 6. task2 is NOT affected -> Job B waits correctly for its own task to complete
+     */
+    @Test
+    public void testOldTaskCompletionDoesNotAffectNewJob() {
+        Set<Long> tabletSet = new HashSet<>(TABLETS);
+
+        // Step 1: Job A creates task1
+        TabletMetadataUpdateAgentTask task1 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task1.setTxnId(1000L);
+        long signatureA = task1.getSignature();
+        MarkedCountDownLatch<Long, Set<Long>> latch1 = new MarkedCountDownLatch<>(1);
+        latch1.addMark(BACKEND_ID, tabletSet);
+        task1.setLatch(latch1);
+        assertTrue(AgentTaskQueue.addTask(task1));
+
+        // Step 2: Job A times out -> remove task from FE queue
+        AgentTaskQueue.removeTask(BACKEND_ID, TASK_TYPE, signatureA);
+        assertNull(AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, signatureA));
+
+        // Step 3: Job B creates task2 with different signature (due to different txnId)
+        TabletMetadataUpdateAgentTask task2 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task2.setTxnId(2000L);
+        long signatureB = task2.getSignature();
+        assertNotEquals(signatureA, signatureB, "Signatures should differ after fix");
+        MarkedCountDownLatch<Long, Set<Long>> latch2 = new MarkedCountDownLatch<>(1);
+        latch2.addMark(BACKEND_ID, tabletSet);
+        task2.setLatch(latch2);
+        assertTrue(AgentTaskQueue.addTask(task2));
+
+        // Step 4: BE finishes OLD task and reports with task1's signature
+        // FE looks up by (backendId, taskType, signatureA) -> finds nothing
+        AgentTask matched = AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, signatureA);
+        assertNull(matched, "Old signature should not match any task in queue");
+
+        // Step 5: Job B's latch is NOT affected
+        assertEquals(1, latch2.getCount(),
+                "Job B's latch should remain at 1 (not incorrectly counted down)");
+
+        // Step 6: Job B's task is still in queue, waiting for its own completion
+        AgentTask task2InQueue = AgentTaskQueue.getTask(BACKEND_ID, TASK_TYPE, signatureB);
+        assertNotNull(task2InQueue, "Job B's task should still be in queue");
+        assertSame(task2, task2InQueue);
+    }
+
+    /**
+     * Verifies that tasks with the same txnId (e.g., retries of the same job)
+     * still produce the same signature, which is the expected dedup behavior.
+     */
+    @Test
+    public void testSameTxnIdProducesSameSignature() {
+        TabletMetadataUpdateAgentTask task1 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task1.setTxnId(1000L);
+
+        TabletMetadataUpdateAgentTask task2 = TabletMetadataUpdateAgentTaskFactory
+                .createTabletSchemaUpdateTask(BACKEND_ID, TABLETS, new TTabletSchema(), true);
+        task2.setTxnId(1000L);
+
+        assertEquals(task1.getSignature(), task2.getSignature(),
+                "Same tablets + same txnId should produce same signature (dedup still works)");
+
+        // AgentTaskQueue correctly deduplicates retries
+        assertTrue(AgentTaskQueue.addTask(task1));
+        // task2 has the same signature, so it should be rejected (correct dedup)
+        // This is intentional: if the same job retries, the old task must be removed first
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When multiple ALTER TABLE jobs operate on the same table/partition in quick succession, `UpdateTabletSchemaTask` produces identical `AgentTaskQueue` signatures because the signature is computed as `tablets.hashCode()`. Since different alter jobs on the same table operate on the same tablet set, they get the same signature, leading to a race condition:

1. **Task rejection**: AgentTaskQueue rejects the new task while the old task with the same signature is still queued
2. **Task mismatch**: After the old task is removed from FE queue (job timeout/cancel), the new task enters the queue with the same signature. When BE finishes executing the old task and reports completion, FE matches it to the new job's task by `(backendId, taskType, signature)` — matching the wrong job
3. **Publish failure**: The new job proceeds to publish with a txnId whose txn log was never written by BE, resulting in a 404 error on object storage

This was observed in production where two consecutive `ALTER TABLE ADD COLUMN` statements on the same table caused the second job to get stuck in `FINISHED_REWRITING` state, continuously failing to publish with "404 Not Found" on txn log.

## What I'm doing:

Update `setTxnId()` in the base class `TabletMetadataUpdateAgentTask` to recompute the signature as `Objects.hash(baseSignature, txnId)`, where `baseSignature` is the original signature saved at construction time. This ensures:

- Different alter jobs produce different signatures even when operating on the same tablet set
- All `TabletMetadataUpdateAgentTask` subclasses benefit defensively (not just `UpdateTabletSchemaTask`)
- `setTxnId()` is idempotent — calling it multiple times with the same txnId always produces the same signature
- No backward compatibility concern — signatures are purely in-memory (`AgentTaskQueue`), never persisted

This is safe because in the `LakeTableAlterMetaJobBase.sendAgentTask()` call chain, `setTxnId(watershedTxnId)` is always called before `AgentTaskQueue.addBatchTask()`, so the signature includes the txnId before the task enters the queue.

**Changed files:**
- `TabletMetadataUpdateAgentTask.java`: Added `baseSignature` field and updated `setTxnId()` to compute `Objects.hash(baseSignature, txnId)`
- `TabletMetadataUpdateAgentTaskFactory.java`: Removed redundant `setTxnId()` override from `UpdateTabletSchemaTask` (now handled by base class)
- `AgentTaskQueueSignatureCollisionTest.java`: 4 test cases covering signature divergence, queue coexistence, race condition prevention, and dedup preservation

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4