### PR TITLE
[BugFix] Fix DefaultValueColumnIterator double-init memory leak for complex types

### DIFF
--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -427,7 +427,24 @@ private:
     MemPool* _mem_pool;
 };
 
+void DefaultValueColumnIterator::_cleanup_initialized_value() {
+    // For complex types (ARRAY/MAP/STRUCT), a Datum is placement-new'd into _mem_value.
+    // MemPool only frees raw memory without calling destructors, so we must explicitly
+    // destroy the Datum to avoid leaking its internal heap-allocated containers.
+    if (_has_complex_datum && _mem_value != nullptr) {
+        reinterpret_cast<Datum*>(_mem_value)->~Datum();
+    }
+    _has_complex_datum = false;
+    _mem_value = nullptr;
+    _type_size = 0;
+    _is_default_value_null = false;
+    _pool.clear();
+}
+
 Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
+    // Some call paths initialize the returned iterator again. Make init idempotent by
+    // cleaning up previous initialized value and rebuilding from scratch.
+    _cleanup_initialized_value();
     _opts = opts;
 
     // be consistent with segment v1
@@ -508,6 +525,7 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                         _is_default_value_null = true;
                     } else {
                         new (_mem_value) Datum(std::move(datum_or.value()));
+                        _has_complex_datum = true;
                         if (_path != nullptr) {
                             _project_default_datum_by_path_if_needed(reinterpret_cast<Datum*>(_mem_value),
                                                                      _type_info.get(), _path);

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -61,9 +61,7 @@ public:
               _num_rows(num_rows),
               _path(path) {}
 
-    ~DefaultValueColumnIterator() override {
-        _cleanup_initialized_value();
-    }
+    ~DefaultValueColumnIterator() override { _cleanup_initialized_value(); }
 
     Status init(const ColumnIteratorOptions& opts) override;
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -62,15 +62,7 @@ public:
               _path(path) {}
 
     ~DefaultValueColumnIterator() override {
-        // For complex types (ARRAY/MAP/STRUCT), a Datum is placement-new'd into _mem_value.
-        // MemPool only frees raw memory without calling destructors, so we must explicitly
-        // destroy the Datum to avoid leaking its internal heap-allocated containers.
-        if (_mem_value != nullptr && _type_info != nullptr && !_is_default_value_null) {
-            auto type = _type_info->type();
-            if (type == TYPE_ARRAY || type == TYPE_MAP || type == TYPE_STRUCT) {
-                reinterpret_cast<Datum*>(_mem_value)->~Datum();
-            }
-        }
+        _cleanup_initialized_value();
     }
 
     Status init(const ColumnIteratorOptions& opts) override;
@@ -117,6 +109,8 @@ public:
     }
 
 private:
+    void _cleanup_initialized_value();
+
     bool _has_default_value;
     std::string _default_value;
     bool _is_nullable;
@@ -125,6 +119,7 @@ private:
     bool _is_default_value_null{false};
     size_t _type_size{0};
     void* _mem_value = nullptr;
+    bool _has_complex_datum{false};
     MemPool _pool;
 
     // current rowid

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -275,6 +275,30 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
         column.set_default_value("10");
         r = segment->new_column_iterator_or_default(column, nullptr);
         ASSERT_TRUE(r.ok()) << r.status();
+
+        // Complex default value path should be safe when caller initializes returned iterator.
+        // Under ASAN, this catches a historical double-init leak in DefaultValueColumnIterator.
+        TabletColumn array_column;
+        array_column.set_unique_id(6);
+        array_column.set_name("c_array");
+        array_column.set_type(LogicalType::TYPE_ARRAY);
+        array_column.set_is_nullable(false);
+        array_column.set_default_value("[1, 2, 3]");
+        array_column.set_length(24);
+
+        TabletColumn item_column;
+        item_column.set_unique_id(7);
+        item_column.set_name("element");
+        item_column.set_type(LogicalType::TYPE_INT);
+        item_column.set_is_nullable(false);
+        item_column.set_length(4);
+        array_column.add_sub_column(item_column);
+
+        auto array_iter_or = segment->new_column_iterator_or_default(array_column, nullptr);
+        ASSERT_TRUE(array_iter_or.ok()) << array_iter_or.status();
+        auto array_iter = std::move(array_iter_or.value());
+        ColumnIteratorOptions iter_opts;
+        ASSERT_OK(array_iter->init(iter_opts));
     }
     // test new_dcg_segment
     {


### PR DESCRIPTION
## Why I'm doing:

`DefaultValueColumnIterator::init()` can be called twice on the same instance, causing a memory leak for complex types (ARRAY/MAP/STRUCT).

The double-init call path is:

1. `Segment::new_column_iterator_or_default()` (`segment.cpp:522-526`) creates a `DefaultValueColumnIterator` and immediately calls `init()` on it with an empty `ColumnIteratorOptions`.
2. The caller `SegmentIterator::_init_column_iterator()` (`segment_iterator.cpp:1200-1232`) receives the already-initialized iterator via `new_column_iterator_or_default()`, then calls `init()` **again** at line 1232 with the real `iter_opts` (containing `read_file`, etc.).

On the second `init()` call, for complex types, a new `Datum` is placement-new'd into `_mem_value` without first destroying the previous one. The old `Datum` (which owns heap-allocated containers like `DatumArray`, `DatumMap`) is silently overwritten, leaking all its internal memory. This is detectable under ASAN as a memory leak.

## What I'm doing:

- Add `_cleanup_initialized_value()` method that explicitly destroys the placement-new'd `Datum` and resets all state (`_mem_value`, `_type_size`, `_is_default_value_null`, `_pool`) before re-initialization, making `init()` idempotent and safe to call multiple times.
- Introduce a `_has_complex_datum` boolean flag to precisely track whether a `Datum` was placement-new'd, replacing the previous type-check-based heuristic in the destructor. This is more reliable because it tracks actual construction rather than inferring it from type info.
- Reuse `_cleanup_initialized_value()` in the destructor, eliminating code duplication.
- Add unit test in `segment_test.cpp` that exercises the double-init path for ARRAY default values, catching the leak under ASAN.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4