### PR TITLE
[BugFix] Fix shared object mutation in PushDownAggregateRewriter for case-when/if

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
@@ -176,29 +176,25 @@ public class PushDownAggregateCollector extends OptExpressionVisitor<Void, Aggre
             return processChild(optExpression, context);
         }
 
-        // rewrite
-        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(project.getColumnRefMap());
-        context.aggregations.replaceAll((k, v) -> (CallOperator) rewriter.rewrite(v));
-        context.groupBys.replaceAll((k, v) -> rewriter.rewrite(v));
+        ColumnRefSet aggUsedColumns = new ColumnRefSet();
+        context.aggregations.values().forEach(v -> aggUsedColumns.union(v.getUsedColumns()));
 
-        if (project.getColumnRefMap().values().stream().allMatch(ScalarOperator::isColumnRef)) {
-            return processChild(optExpression, context);
-        }
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap = project.getColumnRefMap();
+        Map<ColumnRefOperator, ScalarOperator> aggRewriteMap = columnRefMap;
 
         // handle specials functions case-when/if
         // split to groupBys and mock new aggregations by values, don't need to save
         // origin predicate, we just do check in collect phase
-        for (Map.Entry<ColumnRefOperator, CallOperator> entry : context.aggregations.entrySet()) {
-            CallOperator aggFn = entry.getValue();
-            ScalarOperator aggInput = aggFn.getChild(0);
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : columnRefMap.entrySet()) {
+            ColumnRefOperator key = entry.getKey();
+            ScalarOperator value = entry.getValue();
 
-            if (!(aggInput instanceof CallOperator)) {
+            if (!aggUsedColumns.contains(key) || !(value instanceof CallOperator call)) {
                 continue;
             }
 
-            CallOperator callInput = (CallOperator) aggInput;
-            if (aggInput instanceof CaseWhenOperator) {
-                CaseWhenOperator caseWhen = (CaseWhenOperator) aggInput;
+            if (call instanceof CaseWhenOperator) {
+                CaseWhenOperator caseWhen = (CaseWhenOperator) value;
                 for (ScalarOperator condition : caseWhen.getAllConditionClause()) {
                     condition.getUsedColumns().getStream().map(factory::getColumnRef)
                             .forEach(v -> context.groupBys.put(v, v));
@@ -218,19 +214,38 @@ public class PushDownAggregateCollector extends OptExpressionVisitor<Void, Aggre
                 CaseWhenOperator newCaseWhen = new CaseWhenOperator(caseWhen.getType(), null,
                         caseWhen.hasElse() ? caseWhen.getElseClause() : null, newWhenThen);
 
-                // replace origin
-                aggFn.setChild(0, newCaseWhen);
-            } else if (callInput.getFunction() != null &&
-                    FunctionSet.IF.equals(callInput.getFunction().getFunctionName().getFunction())) {
-                if (aggInput.getChildren().stream().skip(1).anyMatch(c -> c.isConstant() && !c.isConstantNull())) {
+                if (aggRewriteMap == columnRefMap) {
+                    aggRewriteMap = Maps.newHashMap(columnRefMap);
+                }
+                aggRewriteMap.put(key, newCaseWhen);
+            } else if (call.getFunction() != null &&
+                        FunctionSet.IF.equals(call.getFunction().getFunctionName().getFunction())) {
+                if (call.getChildren().stream().skip(1).anyMatch(c -> c.isConstant() && !c.isConstantNull())) {
                     // forbidden push down
                     return visit(optExpression, context);
                 }
 
-                aggInput.getChild(0).getUsedColumns().getStream().map(factory::getColumnRef)
+                call.getChild(0).getUsedColumns().getStream().map(factory::getColumnRef)
                         .forEach(v -> context.groupBys.put(v, v));
-                aggInput.setChild(0, ConstantOperator.createBoolean(false));
+
+                CallOperator newIf = new CallOperator(call.getFnName(), call.getType(), Lists.newArrayList(call.getArguments()),
+                        call.getFunction());
+                newIf.setChild(0, ConstantOperator.createBoolean(false));
+
+                if (aggRewriteMap == columnRefMap) {
+                    aggRewriteMap = Maps.newHashMap(columnRefMap);
+                }
+                aggRewriteMap.put(key, newIf);
             }
+        }
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(aggRewriteMap);
+        context.aggregations.replaceAll((k, v) -> (CallOperator) rewriter.rewrite(v));
+        if (aggRewriteMap != columnRefMap) {
+            ReplaceColumnRefRewriter originalRewriter = new ReplaceColumnRefRewriter(columnRefMap);
+            context.groupBys.replaceAll((k, v) -> originalRewriter.rewrite(v));
+        } else {
+            context.groupBys.replaceAll((k, v) -> rewriter.rewrite(v));
         }
 
         // check has constant aggregate, forbidden

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -192,7 +192,10 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
                     && FunctionSet.IF.equals(((CallOperator) aggExpr).getFunction().getFunctionName().getFunction());
 
             if (isCaseWhen) {
-                CaseWhenOperator caseWhen = (CaseWhenOperator) aggExpr;
+                // Clone to avoid mutating the shared object in originProjectMap/project's columnRefMap.
+                // Without clone, when multiple aggregations reference the same CASE WHEN column,
+                // the first aggregation's setThenClause/setElseClause corrupts the shared operator.
+                CaseWhenOperator caseWhen = (CaseWhenOperator) aggExpr.clone();
                 for (ScalarOperator condition : caseWhen.getAllConditionClause()) {
                     condition.getUsedColumns().getStream().map(factory::getColumnRef)
                             .forEach(v -> context.groupBys.put(v, v));
@@ -221,7 +224,8 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
                 context.aggregations.remove(key);
                 originProjectMap.put(key, new CaseWhenOperator(key.getType(), caseWhen));
             } else if (isIfFn) {
-                CallOperator ifFn = (CallOperator) aggExpr;
+                // Clone to avoid mutating the shared object (same reason as CaseWhen above).
+                CallOperator ifFn = (CallOperator) aggExpr.clone();
                 ifFn.getChild(0).getUsedColumns().getStream().map(factory::getColumnRef)
                         .forEach(v -> context.groupBys.put(v, v));
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -341,5 +341,43 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "     tabletList=10140,10142,10144\n" +
                 "     actualRows=0, avgRowSize=6.0\n" +
                 "     cardinality: 1");
+
+    }
+
+    @Test
+    public void testRewriterSharedMutationWithCaseWhen() throws Exception {
+        // Bug: PushDownAggregateRewriter.rewriteProject() mutates shared CaseWhenOperator
+        // in-place via setThenClause(). When two aggregations (SUM + MIN) reference the same
+        // CASE WHEN column, the first aggregation's processing corrupts the CaseWhenOperator,
+        // causing the second aggregation to see pushed-down column refs instead of original columns.
+        String sql = "SELECT SUM(sub.cval), MIN(sub.cval), sub.fk " +
+                "FROM ( " +
+                "    SELECT t1d AS fk, " +
+                "           CASE WHEN t1b = 1 THEN t1e ELSE NULL END AS cval " +
+                "    FROM test_all_type " +
+                ") sub " +
+                "JOIN t0 ON sub.fk = t0.v1 " +
+                "GROUP BY sub.fk";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, "sum");
+        assertContains(plan, "min");
+    }
+
+    @Test
+    public void testRewriterSharedMutationWithIf() throws Exception {
+        // Bug: PushDownAggregateRewriter.rewriteProject() mutates shared CallOperator (IF)
+        // in-place via setChild(). Same root cause as the CaseWhen bug but on the IF path.
+        String sql = "SELECT SUM(sub.cval), MIN(sub.cval), sub.fk " +
+                "FROM ( " +
+                "    SELECT t1d AS fk, " +
+                "           IF(t1b = 1, t1e, NULL) AS cval " +
+                "    FROM test_all_type " +
+                ") sub " +
+                "JOIN t0 ON sub.fk = t0.v1 " +
+                "GROUP BY sub.fk";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "sum");
+        assertContains(plan, "min");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -93,7 +93,6 @@ public class AggregatePushDownTest extends PlanTestBase {
         }
     }
 
-
     @Test
     public void testPushDownDistinctAggBelowWindow()
             throws Exception {
@@ -293,5 +292,54 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  functions: [, sum[([12: sum, DECIMAL128(38,2), true]);" +
                 " args: DECIMAL128; result: DECIMAL128(38,2); args nullable: true; result nullable: true], ]");
         assertContains(plan, "2:AGGREGATE (update finalize)");
+    }
+
+    @Test
+    public void testPushDownWithNestedCaseWhenIfs() throws Exception {
+        String sql = """
+                WITH cte1 AS (
+                  SELECT
+                    t.t1d AS fk,
+                    t.t1a AS cat,
+                    CASE WHEN t.t1b = 1 THEN t.t1e ELSE t.t1f END AS cval
+                  FROM test_all_type t
+                ),
+                cte2 AS (
+                  SELECT a.cval, a.fk, a.cat
+                  FROM cte1 a
+                  LEFT JOIN t1 ON a.fk = t1.v4
+                ),
+                cte3 AS (
+                  SELECT CASE WHEN c.cat THEN c.cval ELSE NULL END gval, c.fk
+                  FROM cte2 c
+                )
+                SELECT SUM(gval)
+                FROM cte3
+                GROUP BY fk;
+                """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: sum[([21: cast, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result" +
+                " nullable: true], sum[([6: t1f, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result" +
+                " nullable: true]\n" +
+                "  |  group by: [1: t1a, VARCHAR, true], [2: t1b, SMALLINT, true], [4: t1d, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: t1a, VARCHAR, true]\n" +
+                "  |  2 <-> [2: t1b, SMALLINT, true]\n" +
+                "  |  4 <-> [4: t1d, BIGINT, true]\n" +
+                "  |  6 <-> [6: t1f, DOUBLE, true]\n" +
+                "  |  21 <-> cast([5: t1e, FLOAT, true] as DOUBLE)\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: test_all_type, rollup: test_all_type\n" +
+                "     preAggregation: on\n" +
+                "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
+                "     tabletList=10140,10142,10144\n" +
+                "     actualRows=0, avgRowSize=6.0\n" +
+                "     cardinality: 1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When pushing down an aggregate whose argument is a nested case-when/if, `PushDownAggregateCollector` didn't add the inner condition columns to the group-by list, causing a query failure.

The issue can be reproduced by the below query:
```sql
WITH cte1 AS (
  SELECT
    t.t1d AS fk,
    t.t1a AS cat,
    CASE WHEN t.t1b = 1 THEN t.t1e ELSE t.t1f END AS cval
  FROM test_all_type t
),
cte2 AS (
  SELECT a.cval, a.fk, a.cat
  FROM cte1 a
  LEFT JOIN t1 ON a.fk = t1.v4
),
cte3 AS (
  SELECT CASE WHEN c.cat THEN c.cval ELSE NULL END gval, c.fk
  FROM cte2 c
)
SELECT SUM(gval)
FROM cte3
GROUP BY fk;
```

It fails with 
```
com.starrocks.sql.common.StarRocksPlannerException: only found column statistics: {1: t1a, 2: t1b, 4: t1d}, but missing statistic of col: 19: sum.
```

## What I'm doing:
### Issue Analysis
The above SQL produces nested IF projections:
```
aggregations={16: sum=sum(15: case)}
15: case->if(cast(1: t1a as boolean), 11: case, null)
11: case->if(2: t1b = 1, cast(5: t1e as double), 6: t1f)
```

When the collector visits the `LogicalProjectOperator` with `15: case`, it rewrites the aggregation to
```
16: sum -> sum(if(cast(1: t1a as boolean), 11: case, null))
```
then it correctly adds `t1a` to the group-by columns.

Later, when the collector visits `LogicalProjectOperator` with `11: case`, it rewrites the aggregation to
```
sum(if(false, if(2: t1b = 1, cast(5: t1e as double), 6: t1f), null))
```
But this time, it doesn't see `t1b` in the "condition" columns, so it doesn't add `t1b` into the group-by columns.


This behavior is different than the rewriter's behavior.

When the collector and the rewriter see different group-by lists, the pushdown fails. However, the rewriter works in a top-down manner ---- it rewrites nodes above first, then it aborts on the table scan ---- this produces an incorrect plan.

### Fix

Modify the collector to add inner case-when/if's condition columns into the group-by list as well.

For the above query, this is the aggregate pushdown's behavior today:

Before the pushdown:
```
LOGICAL
->  LogicalProjectOperator {projection=[16: sum->16: sum]}
    ->  LogicalAggregation {type=GLOBAL ,aggregations={16: sum=sum(15: case)} ,groupKeys=[4: t1d], partitionBys=[4: t1d]}
        ->  LogicalProjectOperator {projection=[4: t1d->4: t1d, 15: case->if(cast(1: t1a as boolean), 11: case, null)]}
            ->  LOGICAL_JOIN {LEFT OUTER JOIN, onPredicate = 4: t1d = 12: v4 , Predicate = null}
                ->  LogicalProjectOperator {projection=[1: t1a->1: t1a, 4: t1d->4: t1d, 11: case->if(2: t1b = 1, cast(5: t1e as double), 6: t1f)]}
                    ->  LogicalOlapScanOperator {table=test_all_type, selectedPartitionId=[10136], selectedIndexMetaId=10138, outputColumns=[1: t1a, 2: t1b, 4: t1d, 5: t1e, 6: t1f], prunedPartitionPredicates=[], limit=-1}
                ->  LogicalProjectOperator {projection=[12: v4->12: v4]}
                    ->  LogicalOlapScanOperator {table=t1, selectedPartitionId=[10012], selectedIndexMetaId=10014, outputColumns=[12: v4], prunedPartitionPredicates=[], limit=-1}
```

After the pushdown:
```
LOGICAL
->  LogicalProjectOperator {projection=[16: sum->16: sum]}
    ->  LogicalAggregation {type=GLOBAL ,aggregations={16: sum=sum(17: sum)} ,groupKeys=[4: t1d], partitionBys=[4: t1d]}
        ->  LogicalProjectOperator {projection=[17: sum->if(cast(1: t1a as boolean), 18: sum, null), 18: sum->18: sum, 4: t1d->4: t1d, 15: case->if(cast(1: t1a as boolean), 18: sum, null)]}
            ->  LOGICAL_JOIN {LEFT OUTER JOIN, onPredicate = 4: t1d = 12: v4 , Predicate = null}
                ->  LogicalProjectOperator {projection=[1: t1a->1: t1a, 18: sum->if(2: t1b = 1, 19: sum, 20: sum), 11: case->if(2: t1b = 1, 19: sum, 20: sum), 19: sum->19: sum, 4: t1d->4: t1d, 20: sum->20: sum]}
                    ->  LogicalAggregation {type=GLOBAL ,aggregations={19: sum=sum(21: cast), 20: sum=sum(6: t1f)} ,groupKeys=[1: t1a, 2: t1b, 4: t1d], partitionBys=[1: t1a, 2: t1b, 4: t1d]}
                        ->  LogicalProjectOperator {projection=[1: t1a->1: t1a, 2: t1b->2: t1b, 4: t1d->4: t1d, 5: t1e->5: t1e, 21: cast->cast(5: t1e as double), 6: t1f->6: t1f]}
                            ->  LogicalOlapScanOperator {table=test_all_type, selectedPartitionId=[10136], selectedIndexMetaId=10138, outputColumns=[1: t1a, 2: t1b, 4: t1d, 5: t1e, 6: t1f], prunedPartitionPredicates=[], limit=-1}
                ->  LogicalProjectOperator {projection=[12: v4->12: v4]}
                    ->  LogicalOlapScanOperator {table=t1, selectedPartitionId=[10012], selectedIndexMetaId=10014, outputColumns=[12: v4], prunedPartitionPredicates=[], limit=-1}
```




## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
