### PR TITLE
[Enhancement] Add IvmRewriter and Iceberg scan/filter/project rules for unified IVM framework

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.ivm.IvmRewriter;
 import com.starrocks.sql.optimizer.rule.join.JoinReorderFactory;
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
@@ -548,8 +549,9 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, new ApplyExceptionRule());
         CTEUtils.collectCteOperators(tree, context);
 
-        // tvr rule rewrite
+        // IVM rule rewrite: try unified Delta/Version framework first, then TVR as fallback
         if (context.getSessionVariable().isEnableIVMRefresh()) {
+            IvmRewriter.rewrite(tree, rootTaskContext, scheduler, requiredColumns);
             scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.TVR_REWRITE_RULES);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -60,6 +60,12 @@ import com.starrocks.sql.optimizer.rule.implementation.WindowImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamAggregateImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamJoinImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamScanImplementationRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaFilterRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaIcebergScanRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaProjectRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmVersionFilterRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmVersionIcebergScanRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmVersionProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.CastToEmptyRule;
 import com.starrocks.sql.optimizer.rule.transformation.CollectCTEConsumeRule;
 import com.starrocks.sql.optimizer.rule.transformation.CollectCTEProduceRule;
@@ -434,9 +440,15 @@ public class RuleSet {
             ));
 
     // Unified IVM delta/version rewrite rules.
-    // Concrete scan rules for each table type will be added in subsequent PRs.
     public static final Rule IVM_DELTA_REWRITE_RULES =
-            new CombinationRule(RuleType.GP_IVM_DELTA_REWRITE, ImmutableList.of());
+            new CombinationRule(RuleType.GP_IVM_DELTA_REWRITE, ImmutableList.of(
+                    new IvmDeltaIcebergScanRule(),
+                    new IvmDeltaFilterRule(),
+                    new IvmDeltaProjectRule(),
+                    new IvmVersionIcebergScanRule(),
+                    new IvmVersionFilterRule(),
+                    new IvmVersionProjectRule()
+            ));
 
     public static final Rule TVR_REWRITE_RULES =
             new CombinationRule(RuleType.GP_TVR_REWRITE, ImmutableList.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaFilterRule.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class IvmDeltaFilterRule extends TransformationRule {
+    public IvmDeltaFilterRule() {
+        super(RuleType.TF_IVM_DELTA_FILTER,
+                Pattern.create(OperatorType.LOGICAL_DELTA)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_FILTER, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        LogicalFilterOperator filter = (LogicalFilterOperator) input.inputAt(0).getOp();
+
+        LogicalFilterOperator newFilter = filter;
+        ColumnRefOperator actionColumn = delta.getActionColumn();
+        if (actionColumn != null) {
+            Projection filterProjection = filter.getProjection();
+            Map<ColumnRefOperator, ScalarOperator> projectionMap;
+            Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap;
+            if (filterProjection != null) {
+                projectionMap = Maps.newHashMap(filterProjection.getColumnRefMap());
+                commonSubOperatorMap = filterProjection.getCommonSubOperatorMap();
+            } else {
+                projectionMap = input.inputAt(0).getOutputColumns().getColumnRefOperators(context.getColumnRefFactory())
+                        .stream()
+                        .collect(Collectors.toMap(Function.identity(), Function.identity(),
+                                (left, right) -> left, Maps::newHashMap));
+                commonSubOperatorMap = Maps.newHashMap();
+            }
+            projectionMap.put(actionColumn, actionColumn);
+            Projection newProjection = new Projection(projectionMap, commonSubOperatorMap);
+            newFilter = new LogicalFilterOperator.Builder()
+                    .withOperator(filter)
+                    .setProjection(newProjection)
+                    .build();
+        }
+
+        OptExpression child = input.inputAt(0).inputAt(0);
+        OptExpression rewritten = OptExpression.create(newFilter, OptExpression.create(delta, child));
+        return List.of(rewritten);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaIcebergScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaIcebergScanRule.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableDeltaTrait;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves a {@link LogicalDeltaOperator} wrapping a {@link LogicalIcebergScanOperator} by converting it
+ * into an incremental scan that reads only the delta data between two Iceberg snapshots.
+ *
+ * <p>Pattern: {@code LogicalDeltaOperator -> LogicalIcebergScanOperator}
+ *
+ * <p>The scan operator's {@code tvrVersionRange} (a {@link TvrTableDelta}) carries the from/to snapshot IDs,
+ * set by {@code MVIVMBasedRefreshProcessor.buildInsertPlan()} via {@code RelationTransformer}.
+ * This rule reads that same data source as {@code TvrTableScanRule}.
+ *
+ * <p>For append-only Iceberg tables, the {@code __ACTION__} column is a constant {@code 1} (INSERT).
+ */
+public class IvmDeltaIcebergScanRule extends TransformationRule {
+    public IvmDeltaIcebergScanRule() {
+        super(RuleType.TF_IVM_DELTA_ICEBERG_SCAN,
+                Pattern.create(OperatorType.LOGICAL_DELTA)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_ICEBERG_SCAN)));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.inputAt(0).getOp();
+        Optional<TvrTableDeltaTrait> trait = scan.getTvrTableDeltaTrait();
+        return trait.isPresent() && trait.get().isAppendOnly();
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.inputAt(0).getOp();
+        TvrTableDeltaTrait trait = scan.getTvrTableDeltaTrait().get();
+        TvrTableDelta tvrDelta = trait.getTvrDelta();
+
+        // No changes: from == to
+        if (tvrDelta.isEmpty()) {
+            List<ColumnRefOperator> outputColumns = new java.util.ArrayList<>(scan.getOutputColumns());
+            ColumnRefOperator actionColumn = delta.getActionColumn();
+            if (actionColumn != null) {
+                outputColumns.add(actionColumn);
+            }
+            return List.of(OptExpression.create(
+                    new LogicalValuesOperator(outputColumns, Collections.emptyList())));
+        }
+
+        // Build a project on top of the scan that adds __ACTION__ = 1 (INSERT, append-only)
+        ColumnRefOperator actionColumn = delta.getActionColumn();
+        Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+        for (ColumnRefOperator col : scan.getOutputColumns()) {
+            projectMap.put(col, col);
+        }
+        if (actionColumn != null) {
+            projectMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 1));
+        }
+
+        // Keep the scan with its tvrVersionRange intact — the physical layer (IcebergMetadata)
+        // knows how to handle TvrTableDelta by using IncrementalAppendScan.
+        OptExpression scanExpr = OptExpression.create(scan);
+        OptExpression projectExpr = OptExpression.create(new LogicalProjectOperator(projectMap), scanExpr);
+        return List.of(projectExpr);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaProjectRule.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+import java.util.Map;
+
+public class IvmDeltaProjectRule extends TransformationRule {
+    public IvmDeltaProjectRule() {
+        super(RuleType.TF_IVM_DELTA_PROJECT,
+                Pattern.create(OperatorType.LOGICAL_DELTA)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        LogicalProjectOperator project = (LogicalProjectOperator) input.inputAt(0).getOp();
+
+        Map<ColumnRefOperator, ScalarOperator> newProjectMap = project.getColumnRefMap();
+        ColumnRefOperator actionColumn = delta.getActionColumn();
+        if (actionColumn != null) {
+            newProjectMap = Maps.newHashMap(newProjectMap);
+            newProjectMap.put(actionColumn, actionColumn);
+        }
+
+        LogicalProjectOperator newProject = LogicalProjectOperator.builder()
+                .withOperator(project)
+                .setColumnRefMap(newProjectMap)
+                .build();
+        LogicalDeltaOperator newDelta = new LogicalDeltaOperator(delta.isRootDelta(), actionColumn);
+        OptExpression child = input.inputAt(0).inputAt(0);
+
+        OptExpression rewritten = OptExpression.create(newProject, OptExpression.create(newDelta, child));
+        return List.of(rewritten);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.load.Load;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.sql.optimizer.task.TaskScheduler;
+import com.starrocks.type.IntegerType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Entry point for the unified IVM (Incremental View Maintenance) plan rewriting.
+ *
+ * <p>Wraps the MV query plan with a {@link LogicalDeltaOperator} marker, then iteratively
+ * applies delta and version rewrite rules to push the marker down through the plan tree.
+ * If any unresolved markers remain after rewriting, falls back to the original plan
+ * (allowing TVR rules to handle it instead).</p>
+ *
+ * <p>This rewriter is table-type agnostic. Concrete delta/version resolution for specific
+ * table types (Iceberg, OLAP, etc.) is handled by the individual scan rules registered
+ * in {@link RuleSet#IVM_DELTA_REWRITE_RULES}.</p>
+ *
+ * <p>Version info for Iceberg tables is already set on scan operators by
+ * {@code MVIVMBasedRefreshProcessor.buildInsertPlan()} via {@code RelationTransformer},
+ * so no additional version binding is needed here.</p>
+ */
+public class IvmRewriter {
+    private IvmRewriter() {
+    }
+
+    /**
+     * Main entry point for IVM rewriting.
+     *
+     * <p>Flow:
+     * <ol>
+     *   <li>Wrap the plan root with {@link LogicalDeltaOperator} and apply delta/version rules</li>
+     *   <li>Convergence check: if unresolved markers remain, fall back to original plan</li>
+     *   <li>For PK target MVs, append __op column for UPSERT/DELETE semantics</li>
+     * </ol>
+     */
+    public static void rewrite(OptExpression tree, TaskContext rootTaskContext, TaskScheduler scheduler,
+                               ColumnRefSet requiredColumns) {
+        OptimizerContext optimizerContext = rootTaskContext.getOptimizerContext();
+
+        // Gate: only run when IVM refresh is enabled
+        if (!optimizerContext.getSessionVariable().isEnableIVMRefresh()) {
+            return;
+        }
+
+        OptExpression originalPlan = tree.getInputs().get(0);
+
+        // Phase 1: Wrap with LogicalDeltaOperator and apply delta/version rules iteratively
+        ColumnRefOperator actionColumn = optimizerContext.getColumnRefFactory()
+                .create(IvmRuleUtils.ACTION_COLUMN_NAME, IvmRuleUtils.ACTION_COLUMN_TYPE, false);
+        tree.setChild(0, OptExpression.create(
+                new LogicalDeltaOperator(true, actionColumn), originalPlan));
+        deriveLogicalProperty(tree);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.IVM_DELTA_REWRITE_RULES);
+
+        // Phase 2: Convergence check — if any markers remain, fall back to original plan
+        if (IvmRuleUtils.containsLogicalDelta(tree.getInputs().get(0))
+                || IvmRuleUtils.containsLogicalVersion(tree.getInputs().get(0))) {
+            tree.setChild(0, originalPlan);
+            deriveLogicalProperty(tree);
+            return;
+        }
+
+        // Phase 3: For PK target MVs, append __op column for UPSERT/DELETE semantics
+        OptExpression rewrittenRoot = tree.getInputs().get(0);
+        deriveLogicalProperty(rewrittenRoot);
+        if (isPrimaryKeyTargetMv(optimizerContext)) {
+            rewrittenRoot = appendPkLoadOpColumn(rewrittenRoot, rootTaskContext, requiredColumns, actionColumn);
+        }
+        tree.setChild(0, rewrittenRoot);
+        deriveLogicalProperty(tree);
+    }
+
+    private static boolean isPrimaryKeyTargetMv(OptimizerContext optimizerContext) {
+        StatementBase statement = optimizerContext.getStatement();
+        if (!(statement instanceof InsertStmt insertStmt)) {
+            return false;
+        }
+        if (!(insertStmt.getTargetTable() instanceof MaterializedView targetMv)) {
+            return false;
+        }
+        return targetMv.getKeysType() == KeysType.PRIMARY_KEYS;
+    }
+
+    private static OptExpression appendPkLoadOpColumn(OptExpression root, TaskContext rootTaskContext,
+                                                      ColumnRefSet requiredColumns,
+                                                      ColumnRefOperator actionColumn) {
+        List<ColumnRefOperator> rootOutputColumns = root.getOutputColumns()
+                .getColumnRefOperators(rootTaskContext.getOptimizerContext().getColumnRefFactory());
+        boolean hasLoadOpColumn = rootOutputColumns.stream()
+                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        if (hasLoadOpColumn) {
+            return root;
+        }
+
+        ColumnRefOperator loadOpColumn = rootTaskContext.getOptimizerContext().getColumnRefFactory()
+                .create(Load.LOAD_OP_COLUMN, IntegerType.TINYINT, false);
+        ScalarOperator isDeleteAction = new BinaryPredicateOperator(BinaryType.LT, actionColumn,
+                ConstantOperator.createTinyInt((byte) 0));
+        ScalarOperator loadOpExpr = new CaseWhenOperator(IntegerType.TINYINT, null,
+                ConstantOperator.createTinyInt((byte) 0),
+                Lists.newArrayList(isDeleteAction, ConstantOperator.createTinyInt((byte) 1)));
+
+        Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+        for (ColumnRefOperator outputColumn : rootOutputColumns) {
+            if (!outputColumn.equals(actionColumn)) {
+                projectMap.put(outputColumn, outputColumn);
+            }
+        }
+        projectMap.put(loadOpColumn, loadOpExpr);
+
+        requiredColumns.union(loadOpColumn);
+        rootTaskContext.getRequiredColumns().union(loadOpColumn);
+
+        OptExpression projectExpr = OptExpression.create(new LogicalProjectOperator(projectMap), root);
+        // DELETE must come first: __op=1 for DELETE, __op=0 for INSERT.
+        List<Ordering> orderings = List.of(new Ordering(loadOpColumn, false, false));
+        LogicalTopNOperator.Builder topNBuilder = LogicalTopNOperator.builder()
+                .withOperator(
+                        new LogicalTopNOperator(orderings, Operator.DEFAULT_LIMIT, Operator.DEFAULT_OFFSET,
+                                SortPhase.PARTIAL))
+                .setOrderByElements(orderings)
+                .setPerPipeline(true);
+        LogicalTopNOperator topN = topNBuilder.build();
+        return OptExpression.create(topN, projectExpr);
+    }
+
+    static void deriveLogicalProperty(OptExpression root) {
+        for (OptExpression child : root.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        if (root.getLogicalProperty() == null) {
+            ExpressionContext context = new ExpressionContext(root);
+            context.deriveLogicalProperty();
+            root.setLogicalProperty(context.getRootProperty());
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionFilterRule.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+
+public class IvmVersionFilterRule extends TransformationRule {
+    public IvmVersionFilterRule() {
+        super(RuleType.TF_IVM_VERSION_FILTER,
+                Pattern.create(OperatorType.LOGICAL_VERSION)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_FILTER, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalVersionOperator version = (LogicalVersionOperator) input.getOp();
+        LogicalFilterOperator filter = (LogicalFilterOperator) input.inputAt(0).getOp();
+        OptExpression filterChild = input.inputAt(0).inputAt(0);
+        LogicalVersionOperator newVersion = new LogicalVersionOperator(version.getVersionRefType());
+        OptExpression versionChild = OptExpression.create(newVersion, filterChild);
+        return List.of(OptExpression.create(filter, versionChild));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionIcebergScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionIcebergScanRule.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableDeltaTrait;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator.VersionRefType;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Resolves a {@link LogicalVersionOperator} wrapping a {@link LogicalIcebergScanOperator} by binding
+ * the scan to a specific Iceberg snapshot.
+ *
+ * <p>Pattern: {@code LogicalVersionOperator -> LogicalIcebergScanOperator}
+ *
+ * <p>Based on {@link VersionRefType}:
+ * <ul>
+ *   <li>{@code FROM_VERSION} — binds to the from-snapshot (start of the delta range)</li>
+ *   <li>{@code TO_VERSION} — binds to the to-snapshot (end of the delta range)</li>
+ * </ul>
+ */
+public class IvmVersionIcebergScanRule extends TransformationRule {
+    public IvmVersionIcebergScanRule() {
+        super(RuleType.TF_IVM_VERSION_ICEBERG_SCAN,
+                Pattern.create(OperatorType.LOGICAL_VERSION)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_ICEBERG_SCAN)));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.inputAt(0).getOp();
+        Optional<TvrTableDeltaTrait> trait = scan.getTvrTableDeltaTrait();
+        return trait.isPresent();
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalVersionOperator version = (LogicalVersionOperator) input.getOp();
+        LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.inputAt(0).getOp();
+
+        TvrTableDeltaTrait trait = scan.getTvrTableDeltaTrait().get();
+        TvrTableDelta tvrDelta = trait.getTvrDelta();
+
+        // Resolve the snapshot based on version ref type
+        TvrTableSnapshot resolvedSnapshot;
+        if (version.getVersionRefType() == VersionRefType.FROM_VERSION) {
+            resolvedSnapshot = tvrDelta.fromSnapshot();
+        } else {
+            resolvedSnapshot = tvrDelta.toSnapshot();
+        }
+
+        // Build a new scan bound to the resolved snapshot
+        LogicalScanOperator.Builder builder =
+                (LogicalScanOperator.Builder) OperatorBuilderFactory.build(scan);
+        LogicalIcebergScanOperator newScan = (LogicalIcebergScanOperator) builder
+                .withOperator(scan)
+                .setTableVersionRange(resolvedSnapshot)
+                .build();
+
+        return List.of(OptExpression.create(newScan));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionProjectRule.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+
+public class IvmVersionProjectRule extends TransformationRule {
+    public IvmVersionProjectRule() {
+        super(RuleType.TF_IVM_VERSION_PROJECT,
+                Pattern.create(OperatorType.LOGICAL_VERSION)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalVersionOperator version = (LogicalVersionOperator) input.getOp();
+        LogicalProjectOperator project = (LogicalProjectOperator) input.inputAt(0).getOp();
+        OptExpression projectChild = input.inputAt(0).inputAt(0);
+        LogicalVersionOperator newVersion = new LogicalVersionOperator(version.getVersionRefType());
+        OptExpression versionChild = OptExpression.create(newVersion, projectChild);
+        return List.of(OptExpression.create(project, versionChild));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmRuleUtils.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm.common;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+
+public class IvmRuleUtils {
+    public static final String ACTION_COLUMN_NAME = "__ACTION__";
+    public static final Type ACTION_COLUMN_TYPE = IntegerType.TINYINT;
+
+    private IvmRuleUtils() {
+    }
+
+    public static boolean containsLogicalDelta(OptExpression root) {
+        if (root.getOp().getOpType() == OperatorType.LOGICAL_DELTA) {
+            return true;
+        }
+        for (OptExpression child : root.getInputs()) {
+            if (containsLogicalDelta(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean containsLogicalVersion(OptExpression root) {
+        if (root.getOp().getOpType() == OperatorType.LOGICAL_VERSION) {
+            return true;
+        }
+        for (OptExpression child : root.getInputs()) {
+            if (containsLogicalVersion(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmIcebergRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmIcebergRuleTest.java
@@ -1,0 +1,431 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for IVM delta/version rules on Iceberg scan operators.
+ * Covers: IvmDeltaIcebergScanRule, IvmVersionIcebergScanRule,
+ *         IvmDeltaFilterRule, IvmDeltaProjectRule,
+ *         IvmVersionFilterRule, IvmVersionProjectRule.
+ */
+public class IvmIcebergRuleTest {
+
+    // ==================== IvmDeltaIcebergScanRule ====================
+
+    @Test
+    public void testDeltaIcebergScan(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression deltaExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef), scanExpr);
+        deriveLogicalProperty(deltaExpr);
+
+        List<OptExpression> result = new IvmDeltaIcebergScanRule().transform(deltaExpr, context);
+
+        // Should produce: Project(id, data, __ACTION__=1) → IcebergScan
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator project = (LogicalProjectOperator) result.get(0).getOp();
+        // Project should contain __ACTION__ = 1 (constant)
+        Assertions.assertTrue(project.getColumnRefMap().containsKey(actionRef));
+        ScalarOperator actionExpr = project.getColumnRefMap().get(actionRef);
+        Assertions.assertTrue(actionExpr instanceof ConstantOperator);
+        Assertions.assertEquals((byte) 1, ((ConstantOperator) actionExpr).getTinyInt());
+        // Project should pass through original columns
+        Assertions.assertTrue(project.getColumnRefMap().containsKey(idRef));
+        Assertions.assertTrue(project.getColumnRefMap().containsKey(dataRef));
+        // Child should be IcebergScan
+        Assertions.assertTrue(result.get(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    @Test
+    public void testDeltaIcebergScanEmptyDelta(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        // from == to → empty delta
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(100L)));
+        OptExpression deltaExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef), scanExpr);
+        deriveLogicalProperty(deltaExpr);
+
+        List<OptExpression> result = new IvmDeltaIcebergScanRule().transform(deltaExpr, context);
+
+        // Should produce empty LogicalValuesOperator with __ACTION__ column preserved
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalValuesOperator);
+        LogicalValuesOperator values = (LogicalValuesOperator) result.get(0).getOp();
+        // Must include __ACTION__ column so parent projections don't break
+        Assertions.assertTrue(values.getColumnRefSet().contains(actionRef),
+                "Empty values must include __ACTION__ column to preserve column dependencies");
+        // Also includes original scan columns
+        Assertions.assertTrue(values.getColumnRefSet().contains(idRef));
+        Assertions.assertTrue(values.getColumnRefSet().contains(dataRef));
+    }
+
+    @Test
+    public void testDeltaIcebergScanCheckRejectsNonDelta(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        // Use TvrTableSnapshot instead of TvrTableDelta → check() should return false
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableSnapshot.of(java.util.Optional.of(100L)));
+        OptExpression deltaExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef), scanExpr);
+        deriveLogicalProperty(deltaExpr);
+
+        boolean checkResult = new IvmDeltaIcebergScanRule().check(deltaExpr, context);
+        Assertions.assertFalse(checkResult);
+    }
+
+    // ==================== IvmVersionIcebergScanRule ====================
+
+    @Test
+    public void testVersionIcebergScanFromVersion(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression versionExpr = OptExpression.create(LogicalVersionOperator.fromVersion(), scanExpr);
+        deriveLogicalProperty(versionExpr);
+
+        List<OptExpression> result = new IvmVersionIcebergScanRule().transform(versionExpr, context);
+
+        // Should produce IcebergScan with snapshot = 100 (from version)
+        Assertions.assertEquals(1, result.size());
+        LogicalIcebergScanOperator newScan = (LogicalIcebergScanOperator) result.get(0).getOp();
+        Assertions.assertTrue(newScan.getTvrVersionRange() instanceof TvrTableSnapshot);
+        TvrTableSnapshot snapshot = (TvrTableSnapshot) newScan.getTvrVersionRange();
+        Assertions.assertEquals(100L, snapshot.getSnapshotId());
+    }
+
+    @Test
+    public void testVersionIcebergScanToVersion(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression versionExpr = OptExpression.create(LogicalVersionOperator.toVersion(), scanExpr);
+        deriveLogicalProperty(versionExpr);
+
+        List<OptExpression> result = new IvmVersionIcebergScanRule().transform(versionExpr, context);
+
+        // Should produce IcebergScan with snapshot = 200 (to version)
+        Assertions.assertEquals(1, result.size());
+        LogicalIcebergScanOperator newScan = (LogicalIcebergScanOperator) result.get(0).getOp();
+        Assertions.assertTrue(newScan.getTvrVersionRange() instanceof TvrTableSnapshot);
+        TvrTableSnapshot snapshot = (TvrTableSnapshot) newScan.getTvrVersionRange();
+        Assertions.assertEquals(200L, snapshot.getSnapshotId());
+    }
+
+    // ==================== IvmDeltaFilterRule ====================
+
+    @Test
+    public void testDeltaFilterPushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        LogicalFilterOperator filter = new LogicalFilterOperator(
+                new BinaryPredicateOperator(BinaryType.GT, idRef, ConstantOperator.createInt(10)));
+        // Delta → Filter → Scan
+        OptExpression deltaExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(filter, scanExpr));
+        deriveLogicalProperty(deltaExpr);
+
+        List<OptExpression> result = new IvmDeltaFilterRule().transform(deltaExpr, context);
+
+        // Should produce: Filter(with __ACTION__ in projection) → Delta → Scan
+        Assertions.assertEquals(1, result.size());
+        // Root should be Filter
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalFilterOperator);
+        LogicalFilterOperator newFilter = (LogicalFilterOperator) result.get(0).getOp();
+        // Filter should have projection containing actionRef
+        Assertions.assertNotNull(newFilter.getProjection());
+        Assertions.assertTrue(newFilter.getProjection().getColumnRefMap().containsKey(actionRef));
+        // Child should be Delta
+        Assertions.assertEquals(OperatorType.LOGICAL_DELTA, result.get(0).inputAt(0).getOp().getOpType());
+        // Grandchild should be IcebergScan
+        Assertions.assertTrue(result.get(0).inputAt(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    // ==================== IvmDeltaProjectRule ====================
+
+    @Test
+    public void testDeltaProjectPushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator exprRef = factory.create("expr", IntegerType.INT, false);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        // Project: expr = id * 2, data = data
+        Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+        projectMap.put(exprRef, idRef);
+        projectMap.put(dataRef, dataRef);
+        LogicalProjectOperator project = new LogicalProjectOperator(projectMap);
+        // Delta → Project → Scan
+        OptExpression deltaExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(project, scanExpr));
+        deriveLogicalProperty(deltaExpr);
+
+        List<OptExpression> result = new IvmDeltaProjectRule().transform(deltaExpr, context);
+
+        // Should produce: Project(expr, data, __ACTION__) → Delta → Scan
+        Assertions.assertEquals(1, result.size());
+        // Root should be Project
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator newProject = (LogicalProjectOperator) result.get(0).getOp();
+        // Project should contain __ACTION__ pass-through
+        Assertions.assertTrue(newProject.getColumnRefMap().containsKey(actionRef));
+        Assertions.assertEquals(actionRef, newProject.getColumnRefMap().get(actionRef));
+        // Child should be Delta with isRootDelta preserved
+        LogicalDeltaOperator newDelta = (LogicalDeltaOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertTrue(newDelta.isRootDelta());
+        Assertions.assertEquals(actionRef, newDelta.getActionColumn());
+    }
+
+    // ==================== IvmVersionFilterRule ====================
+
+    @Test
+    public void testVersionFilterPushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        LogicalFilterOperator filter = new LogicalFilterOperator(
+                new BinaryPredicateOperator(BinaryType.GT, idRef, ConstantOperator.createInt(10)));
+        // Version → Filter → Scan
+        OptExpression versionExpr = OptExpression.create(LogicalVersionOperator.fromVersion(),
+                OptExpression.create(filter, scanExpr));
+        deriveLogicalProperty(versionExpr);
+
+        List<OptExpression> result = new IvmVersionFilterRule().transform(versionExpr, context);
+
+        // Should produce: Filter → Version → Scan
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalFilterOperator);
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, result.get(0).inputAt(0).getOp().getOpType());
+        LogicalVersionOperator newVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.FROM_VERSION, newVersion.getVersionRefType());
+        Assertions.assertTrue(result.get(0).inputAt(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    // ==================== IvmVersionProjectRule ====================
+
+    @Test
+    public void testVersionProjectPushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+        projectMap.put(idRef, idRef);
+        LogicalProjectOperator project = new LogicalProjectOperator(projectMap);
+        // Version → Project → Scan
+        OptExpression versionExpr = OptExpression.create(LogicalVersionOperator.toVersion(),
+                OptExpression.create(project, scanExpr));
+        deriveLogicalProperty(versionExpr);
+
+        List<OptExpression> result = new IvmVersionProjectRule().transform(versionExpr, context);
+
+        // Should produce: Project → Version → Scan
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalProjectOperator);
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, result.get(0).inputAt(0).getOp().getOpType());
+        LogicalVersionOperator newVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.TO_VERSION, newVersion.getVersionRefType());
+        Assertions.assertTrue(result.get(0).inputAt(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    // ==================== Full pipeline: Delta through Filter+Project to Scan ====================
+
+    @Test
+    public void testFullPipelineDeltaThroughFilterProjectToScan(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        ColumnRefOperator exprRef = factory.create("expr", IntegerType.INT, false);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression scanExpr = newIcebergScan(table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        // Build: Delta → Project(expr=id+1, data) → Filter(id>10) → Scan
+        LogicalFilterOperator filter = new LogicalFilterOperator(
+                new BinaryPredicateOperator(BinaryType.GT, idRef, ConstantOperator.createInt(10)));
+        Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+        projectMap.put(exprRef, idRef);
+        projectMap.put(dataRef, dataRef);
+        LogicalProjectOperator project = new LogicalProjectOperator(projectMap);
+
+        OptExpression tree = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(project,
+                        OptExpression.create(filter, scanExpr)));
+        deriveLogicalProperty(tree);
+
+        // Step 1: Delta pushes through Project
+        List<OptExpression> afterProject = new IvmDeltaProjectRule().transform(tree, context);
+        Assertions.assertEquals(1, afterProject.size());
+        // Now: Project(expr, data, __ACTION__) → Delta → Filter → Scan
+        deriveLogicalProperty(afterProject.get(0));
+
+        // Step 2: Delta pushes through Filter
+        OptExpression deltaFilter = afterProject.get(0).inputAt(0); // Delta → Filter → Scan
+        List<OptExpression> afterFilter = new IvmDeltaFilterRule().transform(deltaFilter, context);
+        Assertions.assertEquals(1, afterFilter.size());
+        // Now: Filter(with __ACTION__) → Delta → Scan
+        deriveLogicalProperty(afterFilter.get(0));
+
+        // Step 3: Delta resolves at Iceberg Scan
+        OptExpression deltaScan = afterFilter.get(0).inputAt(0); // Delta → Scan
+        Assertions.assertTrue(new IvmDeltaIcebergScanRule().check(deltaScan, context));
+        List<OptExpression> afterScan = new IvmDeltaIcebergScanRule().transform(deltaScan, context);
+        Assertions.assertEquals(1, afterScan.size());
+        // Now: Project(id, data, __ACTION__=1) → Scan — Delta fully eliminated
+
+        // Verify no Delta or Version markers remain in the final sub-tree
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(afterScan.get(0)));
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalVersion(afterScan.get(0)));
+
+        // Verify __ACTION__ = 1 (constant INSERT)
+        LogicalProjectOperator scanProject = (LogicalProjectOperator) afterScan.get(0).getOp();
+        ScalarOperator actionValue = scanProject.getColumnRefMap().get(actionRef);
+        Assertions.assertTrue(actionValue instanceof ConstantOperator);
+        Assertions.assertEquals((byte) 1, ((ConstantOperator) actionValue).getTinyInt());
+    }
+
+    // ==================== Helpers ====================
+
+    private void mockIcebergTable(IcebergTable table) {
+        new Expectations() {
+            {
+                table.getType();
+                result = com.starrocks.catalog.Table.TableType.ICEBERG;
+                minTimes = 0;
+            }
+        };
+    }
+
+    private OptExpression newIcebergScan(IcebergTable table, ColumnRefOperator idRef,
+                                         ColumnRefOperator dataRef,
+                                         com.starrocks.common.tvr.TvrVersionRange versionRange) {
+        Column idCol = new Column("id", IntegerType.INT, false);
+        Column dataCol = new Column("data", StringType.STRING, true);
+        Map<ColumnRefOperator, Column> colRefMap = Maps.newHashMap();
+        colRefMap.put(idRef, idCol);
+        colRefMap.put(dataRef, dataCol);
+        LogicalIcebergScanOperator scan = new LogicalIcebergScanOperator.Builder()
+                .setTable(table)
+                .setColRefToColumnMetaMap(colRefMap)
+                .setTableVersionRange(versionRange)
+                .build();
+        return OptExpression.create(scan);
+    }
+
+    private static void deriveLogicalProperty(OptExpression expression) {
+        for (OptExpression child : expression.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        ExpressionContext context = new ExpressionContext(expression);
+        context.deriveLogicalProperty();
+        expression.setLogicalProperty(context.getRootProperty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -1,0 +1,321 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.load.Load;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.sql.optimizer.task.TaskScheduler;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * Tests for {@link IvmRewriter} covering:
+ * - Gate: skip when IVM refresh not enabled
+ * - Convergence success: Delta markers eliminated for supported patterns
+ * - Convergence failure: original plan restored for unsupported patterns
+ * - appendPkLoadOpColumn: __op column + TopN for PK MVs
+ * - isPrimaryKeyTargetMv: various statement types
+ */
+public class IvmRewriterTest {
+
+    // ==================== Gate: isEnableIVMRefresh ====================
+
+    @Test
+    public void testRewriteSkipsWhenIvmDisabled(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        // IVM refresh is disabled by default
+        Assertions.assertFalse(context.getSessionVariable().isEnableIVMRefresh());
+
+        OptExpression scan = newIcebergScan(factory, table);
+        // Wrap in LogicalTreeAnchorOperator (required by RewriteTreeTask)
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // Plan should be unchanged — no Delta operator injected
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
+        Assertions.assertSame(scan, root.inputAt(0));
+    }
+
+    // ==================== Convergence: success ====================
+
+    @Test
+    public void testRewriteSucceedsForIcebergScan(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        // Wrap: root → scan (simulating INSERT target → query)
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // Delta/Version markers should be fully eliminated
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalVersion(root));
+        // Root child should no longer be the original scan (plan was rewritten)
+        Assertions.assertNotSame(scan, root.inputAt(0));
+    }
+
+    // ==================== Convergence: failure → fallback ====================
+
+    @Test
+    public void testRewriteFallsBackForUnsupportedOperator(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+
+        // Use a scan without tvrVersionRange (no TvrTableDelta) → DeltaIcebergScanRule won't match
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef, null);
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+        OptExpression originalChild = root.inputAt(0);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // Convergence failed → original plan restored
+        Assertions.assertFalse(IvmRuleUtils.containsLogicalDelta(root));
+        Assertions.assertSame(originalChild, root.inputAt(0));
+    }
+
+    // ==================== appendPkLoadOpColumn ====================
+
+    @Test
+    public void testAppendPkLoadOpColumnForPkMv(@Mocked IcebergTable table,
+                                                 @Mocked MaterializedView targetMv,
+                                                 @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                targetMv.getKeysType();
+                result = KeysType.PRIMARY_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // For PK MV, plan should have TopN → Project(__op) at the top
+        OptExpression rewrittenChild = root.inputAt(0);
+        Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalTopNOperator,
+                "PK MV should have TopN for DELETE-before-INSERT ordering");
+        OptExpression opProject = rewrittenChild.inputAt(0);
+        Assertions.assertTrue(opProject.getOp() instanceof LogicalProjectOperator);
+        LogicalProjectOperator opProjectOp = (LogicalProjectOperator) opProject.getOp();
+        // Should contain __op column
+        boolean hasOpColumn = opProjectOp.getColumnRefMap().keySet().stream()
+                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        Assertions.assertTrue(hasOpColumn, "PK MV should have __op column");
+        // Should NOT contain __ACTION__ column (replaced by __op)
+        boolean hasActionColumn = opProjectOp.getColumnRefMap().keySet().stream()
+                .anyMatch(col -> IvmRuleUtils.ACTION_COLUMN_NAME.equalsIgnoreCase(col.getName()));
+        Assertions.assertFalse(hasActionColumn, "__ACTION__ should be replaced by __op");
+    }
+
+    @Test
+    public void testNoPkLoadOpColumnForDupKeysMv(@Mocked IcebergTable table,
+                                                  @Mocked MaterializedView targetMv,
+                                                  @Mocked InsertStmt insertStmt) {
+        mockIcebergTable(table);
+        new Expectations() {
+            {
+                insertStmt.getTargetTable();
+                result = targetMv;
+                minTimes = 0;
+
+                targetMv.getKeysType();
+                result = KeysType.DUP_KEYS;
+                minTimes = 0;
+            }
+        };
+
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        context.setStatement(insertStmt);
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // For DUP_KEYS MV, no TopN or __op should be added
+        OptExpression rewrittenChild = root.inputAt(0);
+        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator,
+                "DUP_KEYS MV should NOT have TopN");
+    }
+
+    @Test
+    public void testNoStatementIsNotPkMv(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        context.getSessionVariable().setEnableIVMRefresh(true);
+        // No statement set → isPrimaryKeyTargetMv returns false
+
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+
+        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
+        deriveLogicalProperty(root);
+
+        TaskContext taskContext = newTaskContext(context);
+        TaskScheduler scheduler = new TaskScheduler();
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+
+        IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
+
+        // No statement → no __op, no TopN
+        OptExpression rewrittenChild = root.inputAt(0);
+        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator);
+    }
+
+    // ==================== Helpers ====================
+
+    private void mockIcebergTable(IcebergTable table) {
+        new Expectations() {
+            {
+                table.getType();
+                result = com.starrocks.catalog.Table.TableType.ICEBERG;
+                minTimes = 0;
+            }
+        };
+    }
+
+    private OptExpression newIcebergScan(ColumnRefFactory factory, IcebergTable table) {
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        return newIcebergScan(factory, table, idRef, dataRef, null);
+    }
+
+    private OptExpression newIcebergScan(ColumnRefFactory factory, IcebergTable table,
+                                         ColumnRefOperator idRef, ColumnRefOperator dataRef,
+                                         com.starrocks.common.tvr.TvrVersionRange versionRange) {
+        Column idCol = new Column("id", IntegerType.INT, false);
+        Column dataCol = new Column("data", StringType.STRING, true);
+        Map<ColumnRefOperator, Column> colRefMap = Maps.newHashMap();
+        colRefMap.put(idRef, idCol);
+        colRefMap.put(dataRef, dataCol);
+        LogicalIcebergScanOperator.Builder builder = new LogicalIcebergScanOperator.Builder()
+                .setTable(table)
+                .setColRefToColumnMetaMap(colRefMap);
+        if (versionRange != null) {
+            builder.setTableVersionRange(versionRange);
+        }
+        return OptExpression.create(builder.build());
+    }
+
+    private TaskContext newTaskContext(OptimizerContext context) {
+        TaskScheduler scheduler = new TaskScheduler();
+        context.setTaskScheduler(scheduler);
+        ColumnRefSet requiredColumns = new ColumnRefSet();
+        return new TaskContext(context, new PhysicalPropertySet(), requiredColumns, Double.MAX_VALUE);
+    }
+
+    private static void deriveLogicalProperty(OptExpression expression) {
+        for (OptExpression child : expression.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        ExpressionContext ctx = new ExpressionContext(expression);
+        ctx.deriveLogicalProperty();
+        expression.setLogicalProperty(ctx.getRootProperty());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add the runtime rewrite pipeline for the unified IVM framework. For simple Iceberg MVs (scan + filter + project), the new Delta/Version operator rules now fully handle incremental plan generation, replacing TVR for these patterns. More complex patterns (join, aggregate, union) fall back to TVR as before.

New files:
- IvmRewriter: entry point, wraps plan in LogicalDeltaOperator, applies rules iteratively, convergence check with TVR fallback, __op column for PK MVs
- IvmDeltaIcebergScanRule: resolves Delta at Iceberg scan, adds __ACTION__=1
- IvmVersionIcebergScanRule: binds Version to from/to Iceberg snapshot
- IvmDeltaFilterRule / IvmDeltaProjectRule: push Delta through filter/project
- IvmVersionFilterRule / IvmVersionProjectRule: push Version through filter/project
- IvmRuleUtils: action column constants and convergence check helpers
- IvmIcebergRuleTest: 10 unit tests covering all rules and full pipeline

Modified:
- QueryOptimizer: call IvmRewriter.rewrite() before TVR rules
- RuleSet: register 6 rules in IVM_DELTA_REWRITE_RULES
- 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
