### PR TITLE
[BugFix] Fix shared NullColumn issue in map_apply and array_length

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -59,8 +59,9 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
 
         if (arg0->has_null()) {
             // Copy null flags.
-            return NullableColumn::create(std::move(col_result),
-                                          std::move(*(down_cast<const NullableColumn*>(arg0)->null_column())).mutate());
+            auto null_column = NullColumn::static_pointer_cast(
+                    Column::mutate(down_cast<const NullableColumn*>(arg0)->null_column()));
+            return NullableColumn::create(std::move(col_result), std::move(null_column));
         } else {
             return col_result;
         }

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -82,7 +82,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                 input_null_map = FunctionHelper::union_null_column(nullable->null_column(),
                                                                    std::move(input_null_map)); // merge null
             } else {
-                input_null_map = ColumnHelper::as_column<NullColumn>(std::move(*nullable->null_column()).mutate());
+                input_null_map = NullColumn::static_pointer_cast(Column::mutate(nullable->null_column()));
             }
         }
         DCHECK(data_column->is_map());


### PR DESCRIPTION
## Why I'm doing:

Continuing with the fixes at https://github.com/StarRocks/starrocks/pull/71207, further fix a crash (`Check failed: _data_column->size() == _null_column->size()`) caused by two NullableColumns in the same Chunk sharing the same NullColumn object.

### Root Cause

The bug is triggered by an unsafe pattern for obtaining a mutable NullColumn:

```cpp
// WRONG — returns the same object when use_count==1 with COW optimization
std::move(*nullable->null_column()).mutate()

// CORRECT — implicit ColumnPtr copy bumps use_count>=2, forcing clone
Column::mutate(nullable->null_column())
```

### Crash Trigger Path

For the query:
```sql
SELECT t.map2, s.map2 FROM map_test t JOIN map_test s
ON map_apply((k,v)->(k+1,array_length(v)),s.map2) = map_apply((k,v)->(k+1,array_length(v)),t.map2)
```

1. `SelectOperator::push_chunk` evaluates `_common_exprs` (e.g., `map_apply(s.map2)`) and **appends the result as a new column (slot20) to the chunk**
2. `map_apply_expr.cpp:85` uses `std::move(*nullable->null_column()).mutate()` to extract the input's NullColumn — with COW optimization and `use_count==1`, this returns the **same NullColumn object**
3. The result NullableColumn (slot20) and the original column (slot4=t.map2) now **share the same NullColumn** in the chunk
4. `eval_conjuncts_and_in_filters` → `eager_prune_eval_conjuncts` → `Chunk::filter()`
5. `Chunk::filter()` iterates columns: filtering slot4 shrinks the shared NullColumn (3→2)
6. When accessing slot20: `_data_column->size()==3` but `_null_column->size()==2` → **CHECK FAIL / CRASH**

## What I'm doing:

Replace all instances of the unsafe `std::move(*nullable->null_column()).mutate()` pattern with `Column::mutate(nullable->null_column())` in:

- **`map_apply_expr.cpp:85`** — the primary trigger for this crash
- **`array_functions.cpp:62`** (`array_length`) — same unsafe pattern

## Related PRs

Follow-up to #71207 which fixed the same class of bug in `array_functions.cpp`, `binary_function.h`, `map_functions.cpp`, and `ngram.cpp` — but missed the locations fixed in this PR.


Fixes: https://github.com/StarRocks/StarRocksTest/issues/11200

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
