### PR TITLE
[BugFix] Display profile START_TIME/END_TIME with session timezone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -39,12 +39,19 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.estimate.Estimator;
+import com.starrocks.qe.ConnectContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -91,6 +98,8 @@ public class ProfileManager implements MemoryTrackable {
 
     public static class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();
+        public long startTimeMs = -1;
+        public long endTimeMs = -1;
         private byte[] profileContent;
         public ProfilingExecPlan plan;
 
@@ -133,10 +142,11 @@ public class ProfileManager implements MemoryTrackable {
             }
         }
 
-        public List<String> toRow() {
+        public List<String> toRow(ConnectContext context) {
+            ZoneId sessionZone = getSessionZoneId(context);
             List<String> res = Lists.newArrayList();
             res.add(infoStrings.get(QUERY_ID));
-            res.add(infoStrings.get(START_TIME));
+            res.add(formatTimestamp(startTimeMs, sessionZone));
             res.add(infoStrings.get(TOTAL_TIME));
             res.add(infoStrings.get(QUERY_STATE));
             String statement = infoStrings.getOrDefault(SQL_STATEMENT, "");
@@ -183,6 +193,8 @@ public class ProfileManager implements MemoryTrackable {
         for (String header : PROFILE_HEADERS) {
             element.infoStrings.put(header, summaryProfile.getInfoString(header));
         }
+        element.startTimeMs = parseTimeStringToEpochMs(summaryProfile.getInfoString(START_TIME));
+        element.endTimeMs = parseTimeStringToEpochMs(summaryProfile.getInfoString(END_TIME));
         try {
             element.setProfileContent(ProfileSerializer.serialize(fullProfile));
         } catch (IOException e) {
@@ -230,6 +242,7 @@ public class ProfileManager implements MemoryTrackable {
     }
 
     public List<List<String>> getAllQueries() {
+        ZoneId sessionZone = TimeUtils.getTimeZone().toZoneId();
         List<List<String>> result = Lists.newLinkedList();
         readLock.lock();
         try {
@@ -237,7 +250,13 @@ public class ProfileManager implements MemoryTrackable {
                 Map<String, String> infoStrings = element.infoStrings;
                 List<String> row = Lists.newArrayList();
                 for (String str : PROFILE_HEADERS) {
-                    row.add(infoStrings.get(str));
+                    if (START_TIME.equals(str)) {
+                        row.add(formatTimestamp(element.startTimeMs, sessionZone));
+                    } else if (END_TIME.equals(str)) {
+                        row.add(formatTimestamp(element.endTimeMs, sessionZone));
+                    } else {
+                        row.add(infoStrings.get(str));
+                    }
                 }
                 result.add(0, row);
             }
@@ -319,6 +338,63 @@ public class ProfileManager implements MemoryTrackable {
             return Estimator.estimate(profileMap, 10);
         } finally {
             readLock.unlock();
+        }
+    }
+
+    /**
+     * Extracts the session timezone from a {@link ConnectContext}.
+     * Falls back to the default session variable timezone if {@code context} is null.
+     */
+    private static ZoneId getSessionZoneId(ConnectContext context) {
+        String tz;
+        if (context != null && context.getSessionVariable() != null) {
+            tz = context.getSessionVariable().getTimeZone();
+        } else {
+            tz = TimeUtils.getSessionTimeZone();
+        }
+        return TimeUtils.getOrSystemTimeZone(tz).toZoneId();
+    }
+
+    /**
+     * Formats an epoch-millis timestamp in the given session timezone with the offset suffix.
+     * e.g. 1704067200000 with Asia/Shanghai -> "2024-01-01 08:00:00 (+08:00)"
+     */
+    static String formatTimestamp(long epochMs, ZoneId sessionZone) {
+        if (epochMs <= 0) {
+            return FeConstants.NULL_STRING;
+        }
+        Instant instant = Instant.ofEpochMilli(epochMs);
+        ZoneOffset offset = sessionZone.getRules().getOffset(instant);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(sessionZone);
+        return formatter.format(instant) + " (" + offset + ")";
+    }
+
+    private static final DateTimeFormatter STORAGE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Parses a time string formatted by {@link TimeUtils#longToTimeStringWithTimeZone}
+     * (e.g. "2024-01-01 08:00:00 (+08:00)") back to epoch milliseconds.
+     * Also accepts the bare format "2024-01-01 08:00:00" for backward compatibility.
+     */
+    private static long parseTimeStringToEpochMs(String timeStr) {
+        if (timeStr == null || timeStr.isEmpty()) {
+            return -1;
+        }
+        try {
+            // Strip timezone suffix " (+08:00)" or " (Z)" if present
+            String timePart = timeStr;
+            ZoneId zone = TimeUtils.DEFAULT_STORAGE_ZONE;
+            int parenIdx = timeStr.indexOf(" (");
+            if (parenIdx > 0) {
+                timePart = timeStr.substring(0, parenIdx);
+                String offsetStr = timeStr.substring(parenIdx + 2, timeStr.length() - 1);
+                zone = ZoneId.of(offsetStr);
+            }
+            LocalDateTime ldt = LocalDateTime.parse(timePart, STORAGE_FORMATTER);
+            return ldt.atZone(zone).toInstant().toEpochMilli();
+        } catch (Exception e) {
+            return -1;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -67,7 +67,8 @@ public class TimeUtils {
 
     public static final String DEFAULT_TIME_ZONE = "Asia/Shanghai";
 
-    private static final ZoneId TIME_ZONE = ZoneOffset.ofTotalSeconds(8 * 3600);
+    public static final ZoneId DEFAULT_STORAGE_ZONE = ZoneOffset.ofTotalSeconds(8 * 3600);
+    private static final ZoneId TIME_ZONE = DEFAULT_STORAGE_ZONE;
 
     // set CST to +08:00 instead of America/Chicago
     public static final ImmutableMap<String, String> TIME_ZONE_ALIAS_MAP = ImmutableMap.of(
@@ -171,6 +172,29 @@ public class TimeUtils {
             return FeConstants.NULL_STRING;
         }
         return longToTimeString(timeStamp, DATETIME_TO_STRING_FORMAT);
+    }
+
+    /**
+     * Formats a timestamp using the session timezone and appends the UTC offset suffix.
+     * e.g. "2024-01-01 08:00:00 (+08:00)"
+     */
+    public static String longToTimeStringWithTimeZone(long timeStamp) {
+        return longToTimeStringWithTimeZone(timeStamp, getTimeZone().toZoneId());
+    }
+
+    /**
+     * Formats a timestamp using the given timezone and appends the UTC offset suffix.
+     * Use this overload when formatting multiple timestamps that should share the same timezone.
+     */
+    public static String longToTimeStringWithTimeZone(long timeStamp, ZoneId zoneId) {
+        if (timeStamp <= 0L) {
+            return FeConstants.NULL_STRING;
+        }
+        Instant instant = Instant.ofEpochMilli(timeStamp);
+        ZoneOffset offset = zoneId.getRules().getOffset(instant);
+        String time = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                .withZone(zoneId).format(instant);
+        return time + " (" + offset + ")";
     }
 
     public static LocalDate parseDate(String dateStr) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -629,11 +629,12 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
         try {
             RuntimeProfile profile = new RuntimeProfile("Load");
             RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+            java.time.ZoneId profileZone = TimeUtils.getTimeZone().toZoneId();
             summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(loadId));
             summaryProfile.addInfoString(ProfileManager.START_TIME,
-                    TimeUtils.longToTimeString(loadTimeTrace.createTimeMs));
+                    TimeUtils.longToTimeStringWithTimeZone(loadTimeTrace.createTimeMs, profileZone));
             summaryProfile.addInfoString(ProfileManager.END_TIME,
-                    TimeUtils.longToTimeString(loadTimeTrace.endTimeMs.get()));
+                    TimeUtils.longToTimeStringWithTimeZone(loadTimeTrace.endTimeMs.get(), profileZone));
             summaryProfile.addInfoString(ProfileManager.TOTAL_TIME,
                     DebugUtil.getPrettyStringMs(loadTimeTrace.totalCostMs()));
             summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -181,13 +181,15 @@ public class LoadLoadingTask extends LoadTask {
     public RuntimeProfile buildTopLevelProfile(boolean isFinished) {
         RuntimeProfile profile = new RuntimeProfile("Load");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        java.time.ZoneId profileZone = TimeUtils.getTimeZone().toZoneId();
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(getLoadId()));
         summaryProfile.addInfoString(ProfileManager.START_TIME,
-                TimeUtils.longToTimeString(createTimestamp));
+                TimeUtils.longToTimeStringWithTimeZone(createTimestamp, profileZone));
 
         long currentTimestamp = System.currentTimeMillis();
         long totalTimeMs = currentTimestamp - createTimestamp;
-        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
+        summaryProfile.addInfoString(ProfileManager.END_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(currentTimestamp, profileZone));
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1205,13 +1205,15 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
     public RuntimeProfile buildTopLevelProfile(boolean isAborted) {
         RuntimeProfile profile = new RuntimeProfile("Load");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        java.time.ZoneId profileZone = TimeUtils.getTimeZone().toZoneId();
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(loadId));
         summaryProfile.addInfoString(ProfileManager.START_TIME,
-                TimeUtils.longToTimeString(createTimeMs));
+                TimeUtils.longToTimeStringWithTimeZone(createTimeMs, profileZone));
 
         long currentTimestamp = System.currentTimeMillis();
         long totalTimeMs = currentTimestamp - createTimeMs;
-        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
+        summaryProfile.addInfoString(ProfileManager.END_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(currentTimestamp, profileZone));
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1054,7 +1054,7 @@ public class ShowExecutor {
             int count = 0;
             while (iterator.hasNext()) {
                 ProfileManager.ProfileElement element = iterator.next();
-                List<String> row = element.toRow();
+                List<String> row = element.toRow(context);
                 rowSet.add(row);
                 count++;
                 if (statement.getLimit() >= 0 && count >= statement.getLimit()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -410,12 +410,15 @@ public class StmtExecutor {
     private RuntimeProfile buildTopLevelProfile() {
         RuntimeProfile profile = new RuntimeProfile("Query");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        java.time.ZoneId profileZone = TimeUtils.getTimeZone().toZoneId();
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(context.getExecutionId()));
-        summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(context.getStartTime()));
+        summaryProfile.addInfoString(ProfileManager.START_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(context.getStartTime(), profileZone));
 
         long currentTimestamp = System.currentTimeMillis();
         long totalTimeMs = currentTimestamp - context.getStartTime();
-        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
+        summaryProfile.addInfoString(ProfileManager.END_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(currentTimestamp, profileZone));
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
@@ -1575,6 +1578,9 @@ public class StmtExecutor {
         // This process will get information from the context, so it must be executed synchronously.
         // Otherwise, the context may be changed, for example, containing the wrong query id.
         profile = buildTopLevelProfile();
+        // Capture the session timezone now so that the async profile task uses the same zone
+        // as START_TIME (the context may change before the async task runs).
+        java.time.ZoneId profileZoneForAsync = TimeUtils.getTimeZone().toZoneId();
 
         long profileCollectStartTime = System.currentTimeMillis();
         long startTime = context.getStartTime();
@@ -1594,7 +1600,8 @@ public class StmtExecutor {
             // Update TotalTime to include the Profile Collect Time and the time to build the profile.
             long now = System.currentTimeMillis();
             long totalTimeMs = now - startTime;
-            summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(now));
+            summaryProfile.addInfoString(ProfileManager.END_TIME,
+                    TimeUtils.longToTimeStringWithTimeZone(now, profileZoneForAsync));
             summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
             if (retryIndex > 0) {
                 summaryProfile.addInfoString(ProfileManager.RETRY_TIMES, Integer.toString(retryIndex + 1));

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -193,12 +193,15 @@ public class ExportExportingTask extends PriorityLeaderTask {
     private void initProfile() {
         profile = new RuntimeProfile("Query");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        java.time.ZoneId profileZone = TimeUtils.getTimeZone().toZoneId();
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, String.valueOf(job.getId()));
-        summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(job.getStartTimeMs()));
+        summaryProfile.addInfoString(ProfileManager.START_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(job.getStartTimeMs(), profileZone));
 
         long currentTimestamp = System.currentTimeMillis();
         long totalTimeMs = currentTimestamp - job.getStartTimeMs();
-        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
+        summaryProfile.addInfoString(ProfileManager.END_TIME,
+                TimeUtils.longToTimeStringWithTimeZone(currentTimestamp, profileZone));
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileSerializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileSerializerTest.java
@@ -120,8 +120,8 @@ public class ProfileSerializerTest {
         summary.addInfoString(ProfileManager.QUERY_ID, "query-roundtrip-001");
         summary.addInfoString(ProfileManager.SQL_STATEMENT, "SELECT 1");
         summary.addInfoString(ProfileManager.QUERY_STATE, "EOF");
-        summary.addInfoString(ProfileManager.START_TIME, "2024-01-01 00:00:00");
-        summary.addInfoString(ProfileManager.END_TIME, "2024-01-01 00:00:01");
+        summary.addInfoString(ProfileManager.START_TIME, "2024-01-01 00:00:00 (+08:00)");
+        summary.addInfoString(ProfileManager.END_TIME, "2024-01-01 00:00:01 (+08:00)");
         summary.addInfoString(ProfileManager.TOTAL_TIME, "1s500ms");
         summary.addInfoString(ProfileManager.USER, "root");
         summary.addInfoString(ProfileManager.DEFAULT_DB, "tpch");


### PR DESCRIPTION
## Why I'm doing:

- Profile START_TIME/END_TIME now display in the session's `time_zone` with an explicit UTC offset suffix, e.g. `2026-04-08 08:00:00 (+08:00)`
- When viewing profiles via `SHOW PROFILELIST`, times are re-formatted to the querying user's session timezone
- Timestamps within a single profile always use the same timezone to avoid inconsistent offsets between START_TIME and END_TIME

show profile list display time by time zone:
```
mysql> show profilelist;
+--------------------------------------+-------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
| QueryId                              | StartTime               | Time  | State    | Statement                                                                                                                        |
+--------------------------------------+-------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
| 019d6c57-ab33-770f-93ba-adabf0769339 | 2026-04-08 09:06:18 (Z) | 21ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c57-a7ac-76da-a7c5-f3f9269161d6 | 2026-04-08 09:06:17 (Z) | 19ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-f980-729b-8cdf-bd2e4c6e15de | 2026-04-08 09:05:32 (Z) | 573ms | Finished | DELETE FROM `_statistics_`.`column_statistics` WHERE (`_statistics_`.`column_statistics`.`TABLE_ID` IN (3450722, 3450728, 26 ... |
| 019d6c56-f98a-7392-83ac-1392c7c34bbc | 2026-04-08 09:05:32 (Z) | 254ms | Finished | INSERT INTO `_statistics_`.`tablet_write_log_history` SELECT `information_schema`.`be_tablet_write_log`.`be_id`, `informatio ... |
| 019d6c56-6e70-787d-8155-7935cd9b9754 | 2026-04-08 09:04:56 (Z) | 21ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-6944-7e75-995c-0b87c0dcca25 | 2026-04-08 09:04:55 (Z) | 20ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-45f2-7e8e-a988-a3adf23a6132 | 2026-04-08 09:04:46 (Z) | 24ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-3f8f-7f73-a9da-e1062e8fe2c8 | 2026-04-08 09:04:44 (Z) | 51ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
+--------------------------------------+-------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
8 rows in set (0.00 sec)

mysql> set time_zone="+06:00";
Query OK, 0 rows affected (0.00 sec)

mysql> show profilelist;
+--------------------------------------+------------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
| QueryId                              | StartTime                    | Time  | State    | Statement                                                                                                                        |
+--------------------------------------+------------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
| 019d6c57-ec65-7025-b04b-036c7cd220f5 | 2026-04-08 15:06:34 (+06:00) | 20ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c57-e4ce-753c-8e8d-01a0ffb10b53 | 2026-04-08 15:06:32 (+06:00) | 113ms | Finished | INSERT INTO `_statistics_`.`tablet_write_log_history` SELECT `information_schema`.`be_tablet_write_log`.`be_id`, `informatio ... |
| 019d6c57-ab33-770f-93ba-adabf0769339 | 2026-04-08 15:06:18 (+06:00) | 21ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c57-a7ac-76da-a7c5-f3f9269161d6 | 2026-04-08 15:06:17 (+06:00) | 19ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-f980-729b-8cdf-bd2e4c6e15de | 2026-04-08 15:05:32 (+06:00) | 573ms | Finished | DELETE FROM `_statistics_`.`column_statistics` WHERE (`_statistics_`.`column_statistics`.`TABLE_ID` IN (3450722, 3450728, 26 ... |
| 019d6c56-f98a-7392-83ac-1392c7c34bbc | 2026-04-08 15:05:32 (+06:00) | 254ms | Finished | INSERT INTO `_statistics_`.`tablet_write_log_history` SELECT `information_schema`.`be_tablet_write_log`.`be_id`, `informatio ... |
| 019d6c56-6e70-787d-8155-7935cd9b9754 | 2026-04-08 15:04:56 (+06:00) | 21ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-6944-7e75-995c-0b87c0dcca25 | 2026-04-08 15:04:55 (+06:00) | 20ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-45f2-7e8e-a988-a3adf23a6132 | 2026-04-08 15:04:46 (+06:00) | 24ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
| 019d6c56-3f8f-7f73-a9da-e1062e8fe2c8 | 2026-04-08 15:04:44 (+06:00) | 51ms  | Finished | select get_query_profile(last_query_id())                                                                                        |
+--------------------------------------+------------------------------+-------+----------+----------------------------------------------------------------------------------------------------------------------------------+
10 rows in set (0.00 sec)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
