### PR TITLE
[Refactor] Replace raw_data() reinterpret_casts with GetContainer

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -185,7 +185,7 @@ static bool get_predicate_value(ObjectPool* obj_pool, const SlotDescriptor& slot
         // |column_ptr| will be released after this method return, have to ensure that
         // the corresponding external storage will not be deallocated while the slice
         // still been used.
-        const auto slice = GetContainer<TYPE_VARCHAR>::get_data(data.get())[0];
+        const auto slice = GetContainer<TYPE_VARCHAR>::get_data(data.get(), 0);
         std::string* str = obj_pool->add(new std::string(slice.data, slice.size));
         *value = *str;
     } else {

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -185,8 +185,8 @@ static bool get_predicate_value(ObjectPool* obj_pool, const SlotDescriptor& slot
         // |column_ptr| will be released after this method return, have to ensure that
         // the corresponding external storage will not be deallocated while the slice
         // still been used.
-        const auto* slice = reinterpret_cast<const Slice*>(data->raw_data());
-        std::string* str = obj_pool->add(new std::string(slice->data, slice->size));
+        const auto slice = GetContainer<TYPE_VARCHAR>::get_data(data.get())[0];
+        std::string* str = obj_pool->add(new std::string(slice.data, slice.size));
         *value = *str;
     } else {
         *value = *reinterpret_cast<const ValueType*>(data->raw_data());

--- a/be/src/exprs/agg/combinator/agg_state_if.h
+++ b/be/src/exprs/agg/combinator/agg_state_if.h
@@ -132,10 +132,9 @@ public:
                 }
             }
         } else {
-            const auto& predicate_column_raw_data =
-                    ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(predicate_column)->immutable_data();
+            const auto& predicate_data = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(predicate_column)->immutable_data();
             for (size_t i = 0; i < chunk_size; ++i) {
-                fake_null_column_raw_data[i] = !predicate_column_raw_data[i];
+                fake_null_column_raw_data[i] = !predicate_data[i];
             }
         }
 

--- a/be/src/exprs/agg/combinator/agg_state_if.h
+++ b/be/src/exprs/agg/combinator/agg_state_if.h
@@ -111,9 +111,9 @@ public:
             size_t nullCount = nullable_predicate_column->null_count();
 
             if (nullCount == 0) {
-                const uint8_t* __restrict nullable_predicate_data_col_raw_data;
-                nullable_predicate_data_col_raw_data =
-                        ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(nullable_predicate_column->data_column())->raw_data();
+                const auto& nullable_predicate_data_col_raw_data =
+                        ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(nullable_predicate_column->data_column())
+                                ->immutable_data();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     // false is 0, but null is 1
                     fake_null_column_raw_data[i] = !nullable_predicate_data_col_raw_data[i];
@@ -132,8 +132,8 @@ public:
                 }
             }
         } else {
-            const uint8_t* __restrict predicate_column_raw_data =
-                    ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(predicate_column)->raw_data();
+            const auto& predicate_column_raw_data =
+                    ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(predicate_column)->immutable_data();
             for (size_t i = 0; i < chunk_size; ++i) {
                 fake_null_column_raw_data[i] = !predicate_column_raw_data[i];
             }

--- a/be/src/exprs/agg/combinator/agg_state_if.h
+++ b/be/src/exprs/agg/combinator/agg_state_if.h
@@ -111,12 +111,12 @@ public:
             size_t nullCount = nullable_predicate_column->null_count();
 
             if (nullCount == 0) {
-                const auto& nullable_predicate_data_col_raw_data =
+                const auto& nullable_predicate_datas =
                         ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(nullable_predicate_column->data_column())
                                 ->immutable_data();
                 for (size_t i = 0; i < chunk_size; ++i) {
                     // false is 0, but null is 1
-                    fake_null_column_raw_data[i] = !nullable_predicate_data_col_raw_data[i];
+                    fake_null_column_raw_data[i] = !nullable_predicate_datas[i];
                 }
             } else if (nullCount == predicate_column->size()) {
                 fake_null_column = NullColumn::create(columns[0]->size(), 1);

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -209,7 +209,7 @@ public:
                 int64_t frame_end = current_frame_last_position + 1;
                 if (has_null) {
                     const auto null_column = down_cast<const NullColumn*>(columns[1]);
-                    const uint8_t* f_data = null_column->raw_data();
+                    const auto& f_data = null_column->immutable_data();
                     for (size_t i = frame_start; i < frame_end; ++i) {
                         if (f_data[i] == 0) {
                             update(ctx, columns, state, i);
@@ -303,7 +303,7 @@ public:
                 int64_t frame_end = current_frame_last_position + 1;
                 if (has_null) {
                     const auto null_column = down_cast<const NullColumn*>(columns[1]);
-                    const uint8_t* f_data = null_column->raw_data();
+                    const auto& f_data = null_column->immutable_data();
                     for (size_t i = frame_start; i < frame_end; ++i) {
                         if (f_data[i] == 0) {
                             update(ctx, columns, state, i);

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -360,7 +360,7 @@ public:
         if (columns[0]->is_nullable()) {
             const auto* column = down_cast<const NullableColumn*>(columns[0]);
             const Column* data_column = &column->data_column_ref();
-            const uint8_t* f_data = column->null_column()->raw_data();
+            const uint8_t* f_data = column->null_column()->immutable_data().data();
             int offset = 0;
 
             // all not null
@@ -487,7 +487,7 @@ public:
         if (columns[0]->is_nullable()) {
             const auto* column = down_cast<const NullableColumn*>(columns[0]);
             const Column* data_column = &column->data_column_ref();
-            const uint8_t* f_data = column->null_column()->raw_data();
+            const uint8_t* f_data = column->null_column()->immutable_data().data();
             int offset = 0;
 
 #ifdef __AVX2__
@@ -645,7 +645,7 @@ public:
                 return;
             }
 
-            const uint8_t* f_data = column->null_column()->raw_data();
+            const uint8_t* f_data = column->null_column()->immutable_data().data();
             int offset = 0;
 #ifdef __AVX2__
             // !important: filter must be an uint8_t container
@@ -765,7 +765,7 @@ public:
                 return;
             }
 
-            const uint8_t* f_data = column->null_column()->raw_data();
+            const auto& f_data = column->null_column()->immutable_data();
             for (size_t i = frame_start; i < frame_end; ++i) {
                 if (f_data[i] == 0) {
                     this->data(state).is_null = false;
@@ -829,7 +829,7 @@ public:
                     return;
                 }
 
-                const uint8_t* f_data = column->null_column()->raw_data();
+                const auto& f_data = column->null_column()->immutable_data();
                 if (this->data(state).is_frame_init) {
                     // Since frame has been evaluated, we only need to update the boundary
                     const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
@@ -1024,7 +1024,7 @@ public:
                 // compute null_datas for column that has null.
                 if (columns[i]->has_null()) {
                     has_null = true;
-                    auto null_data = column->null_column()->raw_data();
+                    const auto& null_data = column->null_column()->immutable_data();
                     for (size_t j = 0; j < chunk_size; ++j) {
                         null_data_result[j] |= null_data[j];
                     }

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -360,7 +360,7 @@ public:
         if (columns[0]->is_nullable()) {
             const auto* column = down_cast<const NullableColumn*>(columns[0]);
             const Column* data_column = &column->data_column_ref();
-            const uint8_t* f_data = column->null_column()->immutable_data().data();
+            const uint8_t* f_data = column->immutable_null_column_data().data();
             int offset = 0;
 
             // all not null
@@ -487,7 +487,7 @@ public:
         if (columns[0]->is_nullable()) {
             const auto* column = down_cast<const NullableColumn*>(columns[0]);
             const Column* data_column = &column->data_column_ref();
-            const uint8_t* f_data = column->null_column()->immutable_data().data();
+            const uint8_t* f_data = column->immutable_null_column_data().data();
             int offset = 0;
 
 #ifdef __AVX2__
@@ -645,7 +645,7 @@ public:
                 return;
             }
 
-            const uint8_t* f_data = column->null_column()->immutable_data().data();
+            const uint8_t* f_data = column->immutable_null_column_data().data();
             int offset = 0;
 #ifdef __AVX2__
             // !important: filter must be an uint8_t container
@@ -765,7 +765,7 @@ public:
                 return;
             }
 
-            const auto& f_data = column->null_column()->immutable_data();
+            const auto& f_data = column->immutable_null_column_data();
             for (size_t i = frame_start; i < frame_end; ++i) {
                 if (f_data[i] == 0) {
                     this->data(state).is_null = false;
@@ -829,7 +829,7 @@ public:
                     return;
                 }
 
-                const auto& f_data = column->null_column()->immutable_data();
+                const auto& f_data = column->immutable_null_column_data();
                 if (this->data(state).is_frame_init) {
                     // Since frame has been evaluated, we only need to update the boundary
                     const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
@@ -1024,7 +1024,7 @@ public:
                 // compute null_datas for column that has null.
                 if (columns[i]->has_null()) {
                     has_null = true;
-                    const auto& null_data = column->null_column()->immutable_data();
+                    const auto& null_data = column->immutable_null_column_data();
                     for (size_t j = 0; j < chunk_size; ++j) {
                         null_data_result[j] |= null_data[j];
                     }

--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -90,13 +90,13 @@ public:
         }
 
         if (auto* nullable = dynamic_cast<const NullableColumn*>(arg0.get()); nullable != nullptr) {
-            const auto& nulls = nullable->null_column()->immutable_data();
+            const auto& nulls = nullable->immutable_null_column_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[i];
             }
         }
         if (auto* nullable = dynamic_cast<const NullableColumn*>(arg1.get()); nullable != nullptr) {
-            const auto& nulls = nullable->null_column()->immutable_data();
+            const auto& nulls = nullable->immutable_null_column_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[i];
             }
@@ -118,7 +118,7 @@ public:
 
         if (array_elements->has_null()) {
             const auto* nullable_elements = down_cast<const NullableColumn*>(array_elements);
-            const auto& nulls = nullable_elements->null_column()->immutable_data();
+            const auto& nulls = nullable_elements->immutable_null_column_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[selection[i]];
             }

--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -90,13 +90,13 @@ public:
         }
 
         if (auto* nullable = dynamic_cast<const NullableColumn*>(arg0.get()); nullable != nullptr) {
-            const uint8_t* nulls = nullable->null_column()->raw_data();
+            const auto& nulls = nullable->null_column()->immutable_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[i];
             }
         }
         if (auto* nullable = dynamic_cast<const NullableColumn*>(arg1.get()); nullable != nullptr) {
-            const uint8_t* nulls = nullable->null_column()->raw_data();
+            const auto& nulls = nullable->null_column()->immutable_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[i];
             }
@@ -118,7 +118,7 @@ public:
 
         if (array_elements->has_null()) {
             const auto* nullable_elements = down_cast<const NullableColumn*>(array_elements);
-            const uint8_t* nulls = nullable_elements->null_column()->raw_data();
+            const auto& nulls = nullable_elements->null_column()->immutable_data();
             for (size_t i = 0; i < num_rows; i++) {
                 null_flags[i] |= nulls[selection[i]];
             }

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -2403,8 +2403,8 @@ public:
         }
         ColumnPtr array_column = FunctionHelper::get_data_column_of_const(column);
         const auto& [offsets_column, elements_column, null_column] = ColumnHelper::unpack_array_column(array_column);
-        const CppType* elements_data = reinterpret_cast<const CppType*>(elements_column->raw_data());
-        const NullColumn::ValueType* null_data = null_column->raw_data();
+        const auto& elements_data = GetContainer<LT>::get_data(elements_column);
+        const NullColumn::ValueType* null_data = null_column->immutable_data().data();
         const UInt32Column::ValueType* offsets_data = offsets_column->immutable_data().data();
         size_t offset = offsets_data[0];
         size_t array_size = offsets_data[1] - offset;
@@ -2423,8 +2423,8 @@ public:
             const auto& [target_offsets_column, target_elements_column, target_null_column] =
                     ColumnHelper::unpack_array_column(FunctionHelper::get_data_column_of_const(target_column));
 
-            const CppType* target_elements_data = reinterpret_cast<const CppType*>(target_elements_column->raw_data());
-            const NullColumn::ValueType* target_elements_null_data = target_null_column->raw_data();
+            const auto& target_elements_data = GetContainer<LT>::get_data(target_elements_column);
+            const NullColumn::ValueType* target_elements_null_data = target_null_column->immutable_data().data();
             const UInt32Column::ValueType* target_offsets_data = target_offsets_column->immutable_data().data();
 
             size_t target_offset = target_offsets_data[0];
@@ -2509,7 +2509,7 @@ public:
 private:
     static constexpr bool is_supported(LogicalType type) { return is_scalar_logical_type(type); }
 
-    static void _build_hash_table(const CppType* elements_data, const NullColumn::ValueType* elements_null_data,
+    static void _build_hash_table(const ColumnType::ImmContainer& elements_data, const NullColumn::ValueType* elements_null_data,
                                   size_t offset, size_t array_size, ArrayContainsAllState* state) {
         HashMap* hash_map = std::get_if<HashMap>(&(state->variant));
         DCHECK(hash_map != nullptr);
@@ -2528,7 +2528,7 @@ private:
     }
 
     template <bool HTFromLeft>
-    static bool _process_with_hash_table(const ArrayContainsAllState* state, const CppType* elements_data,
+    static bool _process_with_hash_table(const ArrayContainsAllState* state, const ColumnType::ImmContainer& elements_data,
                                          const NullColumn::ValueType* elements_null_data, size_t offset,
                                          size_t array_size) {
         const HashMap* hash_map = std::get_if<HashMap>(&(state->variant));
@@ -2597,7 +2597,7 @@ private:
         return left_data[lhs] == right_data[rhs];
     }
 
-    static void _build_prefix_table(const CppType* elements_data, const NullColumn::ValueType* null_data, size_t offset,
+    static void _build_prefix_table(const ColumnType::ImmContainer& elements_data, const NullColumn::ValueType* null_data, size_t offset,
                                     size_t array_size, ArrayContainsAllState* state) {
         if (array_size == 0) {
             return;
@@ -2626,8 +2626,9 @@ private:
         }
     }
 
-    static bool _process_with_prefix_table(const ArrayContainsAllState* state, const CppType* left_elements_data,
-                                           const CppType* right_elements_data,
+    static bool _process_with_prefix_table(const ArrayContainsAllState* state,
+                                           const ColumnType::ImmContainer& left_elements_data,
+                                           const ColumnType::ImmContainer& right_elements_data,
                                            const NullColumn::ValueType* left_elements_null_data,
                                            const NullColumn::ValueType* right_elements_null_data, size_t left_offset,
                                            size_t left_array_size, size_t right_offset, size_t right_array_size) {
@@ -2679,13 +2680,13 @@ private:
 
         const auto& [left_offsets_column, left_elements_column, left_elements_null_column] =
                 ColumnHelper::unpack_array_column(left_arrays);
-        const CppType* left_elements_data = reinterpret_cast<const CppType*>(left_elements_column->raw_data());
+        const auto& left_elements_data = GetContainer<LT>::get_data(left_elements_column);
         const NullColumn::ValueType* left_elements_null_data = left_elements_null_column->immutable_data().data();
         const auto* left_offsets_data = left_offsets_column->immutable_data().data();
 
         const auto& [right_offsets_column, right_elements_column, right_elements_null_column] =
                 ColumnHelper::unpack_array_column(right_arrays);
-        const CppType* right_elements_data = reinterpret_cast<const CppType*>(right_elements_column->raw_data());
+        const auto& right_elements_data = GetContainer<LT>::get_data(right_elements_column);
         const NullColumn::ValueType* right_elements_null_data = right_elements_null_column->immutable_data().data();
         const auto* right_offsets_data = right_offsets_column->immutable_data().data();
 
@@ -2763,7 +2764,7 @@ private:
                     tmp_state.variant = HashMap{};
                     // we build hash table on the side with less elements
                     build_from_left = left_not_null_element_num <= right_not_null_element_num;
-                    const CppType* build_elements_data = build_from_left ? left_elements_data : right_elements_data;
+                    const auto& build_elements_data = build_from_left ? left_elements_data : right_elements_data;
                     const NullColumn::ValueType* build_elements_null_data =
                             build_from_left ? left_elements_null_data : right_elements_null_data;
                     size_t build_array_offset = build_from_left ? left_array_offset : right_array_offset;
@@ -2774,7 +2775,7 @@ private:
                     state_ref = &tmp_state;
                 }
 
-                const CppType* probe_elements_data = !build_from_left ? left_elements_data : right_elements_data;
+                const auto& probe_elements_data = !build_from_left ? left_elements_data : right_elements_data;
                 const NullColumn::ValueType* probe_elements_null_data =
                         !build_from_left ? left_elements_null_data : right_elements_null_data;
                 size_t probe_array_offset = !build_from_left ? left_array_offset : right_array_offset;

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -2228,7 +2228,7 @@ private:
         const auto& offsets_column = array_column->offsets_column();
 
         const auto& elements_data = GetContainer<LT>::get_data(elements_column);
-        const NullColumn::ValueType* null_data = null_column->raw_data();
+        const auto& null_data = null_column->immutable_data();
         const UInt32Column::ValueType* offsets_data = offsets_column->immutable_data().data();
         // column may be null
         size_t offset = offsets_data[0];
@@ -2259,7 +2259,7 @@ private:
         result_column->resize(is_const_target ? 1 : num_rows);
         size_t result_size = result_column->size();
 
-        const CppType* target_data = reinterpret_cast<const CppType*>(targets->raw_data());
+        const auto& target_data = GetContainer<LT>::get_data(targets);
         auto* result_data = result_column->get_data().data();
 
         for (size_t i = 0; i < result_size; i++) {

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#pragma once
 #include <chrono>
 #include <memory>
 
@@ -2583,8 +2584,8 @@ private:
         return true;
     }
 
-    static inline bool _check_element_equal(const CppType* left_data, const NullColumn::ValueType* left_null_data,
-                                            const CppType* right_data, const NullColumn::ValueType* right_null_data,
+    static inline bool _check_element_equal(const ColumnType::ImmContainer& left_data, const NullColumn::ValueType* left_null_data,
+                                            const ColumnType::ImmContainer& right_data, const NullColumn::ValueType* right_null_data,
                                             size_t lhs, size_t rhs) {
         bool is_lhs_null = left_null_data[lhs];
         bool is_rhs_null = right_null_data[rhs];

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -2509,8 +2509,9 @@ public:
 private:
     static constexpr bool is_supported(LogicalType type) { return is_scalar_logical_type(type); }
 
-    static void _build_hash_table(const ColumnType::ImmContainer& elements_data, const NullColumn::ValueType* elements_null_data,
-                                  size_t offset, size_t array_size, ArrayContainsAllState* state) {
+    static void _build_hash_table(const ColumnType::ImmContainer& elements_data,
+                                  const NullColumn::ValueType* elements_null_data, size_t offset, size_t array_size,
+                                  ArrayContainsAllState* state) {
         HashMap* hash_map = std::get_if<HashMap>(&(state->variant));
         DCHECK(hash_map != nullptr);
 
@@ -2528,7 +2529,8 @@ private:
     }
 
     template <bool HTFromLeft>
-    static bool _process_with_hash_table(const ArrayContainsAllState* state, const ColumnType::ImmContainer& elements_data,
+    static bool _process_with_hash_table(const ArrayContainsAllState* state,
+                                         const ColumnType::ImmContainer& elements_data,
                                          const NullColumn::ValueType* elements_null_data, size_t offset,
                                          size_t array_size) {
         const HashMap* hash_map = std::get_if<HashMap>(&(state->variant));
@@ -2583,9 +2585,10 @@ private:
         return true;
     }
 
-    static inline bool _check_element_equal(const ColumnType::ImmContainer& left_data, const NullColumn::ValueType* left_null_data,
-                                            const ColumnType::ImmContainer& right_data, const NullColumn::ValueType* right_null_data,
-                                            size_t lhs, size_t rhs) {
+    static inline bool _check_element_equal(const ColumnType::ImmContainer& left_data,
+                                            const NullColumn::ValueType* left_null_data,
+                                            const ColumnType::ImmContainer& right_data,
+                                            const NullColumn::ValueType* right_null_data, size_t lhs, size_t rhs) {
         bool is_lhs_null = left_null_data[lhs];
         bool is_rhs_null = right_null_data[rhs];
         if (is_lhs_null ^ is_rhs_null) {
@@ -2597,8 +2600,9 @@ private:
         return left_data[lhs] == right_data[rhs];
     }
 
-    static void _build_prefix_table(const ColumnType::ImmContainer& elements_data, const NullColumn::ValueType* null_data, size_t offset,
-                                    size_t array_size, ArrayContainsAllState* state) {
+    static void _build_prefix_table(const ColumnType::ImmContainer& elements_data,
+                                    const NullColumn::ValueType* null_data, size_t offset, size_t array_size,
+                                    ArrayContainsAllState* state) {
         if (array_size == 0) {
             return;
         }

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -2226,7 +2226,7 @@ private:
                 down_cast<const NullableColumn*>(array_column->elements_column().get())->null_column();
         const auto& offsets_column = array_column->offsets_column();
 
-        const CppType* elements_data = reinterpret_cast<const CppType*>(elements_column->raw_data());
+        const auto& elements_data = GetContainer<LT>::get_data(elements_column);
         const NullColumn::ValueType* null_data = null_column->raw_data();
         const UInt32Column::ValueType* offsets_data = offsets_column->immutable_data().data();
         // column may be null

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -2292,15 +2292,14 @@ private:
         }
 
         const auto& elements_column = down_cast<const ArrayColumn*>(arrays.get())->elements_column();
-        const auto& elements = down_cast<const NullableColumn*>(elements_column.get())->data_column();
-        const CppType* elements_data = reinterpret_cast<const CppType*>(elements->raw_data());
+        const auto& elements_data = GetContainer<LT>::get_data(elements_column);
         const NullColumn::ValueType* elements_null_data =
                 down_cast<const NullableColumn*>(elements_column.get())->immutable_null_column_data().data();
 
         const auto& offsets_column = down_cast<const ArrayColumn*>(arrays.get())->offsets_column();
         const auto offsets_data = offsets_column->immutable_data();
 
-        const CppType* targets_data = reinterpret_cast<const CppType*>(targets->raw_data());
+        const auto& targets_data = GetContainer<LT>::get_data(targets);
 
         // if both two columns are constant, we only compute the first row once
         size_t num_rows = (is_const_array && is_const_target) ? 1 : std::max(arrays->size(), targets->size());

--- a/be/src/exprs/chunk_predicate_evaluator.cpp
+++ b/be/src/exprs/chunk_predicate_evaluator.cpp
@@ -204,7 +204,7 @@ void ChunkPredicateEvaluator::eval_filter_null_values(Chunk* chunk,
         // let compiler does everything.
         // let's pray for compiler,
         // till the end of the world.
-        const auto& nulls = nullable_column->null_column()->immutable_data();
+        const auto& nulls = nullable_column->immutable_null_column_data();
         uint8_t* sel = selection.data();
         for (size_t i = 0; i < before_size; i++) {
             sel[i] &= !nulls[i];

--- a/be/src/exprs/chunk_predicate_evaluator.cpp
+++ b/be/src/exprs/chunk_predicate_evaluator.cpp
@@ -204,7 +204,7 @@ void ChunkPredicateEvaluator::eval_filter_null_values(Chunk* chunk,
         // let compiler does everything.
         // let's pray for compiler,
         // till the end of the world.
-        const uint8_t* nulls = nullable_column->null_column()->raw_data();
+        const auto& nulls = nullable_column->null_column()->immutable_data();
         uint8_t* sel = selection.data();
         for (size_t i = 0; i < before_size; i++) {
             sel[i] &= !nulls[i];

--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -868,7 +868,7 @@ struct EncodeColumnToDigest {
             }
 
             uint8_t marker = static_cast<uint8_t>(marker_type);
-            const uint8_t* null_data = null_col ? null_col->raw_data() : nullptr;
+            const auto* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
                 if (null_data && null_data[row]) {
                     uint8_t null_marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
@@ -888,7 +888,7 @@ struct EncodeColumnToDigest {
             // Fallback for unsupported types (JSON, HLL, OBJECT, STRUCT, ARRAY, MAP, etc.)
             // Cast to string representation and encode
             auto* col = data_col ? down_cast<const ColumnType*>(data_col) : nullptr;
-            const uint8_t* null_data = null_col ? null_col->raw_data() : nullptr;
+            const auto* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
                 if (null_data && null_data[row]) {
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::Null);

--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -830,7 +830,7 @@ struct EncodeColumnToDigest {
         if constexpr (lt_is_string<LT> || lt_is_binary<LT>) {
             // String/Binary types
             auto* col = data_col ? down_cast<const ColumnType*>(data_col) : nullptr;
-            const uint8_t* null_data = null_col ? null_col->raw_data() : nullptr;
+            const uint8_t* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
                 if (null_data && null_data[row]) {
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
@@ -846,7 +846,7 @@ struct EncodeColumnToDigest {
         } else if constexpr (lt_is_arithmetic<LT> || lt_is_date_or_datetime<LT> || lt_is_decimal<LT> ||
                              lt_is_largeint<LT>) {
             // Fixed-length types: numerics, dates, decimals
-            auto* data = data_col ? reinterpret_cast<const CppType*>(data_col->raw_data()) : nullptr;
+            const auto* data = data_col ? GetContainer<LT>::get_data(data_col).data() : nullptr;
             RowFingerprintValueType marker_type;
 
             if constexpr (sizeof(CppType) == 1) {

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -101,7 +101,7 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
         auto data_col_ptr = reinterpret_cast<const int8_t*>(un_col->raw_data());
         const int8_t* null_flags_ptr = nullptr;
         if (un_col_null != nullptr) {
-            null_flags_ptr = reinterpret_cast<const int8_t*>(un_col_null->raw_data());
+            null_flags_ptr = reinterpret_cast<const int8_t*>(un_col_null->immutable_data().data());
         }
         jit_columns.emplace_back(JITColumn{data_col_ptr, null_flags_ptr});
     };

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -705,7 +705,7 @@ Status ScalarColumnWriter::append(const Column& column) {
     const uint8_t* ptr = column.raw_data();
     // Currently, ColumnWriter does not support null-only columns
     const uint8_t* null =
-            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->raw_data() : nullptr;
+            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->immutable_data().data() : nullptr;
     return _append(ptr, null, column.size(), column.has_null());
 }
 
@@ -941,7 +941,7 @@ Status StringColumnWriter::check_string_lengths(const Column& column) {
     size_t limit = length();
     auto row_count = column.size();
     const uint8_t* null =
-            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->raw_data() : nullptr;
+            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->immutable_data().data() : nullptr;
     const BinaryColumn* bin_col;
 
     if (is_nullable()) {

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -705,7 +705,7 @@ Status ScalarColumnWriter::append(const Column& column) {
     const uint8_t* ptr = column.raw_data();
     // Currently, ColumnWriter does not support null-only columns
     const uint8_t* null =
-            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->immutable_data().data() : nullptr;
+            is_nullable() ? down_cast<const NullableColumn*>(&column)->immutable_null_column_data().data() : nullptr;
     return _append(ptr, null, column.size(), column.has_null());
 }
 
@@ -941,7 +941,7 @@ Status StringColumnWriter::check_string_lengths(const Column& column) {
     size_t limit = length();
     auto row_count = column.size();
     const uint8_t* null =
-            is_nullable() ? down_cast<const NullableColumn*>(&column)->null_column()->immutable_data().data() : nullptr;
+            is_nullable() ? down_cast<const NullableColumn*>(&column)->immutable_null_column_data().data() : nullptr;
     const BinaryColumn* bin_col;
 
     if (is_nullable()) {

--- a/be/test/column/fixed_length_column_extended_test.cpp
+++ b/be/test/column/fixed_length_column_extended_test.cpp
@@ -184,7 +184,7 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
     ASSERT_EQ(values.size(), c1->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
-        auto* p = reinterpret_cast<const int32_t*>(c1->raw_data());
+        const auto& p = c1->immutable_data();
         ASSERT_EQ(values[i], p[i]);
     }
 
@@ -192,10 +192,9 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
     auto c2 = NullableColumn::create(Int32Column::create(), NullColumn::create());
     ASSERT_EQ(values.size(), c2->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c2->size());
-    auto* nullable_c2 = down_cast<NullableColumn*>(c2.get());
+    const auto& datas = GetContainer<TYPE_INT>::get_data(c2.get());
     for (size_t i = 0; i < values.size(); i++) {
-        auto* p = reinterpret_cast<const int32_t*>(nullable_c2->data_column()->raw_data());
-        ASSERT_EQ(values[i], p[i]);
+        ASSERT_EQ(values[i], datas[i]);
     }
 }
 
@@ -674,7 +673,7 @@ TEST(FixedLengthColumnTest, test_fill_range) {
     Filter filter{1, 0, 1, 0, 1};
     ASSERT_TRUE(c1->fill_range(ids, filter).ok());
 
-    auto* p = reinterpret_cast<const int64_t*>(c1->raw_data());
+    const auto& p = c1->immutable_data();
     ASSERT_EQ(0, p[0]);
     ASSERT_EQ(values[1], p[1]);
     ASSERT_EQ(0, p[2]);

--- a/be/test/column/fixed_length_column_extended_test.cpp
+++ b/be/test/column/fixed_length_column_extended_test.cpp
@@ -183,8 +183,8 @@ TEST(FixedLengthColumnTest, test_append_numbers) {
     auto c1 = Int32Column::create();
     ASSERT_EQ(values.size(), c1->append_numbers(buff, length));
     ASSERT_EQ(values.size(), c1->size());
+    const auto& p = c1->immutable_data();
     for (size_t i = 0; i < values.size(); i++) {
-        const auto& p = c1->immutable_data();
         ASSERT_EQ(values[i], p[i]);
     }
 

--- a/be/test/formats/parquet/encoding_test.cpp
+++ b/be/test/formats/parquet/encoding_test.cpp
@@ -23,6 +23,7 @@
 #include "column/binary_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column_helper.h"
 #include "common/config_exec_fwd.h"
 #include "formats/parquet/types.h"
 
@@ -270,10 +271,9 @@ struct DecoderChecker<Slice, is_dictionary> {
                 st = decoder->next_batch(values.size(), ColumnContentType::VALUE, column.get());
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
-                const auto* check = (const Slice*)column->data_column()->raw_data();
-                for (auto value : values) {
-                    ASSERT_EQ(value, *check);
-                    check++;
+                const auto& checks = GetContainer<TYPE_VARCHAR>::get_data(column.get());
+                for (size_t i = 0; i < values.size(); i++) {
+                    ASSERT_EQ(values[i], checks[i]);
                 }
 
                 if (!is_dictionary) {
@@ -296,9 +296,9 @@ struct DecoderChecker<Slice, is_dictionary> {
                 st = decoder->next_batch(remain_values, ColumnContentType::VALUE, column.get());
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
-                const auto* check = (const Slice*)column->data_column()->raw_data();
+                const auto& checks = GetContainer<TYPE_VARCHAR>::get_data(column.get());
                 for (size_t i = 0; i < remain_values; i++) {
-                    EXPECT_EQ(values[values_to_skip + i], check[i]);
+                    EXPECT_EQ(values[values_to_skip + i], checks[i]);
                 }
 
                 if (!is_dictionary) {

--- a/be/test/formats/parquet/encoding_test.cpp
+++ b/be/test/formats/parquet/encoding_test.cpp
@@ -21,9 +21,9 @@
 
 #include "base/simd/byte_stream_split.h"
 #include "column/binary_column.h"
+#include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
-#include "column_helper.h"
 #include "common/config_exec_fwd.h"
 #include "formats/parquet/types.h"
 


### PR DESCRIPTION
## Why I'm doing:

This is the 14th step for https://github.com/StarRocks/starrocks/issues/69589

raw_data() followed by reinterpret_cast bypasses the type system and, for BinaryColumn, forces materialization of the _slices cache as a side effect. GetContainer provide type-safe access via the visitor pattern and correctly handle LargeBinaryColumn without special-casing.

## What I'm doing:

Replace raw_data() reinterpret_casts with GetContainer.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
