### PR TITLE
[BugFix][CVE-2026-24281][CVE-2026-24308] pin zookeeper to 3.8.6

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -86,7 +86,6 @@ under the License.
         <hbase.version>2.6.2</hbase.version>
         <lz4-java.version>1.10.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
-        <zookeeper.version>3.8.6</zookeeper.version>
     </properties>
 
     <profiles>
@@ -178,13 +177,6 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
-
-            <!-- CVE-2026-24281 / CVE-2026-24308: pin zookeeper to fix version -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>com.starrocks</groupId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -86,6 +86,7 @@ under the License.
         <hbase.version>2.6.2</hbase.version>
         <lz4-java.version>1.10.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
+        <zookeeper.version>3.8.6</zookeeper.version>
     </properties>
 
     <profiles>
@@ -177,6 +178,13 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- CVE-2026-24281 / CVE-2026-24308: pin zookeeper to fix version -->
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.starrocks</groupId>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -63,10 +63,18 @@
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <lz4-java.version>1.10.1</lz4-java.version>
         <httpclient5.version>5.4.3</httpclient5.version>
+        <zookeeper.version>3.8.6</zookeeper.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- CVE-2026-24281 / CVE-2026-24308: pin zookeeper to fix version -->
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
             <!-- jni connector -->
             <dependency>
                 <groupId>com.starrocks</groupId>


### PR DESCRIPTION
## Why I'm doing:

`org.apache.zookeeper:zookeeper` 3.8.4 (pulled in transitively by Hadoop/Hive dependencies) is affected by CVE-2026-24281 (server impersonation, HIGH) and CVE-2026-24308 (information disclosure).

## What I'm doing:

Pin `org.apache.zookeeper:zookeeper` to 3.8.6 in `fe/pom.xml` and `java-extensions/pom.xml` `dependencyManagement` to override the transitive 3.8.4 from hadoop/hive dependencies.

Fixes #70777
Fixes #70859

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [x] 3.5
  - [x] 3.4
