### PR TITLE
[BugFix] Avoid one-way split sink for null-skew left join rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
@@ -208,11 +208,11 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     generateSplitProducerAndConsumer(leftChild, leftInputJoinKeyExpr, nonNullSkewValues,
                             includeNullSkew, skewOnLeft);
 
-            SplitProducerAndConsumer rightSplit;
-            if (nullOnlyLeftOuterJoinFastPath) {
-                // NULL-only skew: right side does not participate in the skew branch at all.
-                rightSplit = buildSplit(rightChild, ConstantOperator.FALSE, ConstantOperator.TRUE, false);
-            } else {
+            SplitProducerAndConsumer rightSplit = null;
+            // NULL-only skew on the preserved side does not need a skew branch on the non-preserved side.
+            // Reusing the original right input for the shuffle join avoids creating a dangling split branch
+            // that later materializes as a one-way SplitCastDataSink.
+            if (!nullOnlyLeftOuterJoinFastPath) {
                 rightSplit = generateSplitProducerAndConsumer(rightChild, rightInputJoinKeyExpr, nonNullSkewValues,
                         includeNullSkew, !skewOnLeft);
             }
@@ -255,9 +255,10 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             PhysicalConcatenateOperator concatenateOperator = buildConcatenateOperator(outputColumns,
                     localExchangerType, originalShuffleJoinOperator.getLimit());
 
+            OptExpression rightInputOfShuffleJoin =
+                    nullOnlyLeftOuterJoinFastPath ? rightChild : rightSplit.splitConsumerOptForShuffleJoin;
             OptExpression newShuffleJoin = OptExpression.builder().setOp(newShuffleJoinOpt).setInputs(
-                            newArrayList(leftSplit.splitConsumerOptForShuffleJoin,
-                                    rightSplit.splitConsumerOptForShuffleJoin))
+                            newArrayList(leftSplit.splitConsumerOptForShuffleJoin, rightInputOfShuffleJoin))
                     .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
                     .setRequiredProperties(opt.getRequiredProperties()).setCost(opt.getCost()).build();
 
@@ -301,11 +302,14 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
                     .setCost(opt.getCost()).build();
 
-            OptExpression cteAnchorOptExp1 =
-                    OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))
-                            .setInputs(newArrayList(rightSplit.splitProducer, concatenateOptExp))
-                            .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
-                            .setCost(opt.getCost()).build();
+            OptExpression cteAnchorOptExp1 = concatenateOptExp;
+            if (!nullOnlyLeftOuterJoinFastPath) {
+                cteAnchorOptExp1 =
+                        OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))
+                                .setInputs(newArrayList(rightSplit.splitProducer, concatenateOptExp))
+                                .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
+                                .setCost(opt.getCost()).build();
+            }
 
             // if hit once, we give up rewriting the following subtree
             return OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
@@ -576,9 +576,10 @@ public class SkewJoinV2Test extends PlanTestBase {
             try {
                 String sql = "select v2, v5 from t0 left join[shuffle] t1 on v1 = v4";
                 String plan = getVerboseExplain(sql);
-                assertCContains(plan, "SplitCastDataSink:\n" +
+                assertCContains(plan, "Input Partition: RANDOM\n" +
+                        "  SplitCastDataSink:\n" +
                         "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
-                        "  OutPut Exchange Id: 02\n" +
+                        "  OutPut Exchange Id: 01\n" +
                         "  Split expr: [1: v1, BIGINT, true] IS NOT NULL\n" +
                         "  OutPut Partition: RANDOM\n" +
                         "  OutPut Exchange Id: 06\n" +
@@ -592,6 +593,17 @@ public class SkewJoinV2Test extends PlanTestBase {
                         "  |    6:EXCHANGE\n" +
                         "  |       distribution type: ROUND_ROBIN\n" +
                         "  |       cardinality: 20000000");
+                assertContains(plan, "Input Partition: RANDOM\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                        "  OutPut Exchange Id: 03\n" +
+                        "\n" +
+                        "  2:OlapScanNode\n" +
+                        "     table: t1, rollup: t1\n" +
+                        "     preAggregation: on\n" +
+                        "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
+                        "     tabletList=10016,10018,10020\n" +
+                        "     actualRows=0, avgRowSize=9.0\n" +
+                        "     cardinality: 20000000");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
## Why I'm doing:
The null-only skew optimization for `LEFT OUTER JOIN` can generate an invalid split plan shape. In the fast path, the preserved-side input is correctly split into `IS NOT NULL` and `IS NULL` branches, but the non-preserved-side input was still wrapped in a split producer even though it does not participate in the skew branch. This could leave a one-way `SplitCastDataSink` on the right side, which violates the BE-side assumption that split local exchange is two-way and may trigger crashes such as `SplitLocalExchanger::_split_expr_ctxs.size() == 2`.

## What I'm doing:
Skip building the right-side split producer in the null-only skew fast path for preserved-side `LEFT OUTER JOIN`. Reuse the original right input directly for the shuffle join, while keeping the left-side two-way split for the normal join branch and the null fast branch.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/11217

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
