### PR TITLE
[BugFix] Fix CurrentThread offset lookup for clang

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -288,8 +288,14 @@ public:
 
     // Field offsets within CurrentThread, exposed for eBPF programs that locate
     // these fields via g_tls_thread_status_tpoff + g_tls_*_offset.
-    static constexpr size_t query_id_offset() { return offsetof(CurrentThread, _query_id); }
-    static constexpr size_t module_type_offset() { return offsetof(CurrentThread, _module_type); }
+    static size_t query_id_offset() {
+        static const size_t offset = field_offset(&CurrentThread::_query_id);
+        return offset;
+    }
+    static size_t module_type_offset() {
+        static const size_t offset = field_offset(&CurrentThread::_module_type);
+        return offset;
+    }
 
     void set_custom_coredump_msg(const std::string& custom_coredump_msg) { _custom_coredump_msg = custom_coredump_msg; }
 
@@ -401,6 +407,14 @@ public:
     void set_try_consume_mem_size(int64_t mem_size) { _mem_cache_manager.set_try_consume_mem_size(mem_size); }
 
 private:
+    template <typename Member>
+    static size_t field_offset(Member CurrentThread::*member) {
+        const auto* thread = &CurrentThread::current();
+        const auto* base = reinterpret_cast<const char*>(thread);
+        const auto* field = reinterpret_cast<const char*>(&(thread->*member));
+        return static_cast<size_t>(field - base);
+    }
+
     MemCacheManager _mem_cache_manager;
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;


### PR DESCRIPTION
## Why I'm doing:

there are some compilation errors reported by clang when compiling BE.
```
  /home/WorkSpace/silverbullet233/starrocks/be/src/runtime/current_thread.h:292:59: error: 'offsetof' on non-
  standard-layout type 'CurrentThread' [-Werror,-Winvalid-offsetof]
    292 |     static constexpr size_t module_type_offset() { return offsetof(CurrentThread, _module_type); }
        |                                                           ^                       ~~~~~~~~~~~~
  /usr/lib/llvm-21/lib/clang/21/include/__stddef_offsetof.h:16:24: note: expanded from macro 'offsetof'
     16 | #define offsetof(t, d) __builtin_offsetof(t, d)
```
## What I'm doing:


  This change fixes a BE compilation failure with clang caused by offsetof(CurrentThread, ...) on a non-standard-layout
  type.

  CurrentThread contains TUniqueId members, and TUniqueId is generated from thrift as a type with virtual inheritance /
  virtual functions, so CurrentThread is not a standard-layout type. Clang therefore reports -Winvalid-offsetof, and the
  build fails under -Werror.

  To fix this, the patch removes the offsetof usage from CurrentThread::query_id_offset() and
  CurrentThread::module_type_offset(). The offsets are now computed from the live CurrentThread TLS instance via pointer
  arithmetic and cached in function-local static variables, preserving the existing external-profiler / eBPF offset
  semantics without relying on undefined or implementation-specific offsetof behavior.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
