### PR TITLE
[BugFix] Fix no queryable replica on follower FE by syncing StarMgr journal replay

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -73,6 +73,7 @@ import com.starrocks.plugin.AuditEvent.EventType;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
@@ -94,6 +95,7 @@ import com.starrocks.sql.common.LargeInPredicateException;
 import com.starrocks.sql.formatter.FormatOptions;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.staros.StarMgrServer;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
@@ -1116,6 +1118,9 @@ public class ConnectProcessor {
         // no matter the master execute success or fail, the master must transfer the result to follower
         // and tell the follower the current journalID.
         result.setMaxJournalId(GlobalStateMgr.getCurrentState().getMaxJournalId());
+        if (RunMode.isSharedDataMode()) {
+            result.setMaxStarMgrJournalId(StarMgrServer.getCurrentState().getMaxJournalId());
+        }
         // following stmt will not be executed, when current stmt is failed,
         // so only set SERVER_MORE_RESULTS_EXISTS Flag when stmt executed successfully
         if (!ctx.getIsLastStmt()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/JournalObservable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/JournalObservable.java
@@ -23,6 +23,8 @@ import com.starrocks.common.DdlException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.function.LongSupplier;
+
 public class JournalObservable {
     private static final Logger LOG = LogManager.getLogger(JournalObservable.class);
     private Multiset<JournalObserver> obs;
@@ -50,6 +52,20 @@ public class JournalObservable {
                 expectedJournalVersion, timeoutMs);
 
         JournalObserver observer = new JournalObserver(expectedJournalVersion);
+        addObserver(observer);
+        try {
+            observer.waitForReplay(timeoutMs);
+        } finally {
+            deleteObserver(observer);
+        }
+    }
+
+    public void waitOn(Long expectedJournalVersion, int timeoutMs,
+                       LongSupplier replayedJournalIdSupplier) throws DdlException {
+        LOG.info("waiting for the observer to replay journal to {} with timeout: {} ms",
+                expectedJournalVersion, timeoutMs);
+
+        JournalObserver observer = new JournalObserver(expectedJournalVersion, replayedJournalIdSupplier);
         addObserver(observer);
         try {
             observer.waitForReplay(timeoutMs);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/JournalObserver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/JournalObserver.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 public class JournalObserver implements Comparable<JournalObserver> {
     private static final Logger LOG = LogManager.getLogger(JournalObserver.class);
@@ -51,11 +52,17 @@ public class JournalObserver implements Comparable<JournalObserver> {
     private Long id;
     private Long targetJournalVersion;
     private CountDownLatch latch;
+    private LongSupplier replayedJournalIdSupplier;
 
     public JournalObserver(Long targetJournalVersion) {
+        this(targetJournalVersion, () -> GlobalStateMgr.getCurrentState().getReplayedJournalId());
+    }
+
+    public JournalObserver(Long targetJournalVersion, LongSupplier replayedJournalIdSupplier) {
         this.id = idGen.getAndIncrement();
         this.targetJournalVersion = targetJournalVersion;
         this.latch = new CountDownLatch(1);
+        this.replayedJournalIdSupplier = replayedJournalIdSupplier;
     }
 
     public void update() {
@@ -83,7 +90,7 @@ public class JournalObserver implements Comparable<JournalObserver> {
             boolean ok = false;
             do {
                 // check if the replayed journal version is already larger than the expected version
-                long replayedJournalId = GlobalStateMgr.getCurrentState().getReplayedJournalId();
+                long replayedJournalId = replayedJournalIdSupplier.getAsLong();
                 if (replayedJournalId >= targetJournalVersion || timeoutMs <= 0) {
                     LOG.debug("the replayed journal version {} already large than expected version: {}",
                             replayedJournalId, targetJournalVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -49,6 +49,7 @@ import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.GracefulExitFlag;
+import com.starrocks.server.RunMode;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlProxyQueryManager;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlResultDescriptor;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
@@ -60,6 +61,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
 import com.starrocks.sql.ast.txn.RollbackStmt;
+import com.starrocks.staros.StarMgrServer;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TAuditStatistics;
 import com.starrocks.thrift.TMasterOpRequest;
@@ -137,8 +139,19 @@ public class LeaderOpExecutor {
         try {
             forward();
             if (!GracefulExitFlag.isGracefulExit() && !GlobalStateMgr.getCurrentState().isLeader()) {
+                long deadline = System.currentTimeMillis() + waitTimeoutMs;
                 LOG.info("forwarding to leader get result max journal id: {}", result.maxJournalId);
                 ctx.getGlobalStateMgr().getJournalObservable().waitOn(result.maxJournalId, waitTimeoutMs);
+                if (RunMode.isSharedDataMode() && result.isSetMaxStarMgrJournalId()) {
+                    // NOTE: It is a known pitfall that when FE journal catch-up consumes the whole waitTimeoutMs,
+                    // remaining becomes 0, and the subsequent StarMgr wait returns immediately because
+                    // JournalObserver.waitForReplay() treats timeoutMs <= 0 as success even if replay is still behind.
+                    int remaining = (int) Math.max(0, deadline - System.currentTimeMillis());
+                    LOG.info("waiting for star mgr journal replay to {}", result.maxStarMgrJournalId);
+                    StarMgrServer.getCurrentState().getStarMgrJournalObservable().waitOn(
+                            result.maxStarMgrJournalId, remaining,
+                            () -> StarMgrServer.getCurrentState().getReplayId());
+                }
             }
 
             if (result.state != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -31,6 +31,7 @@ import com.starrocks.leader.CheckpointController;
 import com.starrocks.metric.MetricVisitor;
 import com.starrocks.metric.PrometheusRegistryHelper;
 import com.starrocks.persist.Storage;
+import com.starrocks.qe.JournalObservable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import org.apache.logging.log4j.LogManager;
@@ -91,6 +92,7 @@ public class StarMgrServer {
 
     private StarManagerServer starMgrServer;
     private StarOSBDBJEJournalSystem journalSystem;
+    private final JournalObservable starMgrJournalObservable = new JournalObservable();
     private ThreadPoolExecutor grpcExecutor;
 
     public StarMgrServer() {
@@ -140,6 +142,7 @@ public class StarMgrServer {
 
     private void initializeImpl(StarOSBDBJEJournalSystem bdbJournalSystem, String baseImageDir) throws IOException {
         this.journalSystem = bdbJournalSystem;
+        this.journalSystem.setJournalObservable(starMgrJournalObservable);
         imageDir = baseImageDir + IMAGE_SUBDIR;
 
         // TODO: remove separate deployment capability for now
@@ -304,6 +307,10 @@ public class StarMgrServer {
             return;
         }
         PrometheusRegistryHelper.visitPrometheusRegistry(MetricsSystem.METRIC_REGISTRY, visitor);
+    }
+
+    public JournalObservable getStarMgrJournalObservable() {
+        return starMgrJournalObservable;
     }
 
     public long getMaxJournalId() {

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
@@ -32,6 +32,7 @@ import com.starrocks.journal.JournalWriter;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.JournalObservable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,6 +51,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
     private JournalWriter journalWriter;
     private EditLog editLog;
     private AtomicLong replayedJournalId;
+    private JournalObservable journalObservable;
     private Daemon replayer; // TODO: maybe it's better to move this to StarMgr
 
     public StarOSBDBJEJournalSystem(BDBEnvironment environment) {
@@ -87,6 +89,10 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
 
     public void setReplayId(long replayId) {
         replayedJournalId.set(replayId);
+    }
+
+    public void setJournalObservable(JournalObservable journalObservable) {
+        this.journalObservable = journalObservable;
     }
 
     @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
@@ -219,10 +225,13 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
             }
 
             editLog.loadJournal(null /* GlobalStateMgr */, entity);
-            replayedJournalId.incrementAndGet();
+            long newReplayId = replayedJournalId.incrementAndGet();
+            if (journalObservable != null) {
+                journalObservable.notifyObservers(newReplayId);
+            }
             long innerEndTime = System.currentTimeMillis();
 
-            LOG.debug("star mgr journal {} replayed.", replayedJournalId);
+            LOG.debug("star mgr journal {} replayed.", newReplayId);
             if (innerEndTime - innerStartTime > 3000) {
                 LOG.info("star mgr journal replay id:{} op:{} cost {}ms.", replayedJournalId, entity.opCode(),
                         innerEndTime - innerStartTime);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ForwardStarMgrJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ForwardStarMgrJournalTest.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.scheduler.SchedulerTestBase;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.staros.StarMgrServer;
+import com.starrocks.thrift.TMasterOpRequest;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.thrift.TUserIdentity;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ForwardStarMgrJournalTest extends SchedulerTestBase {
+    @BeforeEach
+    public void before() {
+        mockFrontends(FRONTENDS);
+        mockFrontendService(new MockFrontendServiceClient());
+    }
+
+    TMasterOpRequest makeRequest() {
+        TMasterOpRequest request = new TMasterOpRequest();
+        request.setCatalog("default");
+        request.setCluster("default");
+        request.setDb("information_schema");
+        request.setQueryId(UUIDUtil.genTUniqueId());
+        final TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("user1");
+        userIdentity.setHost("%");
+        userIdentity.setIs_ephemeral(true);
+        request.setCurrent_user_ident(userIdentity);
+        return request;
+    }
+
+    @Test
+    public void testProxyExecute_sharedDataMode_setsStarMgrJournalId() throws Exception {
+        final FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
+        final long expectedStarMgrJournalId = 12345L;
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Long getMaxJournalId() {
+                return 100L;
+            }
+
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        new MockUp<StarMgrServer>() {
+            @Mock
+            public StarMgrServer getCurrentState() {
+                return new StarMgrServer() {
+                    @Override
+                    public long getMaxJournalId() {
+                        return expectedStarMgrJournalId;
+                    }
+                };
+            }
+        };
+
+        final TMasterOpRequest request = makeRequest();
+        request.setConnectionId(1);
+        request.setSql("kill QUERY 1");
+
+        final TMasterOpResult result = service.forward(request);
+        Assertions.assertTrue(result.isSetMaxStarMgrJournalId());
+        Assertions.assertEquals(expectedStarMgrJournalId, result.getMaxStarMgrJournalId());
+    }
+
+    @Test
+    public void testProxyExecute_sharedNothingMode_noStarMgrJournalId() throws Exception {
+        final FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Long getMaxJournalId() {
+                return 100L;
+            }
+
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return false;
+            }
+        };
+
+        final TMasterOpRequest request = makeRequest();
+        request.setConnectionId(1);
+        request.setSql("kill QUERY 1");
+
+        final TMasterOpResult result = service.forward(request);
+        Assertions.assertFalse(result.isSetMaxStarMgrJournalId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorStarMgrJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorStarMgrJournalTest.java
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.staros.StarMgrServer;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class LeaderOpExecutorStarMgrJournalTest {
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        Config.bdbje_heartbeat_timeout_second = 60;
+        Config.bdbje_replica_ack_timeout_second = 60;
+        Config.bdbje_lock_timeout_second = 60;
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
+
+        FeConstants.runningUnitTest = true;
+        connectContext = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("d1").useDatabase("d1")
+                .withTable("CREATE TABLE d1.t1(k1 int, k2 int, k3 int)" +
+                        " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+    }
+
+    private GlobalStateMgr mockGlobalStateMgrAsFollower() {
+        GlobalStateMgr mockGsm = Mockito.mock(GlobalStateMgr.class);
+        Mockito.when(mockGsm.isLeader()).thenReturn(false);
+        JournalObservable feObservable = Mockito.mock(JournalObservable.class);
+        Mockito.when(mockGsm.getJournalObservable()).thenReturn(feObservable);
+        NodeMgr mockNodeMgr = Mockito.mock(NodeMgr.class);
+        Mockito.when(mockNodeMgr.getLeaderIpAndRpcPort())
+                .thenReturn(Pair.create("127.0.0.1", 9020));
+        Mockito.when(mockGsm.getNodeMgr()).thenReturn(mockNodeMgr);
+        return mockGsm;
+    }
+
+    @Test
+    public void testExecute_sharedDataMode_waitsForStarMgrJournal() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setMaxJournalId(100L);
+        tMasterOpResult.setMaxStarMgrJournalId(200L);
+
+        GlobalStateMgr mockGsm = mockGlobalStateMgrAsFollower();
+        StarMgrServer mockStarMgrServer = Mockito.mock(StarMgrServer.class);
+        JournalObservable mockStarMgrObservable = Mockito.mock(JournalObservable.class);
+        Mockito.when(mockStarMgrServer.getStarMgrJournalObservable()).thenReturn(mockStarMgrObservable);
+        GlobalStateMgr originalGsm = connectContext.getGlobalStateMgr();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class);
+                MockedStatic<GlobalStateMgr> gsmMock =
+                        Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> runModeMock =
+                        Mockito.mockStatic(RunMode.class);
+                MockedStatic<StarMgrServer> starMgrMock =
+                        Mockito.mockStatic(StarMgrServer.class)) {
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            runModeMock.when(RunMode::isSharedDataMode).thenReturn(true);
+            starMgrMock.when(StarMgrServer::getCurrentState).thenReturn(mockStarMgrServer);
+
+            connectContext.setGlobalStateMgr(mockGsm);
+            LeaderOpExecutor executor = new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(),
+                    connectContext, RedirectStatus.FORWARD_NO_SYNC, false, null);
+            executor.execute();
+
+            Mockito.verify(mockStarMgrObservable).waitOn(
+                    Mockito.eq(200L), Mockito.anyInt(), Mockito.any());
+        } finally {
+            connectContext.setGlobalStateMgr(originalGsm);
+        }
+    }
+
+    @Test
+    public void testExecute_sharedDataMode_starMgrAlreadyCaughtUp() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setMaxJournalId(100L);
+        tMasterOpResult.setMaxStarMgrJournalId(50L);
+
+        GlobalStateMgr mockGsm = mockGlobalStateMgrAsFollower();
+        StarMgrServer mockStarMgrServer = Mockito.mock(StarMgrServer.class);
+        JournalObservable realObservable = new JournalObservable();
+        Mockito.when(mockStarMgrServer.getStarMgrJournalObservable()).thenReturn(realObservable);
+        Mockito.when(mockStarMgrServer.getReplayId()).thenReturn(100L);
+        GlobalStateMgr originalGsm = connectContext.getGlobalStateMgr();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class);
+                MockedStatic<GlobalStateMgr> gsmMock =
+                        Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> runModeMock =
+                        Mockito.mockStatic(RunMode.class);
+                MockedStatic<StarMgrServer> starMgrMock =
+                        Mockito.mockStatic(StarMgrServer.class)) {
+
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            runModeMock.when(RunMode::isSharedDataMode).thenReturn(true);
+            starMgrMock.when(StarMgrServer::getCurrentState).thenReturn(mockStarMgrServer);
+
+            long start = System.currentTimeMillis();
+            connectContext.setGlobalStateMgr(mockGsm);
+            LeaderOpExecutor executor = new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(),
+                    connectContext, RedirectStatus.FORWARD_NO_SYNC, false, null);
+            executor.execute();
+            long elapsed = System.currentTimeMillis() - start;
+
+            Assertions.assertTrue(elapsed < 2000, "Expected fast return but took " + elapsed + "ms");
+        } finally {
+            connectContext.setGlobalStateMgr(originalGsm);
+        }
+    }
+
+    @Test
+    public void testExecute_notSharedDataMode_skipsStarMgrWait() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setMaxJournalId(100L);
+        tMasterOpResult.setMaxStarMgrJournalId(200L);
+
+        GlobalStateMgr mockGsm = mockGlobalStateMgrAsFollower();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class);
+                MockedStatic<GlobalStateMgr> gsmMock =
+                        Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> runModeMock =
+                        Mockito.mockStatic(RunMode.class);
+                MockedStatic<StarMgrServer> starMgrMock =
+                        Mockito.mockStatic(StarMgrServer.class)) {
+
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            runModeMock.when(RunMode::isSharedDataMode).thenReturn(false);
+
+            LeaderOpExecutor executor = new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(),
+                    connectContext, RedirectStatus.FORWARD_NO_SYNC, false, null);
+            executor.execute();
+
+            starMgrMock.verify(StarMgrServer::getCurrentState, Mockito.never());
+        }
+    }
+
+    @Test
+    public void testExecute_starMgrJournalIdNotSet_backwardCompat() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setMaxJournalId(100L);
+
+        GlobalStateMgr mockGsm = mockGlobalStateMgrAsFollower();
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class);
+                MockedStatic<GlobalStateMgr> gsmMock =
+                        Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> runModeMock =
+                        Mockito.mockStatic(RunMode.class);
+                MockedStatic<StarMgrServer> starMgrMock =
+                        Mockito.mockStatic(StarMgrServer.class)) {
+
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            runModeMock.when(RunMode::isSharedDataMode).thenReturn(true);
+
+            LeaderOpExecutor executor = new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(),
+                    connectContext, RedirectStatus.FORWARD_NO_SYNC, false, null);
+            executor.execute();
+
+            starMgrMock.verify(StarMgrServer::getCurrentState, Mockito.never());
+        }
+    }
+
+    @Test
+    public void testExecute_sharedDataMode_starMgrTimeout() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setMaxJournalId(100L);
+        tMasterOpResult.setMaxStarMgrJournalId(99999L);
+
+        GlobalStateMgr mockGsm = mockGlobalStateMgrAsFollower();
+        StarMgrServer mockStarMgrServer = Mockito.mock(StarMgrServer.class);
+        JournalObservable realObservable = new JournalObservable();
+        Mockito.when(mockStarMgrServer.getStarMgrJournalObservable()).thenReturn(realObservable);
+        Mockito.when(mockStarMgrServer.getReplayId()).thenReturn(1L);
+
+        connectContext.getSessionVariable().setQueryTimeoutS(2);
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftMock =
+                        Mockito.mockStatic(ThriftRPCRequestExecutor.class);
+                MockedStatic<GlobalStateMgr> gsmMock =
+                        Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> runModeMock =
+                        Mockito.mockStatic(RunMode.class);
+                MockedStatic<StarMgrServer> starMgrMock =
+                        Mockito.mockStatic(StarMgrServer.class)) {
+
+            thriftMock.when(() -> ThriftRPCRequestExecutor.call(
+                    Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            gsmMock.when(GlobalStateMgr::getCurrentState).thenReturn(mockGsm);
+            runModeMock.when(RunMode::isSharedDataMode).thenReturn(true);
+            starMgrMock.when(StarMgrServer::getCurrentState).thenReturn(mockStarMgrServer);
+
+            LeaderOpExecutor executor = new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(),
+                    connectContext, RedirectStatus.FORWARD_WITH_SYNC, false, null);
+
+            Assertions.assertThrows(DdlException.class, executor::execute);
+        } finally {
+            connectContext.getSessionVariable().setQueryTimeoutS(300);
+        }
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -900,6 +900,8 @@ struct TMasterOpResult {
     9: optional i64 txn_id;
     // SQL digest computed by Leader after analyze
     10:optional string sql_digest;
+    // StarMgr max journal ID for shared-data mode follower sync
+    11:optional i64 maxStarMgrJournalId;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
When a follower FE forwards DDL to the leader in shared-data mode, it only waits for the FE journal replay but not the StarMgr journal. This causes a race condition where newly created lake table shards are not yet known to the follower's local StarMgr, resulting in no queryable replica errors for queries immediately following table creation.

Fix: extend the leader forward result (TMasterOpResult) with the StarMgr max journal ID, and have the follower wait for both FE and StarMgr journal replay before returning to the client. Reuse the existing JournalObservable notification mechanism by parameterizing JournalObserver with a LongSupplier.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
