### PR TITLE
[Refactor] Remove Column::mutable_raw_data

### DIFF
--- a/be/src/bench/parquet_dict_decode_bench.cpp
+++ b/be/src/bench/parquet_dict_decode_bench.cpp
@@ -59,7 +59,7 @@ static void BM_DictDecoder(benchmark::State& state) {
             ColumnHelper::as_column<NullableColumn>(ColumnHelper::create_column(TypeDescriptor{TYPE_INT}, true));
     NullableColumn* nulls = nulls_ptr.get();
     nulls->resize(kTestChunkSize);
-    uint8_t* null_data = nulls->null_column_raw_ptr()->mutable_raw_data();
+    auto& null_data = nulls->null_column_raw_ptr()->get_data();
 
     std::random_device rd;
     std::mt19937 rng(rd());

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -167,11 +167,6 @@ public:
         return _data_column->raw_data();
     }
 
-    uint8_t* mutable_raw_data() override {
-        materialized_nullable();
-        return reinterpret_cast<uint8_t*>(_data_column->mutable_raw_data());
-    }
-
     size_t size() const override {
         if (_state == State::kMaterialized) {
             DCHECK_EQ(_data_column->size(), _null_column->size());

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -54,10 +54,6 @@ const uint8_t* ArrayColumn::raw_data() const {
     return _elements->raw_data();
 }
 
-uint8_t* ArrayColumn::mutable_raw_data() {
-    return _elements->mutable_raw_data();
-}
-
 size_t ArrayColumn::byte_size(size_t from, size_t size) const {
     const auto offsets = _offsets->immutable_data();
     DCHECK_LE(from + size, this->size()) << "Range error";

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -68,8 +68,6 @@ public:
 
     const uint8_t* raw_data() const override;
 
-    uint8_t* mutable_raw_data() override;
-
     size_t size() const override;
 
     size_t capacity() const override;

--- a/be/src/column/array_view_column.h
+++ b/be/src/column/array_view_column.h
@@ -56,11 +56,6 @@ public:
         throw std::runtime_error("ArrayViewColumn::raw_data() is not supported");
     }
 
-    uint8_t* mutable_raw_data() override {
-        DCHECK(false) << "ArrayViewColumn::mutable_raw_data() is not supported";
-        throw std::runtime_error("ArrayViewColumn::mutable_raw_data() is not supported");
-    }
-
     size_t size() const override { return _offsets->size(); }
     size_t capacity() const override { return _offsets->capacity() + _lengths->capacity(); }
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -134,13 +134,6 @@ public:
         return reinterpret_cast<const uint8_t*>(_slices.data());
     }
 
-    uint8_t* mutable_raw_data() override {
-        if (!_slices_cache) {
-            _build_slices();
-        }
-        return reinterpret_cast<uint8_t*>(_slices.data());
-    }
-
     size_t size() const override { return _offsets.size() - 1; }
 
     size_t capacity() const override { return _offsets.capacity() - 1; }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -115,8 +115,6 @@ public:
 
     virtual const uint8_t* raw_data() const = 0;
 
-    virtual uint8_t* mutable_raw_data() = 0;
-
     virtual const uint8_t* continuous_data() const { return raw_data(); }
 
     // Return number of values in column.

--- a/be/src/column/column_view/column_view_base.h
+++ b/be/src/column/column_view/column_view_base.h
@@ -75,7 +75,6 @@ public:
 
     const uint8_t* raw_data() const override { NOT_SUPPORT(); }
 
-    uint8_t* mutable_raw_data() override { NOT_SUPPORT(); }
     size_t capacity() const override { NOT_SUPPORT(); }
     size_t byte_size() const override { NOT_SUPPORT(); }
     size_t type_size() const override { NOT_SUPPORT(); }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -63,8 +63,6 @@ public:
 
     const uint8_t* raw_data() const override { return _data->raw_data(); }
 
-    uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data->mutable_raw_data()); }
-
     size_t size() const override { return _size; }
 
     size_t capacity() const override { return UINT32_MAX; }

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -78,7 +78,7 @@ public:
 
     const uint8_t* raw_data() const override { return reinterpret_cast<const uint8_t*>(immutable_data().data()); }
 
-    uint8_t* mutable_raw_data() override {
+    uint8_t* mutable_raw_data() {
         get_data();
         return reinterpret_cast<uint8_t*>(_data.data());
     }

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -82,11 +82,6 @@ const uint8_t* MapColumn::raw_data() const {
     return nullptr;
 }
 
-uint8_t* MapColumn::mutable_raw_data() {
-    DCHECK(false) << "Don't support map column mutable_raw_data";
-    return nullptr;
-}
-
 size_t MapColumn::byte_size(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     const auto offsets = _offsets->immutable_data();

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -58,8 +58,6 @@ public:
 
     const uint8_t* raw_data() const override;
 
-    uint8_t* mutable_raw_data() override;
-
     size_t size() const override;
 
     size_t capacity() const override;

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -106,8 +106,6 @@ public:
 
     const uint8_t* raw_data() const override { return _data_column->raw_data(); }
 
-    uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data_column->mutable_raw_data()); }
-
     size_t size() const override {
         DCHECK_EQ(_data_column->size(), _null_column->size());
         return _data_column->size();

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -73,11 +73,6 @@ public:
         return nullptr;
     }
 
-    uint8_t* mutable_raw_data() override {
-        DCHECK(false) << "Don't support object column mutable_raw_data";
-        return nullptr;
-    }
-
     size_t size() const override { return _pool.size(); }
 
     size_t capacity() const override { return _pool.capacity(); }

--- a/be/src/column/raw_data_visitor.h
+++ b/be/src/column/raw_data_visitor.h
@@ -31,7 +31,11 @@ namespace starrocks {
 
 // MutableRawDataVisitor calls mutable_raw_data() on the visited column and stores
 // the resulting pointer for the caller to retrieve via result().
-// Supported: FixedLengthColumn<T>, DecimalV3Column<T>, AdaptiveNullableColumn.
+// Supported column types:
+//   - FixedLengthColumn<T>, DecimalV3Column<T>: returns raw data pointer directly
+//   - NullableColumn, ConstColumn: recurses into the inner data column
+//   - ArrayColumn: recurses into the elements column
+//   - AdaptiveNullableColumn: materializes first, then recurses into the data column
 // All other column types return NotSupported.
 class MutableRawDataVisitor final : public ColumnVisitorMutableAdapter<MutableRawDataVisitor> {
 public:

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -62,11 +62,6 @@ const uint8_t* StructColumn::raw_data() const {
     return nullptr;
 }
 
-uint8_t* StructColumn::mutable_raw_data() {
-    // TODO(SmithCruise)
-    DCHECK(false) << "Don't support struct column raw_data";
-    return nullptr;
-}
 size_t StructColumn::size() const {
     return _fields[0]->size();
 }

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -50,8 +50,6 @@ public:
 
     const uint8_t* raw_data() const override;
 
-    uint8_t* mutable_raw_data() override;
-
     size_t size() const override;
 
     size_t capacity() const override;

--- a/be/src/exec/stream/aggregate/agg_state_data.cpp
+++ b/be/src/exec/stream/aggregate/agg_state_data.cpp
@@ -102,7 +102,7 @@ Status AggStateData::output_result(size_t chunk_size, const Columns& group_by_co
                                           agg_group_data[i] + _agg_state_offset);
         }
 
-        uint8_t* is_sync_data = is_sync_col->mutable_raw_data();
+        const auto& is_sync_data = is_sync_col->immutable_data();
         // if need sync, query data from detail table.
         for (size_t i = 0; i < chunk_size; i++) {
             if (!is_sync_data[i]) {

--- a/be/src/formats/parquet/encoding_bss.h
+++ b/be/src/formats/parquet/encoding_bss.h
@@ -22,6 +22,7 @@
 #include "base/string/slice.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/types.h"
@@ -108,6 +109,7 @@ template <tparquet::Type::type PT>
 class ByteStreamSplitDecoder : public Decoder {
 public:
     using T = typename PhysicalTypeTraits<PT>::CppType;
+    static_assert(PT != tparquet::Type::BYTE_ARRAY, "ByteStreamSplitDecoder does not support BYTE_ARRAY");
     static constexpr bool IS_FLBA = (PT == tparquet::Type::FIXED_LEN_BYTE_ARRAY);
 
     ByteStreamSplitDecoder() {
@@ -152,7 +154,9 @@ public:
         } else {
             size_t cur_size = dst->size();
             dst->resize(cur_size + count);
-            T* data = reinterpret_cast<T*>(dst->mutable_raw_data()) + cur_size;
+            MutableRawDataVisitor visitor;
+            RETURN_IF_ERROR(dst->accept_mutable(&visitor));
+            T* data = reinterpret_cast<T*>(visitor.result()) + cur_size;
             RETURN_IF_ERROR(Decode(data, count));
         }
         return Status::OK();

--- a/be/src/formats/parquet/encoding_delta.h
+++ b/be/src/formats/parquet/encoding_delta.h
@@ -24,6 +24,7 @@
 #include "base/string/slice.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
 
@@ -269,7 +270,9 @@ public:
         }
         size_t cur_size = dst->size();
         dst->resize(count + cur_size);
-        T* data = reinterpret_cast<T*>(dst->mutable_raw_data()) + cur_size;
+        MutableRawDataVisitor visitor;
+        RETURN_IF_ERROR(dst->accept_mutable(&visitor));
+        T* data = reinterpret_cast<T*>(visitor.result()) + cur_size;
         RETURN_IF_ERROR(GetInternal(data, count));
         return Status::OK();
     }

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -26,6 +26,7 @@
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
+#include "column/raw_data_visitor.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
@@ -378,7 +379,9 @@ public:
     Status next_batch(size_t count, ColumnContentType content_type, Column* dst, const FilterData* filter) override {
         auto original_size = dst->size();
         dst->resize(original_size + count);
-        auto num_unpacked_values = unpack_batch(count, dst->mutable_raw_data() + original_size);
+        MutableRawDataVisitor visitor;
+        RETURN_IF_ERROR(dst->accept_mutable(&visitor));
+        auto num_unpacked_values = unpack_batch(count, visitor.result() + original_size);
         if (num_unpacked_values < count) {
             return Status::InternalError(strings::Substitute(
                     "going to read out-of-bounds data, count=$0,num_unpacked_values=$1", count, num_unpacked_values));

--- a/be/src/storage/rowset/frame_of_reference_page.h
+++ b/be/src/storage/rowset/frame_of_reference_page.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "column/column.h"
+#include "column/raw_data_visitor.h"
 #include "storage/rowset/options.h"      // for PageBuilderOptions/PageDecoderOptions
 #include "storage/rowset/page_builder.h" // for PageBuilder
 #include "storage/rowset/page_decoder.h" // for PageDecoder
@@ -195,7 +196,9 @@ public:
             Range<> r = iter.next(to_read);
             const size_t ori_size = dst->size();
             dst->resize(ori_size + r.span_size());
-            auto* p = reinterpret_cast<CppType*>(dst->mutable_raw_data()) + ori_size;
+            MutableRawDataVisitor visitor;
+            RETURN_IF_ERROR(dst->accept_mutable(&visitor));
+            auto* p = reinterpret_cast<CppType*>(visitor.result()) + ori_size;
             bool res = _decoder.get_batch(p, r.span_size());
             DCHECK(res);
             _cur_index += r.span_size();

--- a/be/test/column/column_base_test.cpp
+++ b/be/test/column/column_base_test.cpp
@@ -33,7 +33,6 @@ public:
     bool is_array() const override { return _is_array; }
 
     const uint8_t* raw_data() const override { return reinterpret_cast<const uint8_t*>(_data.data()); }
-    uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data.data()); }
 
     size_t size() const override { return _data.size(); }
     size_t capacity() const override { return _data.capacity(); }


### PR DESCRIPTION
## Why I'm doing:

This is the 11th step for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

* Remove Column::mutable_raw_data, use MutableRawDataVisitor instead.
* Remove BinaryColumn::mutable_raw_data.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
