### PR TITLE
[Enhancement] Return more information about skew checks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -163,10 +163,6 @@ public class DataSkew {
             return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.INACCURATE_ROW_COUNT);
         }
 
-        if (columnStatistic.isUnknown()) {
-            return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.UNKNOWN_STATS);
-        }
-
         final var nullSkewInfo = getNullSkewInfo(columnStatistic, thresholds);
         final var mcvSkewInfo = getMcvSkewInfo(statistics, columnStatistic, thresholds);
 
@@ -181,6 +177,10 @@ public class DataSkew {
             return new SkewInfo(SkewType.SKEWED_NULL);
         } else if (mcvSkewInfo.skewed) {
             return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.additionalInfo, mcvSkewInfo.mcvs);
+        }
+
+        if (columnStatistic.isUnknown()) {
+            return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.UNKNOWN_STATS);
         }
 
         // Can not deduce skew.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -175,16 +175,16 @@ public class DataSkew {
             if (nullSkewInfo.nullSkewFactor.get() >= mcvSkewInfo.mcvSkewFactor.get()) {
                 return new SkewInfo(SkewType.SKEWED_NULL);
             } else {
-                return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+                return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.additionalInfo, mcvSkewInfo.mcvs);
             }
         } else if (nullSkewInfo.skewed) {
             return new SkewInfo(SkewType.SKEWED_NULL);
         } else if (mcvSkewInfo.skewed) {
-            return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+            return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.additionalInfo, mcvSkewInfo.mcvs);
         }
 
         // Can not deduce skew.
-        return new SkewInfo(SkewType.NOT_SKEWED);
+        return new SkewInfo(SkewType.NOT_SKEWED, mcvSkewInfo.additionalInfo);
     }
 
     public static SkewCandidates getSkewCandidates(@NotNull Statistics statistics,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -45,9 +45,25 @@ public class DataSkew {
         SKEWED_MCV
     }
 
-    public record SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
+    public enum AdditionalInfo {
+        NONE,
+        UNKNOWN_STATS,
+        INACCURATE_ROW_COUNT,
+        NO_HISTOGRAM,
+        NO_MCV
+    }
+
+    public record SkewInfo(SkewType type, AdditionalInfo additionalInfo, Optional<List<Pair<String, Long>>> maybeMcvs) {
         public SkewInfo(SkewType type) {
-            this(type, Optional.empty());
+            this(type, AdditionalInfo.NONE, Optional.empty());
+        }
+
+        public SkewInfo(SkewType type, AdditionalInfo additionalInfo) {
+            this(type, additionalInfo, Optional.empty());
+        }
+
+        public SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
+            this(type, AdditionalInfo.NONE, maybeMcvs);
         }
 
         public boolean isSkewed() {
@@ -65,36 +81,51 @@ public class DataSkew {
         }
     }
 
-    private record McvSkewInfo(boolean skewed, Optional<Double> mcvSkewFactor, Optional<List<Pair<String, Long>>> mcvs) {
+    private record McvSkewInfo(boolean skewed, Optional<Double> mcvSkewFactor, Optional<List<Pair<String, Long>>> mcvs,
+                               AdditionalInfo additionalInfo) {
         public McvSkewInfo(boolean skewed) {
-            this(skewed, Optional.empty(), Optional.empty());
+            this(skewed, Optional.empty(), Optional.empty(), AdditionalInfo.NONE);
         }
+
+        public McvSkewInfo(boolean skewed, AdditionalInfo additionalInfo) {
+            this(skewed, Optional.empty(), Optional.empty(), additionalInfo);
+        }
+
+        public McvSkewInfo(boolean skewed, Optional<Double> mcvSkewFactor, Optional<List<Pair<String, Long>>> mcvs) {
+            this(skewed, mcvSkewFactor, mcvs, AdditionalInfo.NONE);
+        }
+
     }
 
     private static McvSkewInfo getMcvSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
                                               Thresholds thresholds) {
         final var rowCount = statistics.getOutputRowCount();
         final var histogram = columnStatistic.getHistogram();
-        if (histogram != null) {
-            final var mcv = histogram.getMCV();
 
-            if (mcv != null) {
-                int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
-                List<Pair<String, Long>> mcvs = Lists.newArrayList();
-                mcv.entrySet().stream()
-                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
-                        .limit(mcvLimit)
-                        .forEach(entry -> {
-                            mcvs.add(Pair.create(entry.getKey(), entry.getValue()));
-                        });
+        if (histogram == null) {
+            return new McvSkewInfo(false, AdditionalInfo.NO_HISTOGRAM);
+        }
 
-                long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
-                final var mcvSkewFactor = rowCountOfMcvs / rowCount;
+        final var mcv = histogram.getMCV();
 
-                if (mcvSkewFactor > thresholds.relativeRowThreshold) {
-                    return new McvSkewInfo(true, Optional.of(mcvSkewFactor), Optional.of(mcvs));
-                }
-            }
+        if (mcv == null) {
+            return new McvSkewInfo(false, AdditionalInfo.NO_MCV);
+        }
+
+        int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
+        List<Pair<String, Long>> mcvs = Lists.newArrayList();
+        mcv.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
+                .limit(mcvLimit)
+                .forEach(entry -> {
+                    mcvs.add(Pair.create(entry.getKey(), entry.getValue()));
+                });
+
+        long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
+        final var mcvSkewFactor = rowCountOfMcvs / rowCount;
+
+        if (mcvSkewFactor > thresholds.relativeRowThreshold) {
+            return new McvSkewInfo(true, Optional.of(mcvSkewFactor), Optional.of(mcvs));
         }
 
         return new McvSkewInfo(false);
@@ -129,7 +160,11 @@ public class DataSkew {
                                              Thresholds thresholds) {
         if (statistics.isTableRowCountMayInaccurate() || statistics.getOutputRowCount() < 1) {
             // Without sufficient information we can not make a decision.
-            return new SkewInfo(SkewType.NOT_SKEWED);
+            return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.INACCURATE_ROW_COUNT);
+        }
+
+        if (columnStatistic.isUnknown()) {
+            return new SkewInfo(SkewType.NOT_SKEWED, AdditionalInfo.UNKNOWN_STATS);
         }
 
         final var nullSkewInfo = getNullSkewInfo(columnStatistic, thresholds);


### PR DESCRIPTION
## Why I'm doing:

We would like to track how often we detect skew, and for the cases where we did not detect skew we want to know if it is due to missing stats or because the data was not really skewed. 

## What I'm doing:

This PR adds some additional return information in the `DataSkew` class that the caller can use. There are no semantic changes except that the caller can now understand if there really was no skew or we were just missing stats.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
