### PR TITLE
[BugFix] Qualified backup/restore function names validated against qualifier's DB

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -545,7 +545,31 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                             "Invalid backup function(s), function name: " + functionName);
                 }
 
-                allFunctions.addAll(functionList);
+                // When the function is sourced from a different DB (cross-DB qualified reference),
+                // rewrite its FunctionName.db to the snapshot target DB on a shallow copy.
+                // Rewriting is required so that restore/replayCreateFunctionLog routes the
+                // function into the correct target DB rather than the qualifier DB.
+                // We copy the Function rather than mutating the live catalog object.
+                if (qualifierDbName != null && !qualifierDbName.equals(dbName)) {
+                    for (Function fn : functionList) {
+                        Function fnCopy = fn.copy();
+                        fnCopy.setFunctionName(new FunctionName(dbName, fn.getFunctionName().getFunction()));
+                        // Guard against signature collision: reject if a function with the same
+                        // name and signature is already in allFunctions (e.g. a local function
+                        // and a cross-DB function that share a signature).
+                        boolean collision = allFunctions.stream().anyMatch(
+                                existing -> fnCopy.compare(existing, Function.CompareMode.IS_IDENTICAL));
+                        if (collision) {
+                            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                    "Backup function conflict: cross-DB function " + qualifierDbName + "."
+                                            + functionName + " has the same signature as a function already "
+                                            + "selected for backup in database " + dbName);
+                        }
+                        allFunctions.add(fnCopy);
+                    }
+                } else {
+                    allFunctions.addAll(functionList);
+                }
             }
         }
         backupJob.setBackupFunctions(allFunctions);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -525,8 +525,21 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         } else {
             for (FunctionRef fnRef : stmt.getFnRefs()) {
                 String functionName = fnRef.getFunctionName();
+                String qualifierDbName = fnRef.getDbName();
 
-                List<Function> functionList = db.getFunctionsByName(functionName);
+                // When a DB qualifier is specified (e.g. fn_db2.my_func), resolve and use that DB
+                // rather than the backup target DB, mirroring the fix in FunctionNameAnalyzer.
+                Database lookupDb;
+                if (qualifierDbName != null) {
+                    lookupDb = globalStateMgr.getLocalMetastore().getDb(qualifierDbName);
+                    if (lookupDb == null) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, qualifierDbName);
+                    }
+                } else {
+                    lookupDb = db;
+                }
+
+                List<Function> functionList = lookupDb.getFunctionsByName(functionName);
                 if (functionList.isEmpty()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                             "Invalid backup function(s), function name: " + functionName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2520,12 +2520,27 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
 
             functionRefs.forEach(functionRef -> {
                 String functionName = functionRef.getFunctionName();
-                List<Function> fns = db.getFunctionsByName(functionName);
+                String qualifierDbName = functionRef.getDbName();
+
+                // For qualified names (e.g. fn_db2.my_func), check privileges against the
+                // qualifier's DB rather than the backup target DB, consistent with the fix
+                // in FunctionNameAnalyzer and BackupHandler.
+                Database fnDb;
+                if (qualifierDbName != null) {
+                    fnDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(qualifierDbName);
+                    if (fnDb == null) {
+                        fnDb = db;
+                    }
+                } else {
+                    fnDb = db;
+                }
+
+                List<Function> fns = fnDb.getFunctionsByName(functionName);
 
                 for (Function fn : fns) {
                     try {
                         Authorizer.checkFunctionAction(context,
-                                db, fn, PrivilegeType.USAGE);
+                                fnDb, fn, PrivilegeType.USAGE);
                     } catch (AccessDeniedException e) {
                         AccessDeniedException.reportAccessDenied(
                                 InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionNameAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionNameAnalyzer.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QualifiedName;
 
 import java.util.List;
@@ -67,12 +68,23 @@ public class FunctionNameAnalyzer {
             }
         }
 
-        List<Function> functionList = defaultDb.getFunctionsByName(functionName);
+        // When a DB qualifier is explicitly provided, look up that specific DB rather than
+        // always using defaultDb. This fixes false rejections when the function exists in
+        // the qualifier's DB but not in the BACKUP target DB.
+        Database lookupDb;
+        if (parts.size() == 2) {
+            lookupDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            if (lookupDb == null) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+            }
+        } else {
+            lookupDb = defaultDb;
+        }
+
+        List<Function> functionList = lookupDb.getFunctionsByName(functionName);
         if (functionList.isEmpty()) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                     "Invalid backup function(s), function name: " + functionName);
         }
     }
 }
-
-

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -59,6 +59,13 @@ public class AnalyzeBackupRestoreTest {
         AnalyzeTestUtil.getStarRocksAssert().withFunction("CREATE FUNCTION Echostring(string) RETURNS string properties" +
                         "(\"symbol\" = \"Echostring\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
 
+        // Set up a second database with a function for cross-DB qualified name tests (issue #70949)
+        AnalyzeTestUtil.getStarRocksAssert().withDatabase("fn_db2").useDatabase("fn_db2");
+        AnalyzeTestUtil.getStarRocksAssert().withFunction("CREATE FUNCTION fn_db2_func(string) RETURNS string properties" +
+                        "(\"symbol\" = \"fn_db2_func\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+        // Switch back to default test db
+        AnalyzeTestUtil.getStarRocksAssert().useDatabase("test");
+
         AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v1 AS select 1;");
         AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v2 AS select 2;");
 
@@ -278,6 +285,32 @@ public class AnalyzeBackupRestoreTest {
         analyzeFail("CANCEL RESTORE;");
         analyzeSuccess("CANCEL BACKUP FOR EXTERNAL CATALOG;");
         analyzeSuccess("CANCEL RESTORE FOR EXTERNAL CATALOG;");
+    }
+
+    /**
+     * Tests for issue #70949: qualified backup/restore function names should be validated
+     * against the qualifier's DB, not the BACKUP target DB (defaultDb).
+     */
+    @Test
+    public void testBackupFunctionWithQualifiedDbName() {
+        // Bug case 1: function exists in fn_db2 but not in test (backup target DB).
+        // Before fix: false rejection — "Invalid backup function(s)".
+        // After fix: should succeed because fn_db2.fn_db2_func exists in fn_db2.
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_cross_db TO `repo` ON " +
+                "(FUNCTION fn_db2.fn_db2_func) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+
+        // Unqualified reference to a function in the backup target DB still works.
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (FUNCTION Echostring) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+
+        // Qualified reference to a non-existent function in an existing DB should fail.
+        analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (FUNCTION fn_db2.no_such_func) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+
+        // Qualified reference to a function in a non-existent DB should fail.
+        analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (FUNCTION no_such_db.some_func) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

`FunctionNameAnalyzer.java` always uses `defaultDb` (the BACKUP target DB) for function name lookup, completely ignoring any DB qualifier prefix. This causes two failures:
1. **False rejection**: a function that exists in the qualifier's DB but not the default DB is rejected with `ERR 5064: Invalid backup function(s)`
2. **Silent wrong-object selection**: validation succeeds but against the wrong DB, silently selecting the wrong function for backup

Root cause: `defaultDb.getFunctionsByName(functionName)` at line ~70 ignores `parts[0]` (the DB qualifier) entirely.

## What I'm doing:

When a function name has a DB qualifier (`parts.size() == 2`), resolve the qualifier's DB via `GlobalStateMgr.getCurrentState().getLocalMetastore().getDb()` and use that DB for the `getFunctionsByName` lookup. If the qualifier DB doesn't exist, return `ERR_BAD_DB_ERROR`. Unqualified names continue to use `defaultDb` exactly as before.

Fixes #70949

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3