### PR TITLE
[Tool] trigger CVE scan on pom change

### DIFF
--- a/java-extensions/common-runtime/pom.xml
+++ b/java-extensions/common-runtime/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>common-runtime</artifactId>
 
     <properties>
+        <!-- trigger ci scan -->
         <java-extensions.home>${basedir}/../</java-extensions.home>
     </properties>
 


### PR DESCRIPTION
## Why I'm doing:

Test CVE scan trigger: verify that Trivy CVE scanning runs correctly on the BUILD job when a pom.xml file is modified.

## What I'm doing:

Add a comment to `java-extensions/common-runtime/pom.xml` to trigger the BUILD CI job.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4