### PR TITLE
[BugFix][CVE-2026-24281][CVE-2026-24308] pin zookeeper to 3.8.6 in fe/pom.xml

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -93,6 +93,7 @@ under the License.
         <lz4-java.version>1.10.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <zookeeper.version>3.8.6</zookeeper.version>
     </properties>
 
     <profiles>
@@ -184,6 +185,13 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- CVE-2026-24281 / CVE-2026-24308: pin zookeeper to fix version -->
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
 
             <!-- internal modules unified -->
             <dependency>


### PR DESCRIPTION
## Why I'm doing:

`org.apache.zookeeper:zookeeper` 3.8.4 (pulled in transitively by Hadoop/Hive dependencies in fe/pom.xml) is affected by CVE-2026-24281 (server impersonation, HIGH) and CVE-2026-24308 (information disclosure).

Note: `java-extensions/pom.xml` already pins zookeeper to 3.8.6 (added in #70981). This PR fixes the same for `fe/pom.xml`.

## What I'm doing:

Pin `org.apache.zookeeper:zookeeper` to 3.8.6 in `fe/pom.xml` `dependencyManagement` to override the transitive 3.8.4 from hadoop/hive dependencies.

Fixes #70777
Fixes #70859

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4