### PR TITLE
[Refactor] Add ExecExpr typed expression hierarchy for physical plan layer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArithmetic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArithmetic.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.expression.ExprOpcodeRegistry;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan arithmetic expression (+, -, *, /, %, etc.).
+ */
+public class ExecArithmetic extends ExecExpr {
+    private final ArithmeticExpr.Operator op;
+
+    public ExecArithmetic(Type type, ArithmeticExpr.Operator op, List<ExecExpr> children) {
+        super(type, children);
+        this.op = op;
+    }
+
+    private ExecArithmetic(ExecArithmetic other) {
+        super(other.type, other.cloneChildren());
+        this.op = other.op;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public ArithmeticExpr.Operator getOp() {
+        return op;
+    }
+
+    @Override
+    public boolean isNullable() {
+        if (op == ArithmeticExpr.Operator.DIVIDE || op == ArithmeticExpr.Operator.INT_DIVIDE
+                || op == ArithmeticExpr.Operator.MOD) {
+            return true;
+        }
+        for (ExecExpr child : children) {
+            if (child.isNullable() || child.getType().isDecimalV3()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isSelfMonotonic() {
+        return op.isMonotonic();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.ARITHMETIC_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOpcode(ExprOpcodeRegistry.getArithmeticOpcode(op));
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecArithmetic(this, context);
+    }
+
+    @Override
+    public ExecArithmetic clone() {
+        return new ExecArithmetic(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArrayExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArrayExpr.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan array construction expression.
+ */
+public class ExecArrayExpr extends ExecExpr {
+
+    public ExecArrayExpr(Type type, List<ExecExpr> children) {
+        super(type, children);
+    }
+
+    private ExecArrayExpr(ExecArrayExpr other) {
+        super(other.type, other.cloneChildren());
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.ARRAY_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        // ARRAY_EXPR has no extra fields
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecArrayExpr(this, context);
+    }
+
+    @Override
+    public ExecArrayExpr clone() {
+        return new ExecArrayExpr(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArraySlice.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArraySlice.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan array slice expression (e.g., array[1:3]).
+ */
+public class ExecArraySlice extends ExecExpr {
+
+    public ExecArraySlice(Type type, List<ExecExpr> children) {
+        super(type, children);
+    }
+
+    private ExecArraySlice(ExecArraySlice other) {
+        super(other.type, other.cloneChildren());
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.ARRAY_SLICE_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        // ARRAY_SLICE_EXPR has no extra fields
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecArraySlice(this, context);
+    }
+
+    @Override
+    public ExecArraySlice clone() {
+        return new ExecArraySlice(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecBetweenPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecBetweenPredicate.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.BooleanType;
+
+import java.util.List;
+
+/**
+ * Execution-plan BETWEEN predicate.
+ * Note: BetweenPredicate should normally be rewritten into a CompoundPredicate
+ * before reaching the execution plan. This class exists for completeness.
+ */
+public class ExecBetweenPredicate extends ExecExpr {
+    private final boolean isNotBetween;
+
+    public ExecBetweenPredicate(boolean isNotBetween, List<ExecExpr> children) {
+        super(BooleanType.BOOLEAN, children);
+        this.isNotBetween = isNotBetween;
+    }
+
+    private ExecBetweenPredicate(ExecBetweenPredicate other) {
+        super(other.type, other.cloneChildren());
+        this.isNotBetween = other.isNotBetween;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean isNotBetween() {
+        return isNotBetween;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        throw new IllegalStateException(
+                "BetweenPredicate needs to be rewritten into a CompoundPredicate.");
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        throw new IllegalStateException(
+                "BetweenPredicate needs to be rewritten into a CompoundPredicate.");
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecBetweenPredicate(this, context);
+    }
+
+    @Override
+    public ExecBetweenPredicate clone() {
+        return new ExecBetweenPredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecBinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecBinaryPredicate.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.expression.ExprOpcodeRegistry;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
+
+import java.util.List;
+
+/**
+ * Execution-plan binary predicate (e.g., =, !=, <, >, <=, >=, <=>).
+ */
+public class ExecBinaryPredicate extends ExecExpr {
+    private final BinaryType op;
+
+    public ExecBinaryPredicate(BinaryType op, ExecExpr left, ExecExpr right) {
+        super(BooleanType.BOOLEAN, List.of(left, right));
+        this.op = op;
+    }
+
+    private ExecBinaryPredicate(ExecBinaryPredicate other) {
+        super(other.type, other.cloneChildren());
+        this.op = other.op;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public BinaryType getOp() {
+        return op;
+    }
+
+    @Override
+    public boolean isNullable() {
+        if (op == BinaryType.EQ_FOR_NULL) {
+            return false;
+        }
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.BINARY_PRED;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOpcode(ExprOpcodeRegistry.getBinaryOpcode(op));
+        node.setVector_opcode(TExprOpcode.INVALID_OPCODE);
+        Type childType = children.get(0).getType();
+        if (childType.isComplexType()) {
+            node.setChild_type_desc(TypeSerializer.toThrift(childType));
+        } else {
+            node.setChild_type(TypeSerializer.toThrift(childType.getPrimitiveType()));
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecBinaryPredicate(this, context);
+    }
+
+    @Override
+    public ExecBinaryPredicate clone() {
+        return new ExecBinaryPredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCaseWhen.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCaseWhen.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TCaseExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
+
+import java.util.List;
+
+/**
+ * Execution-plan CASE/WHEN expression.
+ */
+public class ExecCaseWhen extends ExecExpr {
+    private final boolean hasCase;
+    private final boolean hasElse;
+
+    public ExecCaseWhen(Type type, boolean hasCase, boolean hasElse, List<ExecExpr> children) {
+        super(type, children);
+        this.hasCase = hasCase;
+        this.hasElse = hasElse;
+    }
+
+    private ExecCaseWhen(ExecCaseWhen other) {
+        super(other.type, other.cloneChildren());
+        this.hasCase = other.hasCase;
+        this.hasElse = other.hasElse;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean hasCase() {
+        return hasCase;
+    }
+
+    public boolean hasElse() {
+        return hasElse;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.CASE_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.case_expr = new TCaseExpr(hasCase, hasElse);
+        node.setChild_type(TypeSerializer.toThrift(children.get(0).getType().getPrimitiveType()));
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecCaseWhen(this, context);
+    }
+
+    @Override
+    public ExecCaseWhen clone() {
+        return new ExecCaseWhen(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCast.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCast.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
+
+import java.util.List;
+
+/**
+ * Execution-plan cast expression.
+ */
+public class ExecCast extends ExecExpr {
+    private final boolean isImplicit;
+
+    public ExecCast(Type targetType, ExecExpr child, boolean isImplicit) {
+        super(targetType, List.of(child));
+        this.isImplicit = isImplicit;
+    }
+
+    private ExecCast(ExecCast other) {
+        super(other.type, other.cloneChildren());
+        this.isImplicit = other.isImplicit;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean isImplicit() {
+        return isImplicit;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return children.get(0).isNullable();
+    }
+
+    @Override
+    public boolean isSelfMonotonic() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.CAST_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOpcode(TExprOpcode.CAST);
+        Type childType = children.get(0).getType();
+        if (childType.isComplexType() || childType.isDecimalOfAnyVersion()
+                || childType.isChar() || childType.isVarchar()) {
+            node.setChild_type_desc(TypeSerializer.toThrift(childType));
+        }
+        if (!childType.isComplexType()) {
+            node.setChild_type(TypeSerializer.toThrift(childType.getPrimitiveType()));
+        }
+        if (childType.isStructType() && type.isStructType()) {
+            ConnectContext ctx = ConnectContext.get();
+            if (ctx != null && SqlModeHelper.check(ctx.getSessionVariable().getSqlMode(),
+                    SqlModeHelper.MODE_STRUCT_CAST_BY_NAME)) {
+                node.setCast_struct_by_name(true);
+            }
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecCast(this, context);
+    }
+
+    @Override
+    public ExecCast clone() {
+        return new ExecCast(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCast.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCast.java
@@ -48,12 +48,19 @@ public class ExecCast extends ExecExpr {
 
     @Override
     public boolean isNullable() {
-        return children.get(0).isNullable();
+        ExecExpr child = children.get(0);
+        // Non-compatible casts (e.g., VARCHAR→INT) can produce NULL even from non-null input
+        if (child.getType().isFullyCompatible(type)) {
+            return child.isNullable();
+        }
+        return true;
     }
 
     @Override
     public boolean isSelfMonotonic() {
-        return true;
+        // Narrowing casts can overflow to NULL, breaking monotonic order.
+        // e.g., cast(bigint to tinyint) < 10: min/max may overflow, but values in between may not.
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecClone.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecClone.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan clone expression (deep-copies a column value).
+ */
+public class ExecClone extends ExecExpr {
+
+    public ExecClone(Type type, ExecExpr child) {
+        super(type, List.of(child));
+    }
+
+    private ExecClone(ExecClone other) {
+        super(other.type, other.cloneChildren());
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return children.get(0).isNullable();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.CLONE_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        // CLONE_EXPR has no extra fields
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecClone(this, context);
+    }
+
+    @Override
+    public ExecClone clone() {
+        return new ExecClone(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCollectionElement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCollectionElement.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan collection element access (array[index] or map[key]).
+ */
+public class ExecCollectionElement extends ExecExpr {
+    private final boolean checkOutOfBounds;
+
+    public ExecCollectionElement(Type type, boolean checkOutOfBounds, List<ExecExpr> children) {
+        super(type, children);
+        this.checkOutOfBounds = checkOutOfBounds;
+    }
+
+    private ExecCollectionElement(ExecCollectionElement other) {
+        super(other.type, other.cloneChildren());
+        this.checkOutOfBounds = other.checkOutOfBounds;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean isCheckOutOfBounds() {
+        return checkOutOfBounds;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        if (children.get(0).getType().isArrayType()) {
+            return TExprNodeType.ARRAY_ELEMENT_EXPR;
+        }
+        return TExprNodeType.MAP_ELEMENT_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setCheck_is_out_of_bounds(checkOutOfBounds);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecCollectionElement(this, context);
+    }
+
+    @Override
+    public ExecCollectionElement clone() {
+        return new ExecCollectionElement(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCompoundPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecCompoundPredicate.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.BooleanType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Execution-plan compound predicate (AND, OR, NOT).
+ */
+public class ExecCompoundPredicate extends ExecExpr {
+    private final CompoundPredicate.Operator compoundType;
+
+    public ExecCompoundPredicate(CompoundPredicate.Operator compoundType, List<ExecExpr> children) {
+        super(BooleanType.BOOLEAN, children);
+        this.compoundType = compoundType;
+    }
+
+    public ExecCompoundPredicate(CompoundPredicate.Operator compoundType, ExecExpr left, ExecExpr right) {
+        super(BooleanType.BOOLEAN, new ArrayList<>(List.of(left, right)));
+        this.compoundType = compoundType;
+    }
+
+    private ExecCompoundPredicate(ExecCompoundPredicate other) {
+        super(other.type, other.cloneChildren());
+        this.compoundType = other.compoundType;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public CompoundPredicate.Operator getCompoundType() {
+        return compoundType;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.COMPOUND_PRED;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOpcode(ThriftEnumConverter.compoundPredicateOperatorToThrift(compoundType));
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecCompoundPredicate(this, context);
+    }
+
+    @Override
+    public ExecCompoundPredicate clone() {
+        return new ExecCompoundPredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictMapping.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan dictionary mapping expression.
+ */
+public class ExecDictMapping extends ExecExpr {
+
+    public ExecDictMapping(Type type, List<ExecExpr> children) {
+        super(type, children);
+    }
+
+    private ExecDictMapping(ExecDictMapping other) {
+        super(other.type, other.cloneChildren());
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.DICT_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        // DICT_EXPR has no extra fields
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecDictMapping(this, context);
+    }
+
+    @Override
+    public ExecDictMapping clone() {
+        return new ExecDictMapping(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictQuery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictQuery.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TDictQueryExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan dict_query expression.
+ */
+public class ExecDictQuery extends ExecExpr {
+    private final TDictQueryExpr dictQueryExpr;
+
+    public ExecDictQuery(Type type, TDictQueryExpr dictQueryExpr, List<ExecExpr> children) {
+        super(type, children);
+        this.dictQueryExpr = dictQueryExpr;
+    }
+
+    private ExecDictQuery(ExecDictQuery other) {
+        super(other.type, other.cloneChildren());
+        this.dictQueryExpr = other.dictQueryExpr;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public TDictQueryExpr getDictQueryExpr() {
+        return dictQueryExpr;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.DICT_QUERY_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setDict_query_expr(dictQueryExpr);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecDictQuery(this, context);
+    }
+
+    @Override
+    public ExecDictQuery clone() {
+        return new ExecDictQuery(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictionaryGet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecDictionaryGet.java
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TDictionaryGetExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan dictionary_get expression.
+ */
+public class ExecDictionaryGet extends ExecExpr {
+    private final long dictionaryId;
+    private final long txnId;
+    private final int keySize;
+    private final boolean nullIfNotExist;
+
+    public ExecDictionaryGet(Type type, long dictionaryId, long txnId, int keySize,
+                             boolean nullIfNotExist, List<ExecExpr> children) {
+        super(type, children);
+        this.dictionaryId = dictionaryId;
+        this.txnId = txnId;
+        this.keySize = keySize;
+        this.nullIfNotExist = nullIfNotExist;
+    }
+
+    private ExecDictionaryGet(ExecDictionaryGet other) {
+        super(other.type, other.cloneChildren());
+        this.dictionaryId = other.dictionaryId;
+        this.txnId = other.txnId;
+        this.keySize = other.keySize;
+        this.nullIfNotExist = other.nullIfNotExist;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public long getDictionaryId() {
+        return dictionaryId;
+    }
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public int getKeySize() {
+        return keySize;
+    }
+
+    public boolean isNullIfNotExist() {
+        return nullIfNotExist;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.DICTIONARY_GET_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        TDictionaryGetExpr expr = new TDictionaryGetExpr();
+        expr.setDict_id(dictionaryId);
+        expr.setTxn_id(txnId);
+        expr.setKey_size(keySize);
+        expr.setNull_if_not_exist(nullIfNotExist);
+        node.setDictionary_get_expr(expr);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecDictionaryGet(this, context);
+    }
+
+    @Override
+    public ExecDictionaryGet clone() {
+        return new ExecDictionaryGet(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExpr.java
@@ -1,0 +1,172 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base class for execution-plan expressions. Unlike {@link com.starrocks.sql.ast.expression.Expr},
+ * this hierarchy is purpose-built for the physical plan and Thrift serialization,
+ * with no dependency on AST or analysis infrastructure.
+ */
+public abstract class ExecExpr implements Cloneable {
+    protected Type type;
+    protected Type originType;
+    protected List<ExecExpr> children;
+    protected boolean isIndexOnlyFilter;
+
+    protected ExecExpr(Type type) {
+        this.type = type;
+        this.originType = null;
+        this.children = Collections.emptyList();
+    }
+
+    protected ExecExpr(Type type, List<ExecExpr> children) {
+        this.type = type;
+        this.originType = null;
+        this.children = children != null ? children : Collections.emptyList();
+    }
+
+    // ---- Type ----
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Type getOriginType() {
+        if (originType != null) {
+            return originType;
+        }
+        return type;
+    }
+
+    public void setOriginType(Type originType) {
+        this.originType = originType;
+    }
+
+    // ---- Tree structure ----
+
+    public ExecExpr getChild(int i) {
+        return children.get(i);
+    }
+
+    public void setChild(int i, ExecExpr child) {
+        children.set(i, child);
+    }
+
+    public List<ExecExpr> getChildren() {
+        return children;
+    }
+
+    public int getNumChildren() {
+        return children.size();
+    }
+
+    public void addChild(ExecExpr child) {
+        if (children.isEmpty()) {
+            children = new ArrayList<>();
+        }
+        children.add(child);
+    }
+
+    // ---- Properties ----
+
+    public abstract boolean isNullable();
+
+    public boolean hasNullableChild() {
+        for (ExecExpr child : children) {
+            if (child.isNullable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isMonotonic() {
+        if (!isSelfMonotonic()) {
+            return false;
+        }
+        for (ExecExpr child : children) {
+            if (!child.isMonotonic()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean isSelfMonotonic() {
+        return false;
+    }
+
+    public boolean isConstant() {
+        // Match Expr.isConstantImpl() behavior: vacuously true for leaf nodes.
+        // Subclasses like ExecSlotRef/ExecPlaceHolder override to return false.
+        for (ExecExpr child : children) {
+            if (!child.isConstant()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean isIndexOnlyFilter() {
+        return isIndexOnlyFilter;
+    }
+
+    public void setIsIndexOnlyFilter(boolean isIndexOnlyFilter) {
+        this.isIndexOnlyFilter = isIndexOnlyFilter;
+    }
+
+    // ---- Serialization ----
+
+    public abstract TExprNodeType getNodeType();
+
+    /**
+     * Populate type-specific fields on the given {@link TExprNode}.
+     * Common fields (type, num_children, nullable, monotonic, etc.) are handled
+     * by {@link ExecExprSerializer}.
+     */
+    public abstract void toThrift(TExprNode node);
+
+    // ---- Visitor ----
+
+    public abstract <R, C> R accept(ExecExprVisitor<R, C> visitor, C context);
+
+    // ---- Clone ----
+
+    @Override
+    public abstract ExecExpr clone();
+
+    protected List<ExecExpr> cloneChildren() {
+        if (children.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ExecExpr> cloned = new ArrayList<>(children.size());
+        for (ExecExpr child : children) {
+            cloned.add(child.clone());
+        }
+        return cloned;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprExplain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprExplain.java
@@ -1,0 +1,608 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.MatchExpr;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.type.Type;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Generates human-readable strings from {@link ExecExpr} trees for EXPLAIN output.
+ * Follows the same formatting conventions as {@code ExprExplainVisitor} to ensure
+ * test compatibility.
+ */
+public class ExecExprExplain implements ExecExprVisitor<String, Void> {
+
+    private static final ExecExprExplain INSTANCE = new ExecExprExplain();
+
+    public static String explain(ExecExpr expr) {
+        return expr.accept(INSTANCE, null);
+    }
+
+    public static String explainList(java.util.List<? extends ExecExpr> exprs) {
+        return exprs.stream()
+                .map(ExecExprExplain::explain)
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Instance that produces full SQL text without string truncation.
+     * Used for generating actual SQL sent to external databases (MySQL/JDBC filters).
+     */
+    private static final ExecExprExplain SQL_INSTANCE = new ExecExprExplain() {
+        @Override
+        public String visitExecLiteral(ExecLiteral expr, Void context) {
+            ConstantOperator value = expr.getValue();
+            if (value.isNull()) {
+                return "NULL";
+            }
+            Type t = expr.getType();
+            if (t.isStringType() || t.isChar() || t.isVarchar()) {
+                String s = value.getVarchar();
+                s = s.replace("\\", "\\\\");
+                s = s.replace("'", "\\'");
+                // No truncation for SQL output
+                return "'" + s + "'";
+            }
+            // For non-string types, delegate to the standard implementation
+            return INSTANCE.visitExecLiteral(expr, context);
+        }
+    };
+
+    /**
+     * Generate SQL text for an expression without string truncation.
+     * Suitable for SQL sent to external databases (MySQL/JDBC filter pushdown).
+     */
+    public static String toSql(ExecExpr expr) {
+        return expr.accept(SQL_INSTANCE, null);
+    }
+
+    private static final ExecExprExplain VERBOSE_INSTANCE = new ExecExprExplain() {
+        @Override
+        public String visitExecSlotRef(ExecSlotRef expr, Void context) {
+            // Use the descriptor's type for verbose explain, matching the old AST SlotRef behavior
+            // where ExprVerboseVisitor used node.getDesc().getType() (which keeps CHAR as CHAR)
+            // rather than the SlotRef's own type (which converts CHAR -> VARCHAR).
+            com.starrocks.type.Type displayType = expr.getDesc() != null ? expr.getDesc().getType() : expr.getType();
+            boolean nullable = expr.getDesc() != null ? expr.getDesc().getIsNullable() : expr.isNullable();
+            if (expr.getLabel() != null) {
+                return "[" + expr.getLabel() + ", " + displayType + ", " + nullable + "]";
+            } else {
+                return "[" + expr.getSlotId().asInt() + ", " + displayType + ", " + nullable + "]";
+            }
+        }
+
+        @Override
+        public String visitExecCast(ExecCast expr, Void context) {
+            String child = expr.getChild(0).accept(this, context);
+            // Skip display for no-op casts (child type matches target type)
+            if (expr.getChild(0).getType().matchesType(expr.getType())) {
+                return child;
+            }
+            return "cast(" + child + " as " + expr.getType() + ")";
+        }
+
+        @Override
+        public String visitExecFunctionCall(ExecFunctionCall expr, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(expr.getFnName());
+            sb.append("[(");
+            if (expr.isCountStar()) {
+                sb.append("*");
+            } else {
+                if (expr.isDistinct()) {
+                    sb.append("DISTINCT ");
+                }
+                sb.append(expr.getChildren().stream()
+                        .map(c -> c.accept(this, context))
+                        .collect(Collectors.joining(", ")));
+            }
+            sb.append(");");
+            if (expr.getFn() != null) {
+                sb.append(" args: ");
+                com.starrocks.type.Type[] args = expr.getFn().getArgs();
+                for (int i = 0; i < args.length; i++) {
+                    if (i > 0) {
+                        sb.append(",");
+                    }
+                    sb.append(args[i].getPrimitiveType().toString());
+                }
+                sb.append(";");
+                sb.append(" result: ").append(expr.getType()).append(";");
+            }
+            sb.append(" args nullable: ").append(hasNullableChildLegacy(expr)).append(";");
+            sb.append(" result nullable: ").append(expr.isNullable());
+            sb.append("]");
+            return sb.toString();
+        }
+
+    };
+
+    /**
+     * Verbose explain format: recursively uses [slotId: label, TYPE, nullable] for slot refs.
+     * Used for VERBOSE and COSTS EXPLAIN levels.
+     */
+    public static String verboseExplain(ExecExpr expr) {
+        return expr.accept(VERBOSE_INSTANCE, null);
+    }
+
+    public static String verboseExplainList(java.util.List<? extends ExecExpr> exprs) {
+        return exprs.stream()
+                .map(ExecExprExplain::verboseExplain)
+                .collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public String visitExecExpr(ExecExpr expr, Void context) {
+        return "<unknown-exec-expr>";
+    }
+
+    @Override
+    public String visitExecSlotRef(ExecSlotRef expr, Void context) {
+        if (expr.getLabel() != null) {
+            return expr.getLabel();
+        }
+        return "<slot " + expr.getSlotId() + ">";
+    }
+
+    /**
+     * Maximum length for string literal display in explain output.
+     * Matches the old LargeStringLiteral.LEN_LIMIT behavior: strings longer than this
+     * are truncated with "..." appended.
+     */
+    private static final int LARGE_STRING_LEN_LIMIT = 50;
+
+    @Override
+    public String visitExecLiteral(ExecLiteral expr, Void context) {
+        ConstantOperator value = expr.getValue();
+        if (value.isNull()) {
+            return "NULL";
+        }
+        Type t = expr.getType();
+        if (t.isBoolean()) {
+            return value.getBoolean() ? "TRUE" : "FALSE";
+        } else if (t.isTinyint()) {
+            return String.valueOf(value.getTinyInt());
+        } else if (t.isSmallint()) {
+            return String.valueOf(value.getSmallint());
+        } else if (t.isInt()) {
+            return String.valueOf(value.getInt());
+        } else if (t.isBigint()) {
+            return String.valueOf(value.getBigint());
+        } else if (t.isLargeint()) {
+            return value.getLargeInt().toString();
+        } else if (t.isFloatingPointType()) {
+            return String.valueOf(value.getDouble());
+        } else if (t.isTime()) {
+            return String.valueOf(value.getDouble());
+        } else if (t.isStringType() || t.isChar() || t.isVarchar()) {
+            String s = value.getVarchar();
+            s = s.replace("\\", "\\\\");
+            s = s.replace("'", "\\'");
+            String result = "'" + s + "'";
+            // Truncate long strings to match the old LargeStringLiteral explain behavior
+            if (result.length() > LARGE_STRING_LEN_LIMIT) {
+                return result.substring(0, LARGE_STRING_LEN_LIMIT) + "...'";
+            }
+            return result;
+        } else if (t.isDate()) {
+            LocalDateTime dt = value.getDatetime();
+            return String.format("'%04d-%02d-%02d'", dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth());
+        } else if (t.isDatetime()) {
+            LocalDateTime dt = value.getDatetime();
+            long microsecond = dt.getNano() / 1000;
+            if (microsecond != 0) {
+                return String.format("'%04d-%02d-%02d %02d:%02d:%02d.%06d'",
+                        dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth(),
+                        dt.getHour(), dt.getMinute(), dt.getSecond(), microsecond);
+            }
+            return String.format("'%04d-%02d-%02d %02d:%02d:%02d'",
+                    dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth(),
+                    dt.getHour(), dt.getMinute(), dt.getSecond());
+        } else if (t.isDecimalOfAnyVersion()) {
+            return value.getDecimal().toPlainString();
+        } else if (t.isBinaryType()) {
+            return "X'" + bytesToHex(value.getBinary()) + "'";
+        }
+        return String.valueOf(value.getValue());
+    }
+
+    @Override
+    public String visitExecFunctionCall(ExecFunctionCall expr, Void context) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(expr.getFnName()).append("(");
+        if (expr.isCountStar()) {
+            sb.append("*");
+        } else {
+            if (expr.isDistinct()) {
+                sb.append("DISTINCT ");
+            }
+            List<ExecExpr> children = expr.getChildren();
+            for (int i = 0; i < children.size(); i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                String childStr = children.get(i).accept(this, context);
+                sb.append(childStr);
+                // If this direct child is a lambda with its OWN common expressions
+                // and there are more children after it, put them on a new indented line with leading comma
+                if (children.get(i) instanceof ExecLambdaFunction
+                        && ((ExecLambdaFunction) children.get(i)).getCommonSubOperatorNum() > 0
+                        && i < children.size() - 1) {
+                    sb.append("\n        ");
+                    for (int j = i + 1; j < children.size(); j++) {
+                        if (j > i) {
+                            sb.append(", ");
+                        }
+                        sb.append(children.get(j).accept(this, context));
+                    }
+                    break;
+                }
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public String visitExecCast(ExecCast expr, Void context) {
+        String child = expr.getChild(0).accept(this, context);
+        return "CAST(" + child + " AS " + expr.getType() + ")";
+    }
+
+    @Override
+    public String visitExecBinaryPredicate(ExecBinaryPredicate expr, Void context) {
+        String left = expr.getChild(0).accept(this, context);
+        String right = expr.getChild(1).accept(this, context);
+        return left + " " + binaryTypeToString(expr.getOp()) + " " + right;
+    }
+
+    @Override
+    public String visitExecCompoundPredicate(ExecCompoundPredicate expr, Void context) {
+        CompoundPredicate.Operator op = expr.getCompoundType();
+        if (op == CompoundPredicate.Operator.NOT) {
+            return "NOT (" + expr.getChild(0).accept(this, context) + ")";
+        }
+        String left = expr.getChild(0).accept(this, context);
+        String right = expr.getChild(1).accept(this, context);
+        return "(" + left + ") " + op.toString() + " (" + right + ")";
+    }
+
+    @Override
+    public String visitExecInPredicate(ExecInPredicate expr, Void context) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(expr.getChild(0).accept(this, context));
+        if (expr.isNotIn()) {
+            sb.append(" NOT");
+        }
+        sb.append(" IN (");
+        sb.append(expr.getChildren().stream()
+                .skip(1)
+                .map(c -> c.accept(this, context))
+                .collect(Collectors.joining(", ")));
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public String visitExecIsNullPredicate(ExecIsNullPredicate expr, Void context) {
+        String child = expr.getChild(0).accept(this, context);
+        return child + (expr.isNotNull() ? " IS NOT NULL" : " IS NULL");
+    }
+
+    @Override
+    public String visitExecLikePredicate(ExecLikePredicate expr, Void context) {
+        String child = expr.getChild(0).accept(this, context);
+        String pattern = expr.getChild(1).accept(this, context);
+        String opName = expr.isRegexp() ? "REGEXP" : "LIKE";
+        return child + " " + opName + " " + pattern;
+    }
+
+    @Override
+    public String visitExecBetweenPredicate(ExecBetweenPredicate expr, Void context) {
+        String e = expr.getChild(0).accept(this, context);
+        String lower = expr.getChild(1).accept(this, context);
+        String upper = expr.getChild(2).accept(this, context);
+        String notStr = expr.isNotBetween() ? " NOT" : "";
+        return e + notStr + " BETWEEN " + lower + " AND " + upper;
+    }
+
+    @Override
+    public String visitExecCaseWhen(ExecCaseWhen expr, Void context) {
+        StringBuilder sb = new StringBuilder("CASE");
+        int childIdx = 0;
+        if (expr.hasCase()) {
+            sb.append(" ").append(expr.getChild(childIdx++).accept(this, context));
+        }
+        while (childIdx + 2 <= expr.getNumChildren()) {
+            sb.append(" WHEN ").append(expr.getChild(childIdx++).accept(this, context));
+            sb.append(" THEN ").append(expr.getChild(childIdx++).accept(this, context));
+        }
+        if (expr.hasElse()) {
+            sb.append(" ELSE ").append(expr.getChild(expr.getNumChildren() - 1).accept(this, context));
+        }
+        sb.append(" END");
+        return sb.toString();
+    }
+
+    @Override
+    public String visitExecMatchExpr(ExecMatchExpr expr, Void context) {
+        String left = expr.getChild(0).accept(this, context);
+        String right = expr.getChild(1).accept(this, context);
+        return left + " " + matchOpToString(expr.getMatchOp()) + " " + right;
+    }
+
+    @Override
+    public String visitExecArrayExpr(ExecArrayExpr expr, Void context) {
+        return "[" + expr.getChildren().stream()
+                .map(c -> c.accept(this, context))
+                .collect(Collectors.joining(",")) + "]";
+    }
+
+    @Override
+    public String visitExecMapExpr(ExecMapExpr expr, Void context) {
+        StringBuilder sb = new StringBuilder("map{");
+        java.util.List<ExecExpr> children = expr.getChildren();
+        for (int i = 0; i < children.size(); i += 2) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append(children.get(i).accept(this, context));
+            sb.append(":");
+            sb.append(children.get(i + 1).accept(this, context));
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public String visitExecCollectionElement(ExecCollectionElement expr, Void context) {
+        String collection = expr.getChild(0).accept(this, context);
+        String index = expr.getChild(1).accept(this, context);
+        return collection + "[" + index + "]";
+    }
+
+    @Override
+    public String visitExecArraySlice(ExecArraySlice expr, Void context) {
+        String array = expr.getChild(0).accept(this, context);
+        String lower = expr.getChild(1).accept(this, context);
+        String upper = expr.getChild(2).accept(this, context);
+        return array + "[" + lower + ":" + upper + "]";
+    }
+
+    @Override
+    public String visitExecSubfield(ExecSubfield expr, Void context) {
+        String child = expr.getChild(0).accept(this, context);
+        return child + "." + String.join(".", expr.getFieldNames()) + "[" + expr.isCopyFlag() + "]";
+    }
+
+    @Override
+    public String visitExecLambdaFunction(ExecLambdaFunction expr, Void context) {
+        // Children layout: [lambdaBody, arg1, arg2, ..., commonSlot1..N, commonExpr1..N]
+        // Real argument count = totalChildren - 1(body) - 2*commonSubOperatorNum
+        int commonNum = expr.getCommonSubOperatorNum();
+        int realChildrenNum = expr.getNumChildren() - 2 * commonNum;
+        String body = expr.getChild(0).accept(this, context);
+
+        // Build argument names
+        StringBuilder names;
+        if (realChildrenNum == 2) {
+            names = new StringBuilder(expr.getChild(1).accept(this, context));
+        } else {
+            names = new StringBuilder("(");
+            for (int i = 1; i < realChildrenNum; i++) {
+                if (i > 1) {
+                    names.append(", ");
+                }
+                names.append(expr.getChild(i).accept(this, context));
+            }
+            names.append(")");
+        }
+
+        // Build common sub-expression info
+        StringBuilder commonSubOp = new StringBuilder();
+        if (commonNum > 0) {
+            commonSubOp.append("\n        lambda common expressions:");
+            for (int i = 0; i < commonNum; i++) {
+                ExecExpr slot = expr.getChild(realChildrenNum + i);
+                ExecExpr subExpr = expr.getChild(realChildrenNum + commonNum + i);
+                commonSubOp.append("{").append(slot.accept(this, context))
+                        .append(" <-> ").append(subExpr.accept(this, context)).append("}");
+            }
+        }
+
+        return String.format("%s -> %s%s", names, body, commonSubOp);
+    }
+
+    @Override
+    public String visitExecDictMapping(ExecDictMapping expr, Void context) {
+        // Match ExprExplainVisitor.visitDictMappingExpr format: DictDecode/DictDefine(slot, [inner])
+        String fnName = expr.getType().matchesType(expr.getChild(1).getType()) ? "DictDecode" : "DictDefine";
+        if (expr.getNumChildren() == 2) {
+            return fnName + "(" + expr.getChild(0).accept(this, context) +
+                    ", [" + expr.getChild(1).accept(this, context) + "])";
+        }
+        return fnName + "(" + expr.getChild(0).accept(this, context) +
+                ", [" + expr.getChild(1).accept(this, context) + "], " +
+                expr.getChild(2).accept(this, context) + ")";
+    }
+
+    @Override
+    public String visitExecClone(ExecClone expr, Void context) {
+        return "clone(" + expr.getChild(0).accept(this, context) + ")";
+    }
+
+    @Override
+    public String visitExecDictQuery(ExecDictQuery expr, Void context) {
+        return "dict_query(" + expr.getChildren().stream()
+                .map(c -> c.accept(this, context))
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public String visitExecDictionaryGet(ExecDictionaryGet expr, Void context) {
+        return "dictionary_get(" + expr.getChildren().stream()
+                .map(c -> c.accept(this, context))
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public String visitExecPlaceHolder(ExecPlaceHolder expr, Void context) {
+        return "<place-holder>";
+    }
+
+    @Override
+    public String visitExecArithmetic(ExecArithmetic expr, Void context) {
+        ArithmeticExpr.Operator op = expr.getOp();
+        if (expr.getNumChildren() == 1) {
+            return op.toString() + " " + expr.getChild(0).accept(this, context);
+        }
+        String left = expr.getChild(0).accept(this, context);
+        String right = expr.getChild(1).accept(this, context);
+        return left + " " + op.toString() + " " + right;
+    }
+
+    @Override
+    public String visitExecInformationFunction(ExecInformationFunction expr, Void context) {
+        return expr.getFuncName() + "()";
+    }
+
+    // ---- Helpers ----
+
+    private static String binaryTypeToString(BinaryType op) {
+        switch (op) {
+            case EQ:
+                return "=";
+            case NE:
+                return "!=";
+            case LT:
+                return "<";
+            case LE:
+                return "<=";
+            case GT:
+                return ">";
+            case GE:
+                return ">=";
+            case EQ_FOR_NULL:
+                return "<=>";
+            default:
+                return op.toString();
+        }
+    }
+
+    private static String matchOpToString(MatchExpr.MatchOperator op) {
+        switch (op) {
+            case MATCH:
+                return "MATCH";
+            case MATCH_ANY:
+                return "MATCH_ANY";
+            case MATCH_ALL:
+                return "MATCH_ALL";
+            default:
+                return op.toString();
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Compute hasNullableChild using the legacy AST Expr behavior for explain output compatibility.
+     * The old FunctionCallExpr.hasNullableChild() checked isMergeAggFn first, then delegated to
+     * the base Expr.hasNullableChild() which called isNullable() on each child.
+     */
+    private static boolean hasNullableChildLegacy(ExecFunctionCall expr) {
+        if (expr.isMergeAggFn()) {
+            return true;
+        }
+        for (ExecExpr child : expr.getChildren()) {
+            if (isNullableLegacy(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Legacy isNullable: matches the old AST Expr.isNullable() behavior.
+     * The old Expr base class returned true by default. Only certain subclasses overrode it:
+     * - SlotRef: desc.getIsNullable()
+     * - LiteralExpr: this instanceof NullLiteral
+     * - ArithmeticExpr: divide/mod=true, else check children
+     * - BinaryPredicate: !EQ_FOR_NULL && hasNullableChild()
+     * - IsNullPredicate: false
+     * - CastExpr: if fully compatible, delegate to child; else true
+     * - FunctionCallExpr: fn.isNullable() check
+     * Types like CompoundPredicate, InPredicate, CaseExpr, LikePredicate, etc. used the default true.
+     */
+    private static boolean isNullableLegacy(ExecExpr expr) {
+        if (expr instanceof ExecSlotRef) {
+            return expr.isNullable();
+        }
+        if (expr instanceof ExecLiteral) {
+            return ((ExecLiteral) expr).getValue().isNull();
+        }
+        if (expr instanceof ExecArithmetic) {
+            ExecArithmetic arith = (ExecArithmetic) expr;
+            ArithmeticExpr.Operator op = arith.getOp();
+            if (op == ArithmeticExpr.Operator.DIVIDE || op == ArithmeticExpr.Operator.INT_DIVIDE
+                    || op == ArithmeticExpr.Operator.MOD) {
+                return true;
+            }
+            return arith.getChildren().stream().anyMatch(c -> isNullableLegacy(c) || c.getType().isDecimalV3());
+        }
+        if (expr instanceof ExecBinaryPredicate) {
+            ExecBinaryPredicate bp = (ExecBinaryPredicate) expr;
+            if (bp.getOp() == com.starrocks.sql.ast.expression.BinaryType.EQ_FOR_NULL) {
+                return false;
+            }
+            return expr.getChildren().stream().anyMatch(ExecExprExplain::isNullableLegacy);
+        }
+        if (expr instanceof ExecIsNullPredicate) {
+            return false;
+        }
+        if (expr instanceof ExecPlaceHolder) {
+            return ((ExecPlaceHolder) expr).isNullable();
+        }
+        if (expr instanceof ExecCast) {
+            ExecExpr child = expr.getChild(0);
+            if (child.getType().matchesType(expr.getType())) {
+                return isNullableLegacy(child);
+            }
+            return true;
+        }
+        if (expr instanceof ExecFunctionCall) {
+            ExecFunctionCall fn = (ExecFunctionCall) expr;
+            if (fn.getFn() != null && !fn.getFn().isNullable()) {
+                return false;
+            }
+            return true;
+        }
+        // Default: true, matching old Expr.isNullable() default
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprSerializer.java
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import com.starrocks.sql.plan.ScalarOperatorToExecExpr;
+import com.starrocks.sql.ast.expression.NullLiteral;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Serializes an {@link ExecExpr} tree into a {@link TExpr} (Thrift representation).
+ * Serializes ExecExpr trees into Thrift TExpr for BE consumption.
+ */
+public final class ExecExprSerializer {
+
+    private ExecExprSerializer() {
+    }
+
+    public static TExpr serialize(ExecExpr expr) {
+        TExpr result = new TExpr();
+        serializeHelper(expr, result);
+        return result;
+    }
+
+    public static List<TExpr> serializeList(List<? extends ExecExpr> exprs) {
+        List<TExpr> result = Lists.newArrayList();
+        for (ExecExpr expr : exprs) {
+            result.add(serialize(expr));
+        }
+        return result;
+    }
+
+    // ---- AST Expr convenience methods ----
+    // These convert AST Expr objects to ExecExpr and serialize them.
+    // These convert AST Expr to ExecExpr via the scalar operator pipeline, then serialize.
+
+    /**
+     * Serialize an AST {@link Expr} to a {@link TExpr}.
+     * Converts the Expr to an ExecExpr via the scalar operator pipeline, then serializes.
+     */
+    public static TExpr serializeAstExpr(Expr expr) {
+        Expr analyzedExpr = ExprUtils.analyzeAndCastFold(expr);
+        ScalarOperator scalarOp = SqlToScalarOperatorTranslator.translate(analyzedExpr);
+        ExecExpr execExpr = ScalarOperatorToExecExpr.build(scalarOp,
+                new ScalarOperatorToExecExpr.FormatterContext(new java.util.HashMap<>()));
+        return serialize(execExpr);
+    }
+
+    /**
+     * Serialize a list of AST {@link Expr} to a list of {@link TExpr}.
+     */
+    public static List<TExpr> serializeAstExprs(List<? extends Expr> exprs) {
+        List<TExpr> result = Lists.newArrayList();
+        for (Expr expr : exprs) {
+            result.add(serializeAstExpr(expr));
+        }
+        return result;
+    }
+
+    /**
+     * Serialize a {@link LiteralExpr} to a single {@link TExprNode}.
+     * Constructs an {@link ExecLiteral} directly from the literal expression,
+     * avoiding the full scalar operator pipeline.
+     */
+    public static TExprNode serializeLiteralToNode(LiteralExpr literal) {
+        ConstantOperator constOp;
+        if (literal instanceof NullLiteral) {
+            constOp = ConstantOperator.createNull(literal.getType());
+        } else {
+            constOp = ConstantOperator.createObject(literal.getRealObjectValue(), literal.getType());
+        }
+        ExecLiteral execLiteral = new ExecLiteral(constOp, literal.getType());
+        TExpr texpr = serialize(execLiteral);
+        return texpr.getNodes().get(0);
+    }
+
+    /**
+     * Serialize a list of {@link LiteralExpr} to a list of {@link TExprNode}.
+     */
+    public static List<TExprNode> serializeLiteralsToNodes(List<LiteralExpr> literals) {
+        return literals.stream()
+                .map(ExecExprSerializer::serializeLiteralToNode)
+                .collect(Collectors.toList());
+    }
+
+    private static void serializeHelper(ExecExpr expr, TExpr container) {
+        Type exprType = expr.getType();
+
+        // Replace NULL_TYPE with BOOLEAN for BE compatibility.
+        // If the expression has null type, serialize a null literal with boolean type instead.
+        if (exprType.isNull()) {
+            serializeNullLiteral(container);
+            return;
+        }
+
+        TExprNode node = new TExprNode();
+
+        node.type = TypeSerializer.toThrift(exprType);
+        node.num_children = expr.getNumChildren();
+        node.setHas_nullable_child(expr.hasNullableChild());
+        node.setIs_nullable(expr.isNullable());
+        // BE no longer consumes output_scale; keep thrift field populated with a sentinel for wire compat.
+        node.output_scale = -1;
+        node.setIs_monotonic(expr.isMonotonic());
+        node.setIs_index_only_filter(expr.isIndexOnlyFilter());
+        node.node_type = expr.getNodeType();
+
+        // Let the concrete ExecExpr populate type-specific fields
+        expr.toThrift(node);
+
+        container.addToNodes(node);
+
+        // Recursively serialize children (depth-first pre-order)
+        for (ExecExpr child : expr.getChildren()) {
+            serializeHelper(child, container);
+        }
+    }
+
+    /**
+     * Serialize a NULL literal with BOOLEAN type for BE compatibility.
+     */
+    private static void serializeNullLiteral(TExpr container) {
+        Type boolType = BooleanType.BOOLEAN;
+        // Replace NULL_TYPE with BOOLEAN to ensure correctness on the backend
+        boolType = AnalyzerUtils.replaceNullType2Boolean(boolType);
+
+        TExprNode node = new TExprNode();
+        node.type = TypeSerializer.toThrift(boolType);
+        node.num_children = 0;
+        node.setHas_nullable_child(false);
+        node.setIs_nullable(true);
+        node.output_scale = -1;
+        node.setIs_monotonic(false);
+        node.setIs_index_only_filter(false);
+        node.node_type = com.starrocks.thrift.TExprNodeType.NULL_LITERAL;
+
+        container.addToNodes(node);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprUtils.java
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.TupleId;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility methods for working with {@link ExecExpr} trees.
+ * Provides functionality that PlanNode subclasses need (slot collection,
+ * tuple binding checks, compound predicate construction, etc.).
+ */
+public final class ExecExprUtils {
+
+    private ExecExprUtils() {
+    }
+
+    /**
+     * Check whether the given expression is bound by the specified tuple IDs,
+     * i.e., all slot references in the expression refer to slots in one of the given tuples.
+     */
+    public static boolean isBoundByTupleIds(ExecExpr expr, List<TupleId> tids) {
+        if (expr instanceof ExecSlotRef) {
+            ExecSlotRef slotRef = (ExecSlotRef) expr;
+            return tids.contains(slotRef.getTupleId());
+        }
+        for (ExecExpr child : expr.getChildren()) {
+            if (!isBoundByTupleIds(child, tids)) {
+                return false;
+            }
+        }
+        // An expression with no slot refs (e.g., a literal) is considered bound by any tuple.
+        return true;
+    }
+
+    /**
+     * Collect all {@link ExecSlotRef} nodes in the expression tree.
+     */
+    public static List<ExecSlotRef> collectSlotRefs(ExecExpr expr) {
+        List<ExecSlotRef> result = new ArrayList<>();
+        collectSlotRefsHelper(expr, result);
+        return result;
+    }
+
+    private static void collectSlotRefsHelper(ExecExpr expr, List<ExecSlotRef> result) {
+        if (expr instanceof ExecSlotRef) {
+            result.add((ExecSlotRef) expr);
+        }
+        for (ExecExpr child : expr.getChildren()) {
+            collectSlotRefsHelper(child, result);
+        }
+    }
+
+    /**
+     * Get all SlotIds referenced by the expression tree.
+     */
+    public static Set<SlotId> getUsedSlotIds(ExecExpr expr) {
+        Set<SlotId> result = new HashSet<>();
+        for (ExecSlotRef slotRef : collectSlotRefs(expr)) {
+            result.add(slotRef.getSlotId());
+        }
+        return result;
+    }
+
+    /**
+     * Get all SlotIds referenced by a list of expressions.
+     */
+    public static Set<SlotId> getUsedSlotIds(List<? extends ExecExpr> exprs) {
+        Set<SlotId> result = new HashSet<>();
+        for (ExecExpr expr : exprs) {
+            result.addAll(getUsedSlotIds(expr));
+        }
+        return result;
+    }
+
+    /**
+     * Deep-clone a list of expressions.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends ExecExpr> List<T> cloneList(List<T> exprs) {
+        List<T> result = new ArrayList<>(exprs.size());
+        for (T expr : exprs) {
+            result.add((T) expr.clone());
+        }
+        return result;
+    }
+
+    /**
+     * Build an AND compound predicate from a list of conjuncts.
+     * Returns null if the list is empty, the single element if the list has one element,
+     * or a left-deep AND tree otherwise.
+     */
+    public static ExecExpr compoundAnd(List<ExecExpr> conjuncts) {
+        if (conjuncts == null || conjuncts.isEmpty()) {
+            return null;
+        }
+        ExecExpr result = conjuncts.get(0);
+        for (int i = 1; i < conjuncts.size(); i++) {
+            result = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, result, conjuncts.get(i));
+        }
+        return result;
+    }
+
+    /**
+     * Check whether the given expression tree contains an {@link ExecDictMapping} node.
+     */
+    public static boolean containsDictMappingExpr(ExecExpr expr) {
+        if (expr == null) {
+            return false;
+        }
+        if (expr instanceof ExecDictMapping) {
+            return true;
+        }
+        for (ExecExpr child : expr.getChildren()) {
+            if (containsDictMappingExpr(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Unwrap a slot reference from an expression, traversing through CASTs.
+     * Returns null if the expression is not a (possibly cast) slot reference.
+     */
+    public static ExecSlotRef unwrapSlotRef(ExecExpr expr) {
+        if (expr instanceof ExecSlotRef) {
+            return (ExecSlotRef) expr;
+        }
+        if (expr instanceof ExecCast && expr.getNumChildren() == 1) {
+            return unwrapSlotRef(expr.getChild(0));
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprUtils.java
@@ -40,6 +40,10 @@ public final class ExecExprUtils {
     public static boolean isBoundByTupleIds(ExecExpr expr, List<TupleId> tids) {
         if (expr instanceof ExecSlotRef) {
             ExecSlotRef slotRef = (ExecSlotRef) expr;
+            // Lambda argument slots may not have a parent tuple; treat them as unbound.
+            if (slotRef.getDesc().getParent() == null) {
+                return false;
+            }
             return tids.contains(slotRef.getTupleId());
         }
         for (ExecExpr child : expr.getChildren()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecExprVisitor.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+/**
+ * Visitor interface for the {@link ExecExpr} hierarchy.
+ * Every visit method defaults to {@link #visitExecExpr} so that callers only
+ * need to override the node types they care about.
+ */
+public interface ExecExprVisitor<R, C> {
+
+    R visitExecExpr(ExecExpr expr, C context);
+
+    default R visitExecSlotRef(ExecSlotRef expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecLiteral(ExecLiteral expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecFunctionCall(ExecFunctionCall expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecCast(ExecCast expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecBinaryPredicate(ExecBinaryPredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecCompoundPredicate(ExecCompoundPredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecInPredicate(ExecInPredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecIsNullPredicate(ExecIsNullPredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecLikePredicate(ExecLikePredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecBetweenPredicate(ExecBetweenPredicate expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecCaseWhen(ExecCaseWhen expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecMatchExpr(ExecMatchExpr expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecArrayExpr(ExecArrayExpr expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecMapExpr(ExecMapExpr expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecCollectionElement(ExecCollectionElement expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecArraySlice(ExecArraySlice expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecSubfield(ExecSubfield expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecLambdaFunction(ExecLambdaFunction expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecDictMapping(ExecDictMapping expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecClone(ExecClone expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecDictQuery(ExecDictQuery expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecDictionaryGet(ExecDictionaryGet expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecPlaceHolder(ExecPlaceHolder expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecArithmetic(ExecArithmetic expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+
+    default R visitExecInformationFunction(ExecInformationFunction expr, C context) {
+        return visitExecExpr(expr, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecFunctionCall.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecFunctionCall.java
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.catalog.Function;
+import com.starrocks.thrift.TAggregateExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFunction;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan function call (scalar, aggregate, or analytic).
+ */
+public class ExecFunctionCall extends ExecExpr {
+    private final Function fn;
+    private final String fnName;
+    private final boolean isDistinct;
+    private final boolean ignoreNulls;
+    private final boolean isAggregateOrAnalytic;
+    private final boolean isCountStar;
+    private boolean isMergeAggFn;
+    private boolean nullable;
+
+    public ExecFunctionCall(Type type, Function fn, String fnName,
+                            List<ExecExpr> children,
+                            boolean isDistinct, boolean ignoreNulls,
+                            boolean isAggregateOrAnalytic, boolean isMergeAggFn) {
+        this(type, fn, fnName, children, isDistinct, ignoreNulls, isAggregateOrAnalytic, isMergeAggFn, false);
+    }
+
+    public ExecFunctionCall(Type type, Function fn, String fnName,
+                            List<ExecExpr> children,
+                            boolean isDistinct, boolean ignoreNulls,
+                            boolean isAggregateOrAnalytic, boolean isMergeAggFn,
+                            boolean isCountStar) {
+        super(type, children);
+        this.fn = fn;
+        this.fnName = fnName;
+        this.isDistinct = isDistinct;
+        this.ignoreNulls = ignoreNulls;
+        this.isAggregateOrAnalytic = isAggregateOrAnalytic;
+        this.isMergeAggFn = isMergeAggFn;
+        this.isCountStar = isCountStar;
+        this.nullable = true;
+    }
+
+    private ExecFunctionCall(ExecFunctionCall other) {
+        super(other.type, other.cloneChildren());
+        this.fn = other.fn;
+        this.fnName = other.fnName;
+        this.isCountStar = other.isCountStar;
+        this.isDistinct = other.isDistinct;
+        this.ignoreNulls = other.ignoreNulls;
+        this.isAggregateOrAnalytic = other.isAggregateOrAnalytic;
+        this.isMergeAggFn = other.isMergeAggFn;
+        this.nullable = other.nullable;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public Function getFn() {
+        return fn;
+    }
+
+    public String getFnName() {
+        return fnName;
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
+    }
+
+    public boolean isIgnoreNulls() {
+        return ignoreNulls;
+    }
+
+    public boolean isAggregateOrAnalytic() {
+        return isAggregateOrAnalytic;
+    }
+
+    public boolean isCountStar() {
+        return isCountStar;
+    }
+
+    public boolean isMergeAggFn() {
+        return isMergeAggFn;
+    }
+
+    public void setMergeAggFn() {
+        this.isMergeAggFn = true;
+    }
+
+    /**
+     * Creates a new ExecFunctionCall that replaces the function name, function definition,
+     * and distinct flag while keeping the same children and type.
+     */
+    public ExecFunctionCall withReplacedFunction(String newFnName, Function newFn, boolean newIsDistinct) {
+        ExecFunctionCall result = new ExecFunctionCall(
+                this.type, newFn, newFnName, this.cloneChildren(),
+                newIsDistinct, this.ignoreNulls, this.isAggregateOrAnalytic, this.isMergeAggFn);
+        result.nullable = this.nullable;
+        return result;
+    }
+
+    public void setNullable(boolean nullable) {
+        this.nullable = nullable;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    @Override
+    public boolean hasNullableChild() {
+        if (isMergeAggFn) {
+            return true;
+        }
+        return super.hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        if (isAggregateOrAnalytic) {
+            return TExprNodeType.AGG_EXPR;
+        }
+        return TExprNodeType.FUNCTION_CALL;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        if (isAggregateOrAnalytic) {
+            node.setAgg_expr(new TAggregateExpr(isMergeAggFn));
+        }
+        if (fn != null) {
+            TFunction tfn = fn.toThrift();
+            tfn.setIgnore_nulls(ignoreNulls);
+            node.setFn(tfn);
+            if (fn.hasVarArgs()) {
+                node.setVararg_start_idx(fn.getNumArgs() - 1);
+            }
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecFunctionCall(this, context);
+    }
+
+    @Override
+    public ExecFunctionCall clone() {
+        return new ExecFunctionCall(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInPredicate.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.expression.ExprOpcodeRegistry;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TInPredicate;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
+
+import java.util.List;
+
+/**
+ * Execution-plan IN predicate (e.g., col IN (1, 2, 3)).
+ */
+public class ExecInPredicate extends ExecExpr {
+    private final boolean isNotIn;
+
+    public ExecInPredicate(boolean isNotIn, List<ExecExpr> children) {
+        super(BooleanType.BOOLEAN, children);
+        this.isNotIn = isNotIn;
+    }
+
+    private ExecInPredicate(ExecInPredicate other) {
+        super(other.type, other.cloneChildren());
+        this.isNotIn = other.isNotIn;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean isNotIn() {
+        return isNotIn;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.IN_PRED;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.in_predicate = new TInPredicate(isNotIn);
+        node.setOpcode(ExprOpcodeRegistry.getInPredicateOpcode(isNotIn));
+        node.setVector_opcode(TExprOpcode.INVALID_OPCODE);
+        Type childType = children.get(0).getType();
+        if (childType.isComplexType()) {
+            node.setChild_type_desc(TypeSerializer.toThrift(childType));
+        } else {
+            node.setChild_type(TypeSerializer.toThrift(childType.getPrimitiveType()));
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecInPredicate(this, context);
+    }
+
+    @Override
+    public ExecInPredicate clone() {
+        return new ExecInPredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInformationFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecInformationFunction.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TInfoFunc;
+import com.starrocks.type.Type;
+
+/**
+ * Execution-plan information function (database(), user(), current_user(), etc.).
+ */
+public class ExecInformationFunction extends ExecExpr {
+    private final String funcName;
+    private final String strValue;
+    private final long intValue;
+
+    public ExecInformationFunction(Type type, String funcName, String strValue, long intValue) {
+        super(type);
+        this.funcName = funcName;
+        this.strValue = strValue;
+        this.intValue = intValue;
+    }
+
+    private ExecInformationFunction(ExecInformationFunction other) {
+        super(other.type);
+        this.funcName = other.funcName;
+        this.strValue = other.strValue;
+        this.intValue = other.intValue;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public String getFuncName() {
+        return funcName;
+    }
+
+    public String getStrValue() {
+        return strValue;
+    }
+
+    public long getIntValue() {
+        return intValue;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.INFO_FUNC;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.info_func = new TInfoFunc(intValue, strValue);
+        if (FunctionSet.CURRENT_WAREHOUSE.equalsIgnoreCase(funcName) && strValue != null) {
+            node.info_func.setStr_value(strValue);
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecInformationFunction(this, context);
+    }
+
+    @Override
+    public ExecInformationFunction clone() {
+        return new ExecInformationFunction(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecIsNullPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecIsNullPredicate.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFunction;
+import com.starrocks.thrift.TFunctionBinaryType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.InvalidType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan IS NULL / IS NOT NULL predicate.
+ * Serialized as a FUNCTION_CALL with is_null_pred / is_not_null_pred built-in function.
+ */
+public class ExecIsNullPredicate extends ExecExpr {
+    private static final Function IS_NULL_FN = buildNullPredicateFn("is_null_pred");
+    private static final Function IS_NOT_NULL_FN = buildNullPredicateFn("is_not_null_pred");
+
+    private final boolean isNotNull;
+
+    public ExecIsNullPredicate(boolean isNotNull, ExecExpr child) {
+        super(BooleanType.BOOLEAN, List.of(child));
+        this.isNotNull = isNotNull;
+    }
+
+    private ExecIsNullPredicate(ExecIsNullPredicate other) {
+        super(other.type, other.cloneChildren());
+        this.isNotNull = other.isNotNull;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    private static Function buildNullPredicateFn(String name) {
+        Function fn = new Function(new FunctionName(name),
+                new Type[] {InvalidType.INVALID}, BooleanType.BOOLEAN, false);
+        fn.setBinaryType(TFunctionBinaryType.BUILTIN);
+        return fn;
+    }
+
+    public boolean isNotNull() {
+        return isNotNull;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.FUNCTION_CALL;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        Function fn = isNotNull ? IS_NOT_NULL_FN : IS_NULL_FN;
+        TFunction tfn = fn.toThrift();
+        tfn.setIgnore_nulls(false);
+        node.setFn(tfn);
+        if (fn.hasVarArgs()) {
+            node.setVararg_start_idx(fn.getNumArgs() - 1);
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecIsNullPredicate(this, context);
+    }
+
+    @Override
+    public ExecIsNullPredicate clone() {
+        return new ExecIsNullPredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLambdaFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLambdaFunction.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan lambda function expression.
+ */
+public class ExecLambdaFunction extends ExecExpr {
+    private final int commonSubOperatorNum;
+    private final boolean isNondeterministic;
+
+    public ExecLambdaFunction(Type type, int commonSubOperatorNum, boolean isNondeterministic,
+                              List<ExecExpr> children) {
+        super(type, children);
+        this.commonSubOperatorNum = commonSubOperatorNum;
+        this.isNondeterministic = isNondeterministic;
+    }
+
+    private ExecLambdaFunction(ExecLambdaFunction other) {
+        super(other.type, other.cloneChildren());
+        this.commonSubOperatorNum = other.commonSubOperatorNum;
+        this.isNondeterministic = other.isNondeterministic;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public int getCommonSubOperatorNum() {
+        return commonSubOperatorNum;
+    }
+
+    public boolean isNondeterministic() {
+        return isNondeterministic;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.LAMBDA_FUNCTION_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOutput_column(commonSubOperatorNum);
+        node.setIs_nondeterministic(isNondeterministic);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecLambdaFunction(this, context);
+    }
+
+    @Override
+    public ExecLambdaFunction clone() {
+        return new ExecLambdaFunction(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLikePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLikePredicate.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.catalog.Function;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFunction;
+import com.starrocks.type.BooleanType;
+
+import java.util.List;
+
+/**
+ * Execution-plan LIKE / REGEXP predicate.
+ * Serialized as a FUNCTION_CALL with the resolved built-in function.
+ */
+public class ExecLikePredicate extends ExecExpr {
+    private final boolean isRegexp;
+    private final Function fn;
+
+    public ExecLikePredicate(boolean isRegexp, Function fn, List<ExecExpr> children) {
+        super(BooleanType.BOOLEAN, children);
+        this.isRegexp = isRegexp;
+        this.fn = fn;
+    }
+
+    private ExecLikePredicate(ExecLikePredicate other) {
+        super(other.type, other.cloneChildren());
+        this.isRegexp = other.isRegexp;
+        this.fn = other.fn;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public boolean isRegexp() {
+        return isRegexp;
+    }
+
+    public Function getFn() {
+        return fn;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.FUNCTION_CALL;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        if (fn != null) {
+            TFunction tfn = fn.toThrift();
+            tfn.setIgnore_nulls(false);
+            node.setFn(tfn);
+            if (fn.hasVarArgs()) {
+                node.setVararg_start_idx(fn.getNumArgs() - 1);
+            }
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecLikePredicate(this, context);
+    }
+
+    @Override
+    public ExecLikePredicate clone() {
+        return new ExecLikePredicate(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecLiteral.java
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.thrift.TBinaryLiteral;
+import com.starrocks.thrift.TBoolLiteral;
+import com.starrocks.thrift.TDateLiteral;
+import com.starrocks.thrift.TDecimalLiteral;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFloatLiteral;
+import com.starrocks.thrift.TIntLiteral;
+import com.starrocks.thrift.TLargeIntLiteral;
+import com.starrocks.thrift.TStringLiteral;
+import com.starrocks.type.Type;
+
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+
+/**
+ * Unified execution-plan literal. Holds a {@link ConstantOperator} and
+ * dispatches Thrift serialization based on the value's type.
+ */
+public class ExecLiteral extends ExecExpr {
+    private final ConstantOperator value;
+
+    public ExecLiteral(ConstantOperator value, Type type) {
+        super(type);
+        this.value = value;
+    }
+
+    private ExecLiteral(ExecLiteral other) {
+        super(other.type);
+        this.value = other.value;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public ConstantOperator getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return value.isNull();
+    }
+
+    @Override
+    public boolean isConstant() {
+        return true;
+    }
+
+    @Override
+    public boolean isSelfMonotonic() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        if (value.isNull()) {
+            return TExprNodeType.NULL_LITERAL;
+        }
+        Type t = type;
+        if (t.isBoolean()) {
+            return TExprNodeType.BOOL_LITERAL;
+        } else if (t.isIntegerType() || t.isTinyint() || t.isSmallint()) {
+            return TExprNodeType.INT_LITERAL;
+        } else if (t.isLargeint()) {
+            return TExprNodeType.LARGE_INT_LITERAL;
+        } else if (t.isFloatingPointType() || t.isTime()) {
+            return TExprNodeType.FLOAT_LITERAL;
+        } else if (t.isStringType() || t.isChar() || t.isVarchar()) {
+            return TExprNodeType.STRING_LITERAL;
+        } else if (t.isDateType()) {
+            return TExprNodeType.DATE_LITERAL;
+        } else if (t.isDecimalOfAnyVersion()) {
+            return TExprNodeType.DECIMAL_LITERAL;
+        } else if (t.isBinaryType()) {
+            return TExprNodeType.BINARY_LITERAL;
+        }
+        return TExprNodeType.NULL_LITERAL;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        if (value.isNull()) {
+            // NULL_LITERAL has no extra fields
+            return;
+        }
+        Type t = type;
+        if (t.isBoolean()) {
+            node.bool_literal = new TBoolLiteral(value.getBoolean());
+        } else if (t.isTinyint()) {
+            node.int_literal = new TIntLiteral(value.getTinyInt());
+        } else if (t.isSmallint()) {
+            node.int_literal = new TIntLiteral(value.getSmallint());
+        } else if (t.isInt()) {
+            node.int_literal = new TIntLiteral(value.getInt());
+        } else if (t.isBigint()) {
+            node.int_literal = new TIntLiteral(value.getBigint());
+        } else if (t.isLargeint()) {
+            node.large_int_literal = new TLargeIntLiteral(value.getLargeInt().toString());
+        } else if (t.isFloatingPointType() || t.isTime()) {
+            node.float_literal = new TFloatLiteral(value.getDouble());
+        } else if (t.isStringType() || t.isChar() || t.isVarchar()) {
+            node.string_literal = new TStringLiteral(value.getVarchar());
+        } else if (t.isDateType()) {
+            LocalDateTime dt = value.getDatetime();
+            node.date_literal = new TDateLiteral(formatDateLiteral(dt, t));
+        } else if (t.isDecimalOfAnyVersion()) {
+            TDecimalLiteral decimalLiteral = new TDecimalLiteral();
+            decimalLiteral.setValue(value.getDecimal().toPlainString());
+            // Pack decimal as byte array for efficient transfer
+            decimalLiteral.setInteger_value(packDecimal(value));
+            node.decimal_literal = decimalLiteral;
+        } else if (t.isBinaryType()) {
+            node.binary_literal = new TBinaryLiteral(ByteBuffer.wrap(value.getBinary()));
+        }
+    }
+
+    private static String formatDateLiteral(LocalDateTime dt, Type type) {
+        if (type.isDate()) {
+            return String.format("%04d-%02d-%02d", dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth());
+        } else {
+            return String.format("%04d-%02d-%02d %02d:%02d:%02d",
+                    dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth(),
+                    dt.getHour(), dt.getMinute(), dt.getSecond());
+        }
+    }
+
+    private byte[] packDecimal(ConstantOperator value) {
+        // Match DecimalLiteral.packDecimal() behavior: allocate type-sized buffer,
+        // scale the value, and pack in little-endian order.
+        java.nio.ByteBuffer buffer = java.nio.ByteBuffer.allocate(type.getTypeSize());
+        buffer.order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        int scale = ((com.starrocks.type.ScalarType) type).getScalarScale();
+        java.math.BigDecimal scaledValue = value.getDecimal()
+                .multiply(java.math.BigDecimal.TEN.pow(scale));
+        switch (type.getPrimitiveType()) {
+            case DECIMAL32:
+                buffer.putInt(scaledValue.intValue());
+                break;
+            case DECIMAL64:
+                buffer.putLong(scaledValue.longValue());
+                break;
+            default: // DECIMAL128, DECIMAL256, DECIMALV2
+                byte[] bytes = scaledValue.toBigInteger().toByteArray();
+                // BigInteger is big-endian, copy in reverse for little-endian
+                for (int i = 0; i < buffer.capacity(); i++) {
+                    int srcIdx = bytes.length - 1 - i;
+                    buffer.put(i, srcIdx >= 0 ? bytes[srcIdx] : (bytes[0] < 0 ? (byte) -1 : 0));
+                }
+                break;
+        }
+        return buffer.array();
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecLiteral(this, context);
+    }
+
+    @Override
+    public ExecLiteral clone() {
+        return new ExecLiteral(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecMapExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecMapExpr.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan map construction expression.
+ */
+public class ExecMapExpr extends ExecExpr {
+
+    public ExecMapExpr(Type type, List<ExecExpr> children) {
+        super(type, children);
+    }
+
+    private ExecMapExpr(ExecMapExpr other) {
+        super(other.type, other.cloneChildren());
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.MAP_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        // MAP_EXPR has no extra fields
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecMapExpr(this, context);
+    }
+
+    @Override
+    public ExecMapExpr clone() {
+        return new ExecMapExpr(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecMatchExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecMatchExpr.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.sql.ast.expression.MatchExpr;
+import com.starrocks.sql.expression.ExprOpcodeRegistry;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.BooleanType;
+
+import java.util.List;
+
+/**
+ * Execution-plan MATCH expression (full-text search).
+ */
+public class ExecMatchExpr extends ExecExpr {
+    private final MatchExpr.MatchOperator matchOp;
+
+    public ExecMatchExpr(MatchExpr.MatchOperator matchOp, List<ExecExpr> children) {
+        super(BooleanType.BOOLEAN, children);
+        this.matchOp = matchOp;
+    }
+
+    private ExecMatchExpr(ExecMatchExpr other) {
+        super(other.type, other.cloneChildren());
+        this.matchOp = other.matchOp;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public MatchExpr.MatchOperator getMatchOp() {
+        return matchOp;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return hasNullableChild();
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.MATCH_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setOpcode(ExprOpcodeRegistry.getMatchOpcode(matchOp));
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecMatchExpr(this, context);
+    }
+
+    @Override
+    public ExecMatchExpr clone() {
+        return new ExecMatchExpr(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecPlaceHolder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecPlaceHolder.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TPlaceHolder;
+import com.starrocks.type.Type;
+
+/**
+ * Execution-plan placeholder expression.
+ * Used in global dictionary optimization and lambda expressions to represent
+ * a synthetic input column.
+ */
+public class ExecPlaceHolder extends ExecExpr {
+    private final int slotId;
+    private final boolean nullable;
+
+    public ExecPlaceHolder(int slotId, boolean nullable, Type type) {
+        super(type);
+        this.slotId = slotId;
+        this.nullable = nullable;
+    }
+
+    private ExecPlaceHolder(ExecPlaceHolder other) {
+        super(other.type);
+        this.slotId = other.slotId;
+        this.nullable = other.nullable;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public int getSlotId() {
+        return slotId;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.PLACEHOLDER_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        TPlaceHolder placeHolder = new TPlaceHolder();
+        placeHolder.setNullable(nullable);
+        placeHolder.setSlot_id(slotId);
+        node.setVslot_ref(placeHolder);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecPlaceHolder(this, context);
+    }
+
+    @Override
+    public ExecPlaceHolder clone() {
+        return new ExecPlaceHolder(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecSlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecSlotRef.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.TupleId;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TSlotRef;
+import com.starrocks.type.VarcharType;
+
+/**
+ * Execution-plan slot reference. Holds a resolved {@link SlotDescriptor}
+ * and an optional display label.
+ */
+public class ExecSlotRef extends ExecExpr {
+    private final SlotDescriptor desc;
+    private final String label;
+    private boolean nullable;
+
+    public ExecSlotRef(SlotDescriptor desc) {
+        super(desc.getType());
+        this.desc = desc;
+        this.label = null;
+        this.nullable = desc.getIsNullable();
+        // Match AST SlotRef behavior: CHAR types are converted to VARCHAR.
+        // This ensures that getType() returns VARCHAR for CHAR columns, which
+        // propagates correctly when used in slotDesc.setType(sortExpr.getType()).
+        if (this.type.isChar()) {
+            this.type = VarcharType.VARCHAR;
+        }
+    }
+
+    public ExecSlotRef(String label, SlotDescriptor desc) {
+        super(desc.getType());
+        this.desc = desc;
+        this.label = label;
+        this.nullable = desc.getIsNullable();
+        // Match AST SlotRef behavior: CHAR types are converted to VARCHAR.
+        if (this.type.isChar()) {
+            this.type = VarcharType.VARCHAR;
+        }
+    }
+
+    private ExecSlotRef(ExecSlotRef other) {
+        super(other.type);
+        this.desc = other.desc;
+        this.label = other.label;
+        this.nullable = other.nullable;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public SlotDescriptor getDesc() {
+        return desc;
+    }
+
+    public SlotId getSlotId() {
+        return desc.getId();
+    }
+
+    public TupleId getTupleId() {
+        return desc.getParent().getId();
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public boolean isNullable() {
+        if (desc != null) {
+            return desc.getIsNullable();
+        }
+        return nullable;
+    }
+
+    public void setNullable(boolean nullable) {
+        this.nullable = nullable;
+        if (desc != null) {
+            desc.setIsNullable(nullable);
+        }
+    }
+
+    @Override
+    public boolean isSelfMonotonic() {
+        return true;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.SLOT_REF;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        if (desc != null) {
+            if (desc.getParent() != null) {
+                node.slot_ref = new TSlotRef(desc.getId().asInt(), desc.getParent().getId().asInt());
+            } else {
+                node.slot_ref = new TSlotRef(desc.getId().asInt(), 0);
+            }
+        } else {
+            node.slot_ref = new TSlotRef(0, 0);
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecSlotRef(this, context);
+    }
+
+    @Override
+    public ExecSlotRef clone() {
+        return new ExecSlotRef(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecSubfield.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecSubfield.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/**
+ * Execution-plan struct subfield access expression.
+ */
+public class ExecSubfield extends ExecExpr {
+    private final List<String> fieldNames;
+    private final boolean copyFlag;
+
+    public ExecSubfield(Type type, List<String> fieldNames, boolean copyFlag, List<ExecExpr> children) {
+        super(type, children);
+        this.fieldNames = fieldNames;
+        this.copyFlag = copyFlag;
+    }
+
+    private ExecSubfield(ExecSubfield other) {
+        super(other.type, other.cloneChildren());
+        this.fieldNames = other.fieldNames;
+        this.copyFlag = other.copyFlag;
+        this.originType = other.originType;
+        this.isIndexOnlyFilter = other.isIndexOnlyFilter;
+    }
+
+    public List<String> getFieldNames() {
+        return fieldNames;
+    }
+
+    public boolean isCopyFlag() {
+        return copyFlag;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return true;
+    }
+
+    @Override
+    public TExprNodeType getNodeType() {
+        return TExprNodeType.SUBFIELD_EXPR;
+    }
+
+    @Override
+    public void toThrift(TExprNode node) {
+        node.setUsed_subfield_names(fieldNames);
+        node.setCopy_flag(copyFlag);
+    }
+
+    @Override
+    public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+        return visitor.visitExecSubfield(this, context);
+    }
+
+    @Override
+    public ExecSubfield clone() {
+        return new ExecSubfield(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ThriftEnumConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ThriftEnumConverter.java
@@ -1,0 +1,179 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.ast.AssertNumRowsElement;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.SetType;
+import com.starrocks.sql.ast.expression.AnalyticWindow;
+import com.starrocks.sql.ast.expression.AnalyticWindowBoundary;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.thrift.TAnalyticWindow;
+import com.starrocks.thrift.TAnalyticWindowBoundary;
+import com.starrocks.thrift.TAnalyticWindowBoundaryType;
+import com.starrocks.thrift.TAnalyticWindowType;
+import com.starrocks.thrift.TAssertion;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TJoinOp;
+import com.starrocks.thrift.TKeysType;
+import com.starrocks.thrift.TVarType;
+
+/**
+ * Pure enum-to-Thrift conversion methods that have no dependency on AST {@code Expr}.
+ * <p>
+ * Planner nodes use this class for enum conversions.
+ */
+public final class ThriftEnumConverter {
+
+    private ThriftEnumConverter() {
+    }
+
+    public static TJoinOp joinOperatorToThrift(JoinOperator joinOperator) {
+        Preconditions.checkNotNull(joinOperator, "Join operator should not be null");
+        switch (joinOperator) {
+            case INNER_JOIN:
+                return TJoinOp.INNER_JOIN;
+            case LEFT_OUTER_JOIN:
+                return TJoinOp.LEFT_OUTER_JOIN;
+            case LEFT_SEMI_JOIN:
+                return TJoinOp.LEFT_SEMI_JOIN;
+            case LEFT_ANTI_JOIN:
+                return TJoinOp.LEFT_ANTI_JOIN;
+            case RIGHT_SEMI_JOIN:
+                return TJoinOp.RIGHT_SEMI_JOIN;
+            case RIGHT_ANTI_JOIN:
+                return TJoinOp.RIGHT_ANTI_JOIN;
+            case RIGHT_OUTER_JOIN:
+                return TJoinOp.RIGHT_OUTER_JOIN;
+            case FULL_OUTER_JOIN:
+                return TJoinOp.FULL_OUTER_JOIN;
+            case CROSS_JOIN:
+                return TJoinOp.CROSS_JOIN;
+            case NULL_AWARE_LEFT_ANTI_JOIN:
+                return TJoinOp.NULL_AWARE_LEFT_ANTI_JOIN;
+            case ASOF_INNER_JOIN:
+                return TJoinOp.ASOF_INNER_JOIN;
+            case ASOF_LEFT_OUTER_JOIN:
+                return TJoinOp.ASOF_LEFT_OUTER_JOIN;
+            default:
+                throw new IllegalStateException("Unsupported join operator: " + joinOperator);
+        }
+    }
+
+    public static TAssertion assertionToThrift(AssertNumRowsElement.Assertion assertion) {
+        Preconditions.checkNotNull(assertion, "Assertion should not be null");
+        return switch (assertion) {
+            case EQ -> TAssertion.EQ;
+            case NE -> TAssertion.NE;
+            case LT -> TAssertion.LT;
+            case LE -> TAssertion.LE;
+            case GT -> TAssertion.GT;
+            case GE -> TAssertion.GE;
+        };
+    }
+
+    public static TExprOpcode compoundPredicateOperatorToThrift(CompoundPredicate.Operator operator) {
+        Preconditions.checkNotNull(operator, "Compound predicate operator should not be null");
+        switch (operator) {
+            case AND:
+                return TExprOpcode.COMPOUND_AND;
+            case OR:
+                return TExprOpcode.COMPOUND_OR;
+            case NOT:
+                return TExprOpcode.COMPOUND_NOT;
+            default:
+                throw new IllegalStateException("Unsupported compound predicate operator: " + operator);
+        }
+    }
+
+    public static TAnalyticWindow analyticWindowToThrift(AnalyticWindow window) {
+        Preconditions.checkNotNull(window, "Analytic window should not be null when converting to thrift");
+        TAnalyticWindow result = new TAnalyticWindow(analyticWindowTypeToThrift(window.getType()));
+        AnalyticWindowBoundary leftBoundary = window.getLeftBoundary();
+        if (leftBoundary.getBoundaryType() != AnalyticWindowBoundary.BoundaryType.UNBOUNDED_PRECEDING) {
+            result.setWindow_start(analyticWindowBoundaryToThrift(leftBoundary, window.getType()));
+        }
+        AnalyticWindowBoundary rightBoundary = window.getRightBoundary();
+        Preconditions.checkNotNull(rightBoundary, "Right boundary must be set before converting to thrift");
+        if (rightBoundary.getBoundaryType() != AnalyticWindowBoundary.BoundaryType.UNBOUNDED_FOLLOWING) {
+            result.setWindow_end(analyticWindowBoundaryToThrift(rightBoundary, window.getType()));
+        }
+        return result;
+    }
+
+    public static TKeysType keysTypeToThrift(KeysType keysType) {
+        Preconditions.checkNotNull(keysType, "Keys type should not be null");
+        return switch (keysType) {
+            case PRIMARY_KEYS -> TKeysType.PRIMARY_KEYS;
+            case DUP_KEYS -> TKeysType.DUP_KEYS;
+            case UNIQUE_KEYS -> TKeysType.UNIQUE_KEYS;
+            case AGG_KEYS -> TKeysType.AGG_KEYS;
+        };
+    }
+
+    public static TVarType setTypeToThrift(SetType setType) {
+        Preconditions.checkNotNull(setType, "Set type should not be null");
+        if (setType == SetType.GLOBAL) {
+            return TVarType.GLOBAL;
+        }
+        if (setType == SetType.VERBOSE) {
+            return TVarType.VERBOSE;
+        }
+        return TVarType.SESSION;
+    }
+
+    public static SetType setTypeFromThrift(TVarType thriftType) {
+        if (thriftType == TVarType.GLOBAL) {
+            return SetType.GLOBAL;
+        }
+        if (thriftType == TVarType.VERBOSE) {
+            return SetType.VERBOSE;
+        }
+        return SetType.SESSION;
+    }
+
+    private static TAnalyticWindowBoundary analyticWindowBoundaryToThrift(AnalyticWindowBoundary boundary,
+                                                                          AnalyticWindow.Type windowType) {
+        TAnalyticWindowBoundary result = new TAnalyticWindowBoundary(
+                analyticWindowBoundaryTypeToThrift(boundary.getBoundaryType()));
+        if (boundary.getBoundaryType().isOffset() && windowType == AnalyticWindow.Type.ROWS) {
+            Preconditions.checkNotNull(boundary.getOffsetValue(), "Offset value is required for ROWS window");
+            result.setRows_offset_value(boundary.getOffsetValue().longValue());
+        }
+        // TODO: range windows need range_offset_predicate
+        return result;
+    }
+
+    private static TAnalyticWindowBoundaryType analyticWindowBoundaryTypeToThrift(
+            AnalyticWindowBoundary.BoundaryType boundaryType) {
+        Preconditions.checkState(!boundaryType.isAbsolutePos());
+        switch (boundaryType) {
+            case CURRENT_ROW:
+                return TAnalyticWindowBoundaryType.CURRENT_ROW;
+            case PRECEDING:
+                return TAnalyticWindowBoundaryType.PRECEDING;
+            case FOLLOWING:
+                return TAnalyticWindowBoundaryType.FOLLOWING;
+            default:
+                throw new IllegalStateException("Unsupported boundary type: " + boundaryType);
+        }
+    }
+
+    private static TAnalyticWindowType analyticWindowTypeToThrift(AnalyticWindow.Type type) {
+        return type == AnalyticWindow.Type.ROWS ? TAnalyticWindowType.ROWS : TAnalyticWindowType.RANGE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/expression/ExprOpcodeRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/expression/ExprOpcodeRegistry.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.expression;
+
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CastExpr;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.InPredicate;
+import com.starrocks.sql.ast.expression.MatchExpr;
+import com.starrocks.thrift.TExprOpcode;
+
+import java.util.EnumMap;
+import java.util.Objects;
+
+/**
+ * Central registry that maintains the mapping between front-end expression metadata
+ * and the corresponding thrift {@link TExprOpcode}. This decouples expression
+ * classes from thrift-specific details.
+ */
+public final class ExprOpcodeRegistry {
+    private static final EnumMap<BinaryType, TExprOpcode> BINARY_OPCODES = new EnumMap<>(BinaryType.class);
+    private static final EnumMap<ArithmeticExpr.Operator, TExprOpcode> ARITHMETIC_OPCODES =
+            new EnumMap<>(ArithmeticExpr.Operator.class);
+    private static final EnumMap<MatchExpr.MatchOperator, TExprOpcode> MATCH_OPCODES =
+            new EnumMap<>(MatchExpr.MatchOperator.class);
+
+    static {
+        BINARY_OPCODES.put(BinaryType.EQ, TExprOpcode.EQ);
+        BINARY_OPCODES.put(BinaryType.NE, TExprOpcode.NE);
+        BINARY_OPCODES.put(BinaryType.LE, TExprOpcode.LE);
+        BINARY_OPCODES.put(BinaryType.GE, TExprOpcode.GE);
+        BINARY_OPCODES.put(BinaryType.LT, TExprOpcode.LT);
+        BINARY_OPCODES.put(BinaryType.GT, TExprOpcode.GT);
+        BINARY_OPCODES.put(BinaryType.EQ_FOR_NULL, TExprOpcode.EQ_FOR_NULL);
+
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.MULTIPLY, TExprOpcode.MULTIPLY);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.DIVIDE, TExprOpcode.DIVIDE);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.MOD, TExprOpcode.MOD);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.INT_DIVIDE, TExprOpcode.INT_DIVIDE);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.ADD, TExprOpcode.ADD);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.SUBTRACT, TExprOpcode.SUBTRACT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITAND, TExprOpcode.BITAND);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITOR, TExprOpcode.BITOR);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITXOR, TExprOpcode.BITXOR);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITNOT, TExprOpcode.BITNOT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.FACTORIAL, TExprOpcode.FACTORIAL);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_LEFT, TExprOpcode.BIT_SHIFT_LEFT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT, TExprOpcode.BIT_SHIFT_RIGHT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT_LOGICAL,
+                TExprOpcode.BIT_SHIFT_RIGHT_LOGICAL);
+
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH, TExprOpcode.MATCH);
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH_ANY, TExprOpcode.MATCH_ANY);
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH_ALL, TExprOpcode.MATCH_ALL);
+    }
+
+    private ExprOpcodeRegistry() {
+    }
+
+    public static TExprOpcode getBinaryOpcode(BinaryType type) {
+        return BINARY_OPCODES.getOrDefault(type, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getArithmeticOpcode(ArithmeticExpr.Operator operator) {
+        return ARITHMETIC_OPCODES.getOrDefault(operator, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getMatchOpcode(MatchExpr.MatchOperator operator) {
+        return MATCH_OPCODES.getOrDefault(operator, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getInPredicateOpcode(boolean isNotIn) {
+        return isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
+    }
+
+    public static TExprOpcode getCastOpcode() {
+        return TExprOpcode.CAST;
+    }
+
+    /**
+     * Resolve opcode for a specific expression instance. The default value is
+     * {@link TExprOpcode#INVALID_OPCODE} when there is no mapping required.
+     */
+    public static TExprOpcode getExprOpcode(Expr expr) {
+        Objects.requireNonNull(expr, "expr cannot be null");
+        if (expr instanceof BinaryPredicate) {
+            return getBinaryOpcode(((BinaryPredicate) expr).getOp());
+        } else if (expr instanceof InPredicate) {
+            return getInPredicateOpcode(((InPredicate) expr).isNotIn());
+        } else if (expr instanceof ArithmeticExpr) {
+            return getArithmeticOpcode(((ArithmeticExpr) expr).getOp());
+        } else if (expr instanceof CastExpr) {
+            return getCastOpcode();
+        } else if (expr instanceof MatchExpr) {
+            return getMatchOpcode(((MatchExpr) expr).getMatchOperator());
+        }
+        return TExprOpcode.INVALID_OPCODE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExecExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExecExpr.java
@@ -1,0 +1,642 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.common.FeConstants;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.expression.ExecArithmetic;
+import com.starrocks.planner.expression.ExecArrayExpr;
+import com.starrocks.planner.expression.ExecArraySlice;
+import com.starrocks.planner.expression.ExecBetweenPredicate;
+import com.starrocks.planner.expression.ExecBinaryPredicate;
+import com.starrocks.planner.expression.ExecCaseWhen;
+import com.starrocks.planner.expression.ExecCast;
+import com.starrocks.planner.expression.ExecClone;
+import com.starrocks.planner.expression.ExecCollectionElement;
+import com.starrocks.planner.expression.ExecCompoundPredicate;
+import com.starrocks.planner.expression.ExecDictMapping;
+import com.starrocks.planner.expression.ExecDictQuery;
+import com.starrocks.planner.expression.ExecDictionaryGet;
+import com.starrocks.planner.expression.ExecExpr;
+import com.starrocks.planner.expression.ExecFunctionCall;
+import com.starrocks.planner.expression.ExecInPredicate;
+import com.starrocks.planner.expression.ExecInformationFunction;
+import com.starrocks.planner.expression.ExecIsNullPredicate;
+import com.starrocks.planner.expression.ExecLambdaFunction;
+import com.starrocks.planner.expression.ExecLikePredicate;
+import com.starrocks.planner.expression.ExecLiteral;
+import com.starrocks.planner.expression.ExecMapExpr;
+import com.starrocks.planner.expression.ExecMatchExpr;
+import com.starrocks.planner.expression.ExecPlaceHolder;
+import com.starrocks.planner.expression.ExecSlotRef;
+import com.starrocks.planner.expression.ExecSubfield;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.common.LargeInPredicateException;
+import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArraySliceOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CloneOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LargeInPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MapOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MatchExprOperator;
+import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
+import com.starrocks.sql.spm.SPMFunctions;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.FunctionType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Converts a {@link ScalarOperator} tree into an {@link ExecExpr} tree.
+ */
+public class ScalarOperatorToExecExpr {
+
+    public static ExecExpr build(ScalarOperator expression, FormatterContext context) {
+        return expression.accept(new Formatter(ScalarOperatorToExecExpr::build), context);
+    }
+
+    public static ExecExpr buildIgnoreSlot(ScalarOperator expression, FormatterContext context) {
+        return expression.accept(new IgnoreSlotFormatter(ScalarOperatorToExecExpr::buildIgnoreSlot), context);
+    }
+
+    @FunctionalInterface
+    interface BuildExecExpr {
+        ExecExpr build(ScalarOperator expression, FormatterContext context);
+    }
+
+    /**
+     * Context for the conversion, mapping ColumnRefOperators to their resolved ExecExpr.
+     */
+    public static class FormatterContext {
+        private final Map<ColumnRefOperator, ExecExpr> colRefToExecExpr;
+        private final Map<ColumnRefOperator, ScalarOperator> projectOperatorMap;
+
+        public FormatterContext(Map<ColumnRefOperator, ExecExpr> colRefToExecExpr) {
+            this.colRefToExecExpr = colRefToExecExpr;
+            this.projectOperatorMap = new HashMap<>();
+        }
+
+        public FormatterContext(Map<ColumnRefOperator, ExecExpr> colRefToExecExpr,
+                                Map<ColumnRefOperator, ScalarOperator> projectOperatorMap) {
+            this.colRefToExecExpr = colRefToExecExpr;
+            this.projectOperatorMap = projectOperatorMap;
+        }
+
+        public Map<ColumnRefOperator, ExecExpr> getColRefToExecExpr() {
+            return colRefToExecExpr;
+        }
+    }
+
+    public static class Formatter extends ScalarOperatorVisitor<ExecExpr, FormatterContext> {
+        protected final BuildExecExpr buildExpr;
+
+        Formatter(BuildExecExpr buildExpr) {
+            this.buildExpr = buildExpr;
+        }
+
+        /**
+         * Replace NULL_TYPE with BOOLEAN in the expression's type.
+         * The backend cannot handle NULL types.
+         */
+        private static Type replaceNullType(Type type) {
+            Type replaced = AnalyzerUtils.replaceNullType2Boolean(type);
+            return Objects.equals(type, replaced) ? type : replaced;
+        }
+
+        @Override
+        public ExecExpr visit(ScalarOperator scalarOperator, FormatterContext context) {
+            throw new UnsupportedOperationException(
+                    "not yet implemented: visit scalar operator for " + scalarOperator.getClass().getName());
+        }
+
+        @Override
+        public ExecExpr visitVariableReference(ColumnRefOperator node, FormatterContext context) {
+            ExecExpr expr = context.colRefToExecExpr.get(node);
+            if (context.projectOperatorMap.containsKey(node) && expr == null) {
+                final ScalarOperator projected = context.projectOperatorMap.get(node);
+                if (projected.equals(node)) {
+                    throw new SemanticException("Cannot convert ColumnRefOperator to ExecExpr, " +
+                            "please check the input expression: " + node);
+                }
+                expr = buildExpr.build(projected, context);
+                expr.setType(replaceNullType(expr.getType()));
+                context.colRefToExecExpr.put(node, expr);
+                return expr;
+            }
+            if (expr == null) {
+                throw new SemanticException("Cannot convert ColumnRefOperator to ExecExpr, " +
+                        "please check the input expression: " + node);
+            }
+
+            expr.setType(replaceNullType(expr.getType()));
+            return expr;
+        }
+
+        @Override
+        public ExecExpr visitSubfield(SubfieldOperator node, FormatterContext context) {
+            ExecExpr child = buildExpr.build(node.getChild(0), context);
+            Type type = replaceNullType(node.getType());
+            ExecSubfield expr = new ExecSubfield(type, node.getFieldNames(), node.getCopyFlag(),
+                    List.of(child));
+            return expr;
+        }
+
+        @Override
+        public ExecExpr visitArray(ArrayOperator node, FormatterContext context) {
+            List<ExecExpr> children = node.getChildren().stream()
+                    .map(e -> buildExpr.build(e, context))
+                    .collect(Collectors.toList());
+            Type type = replaceNullType(node.getType());
+            return new ExecArrayExpr(type, children);
+        }
+
+        @Override
+        public ExecExpr visitMap(MapOperator node, FormatterContext context) {
+            List<ExecExpr> children = node.getChildren().stream()
+                    .map(e -> buildExpr.build(e, context))
+                    .collect(Collectors.toList());
+            Type type = replaceNullType(node.getType());
+            return new ExecMapExpr(type, children);
+        }
+
+        @Override
+        public ExecExpr visitCollectionElement(CollectionElementOperator node, FormatterContext context) {
+            ExecExpr collection = buildExpr.build(node.getChild(0), context);
+            ExecExpr index = buildExpr.build(node.getChild(1), context);
+            Type type = replaceNullType(node.getType());
+            return new ExecCollectionElement(type, node.isCheckOutOfBounds(), List.of(collection, index));
+        }
+
+        @Override
+        public ExecExpr visitArraySlice(ArraySliceOperator node, FormatterContext context) {
+            ExecExpr array = buildExpr.build(node.getChild(0), context);
+            ExecExpr lower = buildExpr.build(node.getChild(1), context);
+            ExecExpr upper = buildExpr.build(node.getChild(2), context);
+            Type type = replaceNullType(node.getType());
+            return new ExecArraySlice(type, List.of(array, lower, upper));
+        }
+
+        @Override
+        public ExecExpr visitConstant(ConstantOperator literal, FormatterContext context) {
+            Type type = replaceNullType(literal.getType());
+            ExecLiteral expr = new ExecLiteral(literal, type);
+            if (literal.isNull()) {
+                expr.setOriginType(com.starrocks.type.NullType.NULL);
+            }
+            return expr;
+        }
+
+        @Override
+        public ExecExpr visitPredicate(PredicateOperator predicate, FormatterContext context) {
+            return null;
+        }
+
+        @Override
+        public ExecExpr visitCompoundPredicate(CompoundPredicateOperator predicate, FormatterContext context) {
+            ExecExpr result;
+            if (CompoundPredicateOperator.CompoundType.AND.equals(predicate.getCompoundType())) {
+                result = new ExecCompoundPredicate(CompoundPredicate.Operator.AND,
+                        buildExpr.build(predicate.getChild(0), context),
+                        buildExpr.build(predicate.getChild(1), context));
+            } else if (CompoundPredicateOperator.CompoundType.OR.equals(predicate.getCompoundType())) {
+                result = new ExecCompoundPredicate(CompoundPredicate.Operator.OR,
+                        buildExpr.build(predicate.getChild(0), context),
+                        buildExpr.build(predicate.getChild(1), context));
+            } else {
+                // NOT
+                result = new ExecCompoundPredicate(CompoundPredicate.Operator.NOT,
+                        List.of(buildExpr.build(predicate.getChild(0), context)));
+            }
+            result.setIsIndexOnlyFilter(predicate.isIndexOnlyFilter());
+            return result;
+        }
+
+        @Override
+        public ExecExpr visitBinaryPredicate(BinaryPredicateOperator predicate, FormatterContext context) {
+            ExecBinaryPredicate result = new ExecBinaryPredicate(predicate.getBinaryType(),
+                    buildExpr.build(predicate.getChild(0), context),
+                    buildExpr.build(predicate.getChild(1), context));
+            result.setIsIndexOnlyFilter(predicate.isIndexOnlyFilter());
+            return result;
+        }
+
+        @Override
+        public ExecExpr visitBetweenPredicate(BetweenPredicateOperator predicate, FormatterContext context) {
+            List<ExecExpr> children = List.of(
+                    buildExpr.build(predicate.getChild(0), context),
+                    buildExpr.build(predicate.getChild(1), context),
+                    buildExpr.build(predicate.getChild(2), context));
+            return new ExecBetweenPredicate(predicate.isNotBetween(), children);
+        }
+
+        @Override
+        public ExecExpr visitExistsPredicate(ExistsPredicateOperator predicate, FormatterContext context) {
+            return null;
+        }
+
+        @Override
+        public ExecExpr visitInPredicate(InPredicateOperator predicate, FormatterContext context) {
+            List<ExecExpr> children = new ArrayList<>();
+            children.add(buildExpr.build(predicate.getChild(0), context));
+            for (int i = 1; i < predicate.getChildren().size(); ++i) {
+                children.add(buildExpr.build(predicate.getChild(i), context));
+            }
+            return new ExecInPredicate(predicate.isNotIn(), children);
+        }
+
+        @Override
+        public ExecExpr visitLargeInPredicate(LargeInPredicateOperator predicate, FormatterContext context) {
+            throw new LargeInPredicateException(
+                    "LargeInPredicate was not transformed to join during optimization. " +
+                            "This may occur in unsupported contexts such as CASE WHEN expressions. " +
+                            "Retrying query with LargeInPredicate optimization disabled.");
+        }
+
+        @Override
+        public ExecExpr visitIsNullPredicate(IsNullPredicateOperator predicate, FormatterContext context) {
+            return new ExecIsNullPredicate(predicate.isNotNull(),
+                    buildExpr.build(predicate.getChild(0), context));
+        }
+
+        @Override
+        public ExecExpr visitLikePredicateOperator(LikePredicateOperator predicate, FormatterContext context) {
+            ExecExpr child0 = buildExpr.build(predicate.getChild(0), context);
+            ExecExpr child1 = buildExpr.build(predicate.getChild(1), context);
+
+            // Resolve the built-in function for LIKE/REGEXP at construction time
+            String opName = predicate.isRegexp() ? "REGEXP" : "LIKE";
+            Function fn = ExprUtils.getBuiltinFunction(opName,
+                    new Type[] {child0.getType(), child1.getType()},
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+            return new ExecLikePredicate(predicate.isRegexp(), fn, List.of(child0, child1));
+        }
+
+        @Override
+        public ExecExpr visitMatchExprOperator(MatchExprOperator operator, FormatterContext context) {
+            ExecExpr child0 = buildExpr.build(operator.getChild(0), context);
+            ExecExpr child1 = buildExpr.build(operator.getChild(1), context);
+            return new ExecMatchExpr(operator.getMatchOperator(), List.of(child0, child1));
+        }
+
+        @Override
+        public ExecExpr visitCall(CallOperator call, FormatterContext context) {
+            String fnName = call.getFnName();
+            ExecExpr result;
+
+            if (!FeConstants.runningUnitTest && SPMFunctions.isSPMFunctions(call)) {
+                throw UnsupportedException.unsupportedException("spm function only used in create baseline stmt");
+            }
+
+            switch (fnName.toLowerCase()) {
+                // Arithmetic
+                case "add":
+                    result = buildArithmetic(ArithmeticExpr.Operator.ADD, call, context);
+                    break;
+                case "subtract":
+                    result = buildArithmetic(ArithmeticExpr.Operator.SUBTRACT, call, context);
+                    break;
+                case "multiply":
+                    result = buildArithmetic(ArithmeticExpr.Operator.MULTIPLY, call, context);
+                    break;
+                case "divide":
+                    result = buildArithmetic(ArithmeticExpr.Operator.DIVIDE, call, context);
+                    break;
+                case "int_divide":
+                    result = buildArithmetic(ArithmeticExpr.Operator.INT_DIVIDE, call, context);
+                    break;
+                case "mod":
+                    result = buildArithmetic(ArithmeticExpr.Operator.MOD, call, context);
+                    break;
+                case "bitand":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BITAND, call, context);
+                    break;
+                case "bitor":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BITOR, call, context);
+                    break;
+                case "bitxor":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BITXOR, call, context);
+                    break;
+                case "bitnot":
+                    result = new ExecArithmetic(call.getType(), ArithmeticExpr.Operator.BITNOT,
+                            List.of(buildExpr.build(call.getChild(0), context)));
+                    break;
+                case "bit_shift_left":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BIT_SHIFT_LEFT, call, context);
+                    break;
+                case "bit_shift_right":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT, call, context);
+                    break;
+                case "bit_shift_right_logical":
+                    result = buildArithmetic(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT_LOGICAL, call, context);
+                    break;
+
+                // Information functions
+                case "catalog":
+                case "database":
+                case "schema":
+                case "user":
+                case "current_user":
+                case "current_role":
+                case "current_group":
+                case "current_warehouse":
+                case "session_id":
+                    result = new ExecInformationFunction(call.getType(), fnName,
+                            ((ConstantOperator) call.getChild(0)).getVarchar(), 0);
+                    break;
+                case "connection_id":
+                    result = new ExecInformationFunction(call.getType(), fnName,
+                            "", ((ConstantOperator) call.getChild(0)).getBigint());
+                    break;
+
+                // Non-deterministic functions with special child handling
+                case "rand":
+                case "random":
+                case "uuid":
+                case "sleep": {
+                    List<ExecExpr> args = new ArrayList<>();
+                    if (call.getChildren().size() == 2) {
+                        args.add(buildExpr.build(call.getChild(0), context));
+                    }
+                    Preconditions.checkNotNull(call.getFunction());
+                    boolean isAgg = call.isAggregate();
+                    result = new ExecFunctionCall(call.getType(), call.getFunction(), fnName,
+                            args, false, call.getIgnoreNulls(), isAgg, false);
+                    break;
+                }
+
+                // Default: regular function call
+                default: {
+                    List<ExecExpr> args;
+                    if (call.isCountStar()) {
+                        args = new ArrayList<>();
+                    } else {
+                        args = call.getChildren().stream()
+                                .map(e -> buildExpr.build(e, context))
+                                .collect(Collectors.toList());
+                    }
+                    Preconditions.checkNotNull(call.getFunction());
+                    boolean isAgg = call.isAggregate();
+                    result = new ExecFunctionCall(call.getType(), call.getFunction(), fnName,
+                            args, call.isDistinct(), call.getIgnoreNulls(), isAgg, false,
+                            call.isCountStar());
+                    break;
+                }
+            }
+
+            result.setType(replaceNullType(call.getType()));
+            if (result instanceof ExecFunctionCall) {
+                ((ExecFunctionCall) result).setNullable(call.isNullable());
+            }
+            return result;
+        }
+
+        private ExecExpr buildArithmetic(ArithmeticExpr.Operator op, CallOperator call,
+                                         FormatterContext context) {
+            List<ExecExpr> children = new ArrayList<>();
+            children.add(buildExpr.build(call.getChild(0), context));
+            if (call.getChildren().size() > 1) {
+                children.add(buildExpr.build(call.getChild(1), context));
+            }
+            return new ExecArithmetic(call.getType(), op, children);
+        }
+
+        @Override
+        public ExecExpr visitCastOperator(CastOperator operator, FormatterContext context) {
+            ExecExpr child = buildExpr.build(operator.getChild(0), context);
+            Type type = replaceNullType(operator.getType());
+            return new ExecCast(type, child, operator.isImplicit());
+        }
+
+        @Override
+        public ExecExpr visitCaseWhenOperator(CaseWhenOperator operator, FormatterContext context) {
+            // Build children in the same order as CaseExpr expects:
+            // [caseExpr?] [whenExpr, thenExpr]+ [elseExpr?]
+            List<ExecExpr> children = new ArrayList<>();
+
+            if (operator.hasCase()) {
+                children.add(buildExpr.build(operator.getCaseClause(), context));
+            }
+
+            for (int i = 0; i < operator.getWhenClauseSize(); i++) {
+                children.add(buildExpr.build(operator.getWhenClause(i), context));
+                children.add(buildExpr.build(operator.getThenClause(i), context));
+            }
+
+            if (operator.hasElse()) {
+                children.add(buildExpr.build(operator.getElseClause(), context));
+            }
+
+            Type type = replaceNullType(operator.getType());
+            return new ExecCaseWhen(type, operator.hasCase(), operator.hasElse(), children);
+        }
+
+        @Override
+        public ExecExpr visitLambdaFunctionOperator(LambdaFunctionOperator operator, FormatterContext context) {
+            // Lambda arguments → ExecSlotRef
+            List<ExecExpr> arguments = new ArrayList<>();
+            for (ColumnRefOperator ref : operator.getRefColumns()) {
+                SlotDescriptor slotDesc = new SlotDescriptor(
+                        new SlotId(ref.getId()), ref.getName(), ref.getType(), ref.isNullable());
+                ExecSlotRef slot = new ExecSlotRef(slotDesc);
+                slot.setType(replaceNullType(slot.getType()));
+                context.colRefToExecExpr.put(ref, slot);
+                arguments.add(slot);
+            }
+
+            // Common sub-operator map
+            TreeMap<Integer, Map.Entry<ExecSlotRef, ExecExpr>> commonSubMap =
+                    new TreeMap<>();
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : operator.getColumnRefMap().entrySet()) {
+                ColumnRefOperator ref = kv.getKey();
+                SlotDescriptor slotDesc = new SlotDescriptor(
+                        new SlotId(ref.getId()), ref.getName(), ref.getType(), ref.isNullable());
+                ExecSlotRef slot = new ExecSlotRef(slotDesc);
+                slot.setType(replaceNullType(slot.getType()));
+                ExecExpr subExpr = buildExpr.build(kv.getValue(), context);
+                commonSubMap.put(ref.getId(), Map.entry(slot, subExpr));
+                context.colRefToExecExpr.put(ref, slot);
+            }
+
+            // Build lambda body
+            ExecExpr lambdaExpr = buildExpr.build(operator.getLambdaExpr(), context);
+
+            // Assemble children: [lambdaBody, arg1, arg2, ..., commonSlot1, commonSlot2, ..., commonExpr1, commonExpr2, ...]
+            List<ExecExpr> children = new ArrayList<>();
+            children.add(lambdaExpr);
+            children.addAll(arguments);
+            if (!commonSubMap.isEmpty()) {
+                for (Map.Entry<Integer, Map.Entry<ExecSlotRef, ExecExpr>> entry : commonSubMap.entrySet()) {
+                    children.add(entry.getValue().getKey());
+                }
+                for (Map.Entry<Integer, Map.Entry<ExecSlotRef, ExecExpr>> entry : commonSubMap.entrySet()) {
+                    children.add(entry.getValue().getValue());
+                }
+            }
+
+            // Determine nondeterminism from the ScalarOperator tree
+            boolean isNondeterministic = containsNonDeterministicFunction(operator.getLambdaExpr());
+
+            ExecLambdaFunction result = new ExecLambdaFunction(
+                    FunctionType.FUNCTION, commonSubMap.size(), isNondeterministic, children);
+
+            Preconditions.checkState(result.getNumChildren() >= 2 + 2 * commonSubMap.size(),
+                    "lambda expr's children num " + result.getNumChildren() + " should >= " +
+                            (2 + 2 * commonSubMap.size()));
+
+            return result;
+        }
+
+        @Override
+        public ExecExpr visitDictMappingOperator(DictMappingOperator operator, FormatterContext context) {
+            final ColumnRefOperator dictColumn = operator.getDictColumn();
+            final ExecSlotRef dictExpr = (ExecSlotRef) dictColumn.accept(this, context);
+            final ScalarOperator call = operator.getOriginScalaOperator();
+            final ColumnRefOperator key = call.getColumnRefs().get(0);
+
+            // Save the previous expression for this key
+            final ExecExpr old = context.colRefToExecExpr.get(key);
+
+            // Use a placeholder instead of the original column for DictMapping
+            if (key.getType().isArrayType()) {
+                context.colRefToExecExpr.put(key,
+                        new ExecPlaceHolder(dictColumn.getId(), dictExpr.isNullable(), ArrayType.ARRAY_VARCHAR));
+            } else {
+                context.colRefToExecExpr.put(key,
+                        new ExecPlaceHolder(dictColumn.getId(), dictExpr.isNullable(), VarcharType.VARCHAR));
+            }
+            final ExecExpr callExpr = buildExpr.build(call, context);
+
+            // Recover the previous column
+            if (old != null) {
+                context.colRefToExecExpr.put(key, old);
+            }
+
+            List<ExecExpr> children;
+            if (operator.getStringProvideOperator() != null) {
+                final ExecExpr stringExpr = buildExpr.build(operator.getStringProvideOperator(), context);
+                children = List.of(dictExpr, callExpr, stringExpr);
+            } else {
+                children = List.of(dictExpr, callExpr);
+            }
+
+            ExecDictMapping result = new ExecDictMapping(replaceNullType(operator.getType()), children);
+            return result;
+        }
+
+        @Override
+        public ExecExpr visitCloneOperator(CloneOperator operator, FormatterContext context) {
+            ExecExpr child = buildExpr.build(operator.getChild(0), context);
+            return new ExecClone(child.getType(), child);
+        }
+
+        @Override
+        public ExecExpr visitSubqueryOperator(SubqueryOperator operator, FormatterContext context) {
+            // Subquery should not appear in the execution plan's ExecExpr tree.
+            throw new UnsupportedOperationException("SubqueryOperator cannot be converted to ExecExpr");
+        }
+
+        @Override
+        public ExecExpr visitDictQueryOperator(DictQueryOperator operator, FormatterContext context) {
+            List<ExecExpr> children = operator.getChildren().stream()
+                    .map(e -> buildExpr.build(e, context))
+                    .collect(Collectors.toList());
+            return new ExecDictQuery(operator.getType(), operator.getDictQueryExpr(), children);
+        }
+
+        @Override
+        public ExecExpr visitDictionaryGetOperator(DictionaryGetOperator operator, FormatterContext context) {
+            List<ExecExpr> children = operator.getChildren().stream()
+                    .map(e -> buildExpr.build(e, context))
+                    .collect(Collectors.toList());
+            return new ExecDictionaryGet(operator.getType(),
+                    operator.getDictionaryId(), operator.getDictionaryTxnId(),
+                    operator.getKeySize(), operator.getNullIfNotExist(), children);
+        }
+    }
+
+    /**
+     * Variant that creates ExecSlotRef directly from ColumnRefOperator,
+     * without looking up in the context map. Used for cases where
+     * slot descriptors haven't been registered yet.
+     */
+    static class IgnoreSlotFormatter extends Formatter {
+        IgnoreSlotFormatter(BuildExecExpr buildExpr) {
+            super(buildExpr);
+        }
+
+        @Override
+        public ExecExpr visitVariableReference(ColumnRefOperator node, FormatterContext context) {
+            SlotDescriptor descriptor = new SlotDescriptor(
+                    new SlotId(node.getId()), node.getName(), node.getType(), node.isNullable());
+            return new ExecSlotRef(descriptor);
+        }
+    }
+
+    /**
+     * Check if a ScalarOperator tree contains any non-deterministic function call.
+     */
+    private static boolean containsNonDeterministicFunction(ScalarOperator operator) {
+        if (operator instanceof CallOperator) {
+            String fnName = ((CallOperator) operator).getFnName();
+            if (fnName != null && FunctionSet.allNonDeterministicFunctions.contains(fnName)) {
+                return true;
+            }
+        }
+        for (ScalarOperator child : operator.getChildren()) {
+            if (containsNonDeterministicFunction(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -1,0 +1,1251 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner.expression;
+
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.planner.TupleId;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TKeysType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Comprehensive unit tests for the ExecExpr hierarchy, ExecExprVisitor,
+ * ExecExprSerializer, ExecExprExplain, ThriftEnumConverter, and ExprOpcodeRegistry.
+ */
+public class ExecExprTest {
+
+    // ======================================================================
+    // Helper methods for constructing test objects
+    // ======================================================================
+
+    /**
+     * Create a SlotDescriptor attached to a TupleDescriptor, simulating a resolved slot.
+     */
+    private static SlotDescriptor makeSlotDescriptor(int slotId, int tupleId, Type type, boolean nullable) {
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(tupleId));
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(slotId), tupleDesc);
+        slotDesc.setType(type);
+        slotDesc.setIsNullable(nullable);
+        return slotDesc;
+    }
+
+    /**
+     * Create an ExecSlotRef from a fresh SlotDescriptor.
+     */
+    private static ExecSlotRef makeSlotRef(int slotId, int tupleId, Type type, boolean nullable) {
+        SlotDescriptor desc = makeSlotDescriptor(slotId, tupleId, type, nullable);
+        return new ExecSlotRef(desc);
+    }
+
+    /**
+     * Create an ExecLiteral wrapping an integer constant.
+     */
+    private static ExecLiteral makeIntLiteral(int value) {
+        ConstantOperator constOp = ConstantOperator.createInt(value);
+        return new ExecLiteral(constOp, IntegerType.INT);
+    }
+
+    /**
+     * Create a varchar ExecLiteral.
+     */
+    private static ExecLiteral makeVarcharLiteral(String value) {
+        ConstantOperator constOp = ConstantOperator.createVarchar(value);
+        return new ExecLiteral(constOp, VarcharType.VARCHAR);
+    }
+
+    /**
+     * Create a null ExecLiteral.
+     */
+    private static ExecLiteral makeNullLiteral() {
+        ConstantOperator constOp = ConstantOperator.createNull(IntegerType.INT);
+        return new ExecLiteral(constOp, IntegerType.INT);
+    }
+
+    /**
+     * Create a simple ScalarFunction for testing.
+     */
+    private static ScalarFunction makeScalarFunction(String name, Type[] argTypes, Type retType) {
+        return new ScalarFunction(new FunctionName(name), argTypes, retType, false);
+    }
+
+    /**
+     * Create an ExecFunctionCall with the given function name and children.
+     */
+    private static ExecFunctionCall makeFunctionCall(String fnName, Type retType, ScalarFunction fn,
+                                                     List<ExecExpr> children) {
+        return new ExecFunctionCall(retType, fn, fnName, children,
+                false, false, false, false);
+    }
+
+    // ======================================================================
+    // 1. ExecExpr type construction and properties
+    // ======================================================================
+
+    @Test
+    public void testExecSlotRefConstruction() {
+        SlotDescriptor desc = makeSlotDescriptor(5, 2, IntegerType.INT, true);
+        ExecSlotRef slotRef = new ExecSlotRef(desc);
+
+        assertEquals(5, slotRef.getSlotId().asInt());
+        assertEquals(2, slotRef.getTupleId().asInt());
+        assertEquals(IntegerType.INT, slotRef.getType());
+        assertTrue(slotRef.isNullable());
+        assertEquals(TExprNodeType.SLOT_REF, slotRef.getNodeType());
+    }
+
+    @Test
+    public void testExecSlotRefNonNullable() {
+        SlotDescriptor desc = makeSlotDescriptor(3, 1, IntegerType.BIGINT, false);
+        ExecSlotRef slotRef = new ExecSlotRef(desc);
+
+        assertEquals(3, slotRef.getSlotId().asInt());
+        assertFalse(slotRef.isNullable());
+        assertEquals(IntegerType.BIGINT, slotRef.getType());
+    }
+
+    @Test
+    public void testExecSlotRefIsNotConstant() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        assertFalse(slotRef.isConstant());
+    }
+
+    @Test
+    public void testExecSlotRefIsSelfMonotonic() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        assertTrue(slotRef.isSelfMonotonic());
+        assertTrue(slotRef.isMonotonic());
+    }
+
+    @Test
+    public void testExecSlotRefWithLabel() {
+        SlotDescriptor desc = makeSlotDescriptor(7, 3, IntegerType.INT, true);
+        ExecSlotRef slotRef = new ExecSlotRef("my_column", desc);
+
+        assertEquals("my_column", slotRef.getLabel());
+        assertEquals(7, slotRef.getSlotId().asInt());
+    }
+
+    @Test
+    public void testExecSlotRefClone() {
+        ExecSlotRef original = makeSlotRef(5, 2, IntegerType.INT, true);
+        ExecSlotRef cloned = original.clone();
+
+        assertEquals(original.getSlotId().asInt(), cloned.getSlotId().asInt());
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.isNullable(), cloned.isNullable());
+    }
+
+    @Test
+    public void testExecLiteralConstruction() {
+        ExecLiteral literal = makeIntLiteral(42);
+
+        assertEquals(IntegerType.INT, literal.getType());
+        assertTrue(literal.isConstant());
+        assertFalse(literal.isNullable());
+        assertEquals(TExprNodeType.INT_LITERAL, literal.getNodeType());
+
+        ConstantOperator value = literal.getValue();
+        assertNotNull(value);
+        assertEquals(42, value.getInt());
+    }
+
+    @Test
+    public void testExecLiteralNull() {
+        ExecLiteral nullLiteral = makeNullLiteral();
+
+        assertTrue(nullLiteral.isNullable());
+        assertTrue(nullLiteral.isConstant());
+        assertEquals(TExprNodeType.NULL_LITERAL, nullLiteral.getNodeType());
+    }
+
+    @Test
+    public void testExecLiteralVarchar() {
+        ExecLiteral literal = makeVarcharLiteral("hello");
+
+        assertEquals(VarcharType.VARCHAR, literal.getType());
+        assertEquals(TExprNodeType.STRING_LITERAL, literal.getNodeType());
+        assertFalse(literal.isNullable());
+        assertEquals("hello", literal.getValue().getVarchar());
+    }
+
+    @Test
+    public void testExecLiteralBoolean() {
+        ConstantOperator constOp = ConstantOperator.createBoolean(true);
+        ExecLiteral literal = new ExecLiteral(constOp, BooleanType.BOOLEAN);
+
+        assertEquals(TExprNodeType.BOOL_LITERAL, literal.getNodeType());
+        assertTrue(literal.getValue().getBoolean());
+    }
+
+    @Test
+    public void testExecLiteralIsSelfMonotonic() {
+        ExecLiteral literal = makeIntLiteral(10);
+        assertTrue(literal.isSelfMonotonic());
+    }
+
+    @Test
+    public void testExecLiteralClone() {
+        ExecLiteral original = makeIntLiteral(99);
+        ExecLiteral cloned = original.clone();
+
+        assertEquals(original.getValue().getInt(), cloned.getValue().getInt());
+        assertEquals(original.getType(), cloned.getType());
+    }
+
+    @Test
+    public void testExecFunctionCallConstruction() {
+        ExecSlotRef child1 = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecLiteral child2 = makeIntLiteral(10);
+        List<ExecExpr> children = List.of(child1, child2);
+
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        assertNotNull(funcCall.getFn());
+        assertEquals("add", funcCall.getFnName());
+        assertFalse(funcCall.isDistinct());
+        assertEquals(2, funcCall.getNumChildren());
+        assertEquals(TExprNodeType.FUNCTION_CALL, funcCall.getNodeType());
+    }
+
+    @Test
+    public void testExecFunctionCallAggregateNodeType() {
+        List<ExecExpr> children = List.of(makeSlotRef(1, 0, IntegerType.INT, true));
+        ScalarFunction fn = makeScalarFunction("sum", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+
+        ExecFunctionCall aggCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "sum", children,
+                false, false, true, false);
+
+        assertEquals(TExprNodeType.AGG_EXPR, aggCall.getNodeType());
+        assertTrue(aggCall.isAggregateOrAnalytic());
+    }
+
+    @Test
+    public void testExecFunctionCallDistinct() {
+        List<ExecExpr> children = List.of(makeSlotRef(1, 0, IntegerType.INT, true));
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+
+        ExecFunctionCall funcCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", children,
+                true, false, true, false);
+
+        assertTrue(funcCall.isDistinct());
+    }
+
+    @Test
+    public void testExecFunctionCallClone() {
+        List<ExecExpr> children = new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, true)));
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall original = makeFunctionCall("abs", IntegerType.INT, fn, children);
+
+        ExecFunctionCall cloned = original.clone();
+        assertEquals(original.getFnName(), cloned.getFnName());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    @Test
+    public void testExecFunctionCallCountStar() {
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{}, IntegerType.BIGINT);
+        ExecFunctionCall countStar = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", List.of(),
+                false, false, true, false, true);
+
+        assertTrue(countStar.isCountStar());
+    }
+
+    @Test
+    public void testExecCastConstruction() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
+
+        assertEquals(IntegerType.BIGINT, cast.getType());
+        assertEquals(1, cast.getNumChildren());
+        assertEquals(TExprNodeType.CAST_EXPR, cast.getNodeType());
+        assertFalse(cast.isImplicit());
+    }
+
+    @Test
+    public void testExecCastImplicit() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, true);
+
+        assertTrue(cast.isImplicit());
+    }
+
+    @Test
+    public void testExecCastNullability() {
+        // Cast of non-nullable child should be non-nullable
+        ExecLiteral nonNull = makeIntLiteral(42);
+        ExecCast castNonNull = new ExecCast(IntegerType.BIGINT, nonNull, false);
+        assertFalse(castNonNull.isNullable());
+
+        // Cast of nullable child should be nullable
+        ExecSlotRef nullable = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecCast castNullable = new ExecCast(IntegerType.BIGINT, nullable, false);
+        assertTrue(castNullable.isNullable());
+    }
+
+    @Test
+    public void testExecCastIsSelfMonotonic() {
+        ExecLiteral child = makeIntLiteral(1);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
+        assertTrue(cast.isSelfMonotonic());
+    }
+
+    @Test
+    public void testExecCastClone() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast original = new ExecCast(IntegerType.BIGINT, child, false);
+        ExecCast cloned = original.clone();
+
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+        assertEquals(original.isImplicit(), cloned.isImplicit());
+    }
+
+    @Test
+    public void testExecBinaryPredicateConstruction() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, left, right);
+
+        assertEquals(BinaryType.EQ, pred.getOp());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(2, pred.getNumChildren());
+        assertEquals(TExprNodeType.BINARY_PRED, pred.getNodeType());
+    }
+
+    @Test
+    public void testExecBinaryPredicateNullability() {
+        ExecSlotRef nullableSlot = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecLiteral literal = makeIntLiteral(5);
+
+        // EQ with nullable child -> nullable
+        ExecBinaryPredicate eqPred = new ExecBinaryPredicate(BinaryType.EQ, nullableSlot, literal);
+        assertTrue(eqPred.isNullable());
+
+        // EQ_FOR_NULL -> always non-nullable
+        ExecBinaryPredicate eqNullPred = new ExecBinaryPredicate(BinaryType.EQ_FOR_NULL, nullableSlot, literal);
+        assertFalse(eqNullPred.isNullable());
+    }
+
+    @Test
+    public void testExecBinaryPredicateAllOps() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        for (BinaryType op : BinaryType.values()) {
+            ExecBinaryPredicate pred = new ExecBinaryPredicate(op, left, right);
+            assertEquals(op, pred.getOp());
+            assertEquals(TExprNodeType.BINARY_PRED, pred.getNodeType());
+        }
+    }
+
+    @Test
+    public void testExecBinaryPredicateClone() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecBinaryPredicate original = new ExecBinaryPredicate(BinaryType.LT, left, right);
+
+        ExecBinaryPredicate cloned = original.clone();
+        assertEquals(original.getOp(), cloned.getOp());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // ExecExpr base class properties
+    // ======================================================================
+
+    @Test
+    public void testExecExprChildManipulation() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(42);
+
+        List<ExecExpr> children = new ArrayList<>(List.of(slotRef, literal));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        assertEquals(2, funcCall.getNumChildren());
+        assertEquals(slotRef, funcCall.getChild(0));
+        assertEquals(literal, funcCall.getChild(1));
+
+        // Replace a child
+        ExecLiteral newChild = makeIntLiteral(99);
+        funcCall.setChild(1, newChild);
+        assertEquals(newChild, funcCall.getChild(1));
+    }
+
+    @Test
+    public void testExecExprAddChild() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        // Start with no children
+        assertEquals(0, slotRef.getNumChildren());
+
+        // addChild should work even when children starts as empty list
+        slotRef.addChild(makeIntLiteral(1));
+        assertEquals(1, slotRef.getNumChildren());
+    }
+
+    @Test
+    public void testExecExprOriginType() {
+        ExecLiteral literal = makeIntLiteral(42);
+        // When originType is null, getOriginType returns type
+        assertEquals(IntegerType.INT, literal.getOriginType());
+
+        // After setting originType, it returns the explicitly set value
+        literal.setOriginType(IntegerType.BIGINT);
+        assertEquals(IntegerType.BIGINT, literal.getOriginType());
+    }
+
+    @Test
+    public void testExecExprIsConstantVacuouslyTrue() {
+        // A leaf expression with no children should be constant (vacuously true)
+        // ExecLiteral overrides to return true
+        ExecLiteral literal = makeIntLiteral(42);
+        assertTrue(literal.isConstant());
+    }
+
+    @Test
+    public void testExecExprIsConstantWithNonConstantChild() {
+        // FunctionCall with a slotRef child should not be constant
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("abs", IntegerType.INT, fn, children);
+
+        assertFalse(funcCall.isConstant());
+    }
+
+    @Test
+    public void testExecExprIsConstantWithAllConstantChildren() {
+        // FunctionCall with all literal children should be constant
+        List<ExecExpr> children = new ArrayList<>(List.of(makeIntLiteral(1), makeIntLiteral(2)));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        assertTrue(funcCall.isConstant());
+    }
+
+    @Test
+    public void testExecExprHasNullableChild() {
+        ExecSlotRef nullableSlot = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecLiteral literal = makeIntLiteral(10);
+        List<ExecExpr> children = new ArrayList<>(List.of(nullableSlot, literal));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        assertTrue(funcCall.hasNullableChild());
+    }
+
+    @Test
+    public void testExecExprIndexOnlyFilter() {
+        ExecLiteral literal = makeIntLiteral(42);
+        assertFalse(literal.isIndexOnlyFilter());
+
+        literal.setIsIndexOnlyFilter(true);
+        assertTrue(literal.isIndexOnlyFilter());
+    }
+
+    // ======================================================================
+    // 2. ExecExprVisitor
+    // ======================================================================
+
+    /**
+     * A simple counting visitor that counts nodes in the tree by visiting each node
+     * and recursing into children.
+     */
+    private static class NodeCountingVisitor implements ExecExprVisitor<Integer, Void> {
+        @Override
+        public Integer visitExecExpr(ExecExpr expr, Void context) {
+            int count = 1;
+            for (ExecExpr child : expr.getChildren()) {
+                count += child.accept(this, context);
+            }
+            return count;
+        }
+    }
+
+    @Test
+    public void testVisitorCountsThreeNodes() {
+        // Tree: FunctionCall(SlotRef, Literal) -- 3 nodes
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(42);
+        List<ExecExpr> children = new ArrayList<>(List.of(slotRef, literal));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        NodeCountingVisitor counter = new NodeCountingVisitor();
+        int count = funcCall.accept(counter, null);
+        assertEquals(3, count);
+    }
+
+    @Test
+    public void testVisitorCountsSingleNode() {
+        ExecLiteral literal = makeIntLiteral(42);
+        NodeCountingVisitor counter = new NodeCountingVisitor();
+        assertEquals(1, literal.accept(counter, null));
+    }
+
+    @Test
+    public void testVisitorCountsNestedTree() {
+        // Tree: Cast(BinaryPredicate(SlotRef, Literal)) -- 4 nodes
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, slot, literal);
+        ExecCast cast = new ExecCast(IntegerType.INT, pred, false);
+
+        NodeCountingVisitor counter = new NodeCountingVisitor();
+        assertEquals(4, cast.accept(counter, null));
+    }
+
+    /**
+     * A visitor that tracks which visit methods are dispatched.
+     */
+    private static class DispatchTrackingVisitor implements ExecExprVisitor<String, Void> {
+        @Override
+        public String visitExecExpr(ExecExpr expr, Void context) {
+            return "ExecExpr";
+        }
+
+        @Override
+        public String visitExecSlotRef(ExecSlotRef expr, Void context) {
+            return "SlotRef";
+        }
+
+        @Override
+        public String visitExecLiteral(ExecLiteral expr, Void context) {
+            return "Literal";
+        }
+
+        @Override
+        public String visitExecFunctionCall(ExecFunctionCall expr, Void context) {
+            return "FunctionCall";
+        }
+
+        @Override
+        public String visitExecCast(ExecCast expr, Void context) {
+            return "Cast";
+        }
+
+        @Override
+        public String visitExecBinaryPredicate(ExecBinaryPredicate expr, Void context) {
+            return "BinaryPredicate";
+        }
+    }
+
+    @Test
+    public void testVisitorDispatchSlotRef() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        assertEquals("SlotRef", slotRef.accept(new DispatchTrackingVisitor(), null));
+    }
+
+    @Test
+    public void testVisitorDispatchLiteral() {
+        ExecLiteral literal = makeIntLiteral(42);
+        assertEquals("Literal", literal.accept(new DispatchTrackingVisitor(), null));
+    }
+
+    @Test
+    public void testVisitorDispatchFunctionCall() {
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("abs", IntegerType.INT, fn, new ArrayList<>());
+        assertEquals("FunctionCall", funcCall.accept(new DispatchTrackingVisitor(), null));
+    }
+
+    @Test
+    public void testVisitorDispatchCast() {
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, makeIntLiteral(42), false);
+        assertEquals("Cast", cast.accept(new DispatchTrackingVisitor(), null));
+    }
+
+    @Test
+    public void testVisitorDispatchBinaryPredicate() {
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ,
+                makeSlotRef(1, 0, IntegerType.INT, false), makeIntLiteral(10));
+        assertEquals("BinaryPredicate", pred.accept(new DispatchTrackingVisitor(), null));
+    }
+
+    @Test
+    public void testVisitorDefaultFallback() {
+        // An unoverridden visit method falls back to visitExecExpr
+        ExecExprVisitor<String, Void> minimalVisitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "default";
+            }
+        };
+
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, false);
+        assertEquals("default", slotRef.accept(minimalVisitor, null));
+
+        ExecLiteral literal = makeIntLiteral(42);
+        assertEquals("default", literal.accept(minimalVisitor, null));
+    }
+
+    // ======================================================================
+    // 3. ExecExprSerializer
+    // ======================================================================
+
+    @Test
+    public void testSerializeIntLiteral() {
+        ExecLiteral literal = makeIntLiteral(42);
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+
+        assertNotNull(texpr);
+        assertNotNull(texpr.getNodes());
+        assertEquals(1, texpr.getNodes().size());
+
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.INT_LITERAL, node.node_type);
+        assertNotNull(node.int_literal);
+        assertEquals(42, node.int_literal.value);
+        assertEquals(0, node.num_children);
+    }
+
+    @Test
+    public void testSerializeBoolLiteral() {
+        ConstantOperator constOp = ConstantOperator.createBoolean(true);
+        ExecLiteral literal = new ExecLiteral(constOp, BooleanType.BOOLEAN);
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+
+        assertEquals(1, texpr.getNodes().size());
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.BOOL_LITERAL, node.node_type);
+        assertNotNull(node.bool_literal);
+        assertTrue(node.bool_literal.value);
+    }
+
+    @Test
+    public void testSerializeVarcharLiteral() {
+        ExecLiteral literal = makeVarcharLiteral("hello");
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+
+        assertEquals(1, texpr.getNodes().size());
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.STRING_LITERAL, node.node_type);
+        assertNotNull(node.string_literal);
+        assertEquals("hello", node.string_literal.value);
+    }
+
+    @Test
+    public void testSerializeNullLiteral() {
+        ExecLiteral nullLiteral = makeNullLiteral();
+        TExpr texpr = ExecExprSerializer.serialize(nullLiteral);
+
+        assertEquals(1, texpr.getNodes().size());
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.NULL_LITERAL, node.node_type);
+    }
+
+    @Test
+    public void testSerializeSlotRef() {
+        ExecSlotRef slotRef = makeSlotRef(5, 2, IntegerType.INT, true);
+        TExpr texpr = ExecExprSerializer.serialize(slotRef);
+
+        assertNotNull(texpr);
+        assertEquals(1, texpr.getNodes().size());
+
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.SLOT_REF, node.node_type);
+        assertNotNull(node.slot_ref);
+        assertEquals(5, node.slot_ref.slot_id);
+        assertEquals(2, node.slot_ref.tuple_id);
+        assertTrue(node.is_nullable);
+        assertEquals(0, node.num_children);
+    }
+
+    @Test
+    public void testSerializeSlotRefNonNullable() {
+        ExecSlotRef slotRef = makeSlotRef(3, 1, IntegerType.INT, false);
+        TExpr texpr = ExecExprSerializer.serialize(slotRef);
+
+        TExprNode node = texpr.getNodes().get(0);
+        assertFalse(node.is_nullable);
+    }
+
+    @Test
+    public void testSerializeFunctionCallWithChildren() {
+        ExecSlotRef child1 = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral child2 = makeIntLiteral(10);
+        List<ExecExpr> children = new ArrayList<>(List.of(child1, child2));
+
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        TExpr texpr = ExecExprSerializer.serialize(funcCall);
+
+        assertNotNull(texpr);
+        // Should have 3 nodes: funcCall, slotRef, literal (pre-order DFS)
+        assertEquals(3, texpr.getNodes().size());
+
+        TExprNode funcNode = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.FUNCTION_CALL, funcNode.node_type);
+        assertEquals(2, funcNode.num_children);
+
+        TExprNode slotNode = texpr.getNodes().get(1);
+        assertEquals(TExprNodeType.SLOT_REF, slotNode.node_type);
+
+        TExprNode literalNode = texpr.getNodes().get(2);
+        assertEquals(TExprNodeType.INT_LITERAL, literalNode.node_type);
+    }
+
+    @Test
+    public void testSerializeAggFunctionCall() {
+        List<ExecExpr> children = new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, true)));
+        ScalarFunction fn = makeScalarFunction("sum", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+        ExecFunctionCall aggCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "sum", children,
+                false, false, true, false);
+
+        TExpr texpr = ExecExprSerializer.serialize(aggCall);
+        TExprNode aggNode = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.AGG_EXPR, aggNode.node_type);
+        assertNotNull(aggNode.agg_expr);
+    }
+
+    @Test
+    public void testSerializeCastWithChild() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
+
+        TExpr texpr = ExecExprSerializer.serialize(cast);
+
+        assertNotNull(texpr);
+        // Should have 2 nodes: cast, literal
+        assertEquals(2, texpr.getNodes().size());
+
+        TExprNode castNode = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.CAST_EXPR, castNode.node_type);
+        assertEquals(1, castNode.num_children);
+        assertEquals(TExprOpcode.CAST, castNode.opcode);
+
+        TExprNode literalNode = texpr.getNodes().get(1);
+        assertEquals(TExprNodeType.INT_LITERAL, literalNode.node_type);
+    }
+
+    @Test
+    public void testSerializeBinaryPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, left, right);
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+
+        assertEquals(3, texpr.getNodes().size());
+
+        TExprNode predNode = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.BINARY_PRED, predNode.node_type);
+        assertEquals(2, predNode.num_children);
+        assertEquals(TExprOpcode.EQ, predNode.opcode);
+    }
+
+    @Test
+    public void testSerializeCommonFields() {
+        // Verify common fields are populated: type, is_nullable, is_monotonic, output_scale, is_index_only_filter
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, true);
+        slotRef.setIsIndexOnlyFilter(true);
+
+        TExpr texpr = ExecExprSerializer.serialize(slotRef);
+        TExprNode node = texpr.getNodes().get(0);
+
+        assertNotNull(node.type);
+        assertTrue(node.is_nullable);
+        assertTrue(node.is_monotonic); // SlotRef is self-monotonic
+        assertEquals(-1, node.output_scale);
+        assertTrue(node.is_index_only_filter);
+    }
+
+    @Test
+    public void testSerializeList() {
+        ExecLiteral lit1 = makeIntLiteral(1);
+        ExecLiteral lit2 = makeIntLiteral(2);
+        ExecLiteral lit3 = makeIntLiteral(3);
+
+        List<TExpr> results = ExecExprSerializer.serializeList(List.of(lit1, lit2, lit3));
+        assertEquals(3, results.size());
+        for (TExpr texpr : results) {
+            assertEquals(1, texpr.getNodes().size());
+            assertEquals(TExprNodeType.INT_LITERAL, texpr.getNodes().get(0).node_type);
+        }
+    }
+
+    @Test
+    public void testSerializeDeepTree() {
+        // Build a deeper tree: BinaryPred(Cast(SlotRef), FuncCall(Literal))
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, slot, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("abs", IntegerType.INT, fn, new ArrayList<>(List.of(literal)));
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.GT, cast, funcCall);
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+        // 5 nodes: pred, cast, slot, funcCall, literal
+        assertEquals(5, texpr.getNodes().size());
+
+        assertEquals(TExprNodeType.BINARY_PRED, texpr.getNodes().get(0).node_type);
+        assertEquals(TExprNodeType.CAST_EXPR, texpr.getNodes().get(1).node_type);
+        assertEquals(TExprNodeType.SLOT_REF, texpr.getNodes().get(2).node_type);
+        assertEquals(TExprNodeType.FUNCTION_CALL, texpr.getNodes().get(3).node_type);
+        assertEquals(TExprNodeType.INT_LITERAL, texpr.getNodes().get(4).node_type);
+    }
+
+    // ======================================================================
+    // 4. ExecExprExplain
+    // ======================================================================
+
+    @Test
+    public void testExplainSlotRefWithoutLabel() {
+        ExecSlotRef slotRef = makeSlotRef(5, 0, IntegerType.INT, false);
+        String explain = ExecExprExplain.explain(slotRef);
+
+        // Format: "<slot N>" where N is the slot ID
+        assertEquals("<slot 5>", explain);
+    }
+
+    @Test
+    public void testExplainSlotRefWithLabel() {
+        SlotDescriptor desc = makeSlotDescriptor(5, 0, IntegerType.INT, false);
+        ExecSlotRef slotRef = new ExecSlotRef("my_col", desc);
+        String explain = ExecExprExplain.explain(slotRef);
+
+        assertEquals("my_col", explain);
+    }
+
+    @Test
+    public void testExplainIntLiteral() {
+        ExecLiteral literal = makeIntLiteral(42);
+        String explain = ExecExprExplain.explain(literal);
+
+        assertEquals("42", explain);
+    }
+
+    @Test
+    public void testExplainBigintLiteral() {
+        ConstantOperator constOp = ConstantOperator.createBigint(123456789L);
+        ExecLiteral literal = new ExecLiteral(constOp, IntegerType.BIGINT);
+        String explain = ExecExprExplain.explain(literal);
+
+        assertEquals("123456789", explain);
+    }
+
+    @Test
+    public void testExplainBoolLiteral() {
+        ConstantOperator trueOp = ConstantOperator.createBoolean(true);
+        ExecLiteral trueLiteral = new ExecLiteral(trueOp, BooleanType.BOOLEAN);
+        assertEquals("TRUE", ExecExprExplain.explain(trueLiteral));
+
+        ConstantOperator falseOp = ConstantOperator.createBoolean(false);
+        ExecLiteral falseLiteral = new ExecLiteral(falseOp, BooleanType.BOOLEAN);
+        assertEquals("FALSE", ExecExprExplain.explain(falseLiteral));
+    }
+
+    @Test
+    public void testExplainVarcharLiteral() {
+        ExecLiteral literal = makeVarcharLiteral("hello world");
+        String explain = ExecExprExplain.explain(literal);
+
+        assertEquals("'hello world'", explain);
+    }
+
+    @Test
+    public void testExplainVarcharLiteralWithEscapes() {
+        ExecLiteral literal = makeVarcharLiteral("it's a \"test\"");
+        String explain = ExecExprExplain.explain(literal);
+
+        assertEquals("'it\\'s a \"test\"'", explain);
+    }
+
+    @Test
+    public void testExplainNullLiteral() {
+        ExecLiteral nullLiteral = makeNullLiteral();
+        assertEquals("NULL", ExecExprExplain.explain(nullLiteral));
+    }
+
+    @Test
+    public void testExplainFunctionCall() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot, literal));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+
+        String explain = ExecExprExplain.explain(funcCall);
+        // Format: "fnName(child1, child2)"
+        assertEquals("add(<slot 1>, 10)", explain);
+    }
+
+    @Test
+    public void testExplainFunctionCallDistinct() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+        ExecFunctionCall funcCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", children,
+                true, false, true, false);
+
+        String explain = ExecExprExplain.explain(funcCall);
+        assertTrue(explain.contains("DISTINCT"));
+    }
+
+    @Test
+    public void testExplainFunctionCallCountStar() {
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{}, IntegerType.BIGINT);
+        ExecFunctionCall countStar = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", List.of(),
+                false, false, true, false, true);
+
+        String explain = ExecExprExplain.explain(countStar);
+        assertEquals("count(*)", explain);
+    }
+
+    @Test
+    public void testExplainCast() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
+        String explain = ExecExprExplain.explain(cast);
+
+        assertEquals("CAST(42 AS BIGINT)", explain);
+    }
+
+    @Test
+    public void testExplainBinaryPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        assertEquals("<slot 1> = 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.EQ, left, right)));
+        assertEquals("<slot 1> != 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.NE, left, right)));
+        assertEquals("<slot 1> < 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.LT, left, right)));
+        assertEquals("<slot 1> <= 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.LE, left, right)));
+        assertEquals("<slot 1> > 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.GT, left, right)));
+        assertEquals("<slot 1> >= 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.GE, left, right)));
+        assertEquals("<slot 1> <=> 10",
+                ExecExprExplain.explain(new ExecBinaryPredicate(BinaryType.EQ_FOR_NULL, left, right)));
+    }
+
+    @Test
+    public void testExplainNestedExpression() {
+        // CAST(add(<slot 1>, 10) AS BIGINT)
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot, literal));
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn, children);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, funcCall, false);
+
+        String explain = ExecExprExplain.explain(cast);
+        assertEquals("CAST(add(<slot 1>, 10) AS BIGINT)", explain);
+    }
+
+    @Test
+    public void testExplainList() {
+        ExecLiteral lit1 = makeIntLiteral(1);
+        ExecLiteral lit2 = makeIntLiteral(2);
+        ExecLiteral lit3 = makeIntLiteral(3);
+
+        String result = ExecExprExplain.explainList(List.of(lit1, lit2, lit3));
+        assertEquals("1, 2, 3", result);
+    }
+
+    @Test
+    public void testVerboseExplainSlotRef() {
+        ExecSlotRef slotRef = makeSlotRef(5, 0, IntegerType.INT, true);
+        String explain = ExecExprExplain.verboseExplain(slotRef);
+
+        // Verbose format: [slotId, TYPE, nullable]
+        assertEquals("[5, INT, true]", explain);
+    }
+
+    @Test
+    public void testVerboseExplainSlotRefWithLabel() {
+        SlotDescriptor desc = makeSlotDescriptor(5, 0, IntegerType.INT, false);
+        ExecSlotRef slotRef = new ExecSlotRef("my_col", desc);
+        String explain = ExecExprExplain.verboseExplain(slotRef);
+
+        assertEquals("[my_col, INT, false]", explain);
+    }
+
+    @Test
+    public void testVerboseExplainCast() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, slot, false);
+        String explain = ExecExprExplain.verboseExplain(cast);
+
+        assertTrue(explain.contains("cast("));
+        assertTrue(explain.contains("BIGINT"));
+    }
+
+    @Test
+    public void testToSqlVarchar() {
+        ExecLiteral literal = makeVarcharLiteral("hello");
+        String sql = ExecExprExplain.toSql(literal);
+        assertEquals("'hello'", sql);
+    }
+
+    // ======================================================================
+    // 5. ThriftEnumConverter
+    // ======================================================================
+
+    @Test
+    public void testKeysTypeToThriftDupKeys() {
+        assertEquals(TKeysType.DUP_KEYS, ThriftEnumConverter.keysTypeToThrift(KeysType.DUP_KEYS));
+    }
+
+    @Test
+    public void testKeysTypeToThriftAggKeys() {
+        assertEquals(TKeysType.AGG_KEYS, ThriftEnumConverter.keysTypeToThrift(KeysType.AGG_KEYS));
+    }
+
+    @Test
+    public void testKeysTypeToThriftUniqueKeys() {
+        assertEquals(TKeysType.UNIQUE_KEYS, ThriftEnumConverter.keysTypeToThrift(KeysType.UNIQUE_KEYS));
+    }
+
+    @Test
+    public void testKeysTypeToThriftPrimaryKeys() {
+        assertEquals(TKeysType.PRIMARY_KEYS, ThriftEnumConverter.keysTypeToThrift(KeysType.PRIMARY_KEYS));
+    }
+
+    @Test
+    public void testKeysTypeToThriftAllValues() {
+        // Verify every KeysType value has a mapping
+        for (KeysType keysType : KeysType.values()) {
+            TKeysType result = ThriftEnumConverter.keysTypeToThrift(keysType);
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    public void testCompoundPredicateOperatorToThrift() {
+        assertEquals(TExprOpcode.COMPOUND_AND,
+                ThriftEnumConverter.compoundPredicateOperatorToThrift(
+                        com.starrocks.sql.ast.expression.CompoundPredicate.Operator.AND));
+        assertEquals(TExprOpcode.COMPOUND_OR,
+                ThriftEnumConverter.compoundPredicateOperatorToThrift(
+                        com.starrocks.sql.ast.expression.CompoundPredicate.Operator.OR));
+        assertEquals(TExprOpcode.COMPOUND_NOT,
+                ThriftEnumConverter.compoundPredicateOperatorToThrift(
+                        com.starrocks.sql.ast.expression.CompoundPredicate.Operator.NOT));
+    }
+
+    @Test
+    public void testSetTypeConversionRoundTrip() {
+        // Test GLOBAL round-trip
+        assertEquals(com.starrocks.sql.ast.SetType.GLOBAL,
+                ThriftEnumConverter.setTypeFromThrift(
+                        ThriftEnumConverter.setTypeToThrift(com.starrocks.sql.ast.SetType.GLOBAL)));
+
+        // Test SESSION round-trip
+        assertEquals(com.starrocks.sql.ast.SetType.SESSION,
+                ThriftEnumConverter.setTypeFromThrift(
+                        ThriftEnumConverter.setTypeToThrift(com.starrocks.sql.ast.SetType.SESSION)));
+
+        // Test VERBOSE round-trip
+        assertEquals(com.starrocks.sql.ast.SetType.VERBOSE,
+                ThriftEnumConverter.setTypeFromThrift(
+                        ThriftEnumConverter.setTypeToThrift(com.starrocks.sql.ast.SetType.VERBOSE)));
+    }
+
+    // ======================================================================
+    // 6. ExprOpcodeRegistry
+    // ======================================================================
+
+    @Test
+    public void testBinaryOpcodeEQ() {
+        assertEquals(TExprOpcode.EQ, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.EQ));
+    }
+
+    @Test
+    public void testBinaryOpcodeLT() {
+        assertEquals(TExprOpcode.LT, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.LT));
+    }
+
+    @Test
+    public void testBinaryOpcodeGT() {
+        assertEquals(TExprOpcode.GT, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.GT));
+    }
+
+    @Test
+    public void testBinaryOpcodeLE() {
+        assertEquals(TExprOpcode.LE, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.LE));
+    }
+
+    @Test
+    public void testBinaryOpcodeGE() {
+        assertEquals(TExprOpcode.GE, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.GE));
+    }
+
+    @Test
+    public void testBinaryOpcodeNE() {
+        assertEquals(TExprOpcode.NE, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.NE));
+    }
+
+    @Test
+    public void testBinaryOpcodeEqForNull() {
+        assertEquals(TExprOpcode.EQ_FOR_NULL, ExprOpcodeRegistry.getBinaryOpcode(BinaryType.EQ_FOR_NULL));
+    }
+
+    @Test
+    public void testAllBinaryOpcodes() {
+        // Verify every BinaryType has a mapped opcode (not INVALID_OPCODE)
+        for (BinaryType bt : BinaryType.values()) {
+            TExprOpcode opcode = ExprOpcodeRegistry.getBinaryOpcode(bt);
+            assertNotNull(opcode);
+            assertTrue(opcode != TExprOpcode.INVALID_OPCODE,
+                    "BinaryType " + bt + " should have a valid opcode mapping");
+        }
+    }
+
+    @Test
+    public void testArithmeticOpcodeAdd() {
+        assertEquals(TExprOpcode.ADD, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.ADD));
+    }
+
+    @Test
+    public void testArithmeticOpcodeSubtract() {
+        assertEquals(TExprOpcode.SUBTRACT, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.SUBTRACT));
+    }
+
+    @Test
+    public void testArithmeticOpcodeMultiply() {
+        assertEquals(TExprOpcode.MULTIPLY, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.MULTIPLY));
+    }
+
+    @Test
+    public void testArithmeticOpcodeDivide() {
+        assertEquals(TExprOpcode.DIVIDE, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.DIVIDE));
+    }
+
+    @Test
+    public void testArithmeticOpcodeMod() {
+        assertEquals(TExprOpcode.MOD, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.MOD));
+    }
+
+    @Test
+    public void testArithmeticOpcodeIntDivide() {
+        assertEquals(TExprOpcode.INT_DIVIDE,
+                ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.INT_DIVIDE));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitAnd() {
+        assertEquals(TExprOpcode.BITAND, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BITAND));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitOr() {
+        assertEquals(TExprOpcode.BITOR, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BITOR));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitXor() {
+        assertEquals(TExprOpcode.BITXOR, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BITXOR));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitNot() {
+        assertEquals(TExprOpcode.BITNOT, ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BITNOT));
+    }
+
+    @Test
+    public void testArithmeticOpcodeFactorial() {
+        assertEquals(TExprOpcode.FACTORIAL,
+                ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.FACTORIAL));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitShiftLeft() {
+        assertEquals(TExprOpcode.BIT_SHIFT_LEFT,
+                ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BIT_SHIFT_LEFT));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitShiftRight() {
+        assertEquals(TExprOpcode.BIT_SHIFT_RIGHT,
+                ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT));
+    }
+
+    @Test
+    public void testArithmeticOpcodeBitShiftRightLogical() {
+        assertEquals(TExprOpcode.BIT_SHIFT_RIGHT_LOGICAL,
+                ExprOpcodeRegistry.getArithmeticOpcode(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT_LOGICAL));
+    }
+
+    @Test
+    public void testAllArithmeticOpcodes() {
+        // Verify every ArithmeticExpr.Operator has a mapped opcode
+        for (ArithmeticExpr.Operator op : ArithmeticExpr.Operator.values()) {
+            TExprOpcode opcode = ExprOpcodeRegistry.getArithmeticOpcode(op);
+            assertNotNull(opcode);
+            assertTrue(opcode != TExprOpcode.INVALID_OPCODE,
+                    "ArithmeticExpr.Operator " + op + " should have a valid opcode mapping");
+        }
+    }
+
+    @Test
+    public void testGetCastOpcode() {
+        assertEquals(TExprOpcode.CAST, ExprOpcodeRegistry.getCastOpcode());
+    }
+
+    @Test
+    public void testGetInPredicateOpcode() {
+        assertEquals(TExprOpcode.FILTER_IN, ExprOpcodeRegistry.getInPredicateOpcode(false));
+        assertEquals(TExprOpcode.FILTER_NOT_IN, ExprOpcodeRegistry.getInPredicateOpcode(true));
+    }
+
+    @Test
+    public void testGetMatchOpcode() {
+        assertEquals(TExprOpcode.MATCH,
+                ExprOpcodeRegistry.getMatchOpcode(com.starrocks.sql.ast.expression.MatchExpr.MatchOperator.MATCH));
+        assertEquals(TExprOpcode.MATCH_ANY,
+                ExprOpcodeRegistry.getMatchOpcode(
+                        com.starrocks.sql.ast.expression.MatchExpr.MatchOperator.MATCH_ANY));
+        assertEquals(TExprOpcode.MATCH_ALL,
+                ExprOpcodeRegistry.getMatchOpcode(
+                        com.starrocks.sql.ast.expression.MatchExpr.MatchOperator.MATCH_ALL));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -23,25 +23,32 @@ import com.starrocks.planner.TupleId;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
 import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.MatchExpr;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.thrift.TDictQueryExpr;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
 import com.starrocks.thrift.TKeysType;
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -1247,5 +1254,1729 @@ public class ExecExprTest {
         assertEquals(TExprOpcode.MATCH_ALL,
                 ExprOpcodeRegistry.getMatchOpcode(
                         com.starrocks.sql.ast.expression.MatchExpr.MatchOperator.MATCH_ALL));
+    }
+
+    // ======================================================================
+    // 7. ExecCompoundPredicate
+    // ======================================================================
+
+    @Test
+    public void testExecCompoundPredicateAndConstruction() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+
+        assertEquals(CompoundPredicate.Operator.AND, pred.getCompoundType());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(2, pred.getNumChildren());
+        assertEquals(TExprNodeType.COMPOUND_PRED, pred.getNodeType());
+    }
+
+    @Test
+    public void testExecCompoundPredicateOrConstruction() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.OR, left, right);
+        assertEquals(CompoundPredicate.Operator.OR, pred.getCompoundType());
+    }
+
+    @Test
+    public void testExecCompoundPredicateNotConstruction() {
+        ExecSlotRef child = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(
+                CompoundPredicate.Operator.NOT, new ArrayList<>(List.of(child)));
+
+        assertEquals(CompoundPredicate.Operator.NOT, pred.getCompoundType());
+        assertEquals(1, pred.getNumChildren());
+    }
+
+    @Test
+    public void testExecCompoundPredicateNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, BooleanType.BOOLEAN, true);
+        ExecSlotRef nonNullable = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+
+        ExecCompoundPredicate withNullable = new ExecCompoundPredicate(
+                CompoundPredicate.Operator.AND, nullable, nonNullable);
+        assertTrue(withNullable.isNullable());
+
+        ExecCompoundPredicate withoutNullable = new ExecCompoundPredicate(
+                CompoundPredicate.Operator.AND, nonNullable, nonNullable.clone());
+        assertFalse(withoutNullable.isNullable());
+    }
+
+    @Test
+    public void testExecCompoundPredicateToThrift() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+
+        ExecCompoundPredicate andPred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+        TExprNode node = new TExprNode();
+        andPred.toThrift(node);
+        assertEquals(TExprOpcode.COMPOUND_AND, node.opcode);
+
+        ExecCompoundPredicate orPred = new ExecCompoundPredicate(CompoundPredicate.Operator.OR, left, right);
+        TExprNode node2 = new TExprNode();
+        orPred.toThrift(node2);
+        assertEquals(TExprOpcode.COMPOUND_OR, node2.opcode);
+    }
+
+    @Test
+    public void testExecCompoundPredicateVisitorDispatch() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecCompoundPredicate(ExecCompoundPredicate expr, Void context) {
+                return "CompoundPredicate";
+            }
+        };
+        assertEquals("CompoundPredicate", pred.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecCompoundPredicateClone() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate original = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+        original.setIsIndexOnlyFilter(true);
+
+        ExecCompoundPredicate cloned = original.clone();
+        assertEquals(original.getCompoundType(), cloned.getCompoundType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+        assertTrue(cloned.isIndexOnlyFilter());
+    }
+
+    // ======================================================================
+    // 8. ExecLikePredicate
+    // ======================================================================
+
+    @Test
+    public void testExecLikePredicateConstruction() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        assertFalse(pred.isRegexp());
+        assertEquals(fn, pred.getFn());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(2, pred.getNumChildren());
+        assertEquals(TExprNodeType.FUNCTION_CALL, pred.getNodeType());
+    }
+
+    @Test
+    public void testExecLikePredicateRegexp() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("^test.*$");
+        ScalarFunction fn = makeScalarFunction("regexp", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+
+        ExecLikePredicate pred = new ExecLikePredicate(true, fn, new ArrayList<>(List.of(col, pattern)));
+        assertTrue(pred.isRegexp());
+    }
+
+    @Test
+    public void testExecLikePredicateNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, VarcharType.VARCHAR, true);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(nullable, pattern)));
+        assertTrue(pred.isNullable());
+    }
+
+    @Test
+    public void testExecLikePredicateToThrift() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+        assertNotNull(node.getFn());
+    }
+
+    @Test
+    public void testExecLikePredicateToThriftNullFn() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+
+        ExecLikePredicate pred = new ExecLikePredicate(false, null, new ArrayList<>(List.of(col, pattern)));
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+        // Should not throw; fn is null so no function is set
+        assertNull(node.getFn());
+    }
+
+    @Test
+    public void testExecLikePredicateVisitorDispatch() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecLikePredicate(ExecLikePredicate expr, Void context) {
+                return "LikePredicate";
+            }
+        };
+        assertEquals("LikePredicate", pred.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecLikePredicateClone() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate original = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        ExecLikePredicate cloned = original.clone();
+        assertEquals(original.isRegexp(), cloned.isRegexp());
+        assertEquals(original.getFn(), cloned.getFn());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 9. ExecInPredicate
+    // ======================================================================
+
+    @Test
+    public void testExecInPredicateConstruction() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecLiteral v2 = makeIntLiteral(2);
+        ExecLiteral v3 = makeIntLiteral(3);
+
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1, v2, v3)));
+
+        assertFalse(pred.isNotIn());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(4, pred.getNumChildren());
+        assertEquals(TExprNodeType.IN_PRED, pred.getNodeType());
+    }
+
+    @Test
+    public void testExecInPredicateNotIn() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+
+        ExecInPredicate pred = new ExecInPredicate(true, new ArrayList<>(List.of(col, v1)));
+        assertTrue(pred.isNotIn());
+    }
+
+    @Test
+    public void testExecInPredicateNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecLiteral v1 = makeIntLiteral(1);
+
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(nullable, v1)));
+        assertTrue(pred.isNullable());
+
+        ExecSlotRef nonNullable = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecInPredicate pred2 = new ExecInPredicate(false, new ArrayList<>(List.of(nonNullable, v1)));
+        assertFalse(pred2.isNullable());
+    }
+
+    @Test
+    public void testExecInPredicateToThrift() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecLiteral v2 = makeIntLiteral(2);
+
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1, v2)));
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+
+        assertNotNull(node.in_predicate);
+        assertFalse(node.in_predicate.is_not_in);
+        assertEquals(TExprOpcode.FILTER_IN, node.opcode);
+    }
+
+    @Test
+    public void testExecInPredicateToThriftNotIn() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+
+        ExecInPredicate pred = new ExecInPredicate(true, new ArrayList<>(List.of(col, v1)));
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+
+        assertTrue(node.in_predicate.is_not_in);
+        assertEquals(TExprOpcode.FILTER_NOT_IN, node.opcode);
+    }
+
+    @Test
+    public void testExecInPredicateVisitorDispatch() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecInPredicate(ExecInPredicate expr, Void context) {
+                return "InPredicate";
+            }
+        };
+        assertEquals("InPredicate", pred.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecInPredicateClone() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecInPredicate original = new ExecInPredicate(true, new ArrayList<>(List.of(col, v1)));
+
+        ExecInPredicate cloned = original.clone();
+        assertEquals(original.isNotIn(), cloned.isNotIn());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 10. ExecIsNullPredicate
+    // ======================================================================
+
+    @Test
+    public void testExecIsNullPredicateIsNull() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(false, col);
+
+        assertFalse(pred.isNotNull());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(1, pred.getNumChildren());
+        assertEquals(TExprNodeType.FUNCTION_CALL, pred.getNodeType());
+        // IS NULL predicate is never nullable itself
+        assertFalse(pred.isNullable());
+    }
+
+    @Test
+    public void testExecIsNullPredicateIsNotNull() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(true, col);
+
+        assertTrue(pred.isNotNull());
+        assertFalse(pred.isNullable());
+    }
+
+    @Test
+    public void testExecIsNullPredicateToThriftIsNull() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(false, col);
+
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+        assertNotNull(node.getFn());
+        assertEquals("is_null_pred", node.getFn().getName().getFunction_name());
+    }
+
+    @Test
+    public void testExecIsNullPredicateToThriftIsNotNull() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(true, col);
+
+        TExprNode node = new TExprNode();
+        pred.toThrift(node);
+        assertNotNull(node.getFn());
+        assertEquals("is_not_null_pred", node.getFn().getName().getFunction_name());
+    }
+
+    @Test
+    public void testExecIsNullPredicateVisitorDispatch() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(false, col);
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecIsNullPredicate(ExecIsNullPredicate expr, Void context) {
+                return "IsNullPredicate";
+            }
+        };
+        assertEquals("IsNullPredicate", pred.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecIsNullPredicateClone() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate original = new ExecIsNullPredicate(true, col);
+
+        ExecIsNullPredicate cloned = original.clone();
+        assertEquals(original.isNotNull(), cloned.isNotNull());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 11. ExecMatchExpr
+    // ======================================================================
+
+    @Test
+    public void testExecMatchExprConstruction() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals(MatchExpr.MatchOperator.MATCH, expr.getMatchOp());
+        assertEquals(BooleanType.BOOLEAN, expr.getType());
+        assertEquals(2, expr.getNumChildren());
+        assertEquals(TExprNodeType.MATCH_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecMatchExprMatchAny() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH_ANY,
+                new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals(MatchExpr.MatchOperator.MATCH_ANY, expr.getMatchOp());
+    }
+
+    @Test
+    public void testExecMatchExprNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, VarcharType.VARCHAR, true);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(nullable, pattern)));
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecMatchExprToThrift() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        assertEquals(TExprOpcode.MATCH, node.opcode);
+    }
+
+    @Test
+    public void testExecMatchExprToThriftMatchAll() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH_ALL,
+                new ArrayList<>(List.of(col, pattern)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        assertEquals(TExprOpcode.MATCH_ALL, node.opcode);
+    }
+
+    @Test
+    public void testExecMatchExprVisitorDispatch() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr2, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecMatchExpr(ExecMatchExpr expr2, Void context) {
+                return "MatchExpr";
+            }
+        };
+        assertEquals("MatchExpr", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecMatchExprClone() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr original = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        ExecMatchExpr cloned = original.clone();
+        assertEquals(original.getMatchOp(), cloned.getMatchOp());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 12. ExecArithmetic
+    // ======================================================================
+
+    @Test
+    public void testExecArithmeticConstruction() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        ExecArithmetic expr = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+
+        assertEquals(ArithmeticExpr.Operator.ADD, expr.getOp());
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(2, expr.getNumChildren());
+        assertEquals(TExprNodeType.ARITHMETIC_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecArithmeticNullabilityDivide() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        // DIVIDE is always nullable (division by zero)
+        ExecArithmetic divide = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.DIVIDE,
+                new ArrayList<>(List.of(left, right)));
+        assertTrue(divide.isNullable());
+
+        // INT_DIVIDE is always nullable
+        ExecArithmetic intDivide = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.INT_DIVIDE,
+                new ArrayList<>(List.of(left, right)));
+        assertTrue(intDivide.isNullable());
+
+        // MOD is always nullable
+        ExecArithmetic mod = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.MOD,
+                new ArrayList<>(List.of(left, right)));
+        assertTrue(mod.isNullable());
+    }
+
+    @Test
+    public void testExecArithmeticNullabilityAdd() {
+        ExecSlotRef nonNullable = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+
+        // ADD with non-nullable children -> not nullable
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(nonNullable, literal)));
+        assertFalse(add.isNullable());
+
+        // ADD with nullable child -> nullable
+        ExecSlotRef nullable = makeSlotRef(2, 0, IntegerType.INT, true);
+        ExecArithmetic addNullable = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(nullable, literal)));
+        assertTrue(addNullable.isNullable());
+    }
+
+    @Test
+    public void testExecArithmeticSelfMonotonic() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+        assertTrue(add.isSelfMonotonic());
+    }
+
+    @Test
+    public void testExecArithmeticToThrift() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+        TExprNode node = new TExprNode();
+        add.toThrift(node);
+        assertEquals(TExprOpcode.ADD, node.opcode);
+
+        ExecArithmetic sub = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.SUBTRACT,
+                new ArrayList<>(List.of(left, right)));
+        TExprNode node2 = new TExprNode();
+        sub.toThrift(node2);
+        assertEquals(TExprOpcode.SUBTRACT, node2.opcode);
+    }
+
+    @Test
+    public void testExecArithmeticVisitorDispatch() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic expr = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecArithmetic(ExecArithmetic e, Void context) {
+                return "Arithmetic";
+            }
+        };
+        assertEquals("Arithmetic", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecArithmeticClone() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic original = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.MULTIPLY,
+                new ArrayList<>(List.of(left, right)));
+
+        ExecArithmetic cloned = original.clone();
+        assertEquals(original.getOp(), cloned.getOp());
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 13. ExecCaseWhen
+    // ======================================================================
+
+    @Test
+    public void testExecCaseWhenConstruction() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecLiteral elseVal = makeIntLiteral(0);
+
+        ExecCaseWhen expr = new ExecCaseWhen(IntegerType.INT, false, true,
+                new ArrayList<>(List.of(cond, thenVal, elseVal)));
+
+        assertFalse(expr.hasCase());
+        assertTrue(expr.hasElse());
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(3, expr.getNumChildren());
+        assertEquals(TExprNodeType.CASE_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecCaseWhenWithCaseExpr() {
+        ExecSlotRef caseExpr = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral when1 = makeIntLiteral(1);
+        ExecLiteral then1 = makeIntLiteral(100);
+
+        ExecCaseWhen expr = new ExecCaseWhen(IntegerType.INT, true, false,
+                new ArrayList<>(List.of(caseExpr, when1, then1)));
+
+        assertTrue(expr.hasCase());
+        assertFalse(expr.hasElse());
+    }
+
+    @Test
+    public void testExecCaseWhenAlwaysNullable() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecCaseWhen expr = new ExecCaseWhen(IntegerType.INT, false, false,
+                new ArrayList<>(List.of(cond, thenVal)));
+
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecCaseWhenToThrift() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecLiteral elseVal = makeIntLiteral(0);
+
+        ExecCaseWhen expr = new ExecCaseWhen(IntegerType.INT, true, true,
+                new ArrayList<>(List.of(cond, thenVal, elseVal)));
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertNotNull(node.case_expr);
+        assertTrue(node.case_expr.has_case_expr);
+        assertTrue(node.case_expr.has_else_expr);
+    }
+
+    @Test
+    public void testExecCaseWhenVisitorDispatch() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecCaseWhen expr = new ExecCaseWhen(IntegerType.INT, false, false,
+                new ArrayList<>(List.of(cond, thenVal)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecCaseWhen(ExecCaseWhen e, Void context) {
+                return "CaseWhen";
+            }
+        };
+        assertEquals("CaseWhen", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecCaseWhenClone() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecCaseWhen original = new ExecCaseWhen(IntegerType.INT, true, true,
+                new ArrayList<>(List.of(cond, thenVal)));
+
+        ExecCaseWhen cloned = original.clone();
+        assertEquals(original.hasCase(), cloned.hasCase());
+        assertEquals(original.hasElse(), cloned.hasElse());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 14. ExecBetweenPredicate
+    // ======================================================================
+
+    @Test
+    public void testExecBetweenPredicateConstruction() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        assertFalse(pred.isNotBetween());
+        assertEquals(BooleanType.BOOLEAN, pred.getType());
+        assertEquals(3, pred.getNumChildren());
+    }
+
+    @Test
+    public void testExecBetweenPredicateNotBetween() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(true,
+                new ArrayList<>(List.of(col, low, high)));
+        assertTrue(pred.isNotBetween());
+    }
+
+    @Test
+    public void testExecBetweenPredicateNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(nullable, low, high)));
+        assertTrue(pred.isNullable());
+    }
+
+    @Test
+    public void testExecBetweenPredicateThrowsOnGetNodeType() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        assertThrows(IllegalStateException.class, pred::getNodeType);
+    }
+
+    @Test
+    public void testExecBetweenPredicateThrowsOnToThrift() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        assertThrows(IllegalStateException.class, () -> pred.toThrift(new TExprNode()));
+    }
+
+    @Test
+    public void testExecBetweenPredicateVisitorDispatch() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecBetweenPredicate(ExecBetweenPredicate e, Void context) {
+                return "BetweenPredicate";
+            }
+        };
+        assertEquals("BetweenPredicate", pred.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecBetweenPredicateClone() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate original = new ExecBetweenPredicate(true,
+                new ArrayList<>(List.of(col, low, high)));
+
+        ExecBetweenPredicate cloned = original.clone();
+        assertEquals(original.isNotBetween(), cloned.isNotBetween());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 15. ExecArrayExpr
+    // ======================================================================
+
+    @Test
+    public void testExecArrayExprConstruction() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecLiteral e2 = makeIntLiteral(2);
+
+        ExecArrayExpr expr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1, e2)));
+
+        assertEquals(arrayType, expr.getType());
+        assertEquals(2, expr.getNumChildren());
+        assertEquals(TExprNodeType.ARRAY_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecArrayExprToThrift() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecArrayExpr expr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        // ARRAY_EXPR has no extra fields -- just verify it doesn't throw
+    }
+
+    @Test
+    public void testExecArrayExprVisitorDispatch() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecArrayExpr expr = new ExecArrayExpr(arrayType, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecArrayExpr(ExecArrayExpr e, Void context) {
+                return "ArrayExpr";
+            }
+        };
+        assertEquals("ArrayExpr", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecArrayExprClone() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecArrayExpr original = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1)));
+
+        ExecArrayExpr cloned = original.clone();
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 16. ExecArraySlice
+    // ======================================================================
+
+    @Test
+    public void testExecArraySliceConstruction() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral offset = makeIntLiteral(1);
+        ExecLiteral length = makeIntLiteral(3);
+
+        ExecArraySlice expr = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, offset, length)));
+
+        assertEquals(arrayType, expr.getType());
+        assertEquals(3, expr.getNumChildren());
+        assertEquals(TExprNodeType.ARRAY_SLICE_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecArraySliceNullability() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef nullableArr = makeSlotRef(1, 0, arrayType, true);
+        ExecLiteral offset = makeIntLiteral(1);
+
+        ExecArraySlice expr = new ExecArraySlice(arrayType, new ArrayList<>(List.of(nullableArr, offset)));
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecArraySliceToThrift() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral offset = makeIntLiteral(1);
+        ExecArraySlice expr = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, offset)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        // No extra fields -- just verify it doesn't throw
+    }
+
+    @Test
+    public void testExecArraySliceVisitorDispatch() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecArraySlice expr = new ExecArraySlice(arrayType, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecArraySlice(ExecArraySlice e, Void context) {
+                return "ArraySlice";
+            }
+        };
+        assertEquals("ArraySlice", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecArraySliceClone() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral offset = makeIntLiteral(1);
+        ExecArraySlice original = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, offset)));
+
+        ExecArraySlice cloned = original.clone();
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 17. ExecMapExpr
+    // ======================================================================
+
+    @Test
+    public void testExecMapExprConstruction() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key = makeVarcharLiteral("key1");
+        ExecLiteral val = makeIntLiteral(1);
+
+        ExecMapExpr expr = new ExecMapExpr(mapType, new ArrayList<>(List.of(key, val)));
+
+        assertEquals(mapType, expr.getType());
+        assertEquals(2, expr.getNumChildren());
+        assertEquals(TExprNodeType.MAP_EXPR, expr.getNodeType());
+        assertFalse(expr.isNullable());
+    }
+
+    @Test
+    public void testExecMapExprToThrift() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecMapExpr expr = new ExecMapExpr(mapType, new ArrayList<>());
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        // No extra fields
+    }
+
+    @Test
+    public void testExecMapExprVisitorDispatch() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecMapExpr expr = new ExecMapExpr(mapType, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecMapExpr(ExecMapExpr e, Void context) {
+                return "MapExpr";
+            }
+        };
+        assertEquals("MapExpr", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecMapExprClone() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key = makeVarcharLiteral("key1");
+        ExecLiteral val = makeIntLiteral(1);
+        ExecMapExpr original = new ExecMapExpr(mapType, new ArrayList<>(List.of(key, val)));
+
+        ExecMapExpr cloned = original.clone();
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 18. ExecClone
+    // ======================================================================
+
+    @Test
+    public void testExecCloneConstruction() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone expr = new ExecClone(IntegerType.INT, child);
+
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(1, expr.getNumChildren());
+        assertEquals(TExprNodeType.CLONE_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecCloneNullability() {
+        ExecSlotRef nullable = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecClone cloneNullable = new ExecClone(IntegerType.INT, nullable);
+        assertTrue(cloneNullable.isNullable());
+
+        ExecSlotRef nonNullable = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecClone cloneNonNullable = new ExecClone(IntegerType.INT, nonNullable);
+        assertFalse(cloneNonNullable.isNullable());
+    }
+
+    @Test
+    public void testExecCloneToThrift() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone expr = new ExecClone(IntegerType.INT, child);
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        // No extra fields
+    }
+
+    @Test
+    public void testExecCloneVisitorDispatch() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone expr = new ExecClone(IntegerType.INT, child);
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecClone(ExecClone e, Void context) {
+                return "Clone";
+            }
+        };
+        assertEquals("Clone", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecCloneClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone original = new ExecClone(IntegerType.INT, child);
+
+        ExecClone cloned = original.clone();
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 19. ExecDictMapping
+    // ======================================================================
+
+    @Test
+    public void testExecDictMappingConstruction() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictMapping expr = new ExecDictMapping(VarcharType.VARCHAR, new ArrayList<>(List.of(child)));
+
+        assertEquals(VarcharType.VARCHAR, expr.getType());
+        assertEquals(1, expr.getNumChildren());
+        assertEquals(TExprNodeType.DICT_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecDictMappingToThrift() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictMapping expr = new ExecDictMapping(VarcharType.VARCHAR, new ArrayList<>(List.of(child)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        // No extra fields
+    }
+
+    @Test
+    public void testExecDictMappingVisitorDispatch() {
+        ExecDictMapping expr = new ExecDictMapping(VarcharType.VARCHAR, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecDictMapping(ExecDictMapping e, Void context) {
+                return "DictMapping";
+            }
+        };
+        assertEquals("DictMapping", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecDictMappingClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictMapping original = new ExecDictMapping(VarcharType.VARCHAR, new ArrayList<>(List.of(child)));
+
+        ExecDictMapping cloned = original.clone();
+        assertEquals(original.getType(), cloned.getType());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 20. ExecDictQuery
+    // ======================================================================
+
+    @Test
+    public void testExecDictQueryConstruction() {
+        TDictQueryExpr tDictQueryExpr = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery expr = new ExecDictQuery(VarcharType.VARCHAR, tDictQueryExpr,
+                new ArrayList<>(List.of(child)));
+
+        assertEquals(VarcharType.VARCHAR, expr.getType());
+        assertEquals(tDictQueryExpr, expr.getDictQueryExpr());
+        assertEquals(1, expr.getNumChildren());
+        assertEquals(TExprNodeType.DICT_QUERY_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecDictQueryToThrift() {
+        TDictQueryExpr tDictQueryExpr = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery expr = new ExecDictQuery(VarcharType.VARCHAR, tDictQueryExpr,
+                new ArrayList<>(List.of(child)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+        assertEquals(tDictQueryExpr, node.getDict_query_expr());
+    }
+
+    @Test
+    public void testExecDictQueryVisitorDispatch() {
+        TDictQueryExpr tDictQueryExpr = new TDictQueryExpr();
+        ExecDictQuery expr = new ExecDictQuery(VarcharType.VARCHAR, tDictQueryExpr, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecDictQuery(ExecDictQuery e, Void context) {
+                return "DictQuery";
+            }
+        };
+        assertEquals("DictQuery", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecDictQueryClone() {
+        TDictQueryExpr tDictQueryExpr = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery original = new ExecDictQuery(VarcharType.VARCHAR, tDictQueryExpr,
+                new ArrayList<>(List.of(child)));
+
+        ExecDictQuery cloned = original.clone();
+        assertEquals(original.getDictQueryExpr(), cloned.getDictQueryExpr());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 21. ExecDictionaryGet
+    // ======================================================================
+
+    @Test
+    public void testExecDictionaryGetConstruction() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet expr = new ExecDictionaryGet(VarcharType.VARCHAR,
+                100L, 200L, 1, true, new ArrayList<>(List.of(key)));
+
+        assertEquals(VarcharType.VARCHAR, expr.getType());
+        assertEquals(100L, expr.getDictionaryId());
+        assertEquals(200L, expr.getTxnId());
+        assertEquals(1, expr.getKeySize());
+        assertTrue(expr.isNullIfNotExist());
+        assertEquals(1, expr.getNumChildren());
+        assertEquals(TExprNodeType.DICTIONARY_GET_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecDictionaryGetNotNullIfNotExist() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet expr = new ExecDictionaryGet(VarcharType.VARCHAR,
+                50L, 60L, 2, false, new ArrayList<>(List.of(key)));
+
+        assertFalse(expr.isNullIfNotExist());
+        assertEquals(50L, expr.getDictionaryId());
+        assertEquals(60L, expr.getTxnId());
+        assertEquals(2, expr.getKeySize());
+    }
+
+    @Test
+    public void testExecDictionaryGetToThrift() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet expr = new ExecDictionaryGet(VarcharType.VARCHAR,
+                100L, 200L, 1, true, new ArrayList<>(List.of(key)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertNotNull(node.getDictionary_get_expr());
+        assertEquals(100L, node.getDictionary_get_expr().getDict_id());
+        assertEquals(200L, node.getDictionary_get_expr().getTxn_id());
+        assertEquals(1, node.getDictionary_get_expr().getKey_size());
+        assertTrue(node.getDictionary_get_expr().isNull_if_not_exist());
+    }
+
+    @Test
+    public void testExecDictionaryGetVisitorDispatch() {
+        ExecDictionaryGet expr = new ExecDictionaryGet(VarcharType.VARCHAR,
+                1L, 2L, 1, false, new ArrayList<>());
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecDictionaryGet(ExecDictionaryGet e, Void context) {
+                return "DictionaryGet";
+            }
+        };
+        assertEquals("DictionaryGet", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecDictionaryGetClone() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet original = new ExecDictionaryGet(VarcharType.VARCHAR,
+                100L, 200L, 1, true, new ArrayList<>(List.of(key)));
+
+        ExecDictionaryGet cloned = original.clone();
+        assertEquals(original.getDictionaryId(), cloned.getDictionaryId());
+        assertEquals(original.getTxnId(), cloned.getTxnId());
+        assertEquals(original.getKeySize(), cloned.getKeySize());
+        assertEquals(original.isNullIfNotExist(), cloned.isNullIfNotExist());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 22. ExecSubfield
+    // ======================================================================
+
+    @Test
+    public void testExecSubfieldConstruction() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        List<String> fieldNames = List.of("a", "b", "c");
+
+        ExecSubfield expr = new ExecSubfield(IntegerType.INT, fieldNames, false,
+                new ArrayList<>(List.of(structCol)));
+
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(fieldNames, expr.getFieldNames());
+        assertFalse(expr.isCopyFlag());
+        assertEquals(1, expr.getNumChildren());
+        assertEquals(TExprNodeType.SUBFIELD_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecSubfieldWithCopyFlag() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield expr = new ExecSubfield(IntegerType.INT, List.of("x"), true,
+                new ArrayList<>(List.of(structCol)));
+
+        assertTrue(expr.isCopyFlag());
+    }
+
+    @Test
+    public void testExecSubfieldToThrift() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        List<String> fieldNames = List.of("field1", "field2");
+        ExecSubfield expr = new ExecSubfield(IntegerType.INT, fieldNames, true,
+                new ArrayList<>(List.of(structCol)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertEquals(fieldNames, node.getUsed_subfield_names());
+        assertTrue(node.isCopy_flag());
+    }
+
+    @Test
+    public void testExecSubfieldVisitorDispatch() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield expr = new ExecSubfield(IntegerType.INT, List.of("a"), false,
+                new ArrayList<>(List.of(structCol)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecSubfield(ExecSubfield e, Void context) {
+                return "Subfield";
+            }
+        };
+        assertEquals("Subfield", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecSubfieldClone() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield original = new ExecSubfield(IntegerType.INT, List.of("a", "b"), true,
+                new ArrayList<>(List.of(structCol)));
+
+        ExecSubfield cloned = original.clone();
+        assertEquals(original.getFieldNames(), cloned.getFieldNames());
+        assertEquals(original.isCopyFlag(), cloned.isCopyFlag());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 23. ExecLambdaFunction
+    // ======================================================================
+
+    @Test
+    public void testExecLambdaFunctionConstruction() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+
+        ExecLambdaFunction expr = new ExecLambdaFunction(IntegerType.INT, 3, false,
+                new ArrayList<>(List.of(body, arg)));
+
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(3, expr.getCommonSubOperatorNum());
+        assertFalse(expr.isNondeterministic());
+        assertEquals(2, expr.getNumChildren());
+        assertEquals(TExprNodeType.LAMBDA_FUNCTION_EXPR, expr.getNodeType());
+        assertTrue(expr.isNullable());
+    }
+
+    @Test
+    public void testExecLambdaFunctionNondeterministic() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLambdaFunction expr = new ExecLambdaFunction(IntegerType.INT, 0, true,
+                new ArrayList<>(List.of(body)));
+
+        assertTrue(expr.isNondeterministic());
+    }
+
+    @Test
+    public void testExecLambdaFunctionToThrift() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLambdaFunction expr = new ExecLambdaFunction(IntegerType.INT, 5, true,
+                new ArrayList<>(List.of(body)));
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertEquals(5, node.getOutput_column());
+        assertTrue(node.isIs_nondeterministic());
+    }
+
+    @Test
+    public void testExecLambdaFunctionVisitorDispatch() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLambdaFunction expr = new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(body)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecLambdaFunction(ExecLambdaFunction e, Void context) {
+                return "LambdaFunction";
+            }
+        };
+        assertEquals("LambdaFunction", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecLambdaFunctionClone() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLambdaFunction original = new ExecLambdaFunction(IntegerType.INT, 3, true,
+                new ArrayList<>(List.of(body)));
+
+        ExecLambdaFunction cloned = original.clone();
+        assertEquals(original.getCommonSubOperatorNum(), cloned.getCommonSubOperatorNum());
+        assertEquals(original.isNondeterministic(), cloned.isNondeterministic());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+    }
+
+    // ======================================================================
+    // 24. ExecPlaceHolder
+    // ======================================================================
+
+    @Test
+    public void testExecPlaceHolderConstruction() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(42, true, IntegerType.INT);
+
+        assertEquals(42, expr.getSlotId());
+        assertTrue(expr.isNullable());
+        assertEquals(IntegerType.INT, expr.getType());
+        assertEquals(0, expr.getNumChildren());
+        assertEquals(TExprNodeType.PLACEHOLDER_EXPR, expr.getNodeType());
+    }
+
+    @Test
+    public void testExecPlaceHolderNonNullable() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(10, false, VarcharType.VARCHAR);
+
+        assertFalse(expr.isNullable());
+        assertEquals(10, expr.getSlotId());
+    }
+
+    @Test
+    public void testExecPlaceHolderIsNotConstant() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(1, false, IntegerType.INT);
+        assertFalse(expr.isConstant());
+    }
+
+    @Test
+    public void testExecPlaceHolderToThrift() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(42, true, IntegerType.INT);
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertNotNull(node.getVslot_ref());
+        assertEquals(42, node.getVslot_ref().getSlot_id());
+        assertTrue(node.getVslot_ref().isNullable());
+    }
+
+    @Test
+    public void testExecPlaceHolderToThriftNonNullable() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(7, false, IntegerType.INT);
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertEquals(7, node.getVslot_ref().getSlot_id());
+        assertFalse(node.getVslot_ref().isNullable());
+    }
+
+    @Test
+    public void testExecPlaceHolderVisitorDispatch() {
+        ExecPlaceHolder expr = new ExecPlaceHolder(1, false, IntegerType.INT);
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecPlaceHolder(ExecPlaceHolder e, Void context) {
+                return "PlaceHolder";
+            }
+        };
+        assertEquals("PlaceHolder", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecPlaceHolderClone() {
+        ExecPlaceHolder original = new ExecPlaceHolder(42, true, IntegerType.INT);
+
+        ExecPlaceHolder cloned = original.clone();
+        assertEquals(original.getSlotId(), cloned.getSlotId());
+        assertEquals(original.isNullable(), cloned.isNullable());
+        assertEquals(original.getType(), cloned.getType());
+    }
+
+    // ======================================================================
+    // 25. ExecInformationFunction
+    // ======================================================================
+
+    @Test
+    public void testExecInformationFunctionConstruction() {
+        ExecInformationFunction expr = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "mydb", 0L);
+
+        assertEquals(VarcharType.VARCHAR, expr.getType());
+        assertEquals("database", expr.getFuncName());
+        assertEquals("mydb", expr.getStrValue());
+        assertEquals(0L, expr.getIntValue());
+        assertEquals(0, expr.getNumChildren());
+        assertEquals(TExprNodeType.INFO_FUNC, expr.getNodeType());
+        assertFalse(expr.isNullable());
+        assertTrue(expr.isConstant());
+    }
+
+    @Test
+    public void testExecInformationFunctionWithIntValue() {
+        ExecInformationFunction expr = new ExecInformationFunction(
+                IntegerType.BIGINT, "connection_id", "", 12345L);
+
+        assertEquals("connection_id", expr.getFuncName());
+        assertEquals(12345L, expr.getIntValue());
+    }
+
+    @Test
+    public void testExecInformationFunctionToThrift() {
+        ExecInformationFunction expr = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "testdb", 0L);
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertNotNull(node.info_func);
+        assertEquals("testdb", node.info_func.getStr_value());
+        assertEquals(0L, node.info_func.getInt_value());
+    }
+
+    @Test
+    public void testExecInformationFunctionToThriftCurrentWarehouse() {
+        ExecInformationFunction expr = new ExecInformationFunction(
+                VarcharType.VARCHAR, "current_warehouse", "wh1", 0L);
+
+        TExprNode node = new TExprNode();
+        expr.toThrift(node);
+
+        assertNotNull(node.info_func);
+        assertEquals("wh1", node.info_func.getStr_value());
+    }
+
+    @Test
+    public void testExecInformationFunctionVisitorDispatch() {
+        ExecInformationFunction expr = new ExecInformationFunction(
+                VarcharType.VARCHAR, "user", "root", 0L);
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecInformationFunction(ExecInformationFunction e, Void context) {
+                return "InformationFunction";
+            }
+        };
+        assertEquals("InformationFunction", expr.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecInformationFunctionClone() {
+        ExecInformationFunction original = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "mydb", 0L);
+
+        ExecInformationFunction cloned = original.clone();
+        assertEquals(original.getFuncName(), cloned.getFuncName());
+        assertEquals(original.getStrValue(), cloned.getStrValue());
+        assertEquals(original.getIntValue(), cloned.getIntValue());
+        assertEquals(original.getType(), cloned.getType());
+    }
+
+    // ======================================================================
+    // 26. ExecExprUtils
+    // ======================================================================
+
+    @Test
+    public void testExecExprUtilsCollectSlotRefs() {
+        ExecSlotRef slot1 = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef slot2 = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+
+        ScalarFunction fn = makeScalarFunction("add", new Type[]{IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("add", IntegerType.INT, fn,
+                new ArrayList<>(List.of(slot1, literal)));
+
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, funcCall, slot2);
+
+        List<ExecSlotRef> slotRefs = ExecExprUtils.collectSlotRefs(pred);
+        assertEquals(2, slotRefs.size());
+    }
+
+    @Test
+    public void testExecExprUtilsCollectSlotRefsNoSlots() {
+        ExecLiteral literal = makeIntLiteral(42);
+        List<ExecSlotRef> slotRefs = ExecExprUtils.collectSlotRefs(literal);
+        assertTrue(slotRefs.isEmpty());
+    }
+
+    @Test
+    public void testExecExprUtilsGetUsedSlotIdsSingleExpr() {
+        ExecSlotRef slot1 = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef slot2 = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, slot1, slot2);
+
+        Set<SlotId> slotIds = ExecExprUtils.getUsedSlotIds(pred);
+        assertEquals(2, slotIds.size());
+        assertTrue(slotIds.contains(new SlotId(1)));
+        assertTrue(slotIds.contains(new SlotId(2)));
+    }
+
+    @Test
+    public void testExecExprUtilsGetUsedSlotIdsList() {
+        ExecSlotRef slot1 = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef slot2 = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecSlotRef slot3 = makeSlotRef(3, 0, IntegerType.INT, false);
+
+        Set<SlotId> slotIds = ExecExprUtils.getUsedSlotIds(List.of(slot1, slot2, slot3));
+        assertEquals(3, slotIds.size());
+    }
+
+    @Test
+    public void testExecExprUtilsIsBoundByTupleIds() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, slot, literal);
+
+        assertTrue(ExecExprUtils.isBoundByTupleIds(pred, List.of(new TupleId(0))));
+        assertFalse(ExecExprUtils.isBoundByTupleIds(pred, List.of(new TupleId(1))));
+    }
+
+    @Test
+    public void testExecExprUtilsIsBoundByTupleIdsLiteralOnly() {
+        ExecLiteral literal = makeIntLiteral(42);
+        // A literal is bound by any tuple
+        assertTrue(ExecExprUtils.isBoundByTupleIds(literal, List.of(new TupleId(999))));
+    }
+
+    @Test
+    public void testExecExprUtilsCloneList() {
+        ExecLiteral lit1 = makeIntLiteral(1);
+        ExecLiteral lit2 = makeIntLiteral(2);
+        ExecLiteral lit3 = makeIntLiteral(3);
+
+        List<ExecLiteral> originals = List.of(lit1, lit2, lit3);
+        List<ExecLiteral> clones = ExecExprUtils.cloneList(originals);
+
+        assertEquals(3, clones.size());
+        for (int i = 0; i < originals.size(); i++) {
+            assertEquals(originals.get(i).getValue().getInt(), clones.get(i).getValue().getInt());
+            assertTrue(originals.get(i) != clones.get(i)); // Different objects
+        }
+    }
+
+    @Test
+    public void testExecExprUtilsCompoundAndEmpty() {
+        assertNull(ExecExprUtils.compoundAnd(List.of()));
+        assertNull(ExecExprUtils.compoundAnd(null));
+    }
+
+    @Test
+    public void testExecExprUtilsCompoundAndSingle() {
+        ExecSlotRef slot = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecExpr result = ExecExprUtils.compoundAnd(List.of(slot));
+
+        // Single element should be returned as-is
+        assertEquals(slot, result);
+    }
+
+    @Test
+    public void testExecExprUtilsCompoundAndMultiple() {
+        ExecSlotRef slot1 = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef slot2 = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef slot3 = makeSlotRef(3, 0, BooleanType.BOOLEAN, false);
+
+        ExecExpr result = ExecExprUtils.compoundAnd(List.of(slot1, slot2, slot3));
+
+        // Should be a left-deep AND tree: AND(AND(slot1, slot2), slot3)
+        assertTrue(result instanceof ExecCompoundPredicate);
+        ExecCompoundPredicate outerAnd = (ExecCompoundPredicate) result;
+        assertEquals(CompoundPredicate.Operator.AND, outerAnd.getCompoundType());
+        assertTrue(outerAnd.getChild(0) instanceof ExecCompoundPredicate);
+    }
+
+    @Test
+    public void testExecExprUtilsContainsDictMappingExprFalse() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral literal = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, slot, literal);
+
+        assertFalse(ExecExprUtils.containsDictMappingExpr(pred));
+        assertFalse(ExecExprUtils.containsDictMappingExpr(null));
+    }
+
+    @Test
+    public void testExecExprUtilsContainsDictMappingExprTrue() {
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, false))));
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, dictMapping, makeIntLiteral(1));
+
+        assertTrue(ExecExprUtils.containsDictMappingExpr(pred));
+    }
+
+    @Test
+    public void testExecExprUtilsContainsDictMappingExprNested() {
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, false))));
+        ExecCast cast = new ExecCast(IntegerType.INT, dictMapping, false);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, cast, makeIntLiteral(1));
+
+        assertTrue(ExecExprUtils.containsDictMappingExpr(pred));
+    }
+
+    @Test
+    public void testExecExprUtilsUnwrapSlotRefDirect() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef unwrapped = ExecExprUtils.unwrapSlotRef(slot);
+        assertEquals(slot, unwrapped);
+    }
+
+    @Test
+    public void testExecExprUtilsUnwrapSlotRefThroughCast() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, slot, false);
+
+        ExecSlotRef unwrapped = ExecExprUtils.unwrapSlotRef(cast);
+        assertNotNull(unwrapped);
+        assertEquals(1, unwrapped.getSlotId().asInt());
+    }
+
+    @Test
+    public void testExecExprUtilsUnwrapSlotRefNestedCasts() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast1 = new ExecCast(IntegerType.BIGINT, slot, false);
+        ExecCast cast2 = new ExecCast(VarcharType.VARCHAR, cast1, false);
+
+        ExecSlotRef unwrapped = ExecExprUtils.unwrapSlotRef(cast2);
+        assertNotNull(unwrapped);
+        assertEquals(1, unwrapped.getSlotId().asInt());
+    }
+
+    @Test
+    public void testExecExprUtilsUnwrapSlotRefNonSlot() {
+        ExecLiteral literal = makeIntLiteral(42);
+        assertNull(ExecExprUtils.unwrapSlotRef(literal));
+    }
+
+    @Test
+    public void testExecExprUtilsUnwrapSlotRefCastOfNonSlot() {
+        ExecLiteral literal = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, literal, false);
+
+        assertNull(ExecExprUtils.unwrapSlotRef(cast));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -344,9 +344,10 @@ public class ExecExprTest {
 
     @Test
     public void testExecCastIsSelfMonotonic() {
+        // Cast is NOT self-monotonic: narrowing casts can overflow to NULL, breaking order
         ExecLiteral child = makeIntLiteral(1);
         ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
-        assertTrue(cast.isSelfMonotonic());
+        assertFalse(cast.isSelfMonotonic());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -26,19 +26,32 @@ import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.MatchExpr;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.ast.AssertNumRowsElement;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.SetType;
+import com.starrocks.thrift.TAssertion;
 import com.starrocks.thrift.TDictQueryExpr;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TJoinOp;
 import com.starrocks.thrift.TKeysType;
+import com.starrocks.thrift.TVarType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.DecimalType;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -2978,5 +2991,1712 @@ public class ExecExprTest {
         ExecCast cast = new ExecCast(IntegerType.BIGINT, literal, false);
 
         assertNull(ExecExprUtils.unwrapSlotRef(cast));
+    }
+
+    // ======================================================================
+    // 27. ExecExprExplain - verbose() and toSql() coverage
+    // ======================================================================
+
+    @Test
+    public void testVerboseExplainFunctionCall() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, true);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ScalarFunction fn = makeScalarFunction("sum", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+        ExecFunctionCall funcCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "sum", children,
+                false, false, true, false);
+
+        String verbose = ExecExprExplain.verboseExplain(funcCall);
+        // Verbose format includes function name, args, result type, nullable info
+        assertTrue(verbose.contains("sum"));
+        assertTrue(verbose.contains("args:"));
+        assertTrue(verbose.contains("result:"));
+        assertTrue(verbose.contains("args nullable:"));
+        assertTrue(verbose.contains("result nullable:"));
+    }
+
+    @Test
+    public void testVerboseExplainFunctionCallDistinct() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, true);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{IntegerType.INT}, IntegerType.BIGINT);
+        ExecFunctionCall funcCall = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", children,
+                true, false, true, false);
+
+        String verbose = ExecExprExplain.verboseExplain(funcCall);
+        assertTrue(verbose.contains("DISTINCT"));
+    }
+
+    @Test
+    public void testVerboseExplainFunctionCallCountStar() {
+        ScalarFunction fn = makeScalarFunction("count", new Type[]{}, IntegerType.BIGINT);
+        ExecFunctionCall countStar = new ExecFunctionCall(
+                IntegerType.BIGINT, fn, "count", List.of(),
+                false, false, true, false, true);
+
+        String verbose = ExecExprExplain.verboseExplain(countStar);
+        assertTrue(verbose.contains("count"));
+        assertTrue(verbose.contains("*"));
+    }
+
+    @Test
+    public void testVerboseExplainFunctionCallNoFn() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, true);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ExecFunctionCall funcCall = new ExecFunctionCall(
+                IntegerType.BIGINT, null, "my_func", children,
+                false, false, false, false);
+
+        String verbose = ExecExprExplain.verboseExplain(funcCall);
+        assertTrue(verbose.contains("my_func"));
+        // Without fn, no "args:" section
+        assertFalse(verbose.contains("args: "));
+    }
+
+    @Test
+    public void testVerboseExplainCastNoOp() {
+        // When child type matches target type, verbose should skip the cast display
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast = new ExecCast(IntegerType.INT, slot, false);
+
+        String verbose = ExecExprExplain.verboseExplain(cast);
+        // No-op cast should just show the child
+        assertFalse(verbose.contains("cast("));
+    }
+
+    @Test
+    public void testVerboseExplainCastWithTypeChange() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, slot, false);
+
+        String verbose = ExecExprExplain.verboseExplain(cast);
+        assertTrue(verbose.contains("cast("));
+        assertTrue(verbose.contains("BIGINT"));
+    }
+
+    @Test
+    public void testVerboseExplainBinaryPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.EQ, left, right);
+
+        String verbose = ExecExprExplain.verboseExplain(pred);
+        assertTrue(verbose.contains("="));
+        assertTrue(verbose.contains("10"));
+    }
+
+    @Test
+    public void testVerboseExplainCompoundPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+
+        ExecCompoundPredicate andPred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+        String verbose = ExecExprExplain.verboseExplain(andPred);
+        assertTrue(verbose.contains("AND"));
+
+        ExecCompoundPredicate orPred = new ExecCompoundPredicate(CompoundPredicate.Operator.OR, left, right);
+        verbose = ExecExprExplain.verboseExplain(orPred);
+        assertTrue(verbose.contains("OR"));
+
+        ExecCompoundPredicate notPred = new ExecCompoundPredicate(
+                CompoundPredicate.Operator.NOT, new ArrayList<>(List.of(left)));
+        verbose = ExecExprExplain.verboseExplain(notPred);
+        assertTrue(verbose.contains("NOT"));
+    }
+
+    @Test
+    public void testVerboseExplainInPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecLiteral v2 = makeIntLiteral(2);
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1, v2)));
+
+        String verbose = ExecExprExplain.verboseExplain(pred);
+        assertTrue(verbose.contains("IN"));
+
+        ExecInPredicate notIn = new ExecInPredicate(true, new ArrayList<>(List.of(col, v1)));
+        verbose = ExecExprExplain.verboseExplain(notIn);
+        assertTrue(verbose.contains("NOT"));
+        assertTrue(verbose.contains("IN"));
+    }
+
+    @Test
+    public void testVerboseExplainIsNullPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate isNull = new ExecIsNullPredicate(false, col);
+        String verbose = ExecExprExplain.verboseExplain(isNull);
+        assertTrue(verbose.contains("IS NULL"));
+
+        ExecIsNullPredicate isNotNull = new ExecIsNullPredicate(true, col);
+        verbose = ExecExprExplain.verboseExplain(isNotNull);
+        assertTrue(verbose.contains("IS NOT NULL"));
+    }
+
+    @Test
+    public void testVerboseExplainLikePredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate like = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        String verbose = ExecExprExplain.verboseExplain(like);
+        assertTrue(verbose.contains("LIKE"));
+
+        ExecLikePredicate regexp = new ExecLikePredicate(true, fn, new ArrayList<>(List.of(col, pattern)));
+        verbose = ExecExprExplain.verboseExplain(regexp);
+        assertTrue(verbose.contains("REGEXP"));
+    }
+
+    @Test
+    public void testVerboseExplainArithmetic() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+
+        String verbose = ExecExprExplain.verboseExplain(add);
+        assertTrue(verbose.contains("+"));
+    }
+
+    @Test
+    public void testVerboseExplainArithmeticUnary() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecArithmetic bitnot = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.BITNOT,
+                new ArrayList<>(List.of(child)));
+
+        String verbose = ExecExprExplain.verboseExplain(bitnot);
+        assertNotNull(verbose);
+    }
+
+    @Test
+    public void testVerboseExplainCaseWhen() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecLiteral elseVal = makeIntLiteral(0);
+        ExecCaseWhen caseWhen = new ExecCaseWhen(IntegerType.INT, false, true,
+                new ArrayList<>(List.of(cond, thenVal, elseVal)));
+
+        String verbose = ExecExprExplain.verboseExplain(caseWhen);
+        assertTrue(verbose.contains("CASE"));
+        assertTrue(verbose.contains("WHEN"));
+        assertTrue(verbose.contains("THEN"));
+        assertTrue(verbose.contains("ELSE"));
+        assertTrue(verbose.contains("END"));
+    }
+
+    @Test
+    public void testVerboseExplainCaseWhenWithCaseExpr() {
+        ExecSlotRef caseExpr = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral when1 = makeIntLiteral(1);
+        ExecLiteral then1 = makeIntLiteral(100);
+        ExecCaseWhen caseWhen = new ExecCaseWhen(IntegerType.INT, true, false,
+                new ArrayList<>(List.of(caseExpr, when1, then1)));
+
+        String verbose = ExecExprExplain.verboseExplain(caseWhen);
+        assertTrue(verbose.contains("CASE"));
+    }
+
+    @Test
+    public void testVerboseExplainBetweenPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate between = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        String verbose = ExecExprExplain.verboseExplain(between);
+        assertTrue(verbose.contains("BETWEEN"));
+        assertTrue(verbose.contains("AND"));
+
+        ExecBetweenPredicate notBetween = new ExecBetweenPredicate(true,
+                new ArrayList<>(List.of(col, low, high)));
+        verbose = ExecExprExplain.verboseExplain(notBetween);
+        assertTrue(verbose.contains("NOT"));
+        assertTrue(verbose.contains("BETWEEN"));
+    }
+
+    @Test
+    public void testVerboseExplainArrayExpr() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecLiteral e2 = makeIntLiteral(2);
+        ExecArrayExpr arr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1, e2)));
+
+        String verbose = ExecExprExplain.verboseExplain(arr);
+        assertTrue(verbose.contains("["));
+        assertTrue(verbose.contains("]"));
+    }
+
+    @Test
+    public void testVerboseExplainMapExpr() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key = makeVarcharLiteral("k");
+        ExecLiteral val = makeIntLiteral(1);
+        ExecMapExpr mapExpr = new ExecMapExpr(mapType, new ArrayList<>(List.of(key, val)));
+
+        String verbose = ExecExprExplain.verboseExplain(mapExpr);
+        assertTrue(verbose.contains("map{"));
+        assertTrue(verbose.contains("}"));
+    }
+
+    @Test
+    public void testVerboseExplainArraySlice() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral lower = makeIntLiteral(1);
+        ExecLiteral upper = makeIntLiteral(3);
+        ExecArraySlice slice = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, lower, upper)));
+
+        String verbose = ExecExprExplain.verboseExplain(slice);
+        assertTrue(verbose.contains("["));
+        assertTrue(verbose.contains(":"));
+    }
+
+    @Test
+    public void testVerboseExplainCollectionElement() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(arr, index)));
+
+        String verbose = ExecExprExplain.verboseExplain(elem);
+        assertTrue(verbose.contains("["));
+        assertTrue(verbose.contains("]"));
+    }
+
+    @Test
+    public void testVerboseExplainClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone clone = new ExecClone(IntegerType.INT, child);
+
+        String verbose = ExecExprExplain.verboseExplain(clone);
+        assertTrue(verbose.contains("clone("));
+    }
+
+    @Test
+    public void testVerboseExplainLambdaFunction() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(body, arg)));
+
+        String verbose = ExecExprExplain.verboseExplain(lambda);
+        assertTrue(verbose.contains("->"));
+    }
+
+    @Test
+    public void testVerboseExplainLambdaFunctionMultipleArgs() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg1 = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecSlotRef arg2 = makeSlotRef(3, 0, IntegerType.INT, false);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(body, arg1, arg2)));
+
+        String verbose = ExecExprExplain.verboseExplain(lambda);
+        assertTrue(verbose.contains("->"));
+        assertTrue(verbose.contains("("));
+    }
+
+    @Test
+    public void testVerboseExplainLambdaFunctionWithCommonSubExpr() {
+        // layout: [body, arg1, commonSlot1, commonExpr1]
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecSlotRef commonSlot = makeSlotRef(3, 0, IntegerType.INT, false);
+        ExecLiteral commonExpr = makeIntLiteral(42);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 1, false,
+                new ArrayList<>(List.of(body, arg, commonSlot, commonExpr)));
+
+        String verbose = ExecExprExplain.verboseExplain(lambda);
+        assertTrue(verbose.contains("lambda common expressions:"));
+        assertTrue(verbose.contains("<->"));
+    }
+
+    @Test
+    public void testVerboseExplainSubfield() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield subfield = new ExecSubfield(IntegerType.INT, List.of("a", "b"), true,
+                new ArrayList<>(List.of(structCol)));
+
+        String verbose = ExecExprExplain.verboseExplain(subfield);
+        assertTrue(verbose.contains("a.b"));
+        assertTrue(verbose.contains("[true]"));
+    }
+
+    @Test
+    public void testVerboseExplainDictMapping() {
+        // DictDecode when type matches child type
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef inner = makeSlotRef(2, 0, VarcharType.VARCHAR, false);
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(slot, inner)));
+
+        String verbose = ExecExprExplain.verboseExplain(dictMapping);
+        assertTrue(verbose.contains("DictDecode") || verbose.contains("DictDefine"));
+    }
+
+    @Test
+    public void testVerboseExplainDictMappingWithThreeChildren() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef inner = makeSlotRef(2, 0, VarcharType.VARCHAR, false);
+        ExecLiteral third = makeIntLiteral(0);
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(slot, inner, third)));
+
+        String verbose = ExecExprExplain.verboseExplain(dictMapping);
+        assertNotNull(verbose);
+    }
+
+    @Test
+    public void testVerboseExplainMatchExpr() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+
+        for (MatchExpr.MatchOperator op : MatchExpr.MatchOperator.values()) {
+            ExecMatchExpr expr = new ExecMatchExpr(op, new ArrayList<>(List.of(col, pattern)));
+            String verbose = ExecExprExplain.verboseExplain(expr);
+            assertTrue(verbose.contains("MATCH"));
+        }
+    }
+
+    @Test
+    public void testVerboseExplainPlaceHolder() {
+        ExecPlaceHolder ph = new ExecPlaceHolder(42, true, IntegerType.INT);
+        String verbose = ExecExprExplain.verboseExplain(ph);
+        assertEquals("<place-holder>", verbose);
+    }
+
+    @Test
+    public void testVerboseExplainInformationFunction() {
+        ExecInformationFunction info = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "mydb", 0L);
+        String verbose = ExecExprExplain.verboseExplain(info);
+        assertEquals("database()", verbose);
+    }
+
+    @Test
+    public void testVerboseExplainDictionaryGet() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet dictGet = new ExecDictionaryGet(VarcharType.VARCHAR,
+                100L, 200L, 1, true, new ArrayList<>(List.of(key)));
+
+        String verbose = ExecExprExplain.verboseExplain(dictGet);
+        assertTrue(verbose.contains("dictionary_get("));
+    }
+
+    @Test
+    public void testVerboseExplainDictQuery() {
+        TDictQueryExpr tDict = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery dictQuery = new ExecDictQuery(VarcharType.VARCHAR, tDict,
+                new ArrayList<>(List.of(child)));
+
+        String verbose = ExecExprExplain.verboseExplain(dictQuery);
+        assertTrue(verbose.contains("dict_query("));
+    }
+
+    @Test
+    public void testVerboseExplainList() {
+        ExecLiteral lit1 = makeIntLiteral(1);
+        ExecLiteral lit2 = makeIntLiteral(2);
+        String result = ExecExprExplain.verboseExplainList(List.of(lit1, lit2));
+        assertEquals("1, 2", result);
+    }
+
+    @Test
+    public void testToSqlNullLiteral() {
+        ExecLiteral nullLit = makeNullLiteral();
+        assertEquals("NULL", ExecExprExplain.toSql(nullLit));
+    }
+
+    @Test
+    public void testToSqlIntLiteral() {
+        ExecLiteral lit = makeIntLiteral(42);
+        assertEquals("42", ExecExprExplain.toSql(lit));
+    }
+
+    @Test
+    public void testToSqlVarcharLiteralNoTruncation() {
+        // toSql should not truncate long strings (unlike explain which does)
+        String longStr = "a".repeat(100);
+        ExecLiteral literal = makeVarcharLiteral(longStr);
+        String sql = ExecExprExplain.toSql(literal);
+        // toSql does NOT truncate
+        assertEquals("'" + longStr + "'", sql);
+    }
+
+    @Test
+    public void testToSqlVarcharWithEscapes() {
+        ExecLiteral literal = makeVarcharLiteral("it's a \\test");
+        String sql = ExecExprExplain.toSql(literal);
+        assertTrue(sql.contains("\\'"));
+        assertTrue(sql.contains("\\\\"));
+    }
+
+    @Test
+    public void testToSqlFunctionCall() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        List<ExecExpr> children = new ArrayList<>(List.of(slot));
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        ExecFunctionCall funcCall = makeFunctionCall("abs", IntegerType.INT, fn, children);
+
+        String sql = ExecExprExplain.toSql(funcCall);
+        assertTrue(sql.contains("abs("));
+    }
+
+    @Test
+    public void testToSqlBinaryPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecBinaryPredicate pred = new ExecBinaryPredicate(BinaryType.LT, left, right);
+
+        String sql = ExecExprExplain.toSql(pred);
+        assertTrue(sql.contains("<"));
+    }
+
+    @Test
+    public void testToSqlCast() {
+        ExecLiteral child = makeIntLiteral(42);
+        ExecCast cast = new ExecCast(IntegerType.BIGINT, child, false);
+        String sql = ExecExprExplain.toSql(cast);
+        assertTrue(sql.contains("CAST("));
+        assertTrue(sql.contains("BIGINT"));
+    }
+
+    @Test
+    public void testToSqlCompoundPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+        String sql = ExecExprExplain.toSql(pred);
+        assertTrue(sql.contains("AND"));
+    }
+
+    @Test
+    public void testToSqlInPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1)));
+        String sql = ExecExprExplain.toSql(pred);
+        assertTrue(sql.contains("IN"));
+    }
+
+    @Test
+    public void testToSqlIsNullPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(false, col);
+        String sql = ExecExprExplain.toSql(pred);
+        assertTrue(sql.contains("IS NULL"));
+    }
+
+    @Test
+    public void testToSqlLikePredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+        String sql = ExecExprExplain.toSql(pred);
+        assertTrue(sql.contains("LIKE"));
+    }
+
+    @Test
+    public void testToSqlArithmetic() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+        String sql = ExecExprExplain.toSql(add);
+        assertTrue(sql.contains("+"));
+    }
+
+    @Test
+    public void testToSqlCaseWhen() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecCaseWhen caseWhen = new ExecCaseWhen(IntegerType.INT, false, false,
+                new ArrayList<>(List.of(cond, thenVal)));
+        String sql = ExecExprExplain.toSql(caseWhen);
+        assertTrue(sql.contains("CASE"));
+        assertTrue(sql.contains("END"));
+    }
+
+    @Test
+    public void testToSqlBetweenPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate between = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+        String sql = ExecExprExplain.toSql(between);
+        assertTrue(sql.contains("BETWEEN"));
+    }
+
+    @Test
+    public void testToSqlArrayExpr() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecArrayExpr arr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1)));
+        String sql = ExecExprExplain.toSql(arr);
+        assertTrue(sql.contains("["));
+    }
+
+    @Test
+    public void testToSqlMapExpr() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key = makeVarcharLiteral("k");
+        ExecLiteral val = makeIntLiteral(1);
+        ExecMapExpr mapExpr = new ExecMapExpr(mapType, new ArrayList<>(List.of(key, val)));
+        String sql = ExecExprExplain.toSql(mapExpr);
+        assertTrue(sql.contains("map{"));
+    }
+
+    @Test
+    public void testToSqlCollectionElement() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(arr, index)));
+        String sql = ExecExprExplain.toSql(elem);
+        assertTrue(sql.contains("["));
+    }
+
+    @Test
+    public void testToSqlClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone clone = new ExecClone(IntegerType.INT, child);
+        String sql = ExecExprExplain.toSql(clone);
+        assertTrue(sql.contains("clone("));
+    }
+
+    @Test
+    public void testToSqlSubfield() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield subfield = new ExecSubfield(IntegerType.INT, List.of("a"), false,
+                new ArrayList<>(List.of(structCol)));
+        String sql = ExecExprExplain.toSql(subfield);
+        assertTrue(sql.contains(".a"));
+    }
+
+    @Test
+    public void testToSqlMatchExpr() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH_ANY,
+                new ArrayList<>(List.of(col, pattern)));
+        String sql = ExecExprExplain.toSql(expr);
+        assertTrue(sql.contains("MATCH_ANY"));
+    }
+
+    @Test
+    public void testToSqlInformationFunction() {
+        ExecInformationFunction info = new ExecInformationFunction(
+                VarcharType.VARCHAR, "user", "root", 0L);
+        String sql = ExecExprExplain.toSql(info);
+        assertEquals("user()", sql);
+    }
+
+    @Test
+    public void testToSqlDictionaryGet() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet dictGet = new ExecDictionaryGet(VarcharType.VARCHAR,
+                1L, 2L, 1, false, new ArrayList<>(List.of(key)));
+        String sql = ExecExprExplain.toSql(dictGet);
+        assertTrue(sql.contains("dictionary_get("));
+    }
+
+    @Test
+    public void testToSqlDictQuery() {
+        TDictQueryExpr tDict = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery dictQuery = new ExecDictQuery(VarcharType.VARCHAR, tDict,
+                new ArrayList<>(List.of(child)));
+        String sql = ExecExprExplain.toSql(dictQuery);
+        assertTrue(sql.contains("dict_query("));
+    }
+
+    @Test
+    public void testToSqlPlaceHolder() {
+        ExecPlaceHolder ph = new ExecPlaceHolder(1, false, IntegerType.INT);
+        String sql = ExecExprExplain.toSql(ph);
+        assertEquals("<place-holder>", sql);
+    }
+
+    @Test
+    public void testToSqlLambdaFunction() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(body, arg)));
+        String sql = ExecExprExplain.toSql(lambda);
+        assertTrue(sql.contains("->"));
+    }
+
+    @Test
+    public void testToSqlArraySlice() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral lower = makeIntLiteral(1);
+        ExecLiteral upper = makeIntLiteral(3);
+        ExecArraySlice slice = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, lower, upper)));
+        String sql = ExecExprExplain.toSql(slice);
+        assertTrue(sql.contains("["));
+        assertTrue(sql.contains(":"));
+    }
+
+    @Test
+    public void testExplainLargeStringTruncation() {
+        // Strings over 50 chars should be truncated in explain()
+        String longStr = "a".repeat(100);
+        ExecLiteral literal = makeVarcharLiteral(longStr);
+        String explain = ExecExprExplain.explain(literal);
+        assertTrue(explain.length() < 60); // Truncated
+        assertTrue(explain.endsWith("...'"));
+    }
+
+    @Test
+    public void testExplainDefaultVisitExecExpr() {
+        // The base visitExecExpr returns "<unknown-exec-expr>"
+        // We trigger it by passing an unknown expr type or using explain directly
+        String result = ExecExprExplain.explain(new ExecExpr(IntegerType.INT) {
+            @Override
+            public boolean isNullable() { return false; }
+
+            @Override
+            public TExprNodeType getNodeType() { return TExprNodeType.NULL_LITERAL; }
+
+            @Override
+            public void toThrift(TExprNode node) {}
+
+            @Override
+            public <R, C> R accept(ExecExprVisitor<R, C> visitor, C context) {
+                return visitor.visitExecExpr(this, context);
+            }
+
+            @Override
+            public ExecExpr clone() { return this; }
+        });
+        assertEquals("<unknown-exec-expr>", result);
+    }
+
+    // ======================================================================
+    // 28. ExecCollectionElement - 0% coverage
+    // ======================================================================
+
+    @Test
+    public void testExecCollectionElementConstructionArray() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, true,
+                new ArrayList<>(List.of(arr, index)));
+
+        assertEquals(IntegerType.INT, elem.getType());
+        assertTrue(elem.isCheckOutOfBounds());
+        assertTrue(elem.isNullable());
+        assertEquals(2, elem.getNumChildren());
+        assertEquals(TExprNodeType.ARRAY_ELEMENT_EXPR, elem.getNodeType());
+    }
+
+    @Test
+    public void testExecCollectionElementConstructionMap() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecSlotRef map = makeSlotRef(1, 0, mapType, false);
+        ExecLiteral key = makeVarcharLiteral("key1");
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(map, key)));
+
+        assertFalse(elem.isCheckOutOfBounds());
+        assertEquals(TExprNodeType.MAP_ELEMENT_EXPR, elem.getNodeType());
+    }
+
+    @Test
+    public void testExecCollectionElementToThrift() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, true,
+                new ArrayList<>(List.of(arr, index)));
+
+        TExprNode node = new TExprNode();
+        elem.toThrift(node);
+        assertTrue(node.isCheck_is_out_of_bounds());
+    }
+
+    @Test
+    public void testExecCollectionElementClone() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement original = new ExecCollectionElement(IntegerType.INT, true,
+                new ArrayList<>(List.of(arr, index)));
+        original.setIsIndexOnlyFilter(true);
+
+        ExecCollectionElement cloned = original.clone();
+        assertEquals(original.isCheckOutOfBounds(), cloned.isCheckOutOfBounds());
+        assertEquals(original.getNumChildren(), cloned.getNumChildren());
+        assertTrue(cloned.isIndexOnlyFilter());
+    }
+
+    @Test
+    public void testExecCollectionElementVisitorDispatch() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(arr, index)));
+
+        ExecExprVisitor<String, Void> visitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr e, Void context) {
+                return "default";
+            }
+
+            @Override
+            public String visitExecCollectionElement(ExecCollectionElement e, Void context) {
+                return "CollectionElement";
+            }
+        };
+        assertEquals("CollectionElement", elem.accept(visitor, null));
+    }
+
+    @Test
+    public void testExecCollectionElementSerialization() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, true,
+                new ArrayList<>(List.of(arr, index)));
+
+        TExpr texpr = ExecExprSerializer.serialize(elem);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.ARRAY_ELEMENT_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    // ======================================================================
+    // 29. ThriftEnumConverter - joinOperatorToThrift, assertionToThrift
+    // ======================================================================
+
+    @Test
+    public void testJoinOperatorToThriftAllValues() {
+        assertEquals(TJoinOp.INNER_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.INNER_JOIN));
+        assertEquals(TJoinOp.LEFT_OUTER_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.LEFT_OUTER_JOIN));
+        assertEquals(TJoinOp.LEFT_SEMI_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.LEFT_SEMI_JOIN));
+        assertEquals(TJoinOp.LEFT_ANTI_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.LEFT_ANTI_JOIN));
+        assertEquals(TJoinOp.RIGHT_SEMI_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.RIGHT_SEMI_JOIN));
+        assertEquals(TJoinOp.RIGHT_ANTI_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.RIGHT_ANTI_JOIN));
+        assertEquals(TJoinOp.RIGHT_OUTER_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.RIGHT_OUTER_JOIN));
+        assertEquals(TJoinOp.FULL_OUTER_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.FULL_OUTER_JOIN));
+        assertEquals(TJoinOp.CROSS_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.CROSS_JOIN));
+        assertEquals(TJoinOp.NULL_AWARE_LEFT_ANTI_JOIN,
+                ThriftEnumConverter.joinOperatorToThrift(JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN));
+        assertEquals(TJoinOp.ASOF_INNER_JOIN, ThriftEnumConverter.joinOperatorToThrift(JoinOperator.ASOF_INNER_JOIN));
+        assertEquals(TJoinOp.ASOF_LEFT_OUTER_JOIN,
+                ThriftEnumConverter.joinOperatorToThrift(JoinOperator.ASOF_LEFT_OUTER_JOIN));
+    }
+
+    @Test
+    public void testAssertionToThriftAllValues() {
+        assertEquals(TAssertion.EQ, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.EQ));
+        assertEquals(TAssertion.NE, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.NE));
+        assertEquals(TAssertion.LT, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.LT));
+        assertEquals(TAssertion.LE, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.LE));
+        assertEquals(TAssertion.GT, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.GT));
+        assertEquals(TAssertion.GE, ThriftEnumConverter.assertionToThrift(AssertNumRowsElement.Assertion.GE));
+    }
+
+    @Test
+    public void testSetTypeToThriftAndBack() {
+        assertEquals(TVarType.GLOBAL, ThriftEnumConverter.setTypeToThrift(SetType.GLOBAL));
+        assertEquals(TVarType.SESSION, ThriftEnumConverter.setTypeToThrift(SetType.SESSION));
+        assertEquals(TVarType.VERBOSE, ThriftEnumConverter.setTypeToThrift(SetType.VERBOSE));
+
+        assertEquals(SetType.GLOBAL, ThriftEnumConverter.setTypeFromThrift(TVarType.GLOBAL));
+        assertEquals(SetType.SESSION, ThriftEnumConverter.setTypeFromThrift(TVarType.SESSION));
+        assertEquals(SetType.VERBOSE, ThriftEnumConverter.setTypeFromThrift(TVarType.VERBOSE));
+    }
+
+    // ======================================================================
+    // 30. ExecExprSerializer - serialize less-common types
+    // ======================================================================
+
+    @Test
+    public void testSerializeCompoundPredicate() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.COMPOUND_PRED, texpr.getNodes().get(0).node_type);
+        assertEquals(TExprOpcode.COMPOUND_AND, texpr.getNodes().get(0).opcode);
+    }
+
+    @Test
+    public void testSerializeInPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecLiteral v2 = makeIntLiteral(2);
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1, v2)));
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+        assertEquals(4, texpr.getNodes().size());
+        assertEquals(TExprNodeType.IN_PRED, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeIsNullPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate pred = new ExecIsNullPredicate(false, col);
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.FUNCTION_CALL, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeLikePredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate pred = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        TExpr texpr = ExecExprSerializer.serialize(pred);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.FUNCTION_CALL, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeArithmetic() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+
+        TExpr texpr = ExecExprSerializer.serialize(add);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.ARITHMETIC_EXPR, texpr.getNodes().get(0).node_type);
+        assertEquals(TExprOpcode.ADD, texpr.getNodes().get(0).opcode);
+    }
+
+    @Test
+    public void testSerializeCaseWhen() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecLiteral elseVal = makeIntLiteral(0);
+        ExecCaseWhen caseWhen = new ExecCaseWhen(IntegerType.INT, false, true,
+                new ArrayList<>(List.of(cond, thenVal, elseVal)));
+
+        TExpr texpr = ExecExprSerializer.serialize(caseWhen);
+        assertEquals(4, texpr.getNodes().size());
+        assertEquals(TExprNodeType.CASE_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeMatchExpr() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr expr = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        TExpr texpr = ExecExprSerializer.serialize(expr);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.MATCH_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeNullTypeExpr() {
+        // When type is NULL_TYPE, serializer should emit a null literal with boolean type
+        ConstantOperator nullOp = ConstantOperator.createNull(com.starrocks.type.NullType.NULL);
+        ExecLiteral nullLit = new ExecLiteral(nullOp, com.starrocks.type.NullType.NULL);
+
+        TExpr texpr = ExecExprSerializer.serialize(nullLit);
+        assertEquals(1, texpr.getNodes().size());
+        assertEquals(TExprNodeType.NULL_LITERAL, texpr.getNodes().get(0).node_type);
+    }
+
+    // ======================================================================
+    // 31. ExecLiteral - BigInt, Float, Double, Decimal, Date, DateTime
+    // ======================================================================
+
+    @Test
+    public void testExecLiteralBigint() {
+        ConstantOperator constOp = ConstantOperator.createBigint(9876543210L);
+        ExecLiteral literal = new ExecLiteral(constOp, IntegerType.BIGINT);
+
+        assertEquals(TExprNodeType.INT_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.INT_LITERAL, node.node_type);
+        assertEquals(9876543210L, node.int_literal.value);
+
+        assertEquals("9876543210", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralFloat() {
+        ConstantOperator constOp = ConstantOperator.createFloat(3.14);
+        ExecLiteral literal = new ExecLiteral(constOp, FloatType.FLOAT);
+
+        assertEquals(TExprNodeType.FLOAT_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.FLOAT_LITERAL, node.node_type);
+        assertEquals(3.14, node.float_literal.value, 0.001);
+
+        String explain = ExecExprExplain.explain(literal);
+        assertTrue(explain.contains("3.14"));
+    }
+
+    @Test
+    public void testExecLiteralDouble() {
+        ConstantOperator constOp = ConstantOperator.createDouble(2.718281828);
+        ExecLiteral literal = new ExecLiteral(constOp, FloatType.DOUBLE);
+
+        assertEquals(TExprNodeType.FLOAT_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.FLOAT_LITERAL, node.node_type);
+    }
+
+    @Test
+    public void testExecLiteralDecimal() {
+        BigDecimal decVal = new BigDecimal("123.456");
+        DecimalType decType = new DecimalType(com.starrocks.type.PrimitiveType.DECIMAL64, 18, 6);
+        ConstantOperator constOp = ConstantOperator.createDecimal(decVal, decType);
+        ExecLiteral literal = new ExecLiteral(constOp, decType);
+
+        assertEquals(TExprNodeType.DECIMAL_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.DECIMAL_LITERAL, node.node_type);
+        assertNotNull(node.decimal_literal);
+        assertEquals("123.456", node.decimal_literal.value);
+
+        assertEquals("123.456", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralDecimal32() {
+        BigDecimal decVal = new BigDecimal("12.34");
+        DecimalType decType = new DecimalType(com.starrocks.type.PrimitiveType.DECIMAL32, 9, 2);
+        ConstantOperator constOp = ConstantOperator.createDecimal(decVal, decType);
+        ExecLiteral literal = new ExecLiteral(constOp, decType);
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.DECIMAL_LITERAL, node.node_type);
+        assertNotNull(node.decimal_literal.getInteger_value());
+    }
+
+    @Test
+    public void testExecLiteralDecimal128() {
+        BigDecimal decVal = new BigDecimal("123456789012345.678901234");
+        DecimalType decType = new DecimalType(com.starrocks.type.PrimitiveType.DECIMAL128, 38, 9);
+        ConstantOperator constOp = ConstantOperator.createDecimal(decVal, decType);
+        ExecLiteral literal = new ExecLiteral(constOp, decType);
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.DECIMAL_LITERAL, node.node_type);
+    }
+
+    @Test
+    public void testExecLiteralDate() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 3, 15, 0, 0, 0);
+        ConstantOperator constOp = ConstantOperator.createDate(dateTime);
+        ExecLiteral literal = new ExecLiteral(constOp, DateType.DATE);
+
+        assertEquals(TExprNodeType.DATE_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.DATE_LITERAL, node.node_type);
+        assertNotNull(node.date_literal);
+        assertEquals("2024-03-15", node.date_literal.value);
+
+        assertEquals("'2024-03-15'", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralDatetime() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 3, 15, 10, 30, 45);
+        ConstantOperator constOp = ConstantOperator.createDatetime(dateTime);
+        ExecLiteral literal = new ExecLiteral(constOp, DateType.DATETIME);
+
+        assertEquals(TExprNodeType.DATE_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.DATE_LITERAL, node.node_type);
+        assertEquals("2024-03-15 10:30:45", node.date_literal.value);
+
+        assertEquals("'2024-03-15 10:30:45'", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralDatetimeWithMicroseconds() {
+        LocalDateTime dateTime = LocalDateTime.of(2024, 3, 15, 10, 30, 45, 123456000);
+        ConstantOperator constOp = ConstantOperator.createDatetime(dateTime);
+        ExecLiteral literal = new ExecLiteral(constOp, DateType.DATETIME);
+
+        String explain = ExecExprExplain.explain(literal);
+        assertTrue(explain.contains("123456"));
+    }
+
+    @Test
+    public void testExecLiteralLargeInt() {
+        BigInteger largeInt = new BigInteger("123456789012345678901234567890");
+        ConstantOperator constOp = ConstantOperator.createLargeInt(largeInt);
+        ExecLiteral literal = new ExecLiteral(constOp, IntegerType.LARGEINT);
+
+        assertEquals(TExprNodeType.LARGE_INT_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(TExprNodeType.LARGE_INT_LITERAL, node.node_type);
+        assertNotNull(node.large_int_literal);
+
+        assertEquals("123456789012345678901234567890", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralTinyint() {
+        ConstantOperator constOp = ConstantOperator.createTinyInt((byte) 42);
+        ExecLiteral literal = new ExecLiteral(constOp, IntegerType.TINYINT);
+
+        assertEquals(TExprNodeType.INT_LITERAL, literal.getNodeType());
+
+        TExpr texpr = ExecExprSerializer.serialize(literal);
+        TExprNode node = texpr.getNodes().get(0);
+        assertEquals(42, node.int_literal.value);
+
+        assertEquals("42", ExecExprExplain.explain(literal));
+    }
+
+    @Test
+    public void testExecLiteralSmallint() {
+        ConstantOperator constOp = ConstantOperator.createSmallInt((short) 1024);
+        ExecLiteral literal = new ExecLiteral(constOp, IntegerType.SMALLINT);
+
+        assertEquals(TExprNodeType.INT_LITERAL, literal.getNodeType());
+        assertEquals("1024", ExecExprExplain.explain(literal));
+    }
+
+    // ======================================================================
+    // 32. ExprOpcodeRegistry - getExprOpcode for various expression types
+    // ======================================================================
+
+    @Test
+    public void testGetExprOpcodeBinaryPredicate() {
+        // BinaryPredicate needs actual AST Expr, skip if too complex.
+        // But we can test getMatchOpcode for all values explicitly
+        assertEquals(TExprOpcode.MATCH, ExprOpcodeRegistry.getMatchOpcode(MatchExpr.MatchOperator.MATCH));
+        assertEquals(TExprOpcode.MATCH_ANY, ExprOpcodeRegistry.getMatchOpcode(MatchExpr.MatchOperator.MATCH_ANY));
+        assertEquals(TExprOpcode.MATCH_ALL, ExprOpcodeRegistry.getMatchOpcode(MatchExpr.MatchOperator.MATCH_ALL));
+    }
+
+    // ======================================================================
+    // 33. ExecExprVisitor - default fallback chains for all types
+    // ======================================================================
+
+    @Test
+    public void testVisitorDefaultFallbackAllTypes() {
+        // A minimal visitor that only overrides visitExecExpr.
+        // All specific types should fall back to visitExecExpr.
+        ExecExprVisitor<String, Void> defaultVisitor = new ExecExprVisitor<>() {
+            @Override
+            public String visitExecExpr(ExecExpr expr, Void context) {
+                return "fallback";
+            }
+        };
+
+        // Test each ExecExpr subclass falls back to visitExecExpr
+        assertEquals("fallback", makeSlotRef(1, 0, IntegerType.INT, false).accept(defaultVisitor, null));
+        assertEquals("fallback", makeIntLiteral(1).accept(defaultVisitor, null));
+
+        ScalarFunction fn = makeScalarFunction("abs", new Type[]{IntegerType.INT}, IntegerType.INT);
+        assertEquals("fallback", makeFunctionCall("abs", IntegerType.INT, fn, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecCast(IntegerType.BIGINT, makeIntLiteral(1), false)
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecBinaryPredicate(BinaryType.EQ,
+                makeSlotRef(1, 0, IntegerType.INT, false), makeIntLiteral(1))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecCompoundPredicate(CompoundPredicate.Operator.AND,
+                makeSlotRef(1, 0, BooleanType.BOOLEAN, false),
+                makeSlotRef(2, 0, BooleanType.BOOLEAN, false))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecInPredicate(false,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, false), makeIntLiteral(1))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecIsNullPredicate(false,
+                makeSlotRef(1, 0, IntegerType.INT, true))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecLikePredicate(false, null,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, VarcharType.VARCHAR, false), makeVarcharLiteral("x"))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(makeIntLiteral(5), makeIntLiteral(1), makeIntLiteral(10))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecCaseWhen(IntegerType.INT, false, false,
+                new ArrayList<>(List.of(makeIntLiteral(1), makeIntLiteral(2))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, VarcharType.VARCHAR, false), makeVarcharLiteral("x"))))
+                .accept(defaultVisitor, null));
+
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        assertEquals("fallback", new ExecArrayExpr(arrayType, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        assertEquals("fallback", new ExecMapExpr(mapType, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, arrayType, false), makeIntLiteral(0))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecArraySlice(arrayType, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecSubfield(IntegerType.INT, List.of("a"), false,
+                new ArrayList<>(List.of(makeSlotRef(1, 0, IntegerType.INT, false))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(makeIntLiteral(1))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecDictMapping(VarcharType.VARCHAR, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecClone(IntegerType.INT, makeIntLiteral(1))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecDictQuery(VarcharType.VARCHAR, new TDictQueryExpr(),
+                new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecDictionaryGet(VarcharType.VARCHAR,
+                1L, 2L, 1, false, new ArrayList<>())
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecPlaceHolder(1, false, IntegerType.INT)
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(makeIntLiteral(1), makeIntLiteral(2))))
+                .accept(defaultVisitor, null));
+
+        assertEquals("fallback", new ExecInformationFunction(VarcharType.VARCHAR, "user", "root", 0L)
+                .accept(defaultVisitor, null));
+    }
+
+    // ======================================================================
+    // 34. ExecSlotRef - additional coverage for setNullable and label constructor
+    // ======================================================================
+
+    @Test
+    public void testExecSlotRefSetNullable() {
+        ExecSlotRef slotRef = makeSlotRef(1, 0, IntegerType.INT, true);
+        assertTrue(slotRef.isNullable());
+
+        // setNullable should propagate to the descriptor
+        slotRef.setNullable(false);
+        assertFalse(slotRef.isNullable());
+        assertFalse(slotRef.getDesc().getIsNullable());
+
+        slotRef.setNullable(true);
+        assertTrue(slotRef.isNullable());
+        assertTrue(slotRef.getDesc().getIsNullable());
+    }
+
+    @Test
+    public void testExecSlotRefLabelConstructorClone() {
+        SlotDescriptor desc = makeSlotDescriptor(7, 3, IntegerType.INT, true);
+        ExecSlotRef original = new ExecSlotRef("my_column", desc);
+
+        ExecSlotRef cloned = original.clone();
+        assertEquals("my_column", cloned.getLabel());
+        assertEquals(7, cloned.getSlotId().asInt());
+        assertEquals(original.isNullable(), cloned.isNullable());
+    }
+
+    @Test
+    public void testExecSlotRefCharToVarcharConversion() {
+        // CHAR types should be converted to VARCHAR in constructor
+        com.starrocks.type.ScalarType charType = new com.starrocks.type.ScalarType(
+                com.starrocks.type.PrimitiveType.CHAR);
+        SlotDescriptor desc = makeSlotDescriptor(1, 0, charType, false);
+        ExecSlotRef slotRef = new ExecSlotRef(desc);
+
+        // Type should have been converted to VARCHAR
+        assertTrue(slotRef.getType().isVarchar());
+    }
+
+    @Test
+    public void testExecSlotRefCharToVarcharLabelConstructor() {
+        com.starrocks.type.ScalarType charType = new com.starrocks.type.ScalarType(
+                com.starrocks.type.PrimitiveType.CHAR);
+        SlotDescriptor desc = makeSlotDescriptor(1, 0, charType, false);
+        ExecSlotRef slotRef = new ExecSlotRef("char_col", desc);
+
+        assertTrue(slotRef.getType().isVarchar());
+    }
+
+    // ======================================================================
+    // 35. ExecExprExplain - explain for CompoundPredicate, InPredicate etc.
+    // ======================================================================
+
+    @Test
+    public void testExplainCompoundPredicateAnd() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.AND, left, right);
+
+        String explain = ExecExprExplain.explain(pred);
+        assertTrue(explain.contains("AND"));
+        assertTrue(explain.contains("("));
+    }
+
+    @Test
+    public void testExplainCompoundPredicateOr() {
+        ExecSlotRef left = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecSlotRef right = makeSlotRef(2, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(CompoundPredicate.Operator.OR, left, right);
+
+        String explain = ExecExprExplain.explain(pred);
+        assertTrue(explain.contains("OR"));
+    }
+
+    @Test
+    public void testExplainCompoundPredicateNot() {
+        ExecSlotRef child = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecCompoundPredicate pred = new ExecCompoundPredicate(
+                CompoundPredicate.Operator.NOT, new ArrayList<>(List.of(child)));
+
+        String explain = ExecExprExplain.explain(pred);
+        assertTrue(explain.contains("NOT"));
+    }
+
+    @Test
+    public void testExplainInPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecLiteral v2 = makeIntLiteral(2);
+        ExecInPredicate pred = new ExecInPredicate(false, new ArrayList<>(List.of(col, v1, v2)));
+
+        String explain = ExecExprExplain.explain(pred);
+        assertTrue(explain.contains("IN"));
+        assertTrue(explain.contains("1"));
+        assertTrue(explain.contains("2"));
+    }
+
+    @Test
+    public void testExplainInPredicateNotIn() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral v1 = makeIntLiteral(1);
+        ExecInPredicate pred = new ExecInPredicate(true, new ArrayList<>(List.of(col, v1)));
+
+        String explain = ExecExprExplain.explain(pred);
+        assertTrue(explain.contains("NOT"));
+        assertTrue(explain.contains("IN"));
+    }
+
+    @Test
+    public void testExplainIsNullPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, true);
+        ExecIsNullPredicate isNull = new ExecIsNullPredicate(false, col);
+        String explain = ExecExprExplain.explain(isNull);
+        assertTrue(explain.contains("IS NULL"));
+
+        ExecIsNullPredicate isNotNull = new ExecIsNullPredicate(true, col);
+        explain = ExecExprExplain.explain(isNotNull);
+        assertTrue(explain.contains("IS NOT NULL"));
+    }
+
+    @Test
+    public void testExplainLikePredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("%test%");
+        ScalarFunction fn = makeScalarFunction("like", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate like = new ExecLikePredicate(false, fn, new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals("<slot 1> LIKE '%test%'", ExecExprExplain.explain(like));
+    }
+
+    @Test
+    public void testExplainRegexpPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("^test.*$");
+        ScalarFunction fn = makeScalarFunction("regexp", new Type[]{VarcharType.VARCHAR, VarcharType.VARCHAR},
+                BooleanType.BOOLEAN);
+        ExecLikePredicate regexp = new ExecLikePredicate(true, fn, new ArrayList<>(List.of(col, pattern)));
+
+        String explain = ExecExprExplain.explain(regexp);
+        assertTrue(explain.contains("REGEXP"));
+    }
+
+    @Test
+    public void testExplainArithmetic() {
+        ExecSlotRef left = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral right = makeIntLiteral(10);
+        ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
+                new ArrayList<>(List.of(left, right)));
+
+        String explain = ExecExprExplain.explain(add);
+        assertTrue(explain.contains("+"));
+    }
+
+    @Test
+    public void testExplainArithmeticUnary() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecArithmetic bitnot = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.BITNOT,
+                new ArrayList<>(List.of(child)));
+
+        String explain = ExecExprExplain.explain(bitnot);
+        assertNotNull(explain);
+        assertTrue(explain.contains("~"));
+    }
+
+    @Test
+    public void testExplainCaseWhen() {
+        ExecSlotRef cond = makeSlotRef(1, 0, BooleanType.BOOLEAN, false);
+        ExecLiteral thenVal = makeIntLiteral(1);
+        ExecLiteral elseVal = makeIntLiteral(0);
+        ExecCaseWhen caseWhen = new ExecCaseWhen(IntegerType.INT, false, true,
+                new ArrayList<>(List.of(cond, thenVal, elseVal)));
+
+        String explain = ExecExprExplain.explain(caseWhen);
+        assertTrue(explain.contains("CASE"));
+        assertTrue(explain.contains("WHEN"));
+        assertTrue(explain.contains("THEN"));
+        assertTrue(explain.contains("ELSE"));
+        assertTrue(explain.contains("END"));
+    }
+
+    @Test
+    public void testExplainBetweenPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate between = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        String explain = ExecExprExplain.explain(between);
+        assertEquals("<slot 1> BETWEEN 1 AND 10", explain);
+    }
+
+    @Test
+    public void testExplainNotBetweenPredicate() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate notBetween = new ExecBetweenPredicate(true,
+                new ArrayList<>(List.of(col, low, high)));
+
+        String explain = ExecExprExplain.explain(notBetween);
+        assertEquals("<slot 1> NOT BETWEEN 1 AND 10", explain);
+    }
+
+    @Test
+    public void testExplainArrayExpr() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecLiteral e2 = makeIntLiteral(2);
+        ExecLiteral e3 = makeIntLiteral(3);
+        ExecArrayExpr arr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1, e2, e3)));
+
+        assertEquals("[1,2,3]", ExecExprExplain.explain(arr));
+    }
+
+    @Test
+    public void testExplainMapExpr() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key1 = makeVarcharLiteral("a");
+        ExecLiteral val1 = makeIntLiteral(1);
+        ExecLiteral key2 = makeVarcharLiteral("b");
+        ExecLiteral val2 = makeIntLiteral(2);
+        ExecMapExpr mapExpr = new ExecMapExpr(mapType, new ArrayList<>(List.of(key1, val1, key2, val2)));
+
+        String explain = ExecExprExplain.explain(mapExpr);
+        assertEquals("map{'a':1,'b':2}", explain);
+    }
+
+    @Test
+    public void testExplainArraySlice() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral lower = makeIntLiteral(1);
+        ExecLiteral upper = makeIntLiteral(3);
+        ExecArraySlice slice = new ExecArraySlice(arrayType, new ArrayList<>(List.of(arr, lower, upper)));
+
+        String explain = ExecExprExplain.explain(slice);
+        assertEquals("<slot 1>[1:3]", explain);
+    }
+
+    @Test
+    public void testExplainCollectionElement() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecSlotRef arr = makeSlotRef(1, 0, arrayType, false);
+        ExecLiteral index = makeIntLiteral(0);
+        ExecCollectionElement elem = new ExecCollectionElement(IntegerType.INT, false,
+                new ArrayList<>(List.of(arr, index)));
+
+        String explain = ExecExprExplain.explain(elem);
+        assertEquals("<slot 1>[0]", explain);
+    }
+
+    @Test
+    public void testExplainClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone clone = new ExecClone(IntegerType.INT, child);
+
+        assertEquals("clone(<slot 1>)", ExecExprExplain.explain(clone));
+    }
+
+    @Test
+    public void testExplainSubfield() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield subfield = new ExecSubfield(IntegerType.INT, List.of("a", "b"), true,
+                new ArrayList<>(List.of(structCol)));
+
+        String explain = ExecExprExplain.explain(subfield);
+        assertEquals("<slot 1>.a.b[true]", explain);
+    }
+
+    @Test
+    public void testExplainDictMapping() {
+        ExecSlotRef slot = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef inner = makeSlotRef(2, 0, VarcharType.VARCHAR, false);
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(slot, inner)));
+
+        String explain = ExecExprExplain.explain(dictMapping);
+        assertTrue(explain.contains("DictDecode") || explain.contains("DictDefine"));
+        assertTrue(explain.contains("["));
+    }
+
+    @Test
+    public void testExplainDictQuery() {
+        TDictQueryExpr tDict = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery dictQuery = new ExecDictQuery(VarcharType.VARCHAR, tDict,
+                new ArrayList<>(List.of(child)));
+
+        String explain = ExecExprExplain.explain(dictQuery);
+        assertTrue(explain.contains("dict_query("));
+    }
+
+    @Test
+    public void testExplainDictionaryGet() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet dictGet = new ExecDictionaryGet(VarcharType.VARCHAR,
+                1L, 2L, 1, false, new ArrayList<>(List.of(key)));
+
+        String explain = ExecExprExplain.explain(dictGet);
+        assertTrue(explain.contains("dictionary_get("));
+    }
+
+    @Test
+    public void testExplainPlaceHolder() {
+        ExecPlaceHolder ph = new ExecPlaceHolder(42, true, IntegerType.INT);
+        assertEquals("<place-holder>", ExecExprExplain.explain(ph));
+    }
+
+    @Test
+    public void testExplainInformationFunction() {
+        ExecInformationFunction info = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "mydb", 0L);
+        assertEquals("database()", ExecExprExplain.explain(info));
+    }
+
+    @Test
+    public void testExplainMatchExpr() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr match = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH,
+                new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals("<slot 1> MATCH 'test'", ExecExprExplain.explain(match));
+    }
+
+    @Test
+    public void testExplainMatchExprAny() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr match = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH_ANY,
+                new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals("<slot 1> MATCH_ANY 'test'", ExecExprExplain.explain(match));
+    }
+
+    @Test
+    public void testExplainMatchExprAll() {
+        ExecSlotRef col = makeSlotRef(1, 0, VarcharType.VARCHAR, false);
+        ExecLiteral pattern = makeVarcharLiteral("test");
+        ExecMatchExpr match = new ExecMatchExpr(MatchExpr.MatchOperator.MATCH_ALL,
+                new ArrayList<>(List.of(col, pattern)));
+
+        assertEquals("<slot 1> MATCH_ALL 'test'", ExecExprExplain.explain(match));
+    }
+
+    @Test
+    public void testExplainLambdaFunction() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 0, false,
+                new ArrayList<>(List.of(body, arg)));
+
+        String explain = ExecExprExplain.explain(lambda);
+        assertTrue(explain.contains("->"));
+    }
+
+    // ======================================================================
+    // 36. Additional serialization edge cases
+    // ======================================================================
+
+    @Test
+    public void testSerializeArrayExpr() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ExecLiteral e1 = makeIntLiteral(1);
+        ExecArrayExpr arr = new ExecArrayExpr(arrayType, new ArrayList<>(List.of(e1)));
+
+        TExpr texpr = ExecExprSerializer.serialize(arr);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.ARRAY_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeMapExpr() {
+        MapType mapType = new MapType(VarcharType.VARCHAR, IntegerType.INT);
+        ExecLiteral key = makeVarcharLiteral("k");
+        ExecLiteral val = makeIntLiteral(1);
+        ExecMapExpr mapExpr = new ExecMapExpr(mapType, new ArrayList<>(List.of(key, val)));
+
+        TExpr texpr = ExecExprSerializer.serialize(mapExpr);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.MAP_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeClone() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecClone clone = new ExecClone(IntegerType.INT, child);
+
+        TExpr texpr = ExecExprSerializer.serialize(clone);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.CLONE_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeSubfield() {
+        ExecSlotRef structCol = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSubfield subfield = new ExecSubfield(IntegerType.INT, List.of("a", "b"), true,
+                new ArrayList<>(List.of(structCol)));
+
+        TExpr texpr = ExecExprSerializer.serialize(subfield);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.SUBFIELD_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeLambdaFunction() {
+        ExecSlotRef body = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecSlotRef arg = makeSlotRef(2, 0, IntegerType.INT, false);
+        ExecLambdaFunction lambda = new ExecLambdaFunction(IntegerType.INT, 3, true,
+                new ArrayList<>(List.of(body, arg)));
+
+        TExpr texpr = ExecExprSerializer.serialize(lambda);
+        assertEquals(3, texpr.getNodes().size());
+        assertEquals(TExprNodeType.LAMBDA_FUNCTION_EXPR, texpr.getNodes().get(0).node_type);
+        assertEquals(3, texpr.getNodes().get(0).getOutput_column());
+        assertTrue(texpr.getNodes().get(0).isIs_nondeterministic());
+    }
+
+    @Test
+    public void testSerializePlaceHolder() {
+        ExecPlaceHolder ph = new ExecPlaceHolder(42, true, IntegerType.INT);
+
+        TExpr texpr = ExecExprSerializer.serialize(ph);
+        assertEquals(1, texpr.getNodes().size());
+        assertEquals(TExprNodeType.PLACEHOLDER_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeInformationFunction() {
+        ExecInformationFunction info = new ExecInformationFunction(
+                VarcharType.VARCHAR, "database", "mydb", 0L);
+
+        TExpr texpr = ExecExprSerializer.serialize(info);
+        assertEquals(1, texpr.getNodes().size());
+        assertEquals(TExprNodeType.INFO_FUNC, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeDictionaryGet() {
+        ExecSlotRef key = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictionaryGet dictGet = new ExecDictionaryGet(VarcharType.VARCHAR,
+                100L, 200L, 1, true, new ArrayList<>(List.of(key)));
+
+        TExpr texpr = ExecExprSerializer.serialize(dictGet);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.DICTIONARY_GET_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeDictQuery() {
+        TDictQueryExpr tDict = new TDictQueryExpr();
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictQuery dictQuery = new ExecDictQuery(VarcharType.VARCHAR, tDict,
+                new ArrayList<>(List.of(child)));
+
+        TExpr texpr = ExecExprSerializer.serialize(dictQuery);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.DICT_QUERY_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeDictMapping() {
+        ExecSlotRef child = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecDictMapping dictMapping = new ExecDictMapping(VarcharType.VARCHAR,
+                new ArrayList<>(List.of(child)));
+
+        TExpr texpr = ExecExprSerializer.serialize(dictMapping);
+        assertEquals(2, texpr.getNodes().size());
+        assertEquals(TExprNodeType.DICT_EXPR, texpr.getNodes().get(0).node_type);
+    }
+
+    @Test
+    public void testSerializeBetweenPredicateThrows() {
+        ExecSlotRef col = makeSlotRef(1, 0, IntegerType.INT, false);
+        ExecLiteral low = makeIntLiteral(1);
+        ExecLiteral high = makeIntLiteral(10);
+        ExecBetweenPredicate pred = new ExecBetweenPredicate(false,
+                new ArrayList<>(List.of(col, low, high)));
+
+        // BetweenPredicate throws on toThrift/getNodeType since it should be rewritten
+        assertThrows(IllegalStateException.class, () -> ExecExprSerializer.serialize(pred));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScalarOperatorToExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScalarOperatorToExecExprTest.java
@@ -1,0 +1,713 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.common.FeConstants;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.expression.ExecArithmetic;
+import com.starrocks.planner.expression.ExecArrayExpr;
+import com.starrocks.planner.expression.ExecBetweenPredicate;
+import com.starrocks.planner.expression.ExecBinaryPredicate;
+import com.starrocks.planner.expression.ExecCaseWhen;
+import com.starrocks.planner.expression.ExecCast;
+import com.starrocks.planner.expression.ExecCompoundPredicate;
+import com.starrocks.planner.expression.ExecExpr;
+import com.starrocks.planner.expression.ExecFunctionCall;
+import com.starrocks.planner.expression.ExecInPredicate;
+import com.starrocks.planner.expression.ExecInformationFunction;
+import com.starrocks.planner.expression.ExecIsNullPredicate;
+import com.starrocks.planner.expression.ExecLambdaFunction;
+import com.starrocks.planner.expression.ExecLikePredicate;
+import com.starrocks.planner.expression.ExecLiteral;
+import com.starrocks.planner.expression.ExecMapExpr;
+import com.starrocks.planner.expression.ExecSlotRef;
+import com.starrocks.planner.expression.ExecSubfield;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.ArithmeticExpr;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MapOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
+import com.starrocks.thrift.TFunctionBinaryType;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScalarOperatorToExecExprTest {
+
+    @BeforeAll
+    public static void setUp() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        FeConstants.runningUnitTest = false;
+    }
+
+    // ---- Helper methods ----
+
+    private static ScalarOperatorToExecExpr.FormatterContext makeContext(
+            Map<ColumnRefOperator, ExecExpr> colRefToExecExpr) {
+        return new ScalarOperatorToExecExpr.FormatterContext(colRefToExecExpr);
+    }
+
+    private static ScalarOperatorToExecExpr.FormatterContext emptyContext() {
+        return makeContext(new HashMap<>());
+    }
+
+    private static ExecSlotRef makeSlotRef(int id, String name, Type type, boolean nullable) {
+        SlotDescriptor desc = new SlotDescriptor(new SlotId(id), name, type, nullable);
+        return new ExecSlotRef(desc);
+    }
+
+    private static Function makeScalarFunction(String name, Type[] argTypes, Type retType) {
+        Function fn = new Function(new FunctionName(name), argTypes, retType, false);
+        fn.setBinaryType(TFunctionBinaryType.BUILTIN);
+        return fn;
+    }
+
+    // ---- Tests ----
+
+    @Test
+    public void testVisitVariableReference() {
+        ColumnRefOperator colRef = new ColumnRefOperator(1, IntegerType.INT, "col1", true);
+        ExecSlotRef slotRef = makeSlotRef(1, "col1", IntegerType.INT, true);
+
+        Map<ColumnRefOperator, ExecExpr> map = new HashMap<>();
+        map.put(colRef, slotRef);
+        ScalarOperatorToExecExpr.FormatterContext ctx = makeContext(map);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(colRef, ctx);
+        assertInstanceOf(ExecSlotRef.class, result);
+        assertEquals(IntegerType.INT, result.getType());
+    }
+
+    @Test
+    public void testVisitVariableReferenceNotFound() {
+        ColumnRefOperator colRef = new ColumnRefOperator(1, IntegerType.INT, "col1", true);
+        ScalarOperatorToExecExpr.FormatterContext ctx = emptyContext();
+
+        SemanticException ex = assertThrows(SemanticException.class, () -> {
+            ScalarOperatorToExecExpr.build(colRef, ctx);
+        });
+        assertTrue(ex.getMessage().contains("Cannot convert ColumnRefOperator"));
+    }
+
+    @Test
+    public void testVisitVariableReferenceWithProjectMap() {
+        ColumnRefOperator colRef = new ColumnRefOperator(1, IntegerType.INT, "col1", true);
+        // The projected expression is a constant
+        ConstantOperator projected = ConstantOperator.createInt(42);
+
+        Map<ColumnRefOperator, ExecExpr> colRefToExecExpr = new HashMap<>();
+        Map<ColumnRefOperator, com.starrocks.sql.optimizer.operator.scalar.ScalarOperator> projectMap =
+                new HashMap<>();
+        projectMap.put(colRef, projected);
+
+        ScalarOperatorToExecExpr.FormatterContext ctx =
+                new ScalarOperatorToExecExpr.FormatterContext(colRefToExecExpr, projectMap);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(colRef, ctx);
+        assertInstanceOf(ExecLiteral.class, result);
+        assertEquals(42, ((ExecLiteral) result).getValue().getInt());
+    }
+
+    @Test
+    public void testVisitConstantInt() {
+        ConstantOperator intConst = ConstantOperator.createInt(100);
+        ExecExpr result = ScalarOperatorToExecExpr.build(intConst, emptyContext());
+
+        assertInstanceOf(ExecLiteral.class, result);
+        ExecLiteral literal = (ExecLiteral) result;
+        assertEquals(IntegerType.INT, literal.getType());
+        assertEquals(100, literal.getValue().getInt());
+        assertFalse(literal.isNullable());
+    }
+
+    @Test
+    public void testVisitConstantVarchar() {
+        ConstantOperator strConst = ConstantOperator.createVarchar("hello");
+        ExecExpr result = ScalarOperatorToExecExpr.build(strConst, emptyContext());
+
+        assertInstanceOf(ExecLiteral.class, result);
+        ExecLiteral literal = (ExecLiteral) result;
+        assertEquals("hello", literal.getValue().getVarchar());
+    }
+
+    @Test
+    public void testVisitConstantBoolean() {
+        ConstantOperator boolConst = ConstantOperator.createBoolean(true);
+        ExecExpr result = ScalarOperatorToExecExpr.build(boolConst, emptyContext());
+
+        assertInstanceOf(ExecLiteral.class, result);
+        ExecLiteral literal = (ExecLiteral) result;
+        assertEquals(BooleanType.BOOLEAN, literal.getType());
+        assertTrue(literal.getValue().getBoolean());
+    }
+
+    @Test
+    public void testVisitConstantNull() {
+        ConstantOperator nullConst = ConstantOperator.createNull(IntegerType.INT);
+        ExecExpr result = ScalarOperatorToExecExpr.build(nullConst, emptyContext());
+
+        assertInstanceOf(ExecLiteral.class, result);
+        ExecLiteral literal = (ExecLiteral) result;
+        assertTrue(literal.isNullable());
+        assertTrue(literal.getValue().isNull());
+    }
+
+    @Test
+    public void testVisitCallOperatorDefault() {
+        // Test a generic function call: upper(varchar) -> varchar
+        Function fn = makeScalarFunction("upper",
+                new Type[] {VarcharType.VARCHAR}, VarcharType.VARCHAR);
+        CallOperator call = new CallOperator("upper", VarcharType.VARCHAR,
+                List.of(ConstantOperator.createVarchar("hello")), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecFunctionCall.class, result);
+        ExecFunctionCall funcCall = (ExecFunctionCall) result;
+        assertEquals("upper", funcCall.getFnName());
+        assertEquals(fn, funcCall.getFn());
+        assertEquals(1, funcCall.getNumChildren());
+        assertInstanceOf(ExecLiteral.class, funcCall.getChild(0));
+    }
+
+    @Test
+    public void testVisitCallOperatorArithmeticAdd() {
+        Function fn = makeScalarFunction("add",
+                new Type[] {IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        CallOperator call = new CallOperator("add", IntegerType.INT,
+                List.of(ConstantOperator.createInt(1), ConstantOperator.createInt(2)), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecArithmetic.class, result);
+        ExecArithmetic arith = (ExecArithmetic) result;
+        assertEquals(ArithmeticExpr.Operator.ADD, arith.getOp());
+        assertEquals(2, arith.getNumChildren());
+    }
+
+    @Test
+    public void testVisitCallOperatorArithmeticSubtract() {
+        Function fn = makeScalarFunction("subtract",
+                new Type[] {IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        CallOperator call = new CallOperator("subtract", IntegerType.INT,
+                List.of(ConstantOperator.createInt(5), ConstantOperator.createInt(3)), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecArithmetic.class, result);
+        ExecArithmetic arith = (ExecArithmetic) result;
+        assertEquals(ArithmeticExpr.Operator.SUBTRACT, arith.getOp());
+    }
+
+    @Test
+    public void testVisitCallOperatorInformationFunction() {
+        // database() takes a ConstantOperator(varchar) child with the current db name
+        Function fn = makeScalarFunction("database",
+                new Type[] {VarcharType.VARCHAR}, VarcharType.VARCHAR);
+        CallOperator call = new CallOperator("database", VarcharType.VARCHAR,
+                List.of(ConstantOperator.createVarchar("test_db")), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecInformationFunction.class, result);
+        ExecInformationFunction infoFn = (ExecInformationFunction) result;
+        assertEquals("database", infoFn.getFuncName());
+        assertEquals("test_db", infoFn.getStrValue());
+        assertEquals(0, infoFn.getIntValue());
+    }
+
+    @Test
+    public void testVisitCallOperatorConnectionId() {
+        Function fn = makeScalarFunction("connection_id",
+                new Type[] {IntegerType.BIGINT}, IntegerType.BIGINT);
+        CallOperator call = new CallOperator("connection_id", IntegerType.BIGINT,
+                List.of(ConstantOperator.createBigint(12345L)), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecInformationFunction.class, result);
+        ExecInformationFunction infoFn = (ExecInformationFunction) result;
+        assertEquals("connection_id", infoFn.getFuncName());
+        assertEquals(12345L, infoFn.getIntValue());
+    }
+
+    @Test
+    public void testVisitCastOperator() {
+        // CAST(INT to BIGINT)
+        ConstantOperator child = ConstantOperator.createInt(42);
+        CastOperator castOp = new CastOperator(IntegerType.BIGINT, child);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(castOp, emptyContext());
+
+        assertInstanceOf(ExecCast.class, result);
+        ExecCast cast = (ExecCast) result;
+        assertEquals(IntegerType.BIGINT, cast.getType());
+        assertFalse(cast.isImplicit());
+        assertEquals(1, cast.getNumChildren());
+        assertInstanceOf(ExecLiteral.class, cast.getChild(0));
+    }
+
+    @Test
+    public void testVisitCastOperatorImplicit() {
+        ConstantOperator child = ConstantOperator.createInt(42);
+        CastOperator castOp = new CastOperator(IntegerType.BIGINT, child, true);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(castOp, emptyContext());
+
+        assertInstanceOf(ExecCast.class, result);
+        ExecCast cast = (ExecCast) result;
+        assertTrue(cast.isImplicit());
+    }
+
+    @Test
+    public void testVisitBinaryPredicateEQ() {
+        ConstantOperator left = ConstantOperator.createInt(1);
+        ConstantOperator right = ConstantOperator.createInt(1);
+        BinaryPredicateOperator binPred = new BinaryPredicateOperator(BinaryType.EQ, left, right);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(binPred, emptyContext());
+
+        assertInstanceOf(ExecBinaryPredicate.class, result);
+        ExecBinaryPredicate pred = (ExecBinaryPredicate) result;
+        assertEquals(BinaryType.EQ, pred.getOp());
+        assertEquals(2, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitBinaryPredicateLT() {
+        ConstantOperator left = ConstantOperator.createInt(1);
+        ConstantOperator right = ConstantOperator.createInt(5);
+        BinaryPredicateOperator binPred = new BinaryPredicateOperator(BinaryType.LT, left, right);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(binPred, emptyContext());
+
+        assertInstanceOf(ExecBinaryPredicate.class, result);
+        ExecBinaryPredicate pred = (ExecBinaryPredicate) result;
+        assertEquals(BinaryType.LT, pred.getOp());
+    }
+
+    @Test
+    public void testVisitBinaryPredicateEqForNull() {
+        ConstantOperator left = ConstantOperator.createInt(1);
+        ConstantOperator right = ConstantOperator.createNull(IntegerType.INT);
+        BinaryPredicateOperator binPred = new BinaryPredicateOperator(BinaryType.EQ_FOR_NULL, left, right);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(binPred, emptyContext());
+
+        assertInstanceOf(ExecBinaryPredicate.class, result);
+        ExecBinaryPredicate pred = (ExecBinaryPredicate) result;
+        assertEquals(BinaryType.EQ_FOR_NULL, pred.getOp());
+        // EQ_FOR_NULL should not be nullable
+        assertFalse(pred.isNullable());
+    }
+
+    @Test
+    public void testVisitCompoundPredicateAND() {
+        ConstantOperator t = ConstantOperator.createBoolean(true);
+        ConstantOperator f = ConstantOperator.createBoolean(false);
+        CompoundPredicateOperator andPred =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, t, f);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(andPred, emptyContext());
+
+        assertInstanceOf(ExecCompoundPredicate.class, result);
+        ExecCompoundPredicate pred = (ExecCompoundPredicate) result;
+        assertEquals(CompoundPredicate.Operator.AND, pred.getCompoundType());
+        assertEquals(2, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitCompoundPredicateOR() {
+        ConstantOperator t = ConstantOperator.createBoolean(true);
+        ConstantOperator f = ConstantOperator.createBoolean(false);
+        CompoundPredicateOperator orPred =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, t, f);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(orPred, emptyContext());
+
+        assertInstanceOf(ExecCompoundPredicate.class, result);
+        ExecCompoundPredicate pred = (ExecCompoundPredicate) result;
+        assertEquals(CompoundPredicate.Operator.OR, pred.getCompoundType());
+    }
+
+    @Test
+    public void testVisitCompoundPredicateNOT() {
+        ConstantOperator t = ConstantOperator.createBoolean(true);
+        CompoundPredicateOperator notPred =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, t);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(notPred, emptyContext());
+
+        assertInstanceOf(ExecCompoundPredicate.class, result);
+        ExecCompoundPredicate pred = (ExecCompoundPredicate) result;
+        assertEquals(CompoundPredicate.Operator.NOT, pred.getCompoundType());
+        assertEquals(1, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitInPredicate() {
+        ConstantOperator col = ConstantOperator.createInt(1);
+        ConstantOperator val1 = ConstantOperator.createInt(1);
+        ConstantOperator val2 = ConstantOperator.createInt(2);
+        ConstantOperator val3 = ConstantOperator.createInt(3);
+        InPredicateOperator inPred = new InPredicateOperator(false, col, val1, val2, val3);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(inPred, emptyContext());
+
+        assertInstanceOf(ExecInPredicate.class, result);
+        ExecInPredicate pred = (ExecInPredicate) result;
+        assertFalse(pred.isNotIn());
+        assertEquals(4, pred.getNumChildren()); // 1 subject + 3 values
+    }
+
+    @Test
+    public void testVisitInPredicateNotIn() {
+        ConstantOperator col = ConstantOperator.createInt(1);
+        ConstantOperator val1 = ConstantOperator.createInt(1);
+        InPredicateOperator inPred = new InPredicateOperator(true, col, val1);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(inPred, emptyContext());
+
+        assertInstanceOf(ExecInPredicate.class, result);
+        ExecInPredicate pred = (ExecInPredicate) result;
+        assertTrue(pred.isNotIn());
+    }
+
+    @Test
+    public void testVisitIsNullPredicate() {
+        ConstantOperator child = ConstantOperator.createInt(1);
+        IsNullPredicateOperator isNullOp = new IsNullPredicateOperator(child);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(isNullOp, emptyContext());
+
+        assertInstanceOf(ExecIsNullPredicate.class, result);
+        ExecIsNullPredicate pred = (ExecIsNullPredicate) result;
+        assertFalse(pred.isNotNull());
+        assertEquals(1, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitIsNotNullPredicate() {
+        ConstantOperator child = ConstantOperator.createInt(1);
+        IsNullPredicateOperator isNotNullOp = new IsNullPredicateOperator(true, child);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(isNotNullOp, emptyContext());
+
+        assertInstanceOf(ExecIsNullPredicate.class, result);
+        ExecIsNullPredicate pred = (ExecIsNullPredicate) result;
+        assertTrue(pred.isNotNull());
+    }
+
+    @Test
+    public void testVisitLikePredicateOperator() {
+        ConstantOperator col = ConstantOperator.createVarchar("hello");
+        ConstantOperator pattern = ConstantOperator.createVarchar("%ell%");
+        LikePredicateOperator likeOp = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE, col, pattern);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(likeOp, emptyContext());
+
+        assertInstanceOf(ExecLikePredicate.class, result);
+        ExecLikePredicate pred = (ExecLikePredicate) result;
+        assertFalse(pred.isRegexp());
+        assertEquals(2, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitLikePredicateOperatorRegexp() {
+        ConstantOperator col = ConstantOperator.createVarchar("hello");
+        ConstantOperator pattern = ConstantOperator.createVarchar(".*ell.*");
+        LikePredicateOperator regexpOp = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.REGEXP, col, pattern);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(regexpOp, emptyContext());
+
+        assertInstanceOf(ExecLikePredicate.class, result);
+        ExecLikePredicate pred = (ExecLikePredicate) result;
+        assertTrue(pred.isRegexp());
+    }
+
+    @Test
+    public void testVisitCaseWhenOperatorSimple() {
+        // CASE WHEN true THEN 1 ELSE 0 END
+        ConstantOperator whenClause = ConstantOperator.createBoolean(true);
+        ConstantOperator thenClause = ConstantOperator.createInt(1);
+        ConstantOperator elseClause = ConstantOperator.createInt(0);
+        List<com.starrocks.sql.optimizer.operator.scalar.ScalarOperator> whenThen =
+                List.of(whenClause, thenClause);
+        CaseWhenOperator caseWhen = new CaseWhenOperator(IntegerType.INT, null, elseClause, whenThen);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(caseWhen, emptyContext());
+
+        assertInstanceOf(ExecCaseWhen.class, result);
+        ExecCaseWhen cw = (ExecCaseWhen) result;
+        assertFalse(cw.hasCase());
+        assertTrue(cw.hasElse());
+        // Children: [whenExpr, thenExpr, elseExpr] = 3
+        assertEquals(3, cw.getNumChildren());
+    }
+
+    @Test
+    public void testVisitCaseWhenOperatorWithCase() {
+        // CASE col WHEN 1 THEN 'a' WHEN 2 THEN 'b' END
+        ConstantOperator caseClause = ConstantOperator.createInt(1);
+        ConstantOperator when1 = ConstantOperator.createInt(1);
+        ConstantOperator then1 = ConstantOperator.createVarchar("a");
+        ConstantOperator when2 = ConstantOperator.createInt(2);
+        ConstantOperator then2 = ConstantOperator.createVarchar("b");
+        List<com.starrocks.sql.optimizer.operator.scalar.ScalarOperator> whenThen =
+                List.of(when1, then1, when2, then2);
+        CaseWhenOperator caseWhen = new CaseWhenOperator(VarcharType.VARCHAR, caseClause, null, whenThen);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(caseWhen, emptyContext());
+
+        assertInstanceOf(ExecCaseWhen.class, result);
+        ExecCaseWhen cw = (ExecCaseWhen) result;
+        assertTrue(cw.hasCase());
+        assertFalse(cw.hasElse());
+        // Children: [caseExpr, when1, then1, when2, then2] = 5
+        assertEquals(5, cw.getNumChildren());
+    }
+
+    @Test
+    public void testVisitArrayOperator() {
+        ArrayType arrayType = new ArrayType(IntegerType.INT);
+        ArrayOperator arrayOp = new ArrayOperator(arrayType, true,
+                List.of(ConstantOperator.createInt(1), ConstantOperator.createInt(2)));
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(arrayOp, emptyContext());
+
+        assertInstanceOf(ExecArrayExpr.class, result);
+        ExecArrayExpr arr = (ExecArrayExpr) result;
+        assertEquals(2, arr.getNumChildren());
+        assertTrue(arr.getType() instanceof ArrayType);
+    }
+
+    @Test
+    public void testVisitMapOperator() {
+        MapType mapType = new MapType(IntegerType.INT, VarcharType.VARCHAR);
+        MapOperator mapOp = new MapOperator(mapType,
+                List.of(ConstantOperator.createInt(1), ConstantOperator.createVarchar("v1")));
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(mapOp, emptyContext());
+
+        assertInstanceOf(ExecMapExpr.class, result);
+        ExecMapExpr map = (ExecMapExpr) result;
+        assertEquals(2, map.getNumChildren());
+        assertTrue(map.getType() instanceof MapType);
+    }
+
+    @Test
+    public void testVisitLambdaFunctionOperator() {
+        // Lambda: x -> x + 1
+        ColumnRefOperator lambdaArg = new ColumnRefOperator(100, IntegerType.INT, "x", true, true);
+
+        Function addFn = makeScalarFunction("add",
+                new Type[] {IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+        CallOperator addCall = new CallOperator("add", IntegerType.INT,
+                List.of(lambdaArg, ConstantOperator.createInt(1)), addFn);
+
+        LambdaFunctionOperator lambdaOp = new LambdaFunctionOperator(
+                List.of(lambdaArg), addCall, IntegerType.INT);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(lambdaOp, emptyContext());
+
+        assertInstanceOf(ExecLambdaFunction.class, result);
+        ExecLambdaFunction lambda = (ExecLambdaFunction) result;
+        assertEquals(0, lambda.getCommonSubOperatorNum());
+        assertFalse(lambda.isNondeterministic());
+        // Children: [lambdaBody, arg] = 2
+        assertTrue(lambda.getNumChildren() >= 2);
+    }
+
+    @Test
+    public void testVisitSubfieldOperator() {
+        // Access struct.field_a
+        StructType structType = new StructType(
+                new java.util.ArrayList<>(List.of(new StructField("field_a", IntegerType.INT))));
+        ColumnRefOperator colRef = new ColumnRefOperator(1, structType, "struct_col", true);
+        ExecSlotRef slotRef = makeSlotRef(1, "struct_col", structType, true);
+
+        Map<ColumnRefOperator, ExecExpr> map = new HashMap<>();
+        map.put(colRef, slotRef);
+        ScalarOperatorToExecExpr.FormatterContext ctx = makeContext(map);
+
+        SubfieldOperator subfieldOp = new SubfieldOperator(colRef, IntegerType.INT,
+                ImmutableList.of("field_a"));
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(subfieldOp, ctx);
+
+        assertInstanceOf(ExecSubfield.class, result);
+        ExecSubfield subfield = (ExecSubfield) result;
+        assertEquals(IntegerType.INT, subfield.getType());
+        assertEquals(List.of("field_a"), subfield.getFieldNames());
+        assertTrue(subfield.isCopyFlag());
+        assertEquals(1, subfield.getNumChildren());
+    }
+
+    @Test
+    public void testVisitBetweenPredicate() {
+        ConstantOperator col = ConstantOperator.createInt(5);
+        ConstantOperator low = ConstantOperator.createInt(1);
+        ConstantOperator high = ConstantOperator.createInt(10);
+        BetweenPredicateOperator between = new BetweenPredicateOperator(false, col, low, high);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(between, emptyContext());
+
+        assertInstanceOf(ExecBetweenPredicate.class, result);
+        ExecBetweenPredicate pred = (ExecBetweenPredicate) result;
+        assertFalse(pred.isNotBetween());
+        assertEquals(3, pred.getNumChildren());
+    }
+
+    @Test
+    public void testVisitBetweenPredicateNotBetween() {
+        ConstantOperator col = ConstantOperator.createInt(5);
+        ConstantOperator low = ConstantOperator.createInt(1);
+        ConstantOperator high = ConstantOperator.createInt(10);
+        BetweenPredicateOperator notBetween = new BetweenPredicateOperator(true, col, low, high);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(notBetween, emptyContext());
+
+        assertInstanceOf(ExecBetweenPredicate.class, result);
+        ExecBetweenPredicate pred = (ExecBetweenPredicate) result;
+        assertTrue(pred.isNotBetween());
+    }
+
+    @Test
+    public void testBuildIgnoreSlot() {
+        // buildIgnoreSlot should create ExecSlotRef directly from ColumnRefOperator
+        ColumnRefOperator colRef = new ColumnRefOperator(5, IntegerType.INT, "col_x", false);
+
+        ExecExpr result = ScalarOperatorToExecExpr.buildIgnoreSlot(colRef, emptyContext());
+
+        assertInstanceOf(ExecSlotRef.class, result);
+        ExecSlotRef slotRef = (ExecSlotRef) result;
+        assertEquals(5, slotRef.getSlotId().asInt());
+        assertEquals(IntegerType.INT, slotRef.getType());
+    }
+
+    @Test
+    public void testVisitBinaryPredicateIndexOnlyFilter() {
+        ConstantOperator left = ConstantOperator.createInt(1);
+        ConstantOperator right = ConstantOperator.createInt(2);
+        BinaryPredicateOperator binPred = new BinaryPredicateOperator(BinaryType.EQ, left, right);
+        binPred.setIndexOnlyFilter(true);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(binPred, emptyContext());
+
+        assertInstanceOf(ExecBinaryPredicate.class, result);
+        assertTrue(result.isIndexOnlyFilter());
+    }
+
+    @Test
+    public void testVisitCompoundPredicateIndexOnlyFilter() {
+        ConstantOperator t = ConstantOperator.createBoolean(true);
+        ConstantOperator f = ConstantOperator.createBoolean(false);
+        CompoundPredicateOperator andPred =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, t, f);
+        andPred.setIndexOnlyFilter(true);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(andPred, emptyContext());
+
+        assertTrue(result.isIndexOnlyFilter());
+    }
+
+    @Test
+    public void testVisitCallOperatorMultipleArithmeticOps() {
+        // Test multiply, divide, mod
+        for (String opName : List.of("multiply", "divide", "int_divide", "mod",
+                "bitand", "bitor", "bitxor", "bit_shift_left", "bit_shift_right",
+                "bit_shift_right_logical")) {
+            Function fn = makeScalarFunction(opName,
+                    new Type[] {IntegerType.INT, IntegerType.INT}, IntegerType.INT);
+            CallOperator call = new CallOperator(opName, IntegerType.INT,
+                    List.of(ConstantOperator.createInt(10), ConstantOperator.createInt(3)), fn);
+
+            ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+            assertInstanceOf(ExecArithmetic.class, result,
+                    "Expected ExecArithmetic for op: " + opName);
+        }
+    }
+
+    @Test
+    public void testVisitCallOperatorBitnot() {
+        Function fn = makeScalarFunction("bitnot",
+                new Type[] {IntegerType.INT}, IntegerType.INT);
+        CallOperator call = new CallOperator("bitnot", IntegerType.INT,
+                List.of(ConstantOperator.createInt(42)), fn);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(call, emptyContext());
+
+        assertInstanceOf(ExecArithmetic.class, result);
+        ExecArithmetic arith = (ExecArithmetic) result;
+        assertEquals(ArithmeticExpr.Operator.BITNOT, arith.getOp());
+        assertEquals(1, arith.getNumChildren());
+    }
+
+    @Test
+    public void testVisitConstantNullReplacesNullType() {
+        // NULL_TYPE should be replaced with BOOLEAN
+        ConstantOperator nullConst = ConstantOperator.createNull(
+                com.starrocks.type.NullType.NULL);
+
+        ExecExpr result = ScalarOperatorToExecExpr.build(nullConst, emptyContext());
+
+        assertInstanceOf(ExecLiteral.class, result);
+        ExecLiteral literal = (ExecLiteral) result;
+        // NULL_TYPE gets replaced with BOOLEAN
+        assertEquals(BooleanType.BOOLEAN, literal.getType());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The current FE uses AST `Expr` classes for both parsing/analysis and physical plan execution. This tight coupling prevents moving expression classes (e.g., `FunctionCallExpr`, `SlotRef`) to the `fe-parser` module and makes the planner depend on mutable AST state. A separate, typed, immutable expression hierarchy for the physical plan layer is needed.

## What I'm doing:

Introduce the `ExecExpr` hierarchy — a typed, immutable expression representation for the physical plan layer, fully decoupled from AST `Expr`. **This is a pure addition: 33 new files, zero modifications to existing code.**

New components:
- **`ExecExpr`** base class + **28 concrete types** (`ExecSlotRef`, `ExecFunctionCall`, `ExecLiteral`, `ExecCast`, `ExecBinaryPredicate`, `ExecCompoundPredicate`, etc.)
- **`ExecExprVisitor`** — type-safe visitor for traversal
- **`ExecExprSerializer`** — serializes `ExecExpr` → Thrift `TExpr`
- **`ExecExprExplain`** — EXPLAIN formatting for `ExecExpr`
- **`ScalarOperatorToExecExpr`** — converts optimizer `ScalarOperator` → `ExecExpr`
- **`ThriftEnumConverter`** — centralized keys-type and opcode Thrift conversions
- **`ExprOpcodeRegistry`** — maps AST expression metadata to `TExprOpcode`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4