### PR TITLE
[Enhancement] Add memory index for PhysicalPartition to Partition in CatalogRecycleBin to accelerate PhysicalPartition lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -95,6 +95,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     // The first Long type is DdId, the second String is TableName
     private final com.google.common.collect.Table<Long, String, RecycleTableInfo> nameToTableInfo;
     private final Map<Long, RecyclePartitionInfo> idToPartition;
+    private final Map<Long, Long> physicalPartitionIdToPartitionId;
 
     private Map<RecyclePartitionInfo, CompletableFuture<Boolean>> asyncDeleteForPartitions;
     private Map<RecycleTableInfo, CompletableFuture<Boolean>> asyncDeleteForTables;
@@ -121,6 +122,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         idToTableInfo = HashBasedTable.create();
         nameToTableInfo = HashBasedTable.create();
         idToPartition = Maps.newHashMap();
+        physicalPartitionIdToPartitionId = Maps.newHashMap();
         idToRecycleTime = Maps.newHashMap();
         enableEraseLater = new HashSet<>();
         asyncDeleteForPartitions = Maps.newHashMap();
@@ -130,6 +132,42 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     private void removeRecycleMarkers(Long id) {
         idToRecycleTime.remove(id);
         enableEraseLater.remove(id);
+    }
+
+    private void addPhysicalPartitionIndex(RecyclePartitionInfo recyclePartitionInfo) {
+        long partitionId = recyclePartitionInfo.getPartition().getId();
+        for (PhysicalPartition physicalPartition : recyclePartitionInfo.getPartition().getSubPartitions()) {
+            physicalPartitionIdToPartitionId.put(physicalPartition.getId(), partitionId);
+        }
+    }
+
+    private void removePhysicalPartitionIndex(@Nullable RecyclePartitionInfo recyclePartitionInfo) {
+        if (recyclePartitionInfo == null) {
+            return;
+        }
+        for (PhysicalPartition physicalPartition : recyclePartitionInfo.getPartition().getSubPartitions()) {
+            physicalPartitionIdToPartitionId.remove(physicalPartition.getId());
+        }
+    }
+
+    private void putPartitionToRecycleBin(RecyclePartitionInfo recyclePartitionInfo) {
+        RecyclePartitionInfo oldPartitionInfo =
+                idToPartition.put(recyclePartitionInfo.getPartition().getId(), recyclePartitionInfo);
+        removePhysicalPartitionIndex(oldPartitionInfo);
+        addPhysicalPartitionIndex(recyclePartitionInfo);
+    }
+
+    @Nullable
+    private RecyclePartitionInfo removePartitionFromRecycleBinInternal(long partitionId) {
+        RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
+        removePhysicalPartitionIndex(partitionInfo);
+        return partitionInfo;
+    }
+
+    private void removePartitionFromRecycleBinInternal(Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator,
+                                                       RecyclePartitionInfo partitionInfo) {
+        removePhysicalPartitionIndex(partitionInfo);
+        iterator.remove();
     }
 
     public synchronized void recycleDatabase(Database db, Set<String> tableNames, boolean recoverable) {
@@ -226,7 +264,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         disableRecoverPartitionWithSameName(dbId, tableId, partitionName);
 
         idToRecycleTime.put(partitionId, System.currentTimeMillis());
-        idToPartition.put(partitionId, recyclePartitionInfo);
+        putPartitionToRecycleBin(recyclePartitionInfo);
         LOG.debug("Finished put partition '{}' to recycle bin. dbId: {} tableId: {} partitionId: {} recoverable: {}",
                 partitionName, dbId, tableId, partitionId, recyclePartitionInfo.isRecoverable());
     }
@@ -240,16 +278,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     }
 
     public synchronized PhysicalPartition getPhysicalPartition(long physicalPartitionId) {
-        for (Partition partition : idToPartition.values().stream()
-                .map(RecyclePartitionInfo::getPartition)
-                .collect(Collectors.toList())) {
-            for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-                if (subPartition.getId() == physicalPartitionId) {
-                    return subPartition;
-                }
-            }
+        Long partitionId = physicalPartitionIdToPartitionId.get(physicalPartitionId);
+        if (partitionId == null) {
+            return null;
         }
-        return null;
+        RecyclePartitionInfo partitionInfo = idToPartition.get(partitionId);
+        return partitionInfo != null ? partitionInfo.getPartition().getSubPartition(physicalPartitionId) : null;
     }
 
     public synchronized short getPartitionReplicationNum(long partitionId) {
@@ -698,7 +732,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
 
             if (finished) {
                 GlobalStateMgr.getCurrentState().getEditLog().logErasePartition(partitionId, wal -> {
-                    iterator.remove();
+                    removePartitionFromRecycleBinInternal(iterator, partitionInfo);
                     asyncDeleteForPartitions.remove(partitionInfo);
                     removeRecycleMarkers(partitionId);
                 });
@@ -750,7 +784,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     }
 
     public synchronized void replayErasePartition(long partitionId) {
-        RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
+        RecyclePartitionInfo partitionInfo = removePartitionFromRecycleBinInternal(partitionId);
         idToRecycleTime.remove(partitionId);
 
         Partition partition = partitionInfo.getPartition();
@@ -916,7 +950,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         GlobalStateMgr.getCurrentState().getEditLog().logRecoverPartition(recoverInfo, wal -> {
             finalRecoverPartitionInfo.recover(table);
             // remove from recycle bin
-            idToPartition.remove(partitionId);
+            removePartitionFromRecycleBinInternal(partitionId);
             removeRecycleMarkers(partitionId);
         });
         LOG.info("Recovered partition '{}' of table '{}'. dbId={} tableId={} partitionId={}", partitionName,
@@ -952,7 +986,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
             // updated to match the table's current datacache.enable value.
             partitionInfo.syncDataCacheInfoWithTable(table, rangePartitionInfo, partitionId);
 
-            iterator.remove();
+            removePartitionFromRecycleBinInternal(iterator, partitionInfo);
             idToRecycleTime.remove(partitionId);
 
             LOG.info("replay recover partition[{}-{}] finished", partitionId, partitionInfo.getPartition().getName());
@@ -1332,6 +1366,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
+        physicalPartitionIdToPartitionId.clear();
         reader.readCollection(RecycleDatabaseInfo.class, recycleDatabaseInfo -> {
             idToDatabase.put(recycleDatabaseInfo.db.getId(), recycleDatabaseInfo);
         });
@@ -1342,7 +1377,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         });
 
         reader.readCollection(RecyclePartitionInfoV2.class, recyclePartitionInfo -> {
-            idToPartition.put(recyclePartitionInfo.partition.getId(), recyclePartitionInfo);
+            putPartitionToRecycleBin(recyclePartitionInfo);
         });
 
         idToRecycleTime = (Map<Long, Long>) reader.readJson(new TypeToken<Map<Long, Long>>() {
@@ -1382,6 +1417,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         idToTableInfo.clear();
         nameToTableInfo.clear();
         idToPartition.clear();
+        physicalPartitionIdToPartitionId.clear();
         idToRecycleTime.clear();
         enableEraseLater.clear();
         asyncDeleteForPartitions.clear();
@@ -1390,7 +1426,8 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
 
     // for test
     protected void setPartitionInfo(long partitionId, RecyclePartitionInfo partitionInfo) {
-        idToPartition.put(partitionId, partitionInfo);
+        Preconditions.checkState(partitionId == partitionInfo.getPartition().getId());
+        putPartitionToRecycleBin(partitionInfo);
     }
 
     // for test
@@ -1405,7 +1442,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
 
     // for test
     public void removePartitionFromRecycleBin(long partitionId) {
-        idToPartition.remove(partitionId);
+        removePartitionFromRecycleBinInternal(partitionId);
         idToRecycleTime.remove(partitionId);
         enableEraseLater.remove(partitionId);
     }
@@ -1416,6 +1453,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
                 .put("Database", (long) idToDatabase.size())
                 .put("Table", (long) idToTableInfo.size())
                 .put("Partition", (long) idToPartition.size())
+                .put("PhysicalPartitionIndex", (long) physicalPartitionIdToPartitionId.size())
                 .put("AsyncDeletePartition", (long) asyncDeleteForPartitions.size())
                 .put("AsyncDeleteTable", (long) asyncDeleteForTables.size())
                 .build();
@@ -1426,6 +1464,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
         return Estimator.estimate(idToDatabase, 20) +
                 Estimator.estimate(idToTableInfo.rowMap(), 20) +
                 Estimator.estimate(idToPartition, 20) +
+                Estimator.estimate(physicalPartitionIdToPartitionId, 20) +
                 Estimator.estimate(idToRecycleTime, 20);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinEditLogTest.java
@@ -314,6 +314,7 @@ public class CatalogRecycleBinEditLogTest {
 
         // 5. Verify master state - partition should be removed
         Assertions.assertNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(recycleBin.getPhysicalPartition(PHYSICAL_PARTITION_ID));
         Assertions.assertFalse(recycleBin.isContainedInidToRecycleTime(PARTITION_ID));
 
         // 6. Test follower replay
@@ -341,6 +342,7 @@ public class CatalogRecycleBinEditLogTest {
 
         // 7. Verify follower state
         Assertions.assertNull(followerRecycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(followerRecycleBin.getPhysicalPartition(PHYSICAL_PARTITION_ID));
         Assertions.assertFalse(followerRecycleBin.isContainedInidToRecycleTime(PARTITION_ID));
     }
 
@@ -510,6 +512,7 @@ public class CatalogRecycleBinEditLogTest {
 
         // 3. Verify master state
         Assertions.assertNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(recycleBin.getPhysicalPartition(PHYSICAL_PARTITION_ID));
         Partition recoveredPartition = table.getPartition(PARTITION_NAME);
         Assertions.assertNotNull(recoveredPartition);
         Assertions.assertEquals(PARTITION_NAME, recoveredPartition.getName());
@@ -554,6 +557,7 @@ public class CatalogRecycleBinEditLogTest {
 
         // 5. Verify follower state
         Assertions.assertNull(followerRecycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(followerRecycleBin.getPhysicalPartition(PHYSICAL_PARTITION_ID));
         Partition followerRecoveredPartition = followerTable.getPartition(PARTITION_NAME);
         Assertions.assertNotNull(followerRecoveredPartition);
         Assertions.assertEquals(PARTITION_NAME, followerRecoveredPartition.getName());
@@ -603,6 +607,7 @@ public class CatalogRecycleBinEditLogTest {
 
         // 4. Verify partition is still in recycle bin after exception
         Assertions.assertNotNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNotNull(recycleBin.getPhysicalPartition(PHYSICAL_PARTITION_ID));
         Assertions.assertNull(table.getPartition(PARTITION_NAME));
     }
 
@@ -627,4 +632,3 @@ public class CatalogRecycleBinEditLogTest {
         }
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -206,6 +206,90 @@ public class CatalogRecycleBinTest {
         Assertions.assertNotNull(recycledPart);
         recycledPart = bin.getPhysicalPartition(4L);
         Assertions.assertEquals(4L, recycledPart.getId());
+
+        Partition replacementPartition = new Partition(1L, 5L, "pt", new MaterializedIndex(), null);
+        bin.setPartitionInfo(1L,
+                new RecycleRangePartitionInfo(11L, 22L, replacementPartition, range, dataProperty, (short) 1, null));
+
+        Assertions.assertNull(bin.getPhysicalPartition(3L));
+        recycledPart = bin.getPhysicalPartition(5L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(5L, recycledPart.getId());
+
+        bin.removePartitionFromRecycleBin(1L);
+        Assertions.assertNull(bin.getPhysicalPartition(5L));
+        Assertions.assertNotNull(bin.getPhysicalPartition(4L));
+    }
+
+    @Test
+    public void testLoadRebuildsPhysicalPartitionIndex() throws Exception {
+        CatalogRecycleBin originalBin = new CatalogRecycleBin();
+        List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
+        Range<PartitionKey> range =
+                Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
+                        BoundType.CLOSED,
+                        PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("3")), columns),
+                        BoundType.CLOSED);
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        Partition partition = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+        originalBin.recyclePartition(
+                new RecycleRangePartitionInfo(11L, 22L, partition, range, dataProperty, (short) 1, null));
+        Partition partition2 = new Partition(2L, 4L, "pt2", new MaterializedIndex(), null);
+        originalBin.recyclePartition(
+                new RecycleRangePartitionInfo(11L, 22L, partition2, range, dataProperty, (short) 1, null));
+
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        originalBin.save(image.getImageWriter());
+
+        CatalogRecycleBin loadedBin = new CatalogRecycleBin();
+        loadedBin.load(image.getMetaBlockReader());
+
+        PhysicalPartition recycledPart = loadedBin.getPhysicalPartition(3L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(3L, recycledPart.getId());
+        recycledPart = loadedBin.getPhysicalPartition(4L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(4L, recycledPart.getId());
+        Assertions.assertNull(loadedBin.getPhysicalPartition(5L));
+    }
+
+    @Test
+    public void testEstimateMemoryTracksPhysicalPartitionIndex() throws Exception {
+        CatalogRecycleBin bin = new CatalogRecycleBin();
+        List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
+        Range<PartitionKey> range =
+                Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
+                        BoundType.CLOSED,
+                        PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("3")), columns),
+                        BoundType.CLOSED);
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        Partition initialPartition = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+
+        bin.recyclePartition(
+                new RecycleRangePartitionInfo(11L, 22L, initialPartition, range, dataProperty, (short) 1, null));
+
+        Partition partitionWithTwoPhysicalPartitions = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+        PhysicalPartition extraPhysicalPartition =
+                new PhysicalPartition(4L, partitionWithTwoPhysicalPartitions.getId(), new MaterializedIndex());
+        partitionWithTwoPhysicalPartitions.addSubPartition(extraPhysicalPartition);
+        bin.setPartitionInfo(1L,
+                new RecycleRangePartitionInfo(11L, 22L, partitionWithTwoPhysicalPartitions,
+                        range, dataProperty, (short) 1, null));
+
+        Assertions.assertEquals(1L, bin.estimateCount().get("Partition"));
+        Assertions.assertEquals(2L, bin.estimateCount().get("PhysicalPartitionIndex"));
+        Assertions.assertNotNull(bin.getPhysicalPartition(4L));
+
+        long estimatedSizeWithTwoPhysicalPartitions = bin.estimateSize();
+
+        Partition partitionWithOnePhysicalPartition = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+        bin.setPartitionInfo(1L,
+                new RecycleRangePartitionInfo(11L, 22L, partitionWithOnePhysicalPartition,
+                        range, dataProperty, (short) 1, null));
+
+        Assertions.assertEquals(1L, bin.estimateCount().get("PhysicalPartitionIndex"));
+        Assertions.assertNull(bin.getPhysicalPartition(4L));
+        Assertions.assertTrue(estimatedSizeWithTwoPhysicalPartitions > bin.estimateSize());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Search PhysicalPartition from CatalogRecycleBin can be very slow if there are too many Partition in CatalogRecycleBin.

## What I'm doing:
Add memory index for searching PhysicalPartition in CatalogRecycleBin.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
