### PR TITLE
[Refactor] Move RuntimeFilterProbeCollector::wait to ExecCore

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -23,6 +23,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/exec")
 set(EXEC_CORE_FILES
     runtime_filter/runtime_filter_descriptor.cpp
     runtime_filter/runtime_filter_probe.cpp
+    runtime_filter/runtime_filter_probe_wait.cpp
     runtime_filter/runtime_filter_registry.cpp
     runtime_filter/runtime_filter_helper.cpp
 )
@@ -31,7 +32,7 @@ ADD_BE_LIB(ExecCore
     ${EXEC_CORE_FILES}
 )
 
-target_link_libraries(ExecCore PUBLIC ExprCore)
+target_link_libraries(ExecCore PUBLIC ExprCore RuntimeCore)
 
 set(EXEC_FILES
     fetch_node.cpp

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -153,6 +153,9 @@ Status ExecNode::init_join_runtime_filters(const TPlanNode& tnode, RuntimeState*
     if (state != nullptr && state->query_options().__isset.runtime_filter_scan_wait_time_ms) {
         _runtime_filter_collector.set_scan_wait_timeout_ms(state->query_options().runtime_filter_scan_wait_time_ms);
     }
+    if (state != nullptr && state->exec_env() != nullptr) {
+        _runtime_filter_collector.set_runtime_filter_cache(state->exec_env()->runtime_filter_cache());
+    }
     if (tnode.__isset.filter_null_value_columns) {
         _filter_null_value_columns = tnode.filter_null_value_columns;
     }

--- a/be/src/exec/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.cpp
@@ -162,7 +162,8 @@ RuntimeFilterProbeCollector::RuntimeFilterProbeCollector(RuntimeFilterProbeColle
           _wait_timeout_ms(that._wait_timeout_ms),
           _scan_wait_timeout_ms(that._scan_wait_timeout_ms),
           _eval_context(that._eval_context),
-          _plan_node_id(that._plan_node_id) {}
+          _plan_node_id(that._plan_node_id),
+          _runtime_filter_cache(that._runtime_filter_cache) {}
 
 Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, RuntimeProfile* profile) {
     _runtime_profile = profile;

--- a/be/src/exec/runtime_filter/runtime_filter_probe.h
+++ b/be/src/exec/runtime_filter/runtime_filter_probe.h
@@ -43,6 +43,7 @@ namespace starrocks {
 class HashJoinNode;
 class RowDescriptor;
 class RuntimeProfile;
+class RuntimeFilterCache;
 
 class RuntimeFilterProbeDescriptor {
 public:
@@ -198,6 +199,7 @@ public:
     int wait_timeout_ms() const { return _wait_timeout_ms; }
     void set_scan_wait_timeout_ms(int v) { _scan_wait_timeout_ms = v; }
     long scan_wait_timeout_ms() const { return _scan_wait_timeout_ms; }
+    void set_runtime_filter_cache(RuntimeFilterCache* cache) { _runtime_filter_cache = cache; }
     // wait for all runtime filters are ready.
     void wait(bool on_scan_node);
 
@@ -225,6 +227,7 @@ private:
     RuntimeMembershipFilterEvalContext _eval_context;
     int _plan_node_id = -1;
     RuntimeState* _runtime_state = nullptr;
+    RuntimeFilterCache* _runtime_filter_cache = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/exec/runtime_filter/runtime_filter_probe_wait.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_probe_wait.cpp
@@ -16,7 +16,6 @@
 #include <thread>
 
 #include "exec/runtime_filter/runtime_filter_probe.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_filter_cache.h"
 #include "runtime/runtime_state.h"
 
@@ -46,9 +45,8 @@ void RuntimeFilterProbeCollector::wait(bool on_scan_node) {
         while (it != wait_list.end()) {
             auto* rf = (*it)->runtime_filter(-1);
             // find runtime filter in cache.
-            if (rf == nullptr) {
-                RuntimeFilterPtr t = _runtime_state->exec_env()->runtime_filter_cache()->get(_runtime_state->query_id(),
-                                                                                             (*it)->filter_id());
+            if (rf == nullptr && _runtime_filter_cache != nullptr) {
+                RuntimeFilterPtr t = _runtime_filter_cache->get(_runtime_state->query_id(), (*it)->filter_id());
                 if (t != nullptr) {
                     VLOG_FILE << "RuntimeFilterCollector::wait: rf found in cache. filter_id = " << (*it)->filter_id()
                               << ", plan_node_id = " << _plan_node_id

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -110,7 +110,6 @@ set(RUNTIME_FILES
     chunk_cursor.cpp
     sorted_chunks_merger.cpp
     tablets_channel.cpp
-    runtime_filter_probe_wait.cpp
     runtime_filter_worker.cpp
     runtime_filter_serde.cpp
     global_dict/decoder.cpp

--- a/be/test/exec/runtime_filter_exec_core_test.cpp
+++ b/be/test/exec/runtime_filter_exec_core_test.cpp
@@ -20,6 +20,7 @@
 #include "exec/runtime_filter/runtime_filter_registry.h"
 #include "exprs/column_ref.h"
 #include "runtime/runtime_filter.h"
+#include "runtime/runtime_filter_cache.h"
 #include "runtime/runtime_filter_layout.h"
 #include "runtime/runtime_state.h"
 #include "testutil/exprs_test_helper.h"
@@ -189,6 +190,39 @@ TEST_F(RuntimeFilterExecCoreTest, RegistryInstallsSharedFilter) {
     registry.install_shared(37, std::static_pointer_cast<const RuntimeFilter>(shared_rf));
 
     EXPECT_EQ(desc.runtime_filter(-1), shared_rf.get());
+}
+
+TEST_F(RuntimeFilterExecCoreTest, ProbeCollectorWaitLoadsCachedFilter) {
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 2;
+    TUniqueId fragment_instance_id;
+    fragment_instance_id.hi = 3;
+    fragment_instance_id.lo = 4;
+    RuntimeState state(query_id, fragment_instance_id, TQueryOptions(), TQueryGlobals(), nullptr);
+
+    RuntimeFilterCache cache(2);
+    ASSERT_OK(cache.init());
+
+    auto* probe_expr = pool.add(new ColumnRef(TypeDescriptor(TYPE_INT), 9));
+    auto* probe_ctx = pool.add(new ExprContext(probe_expr));
+    RuntimeFilterProbeDescriptor desc;
+    ASSERT_OK(desc.init(41, probe_ctx));
+
+    RuntimeFilterProbeCollector collector;
+    collector.add_descriptor(&desc);
+    collector.set_runtime_filter_cache(&cache);
+    ASSERT_OK(collector.prepare(&state, state.runtime_profile()));
+
+    auto bloom = std::make_shared<ComposedRuntimeBloomFilter<TYPE_INT>>();
+    bloom->membership_filter().init(32);
+    bloom->insert(10);
+    cache.put_if_absent(query_id, 41, std::static_pointer_cast<const RuntimeFilter>(bloom));
+
+    collector.wait(false);
+
+    ASSERT_NE(desc.runtime_filter(-1), nullptr);
+    EXPECT_EQ(desc.runtime_filter(-1), bloom.get());
 }
 
 TEST_F(RuntimeFilterExecCoreTest, HelperCreatesMinMaxPredicateForNumericButNotString) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
