### PR TITLE
[Enhancement] Add RawDataVisitor

### DIFF
--- a/be/src/column/raw_data_visitor.h
+++ b/be/src/column/raw_data_visitor.h
@@ -77,6 +77,53 @@ private:
     uint8_t* _result = nullptr;
 };
 
+// RawDataVisitor calls raw_data() on the visited column and stores
+// the resulting pointer for the caller to retrieve via result().
+// This is the const counterpart of MutableRawDataVisitor.
+// Supported column types:
+//   - FixedLengthColumn<T>, DecimalV3Column<T>: returns the raw element buffer
+//   - NullableColumn, ConstColumn: recurses into the inner data column
+//   - ArrayColumn: recurses into the elements column
+//   - AdaptiveNullableColumn: materializes first, then recurses into the data column
+// All other column types return NotSupported.
+class RawDataVisitor final : public ColumnVisitorAdapter<RawDataVisitor> {
+public:
+    RawDataVisitor() : ColumnVisitorAdapter(this) {}
+
+    template <typename T>
+    Status do_visit(const FixedLengthColumn<T>& column) {
+        _result = column.raw_data();
+        return Status::OK();
+    }
+
+    template <typename T>
+    Status do_visit(const DecimalV3Column<T>& column) {
+        _result = column.raw_data();
+        return Status::OK();
+    }
+
+    Status do_visit(const ArrayColumn& column) { return column.elements_column_raw_ptr()->accept(this); }
+
+    Status do_visit(const ConstColumn& column) { return column.data_column_raw_ptr()->accept(this); }
+
+    Status do_visit(const NullableColumn& column) { return column.data_column_raw_ptr()->accept(this); }
+
+    Status do_visit(const AdaptiveNullableColumn& column) {
+        return column.materialized_raw_data_column()->accept(this);
+    }
+
+    // Fallback for all unsupported column types.
+    template <typename T>
+    static Status do_visit(const T& column) {
+        return Status::NotSupported("RawDataVisitor: unsupported column type {}", column.get_name());
+    }
+
+    const uint8_t* result() const { return _result; }
+
+private:
+    const uint8_t* _result = nullptr;
+};
+
 // RawBytesVisitor calls raw_bytes() on the visited column and stores
 // the resulting pointer for the caller to retrieve via result().
 // Supported column types:

--- a/be/test/column/raw_data_visitor_test.cpp
+++ b/be/test/column/raw_data_visitor_test.cpp
@@ -239,4 +239,91 @@ TEST(RawBytesVisitorTest, FallbackNotSupported) {
     EXPECT_TRUE(st.message().find(col->get_name()) != std::string::npos);
 }
 
+// ---- RawDataVisitor tests ----
+
+TEST(RawDataVisitorTest, VisitInt32Column) {
+    RawDataVisitor visitor;
+    auto col = ColumnTestHelper::build_column<int32_t>({42, 7});
+
+    ASSERT_OK(col->accept(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(RawDataVisitorTest, VisitDecimal32Column) {
+    RawDataVisitor visitor;
+    auto col = Decimal32Column::create(9, 2);
+    col->append(int32_t{100});
+    col->append(int32_t{200});
+
+    ASSERT_OK(col->accept(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 100);
+    EXPECT_EQ(data[1], 200);
+}
+
+TEST(RawDataVisitorTest, VisitNullableColumn) {
+    RawDataVisitor visitor;
+    auto col = ColumnTestHelper::build_nullable_column<int32_t>({42, 7});
+
+    ASSERT_OK(col->accept(&visitor));
+    ASSERT_NE(visitor.result(), nullptr);
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(RawDataVisitorTest, VisitConstColumn) {
+    RawDataVisitor visitor;
+    auto inner = ColumnTestHelper::build_column<int32_t>({42});
+    auto col = ConstColumn::create(std::move(inner), 4);
+
+    ASSERT_OK(col->accept(&visitor));
+    ASSERT_NE(visitor.result(), nullptr);
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+}
+
+TEST(RawDataVisitorTest, VisitArrayColumn) {
+    RawDataVisitor visitor;
+    auto elements = ColumnTestHelper::build_column<int32_t>({42, 7});
+    auto offsets = ColumnTestHelper::build_column<uint32_t>({0, 2});
+    auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+    ASSERT_OK(col->accept(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+TEST(RawDataVisitorTest, VisitAdaptiveNullableColumn) {
+    RawDataVisitor visitor;
+    auto col = AdaptiveNullableColumn::create(Int32Column::create(), NullColumn::create());
+    col->append_datum(Datum(static_cast<int32_t>(42)));
+    col->append_datum(Datum(static_cast<int32_t>(7)));
+
+    ASSERT_OK(col->accept(&visitor));
+
+    const auto* data = reinterpret_cast<const int32_t*>(visitor.result());
+    EXPECT_EQ(data[0], 42);
+    EXPECT_EQ(data[1], 7);
+}
+
+// BinaryColumn is not supported by RawDataVisitor; use RawBytesVisitor instead.
+TEST(RawDataVisitorTest, FallbackNotSupported) {
+    RawDataVisitor visitor;
+    auto col = BinaryColumn::create();
+    col->append(Slice("hello"));
+
+    auto st = col->accept(&visitor);
+    EXPECT_TRUE(st.is_not_supported());
+    EXPECT_TRUE(st.message().find(col->get_name()) != std::string::npos);
+}
+
 } // namespace starrocks

--- a/be/test/column/raw_data_visitor_test.cpp
+++ b/be/test/column/raw_data_visitor_test.cpp
@@ -291,7 +291,7 @@ TEST(RawDataVisitorTest, VisitConstColumn) {
 
 TEST(RawDataVisitorTest, VisitArrayColumn) {
     RawDataVisitor visitor;
-    auto elements = ColumnTestHelper::build_column<int32_t>({42, 7});
+    auto elements = ColumnTestHelper::build_nullable_column<int32_t>({42, 7});
     auto offsets = ColumnTestHelper::build_column<uint32_t>({0, 2});
     auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
 


### PR DESCRIPTION
## Why I'm doing:

This is the 13th step for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

  Adds RawDataVisitor to raw_data_visitor.h — the const counterpart of MutableRawDataVisitor. It calls raw_data() on the visited column and supports:                                                          
                  
  - FixedLengthColumn<T>, DecimalV3Column<T>: returns the raw element buffer directly                                                                                                                          
  - NullableColumn, ConstColumn: recurses into the inner data column
  - ArrayColumn: recurses into the elements column                                                                                                                                                             
  - AdaptiveNullableColumn: materializes first, then recurses into the data column
  - All other types (including BinaryColumn/LargeBinaryColumn): NotSupported — use RawBytesVisitor instead  

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
