### PR TITLE
[BugFix] fix const row bug for iceberg transform

### DIFF
--- a/be/src/exprs/binary_functions.cpp
+++ b/be/src/exprs/binary_functions.cpp
@@ -17,6 +17,7 @@
 #include "column/binary_column.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "column/nullable_column.h"
 #include "exprs/encryption_functions.h"
 #include "exprs/function_helper.h"
@@ -115,31 +116,23 @@ Status BinaryFunctions::from_binary_close(FunctionContext* context, FunctionCont
 }
 
 StatusOr<ColumnPtr> BinaryFunctions::iceberg_truncate_binary(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    (void)has_null;
-    const int size = num_rows;
-    int32_t width = c1->get(0).get_int32();
-    uint8_t* raw_null_flags = null_flags->get_data().data();
-    auto col = ColumnHelper::cast_to_raw<TYPE_BINARY>(c0);
-    ColumnBuilder<TYPE_BINARY> result(size);
-    const auto raw_c0 = col->immutable_data();
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
+    }
 
-#define SLICE_SIZE_MIN(x, y) x < y ? x : y
-    for (auto i = 0; i < size; i++) {
-        if (raw_null_flags[i]) {
+    const int size = columns[0]->size();
+    ColumnViewer<TYPE_VARBINARY> viewer(columns[0]);
+    int32_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_BINARY> result(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
             result.append_null();
         } else {
-            Slice src_value = raw_c0[c0_is_const ? 0 : i];
-            result.append(Slice(src_value.get_data(), SLICE_SIZE_MIN(width, src_value.get_size())));
+            Slice src_value = viewer.value(i);
+            result.append(Slice(src_value.get_data(), std::min(width, static_cast<int32_t>(src_value.get_size()))));
         }
     }
-#undef SLICE_SIZE_MIN
     return result.build(ColumnHelper::is_all_const(columns));
 }
 

--- a/be/src/exprs/binary_functions.cpp
+++ b/be/src/exprs/binary_functions.cpp
@@ -119,9 +119,11 @@ StatusOr<ColumnPtr> BinaryFunctions::iceberg_truncate_binary(FunctionContext* co
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
     (void)has_null;
-    const int size = c0->size();
+    const int size = num_rows;
     int32_t width = c1->get(0).get_int32();
     uint8_t* raw_null_flags = null_flags->get_data().data();
     auto col = ColumnHelper::cast_to_raw<TYPE_BINARY>(c0);
@@ -133,7 +135,7 @@ StatusOr<ColumnPtr> BinaryFunctions::iceberg_truncate_binary(FunctionContext* co
         if (raw_null_flags[i]) {
             result.append_null();
         } else {
-            Slice src_value = raw_c0[i];
+            Slice src_value = raw_c0[c0_is_const ? 0 : i];
             result.append(Slice(src_value.get_data(), SLICE_SIZE_MIN(width, src_value.get_size())));
         }
     }

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -127,13 +127,15 @@ inline void FunctionHelper::get_data_of_column<BinaryColumn, Slice>(const Column
         if (c0->only_null() || c1->only_null()) {                       \
             return ColumnHelper::create_const_null_column(c0->size());  \
         }                                                               \
+        num_rows = c0->size();                                          \
+        c0_is_const = c0->is_constant();                                \
         if (c0->has_null() || c1->has_null()) {                         \
             has_null = true;                                            \
             null_flags = FunctionHelper::union_nullable_column(c0, c1); \
         } else {                                                        \
             auto null_flags_mut = NullColumn::create();                 \
-            null_flags_mut->reserve(c0->size());                        \
-            null_flags_mut->append_default(c0->size());                 \
+            null_flags_mut->reserve(num_rows);                          \
+            null_flags_mut->append_default(num_rows);                   \
             null_flags = std::move(null_flags_mut);                     \
         }                                                               \
         c0 = FunctionHelper::get_data_column_of_const(c0);              \

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -122,26 +122,4 @@ inline void FunctionHelper::get_data_of_column<BinaryColumn, Slice>(const Column
         }                                    \
     } while (false)
 
-#define PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1)     \
-    do {                                                                \
-        if (c0->only_null() || c1->only_null()) {                       \
-            return ColumnHelper::create_const_null_column(c0->size());  \
-        }                                                               \
-        num_rows = c0->size();                                          \
-        c0_is_const = c0->is_constant();                                \
-        if (c0->has_null() || c1->has_null()) {                         \
-            has_null = true;                                            \
-            null_flags = FunctionHelper::union_nullable_column(c0, c1); \
-        } else {                                                        \
-            auto null_flags_mut = NullColumn::create();                 \
-            null_flags_mut->reserve(num_rows);                          \
-            null_flags_mut->append_default(num_rows);                   \
-            null_flags = std::move(null_flags_mut);                     \
-        }                                                               \
-        c0 = FunctionHelper::get_data_column_of_const(c0);              \
-        c1 = FunctionHelper::get_data_column_of_const(c1);              \
-        c0 = FunctionHelper::get_data_column_of_nullable(c0);           \
-        c1 = FunctionHelper::get_data_column_of_nullable(c1);           \
-    } while (0)
-
 } // namespace starrocks

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -25,7 +25,9 @@
 
 #include "base/hash/murmur_hash3.h"
 #include "column/array_column.h"
+#include "column/column_builder.h"
 #include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "exprs/expr.h"
 #include "exprs/function_helper.h"
 #include "exprs/math_functions.h"
@@ -326,65 +328,41 @@ DEFINE_MATH_BINARY_WITH_OUTPUT_NAN_CHECK_FN_WITH_IMPL(atan2, TYPE_DOUBLE, TYPE_D
 
 template <LogicalType Type>
 StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-    auto decimalv3_col = ColumnHelper::cast_to_raw<Type>(c0);
-    const int32_t original_scale = decimalv3_col->scale();
-    const int32_t original_precision = decimalv3_col->precision();
-    auto& null_data = null_flags->get_data();
-    uint8_t* raw_null_flags = null_data.data();
-    RunTimeCppType<Type> max_val = 1;
-    int32 pow = original_precision;
-    while (pow > 0) {
-        max_val *= 10;
-        pow--;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    const RunTimeCppType<Type>* raw_c0 = decimalv3_col->get_data().data();
-    MutableColumnPtr res = RunTimeColumnType<Type>::create(original_precision, original_scale);
-    if (c0_is_const) {
-        res->resize_uninitialized(1);
-        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
+    const int size = columns[0]->size();
+    ColumnViewer<Type> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    const int32_t original_scale = viewer.column()->scale();
+    const int32_t original_precision = viewer.column()->precision();
+    RunTimeCppType<Type> max_val = 1;
+    for (int32_t p = original_precision; p > 0; p--) {
+        max_val *= 10;
+    }
+
 #define ABS(x) ((x) < 0 ? -(x) : (x))
-        if (raw_null_flags[0] != 1 && ABS(raw_res[0]) >= max_val) {
-            std::stringstream error;
-            error << "Truncate to decimal(" << original_precision << ", " << original_scale
-                  << ") failed, because the result is overflow.";
-            context->set_error(error.str().c_str());
-            return Status::RuntimeError(error.str());
-        }
-#undef ABS
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        res->resize_uninitialized(size);
-        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-        for (auto i = 0; i < size; i++) {
-            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-        }
-#define ABS(x) ((x) < 0 ? -(x) : (x))
-        for (int i = 0; i < size; i++) {
-            if (raw_null_flags[i] != 1 && ABS(raw_res[i]) >= max_val) {
+    ColumnBuilder<Type> builder(size, original_precision, original_scale);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            RunTimeCppType<Type> val = viewer.value(i);
+            RunTimeCppType<Type> res = val - ((val % width) + width) % width;
+            if (ABS(res) >= max_val) {
                 std::stringstream error;
                 error << "Truncate to decimal(" << original_precision << ", " << original_scale
                       << ") failed, because the result is overflow.";
                 context->set_error(error.str().c_str());
                 return Status::RuntimeError(error.str());
             }
+            builder.append(res);
         }
+    }
 #undef ABS
-    }
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
-    }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 template StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal<TYPE_DECIMAL32>(FunctionContext*, const Columns&);
@@ -393,179 +371,136 @@ template StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal<TYPE_DECIMA
 
 template <LogicalType Type>
 StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
+    }
 
-    const auto& raw_null_flags = null_flags->immutable_data();
-    auto int_col = ColumnHelper::cast_to_raw<Type>(c0);
-    const auto& raw_c0 = int_col->immutable_data();
-    MutableColumnPtr res = RunTimeColumnType<Type>::create();
+    const int size = columns[0]->size();
+    ColumnViewer<Type> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
 
 #define haveDifferentSigns(x, y) (((x) ^ (y)) < 0)
-    if (c0_is_const) {
-        res->resize_uninitialized(1);
-        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
-        if (raw_null_flags[0] != 1 && haveDifferentSigns(raw_res[0], raw_c0[0])) {
-            std::stringstream error;
-            error << "Truncate to integer failed, because the result is overflow.";
-            context->set_error(error.str().c_str());
-            return Status::RuntimeError(error.str());
-        }
-        res = ConstColumn::create(std::move(res), size);
-    } else {
-        res->resize_uninitialized(size);
-        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-        for (auto i = 0; i < size; i++) {
-            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-        }
-        for (int i = 0; i < size; i++) {
-            if (raw_null_flags[i] != 1 && haveDifferentSigns(raw_res[i], raw_c0[i])) {
+    ColumnBuilder<Type> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            RunTimeCppType<Type> val = viewer.value(i);
+            RunTimeCppType<Type> res = val - ((val % width) + width) % width;
+            if (haveDifferentSigns(res, val)) {
                 std::stringstream error;
                 error << "Truncate to integer failed, because the result is overflow.";
                 context->set_error(error.str().c_str());
                 return Status::RuntimeError(error.str());
             }
+            builder.append(res);
         }
     }
 #undef haveDifferentSigns
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
-    }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 template StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int<TYPE_INT>(FunctionContext*, const Columns&);
 template StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int<TYPE_BIGINT>(FunctionContext*, const Columns&);
 
 template <LogicalType Type>
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-
-    auto col = ColumnHelper::cast_to_raw<Type>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
-    res->resize_uninitialized(size);
-    const auto& raw_c0 = col->immutable_data();
-    // result column is mutable, use non-const raw pointer
-    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
-    for (auto i = 0; i < size; i++) {
-        int64_t val = raw_c0[i];
-        murmur_hash3_x86_32(&val, sizeof(val), 0, (void*)&raw_res[i]);
-        raw_res[i] = (raw_res[i] & INT_MAX) % width;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
+    const int size = columns[0]->size();
+    ColumnViewer<Type> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            int64_t val = viewer.value(i);
+            int32_t hash;
+            murmur_hash3_x86_32(&val, sizeof(val), 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
     }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 template StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int<TYPE_INT>(FunctionContext*, const Columns&);
 template StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int<TYPE_BIGINT>(FunctionContext*, const Columns&);
 
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_string(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-
-    auto col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
-    res->resize_uninitialized(size);
-    auto raw_c0 = col->immutable_data();
-    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
-
-    for (auto i = 0; i < size; i++) {
-        murmur_hash3_x86_32(raw_c0[i].data, raw_c0[i].size, 0, &raw_res[i]);
-        raw_res[i] = (raw_res[i] & INT_MAX) % width;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
+    const int size = columns[0]->size();
+    ColumnViewer<TYPE_VARCHAR> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            auto val = viewer.value(i);
+            int32_t hash;
+            murmur_hash3_x86_32(val.data, val.size, 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
     }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_date(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-
-    auto col = ColumnHelper::cast_to_raw<TYPE_DATE>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
-    res->resize_uninitialized(size);
-    const auto& raw_c0 = col->immutable_data();
-    // result column is mutable, use non-const raw pointer
-    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
-
-    for (auto i = 0; i < size; i++) {
-        int64_t val = raw_c0[i].julian() - date::UNIX_EPOCH_JULIAN;
-        murmur_hash3_x86_32(&val, sizeof(int64_t), 0, (void*)&raw_res[i]);
-        raw_res[i] = (raw_res[i] & INT_MAX) % width;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
+    const int size = columns[0]->size();
+    ColumnViewer<TYPE_DATE> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            int64_t val = viewer.value(i).julian() - date::UNIX_EPOCH_JULIAN;
+            int32_t hash;
+            murmur_hash3_x86_32(&val, sizeof(int64_t), 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
     }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-
-    auto col = ColumnHelper::cast_to_raw<TYPE_DATETIME>(c0);
-    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
-    res->resize_uninitialized(size);
-    const auto& raw_c0 = col->immutable_data();
-    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
-
-    for (auto i = 0; i < size; i++) {
-        int64_t result = timestamp::to_julian(raw_c0[i].timestamp());
-        result *= SECS_PER_DAY;
-        result -= timestamp::UNIX_EPOCH_SECONDS;
-        result *= 1000000L;
-        result += timestamp::to_time(raw_c0[i].timestamp());
-        murmur_hash3_x86_32(&result, sizeof(int64_t), 0, (void*)&raw_res[i]);
-        raw_res[i] = (raw_res[i] & INT_MAX) % width;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
+    const int size = columns[0]->size();
+    ColumnViewer<TYPE_DATETIME> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            auto ts = viewer.value(i).timestamp();
+            int64_t val = timestamp::to_julian(ts);
+            val *= SECS_PER_DAY;
+            val -= timestamp::UNIX_EPOCH_SECONDS;
+            val *= 1000000L;
+            val += timestamp::to_time(ts);
+            int32_t hash;
+            murmur_hash3_x86_32(&val, sizeof(int64_t), 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
     }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 template <typename T>
@@ -592,32 +527,27 @@ template vector<uint8_t> MathFunctions::int_to_byte_array<int128_t>(int128_t val
 
 template <LogicalType Type>
 StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_decimal(FunctionContext* context, const Columns& columns) {
-    ColumnPtr c0 = columns[0];
-    ColumnPtr c1 = columns[1];
-    NullColumn::MutablePtr null_flags;
-    bool has_null = false;
-    bool c0_is_const = false;
-    int num_rows = 0;
-    PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = num_rows;
-    int64_t width = c1->get(0).get_int32();
-    auto decimalv3_col = ColumnHelper::cast_to_raw<Type>(c0);
-
-    MutableColumnPtr res = RunTimeColumnType<TYPE_INT>::create();
-    res->resize_uninitialized(size);
-    const auto& raw_c0 = decimalv3_col->immutable_data();
-    auto& raw_res = ColumnHelper::cast_to_raw<TYPE_INT>(res.get())->get_data();
-    for (auto i = 0; i < size; i++) {
-        auto result = raw_c0[i];
-        auto byte_array = int_to_byte_array(result);
-        murmur_hash3_x86_32(byte_array.data(), byte_array.size(), 0, (void*)&raw_res[i]);
-        raw_res[i] = (raw_res[i] & INT_MAX) % width;
+    if (columns[0]->only_null() || columns[1]->only_null()) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
     }
 
-    if (has_null) {
-        res = NullableColumn::create(std::move(res), std::move(null_flags));
+    const int size = columns[0]->size();
+    ColumnViewer<Type> viewer(columns[0]);
+    int64_t width = ColumnViewer<TYPE_INT>(columns[1]).value(0);
+
+    ColumnBuilder<TYPE_INT> builder(size);
+    for (int i = 0; i < size; i++) {
+        if (viewer.is_null(i)) {
+            builder.append_null();
+        } else {
+            auto val = viewer.value(i);
+            auto byte_array = int_to_byte_array(val);
+            int32_t hash;
+            murmur_hash3_x86_32(byte_array.data(), byte_array.size(), 0, &hash);
+            builder.append(static_cast<int32_t>((hash & INT_MAX) % width));
+        }
     }
-    return res;
+    return builder.build(ColumnHelper::is_all_const(columns));
 }
 
 template StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_decimal<TYPE_DECIMAL32>(FunctionContext*, const Columns&);

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -330,8 +330,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* con
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
     auto decimalv3_col = ColumnHelper::cast_to_raw<Type>(c0);
     const int32_t original_scale = decimalv3_col->scale();
@@ -347,24 +349,38 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_decimal(FunctionContext* con
 
     const RunTimeCppType<Type>* raw_c0 = decimalv3_col->get_data().data();
     MutableColumnPtr res = RunTimeColumnType<Type>::create(original_precision, original_scale);
-    res->resize_uninitialized(size);
-
-    // result column is mutable, use non-const raw pointer
-    RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
-    for (auto i = 0; i < size; i++) {
-        raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-    }
+    if (c0_is_const) {
+        res->resize_uninitialized(1);
+        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
+        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
 #define ABS(x) ((x) < 0 ? -(x) : (x))
-    for (int i = 0; i < size; i++) {
-        if (raw_null_flags[i] != 1 && ABS(raw_res[i]) >= max_val) {
+        if (raw_null_flags[0] != 1 && ABS(raw_res[0]) >= max_val) {
             std::stringstream error;
             error << "Truncate to decimal(" << original_precision << ", " << original_scale
                   << ") failed, because the result is overflow.";
             context->set_error(error.str().c_str());
             return Status::RuntimeError(error.str());
         }
-    }
 #undef ABS
+        res = ConstColumn::create(std::move(res), size);
+    } else {
+        res->resize_uninitialized(size);
+        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
+        for (auto i = 0; i < size; i++) {
+            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
+        }
+#define ABS(x) ((x) < 0 ? -(x) : (x))
+        for (int i = 0; i < size; i++) {
+            if (raw_null_flags[i] != 1 && ABS(raw_res[i]) >= max_val) {
+                std::stringstream error;
+                error << "Truncate to decimal(" << original_precision << ", " << original_scale
+                      << ") failed, because the result is overflow.";
+                context->set_error(error.str().c_str());
+                return Status::RuntimeError(error.str());
+            }
+        }
+#undef ABS
+    }
     if (has_null) {
         res = NullableColumn::create(std::move(res), std::move(null_flags));
     }
@@ -381,28 +397,42 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_truncate_int(FunctionContext* context
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
 
     const auto& raw_null_flags = null_flags->immutable_data();
     auto int_col = ColumnHelper::cast_to_raw<Type>(c0);
     const auto& raw_c0 = int_col->immutable_data();
     MutableColumnPtr res = RunTimeColumnType<Type>::create();
-    res->resize_uninitialized(size);
 
-    // result column is mutable, use non-const raw pointer
-    auto& raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data();
-    for (auto i = 0; i < size; i++) {
-        raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
-    }
 #define haveDifferentSigns(x, y) (((x) ^ (y)) < 0)
-    for (int i = 0; i < size; i++) {
-        if (raw_null_flags[i] != 1 && haveDifferentSigns(raw_res[i], raw_c0[i])) {
+    if (c0_is_const) {
+        res->resize_uninitialized(1);
+        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
+        raw_res[0] = raw_c0[0] - ((raw_c0[0] % width) + width) % width;
+        if (raw_null_flags[0] != 1 && haveDifferentSigns(raw_res[0], raw_c0[0])) {
             std::stringstream error;
             error << "Truncate to integer failed, because the result is overflow.";
             context->set_error(error.str().c_str());
             return Status::RuntimeError(error.str());
+        }
+        res = ConstColumn::create(std::move(res), size);
+    } else {
+        res->resize_uninitialized(size);
+        RunTimeCppType<Type>* raw_res = ColumnHelper::cast_to_raw<Type>(res.get())->get_data().data();
+        for (auto i = 0; i < size; i++) {
+            raw_res[i] = raw_c0[i] - ((raw_c0[i] % width) + width) % width;
+        }
+        for (int i = 0; i < size; i++) {
+            if (raw_null_flags[i] != 1 && haveDifferentSigns(raw_res[i], raw_c0[i])) {
+                std::stringstream error;
+                error << "Truncate to integer failed, because the result is overflow.";
+                context->set_error(error.str().c_str());
+                return Status::RuntimeError(error.str());
+            }
         }
     }
 #undef haveDifferentSigns
@@ -420,8 +450,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_int(FunctionContext* context, 
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<Type>(c0);
@@ -450,8 +482,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_string(FunctionContext* contex
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(c0);
@@ -476,8 +510,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_date(FunctionContext* context,
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_DATE>(c0);
@@ -504,8 +540,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_datetime(FunctionContext* cont
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
 
     auto col = ColumnHelper::cast_to_raw<TYPE_DATETIME>(c0);
@@ -558,8 +596,10 @@ StatusOr<ColumnPtr> MathFunctions::iceberg_bucket_decimal(FunctionContext* conte
     ColumnPtr c1 = columns[1];
     NullColumn::MutablePtr null_flags;
     bool has_null = false;
+    bool c0_is_const = false;
+    int num_rows = 0;
     PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC(c0, c1);
-    const int size = c0->size();
+    const int size = num_rows;
     int64_t width = c1->get(0).get_int32();
     auto decimalv3_col = ColumnHelper::cast_to_raw<Type>(c0);
 


### PR DESCRIPTION
## Why I'm doing:
fix some bug according to codex review:

> PREPARE_COLUMN_WITH_CONST_AND_NULL_FOR_ICEBERG_FUNC unwraps ConstColumn Via
get_data_column_of_const , So cO->size（） becomes 1 when the caller passes a const
column （typical for literals/constant-folded exprs）. Using const int size = c0->size（）；
after this macro can therefore produce a 1-row result and/or a size mismatch with
null_flags （which was sized using the original co->size（））， potentially leading to
incorrect results or crashes when const inputs occur. Consider capturing the original input
row count before unwrapping const, and if columns ［e］ is const, either broadcast the
computed value to that row count or return a ConstColumn with the original size （and
ensure the indexing uses row O for const inputs）
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
