### PR TITLE
[Refactor] Avoid using ExecEnv from RuntimeState

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -410,7 +410,8 @@ bool ConnectorScanNode::_submit_scanner(ConnectorScanner* scanner, bool blockabl
         return _submit_streaming_load_scanner(scanner, blockable);
     }
 
-    auto* thread_pool = runtime_state()->exec_env()->thread_pool();
+    auto* query_execution_services = runtime_state()->query_execution_services();
+    auto* thread_pool = query_execution_services->execution->thread_pool;
     int delta = static_cast<int>(!scanner->keep_priority());
     int32_t num_submit = _scanner_submit_count.fetch_add(delta, std::memory_order_relaxed);
 
@@ -437,7 +438,8 @@ bool ConnectorScanNode::_submit_streaming_load_scanner(ConnectorScanner* scanner
 #ifdef BE_TEST
     _use_stream_load_thread_pool = true;
 #endif
-    ThreadPool* thread_pool = runtime_state()->exec_env()->streaming_load_thread_pool();
+    auto* query_execution_services = runtime_state()->query_execution_services();
+    ThreadPool* thread_pool = query_execution_services->execution->streaming_load_thread_pool;
     _running_threads.fetch_add(1, std::memory_order_release);
     // Assume the thread pool is large enough, so there is no need to set the priority
     Status status = thread_pool->submit_func([this, scanner] { _scanner_thread(scanner); });

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -81,7 +81,8 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     // TODO: figure out appropriate buffer size
     DCHECK_GT(_num_senders, 0);
     _sub_plan_query_statistics_recvr = std::make_shared<QueryStatisticsRecvr>();
-    _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
+    auto* query_execution_services = state->query_execution_services();
+    _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _is_merging, _sub_plan_query_statistics_recvr, false, 1, false);
     _stream_recvr->bind_profile(0, _runtime_profile);

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -153,8 +153,10 @@ Status ExecNode::init_join_runtime_filters(const TPlanNode& tnode, RuntimeState*
     if (state != nullptr && state->query_options().__isset.runtime_filter_scan_wait_time_ms) {
         _runtime_filter_collector.set_scan_wait_timeout_ms(state->query_options().runtime_filter_scan_wait_time_ms);
     }
-    if (state != nullptr && state->exec_env() != nullptr) {
-        _runtime_filter_collector.set_runtime_filter_cache(state->exec_env()->runtime_filter_cache());
+    if (state != nullptr && state->query_execution_services() != nullptr &&
+        state->query_execution_services()->runtime != nullptr) {
+        _runtime_filter_collector.set_runtime_filter_cache(
+                state->query_execution_services()->runtime->runtime_filter_cache);
     }
     if (tnode.__isset.filter_null_value_columns) {
         _filter_null_value_columns = tnode.filter_null_value_columns;

--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -292,7 +292,8 @@ Status FileScanner::create_sequential_file(const TBrokerRangeDesc& range_desc, c
         break;
     }
     case TFileType::FILE_STREAM: {
-        auto pipe = _state->exec_env()->load_stream_mgr()->get(range_desc.load_id);
+        auto* query_execution_services = _state->query_execution_services();
+        auto pipe = query_execution_services->runtime->load_stream_mgr->get(range_desc.load_id);
         if (pipe == nullptr) {
             std::stringstream ss("Invalid or outdated load id ");
             range_desc.load_id.printTo(ss);

--- a/be/src/exec/lookup_node.cpp
+++ b/be/src/exec/lookup_node.cpp
@@ -65,7 +65,8 @@ StatusOr<pipeline::OpFactories> LookUpNode::decompose_to_pipeline(pipeline::Pipe
         tuple_ids.emplace_back(tuple_id);
     }
     auto state = runtime_state();
-    auto dispatch_mgr = state->exec_env()->lookup_dispatcher_mgr();
+    auto* query_execution_services = state->query_execution_services();
+    auto dispatch_mgr = query_execution_services->runtime->lookup_dispatcher_mgr;
     auto dispatcher = dispatch_mgr->create_dispatcher(state->query_id(), id(), tuple_ids, _num_peer_fetchers);
 
     int32_t max_io_tasks = context->degree_of_parallelism();

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -666,7 +666,8 @@ int OlapScanNode::compute_priority(int32_t num_submitted_tasks) {
 }
 
 bool OlapScanNode::_submit_scanner(TabletScanner* scanner, bool blockable) {
-    PriorityThreadPool* thread_pool = runtime_state()->exec_env()->thread_pool();
+    auto* query_execution_services = runtime_state()->query_execution_services();
+    PriorityThreadPool* thread_pool = query_execution_services->execution->thread_pool;
     int delta = !scanner->keep_priority();
     int32_t num_submit = _scanner_submit_count.fetch_add(delta, std::memory_order_relaxed);
     PriorityThreadPool::Task task;

--- a/be/src/exec/pipeline/adaptive/event.cpp
+++ b/be/src/exec/pipeline/adaptive/event.cpp
@@ -114,7 +114,8 @@ void CollectStatsSourceInitializeEvent::process(RuntimeState* state) {
             }
         }
 
-        auto* prepare_thread_pool = state->exec_env()->pipeline_prepare_pool();
+        auto* query_execution_services = state->query_execution_services();
+        auto* prepare_thread_pool = query_execution_services->execution->pipeline_prepare_pool;
         DCHECK(prepare_thread_pool != nullptr);
 
         std::vector<DriverPtr> all_drivers;

--- a/be/src/exec/pipeline/audit_statistics_reporter.cpp
+++ b/be/src/exec/pipeline/audit_statistics_reporter.cpp
@@ -21,7 +21,6 @@
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "runtime/client_cache.h"
-#include "runtime/exec_env.h"
 #include "util/thrift_rpc_helper.h"
 
 namespace starrocks::pipeline {
@@ -39,7 +38,7 @@ AuditStatisticsReporter::AuditStatisticsReporter() {
 }
 
 // including the final status when execution finishes.
-Status AuditStatisticsReporter::report_audit_statistics(const TReportAuditStatisticsParams& params, ExecEnv* exec_env,
+Status AuditStatisticsReporter::report_audit_statistics(const TReportAuditStatisticsParams& params,
                                                         const TNetworkAddress& fe_addr) {
     TReportAuditStatisticsResult res;
     Status rpc_status;

--- a/be/src/exec/pipeline/audit_statistics_reporter.h
+++ b/be/src/exec/pipeline/audit_statistics_reporter.h
@@ -22,22 +22,17 @@
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/Types_types.h"
 
-namespace starrocks {
-class ExecEnv;
-
-namespace pipeline {
+namespace starrocks::pipeline {
 
 class AuditStatisticsReporter {
 public:
     AuditStatisticsReporter();
 
-    static Status report_audit_statistics(const TReportAuditStatisticsParams& params, ExecEnv* exec_env,
-                                          const TNetworkAddress& fe_addr);
+    static Status report_audit_statistics(const TReportAuditStatisticsParams& params, const TNetworkAddress& fe_addr);
 
     Status submit(std::function<void()>&& report_task);
 
 private:
     std::unique_ptr<ThreadPool> _thread_pool;
 };
-} // namespace pipeline
-} // namespace starrocks
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -27,7 +27,8 @@ namespace starrocks::pipeline {
 Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
     auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
-    _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
+    auto* query_execution_services = state->query_execution_services();
+    _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, 1, true);
     _stream_recvr->bind_profile(_driver_sequence, _unique_metrics);

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -97,7 +97,8 @@ void ExchangeParallelMergeSourceOperatorFactory::close(RuntimeState* state) {
 DataStreamRecvr* ExchangeParallelMergeSourceOperatorFactory::get_stream_recvr(RuntimeState* state) {
     if (_stream_recvr == nullptr) {
         auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
-        _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
+        auto* query_execution_services = state->query_execution_services();
+        _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
                 state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
                 config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, _degree_of_parallelism, true);
     }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -177,7 +177,8 @@ Status ExchangeSinkOperator::Channel::init(RuntimeState* state) {
         _is_inited = true;
         return Status::OK();
     }
-    _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
+    auto* query_execution_services = state->query_execution_services();
+    _brpc_stub = query_execution_services->rpc->brpc_stub_cache->get_stub(_brpc_dest_addr);
 
     if (_brpc_stub == nullptr) {
         auto msg = fmt::format("The brpc stub of {}:{} is null.", _brpc_dest_addr.hostname, _brpc_dest_addr.port);
@@ -346,7 +347,7 @@ ExchangeSinkOperator::ExchangeSinkOperator(
     RuntimeState* state = fragment_ctx->runtime_state();
 
     PassThroughChunkBuffer* pass_through_chunk_buffer =
-            state->exec_env()->stream_mgr()->get_pass_through_chunk_buffer(state->query_id());
+            state->query_execution_services()->runtime->stream_mgr->get_pass_through_chunk_buffer(state->query_id());
 
     _channels.reserve(destinations.size());
     std::vector<int> driver_sequence_per_channel(destinations.size(), 0);

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -87,7 +87,8 @@ std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_re
         return _stream_recvr;
     }
     auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
-    _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
+    auto* query_execution_services = state->query_execution_services();
+    _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, false, query_statistic_recv, true, _degree_of_parallelism, false);
 

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -160,8 +160,7 @@ std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_s
 }
 
 // including the final status when execution finishes.
-Status ExecStateReporter::report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
-                                             const TNetworkAddress& fe_addr) {
+Status ExecStateReporter::report_exec_status(const TReportExecStatusParams& params, const TNetworkAddress& fe_addr) {
     TReportExecStatusResult res;
     Status rpc_status;
 
@@ -245,8 +244,7 @@ TMVMaintenanceTasks ExecStateReporter::create_report_epoch_params(const QueryCon
 }
 
 // including the final status when execution finishes.
-Status ExecStateReporter::report_epoch(const TMVMaintenanceTasks& params, ExecEnv* exec_env,
-                                       const TNetworkAddress& fe_addr) {
+Status ExecStateReporter::report_epoch(const TMVMaintenanceTasks& params, const TNetworkAddress& fe_addr) {
     Status fe_status;
     TMVReportEpochResponse res;
     Status rpc_status;

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -25,7 +25,6 @@
 #include "gen_cpp/Types_types.h"
 
 namespace starrocks {
-class ExecEnv;
 class RuntimeProfile;
 
 namespace pipeline {
@@ -40,8 +39,7 @@ public:
             QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
             RuntimeProfile* load_channel_profile, const Status& status, bool done);
 
-    static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
-                                     const TNetworkAddress& fe_addr);
+    static Status report_exec_status(const TReportExecStatusParams& params, const TNetworkAddress& fe_addr);
 
     void submit(std::function<void()>&& report_task, bool priority = false);
 
@@ -54,7 +52,7 @@ public:
     static TMVMaintenanceTasks create_report_epoch_params(const QueryContext* query_ctx,
                                                           const std::vector<FragmentContext*>& fragment_ctxs);
 
-    static Status report_epoch(const TMVMaintenanceTasks& params, ExecEnv* exec_env, const TNetworkAddress& fe_addr);
+    static Status report_epoch(const TMVMaintenanceTasks& params, const TNetworkAddress& fe_addr);
 
 public:
     // Accessors exposed only for unit tests (via the friend declaration above).

--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -186,7 +186,8 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
     DLOG(INFO) << "[GLM] send fetch request, source_id: " << source_id << ", " << (void*)processor.get()
                << ", unit: " << unit_debug_string;
     _ctx->send_ts = MonotonicNanos();
-    auto stub = state->exec_env()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
+    auto* query_execution_services = state->query_execution_services();
+    auto stub = query_execution_services->rpc->brpc_stub_cache->get_stub(node_info->host, node_info->brpc_port);
     if (stub == nullptr) {
         auto msg = fmt::format("Connect {}:{} failed.", node_info->host, node_info->brpc_port);
         LOG(WARNING) << msg;
@@ -200,7 +201,8 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
 }
 
 void LookUpCloseTask::submit(RuntimeState* state) {
-    auto stub = state->exec_env()->brpc_stub_cache()->get_stub(_host, _port);
+    auto* query_execution_services = state->query_execution_services();
+    auto stub = query_execution_services->rpc->brpc_stub_cache->get_stub(_host, _port);
     if (stub == nullptr) {
         auto msg = fmt::format("Connect {}:{} failed.", _host, _port);
         LOG(WARNING) << msg;

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -47,6 +47,23 @@
 
 namespace starrocks::pipeline {
 
+namespace {
+
+const QueryExecutionServices& query_execution_services(const RuntimeState* state) {
+    DCHECK(state != nullptr);
+    return *state->query_execution_services();
+}
+
+const ExecutionEnv& execution_services(const RuntimeState* state) {
+    return *query_execution_services(state).execution;
+}
+
+const RuntimeServices& runtime_services(const RuntimeState* state) {
+    return *query_execution_services(state).runtime;
+}
+
+} // namespace
+
 // RAII guard for pass-through chunk buffer lifecycle.
 class PassThroughChunkBufferGuard {
 public:
@@ -159,7 +176,7 @@ void FragmentContext::count_down_execution_group(size_t val) {
         //
         std::shared_ptr<Runnable> runnable;
         runnable = std::make_shared<RpcRunnable>(fe_addr, res, params);
-        (void)state->exec_env()->streaming_load_thread_pool()->submit(runnable);
+        (void)execution_services(state).streaming_load_thread_pool->submit(runnable);
     }
 
     destroy_pass_through_chunk_buffer();
@@ -262,9 +279,10 @@ void FragmentContext::set_final_status(const Status& status) {
                 LOG(WARNING) << cancel_msg;
             }
 
-            const auto* executors = _workgroup != nullptr
-                                            ? _workgroup->executors()
-                                            : _runtime_state->exec_env()->workgroup_manager()->shared_executors();
+            const auto* executors =
+                    _workgroup != nullptr
+                            ? _workgroup->executors()
+                            : execution_services(_runtime_state.get()).workgroup_manager->shared_executors();
             auto* executor = executors->driver_executor();
             iterate_drivers([executor](const DriverPtr& driver) { executor->cancel(driver.get()); });
         }
@@ -323,7 +341,8 @@ void FragmentContext::cancel(const Status& status, bool cancelled_by_fe) {
     if (query_options.query_type == TQueryType::LOAD && (query_options.load_job_type == TLoadJobType::BROKER ||
                                                          query_options.load_job_type == TLoadJobType::INSERT_QUERY ||
                                                          query_options.load_job_type == TLoadJobType::INSERT_VALUES)) {
-        ExecEnv::GetInstance()->profile_report_worker()->unregister_pipeline_load(_query_id, _fragment_instance_id);
+        runtime_services(_runtime_state.get())
+                .profile_report_worker->unregister_pipeline_load(_query_id, _fragment_instance_id);
     }
 }
 
@@ -357,8 +376,8 @@ Status FragmentContextManager::register_ctx(const TUniqueId& fragment_id, Fragme
     if (query_options.query_type == TQueryType::LOAD && (query_options.load_job_type == TLoadJobType::BROKER ||
                                                          query_options.load_job_type == TLoadJobType::INSERT_QUERY ||
                                                          query_options.load_job_type == TLoadJobType::INSERT_VALUES)) {
-        RETURN_IF_ERROR(ExecEnv::GetInstance()->profile_report_worker()->register_pipeline_load(
-                fragment_ctx->query_id(), fragment_id));
+        RETURN_IF_ERROR(runtime_services(fragment_ctx->runtime_state())
+                                .profile_report_worker->register_pipeline_load(fragment_ctx->query_id(), fragment_id));
     }
     _fragment_contexts.emplace(fragment_id, std::move(fragment_ctx));
     return Status::OK();
@@ -386,8 +405,8 @@ void FragmentContextManager::unregister(const TUniqueId& fragment_id) {
              query_options.load_job_type == TLoadJobType::INSERT_QUERY ||
              query_options.load_job_type == TLoadJobType::INSERT_VALUES) &&
             !it->second->runtime_state()->is_cancelled()) {
-            ExecEnv::GetInstance()->profile_report_worker()->unregister_pipeline_load(it->second->query_id(),
-                                                                                      fragment_id);
+            runtime_services(it->second->runtime_state())
+                    .profile_report_worker->unregister_pipeline_load(it->second->query_id(), fragment_id);
         }
         _fragment_contexts.erase(it);
     }
@@ -401,7 +420,7 @@ void FragmentContextManager::cancel(const Status& status) {
 }
 void FragmentContext::prepare_pass_through_chunk_buffer() {
     _pass_through_chunk_buffer_guard =
-            std::make_unique<PassThroughChunkBufferGuard>(_runtime_state->exec_env()->stream_mgr(), _query_id);
+            std::make_unique<PassThroughChunkBufferGuard>(runtime_services(_runtime_state.get()).stream_mgr, _query_id);
 }
 void FragmentContext::destroy_pass_through_chunk_buffer() {
     _pass_through_chunk_buffer_guard.reset();
@@ -512,7 +531,7 @@ Status FragmentContext::prepare_active_drivers() {
         total_active_driver_size += group->total_active_driver_size();
     }
 
-    auto pipeline_prepare_pool = runtime_state()->exec_env()->pipeline_prepare_pool();
+    auto pipeline_prepare_pool = execution_services(runtime_state()).pipeline_prepare_pool;
     // if prepare all drivers parallelly of this fragment will make queue too full, do not prepare parallelly
     if (!config::enable_pipeline_driver_parallel_prepare ||
         pipeline_prepare_pool->get_queue_size() + total_active_driver_size >=
@@ -566,9 +585,9 @@ void FragmentContext::_close_stream_load_contexts() {
     for (const auto& context : _stream_load_contexts) {
         context->body_sink->cancel(Status::Cancelled("Close the stream load pipe"));
         if (context->enable_batch_write) {
-            _runtime_state->exec_env()->batch_write_mgr()->unregister_stream_load_pipe(context);
+            runtime_services(_runtime_state.get()).batch_write_mgr->unregister_stream_load_pipe(context);
         } else {
-            _runtime_state->exec_env()->stream_context_mgr()->remove_channel_context(context);
+            runtime_services(_runtime_state.get()).stream_context_mgr->remove_channel_context(context);
         }
     }
 }

--- a/be/src/exec/pipeline/group_execution/execution_group.cpp
+++ b/be/src/exec/pipeline/group_execution/execution_group.cpp
@@ -74,7 +74,8 @@ size_t ExecutionGroup::total_active_driver_size() {
 
 void ExecutionGroup::prepare_active_drivers_parallel(RuntimeState* state,
                                                      std::shared_ptr<DriverPrepareSyncContext> sync_ctx) {
-    auto pipeline_prepare_pool = state->exec_env()->pipeline_prepare_pool();
+    auto* query_execution_services = state->query_execution_services();
+    auto pipeline_prepare_pool = query_execution_services->execution->pipeline_prepare_pool;
 
     for_each_active_driver(_pipelines, [&](const DriverPtr& driver) {
         // since prepare is async, we must hold the runtime state ptr

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -414,7 +414,8 @@ void OperatorFactory::acquire_runtime_filter(RuntimeState* state) {
         if (desc->is_local() || desc->runtime_filter(-1) != nullptr) {
             continue;
         }
-        auto grf = state->exec_env()->runtime_filter_cache()->get(state->query_id(), filter_id);
+        auto* query_execution_services = state->query_execution_services();
+        auto grf = query_execution_services->runtime->runtime_filter_cache->get(state->query_id(), filter_id);
         ExecEnv::GetInstance()->runtime_filter_cache()->add_rf_event(
                 {state->query_id(), filter_id, BackendOptions::get_localhost(),
                  strings::Substitute("INSTALL_GRF_TO_OPERATOR(op_id=$0, success=$1", this->_plan_node_id,

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -365,15 +365,14 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
         GlobalEnv::GetInstance()->process_mem_tracker()->consume(delta);
     }
 
-    auto exec_env = fragment_ctx->runtime_state()->exec_env();
     auto instance_id = fragment_ctx->fragment_instance_id();
     auto query_id = fragment_ctx->query_id();
 
-    auto report_task = [params, exec_env, fe_addr, instance_id, query_id]() {
+    auto report_task = [params, fe_addr, instance_id, query_id]() {
         int retry_times = 0;
         int max_retry_times = config::report_exec_rpc_request_retry_num;
         while (retry_times++ < max_retry_times) {
-            auto status = ExecStateReporter::report_exec_status(*params, exec_env, fe_addr);
+            auto status = ExecStateReporter::report_exec_status(*params, fe_addr);
 
             FAIL_POINT_TRIGGER_EXECUTE(report_exec_state_failed_status, {
                 if (status.ok()) {
@@ -431,11 +430,10 @@ void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, Frag
         return;
     }
 
-    auto exec_env = fragment_ctx->runtime_state()->exec_env();
     auto fragment_id = fragment_ctx->fragment_instance_id();
 
     auto report_task = [=]() {
-        auto status = AuditStatisticsReporter::report_audit_statistics(params, exec_env, fe_addr);
+        auto status = AuditStatisticsReporter::report_audit_statistics(params, fe_addr);
         if (!status.ok()) {
             if (status.is_not_found()) {
                 LOG(INFO) << "[Driver] Fail to report audit statistics due to query not found: fragment_instance_id="
@@ -472,11 +470,10 @@ void GlobalDriverExecutor::report_audit_statistics_on_failure(QueryContext* quer
         return;
     }
 
-    auto exec_env = fragment_ctx->runtime_state()->exec_env();
     auto fragment_id = fragment_ctx->fragment_instance_id();
 
     auto report_task = [=]() {
-        auto status = AuditStatisticsReporter::report_audit_statistics(params, exec_env, fe_addr);
+        auto status = AuditStatisticsReporter::report_audit_statistics(params, fe_addr);
         if (!status.ok()) {
             if (status.is_not_found()) {
                 LOG(INFO) << "[Driver] Fail to report audit statistics due to query not found: fragment_instance_id="
@@ -510,15 +507,14 @@ void GlobalDriverExecutor::_finalize_epoch(DriverRawPtr driver, RuntimeState* ru
     stream_driver->epoch_finalize(runtime_state, state);
 }
 
-void GlobalDriverExecutor::report_epoch(ExecEnv* exec_env, QueryContext* query_ctx,
-                                        std::vector<FragmentContext*> fragment_ctxs) {
+void GlobalDriverExecutor::report_epoch(QueryContext* query_ctx, std::vector<FragmentContext*> fragment_ctxs) {
     DCHECK_LT(0, fragment_ctxs.size());
     auto params = ExecStateReporter::create_report_epoch_params(query_ctx, fragment_ctxs);
     // TODO(lism): Check all fragment_ctx's fe_addr are the same.
     auto fe_addr = fragment_ctxs[0]->fe_addr();
     auto query_id = query_ctx->query_id();
     auto report_task = [=]() {
-        auto status = ExecStateReporter::report_epoch(params, exec_env, fe_addr);
+        auto status = ExecStateReporter::report_epoch(params, fe_addr);
         if (!status.ok()) {
             if (status.is_not_found()) {
                 LOG(INFO) << "[Driver] Fail to report epoch exec state due to query not found: query_id="

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -62,8 +62,7 @@ public:
 
     virtual size_t activate_parked_driver(const ConstDriverPredicator& predicate_func) = 0;
 
-    virtual void report_epoch(ExecEnv* exec_env, QueryContext* query_ctx,
-                              std::vector<FragmentContext*> fragment_ctxs) = 0;
+    virtual void report_epoch(QueryContext* query_ctx, std::vector<FragmentContext*> fragment_ctxs) = 0;
 
     virtual size_t calculate_parked_driver(const ConstDriverPredicator& predicate_func) const = 0;
 
@@ -93,7 +92,7 @@ public:
     size_t activate_parked_driver(const ConstDriverPredicator& predicate_func) override;
     size_t calculate_parked_driver(const ConstDriverPredicator& predicate_func) const override;
 
-    void report_epoch(ExecEnv* exec_env, QueryContext* query_ctx, std::vector<FragmentContext*> fragment_ctxs) override;
+    void report_epoch(QueryContext* query_ctx, std::vector<FragmentContext*> fragment_ctxs) override;
 
     void bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuUtil::CpuIds>& borrowed_cpuids) override;
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -625,7 +625,8 @@ void ScanOperator::_merge_chunk_source_profiles(RuntimeState* state) {
     // _query_ctx uses lazy initialization, maybe it is not initialized
     // under certain circumstance
     if (query_ctx == nullptr) {
-        query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
+        auto* query_execution_services = state->query_execution_services();
+        query_ctx = query_execution_services->runtime->query_context_mgr->get(state->query_id());
         DCHECK(query_ctx != nullptr);
     }
     if (!query_ctx->enable_profile()) {

--- a/be/src/exec/pipeline/sink/file_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/file_sink_operator.cpp
@@ -67,8 +67,9 @@ Status FileSinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile* parent_pro
     }
 
     auto dop = state->query_options().pipeline_dop;
-    RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(),
-                                                                   std::min(dop << 1, 1024), &_sender));
+    auto* query_execution_services = state->query_execution_services();
+    RETURN_IF_ERROR(query_execution_services->runtime->result_mgr->create_sender(state->fragment_instance_id(),
+                                                                                 std::min(dop << 1, 1024), &_sender));
     _writer = std::make_shared<FileResultWriter>(_file_opts.get(), _output_expr_ctxs, parent_profile);
     RETURN_IF_ERROR(_writer->init(state));
 
@@ -101,7 +102,8 @@ void FileSinkIOBuffer::close(RuntimeState* state) {
         WARN_IF_ERROR(_sender->close(final_status), "close sender failed");
         _sender.reset();
 
-        (void)_state->exec_env()->result_mgr()->cancel_at_time(
+        auto* query_execution_services = _state->query_execution_services();
+        (void)query_execution_services->runtime->result_mgr->cancel_at_time(
                 time(nullptr) + config::result_buffer_cancelled_interval_time, state->fragment_instance_id());
     }
     SinkIOBuffer::close(state);

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
@@ -135,7 +135,8 @@ Status MemoryScratchSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, _id_to_col_name, &_arrow_schema, _output_expr_ctxs));
 
     TUniqueId fragment_instance_id = state->fragment_instance_id();
-    state->exec_env()->result_queue_mgr()->create_queue(fragment_instance_id, &_queue);
+    auto* query_execution_services = state->query_execution_services();
+    query_execution_services->runtime->result_queue_mgr->create_queue(fragment_instance_id, &_queue);
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/sink/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/result_sink_operator.cpp
@@ -111,7 +111,8 @@ void ResultSinkOperator::close(RuntimeState* state) {
             WARN_IF_ERROR(_sender->close(final_status), "close sender failed");
         }
 
-        (void)state->exec_env()->result_mgr()->cancel_at_time(
+        auto* query_execution_services = state->query_execution_services();
+        (void)query_execution_services->runtime->result_mgr->cancel_at_time(
                 time(nullptr) + config::result_buffer_cancelled_interval_time, state->fragment_instance_id());
     }
 
@@ -157,8 +158,9 @@ Status ResultSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk
 
 Status ResultSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(),
-                                                                   std::min<int>(_dop << 1, 1024), &_sender));
+    auto* query_execution_services = state->query_execution_services();
+    RETURN_IF_ERROR(query_execution_services->runtime->result_mgr->create_sender(
+            state->fragment_instance_id(), std::min<int>(_dop << 1, 1024), &_sender));
 
     RETURN_IF_ERROR(ExprFactory::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs, state));
 

--- a/be/src/exec/pipeline/stream_epoch_manager.cpp
+++ b/be/src/exec/pipeline/stream_epoch_manager.cpp
@@ -179,8 +179,7 @@ void StreamEpochManager::count_down_fragment_ctx(RuntimeState* state, FragmentCo
 
     // do epoch report stats
     auto* query_ctx = state->query_ctx();
-    fragment_ctx->workgroup()->executors()->driver_executor()->report_epoch(state->exec_env(), query_ctx,
-                                                                            _finished_fragment_ctxs);
+    fragment_ctx->workgroup()->executors()->driver_executor()->report_epoch(query_ctx, _finished_fragment_ctxs);
 }
 
 const BinlogOffset* StreamEpochManager::_get_epoch_unlock(const TabletId2BinlogOffset& tablet_id_scan_ranges_mapping,

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -154,8 +154,9 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     }
     _enable_automatic_partition = _vectorized_partition->enable_automatic_partition();
     if (_enable_automatic_partition) {
-        _automatic_partition_token =
-                state->exec_env()->automatic_partition_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+        auto* query_execution_services = state->query_execution_services();
+        _automatic_partition_token = query_execution_services->execution->automatic_partition_pool->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
     }
     // init _colocate_mv_index: Only use colocate mv when both FE/BE's config are set true.
     if (table_sink.__isset.enable_colocate_mv_index) {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -98,7 +98,8 @@ Status NodeChannel::init(RuntimeState* state) {
         return _err_st;
     }
 
-    _stub = state->exec_env()->brpc_stub_cache()->get_stub(_node_info->host, _node_info->brpc_port);
+    auto* query_execution_services = state->query_execution_services();
+    _stub = query_execution_services->rpc->brpc_stub_cache->get_stub(_node_info->host, _node_info->brpc_port);
     if (_stub == nullptr) {
         _cancelled = true;
         auto msg = fmt::format("Connect {}:{} failed.", _node_info->host, _node_info->brpc_port);

--- a/be/src/runtime/arrow_result_writer.cpp
+++ b/be/src/runtime/arrow_result_writer.cpp
@@ -68,7 +68,8 @@ Status ArrowResultWriter::init(RuntimeState* state) {
     RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, temp_id_to_col_name, &_arrow_schema, _output_expr_ctxs,
                                             &_output_column_names, state->arrow_flight_sql_version()));
 
-    state->exec_env()->result_mgr()->set_arrow_schema(state->fragment_instance_id(), _arrow_schema);
+    auto* query_execution_services = state->query_execution_services();
+    query_execution_services->runtime->result_mgr->set_arrow_schema(state->fragment_instance_id(), _arrow_schema);
 
     return Status::OK();
 }

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -201,7 +201,8 @@ Status DataStreamSender::Channel::init(RuntimeState* state) {
                         ", maybe version is not compatible.";
         return Status::InternalError("no brpc destination");
     }
-    _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
+    auto* query_execution_services = state->query_execution_services();
+    _brpc_stub = query_execution_services->rpc->brpc_stub_cache->get_stub(_brpc_dest_addr);
     if (UNLIKELY(_brpc_stub == nullptr)) {
         auto msg = fmt::format("The brpc stub of {}:{} is null.", _brpc_dest_addr.hostname, _brpc_dest_addr.port);
         LOG(WARNING) << msg;

--- a/be/src/runtime/memory_scratch_sink.cpp
+++ b/be/src/runtime/memory_scratch_sink.cpp
@@ -89,7 +89,8 @@ Status MemoryScratchSink::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(prepare_exprs(state));
     // create queue
     TUniqueId fragment_instance_id = state->fragment_instance_id();
-    state->exec_env()->result_queue_mgr()->create_queue(fragment_instance_id, &_queue);
+    auto* query_execution_services = state->query_execution_services();
+    query_execution_services->runtime->result_queue_mgr->create_queue(fragment_instance_id, &_queue);
     std::stringstream title;
     title << "MemoryScratchSink (frag_id=" << fragment_instance_id << ")";
     // create profile

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -67,8 +67,6 @@ namespace starrocks {
 namespace {
 
 const RuntimeServices& runtime_services(const QueryExecutionServices* query_execution_services) {
-    DCHECK(query_execution_services != nullptr);
-    DCHECK(query_execution_services->runtime != nullptr);
     return *query_execution_services->runtime;
 }
 

--- a/be/src/runtime/result_sink.cpp
+++ b/be/src/runtime/result_sink.cpp
@@ -105,7 +105,9 @@ Status ResultSink::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(prepare_exprs(state));
 
     // create sender
-    RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(), _buf_size, &_sender));
+    auto* query_execution_services = state->query_execution_services();
+    RETURN_IF_ERROR(query_execution_services->runtime->result_mgr->create_sender(state->fragment_instance_id(),
+                                                                                 _buf_size, &_sender));
 
     // create writer based on sink type
     switch (_sink_type) {
@@ -172,8 +174,9 @@ Status ResultSink::close(RuntimeState* state, const Status& exec_status) {
         }
         (void)_sender->close(final_status);
     }
-    (void)state->exec_env()->result_mgr()->cancel_at_time(time(nullptr) + config::result_buffer_cancelled_interval_time,
-                                                          state->fragment_instance_id());
+    auto* query_execution_services = state->query_execution_services();
+    (void)query_execution_services->runtime->result_mgr->cancel_at_time(
+            time(nullptr) + config::result_buffer_cancelled_interval_time, state->fragment_instance_id());
     ExprExecutor::close(_output_expr_ctxs, state);
 
     _closed = true;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -45,6 +45,19 @@
 
 namespace starrocks {
 
+namespace {
+
+const QueryExecutionServices& query_execution_services(RuntimeState* state) {
+    DCHECK(state != nullptr);
+    return *state->query_execution_services();
+}
+
+const RuntimeServices& runtime_services(RuntimeState* state) {
+    return *query_execution_services(state).runtime;
+}
+
+} // namespace
+
 // Using a query-level mem_tracker beyond QueryContext's lifetime may access already destructed parent mem_tracker.
 // mem_trackers has a hierarchy: process->query_pool->resource_group->query, so when resource_group is dropped or
 // altered, resource_group-level mem_tracker would be destructed, such a dangling query-level mem_tracker would cause
@@ -188,11 +201,11 @@ void RuntimeFilterPort::publish_runtime_filters(const std::list<RuntimeFilterBui
                     std::min_element(rf_desc->broadcast_grf_senders().begin(), rf_desc->broadcast_grf_senders().end(),
                                      [](const auto& a, const auto& b) { return a.lo < b.lo; });
             if (passthrough_delivery || *sender_id == state->fragment_instance_id()) {
-                state->exec_env()->runtime_filter_worker()->send_broadcast_runtime_filter(
+                runtime_services(state).runtime_filter_worker->send_broadcast_runtime_filter(
                         std::move(params), rf_desc->broadcast_grf_destinations(), timeout_ms, rpc_http_min_size);
             }
         } else {
-            state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(
+            runtime_services(state).runtime_filter_worker->send_part_runtime_filter(
                     std::move(params), rf_desc->merge_nodes(), timeout_ms, rpc_http_min_size, EventType::SEND_PART_RF);
         }
     }
@@ -239,9 +252,9 @@ void RuntimeFilterPort::publish_skew_broadcast_join_key_columns(RuntimeFilterBui
     RETURN_IF(!actual_size.status().ok(), (void)nullptr);
     rf_data->resize(actual_size.value());
     *(params.mutable_columntype()) = type_desc.to_protobuf();
-    state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
-                                                                         timeout_ms, rpc_http_min_size,
-                                                                         EventType::SEND_SKEW_JOIN_BROADCAST_RF);
+    runtime_services(state).runtime_filter_worker->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
+                                                                            timeout_ms, rpc_http_min_size,
+                                                                            EventType::SEND_SKEW_JOIN_BROADCAST_RF);
 }
 
 void RuntimeFilterPort::prepare_params(PTransmitRuntimeFilterParams& params, RuntimeState* state,
@@ -272,7 +285,7 @@ void RuntimeFilterPort::publish_local_colocate_filters(std::list<RuntimeFilterBu
 }
 
 void RuntimeFilterPort::receive_runtime_filter(int32_t filter_id, const RuntimeFilter* rf) {
-    _state->exec_env()->runtime_filter_cache()->add_rf_event({
+    runtime_services(_state).runtime_filter_cache->add_rf_event({
             _state->query_id(),
             filter_id,
             "",

--- a/be/test/exec/cache_stats_scanner_test.cpp
+++ b/be/test/exec/cache_stats_scanner_test.cpp
@@ -59,8 +59,9 @@ public:
         TQueryOptions query_options;
         TQueryGlobals query_globals;
         TUniqueId fragment_id;
-        _state = _pool.add(
-                new RuntimeState(query_id, fragment_id, query_options, query_globals, ExecEnv::GetInstance()));
+        auto* exec_env = ExecEnv::GetInstance();
+        _state = _pool.add(new RuntimeState(query_id, fragment_id, query_options, query_globals,
+                                            &exec_env->query_execution_services(), exec_env));
         _state->init_mem_trackers(query_id);
     }
 

--- a/be/test/exec/file_scanner/json_scanner_test.cpp
+++ b/be/test/exec/file_scanner/json_scanner_test.cpp
@@ -143,11 +143,12 @@ protected:
     }
 
     std::shared_ptr<RuntimeState> create_runtime_state() {
+        ExecEnv* exec_env = ExecEnv::GetInstance();
         TQueryOptions query_options;
         TUniqueId fragment_id;
         TQueryGlobals query_globals;
-        std::shared_ptr<RuntimeState> runtime_state =
-                std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, ExecEnv::GetInstance());
+        std::shared_ptr<RuntimeState> runtime_state = std::make_shared<RuntimeState>(
+                fragment_id, query_options, query_globals, &exec_env->query_execution_services(), exec_env);
         TUniqueId id;
         runtime_state->init_mem_trackers(id);
         return runtime_state;

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -94,8 +94,9 @@ public:
         TUniqueId fragment_id;
         TQueryOptions query_options;
         TQueryGlobals query_globals;
-        _state = _pool.add(
-                new RuntimeState(query_id, fragment_id, query_options, query_globals, ExecEnv::GetInstance()));
+        auto* exec_env = ExecEnv::GetInstance();
+        _state = _pool.add(new RuntimeState(query_id, fragment_id, query_options, query_globals,
+                                            &exec_env->query_execution_services(), exec_env));
         _state->init_mem_trackers(query_id);
 
         // Setup FragmentContext with fe_addr for schema RPC

--- a/be/test/exec/pipeline/exec_group_test.cpp
+++ b/be/test/exec/pipeline/exec_group_test.cpp
@@ -52,8 +52,7 @@ public:
 
     size_t activate_parked_driver(const ConstDriverPredicator& predicate_func) override { return 0; }
 
-    void report_epoch(ExecEnv* exec_env, QueryContext* query_ctx,
-                      std::vector<FragmentContext*> fragment_ctxs) override {}
+    void report_epoch(QueryContext* query_ctx, std::vector<FragmentContext*> fragment_ctxs) override {}
 
     size_t calculate_parked_driver(const ConstDriverPredicator& predicate_func) const override { return 0; }
 

--- a/be/test/exec/pipeline/fetch_task_test.cpp
+++ b/be/test/exec/pipeline/fetch_task_test.cpp
@@ -81,13 +81,15 @@ std::shared_ptr<FetchProcessor> create_fetch_processor(const std::shared_ptr<Sta
 }
 
 std::unique_ptr<RuntimeState> create_runtime_state(int query_timeout_s) {
+    ExecEnv* exec_env = ExecEnv::GetInstance();
     TUniqueId fragment_instance_id;
     fragment_instance_id.hi = 1;
     fragment_instance_id.lo = 2;
     TQueryOptions query_options;
     query_options.__set_query_timeout(query_timeout_s);
     TQueryGlobals query_globals;
-    return std::make_unique<RuntimeState>(fragment_instance_id, query_options, query_globals, ExecEnv::GetInstance());
+    return std::make_unique<RuntimeState>(fragment_instance_id, query_options, query_globals,
+                                          &exec_env->query_execution_services(), exec_env);
 }
 
 bool wait_task_done(const FetchTaskPtr& task, int timeout_ms) {

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -85,7 +85,8 @@ public:
         _fragment_ctx->set_fragment_instance_id(fragment_id);
         _fragment_ctx->set_runtime_state(
                 std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                               _request.query_options, _request.query_globals, _exec_env));
+                                               _request.query_options, _request.query_globals,
+                                               &_exec_env->query_execution_services(), _exec_env));
 
         _fragment_future = _fragment_ctx->finish_future();
         _runtime_state = _fragment_ctx->runtime_state();

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -83,10 +83,9 @@ public:
         _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
         _fragment_ctx->set_query_id(query_id);
         _fragment_ctx->set_fragment_instance_id(fragment_id);
-        _fragment_ctx->set_runtime_state(
-                std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                               _request.query_options, _request.query_globals,
-                                               &_exec_env->query_execution_services(), _exec_env));
+        _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+                _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+                _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
 
         _fragment_future = _fragment_ctx->finish_future();
         _runtime_state = _fragment_ctx->runtime_state();

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -95,7 +95,8 @@ void PipelineTestBase::_prepare() {
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_workgroup(ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup());
 
     _fragment_future = _fragment_ctx->finish_future();

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -93,10 +93,9 @@ void PipelineTestBase::_prepare() {
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_workgroup(ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup());
 
     _fragment_future = _fragment_ctx->finish_future();

--- a/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
@@ -55,10 +55,9 @@ TEST(ExportSinkOperatorTest, test_set_finishing) {
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_is_stream_pipeline(true);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);
@@ -125,10 +124,9 @@ TEST(ExportSinkOperatorTest, test_export_with_header) {
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_is_stream_pipeline(true);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);

--- a/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
@@ -57,7 +57,8 @@ TEST(ExportSinkOperatorTest, test_set_finishing) {
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);
@@ -126,7 +127,8 @@ TEST(ExportSinkOperatorTest, test_export_with_header) {
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);

--- a/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
@@ -81,7 +81,8 @@ TEST(MemoryScratchSinkOperatorTest, test_cancel) {
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);

--- a/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
@@ -79,10 +79,9 @@ TEST(MemoryScratchSinkOperatorTest, test_cancel) {
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_is_stream_pipeline(true);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     RuntimeState* _runtime_state = _fragment_ctx->runtime_state();
     _runtime_state->set_query_ctx(_query_ctx);
     _runtime_state->set_fragment_ctx(_fragment_ctx);

--- a/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
@@ -82,10 +82,9 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_parquet_format) {
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 
@@ -139,10 +138,9 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_orc_format) {
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 

--- a/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
@@ -84,7 +84,8 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_parquet_format) {
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 
@@ -140,7 +141,8 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_orc_format) {
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 

--- a/be/test/exec/stream/stream_pipeline_test.cpp
+++ b/be/test/exec/stream/stream_pipeline_test.cpp
@@ -56,10 +56,9 @@ Status StreamPipelineTest::prepare() {
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);
     _fragment_ctx->set_fragment_instance_id(fragment_id);
-    _fragment_ctx->set_runtime_state(
-            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals,
-                                           &_exec_env->query_execution_services(), _exec_env));
+    _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
+            _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
+            _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 

--- a/be/test/exec/stream/stream_pipeline_test.cpp
+++ b/be/test/exec/stream/stream_pipeline_test.cpp
@@ -58,7 +58,8 @@ Status StreamPipelineTest::prepare() {
     _fragment_ctx->set_fragment_instance_id(fragment_id);
     _fragment_ctx->set_runtime_state(
             std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
-                                           _request.query_options, _request.query_globals, _exec_env));
+                                           _request.query_options, _request.query_globals,
+                                           &_exec_env->query_execution_services(), _exec_env));
     _fragment_ctx->set_is_stream_pipeline(true);
     _fragment_ctx->set_is_stream_test(true);
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
