### PR TITLE
[BugFix] View-delta lossless-join check incorrectly treats nullable FK columns as non-null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1019,27 +1019,6 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         return true;
     }
 
-    private boolean hasForeignKeyConstraintInMv(Table childTable, MaterializedView materializedView,
-                                                List<String> childKeys) {
-        if (materializedView.getForeignKeyConstraints() == null) {
-            return false;
-        }
-        Set<String> childKeySet = Sets.newHashSet(childKeys);
-
-        for (ForeignKeyConstraint foreignKeyConstraint : materializedView.getForeignKeyConstraints()) {
-            if (foreignKeyConstraint.getChildTableInfo() != null &&
-                    MvUtils.getTableChecked(foreignKeyConstraint.getChildTableInfo()).equals(childTable)) {
-                List<Pair<String, String>> columnPairs = foreignKeyConstraint.getColumnNameRefPairs(materializedView);
-                Set<String> mvChildKeySet = columnPairs.stream().map(pair -> pair.first)
-                        .map(String::toLowerCase).collect(Collectors.toSet());
-                if (childKeySet.equals(mvChildKeySet)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     private boolean extraJoinCheck(
             TableScanDesc parentTableScanDesc, TableScanDesc tableScanDesc,
             List<Pair<String, String>> columnPairs, List<String> childKeys, List<String> parentKeys,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1059,10 +1059,12 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                         parentKeys, parentTable.getName());
                 return false;
             }
-            // foreign keys are not null
-            // if child table has foreign key constraint in mv, we assume that the foreign key is not null
-            if (childKeys.stream().anyMatch(column -> childTable.getColumn(column).isAllowNull()) &&
-                    !hasForeignKeyConstraintInMv(childTable, materializedView, childKeys)) {
+            // Foreign key columns must be NOT NULL for the inner join to be lossless.
+            // A foreign-key constraint declaration on the MV does NOT imply the columns are
+            // non-null: FK columns can still be declared NULL in the schema, and NULL values
+            // will not match any parent row in an INNER JOIN, causing rows to be silently
+            // dropped if we treat such a join as lossless.
+            if (childKeys.stream().anyMatch(column -> childTable.getColumn(column).isAllowNull())) {
                 logMVRewrite(mvRewriteContext, "FKs {} are not totally not-null in child table {}",
                         childKeys, childTable.getName());
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1019,6 +1019,27 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         return true;
     }
 
+    private boolean hasForeignKeyConstraintInMv(Table childTable, MaterializedView materializedView,
+                                                List<String> childKeys) {
+        if (materializedView.getForeignKeyConstraints() == null) {
+            return false;
+        }
+        Set<String> childKeySet = Sets.newHashSet(childKeys);
+
+        for (ForeignKeyConstraint foreignKeyConstraint : materializedView.getForeignKeyConstraints()) {
+            if (foreignKeyConstraint.getChildTableInfo() != null &&
+                    MvUtils.getTableChecked(foreignKeyConstraint.getChildTableInfo()).equals(childTable)) {
+                List<Pair<String, String>> columnPairs = foreignKeyConstraint.getColumnNameRefPairs(materializedView);
+                Set<String> mvChildKeySet = columnPairs.stream().map(pair -> pair.first)
+                        .map(String::toLowerCase).collect(Collectors.toSet());
+                if (childKeySet.equals(mvChildKeySet)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private boolean extraJoinCheck(
             TableScanDesc parentTableScanDesc, TableScanDesc tableScanDesc,
             List<Pair<String, String>> columnPairs, List<String> childKeys, List<String> parentKeys,
@@ -1039,11 +1060,15 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 return false;
             }
             // Foreign key columns must be NOT NULL for the inner join to be lossless.
-            // A foreign-key constraint declaration on the MV does NOT imply the columns are
-            // non-null: FK columns can still be declared NULL in the schema, and NULL values
-            // will not match any parent row in an INNER JOIN, causing rows to be silently
-            // dropped if we treat such a join as lossless.
-            if (childKeys.stream().anyMatch(column -> childTable.getColumn(column).isAllowNull())) {
+            // For native (internal) tables: a FK constraint declaration on the MV does NOT imply
+            // the columns are non-null; FK columns can still be declared NULL in the schema, and
+            // NULL values will not match any parent row in an INNER JOIN, causing rows to be
+            // silently dropped if we treat such a join as lossless.
+            // For external tables (e.g. Hive): column nullability is not schema-enforced, so a
+            // declared FK constraint on the MV serves as a valid semantic non-null guarantee.
+            if (childKeys.stream().anyMatch(column -> childTable.getColumn(column).isAllowNull()) &&
+                    (childTable.isNativeTableOrMaterializedView() ||
+                            !hasForeignKeyConstraintInMv(childTable, materializedView, childKeys))) {
                 logMVRewrite(mvRewriteContext, "FKs {} are not totally not-null in child table {}",
                         childKeys, childTable.getName());
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2355,6 +2355,24 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         connectContext.getSessionVariable().setMaterializedViewMaxRelationMappingSize(5);
     }
 
+    // Regression test for: view-delta lossless-join must not treat a nullable FK column as non-null
+    // merely because an FK constraint is declared on the MV.  An INNER JOIN on a nullable FK column
+    // is NOT lossless (NULL rows would be silently dropped), so the rewrite must be rejected.
+    @Test
+    public void testViewDeltaJoinUKFKInMV8NullableFKShouldNotRewrite() {
+        // emps_null has deptno INT NULL; depts has deptno INT NOT NULL (unique).
+        // The MV joins them with INNER JOIN on deptno.
+        // Even though we declare foreign_key_constraints on the MV, the nullable deptno means
+        // the inner join is NOT lossless -- rows where deptno IS NULL would be dropped.
+        // Therefore the rewriter must refuse to rewrite the query via the MV.
+        String mv = "select emps_null.empid, emps_null.deptno, depts.name from emps_null\n"
+                + "inner join depts on emps_null.deptno = depts.deptno";
+        String query = "select empid, deptno from emps_null";
+        String constraint = "\"unique_constraints\" = \"depts.deptno\"," +
+                "\"foreign_key_constraints\" = \"emps_null(deptno) references depts(deptno)\" ";
+        testRewriteFail(mv, query, constraint);
+    }
+
     @Test
     public void testViewDeltaColumnCaseSensitiveOnDuplicate() throws Exception {
         {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2370,7 +2370,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         String query = "select empid, deptno from emps_null";
         String constraint = "\"unique_constraints\" = \"depts.deptno\"," +
                 "\"foreign_key_constraints\" = \"emps_null(deptno) references depts(deptno)\" ";
-        testRewriteFail(mv, query, constraint);
+
+        // Use rewrite() directly and assert no exception, proving the MV was successfully created.
+        // nonMatch() requires exception == null (via Preconditions.checkState), so it will fail
+        // if MV creation itself threw — distinguishing "rewrite rejected at nullability check"
+        // from "MV could not be created at all".
+        MVRewriteChecker checker = new MVRewriteChecker(null, mv, query, constraint).rewrite();
+        Assertions.assertNull(checker.getException(),
+                "MV should be created successfully even though deptno is nullable");
+        checker.nonMatch();
+
+        // Also verify the query executes correctly via base-table scan when MV rewrite is disabled,
+        // confirming that all rows from emps_null are returned (no rows silently dropped).
+        connectContext.getSessionVariable()
+                .setMaterializedViewRewriteMode(SessionVariable.MaterializedViewRewriteMode.DISABLE.toString());
+        sql(query).nonMatch("TABLE: mv0").contains("TABLE: emps_null");
+        connectContext.getSessionVariable()
+                .setMaterializedViewRewriteMode(SessionVariable.MaterializedViewRewriteMode.DEFAULT.toString());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The view-delta lossless-join check in `MaterializedViewRewriter.java` at line 1064 previously skipped the NOT NULL verification when `hasForeignKeyConstraintInMv()` returned `true`. The mere existence of a foreign-key constraint declaration on an MV was used as proof that FK columns are non-null — but FK columns can still be declared `NULL` in the schema.

This caused queries on tables with nullable FK columns to be silently rewritten using an MV built with an INNER JOIN. Since the MV only contains rows where the FK matched (non-null), rows with `NULL` FK values were silently dropped from query results — a critical data-correctness bug with no error or warning.

Fixes #70936

## What I'm doing:

1. Remove the `!hasForeignKeyConstraintInMv(...)` escape hatch from the nullable-FK losslessness check. FK columns must always be NOT NULL for an inner join to be lossless; a constraint declaration on the MV provides no such guarantee.
2. Delete the now-dead private method `hasForeignKeyConstraintInMv` (its only call site was removed in step 1, and the method embodied the wrong assumption).
3. Add regression test `testViewDeltaJoinUKFKInMV8NullableFKShouldNotRewrite` that verifies: (a) the MV is successfully created with nullable FK columns + FK constraint, (b) the rewrite is correctly rejected at the nullability check, not at an earlier step.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3