### PR TITLE
[Enhancement] Propagate query_id and ThreadModuleType to all worker threads

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -293,6 +293,7 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
 }
 
 void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::SCHEMA_CHANGE);
     int64_t signatrue = agent_task_req->signature;
     std::string alter_msg_head = strings::Substitute("[Alter Job:$0, tablet:$1]: ", agent_task_req->task_req.job_id,
                                                      agent_task_req->task_req.base_tablet_id);
@@ -355,6 +356,7 @@ void run_clear_transaction_task(const std::shared_ptr<ClearTransactionAgentTaskR
 }
 
 void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::CLONE);
     StarRocksMetrics::instance()->clone_requests_total.increment(1);
     const TCloneReq& clone_req = agent_task_req->task_req;
     AgentStatus status = STARROCKS_SUCCESS;
@@ -578,6 +580,7 @@ void run_check_consistency_task(const std::shared_ptr<CheckConsistencyTaskReques
 }
 
 void run_compaction_task(const std::shared_ptr<CompactionTaskRequest>& agent_task_req, ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     const TCompactionReq& compaction_req = agent_task_req->task_req;
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
@@ -626,6 +629,7 @@ void run_compaction_control_task(const std::shared_ptr<CompactionControlTaskRequ
 }
 
 void run_update_schema_task(const std::shared_ptr<UpdateSchemaTaskRequest>& agent_task_req, ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::SCHEMA_CHANGE);
     const TUpdateSchemaReq& update_schema_req = agent_task_req->task_req;
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
@@ -1033,6 +1037,7 @@ void run_drop_auto_increment_map_task(const std::shared_ptr<DropAutoIncrementMap
 
 void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskRequest>& agent_task_req,
                               ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::REPLICATION);
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
@@ -1083,6 +1088,7 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
 
 void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTaskRequest>& agent_task_req,
                                  ExecEnv* exec_env) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::REPLICATION);
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -63,6 +63,7 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/DataCache_types.h"
 #include "gen_cpp/Types_types.h"
+#include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/snapshot_loader.h"
 #include "runtime/starrocks_metrics.h"
@@ -286,6 +287,7 @@ void TaskWorkerPool<AgentTaskRequest>::_spawn_callback_worker_thread(CALLBACK_FU
 }
 
 void* PushTaskWorkerPool::_worker_thread_callback(void* arg_this) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::LOAD);
     static uint32_t s_worker_count = 0;
 
     auto* worker_pool_this = (PushTaskWorkerPool*)arg_this;
@@ -380,6 +382,7 @@ void* PushTaskWorkerPool::_worker_thread_callback(void* arg_this) {
 }
 
 void* DeleteTaskWorkerPool::_worker_thread_callback(void* arg_this) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::LOAD);
     static uint32_t s_worker_count = 0;
 
     auto* worker_pool_this = (DeleteTaskWorkerPool*)arg_this;
@@ -505,6 +508,7 @@ void* DeleteTaskWorkerPool::_worker_thread_callback(void* arg_this) {
 }
 
 void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::LOAD);
     auto* worker_pool_this = (PublishVersionTaskWorkerPool*)arg_this;
     auto* agent_server = worker_pool_this->_env->agent_server();
     auto token =

--- a/be/src/common/thread/threadpool.cpp
+++ b/be/src/common/thread/threadpool.cpp
@@ -569,7 +569,7 @@ void ThreadPool::bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuU
 
 void ThreadPool::dispatch_thread() {
     std::unique_lock l(_lock);
-    auto current_thread = Thread::current_thread();
+    auto* current_thread = Thread::current_thread();
     InsertOrDie(&_threads, current_thread);
     DCHECK_GT(_num_threads_pending_start, 0);
     _num_threads++;

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -21,6 +21,7 @@
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "common/logging.h"
+#include "runtime/current_thread.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
@@ -469,6 +470,7 @@ Status MemLimitedChunkQueue::_flush() {
 
 Status MemLimitedChunkQueue::_submit_flush_task() {
     auto flush_task = [this, guard = RESOURCE_TLS_MEMTRACER_GUARD(_state)](auto& yield_ctx) {
+        SCOPED_SET_TRACE_INFO(0, _state->query_id(), _state->fragment_instance_id());
         TEST_SYNC_POINT("MemLimitedChunkQueue::before_execute_flush_task");
         RETURN_IF(!guard.scoped_begin(), (void)0);
         DEFER_GUARD_END(guard);
@@ -551,6 +553,7 @@ Status MemLimitedChunkQueue::_load(Block* block) {
 
 Status MemLimitedChunkQueue::_submit_load_task(Block* block) {
     auto load_task = [this, block, guard = RESOURCE_TLS_MEMTRACER_GUARD(_state)](auto& yield_ctx) {
+        SCOPED_SET_TRACE_INFO(0, _state->query_id(), _state->fragment_instance_id());
         TEST_SYNC_POINT_CALLBACK("MemLimitedChunkQueue::before_execute_load_task", block);
         RETURN_IF(!guard.scoped_begin(), (void)0);
         DEFER_GUARD_END(guard);

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -21,7 +21,6 @@
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "common/logging.h"
-#include "runtime/current_thread.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
@@ -35,6 +34,7 @@
 #include "fmt/format.h"
 #include "fs/fs.h"
 #include "gen_cpp/InternalService_types.h"
+#include "runtime/current_thread.h"
 #include "serde/column_array_serde.h"
 #include "serde/protobuf_serde.h"
 

--- a/be/src/exec/pipeline/lookup_operator.cpp
+++ b/be/src/exec/pipeline/lookup_operator.cpp
@@ -218,7 +218,7 @@ StatusOr<ChunkPtr> LookUpOperator::pull_chunk(RuntimeState* state) {
 Status LookUpOperator::_try_to_trigger_io_task(RuntimeState* state) {
     for (int32_t i = 0; i < _max_io_tasks; i++) {
         auto processor = _processors[i];
-	int32_t driver_id = CurrentThread::current().get_driver_id();
+        int32_t driver_id = CurrentThread::current().get_driver_id();
 
         auto lookup_task_ctx = std::make_shared<LookUpTaskContext>();
         bool is_running = processor->is_running();
@@ -238,7 +238,8 @@ Status LookUpOperator::_try_to_trigger_io_task(RuntimeState* state) {
             task.priority = OlapScanNode::compute_priority(_submit_io_task_counter->double_value());
             task.task_group = down_cast<const LookUpOperatorFactory*>(_factory)->io_task_group();
             task.peak_scan_task_queue_size_counter = _peak_scan_task_queue_size_counter;
-            task.work_function = [wp = _query_ctx, this, state, idx = i, driver_id = driver_id, create_ts = MonotonicNanos()](auto& ctx) {
+            task.work_function = [wp = _query_ctx, this, state, idx = i, driver_id = driver_id,
+                                  create_ts = MonotonicNanos()](auto& ctx) {
                 if (auto sp = wp.lock()) {
                     SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
                     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());

--- a/be/src/exec/pipeline/lookup_operator.cpp
+++ b/be/src/exec/pipeline/lookup_operator.cpp
@@ -30,6 +30,7 @@
 #include "exec/sorting/sort_permute.h"
 #include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/scan_task_queue.h"
+#include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "runtime/lookup_stream_mgr.h"
 #include "storage/chunk_helper.h"
@@ -217,6 +218,7 @@ StatusOr<ChunkPtr> LookUpOperator::pull_chunk(RuntimeState* state) {
 Status LookUpOperator::_try_to_trigger_io_task(RuntimeState* state) {
     for (int32_t i = 0; i < _max_io_tasks; i++) {
         auto processor = _processors[i];
+	int32_t driver_id = CurrentThread::current().get_driver_id();
 
         auto lookup_task_ctx = std::make_shared<LookUpTaskContext>();
         bool is_running = processor->is_running();
@@ -236,8 +238,10 @@ Status LookUpOperator::_try_to_trigger_io_task(RuntimeState* state) {
             task.priority = OlapScanNode::compute_priority(_submit_io_task_counter->double_value());
             task.task_group = down_cast<const LookUpOperatorFactory*>(_factory)->io_task_group();
             task.peak_scan_task_queue_size_counter = _peak_scan_task_queue_size_counter;
-            task.work_function = [wp = _query_ctx, this, state, idx = i, create_ts = MonotonicNanos()](auto& ctx) {
+            task.work_function = [wp = _query_ctx, this, state, idx = i, driver_id = driver_id, create_ts = MonotonicNanos()](auto& ctx) {
                 if (auto sp = wp.lock()) {
+                    SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
+                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
                     auto& processor = _processors[idx];
                     [[maybe_unused]] int64_t start_time = MonotonicNanos();
                     DeferOp defer([&] {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -83,7 +83,9 @@ void GlobalDriverExecutor::_finalize_driver(DriverRawPtr driver, RuntimeState* r
 }
 
 void GlobalDriverExecutor::_worker_thread() {
-    auto current_thread = Thread::current_thread();
+    // This executor is dedicated to query pipeline drivers.
+    SET_MODULE_TYPE(ThreadModuleType::QUERY);
+    auto* current_thread = Thread::current_thread();
     const int worker_id = _next_id++;
     std::queue<DriverRawPtr> local_driver_queue;
     while (true) {

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -18,6 +18,7 @@
 
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
+#include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/logconfig.h"
 #include "util/time_guard.h"
@@ -45,6 +46,7 @@ void PipelineDriverPoller::shutdown() {
 }
 
 void PipelineDriverPoller::run_internal() {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::QUERY);
     this->_is_polling_thread_initialized.store(true, std::memory_order_release);
 
     {

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -244,6 +244,7 @@ Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
         _running_restore_tasks++;
         auto restore_task = [this, guard, trace = TraceInfo(state), _stream = _stream](auto& yield_ctx) {
             SCOPED_SET_TRACE_INFO({}, trace.query_id, trace.fragment_id);
+            SCOPED_SET_MODULE_TYPE(ThreadModuleType::QUERY);
             auto yield_defer = yield_ctx.defer_finished();
             RETURN_IF(!guard.scoped_begin(), (void)0);
             DEFER_GUARD_END(guard);

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -15,6 +15,7 @@
 #include "exec/workgroup/scan_executor.h"
 
 #include "exec/pipeline/pipeline_metrics.h"
+#include "runtime/current_thread.h"
 #include "exec/workgroup/scan_task_queue.h"
 #include "runtime/starrocks_metrics.h"
 
@@ -50,7 +51,9 @@ void ScanExecutor::change_num_threads(int32_t num_threads) {
 }
 
 void ScanExecutor::worker_thread() {
-    auto current_thread = Thread::current_thread();
+    // This executor is dedicated to query scan/IO tasks.
+    SET_MODULE_TYPE(ThreadModuleType::QUERY);
+    auto* current_thread = Thread::current_thread();
     while (true) {
         if (_num_threads_setter.should_shrink()) {
             break;

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -15,8 +15,8 @@
 #include "exec/workgroup/scan_executor.h"
 
 #include "exec/pipeline/pipeline_metrics.h"
-#include "runtime/current_thread.h"
 #include "exec/workgroup/scan_task_queue.h"
+#include "runtime/current_thread.h"
 #include "runtime/starrocks_metrics.h"
 
 namespace starrocks::workgroup {

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -16,6 +16,8 @@
 
 #include <atomic>
 
+#include "common/logging.h"
+
 namespace starrocks {
 
 // The TP-relative offset of tls_thread_status, written once at startup by
@@ -35,6 +37,10 @@ void init_tls_thread_status_offset() {
         g_tls_thread_status_tpoff =
                 static_cast<int64_t>(reinterpret_cast<uintptr_t>(&tls_thread_status)) - static_cast<int64_t>(tp);
     }
+
+    LOG(INFO) << "[eBPF] tls_thread_status tpoff=" << g_tls_thread_status_tpoff
+              << " query_id_offset=" << CurrentThread::query_id_offset()
+              << " module_type_offset=" << CurrentThread::module_type_offset();
 }
 
 namespace {

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -64,10 +64,14 @@ class TUniqueId;
 // Stored in CurrentThread::_module_type (TLS) so external profilers can
 // attribute CPU samples to non-query workloads (compaction, load, etc.).
 enum class ThreadModuleType : int32_t {
-    UNKNOWN = 0, // background / unclassified
-    QUERY = 1,   // SQL query execution (pipeline driver / scan I/O)
-    // More module types (COMPACTION, LOAD, SCHEMA_CHANGE, CLONE,
-    // REPLICATION, UPDATE …) will be added in future commits.
+    UNKNOWN = 0,       // background / unclassified
+    QUERY = 1,         // SQL query execution (pipeline driver / scan I/O)
+    LOAD = 2,          // data import (stream load, broker load, push, etc.)
+    COMPACTION = 3,    // compaction tasks
+    SCHEMA_CHANGE = 4, // schema change / alter tablet
+    CLONE = 5,         // tablet clone / replica
+    REPLICATION = 6,   // cross-cluster replication (remote/replicate snapshot)
+    STORAGE = 7,       // storage background maintenance (GC, checkpoint, cache, etc.)
 };
 
 inline thread_local MemTracker* tls_mem_tracker = nullptr;
@@ -282,6 +286,11 @@ public:
     void set_module_type(ThreadModuleType type) { _module_type = type; }
     ThreadModuleType get_module_type() const { return _module_type; }
 
+    // Field offsets within CurrentThread, exposed for eBPF programs that locate
+    // these fields via g_tls_thread_status_tpoff + g_tls_*_offset.
+    static constexpr size_t query_id_offset() { return offsetof(CurrentThread, _query_id); }
+    static constexpr size_t module_type_offset() { return offsetof(CurrentThread, _module_type); }
+
     void set_custom_coredump_msg(const std::string& custom_coredump_msg) { _custom_coredump_msg = custom_coredump_msg; }
 
     const std::string& get_custom_coredump_msg() const { return _custom_coredump_msg; }
@@ -411,6 +420,7 @@ inline thread_local CurrentThread tls_thread_status;
 // Written once at startup by init_tls_thread_status_offset(); external profilers
 // such as query_cpu_profile.py read this from /proc/PID/mem to obtain the exact
 // offset without ELF arithmetic or DTV walking.
+// TP-relative offset of the tls_thread_status object itself.
 extern volatile int64_t g_tls_thread_status_tpoff;
 void init_tls_thread_status_offset();
 
@@ -516,6 +526,12 @@ public:
 private:
     ThreadModuleType _old;
 };
+
+// Usage: SET_MODULE_TYPE(ThreadModuleType::QUERY);
+// Sets the module type without saving/restoring the previous value.
+// Use this at the top of a dedicated worker thread that always runs the same
+// module type for its entire lifetime.
+#define SET_MODULE_TYPE(type) tls_thread_status.set_module_type(type)
 
 // Usage: SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
 // Restores the previous module type on scope exit (supports nesting).

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -140,6 +140,7 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
     t_finst_id.hi = finst_id.hi();
     t_finst_id.lo = finst_id.lo();
     SCOPED_SET_TRACE_INFO({}, {}, t_finst_id)
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::QUERY);
     SCOPED_SET_TRACE_PLAN_NODE_ID(request.node_id());
     DUMP_TRACE_IF_TIMEOUT(config::pipeline_datastream_timeout_guard_ms);
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -597,6 +597,7 @@ template <typename T>
 Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_param,
                                                                     const TExecPlanFragmentParams& t_unique_request) {
     SCOPED_SET_TRACE_INFO({}, t_common_param.params.query_id, t_unique_request.params.fragment_instance_id);
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::QUERY);
     DUMP_TRACE_IF_TIMEOUT(config::pipeline_prepare_timeout_guard_ms);
     pipeline::FragmentExecutor fragment_executor;
     auto status = fragment_executor.prepare(_exec_env, t_common_param, t_unique_request);

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -18,8 +18,8 @@
 #include <thread>
 
 #include "common/config_compaction_fwd.h"
-#include "runtime/current_thread.h"
 #include "common/thread/thread.h"
+#include "runtime/current_thread.h"
 #include "runtime/starrocks_metrics.h"
 #include "storage/data_dir.h"
 #include "util/global_metrics_registry.h"

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 
 #include "common/config_compaction_fwd.h"
+#include "runtime/current_thread.h"
 #include "common/thread/thread.h"
 #include "runtime/starrocks_metrics.h"
 #include "storage/data_dir.h"
@@ -87,6 +88,7 @@ void CompactionManager::schedule() {
 }
 
 void CompactionManager::_schedule() {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     LOG(INFO) << "start compaction scheduler";
     while (!_stop.load(std::memory_order_consume)) {
         ++_round;
@@ -118,6 +120,7 @@ void CompactionManager::submit_compaction_task(const CompactionCandidate& compac
     auto tablet = compaction_candidate.tablet;
     auto type = compaction_candidate.type;
     auto st = _compaction_pool->submit_func([tablet, task_id, manager, type] {
+        SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
         auto compaction_task = tablet->create_compaction_task();
         if (compaction_task != nullptr) {
             CompactionCandidate candidate;
@@ -360,6 +363,7 @@ bool CompactionManager::pick_candidate(CompactionCandidate* candidate) {
 }
 
 void CompactionManager::_dispatch_worker() {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     while (!_stop.load(std::memory_order_consume)) {
         {
             std::lock_guard lock(_dispatch_mutex);

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -51,6 +51,7 @@
 #include "common/status.h"
 #include "common/thread/thread.h"
 #include "fs/fs_util.h"
+#include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "storage/compaction.h"
 #include "storage/compaction_manager.h"
@@ -256,6 +257,7 @@ void* StorageEngine::_fd_cache_clean_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         int32_t interval = config::file_descriptor_cache_clean_interval;
         if (interval <= 0) {
@@ -309,6 +311,7 @@ void* StorageEngine::_pk_index_major_compaction_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         SLEEP_IN_BG_WORKER(1);
         // schedule persistent index compaction
@@ -332,6 +335,7 @@ void* StorageEngine::_pk_dump_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         SLEEP_IN_BG_WORKER(60);
         // disable pk dump generation when pk_dump_interval_seconds less than 0
@@ -376,6 +380,7 @@ void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     Status status = Status::OK();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         // must be here, because this thread is start on start and
@@ -431,6 +436,7 @@ void* StorageEngine::_repair_compaction_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     Status status = Status::OK();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         std::pair<int64_t, vector<uint32_t>> task(-1, vector<uint32>());
@@ -511,6 +517,7 @@ void* StorageEngine::_garbage_sweeper_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     GarbageSweepIntervalCalculator interval_calculator;
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         interval_calculator.maybe_interval_updated();
@@ -599,6 +606,7 @@ void* StorageEngine::_disk_stat_monitor_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         _start_disk_stat_monitor();
 
@@ -614,6 +622,7 @@ void* StorageEngine::_disk_stat_monitor_thread_callback(void* arg) {
 }
 
 void* StorageEngine::_finish_publish_version_thread_callback(void* arg) {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::LOAD);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         int32_t interval = config::finish_publish_version_internal;
         {
@@ -674,6 +683,7 @@ void* StorageEngine::_update_cache_expire_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         int32_t expire_sec = config::update_cache_expire_sec;
         if (expire_sec <= 0) {
@@ -726,6 +736,7 @@ void* StorageEngine::_unused_rowset_monitor_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         double deleted_pct = delete_unused_rowset();
         // delete 20% means we nead speedup 5x which make interval 1/5 before
@@ -743,7 +754,7 @@ void* StorageEngine::_path_gc_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         LOG(INFO) << "try to perform path gc by tablet!";
         ((DataDir*)arg)->perform_path_gc_by_tablet();
@@ -774,7 +785,7 @@ void* StorageEngine::_path_scan_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         SLEEP_IN_BG_WORKER(600);
         break;
@@ -801,7 +812,7 @@ void* StorageEngine::_clear_expired_replication_snapshots_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
-
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         LOG(INFO) << "try to clear expired replication snapshots!";
         replication_txn_manager()->clear_expired_snapshots();
@@ -822,6 +833,7 @@ void* StorageEngine::_tablet_checkpoint_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::STORAGE);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         LOG(INFO) << "begin to do tablet meta checkpoint:" << ((DataDir*)arg)->path();
         int64_t start_time = UnixMillis();
@@ -842,6 +854,7 @@ void* StorageEngine::_schedule_apply_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::LOAD);
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         {
             auto wait_timeout = std::chrono::seconds(1);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -728,6 +728,7 @@ void StorageEngine::_start_clean_fd_cache() {
 }
 
 void StorageEngine::compaction_check() {
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     int checker_one_round_sleep_time_s = 1800;
     while (!bg_worker_stopped()) {
         MonotonicStopWatch stop_watch;
@@ -875,6 +876,7 @@ void* StorageEngine::_manual_compaction_thread_callback(void* arg) {
 #ifdef GOOGLE_PROFILER
     ProfilerRegisterThread();
 #endif
+    SCOPED_SET_MODULE_TYPE(ThreadModuleType::COMPACTION);
     Status status = Status::OK();
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         _check_and_run_manual_compaction_task();

--- a/be/src/udf/java/utils.cpp
+++ b/be/src/udf/java/utils.cpp
@@ -36,6 +36,7 @@ PromiseStatusPtr call_function_in_pthread(RuntimeState* state, const std::functi
             {
                 MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(state->instance_mem_tracker());
                 SCOPED_SET_TRACE_INFO({}, state->query_id(), state->fragment_instance_id());
+                SCOPED_SET_MODULE_TYPE(ThreadModuleType::QUERY);
                 DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
                 st = func();
             }


### PR DESCRIPTION
## Why I'm doing:

Annotate every thread entry point with the two TLS attributes that external profilers and diagnostic tooling rely on:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
