### PR TITLE
[BugFix] Bump zookeeper to 3.8.6 to fix CVE-2026-24281 and CVE-2026-24308

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -86,6 +86,7 @@ under the License.
         <hbase.version>2.6.2</hbase.version>
         <lz4-java.version>1.10.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
+        <zookeeper.version>3.8.6</zookeeper.version>
     </properties>
 
     <profiles>
@@ -177,6 +178,13 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- CVE-2026-24281 / CVE-2026-24308: pin zookeeper to fix version -->
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.starrocks</groupId>


### PR DESCRIPTION
## Summary

Bumps `org.apache.zookeeper:zookeeper` from `3.8.4` to `3.8.6` to resolve `CVE-2026-24281` and `CVE-2026-24308`.

The vulnerable version 3.8.4 was being pulled in transitively by Hadoop/Hive dependencies. This PR pins the version explicitly in `fe/pom.xml` dependencyManagement.

## CVE Details

- **CVE ID:** CVE-2026-24281, CVE-2026-24308
- **Severity:** HIGH
- **Package:** org.apache.zookeeper:zookeeper
- **Installed:** 3.8.4 (transitive via hadoop/hive)
- **Fixed:** 3.8.6

## Root Cause

`fe/pom.xml` did not pin a zookeeper version in `dependencyManagement`, so the transitive version 3.8.4 from `hadoop 3.4.3` / `hive-apache 3.1.2-22` was used. Adding an explicit pin to 3.8.6 forces Maven to use the patched version.

## Files Changed

- `fe/pom.xml` — added `<zookeeper.version>3.8.6</zookeeper.version>` property and explicit `dependencyManagement` entry

## Backport Note

This fix is for `branch-4.0`. Apply the same pin to other affected release branches as needed.

## Checklist
- [x] All files referencing the old version have been updated
- [x] XML syntax validated (xmllint)
- [x] Local Trivy scan: zookeeper CVE no longer present
- [ ] BUILD job passes with Trivy scan green

## Behavior changed

- [ ] Yes, this PR changes data/query/session/cluster behavior
- [x] No, this is a dependency version bump with no behavior change

## Does this PR need documentation?

- [ ] Yes
- [x] No

## Bugfix version

- [ ] v3.3
- [ ] v3.4
- [x] v4.0
