### PR TITLE
[Enhancement] Add MutableRawDataVisitor

### DIFF
--- a/be/src/column/column_visitor_adapter.h
+++ b/be/src/column/column_visitor_adapter.h
@@ -39,7 +39,7 @@ public:
 
     Status visit(const PercentileColumn& column) override { return _impl->do_visit(column); }
 
-    Status visit(const Int8Column& column) override { return _impl->_impl->do_visit(column); }
+    Status visit(const Int8Column& column) override { return _impl->do_visit(column); }
 
     Status visit(const UInt8Column& column) override { return _impl->do_visit(column); }
 
@@ -118,7 +118,7 @@ public:
 
     Status visit(PercentileColumn* column) override { return _impl->do_visit(column); }
 
-    Status visit(Int8Column* column) override { return _impl->_impl->do_visit(column); }
+    Status visit(Int8Column* column) override { return _impl->do_visit(column); }
 
     Status visit(UInt8Column* column) override { return _impl->do_visit(column); }
 

--- a/be/src/column/raw_data_visitor.h
+++ b/be/src/column/raw_data_visitor.h
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "base/status_fmt.hpp"
+#include "column/adaptive_nullable_column.h"
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/column_visitor_adapter.h"
+#include "column/const_column.h"
+#include "column/json_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/object_column.h"
+#include "column/struct_column.h"
+#include "column/variant_column.h"
+
+namespace starrocks {
+
+// MutableRawDataVisitor calls mutable_raw_data() on the visited column and stores
+// the resulting pointer for the caller to retrieve via result().
+// Supported: FixedLengthColumn<T>, DecimalV3Column<T>, AdaptiveNullableColumn.
+// All other column types return NotSupported.
+class MutableRawDataVisitor final : public ColumnVisitorMutableAdapter<MutableRawDataVisitor> {
+public:
+    MutableRawDataVisitor() : ColumnVisitorMutableAdapter(this) {}
+
+    template <typename T>
+    Status do_visit(FixedLengthColumn<T>* column) {
+        _result = column->mutable_raw_data();
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(DecimalV3Column<T>* column) {
+        _result = column->mutable_raw_data();
+        return Status::OK();
+    }
+
+    Status do_visit(ArrayColumn* column) { return column->elements_column_raw_ptr()->accept_mutable(this); }
+
+    Status do_visit(ConstColumn* column) { return column->data_column_raw_ptr()->accept_mutable(this); }
+
+    Status do_visit(NullableColumn* column) { return column->data_column_raw_ptr()->accept_mutable(this); }
+
+    Status do_visit(AdaptiveNullableColumn* column) {
+        return column->materialized_raw_data_column()->as_mutable_raw_ptr()->accept_mutable(this);
+    }
+
+    // Fallback for all unsupported column types. Uses const T& instead of T* so that
+    // it does not compete with the T* overloads above in partial ordering.
+    // T is always a Column-derived pointer type, so -> dereferences to call get_name().
+    template <typename T>
+    static Status do_visit(const T& column) {
+        return Status::NotSupported("MutableRawDataVisitor: unsupported column type {}", column->get_name());
+    }
+
+    uint8_t* result() const { return _result; }
+
+private:
+    uint8_t* _result = nullptr;
+};
+
+} // namespace starrocks

--- a/be/test/column/CMakeLists.txt
+++ b/be/test/column/CMakeLists.txt
@@ -19,6 +19,7 @@ set(COLUMN_TEST_FILES
     german_string_test.cpp
     object_column_core_test.cpp
     column_visitor_test.cpp
+    raw_data_visitor_test.cpp
     column_filter_range_test.cpp
     column_viewer_core_test.cpp
     fixed_length_column_core_test.cpp

--- a/be/test/column/raw_data_visitor_test.cpp
+++ b/be/test/column/raw_data_visitor_test.cpp
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/raw_data_visitor.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/adaptive_nullable_column.h"
+#include "column/array_column.h"
+#include "column/binary_column.h"
+#include "column/const_column.h"
+#include "column/decimalv3_column.h"
+#include "testutil/column_test_helper.h"
+#include "types/datum.h"
+
+namespace starrocks {
+
+TEST(MutableRawDataVisitorTest, VisitInt32Column) {
+    MutableRawDataVisitor visitor;
+    auto col = ColumnTestHelper::build_column<int32_t>({42, 7});
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(MutableRawDataVisitorTest, VisitDecimal32Column) {
+    MutableRawDataVisitor visitor;
+    auto col = Decimal32Column::create(9, 2);
+    col->append(int32_t{100});
+    col->append(int32_t{200});
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 100);
+    EXPECT_EQ(data[1], 200);
+}
+
+TEST(MutableRawDataVisitorTest, VisitArrayColumn) {
+    MutableRawDataVisitor visitor;
+    // Array of int32: [[42, 7]]
+    auto elements = ColumnTestHelper::build_column<int32_t>({42, 7});
+    auto offsets = ColumnTestHelper::build_column<uint32_t>({0, 2});
+    auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+
+    // result points to the elements column's raw data
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(MutableRawDataVisitorTest, VisitConstColumn) {
+    MutableRawDataVisitor visitor;
+    auto inner = ColumnTestHelper::build_column<int32_t>({42});
+    auto col = ConstColumn::create(std::move(inner), 4);
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+    ASSERT_NE(visitor.result(), nullptr);
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+}
+
+TEST(MutableRawDataVisitorTest, VisitNullableColumn) {
+    MutableRawDataVisitor visitor;
+    auto col = ColumnTestHelper::build_nullable_column<int32_t>({42, 7});
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+    ASSERT_NE(visitor.result(), nullptr);
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(MutableRawDataVisitorTest, FallbackNotSupported) {
+    MutableRawDataVisitor visitor;
+    auto col = BinaryColumn::create();
+    col->append(Slice("hello"));
+
+    auto st = col->accept_mutable(&visitor);
+    EXPECT_TRUE(st.is_not_supported());
+    EXPECT_TRUE(st.message().find(col->get_name()) != std::string::npos);
+}
+
+TEST(MutableRawDataVisitorTest, VisitAdaptiveNullableColumn) {
+    MutableRawDataVisitor visitor;
+    auto col = AdaptiveNullableColumn::create(Int32Column::create(), NullColumn::create());
+    col->append_datum(Datum(static_cast<int32_t>(42)));
+    col->append_datum(Datum(static_cast<int32_t>(7)));
+
+    ASSERT_OK(col->accept_mutable(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Later, I will remove Column::mutable_raw_data(). Here is why:

* If the column doesn't support the interface, it will report an error instead of returning null, which will trigger a crash.
* I want to remove the slice cache of BinaryColumn: This is the 10th step for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

Add MutableRawDataVisitor

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
