### PR TITLE
[BugFix] Fix incorrect image_tag for non-thirdparty PRs in BE/FE UT jobs

### DIFF
--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -296,6 +296,7 @@ jobs:
     outputs:
       centos7_image_cache_id: ${{ steps.info.outputs.centos7_image_cache_id }}
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
+      thirdparty_updated: ${{ steps.info.outputs.thirdparty_updated }}
     steps:
       - name: Check Result
         run: |
@@ -319,9 +320,11 @@ jobs:
             echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
             image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info" || echo "")
             echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+            echo "thirdparty_updated=true" >> $GITHUB_OUTPUT
           else
             echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
             echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
+            echo "thirdparty_updated=false" >> $GITHUB_OUTPUT
           fi
 
   be-ut:
@@ -495,7 +498,7 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           IMAGE_CACHE_ID="${{ needs.thirdparty-info.outputs.centos7_image_cache_id }}"
-          if [[ "${IMAGE_CACHE_ID}" != '' ]]; then
+          if [[ "${{ needs.thirdparty-info.outputs.thirdparty_updated }}" == 'true' ]] && [[ "${IMAGE_CACHE_ID}" != '' ]]; then
               export image_cache_id=${IMAGE_CACHE_ID}
               export image_tag=$BRANCH-$PR_NUMBER
           fi

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -484,6 +484,7 @@ jobs:
     outputs:
       centos7_image_cache_id: ${{ steps.info.outputs.centos7_image_cache_id }}
       ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
+      thirdparty_updated: ${{ steps.info.outputs.thirdparty_updated }}
     steps:
       - name: Check Result
         run: |
@@ -507,9 +508,11 @@ jobs:
             echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
             image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info" || echo "")
             echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+            echo "thirdparty_updated=true" >> $GITHUB_OUTPUT
           else
             echo "centos7_image_cache_id=" >> $GITHUB_OUTPUT
             echo "ubuntu_image_cache_id=" >> $GITHUB_OUTPUT
+            echo "thirdparty_updated=false" >> $GITHUB_OUTPUT
           fi
 
   be-ut:
@@ -536,7 +539,7 @@ jobs:
         shell: bash
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
-          if [[ "${IMAGE_CACHE_ID}" != '' ]]; then
+          if [[ "${{ needs.thirdparty-info.outputs.thirdparty_updated }}" == 'true' ]] && [[ "${IMAGE_CACHE_ID}" != '' ]]; then
               export image_cache_id=${IMAGE_CACHE_ID}
               export image_tag=$BRANCH-$PR_NUMBER
           fi
@@ -795,7 +798,7 @@ jobs:
           EXTENSION: ${{ needs.fe-codestyle-check.outputs.extension_filter }}
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
-          if [[ "${IMAGE_CACHE_ID}" != '' ]]; then
+          if [[ "${{ needs.thirdparty-info.outputs.thirdparty_updated }}" == 'true' ]] && [[ "${IMAGE_CACHE_ID}" != '' ]]; then
               export image_cache_id=${IMAGE_CACHE_ID}
               export image_tag=$BRANCH-$PR_NUMBER
           fi


### PR DESCRIPTION
## Why I'm doing:
PR #71127 introduced `IMAGE_CACHE_ID != ''` as the condition for setting custom `image_tag` in BE UT and FE UT jobs. However, `IMAGE_CACHE_ID` can be non-empty even when the PR does not change thirdparty files, causing ECI to use a non-existent image tag (e.g. `branch-4.1-52129`) instead of `latest`, which leads to ECI provisioning failures.

This is inconsistent with BUILD and clang-tidy jobs which correctly check `thirdparty_filter == 'true'` before setting image_tag.

## What I'm doing:
1. Add `thirdparty_updated` output to `thirdparty-info` job in both `ci-pipeline.yml` and `ci-pipeline-branch.yml`, which is `true` only when `thirdparty-update` actually ran successfully.
2. Change BE UT and FE UT jobs to check `thirdparty_updated == 'true'` alongside `IMAGE_CACHE_ID != ''` before setting custom image_tag, ensuring non-thirdparty PRs always use `latest` image.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR