### PR TITLE
[BugFix] jdbc oracle nls format invalid

### DIFF
--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -14,7 +14,11 @@
 
 #include "connector/jdbc_connector.h"
 
+#include <algorithm>
+#include <cctype>
+#include <regex>
 #include <sstream>
+#include <unordered_map>
 
 #include "base/string/slice.h"
 #include "exec/jdbc_scanner.h"
@@ -25,6 +29,231 @@
 #include "storage/chunk_helper.h"
 
 namespace starrocks::connector {
+
+namespace {
+
+using TemporalColumnMap = std::unordered_map<std::string, LogicalType>;
+
+std::string to_lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return std::tolower(ch); });
+    return value;
+}
+
+std::string normalize_column_name(std::string column_name) {
+    if (column_name.size() >= 2 && ((column_name.front() == '"' && column_name.back() == '"') ||
+                                    (column_name.front() == '`' && column_name.back() == '`'))) {
+        column_name = column_name.substr(1, column_name.size() - 2);
+    }
+    return to_lower_ascii(std::move(column_name));
+}
+
+std::vector<std::string> split_identifier_tokens(const std::string& identifier) {
+    std::vector<std::string> tokens;
+    std::string current;
+    current.reserve(identifier.size());
+    for (unsigned char ch : identifier) {
+        if (std::isalnum(ch)) {
+            current.push_back(static_cast<char>(std::tolower(ch)));
+        } else if (!current.empty()) {
+            tokens.emplace_back(std::move(current));
+            current.clear();
+        }
+    }
+    if (!current.empty()) {
+        tokens.emplace_back(std::move(current));
+    }
+    return tokens;
+}
+
+LogicalType infer_temporal_kind_from_name(const std::string& normalized_column_name) {
+    const auto tokens = split_identifier_tokens(normalized_column_name);
+    bool has_date_like_token = false;
+    bool has_time_like_token = false;
+
+    for (const std::string& token : tokens) {
+        if (token == "date" || token == "dt") {
+            has_date_like_token = true;
+            continue;
+        }
+        if (token == "time" || token == "datetime" || token == "timestamp" || token == "ts" || token == "tstz" ||
+            token == "tsltz" || token == "timetz" || token == "timestamptz" || token == "timestampltz" ||
+            token.rfind("timestamp", 0) == 0) {
+            has_time_like_token = true;
+            continue;
+        }
+    }
+
+    if (has_time_like_token) {
+        return TYPE_DATETIME;
+    }
+    if (has_date_like_token) {
+        return TYPE_DATE;
+    }
+    return TYPE_UNKNOWN;
+}
+
+TemporalColumnMap collect_oracle_temporal_columns(const TupleDescriptor* tuple_desc) {
+    TemporalColumnMap temporal_columns;
+    if (tuple_desc == nullptr) {
+        return temporal_columns;
+    }
+
+    for (SlotDescriptor* slot_desc : tuple_desc->slots()) {
+        const auto slot_type = slot_desc->type().type;
+        const std::string normalized_col_name = normalize_column_name(slot_desc->col_name());
+        if (slot_type == TYPE_DATETIME || slot_type == TYPE_DATETIME_V1 || slot_type == TYPE_DATE) {
+            temporal_columns[normalized_col_name] = slot_type;
+            continue;
+        }
+
+        if (slot_type == TYPE_VARCHAR || slot_type == TYPE_CHAR) {
+            const auto inferred_temporal_type = infer_temporal_kind_from_name(normalized_col_name);
+            if (inferred_temporal_type != TYPE_UNKNOWN) {
+                temporal_columns[normalized_col_name] = inferred_temporal_type;
+            }
+        }
+    }
+    return temporal_columns;
+}
+
+bool literal_contains_time_component(const std::string& literal) {
+    return literal.find(':') != std::string::npos || literal.find(' ') != std::string::npos ||
+           literal.find('.') != std::string::npos;
+}
+
+std::string build_oracle_temporal_conversion_expr(const std::string& literal, LogicalType slot_type) {
+    static const std::regex kDatetimeLiteralRegex(
+            R"(^(\d{4})-(\d{2})-(\d{2})(?: (\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?)?$)");
+    std::smatch match;
+    if (!std::regex_match(literal, match, kDatetimeLiteralRegex)) {
+        // Fallback to Oracle NLS-based conversion for non-canonical literals,
+        // such as '2022-01-1'.
+        if (slot_type == TYPE_DATE || !literal_contains_time_component(literal)) {
+            return fmt::format("TO_DATE('{}')", literal);
+        }
+        return fmt::format("TO_TIMESTAMP('{}')", literal);
+    }
+
+    if (!match[4].matched) {
+        if (slot_type == TYPE_DATE) {
+            return fmt::format("TO_DATE('{}', 'YYYY-MM-DD')", literal);
+        }
+        return fmt::format("TO_TIMESTAMP('{}', 'YYYY-MM-DD')", literal);
+    }
+
+    if (!match[7].matched) {
+        if (slot_type == TYPE_DATE) {
+            return fmt::format("TO_DATE('{}', 'YYYY-MM-DD HH24:MI:SS')", literal);
+        }
+        return fmt::format("TO_TIMESTAMP('{}', 'YYYY-MM-DD HH24:MI:SS')", literal);
+    }
+
+    return fmt::format("TO_TIMESTAMP('{}', 'YYYY-MM-DD HH24:MI:SS.FF{}')", literal, match.str(7).size());
+}
+
+std::string rewrite_oracle_column_literal_predicates(const std::string& filter,
+                                                     const TemporalColumnMap& temporal_columns) {
+    static const std::regex kColumnLiteralPredicateRegex(
+            R"((^|[^[:alnum:]_$#])("?[[:alpha:]_][[:alnum:]_$#]*"?)\s*(=|!=|<>|<=|>=|<|>)\s*'([^']*)')",
+            std::regex_constants::icase);
+
+    std::string rewritten;
+    std::smatch match;
+    std::string::const_iterator begin = filter.begin();
+    while (std::regex_search(begin, filter.end(), match, kColumnLiteralPredicateRegex)) {
+        rewritten.append(begin, match[0].first);
+        std::string replacement = match.str(0);
+
+        auto it = temporal_columns.find(normalize_column_name(match.str(2)));
+        if (it != temporal_columns.end()) {
+            const std::string datetime_expr = build_oracle_temporal_conversion_expr(match.str(4), it->second);
+            if (!datetime_expr.empty()) {
+                replacement = match.str(1) + match.str(2) + " " + match.str(3) + " " + datetime_expr;
+            }
+        }
+
+        rewritten.append(replacement);
+        begin = match[0].second;
+    }
+    rewritten.append(begin, filter.end());
+    return rewritten;
+}
+
+std::string rewrite_oracle_literal_column_predicates(const std::string& filter,
+                                                     const TemporalColumnMap& temporal_columns) {
+    static const std::regex kLiteralColumnPredicateRegex(
+            R"((^|[^[:alnum:]_$#])'([^']*)'\s*(=|!=|<>|<=|>=|<|>)\s*("?[[:alpha:]_][[:alnum:]_$#]*"?))",
+            std::regex_constants::icase);
+
+    std::string rewritten;
+    std::smatch match;
+    std::string::const_iterator begin = filter.begin();
+    while (std::regex_search(begin, filter.end(), match, kLiteralColumnPredicateRegex)) {
+        rewritten.append(begin, match[0].first);
+        std::string replacement = match.str(0);
+
+        auto it = temporal_columns.find(normalize_column_name(match.str(4)));
+        if (it != temporal_columns.end()) {
+            const std::string datetime_expr = build_oracle_temporal_conversion_expr(match.str(2), it->second);
+            if (!datetime_expr.empty()) {
+                replacement = match.str(1) + datetime_expr + " " + match.str(3) + " " + match.str(4);
+            }
+        }
+
+        rewritten.append(replacement);
+        begin = match[0].second;
+    }
+    rewritten.append(begin, filter.end());
+    return rewritten;
+}
+
+std::string rewrite_oracle_between_predicates(const std::string& filter, const TemporalColumnMap& temporal_columns) {
+    static const std::regex kBetweenPredicateRegex(
+            R"((^|[^[:alnum:]_$#])("?[[:alpha:]_][[:alnum:]_$#]*"?)\s+BETWEEN\s+'([^']*)'\s+AND\s+'([^']*)')",
+            std::regex_constants::icase);
+
+    std::string rewritten;
+    std::smatch match;
+    std::string::const_iterator begin = filter.begin();
+    while (std::regex_search(begin, filter.end(), match, kBetweenPredicateRegex)) {
+        rewritten.append(begin, match[0].first);
+        std::string replacement = match.str(0);
+
+        auto it = temporal_columns.find(normalize_column_name(match.str(2)));
+        if (it != temporal_columns.end()) {
+            const std::string low_expr = build_oracle_temporal_conversion_expr(match.str(3), it->second);
+            const std::string high_expr = build_oracle_temporal_conversion_expr(match.str(4), it->second);
+            if (!low_expr.empty() && !high_expr.empty()) {
+                replacement = match.str(1) + match.str(2) + " BETWEEN " + low_expr + " AND " + high_expr;
+            }
+        }
+
+        rewritten.append(replacement);
+        begin = match[0].second;
+    }
+    rewritten.append(begin, filter.end());
+    return rewritten;
+}
+
+std::vector<std::string> rewrite_oracle_datetime_filters(const std::vector<std::string>& filters,
+                                                         const TupleDescriptor* tuple_desc) {
+    TemporalColumnMap temporal_columns = collect_oracle_temporal_columns(tuple_desc);
+    if (temporal_columns.empty()) {
+        return filters;
+    }
+
+    std::vector<std::string> rewritten_filters;
+    rewritten_filters.reserve(filters.size());
+    for (const std::string& filter : filters) {
+        std::string rewritten = rewrite_oracle_between_predicates(filter, temporal_columns);
+        rewritten = rewrite_oracle_column_literal_predicates(rewritten, temporal_columns);
+        rewritten = rewrite_oracle_literal_column_predicates(rewritten, temporal_columns);
+        rewritten_filters.emplace_back(std::move(rewritten));
+    }
+    return rewritten_filters;
+}
+
+} // namespace
 
 // ================================
 
@@ -69,7 +298,8 @@ static std::string get_jdbc_sql(const Slice jdbc_url, const std::string& table, 
     if (limit != -1) {
         if (jdbc_url.starts_with("jdbc:oracle")) {
             // oracle doesn't support limit clause, we should generate a subquery to do this
-            // ref: https://stackoverflow.com/questions/470542/how-do-i-limit-the-number-of-rows-returned-by-an-oracle-query-after-ordering
+            // ref:
+            // https://stackoverflow.com/questions/470542/how-do-i-limit-the-number-of-rows-returned-by-an-oracle-query-after-ordering
             return fmt::format("SELECT * FROM ({}) WHERE ROWNUM <= {}", oss.str(), limit);
         } else {
             oss << " LIMIT " << limit;
@@ -151,8 +381,14 @@ Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     scan_ctx.jdbc_url = jdbc_table->jdbc_url();
     scan_ctx.user = jdbc_table->jdbc_user();
     scan_ctx.passwd = jdbc_table->jdbc_passwd();
-    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_scan_node.table_name, jdbc_scan_node.columns,
-                                jdbc_scan_node.filters, _read_limit);
+
+    const std::vector<std::string>& original_filters = jdbc_scan_node.filters;
+    std::vector<std::string> rewritten_filters = original_filters;
+    if (scan_ctx.jdbc_url.starts_with("jdbc:oracle")) {
+        rewritten_filters = rewrite_oracle_datetime_filters(original_filters, _tuple_desc);
+    }
+    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_scan_node.table_name, jdbc_scan_node.columns, rewritten_filters,
+                                _read_limit);
     _scanner = _pool->add(new JDBCScanner(scan_ctx, _tuple_desc, _runtime_profile));
 
     RETURN_IF_ERROR(_scanner->open(state));

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXEC_FILES
         ./common/uri_test.cpp
         ./connector/benchmark_connector_test.cpp
         ./connector/hive_connector_test.cpp
+        ./connector/jdbc_connector_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp

--- a/be/test/connector/jdbc_connector_test.cpp
+++ b/be/test/connector/jdbc_connector_test.cpp
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "types/logical_type.h"
+
+namespace starrocks::connector {
+
+std::vector<std::string> rewrite_oracle_datetime_filters_for_test(
+        const std::vector<std::string>& filters, const std::vector<std::pair<std::string, LogicalType>>& columns);
+
+TEST(JDBCConnectorTest, RewriteDateColumnWithNLSFallback) {
+    std::vector<std::string> filters = {"date_col = '2022-01-1'"};
+    std::vector<std::pair<std::string, LogicalType>> columns = {{"date_col", TYPE_DATE}};
+
+    auto rewritten = rewrite_oracle_datetime_filters_for_test(filters, columns);
+    ASSERT_EQ(1, rewritten.size());
+    EXPECT_EQ("date_col = TO_DATE('2022-01-1')", rewritten[0]);
+}
+
+TEST(JDBCConnectorTest, RewriteDatetimeColumnWithMicroseconds) {
+    std::vector<std::string> filters = {"ts_col = '2026-03-12 09:30:15.123456'"};
+    std::vector<std::pair<std::string, LogicalType>> columns = {{"ts_col", TYPE_DATETIME}};
+
+    auto rewritten = rewrite_oracle_datetime_filters_for_test(filters, columns);
+    ASSERT_EQ(1, rewritten.size());
+    EXPECT_EQ("ts_col = TO_TIMESTAMP('2026-03-12 09:30:15.123456', 'YYYY-MM-DD HH24:MI:SS.FF6')", rewritten[0]);
+}
+
+TEST(JDBCConnectorTest, RewriteTemporalVarcharColumnByNameInference) {
+    std::vector<std::string> filters = {"tstz_col = '2026-03-12 09:30:15.123456'"};
+    std::vector<std::pair<std::string, LogicalType>> columns = {{"tstz_col", TYPE_VARCHAR}};
+
+    auto rewritten = rewrite_oracle_datetime_filters_for_test(filters, columns);
+    ASSERT_EQ(1, rewritten.size());
+    EXPECT_EQ("tstz_col = TO_TIMESTAMP('2026-03-12 09:30:15.123456', 'YYYY-MM-DD HH24:MI:SS.FF6')", rewritten[0]);
+}
+
+TEST(JDBCConnectorTest, KeepNonTemporalVarcharColumnUnchanged) {
+    std::vector<std::string> filters = {"note = '2026-03-12 09:30:15.123456'"};
+    std::vector<std::pair<std::string, LogicalType>> columns = {{"note", TYPE_VARCHAR}};
+
+    auto rewritten = rewrite_oracle_datetime_filters_for_test(filters, columns);
+    ASSERT_EQ(1, rewritten.size());
+    EXPECT_EQ("note = '2026-03-12 09:30:15.123456'", rewritten[0]);
+}
+
+TEST(JDBCConnectorTest, RewriteLiteralColumnPredicate) {
+    std::vector<std::string> filters = {"'2026-03-12 09:30:15' = ts_col"};
+    std::vector<std::pair<std::string, LogicalType>> columns = {{"ts_col", TYPE_DATETIME}};
+
+    auto rewritten = rewrite_oracle_datetime_filters_for_test(filters, columns);
+    ASSERT_EQ(1, rewritten.size());
+    EXPECT_EQ("TO_TIMESTAMP('2026-03-12 09:30:15', 'YYYY-MM-DD HH24:MI:SS') = ts_col", rewritten[0]);
+}
+
+} // namespace starrocks::connector


### PR DESCRIPTION
## Why I'm doing:
for oracle jdbc, the predicate `c1 = '2022-01-1' ` will be pushed down to oracle.

but the date format should match the nls format. so now an error will occur.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
