### PR TITLE
[BugFix] Fix type mismatch in map literal when explicit key/value types are declared

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -573,7 +573,12 @@ public class ExpressionAnalyzer {
                         Expr child = node.getChildren().get(i);
                         if (!child.getType().matchesType(desired)
                                 && TypeManager.canCastTo(child.getType(), desired)) {
-                            ExprCastFunction.castChild(node, desired, i);
+                            try {
+                                ExprCastFunction.castChild(node, desired, i);
+                            } catch (AnalysisException ignored) {
+                                // Value-level cast failed (e.g. '2s' -> INT): leave as-is,
+                                // the runtime will report the error.
+                            }
                         }
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -571,8 +571,7 @@ public class ExpressionAnalyzer {
                     for (int i = 0; i < node.getChildren().size(); i++) {
                         Type desired = (i % 2 == 0) ? keyType : valueType;
                         Expr child = node.getChildren().get(i);
-                        if (!child.getType().matchesType(desired)
-                                && TypeManager.canCastTo(child.getType(), desired)) {
+                        if (!child.getType().matchesType(desired)) {
                             ExprCastFunction.castChild(node, desired, i);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -573,17 +573,12 @@ public class ExpressionAnalyzer {
                         Expr child = node.getChildren().get(i);
                         if (!child.getType().matchesType(desired)
                                 && TypeManager.canCastTo(child.getType(), desired)) {
-                            try {
-                                ExprCastFunction.castChild(node, desired, i);
-                            } catch (Exception ignored) {
-                                // Value-level cast failed (e.g. '2s' -> INT): leave as-is,
-                                // the runtime will report the error.
-                            }
+                            ExprCastFunction.castChild(node, desired, i);
                         }
                     }
 
                     node.setType(new MapType(keyType, valueType));
-                } catch (AnalysisException e) {
+                } catch (Exception e) {
                     throw new SemanticException(e.getMessage());
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -570,7 +570,9 @@ public class ExpressionAnalyzer {
 
                     for (int i = 0; i < node.getChildren().size(); i++) {
                         Type desired = (i % 2 == 0) ? keyType : valueType;
-                        if (!node.getChildren().get(i).getType().matchesType(desired)) {
+                        Expr child = node.getChildren().get(i);
+                        if (!child.getType().matchesType(desired)
+                                && TypeManager.canCastTo(child.getType(), desired)) {
                             ExprCastFunction.castChild(node, desired, i);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -559,7 +559,7 @@ public class ExpressionAnalyzer {
                     if (originalType == AnyMapType.ANY_MAP) {
                         keyType = getKeyCommonType(node);
                         if (!keyType.isValidMapKeyType()) {
-                            throw new SemanticException("Map key don't supported type: " + keyType, node.getPos());
+                            throw new SemanticException("Map key doesn't support type: " + keyType, node.getPos());
                         }
                         valueType = getValueCommonType(node);
                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -552,14 +552,32 @@ public class ExpressionAnalyzer {
         @Override
         public Void visitMapExpr(MapExpr node, Scope scope) {
             if (!node.getChildren().isEmpty()) {
-                Type originalType = node.getType();
-                if (originalType == AnyMapType.ANY_MAP) {
-                    Type keyType = getKeyCommonType(node);
-                    if (!keyType.isValidMapKeyType()) {
-                        throw new SemanticException("Map key don't supported type: " + keyType, node.getPos());
+                try {
+                    Type originalType = node.getType();
+                    Type keyType;
+                    Type valueType;
+                    if (originalType == AnyMapType.ANY_MAP) {
+                        keyType = getKeyCommonType(node);
+                        if (!keyType.isValidMapKeyType()) {
+                            throw new SemanticException("Map key don't supported type: " + keyType, node.getPos());
+                        }
+                        valueType = getValueCommonType(node);
+                    } else {
+                        MapType mapType = (MapType) originalType;
+                        keyType = mapType.getKeyType();
+                        valueType = mapType.getValueType();
                     }
-                    Type valueType = getValueCommonType(node);
+
+                    for (int i = 0; i < node.getChildren().size(); i++) {
+                        Type desired = (i % 2 == 0) ? keyType : valueType;
+                        if (!node.getChildren().get(i).getType().matchesType(desired)) {
+                            ExprCastFunction.castChild(node, desired, i);
+                        }
+                    }
+
                     node.setType(new MapType(keyType, valueType));
+                } catch (AnalysisException e) {
+                    throw new SemanticException(e.getMessage());
                 }
             } else {
                 node.setType(new MapType(NullType.NULL, NullType.NULL));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -575,7 +575,7 @@ public class ExpressionAnalyzer {
                                 && TypeManager.canCastTo(child.getType(), desired)) {
                             try {
                                 ExprCastFunction.castChild(node, desired, i);
-                            } catch (AnalysisException ignored) {
+                            } catch (Exception ignored) {
                                 // Value-level cast failed (e.g. '2s' -> INT): leave as-is,
                                 // the runtime will report the error.
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -577,7 +577,9 @@ public class ExpressionAnalyzer {
                     }
 
                     node.setType(new MapType(keyType, valueType));
-                } catch (Exception e) {
+                } catch (SemanticException e) {
+                    throw e;
+                } catch (AnalysisException e) {
                     throw new SemanticException(e.getMessage());
                 }
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -408,7 +408,7 @@ public class AnalyzeExprTest {
         analyzeSuccess("select map<int,map<varchar,int>>{2:map{3:3}}");
         analyzeSuccess("select map<int,map<int,int>>{2:map{'3':3}}");
         analyzeSuccess("select map<int,map<int,int>>{map{3:3}:2}"); // runtime error will report when cast
-        analyzeSuccess("select map<int,map<int,int>>{'2s':map{3:3}}");
+        analyzeFail("select map<int,map<int,int>>{'2s':map{3:3}}");
 
         analyzeFail("select map(null)");
         analyzeFail("select map(1:4)");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -407,9 +407,9 @@ public class AnalyzeExprTest {
         analyzeSuccess("select map{NULL:NULL}");
         analyzeSuccess("select map<int,map<varchar,int>>{2:map{3:3}}");
         analyzeSuccess("select map<int,map<int,int>>{2:map{'3':3}}");
-        analyzeSuccess("select map<int,map<int,int>>{map{3:3}:2}"); // runtime error will report when cast
-        analyzeFail("select map<int,map<int,int>>{'2s':map{3:3}}");
 
+        analyzeFail("select map<int,map<int,int>>{map{3:3}:2}");
+        analyzeFail("select map<int,map<int,int>>{'2s':map{3:3}}");
         analyzeFail("select map(null)");
         analyzeFail("select map(1:4)");
         analyzeFail("select map(1,3,4)");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -20,7 +20,6 @@ import com.starrocks.catalog.Function;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.CollectionElementExpr;
 import com.starrocks.sql.ast.expression.DictionaryGetExpr;
 import com.starrocks.sql.ast.expression.Expr;
@@ -321,13 +320,12 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         Assertions.assertEquals(IntegerType.SMALLINT, resultType.getKeyType());
         Assertions.assertEquals(IntegerType.SMALLINT, resultType.getValueType());
 
-        // Each child must have been wrapped in a CastExpr targeting SMALLINT,
-        // not left as a raw TINYINT literal — this is what caused the BE crash.
+        // Each child must have been coerced to SMALLINT (the declared map key/value type).
+        // castIntLiteral may fold the cast into a typed IntLiteral rather than a CastExpr,
+        // so we only assert the resulting type — not the specific Expr subclass.
         for (Expr child : mapExpr.getChildren()) {
-            Assertions.assertInstanceOf(CastExpr.class, child,
-                    "Expected CastExpr but got: " + child.getClass().getSimpleName());
             Assertions.assertEquals(IntegerType.SMALLINT, child.getType(),
-                    "Cast target type must be SMALLINT");
+                    "Child type must be SMALLINT after coercion");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -20,12 +20,14 @@ import com.starrocks.catalog.Function;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.CollectionElementExpr;
 import com.starrocks.sql.ast.expression.DictionaryGetExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.LikePredicate;
+import com.starrocks.sql.ast.expression.MapExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.UserVariableExpr;
@@ -41,9 +43,11 @@ import com.starrocks.type.MapType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class ExpressionAnalyzerTest extends PlanTestBase {
@@ -279,26 +283,72 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         verifySuccess.accept("date_part('month', '2023-01-01')");
         verifySuccess.accept("date_part('week', '2023-01-01')");
         verifySuccess.accept("date_part('day', '2023-01-01')");
-        
+
         verifySuccess.accept("date_part('hour', '2023-01-01 12:00:00')");
         verifySuccess.accept("date_part('minute', '2023-01-01 12:00:00')");
         verifySuccess.accept("date_part('second', '2023-01-01 12:00:00')");
 
         verifySuccess.accept("date_part('yy', '2023-01-01')");
         verifySuccess.accept("date_part('qq', '2023-01-01')");
-        verifySuccess.accept("date_part('mm', '2023-01-01')"); 
+        verifySuccess.accept("date_part('mm', '2023-01-01')");
         verifySuccess.accept("date_part('wk', '2023-01-01')");
         verifySuccess.accept("date_part('dd', '2023-01-01')");
         verifySuccess.accept("date_part('hh', '2023-01-01 12:00:00')");
         verifySuccess.accept("date_part('mi', '2023-01-01 12:00:00')");
         verifySuccess.accept("date_part('ss', '2023-01-01 12:00:00')");
-        
+
         verifySuccess.accept("date_part('dow', '2023-01-01')");
         verifySuccess.accept("date_part('doy', '2023-01-01')");
 
         verifyFail.accept("date_part('year')", "DATE_PART requires 2 arguments");
         verifyFail.accept("date_part(123, '2023-01-01')", "must be a constant string literal");
         verifyFail.accept("date_part('invalid_unit', '2023-01-01')", "Unsupported unit for DATE_PART");
+    }
+
+    /**
+     * Regression test for: MAP<SMALLINT, SMALLINT> default value causes BE heap-buffer-overflow.
+     * Integer literals (values 1-4) get TINYINT type by default. When the MapExpr has an explicit
+     * concrete map type, children must be cast to the declared key/value types so the Thrift
+     * serialization sends the correct type to BE.
+     */
+    @Test
+    public void testMapExprChildrenCastToTargetType() {
+        MapExpr mapExpr = getMapExpr();
+
+        // After analysis, the map type must still be MAP<SMALLINT, SMALLINT>
+        Assertions.assertInstanceOf(MapType.class, mapExpr.getType());
+        MapType resultType = (MapType) mapExpr.getType();
+        Assertions.assertEquals(IntegerType.SMALLINT, resultType.getKeyType());
+        Assertions.assertEquals(IntegerType.SMALLINT, resultType.getValueType());
+
+        // Each child must have been wrapped in a CastExpr targeting SMALLINT,
+        // not left as a raw TINYINT literal — this is what caused the BE crash.
+        for (Expr child : mapExpr.getChildren()) {
+            Assertions.assertInstanceOf(CastExpr.class, child,
+                    "Expected CastExpr but got: " + child.getClass().getSimpleName());
+            Assertions.assertEquals(IntegerType.SMALLINT, child.getType(),
+                    "Cast target type must be SMALLINT");
+        }
+    }
+
+    @NotNull
+    private static MapExpr getMapExpr() {
+        ExpressionAnalyzer.Visitor visitor = new ExpressionAnalyzer.Visitor(new AnalyzeState(), new ConnectContext());
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+
+        // Simulate: map<smallint, smallint>{1: 2, 3: 4}
+        // IntLiteral.init() assigns TINYINT for small values (they fit in [-128, 127])
+        MapType smallintMapType = new MapType(IntegerType.SMALLINT, IntegerType.SMALLINT);
+        MapExpr mapExpr = new MapExpr(
+                smallintMapType,
+                Arrays.asList(
+                        new IntLiteral(1),
+                        new IntLiteral(2),
+                        new IntLiteral(3),
+                        new IntLiteral(4)));
+
+        visitor.visitMapExpr(mapExpr, scope);
+        return mapExpr;
     }
 
     @Test

--- a/test/sql/test_default_value/R/test_complex_default_all_paths.sql
+++ b/test/sql/test_default_value/R/test_complex_default_all_paths.sql
@@ -85,6 +85,45 @@ SELECT * FROM nested_complex ORDER BY id;
 1	[[1,2],[3,4,5]]	{1:["a","b"],2:["c","d"]}	{"id":999,"scores":[100,200],"tags":{"k1":1,"k2":2}}
 2	[[1,2],[3,4,5]]	{1:["a","b"],2:["c","d"]}	{"id":999,"scores":[100,200],"tags":{"k1":1,"k2":2}}
 -- !result
+CREATE TABLE type_cast_defaults (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO type_cast_defaults (id) VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN m_bigint MAP<BIGINT, BIGINT>
+  DEFAULT map<smallint, smallint>{1: 2, 3: 4};
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN m_int MAP<INT, INT>
+  DEFAULT map<tinyint, tinyint>{10: 20, 30: 40};
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN m_int_double MAP<INT, DOUBLE>
+  DEFAULT map<int, float>{1: 1.5, 2: 2.5};
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN m_mixed MAP<BIGINT, DOUBLE>
+  DEFAULT map<smallint, float>{1: 1.5, 2: 2.5};
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN a_bigint ARRAY<BIGINT>
+  DEFAULT array<int>[100, 200, 300];
+-- result:
+-- !result
+ALTER TABLE type_cast_defaults ADD COLUMN a_double ARRAY<DOUBLE>
+  DEFAULT array<float>[1.5, 2.5, 3.5];
+-- result:
+-- !result
+SELECT * FROM type_cast_defaults ORDER BY id;
+-- result:
+1	{1:2,3:4}	{10:20,30:40}	{1:1.5,2:2.5}	{1:1.5,2:2.5}	[100,200,300]	[1.5,2.5,3.5]
+2	{1:2,3:4}	{10:20,30:40}	{1:1.5,2:2.5}	{1:1.5,2:2.5}	[100,200,300]	[1.5,2.5,3.5]
+-- !result
 CREATE TABLE map_struct_order (
     id INT NOT NULL
 ) DUPLICATE KEY(id)

--- a/test/sql/test_default_value/T/test_complex_default_all_paths.sql
+++ b/test/sql/test_default_value/T/test_complex_default_all_paths.sql
@@ -46,6 +46,46 @@ ALTER TABLE nested_complex ADD COLUMN complex_struct STRUCT<
 SELECT * FROM nested_complex ORDER BY id;
 
 -- ====================================================================================
+-- SECTION 2.5: Explicitly Declared Type vs Column Type Mismatch (typed literals)
+-- Tests where the typed literal explicitly declares a different type from the column,
+-- requiring implicit casting (e.g., SMALLINT literal → BIGINT column).
+-- ====================================================================================
+
+CREATE TABLE type_cast_defaults (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO type_cast_defaults (id) VALUES (1), (2);
+
+-- MAP<BIGINT, BIGINT> column with map<smallint, smallint> literal (SMALLINT → BIGINT upcast)
+ALTER TABLE type_cast_defaults ADD COLUMN m_bigint MAP<BIGINT, BIGINT>
+  DEFAULT map<smallint, smallint>{1: 2, 3: 4};
+
+-- MAP<INT, INT> column with map<tinyint, tinyint> literal (TINYINT → INT upcast)
+ALTER TABLE type_cast_defaults ADD COLUMN m_int MAP<INT, INT>
+  DEFAULT map<tinyint, tinyint>{10: 20, 30: 40};
+
+-- MAP<INT, DOUBLE> column with map<int, float> literal (FLOAT → DOUBLE upcast for values)
+ALTER TABLE type_cast_defaults ADD COLUMN m_int_double MAP<INT, DOUBLE>
+  DEFAULT map<int, float>{1: 1.5, 2: 2.5};
+
+-- MAP<BIGINT, DOUBLE> column with map<smallint, float> literal (both key and value upcast)
+ALTER TABLE type_cast_defaults ADD COLUMN m_mixed MAP<BIGINT, DOUBLE>
+  DEFAULT map<smallint, float>{1: 1.5, 2: 2.5};
+
+-- ARRAY<BIGINT> column with array<int> literal (INT → BIGINT upcast)
+ALTER TABLE type_cast_defaults ADD COLUMN a_bigint ARRAY<BIGINT>
+  DEFAULT array<int>[100, 200, 300];
+
+-- ARRAY<DOUBLE> column with array<float> literal (FLOAT → DOUBLE upcast)
+ALTER TABLE type_cast_defaults ADD COLUMN a_double ARRAY<DOUBLE>
+  DEFAULT array<float>[1.5, 2.5, 3.5];
+
+SELECT * FROM type_cast_defaults ORDER BY id;
+
+-- ====================================================================================
 -- SECTION 3: MAP with STRUCT - Field Order Preservation Test
 -- ====================================================================================
 CREATE TABLE map_struct_order (

--- a/test/sql/test_map/R/test_map
+++ b/test/sql/test_map/R/test_map
@@ -115,47 +115,47 @@ from (select c1 from (values(map())) as t(c1)) t;
 select map_concat(c1, map(map(),map()))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 37. Detail message: Map key don't supported type: MAP<NULL_TYPE,NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 37. Detail message: Map key doesn't support type: MAP<NULL_TYPE,NULL_TYPE>.")
 -- !result
 select map_concat(c1, map(map(),[]))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key don't supported type: MAP<NULL_TYPE,NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key doesn't support type: MAP<NULL_TYPE,NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([],map()))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map())
 from (select c1 from (values(map([], []))) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map())
 from (select c1 from (values(map([], [[]]))) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([1], [2]))
 from (select c1 from (values(map([], []))) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([1], [[2]]))
 from (select c1 from (values(map([], [[]]))) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map()])))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 73. Detail message: Map key don't supported type: struct<`1` tinyint(4)>.")
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 73. Detail message: Map key doesn't support type: struct<`1` tinyint(4)>.")
 -- !result
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map([],[[named_struct('C', [[map()]])]])])))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 66 to line 1, column 105. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
+E: (1064, "Getting analyzing error from line 1, column 66 to line 1, column 105. Detail message: Map key doesn't support type: ARRAY<NULL_TYPE>.")
 -- !result
 CREATE TABLE test_map(
     col_int INT,


### PR DESCRIPTION
## Why I'm doing:

Fix https://github.com/StarRocks/StarRocksTest/issues/11202

When a map literal is written with an explicit type annotation (e.g., map<smallint, smallint>{1: 2, 3: 4}), the FE analyzer failed to cast the child expressions (key/value literals) to the declared key and value types.            
                                                                                                                                                                                                                                        Integer literals like 1, 2, 3, 4 are inferred as TINYINT by default. Because visitMapExpr only handled the implicit-type case (AnyMapType.ANY_MAP) and had no logic for the explicit-type case, the children retained their inferred TINYINT types. These mistyped expressions were then serialized and sent to the BE.                                                                                                                                                    
                                                                                                                                                                                                                                        On the BE side, MapExpr::evaluate_checked cloned the key column as a FixedLengthColumn<int8_t> (1 byte), but later attempted to append it into a FixedLengthColumnBase<int16_t> (2 bytes), causing a heap-buffer-overflow detected by 
 AddressSanitizer.
                                                                                                                                                                                                                                        
A typical reproducer:

```
  ALTER TABLE t ADD COLUMN c MAP<SMALLINT, SMALLINT>
  DEFAULT map<smallint, smallint>{1: 2, 3: 4};                                                                                                                                                                                          
                                              
  SELECT id, c FROM t ORDER BY id;  -- crashes BE       
```                                                                                                                                                                                
                                                 
Root Cause                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
In ExpressionAnalyzer.visitMapExpr, when the map has an explicit MapType (not AnyMapType.ANY_MAP), no casting was applied to the child expressions. The declared key/value types were simply ignored, and children kept their own inferred types.                                                                                                                                                                                                                       
                                                                                                                                                                                                                                        
The same issue did not exist for ArrayExpr — visitArrayExpr already correctly casts children to the declared item type when an explicit array type is present.                                                                        
   
Fix                                                                                                                                                                                                                                   
                  
When the map literal has an explicit type, extract the declared keyType and valueType from the MapType and cast each key/value child expression to the corresponding type if it doesn't already match — exactly mirroring the existing pattern in visitArrayExpr.

## What I'm doing:

Fix type mismatch in map literal when explicit key/value types are declared

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
