### PR TITLE
[BugFix] Fix Gradle thrift source generation for thrift 0.22 compatibility

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -363,12 +363,6 @@ tasks.register<Task>("generateThriftSources") {
     description = "Generates Java source files from Thrift definitions"
     group = "build"
 
-    // Create a special configuration for the thrift compiler rather than using runtime classpath
-    val thriftGenClasspath = configurations.create("thriftGenClasspath")
-    dependencies {
-        thriftGenClasspath("io.github.decster:thrift-java-maven-plugin:0.1.3")
-    }
-
     val protoDir = file("../../gensrc/thrift")
     val outputDir = layout.buildDirectory.get().dir("generated-sources/thrift").asFile
 
@@ -386,16 +380,29 @@ tasks.register<Task>("generateThriftSources") {
 
     doFirst {
         mkdir(outputDir)
-        // Process each proto file individually
-        project.javaexec {
-            classpath = thriftGenClasspath
-            mainClass.set("io.github.decster.ThriftCompiler")
-            // Build arguments list with the output directory and all thrift files
-            val allArgs = mutableListOf("-o", "$outputDir")
-            protoFiles.forEach { file ->
-                allArgs.add(file.absolutePath)
+
+        // Mirror the binary-discovery logic from gensrc/thrift/Makefile:
+        // prefer $STARROCKS_THIRDPARTY/installed/bin/thrift, fall back to "thrift" on PATH.
+        val thriftBin: String = run {
+            val tp = System.getenv("STARROCKS_THIRDPARTY")
+            if (tp != null) {
+                val candidate = file("$tp/installed/bin/thrift")
+                if (candidate.exists()) return@run candidate.absolutePath
             }
-            args = allArgs
+            "thrift"
+        }
+
+        // Process each thrift file with the native compiler, matching Maven's maven-thrift-plugin args.
+        protoFiles.forEach { thriftFile ->
+            project.exec {
+                commandLine(
+                    thriftBin,
+                    "--gen", "java",
+                    "-out", outputDir.absolutePath,
+                    "-I", protoDir.absolutePath,
+                    thriftFile.absolutePath
+                )
+            }
         }
     }
 }

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -372,25 +372,28 @@ tasks.register<Task>("generateThriftSources") {
         exclude("parquet.thrift")
     }.files
 
-    // Declare inputs (proto files)
+    // Mirror the binary-discovery logic from gensrc/thrift/Makefile:
+    // prefer $STARROCKS_THIRDPARTY/installed/bin/thrift, fall back to "thrift" on PATH.
+    // Resolved at configuration time so Gradle can track it as a task input.
+    val thriftBin: String = run {
+        val tp = System.getenv("STARROCKS_THIRDPARTY")
+        if (tp != null) {
+            val candidate = file("$tp/installed/bin/thrift")
+            if (candidate.exists()) return@run candidate.absolutePath
+        }
+        "thrift"
+    }
+
+    // Declare inputs: proto files and the thrift compiler binary.
+    // Including the binary ensures the task is re-run when the toolchain is upgraded.
     inputs.files(protoFiles)
+    inputs.property("thriftBin", thriftBin)
 
     // Declare output directory
     outputs.dir(outputDir)
 
     doFirst {
         mkdir(outputDir)
-
-        // Mirror the binary-discovery logic from gensrc/thrift/Makefile:
-        // prefer $STARROCKS_THIRDPARTY/installed/bin/thrift, fall back to "thrift" on PATH.
-        val thriftBin: String = run {
-            val tp = System.getenv("STARROCKS_THIRDPARTY")
-            if (tp != null) {
-                val candidate = file("$tp/installed/bin/thrift")
-                if (candidate.exists()) return@run candidate.absolutePath
-            }
-            "thrift"
-        }
 
         // Process each thrift file with the native compiler, matching Maven's maven-thrift-plugin args.
         protoFiles.forEach { thriftFile ->


### PR DESCRIPTION
## Why I'm doing:

After #70822 bumped `libthrift` from 0.20.0 to 0.22.0, the Gradle `generateThriftSources` task broke with compilation errors like:

```
BackendService.java: wrong number of type arguments; required 3
```

Root cause: the task used `io.github.decster:thrift-java-maven-plugin:0.1.3`, a pure-Java thrift generator that internally uses thrift 0.20 code-generation conventions. In libthrift 0.22, `ProcessFunction` changed from 2 to 3 type arguments, so the generated code no longer compiled against the new runtime. Maven's `maven-thrift-plugin` was unaffected because it calls the thirdparty thrift binary directly, which was already updated to 0.22.

## What I'm doing:

Replace the `io.github.decster` plugin with a direct invocation of the native thrift binary in `generateThriftSources`, mirroring the binary-discovery logic already used by `gensrc/thrift/Makefile` and Maven's `maven-thrift-plugin`:

1. Prefer `$STARROCKS_THIRDPARTY/installed/bin/thrift`
2. Fall back to `thrift` on PATH

This aligns both Gradle and Maven build paths to the same compiler binary, so future thrift version bumps in thirdparty automatically apply to both.

## What type of PR is this:

- [x] BugFix

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4