### PR TITLE
[BugFix] Fix use-after-free in ThreadPool::do_submit when thread creation fails

### DIFF
--- a/be/src/common/thread/threadpool.cpp
+++ b/be/src/common/thread/threadpool.cpp
@@ -426,10 +426,37 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int inactive_threads = _num_threads + _num_threads_pending_start - _active_threads;
     int additional_threads = static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
+    bool sole_thread = false;
     if (additional_threads > 0 &&
         _num_threads + _num_threads_pending_start < _max_threads.load(std::memory_order_acquire)) {
         need_a_thread = true;
         _num_threads_pending_start++;
+        sole_thread = (_num_threads + _num_threads_pending_start == 1);
+    }
+
+    // When this submit needs to create the very first thread for the pool
+    // (sole_thread == true), create it while still holding the lock and BEFORE
+    // enqueuing the task.
+    //
+    // Why create before enqueue?
+    //   If thread creation fails and no threads exist, the caller receives an
+    //   error and performs its own cleanup (e.g. counting down a latch). If the
+    //   task were already in the queue, a later successful submit could spawn a
+    //   thread that picks up the orphaned task, executing it against already-
+    //   destroyed state — a use-after-free.
+    //
+    // Why hold the lock during thread creation?
+    //   If we released the lock, a concurrent submitter could see our
+    //   _num_threads_pending_start and assume a thread is available, enqueue
+    //   its task without creating a thread, and then have that task stranded
+    //   if our create_thread() fails. The pool has zero threads here, so no
+    //   worker is blocked waiting for this lock.
+    if (sole_thread) {
+        Status status = create_thread();
+        if (!status.ok()) {
+            _num_threads_pending_start--;
+            return status;
+        }
     }
 
     TEST_SYNC_POINT_CALLBACK("ThreadPool::do_submit:replace_task", &r);
@@ -462,15 +489,11 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     }
     unique_lock.unlock();
 
-    if (need_a_thread) {
+    if (need_a_thread && !sole_thread) {
         Status status = create_thread();
         if (!status.ok()) {
             unique_lock.lock();
             _num_threads_pending_start--;
-            if (_num_threads + _num_threads_pending_start == 0) {
-                // If we have no threads, we can't do any work.
-                return status;
-            }
             // If we failed to create a thread, but there are still some other
             // worker threads, log a warning message and continue.
             LOG(ERROR) << "Thread pool failed to create thread: " << status.to_string() << "\n" << get_stack_trace();
@@ -733,6 +756,11 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
+    Status status;
+    TEST_SYNC_POINT_CALLBACK("ThreadPool::create_thread", &status);
+    if (!status.ok()) {
+        return status;
+    }
     return Thread::create("thread pool", _name, &ThreadPool::dispatch_thread, this, nullptr);
 }
 

--- a/be/test/common/thread/threadpool_test.cpp
+++ b/be/test/common/thread/threadpool_test.cpp
@@ -41,6 +41,7 @@
 #include "base/metrics.h"
 #include "base/random/random.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/time/monotime.h"
 #include "base/utility/scoped_cleanup.h"
 #include "common/logging.h"
@@ -223,7 +224,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.
@@ -989,5 +990,152 @@ TEST_F(ThreadPoolTest, TestLIFOThreadWakeUps) {
     NO_PENDING_FATALS();
 }
 */
+
+// Regression test for a use-after-free bug in do_submit().
+//
+// When the pool has min_threads=0 and all threads have exited, a new submit
+// must create a thread. The old code enqueued the task first, then attempted
+// thread creation. If creation failed (e.g. EAGAIN), it returned an error
+// WITHOUT removing the task from the queue. The caller, seeing the error,
+// would perform its own cleanup (e.g. counting down a latch). A later
+// successful submit could then create a thread that picks up the orphaned
+// task, executing it against already-destroyed state (use-after-free).
+//
+// The fix creates the thread BEFORE enqueuing the task when the pool has
+// zero threads. If thread creation fails, the task is never enqueued.
+TEST_F(ThreadPoolTest, TestSubmitFailsCleanlyWhenNoThreadsExist) {
+    // Pool with min_threads=0 so all threads can idle-exit.
+    ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
+                                                  .set_min_threads(0)
+                                                  .set_max_threads(4)
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                        .ok());
+
+    // Wait for threads to exit (min_threads=0, short idle timeout).
+    ASSERT_EQ(0, _pool->num_threads());
+
+    // Inject create_thread failure to simulate EAGAIN (resource exhaustion).
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::create_thread", [](void* arg) {
+        auto* status = static_cast<Status*>(arg);
+        *status = Status::RuntimeError("Could not create thread: Resource temporarily unavailable");
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SCOPED_CLEANUP({
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::create_thread");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    std::atomic<int> run_count{0};
+    Status s = _pool->submit_func([&]() { run_count++; });
+    // Submit should fail because thread creation failed.
+    ASSERT_FALSE(s.ok());
+    // The task must NOT have been enqueued.
+    ASSERT_EQ(0, _pool->_total_queued_tasks);
+    ASSERT_EQ(0, run_count);
+
+    // Now disable the failure injection and verify normal operation resumes.
+    SyncPoint::GetInstance()->ClearCallBack("ThreadPool::create_thread");
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    CountDownLatch latch(1);
+    s = _pool->submit_func([&]() {
+        run_count++;
+        latch.count_down();
+    });
+    ASSERT_TRUE(s.ok());
+    latch.wait();
+    ASSERT_EQ(1, run_count);
+    _pool->wait();
+    _pool->shutdown();
+}
+
+// Verify that when thread creation fails but other threads exist in the pool,
+// the task is still enqueued and eventually processed (no error returned).
+TEST_F(ThreadPoolTest, TestSubmitSucceedsWhenThreadCreationFailsButThreadsExist) {
+    // Pool with min_threads=1 so at least one thread always exists.
+    ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
+                                                  .set_min_threads(1)
+                                                  .set_max_threads(4)
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(kThreadIdleTimeoutMs)))
+                        .ok());
+    ASSERT_EQ(1, _pool->num_threads());
+
+    // Block the existing thread so a new submit requires a new thread.
+    CountDownLatch block_latch(1);
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&block_latch)).ok());
+
+    // Now inject create_thread failure.
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::create_thread", [](void* arg) {
+        auto* status = static_cast<Status*>(arg);
+        *status = Status::RuntimeError("Could not create thread: Resource temporarily unavailable");
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    // Submit should succeed because existing thread can process the task.
+    std::atomic<int> run_count{0};
+    Status s = _pool->submit_func([&]() { run_count++; });
+    ASSERT_TRUE(s.ok());
+
+    // Disable failure injection and unblock.
+    SyncPoint::GetInstance()->ClearCallBack("ThreadPool::create_thread");
+    SyncPoint::GetInstance()->DisableProcessing();
+    block_latch.count_down();
+
+    _pool->wait();
+    ASSERT_EQ(1, run_count);
+    _pool->shutdown();
+}
+
+// Verify the original crash scenario: a stack-allocated latch captured by
+// reference in a task. If the task were orphaned in the queue after a failed
+// submit, a later thread would execute it and count_down a destroyed latch.
+// With the fix, the task is never enqueued, so the latch is safe.
+TEST_F(ThreadPoolTest, TestSubmitFailureDoesNotCauseUseAfterFree) {
+    ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
+                                                  .set_min_threads(0)
+                                                  .set_max_threads(4)
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                        .ok());
+    ASSERT_EQ(0, _pool->num_threads());
+
+    // First call: fail. Subsequent calls: succeed.
+    std::atomic<int> create_call_count{0};
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::create_thread", [&](void* arg) {
+        if (create_call_count.fetch_add(1) == 0) {
+            auto* status = static_cast<Status*>(arg);
+            *status = Status::RuntimeError("Could not create thread: Resource temporarily unavailable");
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SCOPED_CLEANUP({
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::create_thread");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Simulate the crash scenario: stack-allocated latch, task captured by ref.
+    {
+        const int kNumTasks = 5;
+        CountDownLatch latch(kNumTasks);
+        int submit_failures = 0;
+
+        for (int i = 0; i < kNumTasks; i++) {
+            Status s = _pool->submit_func([&latch]() { latch.count_down(); });
+            if (!s.ok()) {
+                // Caller counts down on failure (like the original bug scenario).
+                latch.count_down();
+                submit_failures++;
+            }
+        }
+        // First submit should fail (injected), rest should succeed.
+        ASSERT_EQ(1, submit_failures);
+        // Wait for all count_downs (from both successful tasks and caller cleanup).
+        latch.wait();
+    }
+    // If the orphaned task bug existed, this point would crash (use-after-free
+    // on the destroyed latch). With the fix, we reach here safely.
+
+    _pool->wait();
+    _pool->shutdown();
+}
 
 } // namespace starrocks

--- a/be/test/common/thread/threadpool_test.cpp
+++ b/be/test/common/thread/threadpool_test.cpp
@@ -224,7 +224,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.


### PR DESCRIPTION
## Why I'm doing:
  When ThreadPool has min_threads=0, all worker threads can idle-exit, leaving _num_threads == 0. A new submit() would:

  1. Enqueue the task into the token's priority queue
  2. Attempt create_thread() outside the lock
  3. If creation fails and _num_threads + _num_threads_pending_start == 0, return error

  The caller receives the error and performs cleanup (e.g. counting down a latch). But the task remains in the queue. A subsequent successful submit() creates a thread that picks up the orphaned task, executing it against already-destroyed state — causing a SIGSEGV crash in butil::LinkNode<ButexWaiter>::InsertBefore due to use-after-free on a stack-allocated BThreadCountDownLatch.

Key Logs
```
W20260403 06:43:42.119449 47099786790656 lake_service.cpp:1217] Fail to get tablet stats task: Runtime error: Could not create thread: Resource temporarily unavailable
W20260403 06:43:42.119535 47099786790656 lake_service.cpp:1217] Fail to get tablet stats task: Runtime error: Could not create thread: Resource temporarily unavailable
W20260403 06:43:42.119611 47099786790656 lake_service.cpp:1217] Fail to get tablet stats task: Runtime error: Could not create thread: Resource temporarily unavailable
W20260403 06:43:42.121087 47099653371648 lake_service.cpp:1217] Fail to get tablet stats task: Runtime error: Could not create thread: Resource temporarily unavailable
W20260403 06:43:42.121156 47099653371648 lake_service.cpp:1217] Fail to get tablet stats task: Runtime error: Could not create thread: Resource temporarily unavailable
```

## What I'm doing:
  Introduce a sole_thread flag: when _num_threads + _num_threads_pending_start == 1 after incrementing (meaning we're creating the pool's only thread), attempt thread creation before enqueuing. If it fails, return error immediately — the task was never enqueued.

  When the pool already has other threads, the original behavior is preserved (enqueue first, then create thread), since that path always returns OK.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11218

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
