### PR TITLE
[BugFix] PK-index fast path respects snapshot version for REPEATABLE READ isolation

### DIFF
--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -172,8 +172,17 @@ Status TabletReader::_init_collector_for_pk_index_read() {
             return Status::InternalError(strings::Substitute("get rowid size not match tablet:$0 $1 != $2",
                                                              _tablet->tablet_id(), rowids.size(), 1));
         }
+        // Verify the PK index snapshot version matches our query snapshot version to guarantee
+        // REPEATABLE READ isolation. If the index has advanced past our snapshot (i.e. a concurrent
+        // write committed after our snapshot was taken), the fast-path result reflects a newer state
+        // than the query is allowed to observe. Return NotSupported so that do_get_next() falls back
+        // to the version-consistent normal read path.
+        if (read_version.major_number() > _version.second) {
+            return Status::NotSupported(strings::Substitute(
+                    "pk index version ($0) is ahead of snapshot version ($1), fallback to normal read, tablet:$2",
+                    read_version.major_number(), _version.second, _tablet->tablet_id()));
+        }
     }
-    // do not check read version in use_pk_index mode
     uint32_t rssid = rowids[0] >> 32;
     uint32_t rowid = rowids[0] & 0xffffffff;
     if (rssid == (uint32_t)-1) {


### PR DESCRIPTION
## Why I'm doing:

The PK-index fast path (`_init_collector_for_pk_index_read`) calls `get_rss_rowids_by_pk`, which internally returns the *current* applied `EditVersion` of the primary index. The returned `read_version` was immediately discarded — a removed comment even made this explicit: *"do not check read version in use_pk_index mode"*.

As a result, a concurrent DML committed **after** the query snapshot was established could be surfaced to the reader, violating **REPEATABLE READ** isolation:

```sql
-- Session 1 (snapshot @ version N):
BEGIN;
SELECT version_num FROM t_pk WHERE id = 1;   -- returns 1 ✓
SELECT SLEEP(5);
SELECT version_num FROM t_pk WHERE id = 1;   -- returns 55 ✗  (post-snapshot update visible)
COMMIT;

-- Session 2 (fires during SLEEP):
UPDATE t_pk SET version_num=55 WHERE id = 1; -- committed @ version N+1
```

## What I'm doing:

Compare `read_version.major_number()` (the version the PK index currently reflects) against `_version.second` (the query snapshot version). When the index has advanced beyond the snapshot, return `Status::NotSupported` so `do_get_next()` falls back to the standard version-consistent iterator path via `_init_collector()`.

Fixes #70944

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4