### PR TITLE
[BugFix] Implement replayOnVisible/replayOnAborted in InsertLoadJob to prevent stuck jobs after FE crash

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -285,16 +285,51 @@ public class InsertLoadJob extends LoadJob {
     public void afterAborted(TransactionState txnState, String txnStatusChangeReason) {
     }
 
+    /**
+     * Replays the cancelled state of this INSERT load job during FE journal replay.
+     *
+     * <p>When FE crashes between the transaction ABORTED journal write and the
+     * {@code OP_END_LOAD_JOB_V2} journal write, the job is left in LOADING/QUEUEING
+     * state after restart. This method finalises the job as CANCELLED so it does not
+     * remain stuck.
+     */
     @Override
     public void replayOnAborted(TransactionState txnState) {
+        writeLock();
+        try {
+            failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnState.getReason());
+            finishTimestamp = txnState.getFinishTime();
+            state = JobState.CANCELLED;
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
+        } finally {
+            writeUnlock();
+        }
     }
 
     @Override
     public void afterVisible(TransactionState txnState) {
     }
 
+    /**
+     * Replays the finished state of this INSERT load job during FE journal replay.
+     *
+     * <p>When FE crashes between the transaction VISIBLE journal write and the
+     * {@code OP_END_LOAD_JOB_V2} journal write, the job is left in LOADING/QUEUEING
+     * state after restart. This method finalises the job as FINISHED so it does not
+     * remain stuck.
+     */
     @Override
     public void replayOnVisible(TransactionState txnState) {
+        writeLock();
+        try {
+            progress = 100;
+            finishTimestamp = txnState.getFinishTime();
+            state = JobState.FINISHED;
+            failMsg = null;
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
+        } finally {
+            writeUnlock();
+        }
     }
 
     public long getTableId() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -444,6 +444,16 @@ public class LoadMgr implements MemoryTrackable {
                 } catch (StarRocksException e) {
                     LOG.warn("failed to abort job: {}", job.getLabel(), e);
                 }
+            } else if (state.getTransactionStatus() == TransactionStatus.VISIBLE) {
+                // The transaction was already committed and visible, but the
+                // OP_END_LOAD_JOB_V2 journal was not written before FE crashed.
+                // Finish the job so it does not remain permanently stuck in QUEUEING.
+                try {
+                    recordFinishedOrCancelledLoadJob(job.getId(), EtlJobType.INSERT, "", "");
+                    LOG.warn("finish job: {}-{} since transaction is already visible", job.getLabel(), job.getId());
+                } catch (StarRocksException e) {
+                    LOG.warn("failed to finish job: {}", job.getLabel(), e);
+                }
             }
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobTest.java
@@ -41,6 +41,9 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TxnStateCallbackFactory;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -137,5 +140,101 @@ public class InsertLoadJobTest {
             Assertions.assertTrue(loadJob.getTabletCommitInfos().isEmpty());
             Assertions.assertTrue(loadJob.getTabletFailInfos().isEmpty());
         }
+    }
+
+    /**
+     * Verifies that {@code replayOnVisible} transitions the job to FINISHED.
+     *
+     * <p>This regression test covers the scenario where FE crashes between the
+     * txn VISIBLE journal write and the OP_END_LOAD_JOB_V2 write; after restart
+     * the transaction-manager replay should call replayOnVisible and the job must
+     * be marked FINISHED rather than remaining stuck in QUEUEING.
+     */
+    @Test
+    public void testReplayOnVisible(@Mocked GlobalStateMgr globalStateMgr,
+                                    @Injectable GlobalTransactionMgr globalTransactionMgr,
+                                    @Injectable TxnStateCallbackFactory callbackFactory,
+                                    @Injectable TransactionState txnState) throws MetaNotFoundException {
+        InsertLoadJob insertLoadJob = new InsertLoadJob("label_visible", 1L, 1L, 1000, "", "", null);
+        // Override state to simulate a mid-execution job (as if FE crashed)
+        Deencapsulation.setField(insertLoadJob, "state", JobState.LOADING);
+        Deencapsulation.setField(insertLoadJob, "progress", 50);
+
+        long finishMs = System.currentTimeMillis();
+        new Expectations() {
+            {
+                globalStateMgr.getGlobalTransactionMgr();
+                minTimes = 0;
+                result = globalTransactionMgr;
+
+                globalTransactionMgr.getCallbackFactory();
+                minTimes = 0;
+                result = callbackFactory;
+
+                callbackFactory.removeCallback(anyLong);
+                minTimes = 0;
+
+                txnState.getFinishTime();
+                minTimes = 0;
+                result = finishMs;
+            }
+        };
+
+        insertLoadJob.replayOnVisible(txnState);
+
+        Assertions.assertEquals(JobState.FINISHED, insertLoadJob.getState());
+        Assertions.assertEquals(100, insertLoadJob.getProgress());
+        Assertions.assertNull(insertLoadJob.getFailMsg());
+        Assertions.assertEquals(finishMs, insertLoadJob.getFinishTimestamp());
+    }
+
+    /**
+     * Verifies that {@code replayOnAborted} transitions the job to CANCELLED.
+     *
+     * <p>This regression test covers the scenario where FE crashes between the
+     * txn ABORTED journal write and the OP_END_LOAD_JOB_V2 write; after restart
+     * the transaction-manager replay should call replayOnAborted and the job must
+     * be marked CANCELLED rather than remaining stuck in QUEUEING.
+     */
+    @Test
+    public void testReplayOnAborted(@Mocked GlobalStateMgr globalStateMgr,
+                                    @Injectable GlobalTransactionMgr globalTransactionMgr,
+                                    @Injectable TxnStateCallbackFactory callbackFactory,
+                                    @Injectable TransactionState txnState) throws MetaNotFoundException {
+        InsertLoadJob insertLoadJob = new InsertLoadJob("label_aborted", 1L, 1L, 1000, "", "", null);
+        Deencapsulation.setField(insertLoadJob, "state", JobState.LOADING);
+        Deencapsulation.setField(insertLoadJob, "progress", 50);
+
+        long finishMs = System.currentTimeMillis();
+        String failReason = "transaction aborted by user";
+        new Expectations() {
+            {
+                globalStateMgr.getGlobalTransactionMgr();
+                minTimes = 0;
+                result = globalTransactionMgr;
+
+                globalTransactionMgr.getCallbackFactory();
+                minTimes = 0;
+                result = callbackFactory;
+
+                callbackFactory.removeCallback(anyLong);
+                minTimes = 0;
+
+                txnState.getFinishTime();
+                minTimes = 0;
+                result = finishMs;
+
+                txnState.getReason();
+                minTimes = 0;
+                result = failReason;
+            }
+        };
+
+        insertLoadJob.replayOnAborted(txnState);
+
+        Assertions.assertEquals(JobState.CANCELLED, insertLoadJob.getState());
+        Assertions.assertNotNull(insertLoadJob.getFailMsg());
+        Assertions.assertEquals(failReason, insertLoadJob.getFailMsg().getMsg());
+        Assertions.assertEquals(finishMs, insertLoadJob.getFinishTimestamp());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When FE crashes between the txn `VISIBLE` (or `ABORTED`) journal write and the `OP_END_LOAD_JOB_V2` journal write, INSERT load jobs get permanently stuck in `QUEUEING`/`LOADING` state after FE restart. This happens because `replayOnVisible()` and `replayOnAborted()` were empty no-ops in `InsertLoadJob`, so replay never finalizes the job state. Additionally, `cancelResidualJob()` skips jobs whose txn status is `VISIBLE`, making them irrecoverable without manual intervention.

## What I'm doing:

- **`InsertLoadJob.replayOnVisible()`**: implement to set `state=FINISHED`, `progress=100`, `finishTimestamp`, and remove the txn callback — mirrors base class `LoadJob.replayOnVisible()`
- **`InsertLoadJob.replayOnAborted()`**: implement to set `state=CANCELLED`, `failMsg`, `finishTimestamp`, and remove the txn callback — mirrors base class `LoadJob.replayOnAborted()`
- **`LoadMgr.cancelResidualJob()`**: also handle `TransactionStatus.VISIBLE` so jobs whose txn committed-and-visible but `OP_END_LOAD_JOB_V2` was never written get finalized as `FINISHED` instead of staying stuck in `QUEUEING` (defense-in-depth safety net)

Fixes #70942

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3