### PR TITLE
[Enhancement] Skip already-covered rows during persistent index rebuild (backport #71082)

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1070,10 +1070,33 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             continue;
         }
         const int64_t rowset_version = rowset->version() != 0 ? rowset->version() : base_version;
+        // Build per-segment rowid ranges to skip rows already covered by SSTables.
+        // For the segment containing rebuild_rss_rowid_point, only rows after that point need rebuild.
+        std::vector<SparseRangePtr> rowid_ranges(rowset->num_segments());
+        if (rebuild_rss_rowid_point > 0) {
+            for (int32_t si = 0; si < rowset->num_segments(); si++) {
+                uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), si);
+                if (rssid == rebuild_rss_id) {
+                    uint32_t low_rowid = rebuild_rss_rowid_point & 0xFFFFFFFF;
+                    if (low_rowid < std::numeric_limits<uint32_t>::max()) {
+                        uint32_t start_rowid = low_rowid + 1;
+                        auto range = std::make_shared<SparseRange<>>();
+                        range->add(Range<>(start_rowid, std::numeric_limits<rowid_t>::max()));
+                        rowid_ranges[si] = std::move(range);
+                    } else {
+                        // low_rowid == UINT32_MAX means the entire segment is covered by SSTables,
+                        // set an empty range so the segment iterator skips all rows.
+                        rowid_ranges[si] = std::make_shared<SparseRange<>>();
+                    }
+                    break;
+                }
+            }
+        }
         StatusOr<std::vector<ChunkIteratorPtr>> res;
         {
             TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_get_segment_iterator_with_delvec_us");
-            res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+            res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats,
+                                                                &rowid_ranges);
         }
         if (!res.ok()) {
             return res.status();

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -469,10 +469,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     return seg_iterators;
 }
 
-StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_delvec(const Schema& schema,
-                                                                                      int64_t version,
-                                                                                      const MetaFileBuilder* builder,
-                                                                                      OlapReaderStatistics* stats) {
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_delvec(
+        const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats,
+        const std::vector<SparseRangePtr>* rowid_range_per_segment) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_iterator_with_delvec_us");
     std::vector<SegmentPtr> segments;
     RETURN_IF_ERROR(load_segments(&segments, false));
@@ -500,6 +499,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
+        }
+        // Apply per-segment rowid range if provided
+        if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
+            seg_options.rowid_range_option = (*rowid_range_per_segment)[i];
+        } else {
+            seg_options.rowid_range_option = nullptr;
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -23,6 +23,7 @@
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
 #include "storage/options.h"
+#include "storage/range.h"
 #include "storage/rowset/base_rowset.h"
 #include "storage/seek_range.h"
 
@@ -91,9 +92,12 @@ public:
     // if the segment is empty, it wouln't add this iterator to iterator list
     // this function does not expect segment schema will be changed, so return error if record predicate exists
     // but does not match its chunk schema
-    StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(const Schema& schema, int64_t version,
-                                                                                  const MetaFileBuilder* builder,
-                                                                                  OlapReaderStatistics* stats);
+    // |rowid_range_per_segment|: if non-null, rowid_range_per_segment[i] specifies the row range
+    // to scan for the i-th segment. If the pointer at index i is null, the entire segment is scanned.
+    // The vector size must equal num_segments() if provided.
+    StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(
+            const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats,
+            const std::vector<SparseRangePtr>* rowid_range_per_segment = nullptr);
 
     [[nodiscard]] bool is_overlapped() const override { return metadata().overlapped(); }
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2526,6 +2526,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_preload_update_state_slow_log) {
 }
 
 // Test that persistent index rebuild skips rows already covered by SSTables.
+// This verifies the optimization where rebuild_rss_rowid_point is used to set
+// a rowid range on the segment iterator, avoiding unnecessary IO for rows
+// that are already in SSTables.
 TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_rows) {
     if (!GetParam().enable_persistent_index ||
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
@@ -2534,8 +2537,11 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
     const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
-    config::l0_max_mem_usage = 10;
+    config::l0_max_mem_usage = 10; // force sstable flush
 
+    // Step 1: Write multiple rowsets to build up SSTables.
+    // Each publish will flush to SSTable due to small l0_max_mem_usage.
+    // This creates a rebuild_rss_rowid_point that covers most existing rows.
     for (int r = 0; r < 3; r++) {
         auto [chunk, indexes] = gen_data_and_index(kChunkSize, r, true, true);
         int64_t txn_id = next_id();
@@ -2555,10 +2561,17 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
+
+    // Verify: 3 non-overlapping chunks
     ASSERT_EQ(kChunkSize * 3, read_rows(tablet_id, version));
 
+    // Step 2: Remove persistent index to force rebuild on next publish.
+    // The rebuild should use rowid range to skip rows covered by SSTables.
     _update_mgr->unload_and_remove_primary_index(tablet_id);
 
+    // Step 3: Write new data. This triggers rebuild where most existing rows
+    // should be skipped (covered by SSTables), only a few rows near the
+    // rebuild_rss_rowid_point boundary need to be read.
     auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 3, true, true);
     {
         int64_t txn_id = next_id();
@@ -2578,6 +2591,8 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
+
+    // Step 4: Verify correctness after rebuild with row skipping
     ASSERT_EQ(kChunkSize * 4, read_rows(tablet_id, version));
 
     config::l0_max_mem_usage = old_l0_max_mem_usage;
@@ -2595,6 +2610,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
     const auto old_l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 10;
 
+    // Write 4 rowsets with overlapping keys (same key range, shift=0)
     for (int r = 0; r < 4; r++) {
         auto [chunk, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
         int64_t txn_id = next_id();
@@ -2614,10 +2630,14 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
+
+    // Should have kChunkSize rows (all upserts to same key range)
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
 
+    // Force rebuild
     _update_mgr->unload_and_remove_primary_index(tablet_id);
 
+    // Write again with overlapping keys
     auto [chunk_new, indexes_new] = gen_data_and_index(kChunkSize, 0, true, true);
     {
         int64_t txn_id = next_id();
@@ -2637,6 +2657,8 @@ TEST_P(LakePrimaryKeyPublishTest, test_rebuild_persistent_index_skip_covered_row
         ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
+
+    // Still kChunkSize rows
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
 
     config::l0_max_mem_usage = old_l0_max_mem_usage;


### PR DESCRIPTION
## Why I'm doing:

This is a replacement for #71282 (mergify auto-backport of #71082 to branch-4.1.0) which had merge conflicts.

This backport includes the original optimization from #71082 plus the bugfix from #71284:

When `low_rowid == UINT32_MAX`, the entire segment is covered by SSTables. Previously,
no `rowid_range` was set (nullptr), causing the segment to be fully scanned and rows
discarded by post-read check, wasting IO. The original comment incorrectly claimed
this would be "skipped by the `rssid < rebuild_rss_id` check", but since
`rssid == rebuild_rss_id` that check evaluates to false.

Now set an empty `SparseRange` so the segment iterator skips all rows immediately
without any IO.

## What I'm doing:

- Backport of #71082: Use `rebuild_rss_rowid_point` to compute a rowid range for the
  boundary segment and pass it to the segment iterator via `SegmentReadOptions::rowid_range_option`,
  skipping rows already covered by SSTables.
- Include bugfix from #71284: When `low_rowid == UINT32_MAX`, set an empty `SparseRange`
  instead of leaving `rowid_range` as nullptr.
- Resolve merge conflicts with branch-4.1.0 (test file conflicts due to
  `test_parallel_sstable_open_on_index_init` test).

Closes #71282

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
