### PR TITLE
[BugFix] Set empty rowid range when segment is fully covered during persistent index rebuild

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1087,9 +1087,11 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                         auto range = std::make_shared<SparseRange<>>();
                         range->add(Range<>(start_rowid, std::numeric_limits<rowid_t>::max()));
                         rowid_ranges[si] = std::move(range);
+                    } else {
+                        // low_rowid == UINT32_MAX means the entire segment is covered by SSTables,
+                        // set an empty range so the segment iterator skips all rows.
+                        rowid_ranges[si] = std::make_shared<SparseRange<>>();
                     }
-                    // If low_rowid == UINT32_MAX, the entire segment is covered,
-                    // and will be skipped by the rssid < rebuild_rss_id check below.
                     break;
                 }
             }


### PR DESCRIPTION
## Why I'm doing:

In `LakePersistentIndex::load_from_lake_tablet`, when building per-segment rowid ranges
for the rebuild optimization (introduced in #71082), the code handles the boundary segment
where `rssid == rebuild_rss_id`. When `low_rowid == UINT32_MAX` (meaning the entire segment
is covered by SSTables), the code previously left `rowid_ranges[si]` as nullptr and relied
on a comment claiming the segment would be "skipped by the `rssid < rebuild_rss_id` check below".

However, this comment is incorrect — since `rssid == rebuild_rss_id`, the check
`rssid < rebuild_rss_id` at line 1115 evaluates to **false**, so the segment is **not** skipped.
The segment is fully scanned and all rows are discarded by the post-read check
(`values.back().get_value() <= rebuild_rss_rowid_point`), wasting IO.

## What I'm doing:

When `low_rowid == UINT32_MAX`, explicitly set `rowid_ranges[si]` to an empty `SparseRange`
instead of leaving it as nullptr. In `SegmentIterator::_get_row_ranges_by_rowid_range()`,
the scan range intersects with this empty range, producing an empty result, so the iterator
returns EOF immediately without any IO.

- `nullptr` rowid_range means "no restriction, scan entire segment"
- Empty `SparseRange` means "scan zero rows"

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)