### PR TITLE
[BugFix] Fix off-by-one in ORC column statistics extraction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
@@ -481,11 +481,12 @@ public class AddFilesProcedure extends IcebergTableProcedure {
                 TypeDescription orcSchema = orcReader.getSchema();
                 ColumnStatistics[] columnStats = orcReader.getStatistics();
 
-                // Extract statistics for each column
-                for (int colId = 0; colId < columnStats.length; colId++) {
-                    ColumnStatistics stats = columnStats[colId];
+                // columnStats[0] is file-level stats; column stats start at index 1
+                int numColumns = Math.min(orcSchema.getChildren().size(),
+                        columnStats.length - 1);
+                for (int colId = 0; colId < numColumns; colId++) {
+                    ColumnStatistics stats = columnStats[colId + 1];
 
-                    // Map ORC column to Iceberg field
                     String columnName = getColumnNameFromOrcSchema(orcSchema, colId);
                     if (columnName != null) {
                         Types.NestedField field = schema.findField(columnName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
@@ -31,6 +31,10 @@ import mockit.Mocked;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
@@ -596,6 +600,75 @@ public class AddFilesProcedureTest {
         assertFalse(metrics.nullValueCounts().containsKey(2));
         assertTrue(metrics.lowerBounds().isEmpty());
         assertTrue(metrics.upperBounds().isEmpty());
+    }
+
+    @Test
+    public void testExtractOrcMetricsOffByOne(@Mocked Table table,
+                                              @Mocked IcebergHiveCatalog catalog,
+                                              @Mocked Reader orcReader) throws Exception {
+        AddFilesProcedure procedure = AddFilesProcedure.getInstance();
+        IcebergTableProcedureContext context =
+                new IcebergTableProcedureContext(catalog, table, null, null, HDFS_ENVIRONMENT, null, null);
+
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get())
+        );
+
+        TypeDescription orcSchema = TypeDescription.createStruct()
+                .addField("id", TypeDescription.createInt())
+                .addField("name", TypeDescription.createString());
+
+        ColumnStatistics fileStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(fileStats.getNumberOfValues()).thenReturn(999L);
+        Mockito.when(fileStats.hasNull()).thenReturn(false);
+
+        ColumnStatistics idStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(idStats.getNumberOfValues()).thenReturn(100L);
+        Mockito.when(idStats.hasNull()).thenReturn(false);
+
+        ColumnStatistics nameStats = Mockito.mock(ColumnStatistics.class);
+        Mockito.when(nameStats.getNumberOfValues()).thenReturn(90L);
+        Mockito.when(nameStats.hasNull()).thenReturn(true);
+
+        ColumnStatistics[] allStats = new ColumnStatistics[] {fileStats, idStats, nameStats};
+
+        FileStatus fileStatus = new FileStatus(1024L, false, 1, 0L, 0L, new Path("/tmp/data.orc"));
+
+        new Expectations() {
+            {
+                table.schema();
+                result = schema;
+
+                orcReader.getSchema();
+                result = orcSchema;
+
+                orcReader.getStatistics();
+                result = allStats;
+
+                orcReader.getNumberOfRows();
+                result = 100L;
+            }
+        };
+
+        new MockUp<OrcFile>() {
+            @Mock
+            public Reader createReader(Path path, OrcFile.ReaderOptions options) {
+                return orcReader;
+            }
+        };
+
+        java.lang.reflect.Method method = AddFilesProcedure.class.getDeclaredMethod("extractOrcMetrics",
+                IcebergTableProcedureContext.class, Table.class, FileStatus.class);
+        method.setAccessible(true);
+        Metrics metrics = (Metrics) method.invoke(procedure, context, table, fileStatus);
+
+        assertEquals(100L, metrics.recordCount());
+        assertEquals(100L, metrics.valueCounts().get(1));
+        assertEquals(90L, metrics.valueCounts().get(2));
+        assertFalse(metrics.nullValueCounts().containsKey(1));
+        assertTrue(metrics.nullValueCounts().containsKey(2));
+        assertEquals(10L, metrics.nullValueCounts().get(2));
     }
 
     private IcebergTableProcedureContext createMockContext(@Mocked Table table, @Mocked IcebergHiveCatalog catalog) {


### PR DESCRIPTION
## Why I'm doing:

`AddFilesProcedure.extractOrcMetrics` incorrectly retrieves ORC column statistics.
ORC's `Reader.getStatistics()` returns file-level stats at index 0, with actual
column stats starting at index 1. The loop iterated from index 0 and passed
`colId` directly to both the stats array and `getColumnNameFromOrcSchema`, causing
all column metrics to be shifted by one position.

## What I'm doing:

- Changed the loop to iterate over `orcSchema.getChildren().size()` (the actual
  number of columns) instead of `columnStats.length`
- Offset the stats array index by +1 (`columnStats[colId + 1]`) to skip the
  file-level entry at index 0

Fixes #71222

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

Made with [Cursor](https://cursor.com)