### PR TITLE
[BugFix] Encode VARBINARY correctly inside nested types in MySQL result sets

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -919,7 +919,7 @@ void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, 
     T start = _offsets[idx];
     T len = _offsets[idx + 1] - start;
     const char* base = reinterpret_cast<const char*>(_data_base());
-    if (_is_varbinary) {
+    if (_is_binary_type) {
         buf->push_binary(base + start, len);
     } else {
         buf->push_string(base + start, len);

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -918,8 +918,12 @@ template <typename T>
 void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     T start = _offsets[idx];
     T len = _offsets[idx + 1] - start;
-    const uint8_t* base = _data_base();
-    buf->push_string(reinterpret_cast<const char*>(base + start), len);
+    const char* base = reinterpret_cast<const char*>(_data_base());
+    if (_is_varbinary) {
+        buf->push_binary(base + start, len);
+    } else {
+        buf->push_string(base + start, len);
+    }
 }
 
 template <typename T>

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -307,6 +307,12 @@ public:
 
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
+    // Mark this column as holding VARBINARY (rather than VARCHAR/CHAR) data.
+    // When set, put_mysql_row_buffer uses push_binary inside nested types so that
+    // raw bytes are encoded as hex/base64 instead of being emitted verbatim.
+    void set_is_varbinary(bool v) { _is_varbinary = v; }
+    bool is_varbinary_type() const { return _is_varbinary; }
+
     std::string get_name() const override {
         static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
         if (std::is_same_v<T, uint32_t>) {
@@ -426,6 +432,11 @@ private:
     mutable bool _slices_cache = false;
     mutable GermanStringContainer _german_strings;
     mutable bool _german_strings_cache = false;
+
+    // True when this column holds VARBINARY data.  Causes put_mysql_row_buffer to
+    // use push_binary (hex/base64 encoding) instead of push_string when inside a
+    // nested type context.
+    bool _is_varbinary = false;
 };
 
 using Offsets = BinaryColumnBase<uint32_t>::Offsets;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -307,11 +307,11 @@ public:
 
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
-    // Mark this column as holding VARBINARY (rather than VARCHAR/CHAR) data.
+    // Mark this column as holding BINARY / VARBINARY (rather than VARCHAR/CHAR) data.
     // When set, put_mysql_row_buffer uses push_binary inside nested types so that
     // raw bytes are encoded as hex/base64 instead of being emitted verbatim.
-    void set_is_varbinary(bool v) { _is_varbinary = v; }
-    bool is_varbinary_type() const { return _is_varbinary; }
+    void set_is_binary_type(bool v) { _is_binary_type = v; }
+    bool is_binary_type() const { return _is_binary_type; }
 
     std::string get_name() const override {
         static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
@@ -433,10 +433,10 @@ private:
     mutable GermanStringContainer _german_strings;
     mutable bool _german_strings_cache = false;
 
-    // True when this column holds VARBINARY data.  Causes put_mysql_row_buffer to
+    // True when this column holds BINARY / VARBINARY data.  Causes put_mysql_row_buffer to
     // use push_binary (hex/base64 encoding) instead of push_string when inside a
     // nested type context.
-    bool _is_varbinary = false;
+    bool _is_binary_type = false;
 };
 
 using Offsets = BinaryColumnBase<uint32_t>::Offsets;

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -118,7 +118,8 @@ void ColumnHelper::mark_binary_columns(const ColumnPtr& column, const TypeDescri
             binary_column->set_is_binary_type(true);
         } else {
             DCHECK(data_column->is_large_binary());
-            auto* large_binary_column = const_cast<LargeBinaryColumn*>(down_cast<const LargeBinaryColumn*>(data_column));
+            auto* large_binary_column =
+                    const_cast<LargeBinaryColumn*>(down_cast<const LargeBinaryColumn*>(data_column));
             large_binary_column->set_is_binary_type(true);
         }
         break;

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -107,6 +107,45 @@ void ColumnHelper::merge_filters(const Columns& columns, Filter* __restrict filt
     }
 }
 
+void ColumnHelper::mark_binary_columns(const ColumnPtr& column, const TypeDescriptor& type) {
+    const Column* data_column = get_data_column(column);
+
+    switch (type.type) {
+    case TYPE_BINARY:
+    case TYPE_VARBINARY: {
+        if (data_column->is_binary()) {
+            auto* binary_column = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_column));
+            binary_column->set_is_binary_type(true);
+        } else {
+            DCHECK(data_column->is_large_binary());
+            auto* large_binary_column = const_cast<LargeBinaryColumn*>(down_cast<const LargeBinaryColumn*>(data_column));
+            large_binary_column->set_is_binary_type(true);
+        }
+        break;
+    }
+    case TYPE_STRUCT: {
+        const auto* struct_column = down_cast<const StructColumn*>(data_column);
+        for (size_t i = 0; i < type.children.size(); ++i) {
+            mark_binary_columns(struct_column->get_column_by_idx(i), type.children[i]);
+        }
+        break;
+    }
+    case TYPE_ARRAY: {
+        const auto* array_column = down_cast<const ArrayColumn*>(data_column);
+        mark_binary_columns(array_column->elements_column(), type.children[0]);
+        break;
+    }
+    case TYPE_MAP: {
+        const auto* map_column = down_cast<const MapColumn*>(data_column);
+        mark_binary_columns(map_column->keys_column(), type.children[0]);
+        mark_binary_columns(map_column->values_column(), type.children[1]);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
 void ColumnHelper::merge_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected, bool* all_zero) {
     uint8_t* data = filter->data();
     size_t num_rows = filter->size();

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -614,6 +614,8 @@ public:
     }
     static const Column* get_data_column(const ColumnPtr& column) { return get_data_column(column.get()); }
 
+    static void mark_binary_columns(const ColumnPtr& column, const TypeDescriptor& type);
+
     static BinaryColumn* get_binary_column(Column* column) { return down_cast<BinaryColumn*>(get_data_column(column)); }
 
     static const BinaryColumn* get_binary_column(const Column* column) {

--- a/be/src/column/mysql_row_buffer.cpp
+++ b/be/src/column/mysql_row_buffer.cpp
@@ -339,29 +339,21 @@ char* MysqlRowBuffer::_escape(char* dst, const char* src, size_t length, char es
 }
 
 void MysqlRowBuffer::push_binary(const char* data, size_t length) {
-    if (_nesting_level == 0) {
-        // Top-level: length-prefixed raw bytes, identical to the current VARBINARY behavior.
-        _push_string_normal(data, length);
-        return;
-    }
-
-    // Inside a nested type (ARRAY / MAP / STRUCT): encode to a printable string
-    // and wrap in double-quotes so the JSON-like output stays valid.
+    const bool should_encode =
+            (_options.binary_encoding_level == MysqlRowBufferOptions::BinaryEncodingLevel::ALL) || (_nesting_level > 0);
     std::string encoded;
-    if (_options.nested_binary_format == MysqlRowBufferOptions::NestedBinaryFormat::BASE64) {
-        strings::Base64Escape(reinterpret_cast<const unsigned char*>(data), static_cast<int>(length), &encoded, true);
-    } else {
-        // Default: HEX
-        encoded = strings::b2a_hex(data, static_cast<int>(length));
+    if (should_encode && _options.binary_encoding_format != MysqlRowBufferOptions::BinaryEncodingFormat::RAW) {
+        if (_options.binary_encoding_format == MysqlRowBufferOptions::BinaryEncodingFormat::BASE64) {
+            strings::Base64Escape(reinterpret_cast<const unsigned char*>(data), static_cast<int>(length), &encoded,
+                                  true);
+        } else {
+            DCHECK(_options.binary_encoding_format == MysqlRowBufferOptions::BinaryEncodingFormat::HEX);
+            encoded = strings::b2a_hex(data, static_cast<int>(length));
+        }
+        data = encoded.data();
+        length = encoded.size();
     }
-
-    char* pos = _resize_extra(encoded.size() + 2);
-    *pos++ = '"';
-    strings::memcpy_inlined(pos, encoded.data(), encoded.size());
-    pos += encoded.size();
-    *pos++ = '"';
-    DCHECK_EQ(_data.data() + _data.size(), pos);
-    _data.resize(pos - _data.data());
+    push_string(data, length);
 }
 
 void MysqlRowBuffer::_push_string_normal(const char* str, size_t length) {

--- a/be/src/column/mysql_row_buffer.cpp
+++ b/be/src/column/mysql_row_buffer.cpp
@@ -46,6 +46,7 @@
 #include "base/url_coding.h"
 #include "base/utility/mysql_global.h"
 #include "common/logging.h"
+#include "exprs/base64.h"
 #include "gutil/strings/escaping.h"
 #include "gutil/strings/fastmem.h"
 
@@ -349,7 +350,10 @@ void MysqlRowBuffer::push_binary(const char* data, size_t length) {
     // and wrap in double-quotes so the JSON-like output stays valid.
     std::string encoded;
     if (_options.nested_binary_format == MysqlRowBufferOptions::NestedBinaryFormat::BASE64) {
-        base64_encode(std::string(data, length), &encoded);
+        encoded.resize(((length + 2) / 3) * 4);
+        const auto encoded_len = base64_encode2(reinterpret_cast<const unsigned char*>(data), length,
+                                                reinterpret_cast<unsigned char*>(encoded.data()));
+        encoded.resize(encoded_len);
     } else {
         // Default: HEX
         encoded = strings::b2a_hex(data, static_cast<int>(length));

--- a/be/src/column/mysql_row_buffer.cpp
+++ b/be/src/column/mysql_row_buffer.cpp
@@ -43,8 +43,10 @@
 
 #include "base/types/int128.h"
 #include "base/types/int256.h"
+#include "base/url_coding.h"
 #include "base/utility/mysql_global.h"
 #include "common/logging.h"
+#include "gutil/strings/escaping.h"
 #include "gutil/strings/fastmem.h"
 
 namespace starrocks {
@@ -90,7 +92,7 @@ void MysqlRowBuffer::push_null(bool is_binary_protocol) {
         return;
     }
 
-    if (_array_level == 0) {
+    if (_nesting_level == 0) {
         _data.push_back(0xfb);
     } else {
         // lowercase 'null' is more convenient for JSON parsing
@@ -146,7 +148,7 @@ void MysqlRowBuffer::push_number(T data, bool is_binary_protocol) {
     int length = 0;
     char* end = nullptr;
     char* pos = nullptr;
-    const int length_prefix_bytes = _array_level == 0 ? 1 : 0;
+    const int length_prefix_bytes = _nesting_level == 0 ? 1 : 0;
     if constexpr (std::is_same_v<T, float>) {
         // 1 for length, 1 for sign, other for digits.
         pos = _resize_extra(2 + MAX_FLOAT_STR_LENGTH);
@@ -191,7 +193,7 @@ void MysqlRowBuffer::push_number(T data, bool is_binary_protocol) {
 }
 
 void MysqlRowBuffer::push_string(const char* str, size_t length, char escape_char) {
-    if (_array_level == 0) {
+    if (_nesting_level == 0) {
         _push_string_normal(str, length);
     } else {
         // Surround the string with two double-quotas.
@@ -213,7 +215,7 @@ void MysqlRowBuffer::push_string(const char* str, size_t length, char escape_cha
 }
 
 void MysqlRowBuffer::push_decimal(const Slice& s) {
-    if (_array_level == 0) {
+    if (_nesting_level == 0) {
         _push_string_normal(s.data, s.size);
     } else {
         char* pos = _resize_extra(s.size);
@@ -272,7 +274,7 @@ void MysqlRowBuffer::push_timestamp(const TimestampValue& data, bool is_binary_p
 }
 
 void MysqlRowBuffer::_enter_scope(char c) {
-    if (++_array_level == 1) {
+    if (++_nesting_level == 1) {
         // Leave one space for storing the string length.
         _data.push_back(0x00);
         _array_offset = _data.size();
@@ -281,9 +283,9 @@ void MysqlRowBuffer::_enter_scope(char c) {
 }
 
 void MysqlRowBuffer::_leave_scope(char c) {
-    DCHECK_GT(_array_level, 0);
+    DCHECK_GT(_nesting_level, 0);
     _data.push_back(c);
-    if (--_array_level == 0) {
+    if (--_nesting_level == 0) {
         uint64_t curr_scope_len = _data.size() - _array_offset;
         if (curr_scope_len < 251) {
             int1store(&_data[_array_offset - 1], curr_scope_len);
@@ -307,7 +309,7 @@ void MysqlRowBuffer::_leave_scope(char c) {
 }
 
 void MysqlRowBuffer::separator(char c) {
-    DCHECK_GT(_array_level, 0);
+    DCHECK_GT(_nesting_level, 0);
     _data.push_back(c);
 }
 
@@ -334,6 +336,32 @@ char* MysqlRowBuffer::_escape(char* dst, const char* src, size_t length, char es
         }
     }
     return dst;
+}
+
+void MysqlRowBuffer::push_binary(const char* data, size_t length) {
+    if (_nesting_level == 0) {
+        // Top-level: length-prefixed raw bytes, identical to the current VARBINARY behavior.
+        _push_string_normal(data, length);
+        return;
+    }
+
+    // Inside a nested type (ARRAY / MAP / STRUCT): encode to a printable string
+    // and wrap in double-quotes so the JSON-like output stays valid.
+    std::string encoded;
+    if (_options.nested_binary_format == MysqlRowBufferOptions::NestedBinaryFormat::BASE64) {
+        base64_encode(std::string(data, length), &encoded);
+    } else {
+        // Default: HEX
+        encoded = strings::b2a_hex(data, static_cast<int>(length));
+    }
+
+    char* pos = _resize_extra(encoded.size() + 2);
+    *pos++ = '"';
+    strings::memcpy_inlined(pos, encoded.data(), encoded.size());
+    pos += encoded.size();
+    *pos++ = '"';
+    DCHECK_EQ(_data.data() + _data.size(), pos);
+    _data.resize(pos - _data.data());
 }
 
 void MysqlRowBuffer::_push_string_normal(const char* str, size_t length) {

--- a/be/src/column/mysql_row_buffer.cpp
+++ b/be/src/column/mysql_row_buffer.cpp
@@ -46,7 +46,6 @@
 #include "base/url_coding.h"
 #include "base/utility/mysql_global.h"
 #include "common/logging.h"
-#include "exprs/base64.h"
 #include "gutil/strings/escaping.h"
 #include "gutil/strings/fastmem.h"
 
@@ -350,10 +349,7 @@ void MysqlRowBuffer::push_binary(const char* data, size_t length) {
     // and wrap in double-quotes so the JSON-like output stays valid.
     std::string encoded;
     if (_options.nested_binary_format == MysqlRowBufferOptions::NestedBinaryFormat::BASE64) {
-        encoded.resize(((length + 2) / 3) * 4);
-        const auto encoded_len = base64_encode2(reinterpret_cast<const unsigned char*>(data), length,
-                                                reinterpret_cast<unsigned char*>(encoded.data()));
-        encoded.resize(encoded_len);
+        strings::Base64Escape(reinterpret_cast<const unsigned char*>(data), static_cast<int>(length), &encoded, true);
     } else {
         // Default: HEX
         encoded = strings::b2a_hex(data, static_cast<int>(length));

--- a/be/src/column/mysql_row_buffer.h
+++ b/be/src/column/mysql_row_buffer.h
@@ -43,15 +43,21 @@
 namespace starrocks {
 
 // Options controlling how MysqlRowBuffer serializes certain types.
-// Currently only affects how binary data is encoded when it appears inside
-// a nested type (ARRAY / MAP / STRUCT).
+// Currently only affects how BINARY / VARBINARY data is serialized.
 struct MysqlRowBufferOptions {
-    enum class NestedBinaryFormat {
+    enum class BinaryEncodingFormat {
+        RAW,    // do not encode; preserve the original bytes
         HEX,    // encode as lowercase hex string, e.g. "48656c6c6f"  (default)
         BASE64, // encode as standard base64 string, e.g. "SGVsbG8="
     };
 
-    NestedBinaryFormat nested_binary_format = NestedBinaryFormat::HEX;
+    enum class BinaryEncodingLevel {
+        ALL,
+        NESTED,
+    };
+
+    BinaryEncodingFormat binary_encoding_format = BinaryEncodingFormat::HEX;
+    BinaryEncodingLevel binary_encoding_level = BinaryEncodingLevel::NESTED;
 };
 
 // Reference:
@@ -81,10 +87,10 @@ public:
     void push_string(const char* str, size_t length, char escape_char = '"');
     void push_string(const Slice& s) { push_string(s.data, s.size); }
 
-    // Serialize raw binary data (VARBINARY).
-    // - At top level (_nesting_level == 0): length-prefixed raw bytes, same as push_string.
-    // - Inside a nested type (_nesting_level > 0): encodes the bytes according to
-    //   options().nested_binary_format (hex or base64) and wraps in double-quotes.
+    // Serialize raw binary data (BINARY / VARBINARY). Encoding behavior depends on options():
+    // - level = nested: encode only inside nested types.
+    // - level = all: encode both top-level and nested binary values.
+    // - format = raw: preserve the original bytes and do not hex/base64 encode.
     void push_binary(const char* data, size_t length);
 
     template <typename T>

--- a/be/src/column/mysql_row_buffer.h
+++ b/be/src/column/mysql_row_buffer.h
@@ -43,11 +43,11 @@
 namespace starrocks {
 
 // Options controlling how MysqlRowBuffer serializes certain types.
-// Currently only affects how binary data (VARBINARY) is encoded when it
-// appears inside a nested type (ARRAY / MAP / STRUCT).
+// Currently only affects how binary data is encoded when it appears inside
+// a nested type (ARRAY / MAP / STRUCT).
 struct MysqlRowBufferOptions {
     enum class NestedBinaryFormat {
-        HEX,    // encode as uppercase hex string, e.g. "48656C6C6F"  (default)
+        HEX,    // encode as lowercase hex string, e.g. "48656c6c6f"  (default)
         BASE64, // encode as standard base64 string, e.g. "SGVsbG8="
     };
 

--- a/be/src/column/mysql_row_buffer.h
+++ b/be/src/column/mysql_row_buffer.h
@@ -42,12 +42,28 @@
 
 namespace starrocks {
 
+// Options controlling how MysqlRowBuffer serializes certain types.
+// Currently only affects how binary data (VARBINARY) is encoded when it
+// appears inside a nested type (ARRAY / MAP / STRUCT).
+struct MysqlRowBufferOptions {
+    enum class NestedBinaryFormat {
+        HEX,    // encode as uppercase hex string, e.g. "48656C6C6F"  (default)
+        BASE64, // encode as standard base64 string, e.g. "SGVsbG8="
+    };
+
+    NestedBinaryFormat nested_binary_format = NestedBinaryFormat::HEX;
+};
+
 // Reference:
 //   https://dev.mysql.com/doc/internals/en/com-query-response.html#text-resultset-row
 class MysqlRowBuffer final {
 public:
     MysqlRowBuffer() = default;
-    MysqlRowBuffer(bool is_binary_format) : _is_binary_format(is_binary_format){};
+    MysqlRowBuffer(bool is_binary_format) : _is_binary_format(is_binary_format) {}
+    MysqlRowBuffer(bool is_binary_format, MysqlRowBufferOptions options)
+            : _is_binary_format(is_binary_format), _options(options) {}
+
+    const MysqlRowBufferOptions& options() const { return _options; }
     ~MysqlRowBuffer() = default;
 
     void reset() { _data.clear(); }
@@ -64,6 +80,12 @@ public:
     void push_double(double data) { push_number(data); }
     void push_string(const char* str, size_t length, char escape_char = '"');
     void push_string(const Slice& s) { push_string(s.data, s.size); }
+
+    // Serialize raw binary data (VARBINARY).
+    // - At top level (_nesting_level == 0): length-prefixed raw bytes, same as push_string.
+    // - Inside a nested type (_nesting_level > 0): encodes the bytes according to
+    //   options().nested_binary_format (hex or base64) and wraps in double-quotes.
+    void push_binary(const char* data, size_t length);
 
     template <typename T>
     void push_number(T data, bool is_binary_protocol = false);
@@ -112,12 +134,15 @@ private:
     void _push_string_normal(const char* str, size_t lenght);
 
     raw::RawString _data;
-    uint32_t _array_level = 0;
+    // Tracks how many nested scopes (ARRAY / MAP / STRUCT) are currently open.
+    // 0 means top-level; > 0 means inside at least one nested type.
+    uint32_t _nesting_level = 0;
     uint32_t _array_offset = 0;
 
     bool _is_binary_format = false;
     // used for calculate null position if is_binary_format = true
     uint32_t _field_pos = 0;
+    MysqlRowBufferOptions _options;
 };
 
 } // namespace starrocks

--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -79,6 +79,7 @@ public:
             column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                              ? ColumnHelper::convert_time_column_from_double_to_str(column)
                              : column;
+            ColumnHelper::mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
             result_columns.emplace_back(std::move(column));
         }
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -59,21 +59,19 @@ namespace starrocks {
 // to a BINARY / VARBINARY field so that put_mysql_row_buffer can encode its bytes
 // correctly when the column is serialised inside a nested type.
 static void mark_binary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
-    // Unwrap ConstColumn and NullableColumn to reach the actual data column.
-    const Column* data_col = col.get();
-    if (data_col->is_constant()) {
-        data_col = down_cast<const ConstColumn*>(data_col)->data_column().get();
-    }
-    if (data_col->is_nullable()) {
-        data_col = down_cast<const NullableColumn*>(data_col)->data_column().get();
-    }
+    const Column* data_col = ColumnHelper::get_data_column(col);
 
     switch (type.type) {
     case TYPE_BINARY:
     case TYPE_VARBINARY: {
-        // Both BINARY and VARBINARY use BinaryColumn as their underlying storage.
-        auto* bin = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_col));
-        bin->set_is_binary_type(true);
+        if (data_col->is_binary()) {
+            auto* bin = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_col));
+            bin->set_is_binary_type(true);
+        } else {
+            DCHECK(data_col->is_large_binary());
+            auto* large_bin = const_cast<LargeBinaryColumn*>(down_cast<const LargeBinaryColumn*>(data_col));
+            large_bin->set_is_binary_type(true);
+        }
         break;
     }
     case TYPE_STRUCT: {

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -36,9 +36,14 @@
 
 #include <column/column_helper.h>
 
+#include "column/array_column.h"
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/const_column.h"
+#include "column/map_column.h"
 #include "column/mysql_row_buffer.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -46,8 +51,49 @@
 #include "runtime/buffer_control_result_writer.h"
 #include "runtime/current_thread.h"
 #include "types/logical_type.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
+
+// Recursively walk a column tree and mark every BinaryColumn that corresponds
+// to a VARBINARY field so that put_mysql_row_buffer can encode its bytes
+// correctly when the column is serialised inside a nested type.
+static void mark_varbinary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
+    // Unwrap NullableColumn to reach the data column.
+    const Column* data_col = col.get();
+    if (data_col->is_nullable()) {
+        data_col = down_cast<const NullableColumn*>(data_col)->data_column().get();
+    }
+
+    switch (type.type) {
+    case TYPE_VARBINARY: {
+        // The underlying storage is always BinaryColumn for VARBINARY.
+        auto* bin = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_col));
+        bin->set_is_varbinary(true);
+        break;
+    }
+    case TYPE_STRUCT: {
+        const auto* struct_col = down_cast<const StructColumn*>(data_col);
+        for (size_t i = 0; i < type.children.size(); ++i) {
+            mark_varbinary_columns(struct_col->get_column_by_idx(i), type.children[i]);
+        }
+        break;
+    }
+    case TYPE_ARRAY: {
+        const auto* arr_col = down_cast<const ArrayColumn*>(data_col);
+        mark_varbinary_columns(arr_col->elements_column(), type.children[0]);
+        break;
+    }
+    case TYPE_MAP: {
+        const auto* map_col = down_cast<const MapColumn*>(data_col);
+        mark_varbinary_columns(map_col->keys_column(), type.children[0]);
+        mark_varbinary_columns(map_col->values_column(), type.children[1]);
+        break;
+    }
+    default:
+        break;
+    }
+}
 
 MysqlResultWriter::MysqlResultWriter(BufferControlBlock* sinker, const std::vector<ExprContext*>& output_expr_ctxs,
                                      bool is_binary_format, RuntimeProfile* parent_profile)
@@ -119,6 +165,9 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                          ? ColumnHelper::convert_time_column_from_double_to_str(column)
                          : column;
+        // Mark BinaryColumns that carry VARBINARY data so that push_binary is
+        // used when they appear inside nested types (ARRAY / MAP / STRUCT).
+        mark_varbinary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 
@@ -161,6 +210,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                          ? ColumnHelper::convert_time_column_from_double_to_str(column)
                          : column;
+        mark_varbinary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -36,14 +36,8 @@
 
 #include <column/column_helper.h>
 
-#include "column/array_column.h"
-#include "column/binary_column.h"
 #include "column/chunk.h"
-#include "column/const_column.h"
-#include "column/map_column.h"
 #include "column/mysql_row_buffer.h"
-#include "column/nullable_column.h"
-#include "column/struct_column.h"
 #include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -54,48 +48,6 @@
 #include "types/type_descriptor.h"
 
 namespace starrocks {
-
-// Recursively walk a column tree and mark every BinaryColumn that corresponds
-// to a BINARY / VARBINARY field so that put_mysql_row_buffer can encode its bytes
-// correctly when the column is serialised inside a nested type.
-static void mark_binary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
-    const Column* data_col = ColumnHelper::get_data_column(col);
-
-    switch (type.type) {
-    case TYPE_BINARY:
-    case TYPE_VARBINARY: {
-        if (data_col->is_binary()) {
-            auto* bin = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_col));
-            bin->set_is_binary_type(true);
-        } else {
-            DCHECK(data_col->is_large_binary());
-            auto* large_bin = const_cast<LargeBinaryColumn*>(down_cast<const LargeBinaryColumn*>(data_col));
-            large_bin->set_is_binary_type(true);
-        }
-        break;
-    }
-    case TYPE_STRUCT: {
-        const auto* struct_col = down_cast<const StructColumn*>(data_col);
-        for (size_t i = 0; i < type.children.size(); ++i) {
-            mark_binary_columns(struct_col->get_column_by_idx(i), type.children[i]);
-        }
-        break;
-    }
-    case TYPE_ARRAY: {
-        const auto* arr_col = down_cast<const ArrayColumn*>(data_col);
-        mark_binary_columns(arr_col->elements_column(), type.children[0]);
-        break;
-    }
-    case TYPE_MAP: {
-        const auto* map_col = down_cast<const MapColumn*>(data_col);
-        mark_binary_columns(map_col->keys_column(), type.children[0]);
-        mark_binary_columns(map_col->values_column(), type.children[1]);
-        break;
-    }
-    default:
-        break;
-    }
-}
 
 MysqlResultWriter::MysqlResultWriter(BufferControlBlock* sinker, const std::vector<ExprContext*>& output_expr_ctxs,
                                      bool is_binary_format, RuntimeProfile* parent_profile)
@@ -169,7 +121,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                          : column;
         // Mark BinaryColumns that carry VARBINARY data so that push_binary is
         // used when they appear inside nested types (ARRAY / MAP / STRUCT).
-        mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
+        ColumnHelper::mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 
@@ -212,7 +164,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                          ? ColumnHelper::convert_time_column_from_double_to_str(column)
                          : column;
-        mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
+        ColumnHelper::mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -56,9 +56,9 @@
 namespace starrocks {
 
 // Recursively walk a column tree and mark every BinaryColumn that corresponds
-// to a VARBINARY field so that put_mysql_row_buffer can encode its bytes
+// to a BINARY / VARBINARY field so that put_mysql_row_buffer can encode its bytes
 // correctly when the column is serialised inside a nested type.
-static void mark_varbinary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
+static void mark_binary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
     // Unwrap ConstColumn and NullableColumn to reach the actual data column.
     const Column* data_col = col.get();
     if (data_col->is_constant()) {
@@ -69,28 +69,29 @@ static void mark_varbinary_columns(const ColumnPtr& col, const TypeDescriptor& t
     }
 
     switch (type.type) {
+    case TYPE_BINARY:
     case TYPE_VARBINARY: {
-        // The underlying storage is always BinaryColumn for VARBINARY.
+        // Both BINARY and VARBINARY use BinaryColumn as their underlying storage.
         auto* bin = const_cast<BinaryColumn*>(down_cast<const BinaryColumn*>(data_col));
-        bin->set_is_varbinary(true);
+        bin->set_is_binary_type(true);
         break;
     }
     case TYPE_STRUCT: {
         const auto* struct_col = down_cast<const StructColumn*>(data_col);
         for (size_t i = 0; i < type.children.size(); ++i) {
-            mark_varbinary_columns(struct_col->get_column_by_idx(i), type.children[i]);
+            mark_binary_columns(struct_col->get_column_by_idx(i), type.children[i]);
         }
         break;
     }
     case TYPE_ARRAY: {
         const auto* arr_col = down_cast<const ArrayColumn*>(data_col);
-        mark_varbinary_columns(arr_col->elements_column(), type.children[0]);
+        mark_binary_columns(arr_col->elements_column(), type.children[0]);
         break;
     }
     case TYPE_MAP: {
         const auto* map_col = down_cast<const MapColumn*>(data_col);
-        mark_varbinary_columns(map_col->keys_column(), type.children[0]);
-        mark_varbinary_columns(map_col->values_column(), type.children[1]);
+        mark_binary_columns(map_col->keys_column(), type.children[0]);
+        mark_binary_columns(map_col->values_column(), type.children[1]);
         break;
     }
     default:
@@ -170,7 +171,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                          : column;
         // Mark BinaryColumns that carry VARBINARY data so that push_binary is
         // used when they appear inside nested types (ARRAY / MAP / STRUCT).
-        mark_varbinary_columns(column, _output_expr_ctxs[i]->root()->type());
+        mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 
@@ -213,7 +214,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
         column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
                          ? ColumnHelper::convert_time_column_from_double_to_str(column)
                          : column;
-        mark_varbinary_columns(column, _output_expr_ctxs[i]->root()->type());
+        mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
         result_columns.emplace_back(std::move(column));
     }
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -59,8 +59,11 @@ namespace starrocks {
 // to a VARBINARY field so that put_mysql_row_buffer can encode its bytes
 // correctly when the column is serialised inside a nested type.
 static void mark_varbinary_columns(const ColumnPtr& col, const TypeDescriptor& type) {
-    // Unwrap NullableColumn to reach the data column.
+    // Unwrap ConstColumn and NullableColumn to reach the actual data column.
     const Column* data_col = col.get();
+    if (data_col->is_constant()) {
+        data_col = down_cast<const ConstColumn*>(data_col)->data_column().get();
+    }
     if (data_col->is_nullable()) {
         data_col = down_cast<const NullableColumn*>(data_col)->data_column().get();
     }

--- a/test/sql/test_binary_type/R/test_binary_in_nested
+++ b/test/sql/test_binary_type/R/test_binary_in_nested
@@ -1,0 +1,97 @@
+-- name: test_binary_in_nested
+-- Verify that BINARY / VARBINARY data inside nested types (STRUCT / ARRAY / MAP)
+-- is serialised as a hex-encoded string rather than raw bytes in the MySQL
+-- result set, which keeps the JSON-like output well-formed.
+
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+
+-- -----------------------------------------------------------------------
+-- STRUCT with BINARY and VARBINARY fields.
+-- Both should appear as lowercase hex; STRING field stays as plain text.
+-- -----------------------------------------------------------------------
+create table t_struct_binary (
+    id      int,
+    payload struct<bin_field varbinary, str_field varchar(64)>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+
+insert into t_struct_binary
+select 1, named_struct('bin_field', unhex('DEADBEEF'), 'str_field', 'hello')
+union all
+select 2, named_struct('bin_field', unhex('CAFE'),     'str_field', 'world')
+union all
+select 3, named_struct('bin_field', null,              'str_field', 'null_bin');
+-- result:
+-- !result
+
+select id, payload from t_struct_binary order by id;
+-- result:
+1	{"bin_field":"deadbeef","str_field":"hello"}
+2	{"bin_field":"cafe","str_field":"world"}
+3	{"bin_field":null,"str_field":"null_bin"}
+-- !result
+
+-- -----------------------------------------------------------------------
+-- ARRAY<VARBINARY>: each element should appear as lowercase hex.
+-- -----------------------------------------------------------------------
+create table t_array_binary (
+    id   int,
+    bins array<varbinary>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+
+insert into t_array_binary values
+    (1, [unhex('AABB'), unhex('CCDD')]),
+    (2, [unhex('00'), null]),
+    (3, null);
+-- result:
+-- !result
+
+select id, bins from t_array_binary order by id;
+-- result:
+1	["aabb","ccdd"]
+2	["00",null]
+3	None
+-- !result
+
+-- -----------------------------------------------------------------------
+-- MAP<VARCHAR, VARBINARY>: values should appear as lowercase hex.
+-- -----------------------------------------------------------------------
+create table t_map_binary (
+    id int,
+    kv map<varchar(32), varbinary>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+
+insert into t_map_binary values
+    (1, map{'k1': unhex('CAFE'), 'k2': unhex('BABE')}),
+    (2, map{'only': null});
+-- result:
+-- !result
+
+select id, kv from t_map_binary order by id;
+-- result:
+1	{"k1":"cafe","k2":"babe"}
+2	{"only":null}
+-- !result
+
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_binary_type/R/test_binary_in_nested
+++ b/test/sql/test_binary_type/R/test_binary_in_nested
@@ -93,21 +93,22 @@ select id, kv from t_map_binary order by id;
 -- !result
 
 -- -----------------------------------------------------------------------
--- Constant nested literals should also be encoded correctly. Expr evaluation
--- returns ConstColumn for these cases, so they cover the unwrap path in
--- mark_binary_columns().
+-- Constant nested literals should also be encoded correctly.
+-- Use TO_BINARY(..., 'hex') here so the test stays scoped to VARBINARY output
+-- without changing UNHEX() semantics in this PR.
 -- -----------------------------------------------------------------------
-select [unhex('AABB'), null];
+select [to_binary('AABB', 'hex'), null];
 -- result:
 ["aabb",null]
 -- !result
 
-select named_struct('bin_field', unhex('DEADBEEF'), 'arr_field', [unhex('00'), unhex('01')]);
+select named_struct('bin_field', to_binary('DEADBEEF', 'hex'), 'arr_field',
+                    [to_binary('00', 'hex'), to_binary('01', 'hex')]);
 -- result:
 {"bin_field":"deadbeef","arr_field":["00","01"]}
 -- !result
 
-select map{'k1': unhex('CAFE'), 'k2': null};
+select map{'k1': to_binary('CAFE', 'hex'), 'k2': null};
 -- result:
 {"k1":"cafe","k2":null}
 -- !result

--- a/test/sql/test_binary_type/R/test_binary_in_nested
+++ b/test/sql/test_binary_type/R/test_binary_in_nested
@@ -92,6 +92,26 @@ select id, kv from t_map_binary order by id;
 2	{"only":null}
 -- !result
 
+-- -----------------------------------------------------------------------
+-- Constant nested literals should also be encoded correctly. Expr evaluation
+-- returns ConstColumn for these cases, so they cover the unwrap path in
+-- mark_binary_columns().
+-- -----------------------------------------------------------------------
+select [unhex('AABB'), null];
+-- result:
+["aabb",null]
+-- !result
+
+select named_struct('bin_field', unhex('DEADBEEF'), 'arr_field', [unhex('00'), unhex('01')]);
+-- result:
+{"bin_field":"deadbeef","arr_field":["00","01"]}
+-- !result
+
+select map{'k1': unhex('CAFE'), 'k2': null};
+-- result:
+{"k1":"cafe","k2":null}
+-- !result
+
 drop database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_binary_type/T/test_binary_in_nested
+++ b/test/sql/test_binary_type/T/test_binary_in_nested
@@ -1,0 +1,65 @@
+-- name: test_binary_in_nested
+-- Verify that BINARY / VARBINARY data inside nested types (STRUCT / ARRAY / MAP)
+-- is serialised as a hex-encoded string rather than raw bytes in the MySQL
+-- result set, which keeps the JSON-like output well-formed.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- -----------------------------------------------------------------------
+-- STRUCT with BINARY and VARBINARY fields.
+-- Both should appear as lowercase hex; STRING field stays as plain text.
+-- -----------------------------------------------------------------------
+create table t_struct_binary (
+    id      int,
+    payload struct<bin_field varbinary, str_field varchar(64)>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+
+insert into t_struct_binary
+select 1, named_struct('bin_field', unhex('DEADBEEF'), 'str_field', 'hello')
+union all
+select 2, named_struct('bin_field', unhex('CAFE'),     'str_field', 'world')
+union all
+select 3, named_struct('bin_field', null,              'str_field', 'null_bin');
+
+select id, payload from t_struct_binary order by id;
+
+-- -----------------------------------------------------------------------
+-- ARRAY<VARBINARY>: each element should appear as lowercase hex.
+-- -----------------------------------------------------------------------
+create table t_array_binary (
+    id   int,
+    bins array<varbinary>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+
+insert into t_array_binary values
+    (1, [unhex('AABB'), unhex('CCDD')]),
+    (2, [unhex('00'), null]),
+    (3, null);
+
+select id, bins from t_array_binary order by id;
+
+-- -----------------------------------------------------------------------
+-- MAP<VARCHAR, VARBINARY>: values should appear as lowercase hex.
+-- -----------------------------------------------------------------------
+create table t_map_binary (
+    id int,
+    kv map<varchar(32), varbinary>
+) duplicate key(id)
+distributed by hash(id)
+buckets 1
+properties('replication_num'='1');
+
+insert into t_map_binary values
+    (1, map{'k1': unhex('CAFE'), 'k2': unhex('BABE')}),
+    (2, map{'only': null});
+
+select id, kv from t_map_binary order by id;
+
+drop database db_${uuid0};

--- a/test/sql/test_binary_type/T/test_binary_in_nested
+++ b/test/sql/test_binary_type/T/test_binary_in_nested
@@ -62,4 +62,15 @@ insert into t_map_binary values
 
 select id, kv from t_map_binary order by id;
 
+-- -----------------------------------------------------------------------
+-- Constant nested literals should also be encoded correctly. Expr evaluation
+-- returns ConstColumn for these cases, so they cover the unwrap path in
+-- mark_binary_columns().
+-- -----------------------------------------------------------------------
+select [unhex('AABB'), null];
+
+select named_struct('bin_field', unhex('DEADBEEF'), 'arr_field', [unhex('00'), unhex('01')]);
+
+select map{'k1': unhex('CAFE'), 'k2': null};
+
 drop database db_${uuid0};

--- a/test/sql/test_binary_type/T/test_binary_in_nested
+++ b/test/sql/test_binary_type/T/test_binary_in_nested
@@ -63,14 +63,15 @@ insert into t_map_binary values
 select id, kv from t_map_binary order by id;
 
 -- -----------------------------------------------------------------------
--- Constant nested literals should also be encoded correctly. Expr evaluation
--- returns ConstColumn for these cases, so they cover the unwrap path in
--- mark_binary_columns().
+-- Constant nested literals should also be encoded correctly.
+-- Use TO_BINARY(..., 'hex') here so the test stays scoped to VARBINARY output
+-- without changing UNHEX() semantics in this PR.
 -- -----------------------------------------------------------------------
-select [unhex('AABB'), null];
+select [to_binary('AABB', 'hex'), null];
 
-select named_struct('bin_field', unhex('DEADBEEF'), 'arr_field', [unhex('00'), unhex('01')]);
+select named_struct('bin_field', to_binary('DEADBEEF', 'hex'), 'arr_field',
+                    [to_binary('00', 'hex'), to_binary('01', 'hex')]);
 
-select map{'k1': unhex('CAFE'), 'k2': null};
+select map{'k1': to_binary('CAFE', 'hex'), 'k2': null};
 
 drop database db_${uuid0};


### PR DESCRIPTION
### Why

When `BINARY` / `VARBINARY` data appears inside nested values such as `ARRAY`, `MAP`, or `STRUCT`, the MySQL result path emits raw bytes directly. That breaks the JSON-like text output when the payload contains null bytes or other non-printable characters.

There is also a gap in the current BE implementation: binary marking only happens in the regular MySQL result writer path, and it does not correctly unwrap constant / nullable wrappers before checking the underlying binary column.

### What

- Add `MysqlRowBufferOptions` to describe binary serialization behavior in `MysqlRowBuffer`.  The current BE default is:
  - `binary_encoding_format = HEX`
  - `binary_encoding_level = NESTED`
- Add `push_binary()` to `MysqlRowBuffer`.  When a binary value is inside a nested scope, it is encoded as a printable string before being  serialized into the JSON-like output. Top-level binary behavior remains unchanged in this PR.
- Rename `_array_level` to `_nesting_level` to reflect that it tracks generic nested depth, not  only arrays.

### Follow-up

This PR keeps the behavior BE-only and uses the default nested `HEX` encoding internally.

A follow-up PR can expose FE session variables to control the encoding format / level, for example:
- `binary_encoding_format`
- `binary_encoding_level`

### Behaviour

```
CREATE TABLE binary_struct_demo (
  id BIGINT,
  payload STRUCT<
    linkId: STRUCT<
      value: BINARY
    >,
    linkId2: STRUCT<
      value: STRING
    >,
    s: STRING
  >
)
USING iceberg;

INSERT INTO binary_struct_demo
SELECT
  1,
  named_struct(
    'linkId', named_struct('value', unhex('2EA7856E70DE45418D2C30B469B57FBF')),
    'linkId2', named_struct('value', unhex('2EA7856E70DE45418D2C30B469B57FBF')),
    's', 'hello'
  );

mysql> select payload.linkId from binary_struct_demo;
+----------------------------------------------+
| linkId                                       |
+----------------------------------------------+
| {"value":"2ea7856e70de45418d2c30b469b57fbf"} |
+----------------------------------------------+
```

Issues: https://github.com/StarRocks/starrocks/issues/71347

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
