### PR TITLE
[BugFix] Stop MV scheduler after inactive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -274,9 +274,6 @@ public class TaskManager implements MemoryTrackable {
         if (task.getType() != Constants.TaskType.PERIODICAL) {
             return false;
         }
-        if (task.getState() == Constants.TaskState.PAUSE) {
-            return true;
-        }
         TaskSchedule taskSchedule = task.getSchedule();
         // this will not happen
         if (taskSchedule == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -991,7 +992,8 @@ public class TaskManagerEditLogTest {
         Task createdTask = masterTaskManager.getTask(taskName);
         Assertions.assertNotNull(createdTask);
         Assertions.assertEquals(Constants.TaskState.ACTIVE, createdTask.getState());
-        Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(createdTask.getId()));
+        ScheduledFuture<?> scheduledFuture = masterTaskManager.getPeriodFutureMap().get(createdTask.getId());
+        Assertions.assertNotNull(scheduledFuture);
 
         // 2. Execute suspendTask operation (master side)
         masterTaskManager.suspendTask(createdTask, false);
@@ -1000,6 +1002,8 @@ public class TaskManagerEditLogTest {
         Task suspendedTask = masterTaskManager.getTask(taskName);
         Assertions.assertNotNull(suspendedTask);
         Assertions.assertEquals(Constants.TaskState.PAUSE, suspendedTask.getState());
+        Assertions.assertTrue(scheduledFuture.isCancelled(),
+                "Suspending a periodical task should cancel the registered scheduler future");
 
         // 4. Test follower replay functionality
         TaskManager followerTaskManager = new TaskManager();


### PR DESCRIPTION
## Why I'm doing:

`ALTER MATERIALIZED VIEW ... INACTIVE` is intended to stop scheduling new periodic MV refresh task runs. Today FE pauses the task before stopping its scheduler, and `stopScheduler()` returns early for `PAUSE` tasks, so the registered `ScheduledFuture` is never canceled. The task keeps firing periodically and fails repeatedly after the MV becomes inactive.

## What I'm doing:

- Remove the early return in `TaskManager.stopScheduler()` for paused periodical tasks so `suspendTask()` still cancels the scheduler future
- Add FE regression coverage to assert suspending a periodical task cancels its registered scheduler future

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
