### PR TITLE
[Enhancement] Handle NULL variant as type-minimum for non-nullable PK columns in SstSeekRange

### DIFF
--- a/be/src/exec/range_router.cpp
+++ b/be/src/exec/range_router.cpp
@@ -87,7 +87,9 @@ Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t 
             }
 
             const auto& value = bound.values[i];
-            if (value.variant_type == TVariantType::NULL_VALUE) {
+            if (value.variant_type == TVariantType::MINIMUM || value.variant_type == TVariantType::MAXIMUM) {
+                return Status::InvalidArgument("MINIMUM/MAXIMUM variant is not supported in range bound");
+            } else if (value.variant_type == TVariantType::NULL_VALUE) {
                 column->append_nulls(1);
             } else if (value.variant_type == TVariantType::NORMAL_VALUE && value.__isset.value) {
                 auto type_info = get_type_info(*type_desc);

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -26,9 +26,56 @@
 #include "storage/datum_variant.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/types.h"
+#include "types/storage_type_traits.h"
 #include "types/type_descriptor.h"
 
 namespace starrocks::lake {
+
+// Produce a Datum holding the minimum value for the given logical type.
+// Uses TypeInfo::set_to_min() which calls std::numeric_limits<CppType>::lowest().
+// Covers all PK-supported types (APPLY_FOR_ALL_PK_SUPPORT_TYPE in logical_type_infra.h).
+template <LogicalType TYPE>
+static Datum datum_from_type_min_impl() {
+    using CppType = StorageCppType<TYPE>;
+    CppType value{};
+    get_type_info(TYPE)->set_to_min(&value);
+    Datum d;
+    d.set(value);
+    return d;
+}
+
+static StatusOr<Datum> datum_from_type_min(LogicalType type) {
+    switch (type) {
+    case TYPE_BOOLEAN: {
+        bool v;
+        get_type_info(TYPE_BOOLEAN)->set_to_min(&v);
+        Datum d;
+        d.set_int8(v);
+        return d;
+    }
+    case TYPE_TINYINT:
+        return datum_from_type_min_impl<TYPE_TINYINT>();
+    case TYPE_SMALLINT:
+        return datum_from_type_min_impl<TYPE_SMALLINT>();
+    case TYPE_INT:
+        return datum_from_type_min_impl<TYPE_INT>();
+    case TYPE_BIGINT:
+        return datum_from_type_min_impl<TYPE_BIGINT>();
+    case TYPE_LARGEINT:
+        return datum_from_type_min_impl<TYPE_LARGEINT>();
+    case TYPE_DATE:
+        return datum_from_type_min_impl<TYPE_DATE>();
+    case TYPE_DATETIME:
+        return datum_from_type_min_impl<TYPE_DATETIME>();
+    case TYPE_VARCHAR: {
+        Datum d;
+        d.set_slice(Slice("", 0));
+        return d;
+    }
+    default:
+        return Status::NotSupported(fmt::format("unsupported type for PK min datum: {}", type));
+    }
+}
 
 Status TabletRangeHelper::_validate_tablet_range(const TabletRangePB& tablet_range_pb) {
     if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
@@ -146,11 +193,18 @@ StatusOr<SstSeekRange> TabletRangeHelper::create_sst_seek_range_from(const Table
             RETURN_IF_ERROR(DatumVariant::from_proto(tuple.values(i), &datum, &type_desc));
             const bool is_nullable = tablet_schema->column(idx).is_nullable();
             if (!is_nullable && datum.is_null()) {
-                return Status::InvalidArgument("Non-nullable primary key contains NULL in tablet range");
+                // PK columns are non-nullable, so a NULL variant in the range boundary
+                // can only represent a MIN sentinel (FE maps MIN → NULL_VALUE).
+                // Fill with the per-type minimum value for correct PK encoding.
+                ASSIGN_OR_RETURN(datum, datum_from_type_min(type_desc.type));
+                auto column = ColumnHelper::create_column(type_desc, false);
+                column->append_datum(datum);
+                chunk->append_column(std::move(column), (SlotId)idx);
+            } else {
+                auto column = ColumnHelper::create_column(type_desc, is_nullable);
+                column->append_datum(datum);
+                chunk->append_column(std::move(column), (SlotId)idx);
             }
-            auto column = ColumnHelper::create_column(type_desc, is_nullable);
-            column->append_datum(datum);
-            chunk->append_column(std::move(column), (SlotId)idx);
         }
 
         std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
@@ -198,15 +252,17 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
 
             if (t_val.__isset.value) {
                 pb_val->set_value(t_val.value);
-            } else {
-                return Status::InvalidArgument("TVariant value is required");
+            } else if (!t_val.__isset.variant_type || t_val.variant_type == TVariantType::NORMAL_VALUE) {
+                return Status::InvalidArgument("TVariant value is required for NORMAL_VALUE variant");
             }
 
-            if (t_val.__isset.variant_type) {
-                pb_val->set_variant_type(static_cast<VariantTypePB>(t_val.variant_type));
-            } else {
+            if (!t_val.__isset.variant_type) {
                 return Status::InvalidArgument("TVariant variant_type is required");
             }
+            if (t_val.variant_type == TVariantType::MINIMUM || t_val.variant_type == TVariantType::MAXIMUM) {
+                return Status::InvalidArgument("MINIMUM/MAXIMUM variant is not supported in tablet range");
+            }
+            pb_val->set_variant_type(static_cast<VariantTypePB>(t_val.variant_type));
         }
         return Status::OK();
     };

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -630,8 +630,8 @@ TEST_F(RangeRouterTest, InitRejectsInvalidBoundVariantType) {
     RangeRouter router;
     auto status = router.init(ranges, 1);
     ASSERT_FALSE(status.ok());
-    ASSERT_TRUE(status.is_internal_error());
-    ASSERT_EQ("Invalid value in range bound", status.message());
+    ASSERT_TRUE(status.is_invalid_argument());
+    ASSERT_NE(std::string::npos, status.message().find("MINIMUM/MAXIMUM variant is not supported in range bound"));
 }
 
 TEST_F(RangeRouterTest, ValidateRangeRejectsInvalidVariantValue) {

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -110,6 +110,14 @@ protected:
         var.set_value(v);
         return var;
     }
+
+    VariantPB make_null_variant_pb(LogicalType ltype) {
+        VariantPB var;
+        TypeDescriptor type_desc(ltype);
+        var.mutable_type()->CopyFrom(type_desc.to_protobuf());
+        var.set_variant_type(VariantTypePB::NULL_VALUE);
+        return var;
+    }
 };
 
 TEST_F(LakePersistentIndexTest, test_basic_api) {
@@ -803,6 +811,53 @@ TEST_F(LakePersistentIndexTest, test_tablet_range_infinite_bounds) {
 
     ASSERT_TRUE(sst_seek_range.seek_key.empty());
     ASSERT_TRUE(sst_seek_range.stop_key.empty());
+}
+
+// NULL on non-nullable PK columns is treated as type-minimum (MIN sentinel from FE).
+TEST_F(LakePersistentIndexTest, test_tablet_range_null_as_min_on_non_nullable_pk) {
+    auto schema_pb = create_tablet_schema_pb({{"pk1", "INT"}, {"pk2", "INT"}, {"v1", "INT"}}, 2);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+
+    TabletRangePB range_pb;
+    auto* lower = range_pb.mutable_lower_bound();
+    lower->add_values()->CopyFrom(make_int_variant_pb(100));
+    lower->add_values()->CopyFrom(make_null_variant_pb(TYPE_INT));
+    range_pb.set_lower_bound_included(true);
+
+    auto* upper = range_pb.mutable_upper_bound();
+    upper->add_values()->CopyFrom(make_int_variant_pb(200));
+    upper->add_values()->CopyFrom(make_null_variant_pb(TYPE_INT));
+    range_pb.set_upper_bound_included(false);
+
+    ASSIGN_OR_ABORT(auto sst_seek_range, TabletRangeHelper::create_sst_seek_range_from(range_pb, schema));
+
+    // Encode expected: (100, INT_MIN) and (200, INT_MIN).
+    std::vector<ColumnId> pk_columns = {0, 1};
+    auto pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
+
+    auto encode_key = [&](int32_t v1, int32_t v2) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col1 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col1->append_datum(Datum(v1));
+        chunk->append_column(std::move(col1), (SlotId)0);
+        auto col2 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col2->append_datum(Datum(v2));
+        chunk->append_column(std::move(col2), (SlotId)1);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(
+                PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get(),
+                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    ASSERT_EQ(sst_seek_range.seek_key, encode_key(100, std::numeric_limits<int32_t>::lowest()));
+    ASSERT_EQ(sst_seek_range.stop_key, encode_key(200, std::numeric_limits<int32_t>::lowest()));
 }
 
 // Helper: build a RowsetMetadataPB with given id, per-segment row counts (segment_metas populated),

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -445,7 +445,6 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_null_values) {
     type_desc.types[0].__isset.scalar_type = true;
     type_desc.__isset.types = true;
     null_val.__set_type(type_desc);
-    null_val.__set_value("");
     null_val.__set_variant_type(TVariantType::NULL_VALUE);
     lower_bound.values.push_back(null_val);
     range.__set_lower_bound(lower_bound);
@@ -463,7 +462,8 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_null_values) {
     EXPECT_EQ(VariantTypePB::NULL_VALUE, pb_range.lower_bound().values(0).variant_type());
 }
 
-TEST_F(LakeTabletManagerTest, create_tablet_with_range_min_max_values) {
+// MINIMUM/MAXIMUM variants should be rejected — FE must map them to NULL_VALUE.
+TEST_F(LakeTabletManagerTest, create_tablet_with_range_rejects_min_max) {
     auto tablet_id = next_id();
     auto schema_id = next_id();
 
@@ -476,7 +476,6 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_min_max_values) {
     req.tablet_schema.__set_short_key_column_count(2);
     req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
 
-    // Set tablet range with MIN and MAX values
     TTabletRange range;
     TTuple lower_bound;
     TVariant min_val;
@@ -487,35 +486,14 @@ TEST_F(LakeTabletManagerTest, create_tablet_with_range_min_max_values) {
     type_desc.types[0].__isset.scalar_type = true;
     type_desc.__isset.types = true;
     min_val.__set_type(type_desc);
-    min_val.__set_value("");
     min_val.__set_variant_type(TVariantType::MINIMUM);
     lower_bound.values.push_back(min_val);
-
-    TTuple upper_bound;
-    TVariant max_val;
-    max_val.__set_type(type_desc);
-    max_val.__set_value("");
-    max_val.__set_variant_type(TVariantType::MAXIMUM);
-    upper_bound.values.push_back(max_val);
-
     range.__set_lower_bound(lower_bound);
-    range.__set_upper_bound(upper_bound);
     req.__set_range(range);
 
-    EXPECT_OK(_tablet_manager->create_tablet(req));
-    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
-    ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(1));
-
-    // Verify range with MIN/MAX values
-    EXPECT_TRUE(metadata->has_range());
-    const auto& pb_range = metadata->range();
-    EXPECT_TRUE(pb_range.has_lower_bound());
-    EXPECT_EQ(1, pb_range.lower_bound().values_size());
-    EXPECT_EQ(VariantTypePB::MINIMUM, pb_range.lower_bound().values(0).variant_type());
-
-    EXPECT_TRUE(pb_range.has_upper_bound());
-    EXPECT_EQ(1, pb_range.upper_bound().values_size());
-    EXPECT_EQ(VariantTypePB::MAXIMUM, pb_range.upper_bound().values(0).variant_type());
+    auto status = _tablet_manager->create_tablet(req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument());
 }
 
 TEST_F(LakeTabletManagerTest, create_tablet_without_range) {

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -18,7 +18,11 @@
 #include <gtest/gtest.h>
 
 #include "base/testutil/assert.h"
+#include "column/binary_column.h"
+#include "column/column_helper.h"
 #include "gen_cpp/AgentService_types.h"
+#include "storage/chunk_helper.h"
+#include "storage/primary_key_encoder.h"
 #include "storage/tablet_range.h"
 #include "storage/tablet_schema.h"
 #include "types/type_descriptor.h"
@@ -190,7 +194,8 @@ TEST(TabletRangeHelperTest, test_create_sst_seek_range_from) {
     ASSERT_THAT(res2.status().to_string(), testing::HasSubstr("Sort key index 0 must be 0, but is 1"));
 }
 
-TEST(TabletRangeHelperTest, test_non_nullable_key_rejects_null_range) {
+// NULL on a non-nullable PK column is treated as type-minimum (MIN sentinel from FE).
+TEST(TabletRangeHelperTest, test_non_nullable_key_null_fills_type_min) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(PRIMARY_KEYS);
     schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
@@ -213,10 +218,10 @@ TEST(TabletRangeHelperTest, test_non_nullable_key_rejects_null_range) {
     v0->set_variant_type(VariantTypePB::NULL_VALUE);
     range_pb.set_lower_bound_included(true);
 
+    // Should succeed — NULL is filled with INT_MIN.
     auto res = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema);
-    ASSERT_FALSE(res.ok());
-    ASSERT_TRUE(res.status().is_invalid_argument());
-    ASSERT_EQ("Non-nullable primary key contains NULL in tablet range", res.status().message());
+    ASSERT_OK(res.status());
+    ASSERT_FALSE(res.value().seek_key.empty());
 }
 
 TEST(TabletRangeHelperTest, test_create_sst_seek_range_requires_v2_encoding) {
@@ -337,7 +342,6 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_with_nulls) {
     type_desc.types[0].scalar_type.__set_type(TPrimitiveType::INT);
     type_desc.types[0].__isset.scalar_type = true;
     null_value.__set_type(type_desc);
-    null_value.__set_value("");
     null_value.__set_variant_type(TVariantType::NULL_VALUE);
     lower_bound.values.push_back(null_value);
 
@@ -352,16 +356,15 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_with_nulls) {
     ASSERT_TRUE(pb_range.has_lower_bound());
     ASSERT_EQ(1, pb_range.lower_bound().values_size());
     ASSERT_EQ(VariantTypePB::NULL_VALUE, pb_range.lower_bound().values(0).variant_type());
-    ASSERT_TRUE(pb_range.lower_bound().values(0).has_value());
+    ASSERT_FALSE(pb_range.lower_bound().values(0).has_value());
     ASSERT_TRUE(pb_range.has_lower_bound_included());
     ASSERT_TRUE(pb_range.lower_bound_included());
     ASSERT_FALSE(pb_range.has_upper_bound());
 }
 
-TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_min_max_values) {
+// MINIMUM/MAXIMUM in TTabletRange should be rejected at conversion time.
+TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_rejects_min_max_in_lower) {
     TTabletRange t_range;
-
-    // Lower bound with MIN_VALUE
     TTuple lower_bound;
     TVariant min_value;
     TTypeDesc type_desc;
@@ -371,32 +374,14 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_min_max_values) {
     type_desc.types[0].scalar_type.__set_type(TPrimitiveType::BIGINT);
     type_desc.types[0].__isset.scalar_type = true;
     min_value.__set_type(type_desc);
-    min_value.__set_value("");
     min_value.__set_variant_type(TVariantType::MINIMUM);
     lower_bound.values.push_back(min_value);
     t_range.__set_lower_bound(lower_bound);
 
-    // Upper bound with MAX_VALUE
-    TTuple upper_bound;
-    TVariant max_value;
-    max_value.__set_type(type_desc);
-    max_value.__set_value("");
-    max_value.__set_variant_type(TVariantType::MAXIMUM);
-    upper_bound.values.push_back(max_value);
-    t_range.__set_upper_bound(upper_bound);
-
-    // Convert and verify
     auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
-    ASSERT_OK(res.status());
-    TabletRangePB pb_range = res.value();
-
-    ASSERT_TRUE(pb_range.has_lower_bound());
-    ASSERT_EQ(1, pb_range.lower_bound().values_size());
-    ASSERT_EQ(VariantTypePB::MINIMUM, pb_range.lower_bound().values(0).variant_type());
-
-    ASSERT_TRUE(pb_range.has_upper_bound());
-    ASSERT_EQ(1, pb_range.upper_bound().values_size());
-    ASSERT_EQ(VariantTypePB::MAXIMUM, pb_range.upper_bound().values(0).variant_type());
+    ASSERT_FALSE(res.ok());
+    ASSERT_TRUE(res.status().is_invalid_argument());
+    ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
 }
 
 TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_only_lower_bound) {
@@ -559,51 +544,44 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_complex_types) {
     ASSERT_EQ(TPrimitiveType::DATETIME, pb_datetime_val.type().types(0).scalar_type().type());
 }
 
-TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_partial_fields) {
-    TTabletRange t_range;
-
-    TTuple lower_bound;
-
+// MINIMUM/MAXIMUM variants should be rejected — FE must map them to NULL_VALUE.
+TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_rejects_min_max) {
     TTypeDesc type_desc;
     type_desc.types.resize(1);
     type_desc.__isset.types = true;
     type_desc.types[0].type = TTypeNodeType::SCALAR;
     type_desc.types[0].scalar_type.__set_type(TPrimitiveType::INT);
     type_desc.types[0].__isset.scalar_type = true;
-    // Value with all fields set (MINIMUM) - OK
-    TVariant value1;
-    value1.__set_type(type_desc);
-    value1.__set_value("");
-    value1.__set_variant_type(TVariantType::MINIMUM);
-    lower_bound.values.push_back(value1);
 
-    // Value with all fields set (MAXIMUM) - OK
-    TVariant value2;
-    value2.__set_type(type_desc);
-    value2.__set_value("");
-    value2.__set_variant_type(TVariantType::MAXIMUM);
-    lower_bound.values.push_back(value2);
+    {
+        TTabletRange t_range;
+        TTuple lower_bound;
+        TVariant min_val;
+        min_val.__set_type(type_desc);
+        min_val.__set_variant_type(TVariantType::MINIMUM);
+        lower_bound.values.push_back(min_val);
+        t_range.__set_lower_bound(lower_bound);
 
-    t_range.__set_lower_bound(lower_bound);
+        auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
+        ASSERT_FALSE(res.ok());
+        ASSERT_TRUE(res.status().is_invalid_argument());
+        ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
+    }
 
-    auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
-    ASSERT_OK(res.status());
-    TabletRangePB pb_range = res.value();
+    {
+        TTabletRange t_range;
+        TTuple upper_bound;
+        TVariant max_val;
+        max_val.__set_type(type_desc);
+        max_val.__set_variant_type(TVariantType::MAXIMUM);
+        upper_bound.values.push_back(max_val);
+        t_range.__set_upper_bound(upper_bound);
 
-    ASSERT_TRUE(pb_range.has_lower_bound());
-    ASSERT_EQ(2, pb_range.lower_bound().values_size());
-
-    // Check first value (MINIMUM)
-    const auto& val1 = pb_range.lower_bound().values(0);
-    ASSERT_EQ(VariantTypePB::MINIMUM, val1.variant_type());
-    ASSERT_TRUE(val1.has_value());
-    ASSERT_TRUE(val1.has_type());
-
-    // Check second value (MAXIMUM)
-    const auto& val2 = pb_range.lower_bound().values(1);
-    ASSERT_EQ(VariantTypePB::MAXIMUM, val2.variant_type());
-    ASSERT_TRUE(val2.has_value());
-    ASSERT_TRUE(val2.has_type());
+        auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
+        ASSERT_FALSE(res.ok());
+        ASSERT_TRUE(res.status().is_invalid_argument());
+        ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
+    }
 }
 
 TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_missing_fields) {
@@ -641,7 +619,8 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_missing_fields) {
         auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
         ASSERT_FALSE(res.ok());
         ASSERT_TRUE(res.status().is_invalid_argument());
-        ASSERT_THAT(res.status().to_string(), testing::HasSubstr("TVariant value is required"));
+        ASSERT_THAT(res.status().to_string(),
+                    testing::HasSubstr("TVariant value is required for NORMAL_VALUE variant"));
     }
 
     {
@@ -677,6 +656,157 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_invalid_type) {
     ASSERT_FALSE(res.ok());
     ASSERT_TRUE(res.status().is_invalid_argument());
     ASSERT_THAT(res.status().to_string(), testing::HasSubstr("TVariant type is set but types list is empty"));
+}
+
+// NULL on a non-nullable PK column is treated as type-minimum (MIN sentinel from FE).
+TEST(TabletRangeHelperTest, test_sst_seek_range_null_as_min_on_non_nullable_pk) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+
+    auto c0 = schema_pb.add_column();
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema_pb.add_column();
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(true);
+    c1->set_is_nullable(false);
+
+    schema_pb.clear_sort_key_idxes();
+    schema_pb.add_sort_key_idxes(0);
+    schema_pb.add_sort_key_idxes(1);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    TypeDescriptor type_int(TYPE_INT);
+
+    // Build range [(100, NULL), (200, NULL)) where NULL represents MIN from FE.
+    TabletRangePB range_pb;
+    {
+        auto* lower = range_pb.mutable_lower_bound();
+        auto* v0 = lower->add_values();
+        v0->mutable_type()->CopyFrom(type_int.to_protobuf());
+        v0->set_value("100");
+        v0->set_variant_type(VariantTypePB::NORMAL_VALUE);
+        auto* v1 = lower->add_values();
+        v1->mutable_type()->CopyFrom(type_int.to_protobuf());
+        v1->set_variant_type(VariantTypePB::NULL_VALUE);
+        range_pb.set_lower_bound_included(true);
+    }
+    {
+        auto* upper = range_pb.mutable_upper_bound();
+        auto* v0 = upper->add_values();
+        v0->mutable_type()->CopyFrom(type_int.to_protobuf());
+        v0->set_value("200");
+        v0->set_variant_type(VariantTypePB::NORMAL_VALUE);
+        auto* v1 = upper->add_values();
+        v1->mutable_type()->CopyFrom(type_int.to_protobuf());
+        v1->set_variant_type(VariantTypePB::NULL_VALUE);
+        range_pb.set_upper_bound_included(false);
+    }
+
+    // Should succeed — NULL on non-nullable column is filled with type-min.
+    ASSIGN_OR_ABORT(auto sst_seek_range, TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema));
+
+    // Build expected: encode (100, INT_MIN) and (200, INT_MIN).
+    std::vector<ColumnId> pk_columns = {0, 1};
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    auto encode_key = [&](int32_t v1, int32_t v2) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col1 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col1->append_datum(Datum(v1));
+        chunk->append_column(std::move(col1), (SlotId)0);
+        auto col2 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col2->append_datum(Datum(v2));
+        chunk->append_column(std::move(col2), (SlotId)1);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(
+                PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get(),
+                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    ASSERT_EQ(sst_seek_range.seek_key, encode_key(100, std::numeric_limits<int32_t>::lowest()));
+    ASSERT_EQ(sst_seek_range.stop_key, encode_key(200, std::numeric_limits<int32_t>::lowest()));
+}
+
+// Exercise datum_from_type_min() for every PK-supported type.
+// Each case builds a 1-column PK schema, puts NULL in the range bound,
+// and verifies that create_sst_seek_range_from succeeds (NULL → type-min fill).
+TEST(TabletRangeHelperTest, test_sst_seek_range_null_as_min_all_pk_types) {
+    struct TypeCase {
+        const char* type_name;
+        LogicalType logical_type;
+    };
+    // All types from APPLY_FOR_ALL_PK_SUPPORT_TYPE (logical_type_infra.h).
+    std::vector<TypeCase> cases = {
+            {"BOOLEAN", TYPE_BOOLEAN}, {"TINYINT", TYPE_TINYINT},   {"SMALLINT", TYPE_SMALLINT},
+            {"INT", TYPE_INT},         {"BIGINT", TYPE_BIGINT},     {"LARGEINT", TYPE_LARGEINT},
+            {"DATE", TYPE_DATE},       {"DATETIME", TYPE_DATETIME}, {"VARCHAR", TYPE_VARCHAR},
+    };
+
+    for (const auto& tc : cases) {
+        SCOPED_TRACE(tc.type_name);
+
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        auto c0 = schema_pb.add_column();
+        c0->set_name("c0");
+        c0->set_type(tc.type_name);
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        schema_pb.add_sort_key_idxes(0);
+        auto tablet_schema = TabletSchema::create(schema_pb);
+
+        TabletRangePB range_pb;
+        auto* lower = range_pb.mutable_lower_bound();
+        auto* v0 = lower->add_values();
+        TypeDescriptor type_desc(tc.logical_type);
+        v0->mutable_type()->CopyFrom(type_desc.to_protobuf());
+        v0->set_variant_type(VariantTypePB::NULL_VALUE);
+        range_pb.set_lower_bound_included(true);
+
+        auto res = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema);
+        ASSERT_TRUE(res.ok()) << "type=" << tc.type_name << " error=" << res.status().to_string();
+    }
+}
+
+// Unsupported type should return NotSupported, not crash.
+TEST(TabletRangeHelperTest, test_sst_seek_range_null_as_min_unsupported_type) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    auto c0 = schema_pb.add_column();
+    c0->set_name("c0");
+    c0->set_type("FLOAT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+    schema_pb.add_sort_key_idxes(0);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    TabletRangePB range_pb;
+    auto* lower = range_pb.mutable_lower_bound();
+    auto* v0 = lower->add_values();
+    TypeDescriptor type_desc(TYPE_FLOAT);
+    v0->mutable_type()->CopyFrom(type_desc.to_protobuf());
+    v0->set_variant_type(VariantTypePB::NULL_VALUE);
+    range_pb.set_lower_bound_included(true);
+
+    auto res = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema);
+    ASSERT_FALSE(res.ok());
+    ASSERT_TRUE(res.status().is_not_supported());
+    ASSERT_THAT(res.status().to_string(), testing::HasSubstr("unsupported type for PK min datum"));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -381,7 +381,8 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_rejects_min_max_in_
     auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
     ASSERT_FALSE(res.ok());
     ASSERT_TRUE(res.status().is_invalid_argument());
-    ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
+    ASSERT_THAT(res.status().to_string(),
+                testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
 }
 
 TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_only_lower_bound) {
@@ -565,7 +566,8 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_rejects_min_max) {
         auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
         ASSERT_FALSE(res.ok());
         ASSERT_TRUE(res.status().is_invalid_argument());
-        ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
+        ASSERT_THAT(res.status().to_string(),
+                    testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
     }
 
     {
@@ -580,7 +582,8 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_rejects_min_max) {
         auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
         ASSERT_FALSE(res.ok());
         ASSERT_TRUE(res.status().is_invalid_argument());
-        ASSERT_THAT(res.status().to_string(), testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
+        ASSERT_THAT(res.status().to_string(),
+                    testing::HasSubstr("MINIMUM/MAXIMUM variant is not supported in tablet range"));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

  Range distribution tables in shared-data mode support tablet split/merge with composite sort-key ranges. FE uses MIN sentinels to represent negative-infinity bounds in per-column range boundaries, mapped to NULL_VALUE before sending to BE. However, BE's `create_sst_seek_range_from()` rejects NULL on non-nullable PK columns, and `convert_t_range_to_pb_range()` rejects any TVariant without a value field. This blocks range distribution with multi-column sort keys.

## What I'm doing:

  Two source-level fixes in `tablet_range_helper.cpp`, plus explicit rejection of raw MINIMUM/MAXIMUM variants that FE should never send:

  1. **`create_sst_seek_range_from`**: For non-nullable PK columns, a NULL datum can only represent a MIN sentinel (PK columns cannot hold real NULLs). Instead of rejecting it, fill with the per-type minimum value via `TypeInfo::set_to_min()` for correct PK encoding.

  2. **`convert_t_range_to_pb_range`**: Accept missing `value` field for non-NORMAL_VALUE variants (NULL_VALUE, MINIMUM, MAXIMUM). FE's `NullVariant.toThrift()` omits the value field, which previously caused an unconditional rejection.

  3. **Explicit MINIMUM/MAXIMUM rejection**: Add early validation in `convert_t_range_to_pb_range` and `RangeRouter::parse_bound` to reject raw MINIMUM/MAXIMUM variants with clear error messages, preventing silent data corruption if FE sends them without mapping to NULL_VALUE first.


Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
