### PR TITLE
[Enhancement] Create PACK shard group and colocate-aligned tablets for range colocate tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1038,7 +1038,7 @@ public class RestoreJob extends AbstractJob {
         if (isColocate) {
             try {
                 isColocate = GlobalStateMgr.getCurrentState().getColocateTableIndex()
-                        .addTableToGroup(db, remoteOlapTbl, colocateGroup, false);
+                        .addTableToGroup(db, remoteOlapTbl, colocateGroup, false /* afterTabletCreation */);
             } catch (Exception e) {
                 return new Status(ErrCode.COMMON_ERROR,
                         "check colocate restore failed, errmsg: " + e.getMessage() +

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.staros.proto.PlacementPolicy;
+import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.ColocatePropertyInfo;
@@ -145,8 +147,9 @@ public class ColocateTableIndex implements Writable {
     @SerializedName("crm")
     private ColocateRangeMgr colocateRangeMgr = new ColocateRangeMgr();
 
-    // lake group, in memory
-    private final Set<GroupId> lakeGroups = Sets.newHashSet();
+    // Colocate groups that use StarOS MetaGroup (hash colocate lake tables only), in memory.
+    // Range colocate uses PACK shard groups instead.
+    private final Set<GroupId> metaGroups = Sets.newHashSet();
 
     private final transient ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -179,13 +182,21 @@ public class ColocateTableIndex implements Writable {
     }
 
     public boolean addTableToGroup(Database db,
-                                   OlapTable olapTable, String colocateGroup, boolean expectLakeTable)
+                                   OlapTable olapTable, String colocateGroup, boolean afterTabletCreation)
             throws DdlException {
         if (Strings.isNullOrEmpty(colocateGroup)) {
             return false;
         }
 
-        if (olapTable.isCloudNativeTableOrMaterializedView() != expectLakeTable) {
+        boolean isLakeTable = olapTable.isCloudNativeTableOrMaterializedView();
+        boolean isRangeColocate = olapTable.getDefaultDistributionInfo().getType()
+                == DistributionInfoType.RANGE;
+        // Hash colocate lake tables: handle after tablet creation,
+        //   because MetaGroup creation needs shard group IDs.
+        // All others (non-lake tables, range colocate lake tables): handle before tablet creation,
+        //   because range colocate needs PACK shard group to exist before tablets are created.
+        boolean requiresAfterTabletCreation = isLakeTable && !isRangeColocate;
+        if (requiresAfterTabletCreation != afterTabletCreation) {
             return false;
         }
 
@@ -234,7 +245,13 @@ public class ColocateTableIndex implements Writable {
 
             if (groupName2Id.containsKey(fullGroupName)) {
                 groupId = groupName2Id.get(fullGroupName);
-                group2Schema.get(groupId).checkColocateSchema(tbl, colocateGroup);
+                ColocateGroupSchema existingSchema = group2Schema.get(groupId);
+                existingSchema.checkColocateSchema(tbl, colocateGroup);
+                // Fail fast if range colocate metadata is missing (e.g., not yet restored via image/edit log)
+                if (existingSchema.isRangeColocate() && !colocateRangeMgr.containsColocateGroup(groupId.grpId)) {
+                    throw new DdlException("Range colocate group '" + colocateGroup
+                            + "' exists but colocate range metadata is missing");
+                }
             } else {
                 if (assignedGroupId != null) {
                     // use the given group id, eg, in replay process or cross db colocation
@@ -253,9 +270,11 @@ public class ColocateTableIndex implements Writable {
                             0, tbl.getDefaultReplicationNum(),
                             distributionInfo.getType());
 
-                    if (!colocateRangeMgr.containsColocateGroup(groupId.grpId)) {
-                        // TODO: create actual PACK shard group via StarOSAgent
-                        colocateRangeMgr.initColocateGroup(groupId.grpId, 0);
+                    if (!isReplay && !colocateRangeMgr.containsColocateGroup(groupId.grpId)) {
+                        long packShardGroupId = GlobalStateMgr.getCurrentState()
+                                .getStarOSAgent().createShardGroup(
+                                        dbId, tbl.getId(), 0, 0, PlacementPolicy.PACK);
+                        colocateRangeMgr.initColocateGroup(groupId.grpId, packShardGroupId);
                     }
                 } else if (distributionInfo instanceof HashDistributionInfo) {
                     HashDistributionInfo hashDistInfo = (HashDistributionInfo) distributionInfo;
@@ -286,8 +305,8 @@ public class ColocateTableIndex implements Writable {
                     && tbl.isCloudNativeTableOrMaterializedView()) {
                 if (!isReplay) { // leader create or update meta group
                     List<Long> shardGroupIds = tbl.getShardGroupIds();
-                    // check the group existence in lakeGroups
-                    boolean groupAlreadyExist = lakeGroups.stream().anyMatch(gid -> Objects.equals(gid.grpId, groupId.grpId));
+                    // check the group existence in metaGroups
+                    boolean groupAlreadyExist = metaGroups.stream().anyMatch(gid -> Objects.equals(gid.grpId, groupId.grpId));
                     if (!groupAlreadyExist) {
                         GlobalStateMgr.getCurrentState().getStarOSAgent().createMetaGroup(groupId.grpId, shardGroupIds);
                     } else {
@@ -295,7 +314,7 @@ public class ColocateTableIndex implements Writable {
                                 .updateMetaGroup(groupId.grpId, shardGroupIds, true /* isJoin */);
                     }
                 }
-                lakeGroups.add(groupId);
+                metaGroups.add(groupId);
             }
 
             group2Tables.put(groupId, tbl.getId());
@@ -385,12 +404,16 @@ public class ColocateTableIndex implements Writable {
             GroupId groupId = table2Group.remove(tableId);
 
             if (tbl != null && tbl.isCloudNativeTableOrMaterializedView() && !isReplay) {
-                List<Long> shardGroupIds = tbl.getShardGroupIds();
-                try {
-                    GlobalStateMgr.getCurrentState().getStarOSAgent().updateMetaGroup(groupId.grpId, shardGroupIds,
-                            false /* isJoin */);
-                } catch (DdlException e) {
-                    LOG.error(e.getMessage(), e);
+                // Range colocate uses PACK shard groups instead of MetaGroup, skip.
+                ColocateGroupSchema schema = group2Schema.get(groupId);
+                if (schema == null || !schema.isRangeColocate()) {
+                    List<Long> shardGroupIds = tbl.getShardGroupIds();
+                    try {
+                        GlobalStateMgr.getCurrentState().getStarOSAgent().updateMetaGroup(groupId.grpId, shardGroupIds,
+                                false /* isJoin */);
+                    } catch (DdlException e) {
+                        LOG.error(e.getMessage(), e);
+                    }
                 }
             }
 
@@ -400,7 +423,7 @@ public class ColocateTableIndex implements Writable {
                 group2BackendsPerBucketSeq.remove(groupId);
                 group2Schema.remove(groupId);
                 unstableGroups.remove(groupId);
-                lakeGroups.remove(groupId);
+                metaGroups.remove(groupId);
                 String fullGroupName = null;
                 for (Map.Entry<String, GroupId> entry : groupName2Id.entrySet()) {
                     if (entry.getValue().equals(groupId)) {
@@ -422,7 +445,7 @@ public class ColocateTableIndex implements Writable {
     public boolean isGroupUnstable(GroupId groupId) {
         readLock();
         try {
-            if (lakeGroups.contains(groupId)) {
+            if (metaGroups.contains(groupId)) {
                 return !GlobalStateMgr.getCurrentState().getStarOSAgent().queryMetaGroupStable(groupId.grpId);
             } else {
                 return unstableGroups.contains(groupId);
@@ -441,14 +464,14 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
-    public boolean isLakeColocateTable(long tableId) {
+    public boolean isMetaGroupColocateTable(long tableId) {
         readLock();
         try {
             GroupId groupId = table2Group.get(tableId);
             if (groupId == null) {
                 return false;
             }
-            return lakeGroups.contains(groupId);
+            return metaGroups.contains(groupId);
         } finally {
             readUnlock();
         }
@@ -807,7 +830,7 @@ public class ColocateTableIndex implements Writable {
         this.colocateRangeMgr = data.colocateRangeMgr != null ? data.colocateRangeMgr : new ColocateRangeMgr();
 
         cleanupInvalidDbOrTable(GlobalStateMgr.getCurrentState());
-        constructLakeGroups(GlobalStateMgr.getCurrentState());
+        constructMetaGroups(GlobalStateMgr.getCurrentState());
         LOG.info("finished replay colocateTableIndex from image");
     }
 
@@ -1064,6 +1087,12 @@ public class ColocateTableIndex implements Writable {
                 groupId = table2Group.get(olapTable.getId());
             }
 
+            // Range colocate uses PACK shard groups instead of MetaGroup, skip.
+            ColocateGroupSchema schema = group2Schema.get(groupId);
+            if (schema != null && schema.isRangeColocate()) {
+                return;
+            }
+
             List<Long> shardGroupIds = olapTable.getShardGroupIds();
             LOG.info("update meta group id {}, table {}, shard groups: {}, join: {}",
                     groupId.grpId, olapTable.getId(), shardGroupIds, isJoin);
@@ -1073,7 +1102,7 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
-    private void constructLakeGroups(GlobalStateMgr globalStateMgr) {
+    private void constructMetaGroups(GlobalStateMgr globalStateMgr) {
         if (RunMode.isSharedNothingMode()) {
             return;
         }
@@ -1085,7 +1114,13 @@ public class ColocateTableIndex implements Writable {
             Database database = globalStateMgr.getLocalMetastore().getDbIncludeRecycleBin(dbId);
             Table table = globalStateMgr.getLocalMetastore().getTableIncludeRecycleBin(database, tableId);
             if (table.isCloudNativeTableOrMaterializedView()) {
-                lakeGroups.add(entry.getValue());
+                // metaGroups tracks hash colocate groups that use MetaGroup.
+                // Range colocate uses PACK shard groups instead, skip.
+                ColocateGroupSchema schema = group2Schema.get(entry.getValue());
+                if (schema != null && schema.isRangeColocate()) {
+                    continue;
+                }
+                metaGroups.add(entry.getValue());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -273,7 +273,10 @@ public class ColocateTableIndex implements Writable {
                     if (!isReplay && !colocateRangeMgr.containsColocateGroup(groupId.grpId)) {
                         long packShardGroupId = GlobalStateMgr.getCurrentState()
                                 .getStarOSAgent().createShardGroup(
-                                        dbId, tbl.getId(), 0, 0, PlacementPolicy.PACK);
+                                        dbId, tbl.getId(),
+                                        0 /* partitionId: not partition-specific */,
+                                        0 /* indexId: not index-specific */,
+                                        PlacementPolicy.PACK);
                         colocateRangeMgr.initColocateGroup(groupId.grpId, packShardGroupId);
                     }
                 } else if (distributionInfo instanceof HashDistributionInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1959,7 +1959,7 @@ public class PropertyAnalyzer {
                     throw new AnalysisException(": random distribution does not support 'colocate_with'");
                 }
                 GlobalStateMgr.getCurrentState().getColocateTableIndex().addTableToGroup(
-                        db, materializedView, colocateGroup, false /* expectLakeTable */);
+                        db, materializedView, colocateGroup, false /* afterTabletCreation */);
             }
 
             // enable_query_rewrite

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -575,7 +575,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
 
     private void syncTableColocationInfo(Database db, OlapTable table) throws DdlException {
         // quick check
-        if (!GlobalStateMgr.getCurrentState().getColocateTableIndex().isLakeColocateTable(table.getId())) {
+        if (!GlobalStateMgr.getCurrentState().getColocateTableIndex().isMetaGroupColocateTable(table.getId())) {
             return;
         }
         Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -56,6 +56,8 @@ import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeUtils;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
@@ -83,6 +85,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -2268,13 +2271,25 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         properties.put(LakeTablet.PROPERTY_KEY_TABLE_ID, Long.toString(table.getId()));
         properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
         properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(index.getId()));
-        int bucketNum = distributionInfo.getBucketNum();
         final long warehouseId = computeResource.getWarehouseId();
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (!warehouseManager.isResourceAvailable(computeResource)) {
             Warehouse warehouse = warehouseManager.getWarehouse(warehouseId);
             throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
         }
+
+        // For range colocate tables: create tablets aligned with colocate ranges,
+        // each tablet belonging to both SPREAD and PACK shard groups.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        if (distributionInfo instanceof RangeDistributionInfo
+                && colocateTableIndex.isColocateTable(table.getId())) {
+            createRangeColocateLakeTablets(table, physicalPartitionId, shardGroupId,
+                    index, tabletMeta, tabletIdSet, computeResource, properties,
+                    colocateTableIndex.getGroup(table.getId()));
+            return;
+        }
+
+        int bucketNum = distributionInfo.getBucketNum();
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),
@@ -2287,6 +2302,39 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             index.addTablet(tablet, tabletMeta);
             tabletIdSet.add(tablet.getId());
+        }
+    }
+
+    private void createRangeColocateLakeTablets(OlapTable table, long physicalPartitionId,
+                                                 long spreadShardGroupId, MaterializedIndex index,
+                                                 TabletMeta tabletMeta, Set<Long> tabletIdSet,
+                                                 ComputeResource computeResource,
+                                                 Map<String, String> properties,
+                                                 ColocateTableIndex.GroupId groupId)
+            throws DdlException {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> colocateRanges = colocateTableIndex.getColocateRangeMgr()
+                .getColocateRanges(groupId.grpId);
+        if (colocateRanges.isEmpty()) {
+            throw new DdlException("Colocate range metadata is missing for group '"
+                    + table.getColocateGroup() + "', cannot create range colocate tablets");
+        }
+        int colocateColumnCount = colocateTableIndex.getGroupSchema(groupId).getColocateColumnCount();
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
+
+        for (ColocateRange colocateRange : colocateRanges) {
+            List<Long> shardIds = stateMgr.getStarOSAgent().createShards(1,
+                    table.getPartitionFilePathInfo(physicalPartitionId),
+                    table.getPartitionFileCacheInfo(physicalPartitionId),
+                    List.of(spreadShardGroupId, colocateRange.getShardGroupId()),
+                    null, properties, computeResource);
+
+            long shardId = shardIds.get(0);
+            TabletRange tabletRange = new TabletRange(ColocateRangeUtils.expandToFullSortKey(
+                    colocateRange.getRange(), sortKeyColumns, colocateColumnCount));
+            LakeTablet tablet = new LakeTablet(shardId, tabletRange);
+            index.addTablet(tablet, tabletMeta);
+            tabletIdSet.add(shardId);
         }
     }
 
@@ -3316,6 +3364,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         boolean isNonPartitioned = partitionInfo.isUnPartitioned();
         DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
         String colocateGroup = properties.get(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH);
+        // PropertyAnalyzer.analyzeMVProperties calls addTableToGroup(false) internally,
+        // which handles non-lake MVs and range colocate lake MVs (before tablet creation).
         PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
                 stmt.getPartitionByExprToAdjustExprMap());
         final long warehouseId = materializedView.getWarehouseId();
@@ -3337,9 +3387,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 materializedView.setPartitionExprMaps(partitionExprMaps);
             }
 
-            // shared-data mv's colocation info must be updated after tablet creation
+            // Hash colocate lake tables: set up MetaGroup after tablet creation
             if (StringUtils.isNotEmpty(colocateGroup)) {
-                colocateTableIndex.addTableToGroup(db, materializedView, colocateGroup, true /* expectLakeTable */);
+                colocateTableIndex.addTableToGroup(db, materializedView, colocateGroup,
+                        true /* afterTabletCreation */);
             }
 
             GlobalStateMgr.getCurrentState().getMaterializedViewMgr().prepareMaintenanceWork(stmt, materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -655,16 +655,6 @@ public class OlapTableFactory implements AbstractTableFactory {
                 partitionInfo.setDataCacheInfo(partitionId, dataCacheInfo);
             }
 
-            // check colocation properties
-            String colocateGroup = PropertyAnalyzer.analyzeColocate(properties);
-            if (StringUtils.isNotEmpty(colocateGroup)) {
-                if (!distributionInfo.supportColocate()) {
-                    throw new DdlException("random distribution does not support 'colocate_with'");
-                }
-
-                colocateTableIndex.addTableToGroup(db, table, colocateGroup, false /* expectLakeTable */);
-            }
-
             // get base index storage type. default is COLUMN
             TStorageType baseIndexStorageType;
             try {
@@ -690,6 +680,17 @@ public class OlapTableFactory implements AbstractTableFactory {
             } else {
                 table.setIndexMeta(baseIndexMetaId, tableName, baseSchema, schemaVersion, schemaHash,
                         shortKeyColumnCount, baseIndexStorageType, keysType, null);
+            }
+
+            // check colocation properties and set up colocate group before tablet creation.
+            // Must be after setIndexMeta because range colocate needs baseIndexMeta to resolve sort key columns.
+            String colocateGroup = PropertyAnalyzer.analyzeColocate(properties);
+            if (StringUtils.isNotEmpty(colocateGroup)) {
+                if (!distributionInfo.supportColocate()) {
+                    throw new DdlException("random distribution does not support 'colocate_with'");
+                }
+
+                colocateTableIndex.addTableToGroup(db, table, colocateGroup, false /* afterTabletCreation */);
             }
 
             for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
@@ -883,7 +884,7 @@ public class OlapTableFactory implements AbstractTableFactory {
             }
 
             // process lake table colocation properties, after partition and tablet creation
-            colocateTableIndex.addTableToGroup(db, table, colocateGroup, true /* expectLakeTable */);
+            colocateTableIndex.addTableToGroup(db, table, colocateGroup, true /* afterTabletCreation */);
         } catch (DdlException e) {
             GlobalStateMgr.getCurrentState().getStorageVolumeMgr().unbindTableToStorageVolume(tableId);
             throw e;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/RangeColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/RangeColocateTableTest.java
@@ -1,0 +1,189 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeMgr;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.RangeDistributionInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class RangeColocateTableTest {
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+    }
+
+    @Test
+    public void testCreateRangeColocateTable() throws Exception {
+        String sql = "create table t_colocate_range (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg1:k1');";
+        starRocksAssert.withTable(sql);
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_range");
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table.isCloudNativeTableOrMaterializedView());
+        Assertions.assertInstanceOf(RangeDistributionInfo.class, table.getDefaultDistributionInfo());
+
+        // Verify colocate group
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        Assertions.assertTrue(colocateTableIndex.isColocateTable(table.getId()));
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(table.getId());
+        Assertions.assertNotNull(groupId);
+
+        // Verify group schema is RANGE type
+        ColocateGroupSchema schema = colocateTableIndex.getGroupSchema(groupId);
+        Assertions.assertNotNull(schema);
+        Assertions.assertTrue(schema.isRangeColocate());
+        Assertions.assertEquals(DistributionInfo.DistributionInfoType.RANGE, schema.getDistributionType());
+        Assertions.assertEquals(1, schema.getColocateColumnCount());
+
+        // Verify range colocate uses PACK shard group, not MetaGroup
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(table.getId()));
+
+        // Verify ColocateRangeMgr is initialized with ALL range
+        ColocateRangeMgr rangeMgr = colocateTableIndex.getColocateRangeMgr();
+        Assertions.assertTrue(rangeMgr.containsColocateGroup(groupId.grpId));
+        List<ColocateRange> ranges = rangeMgr.getColocateRanges(groupId.grpId);
+        Assertions.assertEquals(1, ranges.size());
+        Assertions.assertTrue(ranges.get(0).getRange().isAll());
+
+        // Verify tablets were created as LakeTablet
+        PhysicalPartition partition = table.getPartitions().iterator().next()
+                .getDefaultPhysicalPartition();
+        MaterializedIndex index = partition.getLatestBaseIndex();
+        List<Tablet> tablets = index.getTablets();
+        Assertions.assertEquals(1, tablets.size());
+        Assertions.assertInstanceOf(LakeTablet.class, tablets.get(0));
+    }
+
+    @Test
+    public void testSecondTableJoinsExistingRangeColocateGroup() throws Exception {
+        String sql1 = "create table t_colocate_join1 (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_join:k1');";
+        starRocksAssert.withTable(sql1);
+
+        OlapTable table1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_join1");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId1 = colocateTableIndex.getGroup(table1.getId());
+
+        String sql2 = "create table t_colocate_join2 (k1 int, k2 int, v2 varchar(10))\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_join:k1');";
+        starRocksAssert.withTable(sql2);
+
+        OlapTable table2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_join2");
+
+        // Both tables should be in the same colocate group
+        ColocateTableIndex.GroupId groupId2 = colocateTableIndex.getGroup(table2.getId());
+        Assertions.assertEquals(groupId1.grpId, groupId2.grpId);
+
+        // Both should NOT be in metaGroups
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(table1.getId()));
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(table2.getId()));
+    }
+
+    @Test
+    public void testRangeColocateSchemaMismatchRejected() throws Exception {
+        String sql1 = "create table t_colocate_mismatch1 (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_mismatch:k1');";
+        starRocksAssert.withTable(sql1);
+
+        // Different colocate column count should fail
+        String sql2 = "create table t_colocate_mismatch2 (k1 int, k2 int, v2 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_mismatch:k1,k2');";
+        Assertions.assertThrows(Exception.class, () -> starRocksAssert.withTable(sql2));
+    }
+
+    @Test
+    public void testUpdateLakeTableColocationInfoSkipsRangeColocate() throws Exception {
+        String sql = "create table t_colocate_update (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_update:k1');";
+        starRocksAssert.withTable(sql);
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_update");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+
+        // Should NOT throw — skips MetaGroup operations for range colocate
+        Assertions.assertDoesNotThrow(() ->
+                colocateTableIndex.updateLakeTableColocationInfo(table, true /* isJoin */, null));
+    }
+
+    @Test
+    public void testCreateMultipleIndependentRangeColocateGroups() throws Exception {
+        String sql1 = "create table t_colocate_grp_a (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_a:k1');";
+        starRocksAssert.withTable(sql1);
+
+        String sql2 = "create table t_colocate_grp_b (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_b:k1,k2');";
+        starRocksAssert.withTable(sql2);
+
+        OlapTable table1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_grp_a");
+        OlapTable table2 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_grp_b");
+
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateTableIndex.GroupId groupId1 = colocateTableIndex.getGroup(table1.getId());
+        ColocateTableIndex.GroupId groupId2 = colocateTableIndex.getGroup(table2.getId());
+
+        Assertions.assertNotEquals(groupId1.grpId, groupId2.grpId);
+        Assertions.assertEquals(1, colocateTableIndex.getGroupSchema(groupId1).getColocateColumnCount());
+        Assertions.assertEquals(2, colocateTableIndex.getGroupSchema(groupId2).getColocateColumnCount());
+
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(table1.getId()));
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(table2.getId()));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.staros.proto.PlacementPolicy;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
@@ -306,17 +307,17 @@ public class ColocateTableIndexTest {
 
         colocateTableIndex.addTableToGroup(
                 dbId, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId, 10000), false /* isReplay */);
-        Assertions.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
+        Assertions.assertTrue(colocateTableIndex.isMetaGroupColocateTable(tableId));
         colocateTableIndex.addTableToGroup(
                 dbId2, (OlapTable) olapTable, "lakeGroup", new ColocateTableIndex.GroupId(dbId2, 10000),
                 false /* isReplay */);
-        Assertions.assertTrue(colocateTableIndex.isLakeColocateTable(tableId));
+        Assertions.assertTrue(colocateTableIndex.isMetaGroupColocateTable(tableId));
 
         Assertions.assertTrue(colocateTableIndex.isGroupUnstable(new ColocateTableIndex.GroupId(dbId, 10000)));
         Assertions.assertFalse(colocateTableIndex.isGroupUnstable(new ColocateTableIndex.GroupId(dbId, 10001)));
 
         colocateTableIndex.removeTable(tableId, null, false /* isReplay */);
-        Assertions.assertFalse(colocateTableIndex.isLakeColocateTable(tableId));
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(tableId));
     }
 
     // Regression test: when addTableToGroup is called with a non-null assignedGroupId
@@ -473,6 +474,12 @@ public class ColocateTableIndexTest {
             @Mock
             public void createMetaGroup(long metaGroupId, List<Long> shardGroupIds) {
             }
+
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
         };
 
         new MockUp<GlobalStateMgr>() {
@@ -604,6 +611,21 @@ public class ColocateTableIndexTest {
             }
         };
 
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
         colocateTableIndex.addTableToGroup(100L, firstTable, "rg1:k1", null, false);
         Assertions.assertThrows(DdlException.class,
                 () -> colocateTableIndex.addTableToGroup(100L, secondTable, "rg1:k1,k2", null, false));
@@ -664,8 +686,425 @@ public class ColocateTableIndexTest {
             }
         };
 
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
         colocateTableIndex.addTableToGroup(100L, existingTable, "rg1:k1", null, false);
         Assertions.assertThrows(DdlException.class,
                 () -> colocateTableIndex.checkColocateSchemaWithGroupInOtherDb("rg1:k1,k2", 101L, newTable));
+    }
+
+    // ========== Tests for public addTableToGroup afterTabletCreation routing ==========
+
+    @Test
+    public void testAfterTabletCreationRoutingForNonLakeTable(
+            @Mocked Database db, @Mocked OlapTable olapTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        new Expectations() {
+            {
+                db.getId();
+                result = 100L;
+                minTimes = 0;
+                olapTable.isCloudNativeTableOrMaterializedView();
+                result = false;
+                minTimes = 0;
+                olapTable.getDefaultDistributionInfo();
+                result = new HashDistributionInfo();
+                minTimes = 0;
+            }
+        };
+
+        // Non-lake table: afterTabletCreation=false should proceed
+        Assertions.assertTrue(
+                colocateTableIndex.addTableToGroup(db, olapTable, "g1", false /* afterTabletCreation */));
+        // Non-lake table: afterTabletCreation=true should be skipped
+        Assertions.assertFalse(
+                colocateTableIndex.addTableToGroup(db, olapTable, "g1", true /* afterTabletCreation */));
+    }
+
+    @Test
+    public void testAfterTabletCreationRoutingForHashColocateLakeTable(
+            @Mocked Database db, @Mocked LakeTable lakeTable, @Mocked StarOSAgent starOSAgent) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new Expectations() {
+            {
+                db.getId();
+                result = 100L;
+                minTimes = 0;
+                lakeTable.getId();
+                result = 200L;
+                minTimes = 0;
+                lakeTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                lakeTable.getDefaultDistributionInfo();
+                result = new HashDistributionInfo();
+                minTimes = 0;
+                lakeTable.getShardGroupIds();
+                result = new ArrayList<>();
+                minTimes = 0;
+            }
+        };
+
+        // Hash colocate lake table: afterTabletCreation=false should be skipped
+        Assertions.assertFalse(
+                colocateTableIndex.addTableToGroup(db, lakeTable, "g1", false /* afterTabletCreation */));
+        // Hash colocate lake table: afterTabletCreation=true should proceed
+        Assertions.assertTrue(
+                colocateTableIndex.addTableToGroup(db, lakeTable, "g1", true /* afterTabletCreation */));
+    }
+
+    @Test
+    public void testAfterTabletCreationRoutingForRangeColocateLakeTable(
+            @Mocked Database db, @Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        new Expectations() {
+            {
+                db.getId();
+                result = 100L;
+                minTimes = 0;
+                lakeTable.getId();
+                result = 200L;
+                minTimes = 0;
+                lakeTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+                lakeTable.getDefaultDistributionInfo();
+                result = new RangeDistributionInfo();
+                minTimes = 0;
+                lakeTable.getDefaultReplicationNum();
+                result = (short) 1;
+                minTimes = 0;
+            }
+        };
+
+        // Range colocate lake table: afterTabletCreation=false should proceed
+        Assertions.assertTrue(
+                colocateTableIndex.addTableToGroup(db, lakeTable, "rg1:k1", false /* afterTabletCreation */));
+        // Verify table was registered
+        Assertions.assertNotNull(colocateTableIndex.getGroup(200L));
+
+        // Range colocate lake table: afterTabletCreation=true should be skipped
+        Assertions.assertFalse(
+                colocateTableIndex.addTableToGroup(db, lakeTable, "rg1:k1", true /* afterTabletCreation */));
+    }
+
+    @Test
+    public void testReplaySkipsPackShardGroupCreation(@Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        AtomicBoolean createShardGroupCalled = new AtomicBoolean(false);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                createShardGroupCalled.set(true);
+                return 9999L;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return 200L;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new RangeDistributionInfo();
+            }
+
+            @Mock
+            public short getDefaultReplicationNum() {
+                return 1;
+            }
+        };
+
+        // Replay should NOT call createShardGroup
+        colocateTableIndex.addTableToGroup(
+                100L, (OlapTable) lakeTable, "rg1:k1", null, true /* isReplay */);
+        Assertions.assertFalse(createShardGroupCalled.get(),
+                "createShardGroup(PACK) should NOT be called during replay");
+
+        // Verify group was created but ColocateRangeMgr was NOT initialized
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(200L);
+        Assertions.assertNotNull(groupId);
+        Assertions.assertFalse(colocateTableIndex.getColocateRangeMgr().containsColocateGroup(groupId.grpId));
+    }
+
+    @Test
+    public void testRemoveTableSkipsMetaGroupForRangeColocate(@Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        AtomicBoolean updateMetaGroupCalled = new AtomicBoolean(false);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+
+            @Mock
+            public void updateMetaGroup(long metaGroupId, List<Long> shardGroupIds, boolean isJoin) {
+                updateMetaGroupCalled.set(true);
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        long tableId = 200L;
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return tableId;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new RangeDistributionInfo();
+            }
+
+            @Mock
+            public short getDefaultReplicationNum() {
+                return 1;
+            }
+        };
+
+        new MockUp<LakeTable>() {
+            @Mock
+            public List<Long> getShardGroupIds() {
+                return Arrays.asList(5001L);
+            }
+        };
+
+        // Add range colocate table
+        colocateTableIndex.addTableToGroup(
+                100L, (OlapTable) lakeTable, "rg1:k1", null, false /* isReplay */);
+        Assertions.assertNotNull(colocateTableIndex.getGroup(tableId));
+
+        // Remove table — should NOT call updateMetaGroup for range colocate
+        colocateTableIndex.removeTable(tableId, (OlapTable) lakeTable, false /* isReplay */);
+        Assertions.assertFalse(updateMetaGroupCalled.get(),
+                "updateMetaGroup should NOT be called when removing a range colocate table");
+    }
+
+    @Test
+    public void testUpdateLakeTableColocationInfoSkipsRangeColocate(@Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        AtomicBoolean updateMetaGroupCalled = new AtomicBoolean(false);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+
+            @Mock
+            public void updateMetaGroup(long metaGroupId, List<Long> shardGroupIds, boolean isJoin) {
+                updateMetaGroupCalled.set(true);
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        long tableId = 200L;
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return tableId;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new RangeDistributionInfo();
+            }
+
+            @Mock
+            public short getDefaultReplicationNum() {
+                return 1;
+            }
+        };
+
+        new MockUp<LakeTable>() {
+            @Mock
+            public List<Long> getShardGroupIds() {
+                return Arrays.asList(5001L);
+            }
+        };
+
+        // Add range colocate table
+        colocateTableIndex.addTableToGroup(
+                100L, (OlapTable) lakeTable, "rg1:k1", null, false /* isReplay */);
+
+        // updateLakeTableColocationInfo should skip range colocate
+        colocateTableIndex.updateLakeTableColocationInfo(
+                (OlapTable) lakeTable, true /* isJoin */, null);
+        Assertions.assertFalse(updateMetaGroupCalled.get(),
+                "updateMetaGroup should NOT be called for range colocate table");
+    }
+
+    @Test
+    public void testConstructMetaGroupsSkipsRangeColocate(@Mocked LakeTable lakeTable) throws Exception {
+        ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId,
+                                          long indexId, PlacementPolicy placementPolicy) {
+                return 9999L;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return new StarOSAgent();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeColocateColumns(OlapTable olapTable, List<String> colocateColumnNames) {
+                return Arrays.asList(new Column("k1", com.starrocks.type.IntegerType.INT));
+            }
+        };
+
+        long tableId = 200L;
+        new MockUp<OlapTable>() {
+            @Mock
+            public long getId() {
+                return tableId;
+            }
+
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+
+            @Mock
+            public DistributionInfo getDefaultDistributionInfo() {
+                return new RangeDistributionInfo();
+            }
+
+            @Mock
+            public short getDefaultReplicationNum() {
+                return 1;
+            }
+        };
+
+        // Add range colocate table
+        colocateTableIndex.addTableToGroup(
+                100L, (OlapTable) lakeTable, "rg1:k1", null, false /* isReplay */);
+        ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
+        Assertions.assertNotNull(groupId);
+
+        // Range colocate table should NOT be in metaGroups
+        Assertions.assertFalse(colocateTableIndex.isMetaGroupColocateTable(tableId));
+
+        // constructMetaGroups is private, invoked by loadColocateTableIndexV2.
+        // Verify via isGroupUnstable: for non-metaGroups, it checks unstableGroups (not MetaGroup).
+        // Since we didn't mark it unstable, it should return false.
+        Assertions.assertFalse(colocateTableIndex.isGroupUnstable(groupId));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -512,13 +512,13 @@ public class LakeMaterializedViewTest extends StarRocksTestBase {
                 (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv6");
         Assertions.assertTrue(mv.isCloudNativeMaterializedView());
         ColocateTableIndex index = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        Assertions.assertTrue(index.isLakeColocateTable(mv.getId()));
+        Assertions.assertTrue(index.isMetaGroupColocateTable(mv.getId()));
 
         String alterMvSql = "alter materialized view mv6 set ('colocate_with'='');";
         StatementBase statement = SqlParser.parseSingleStatement(alterMvSql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statement);
         stmtExecutor.execute();
-        Assertions.assertFalse(index.isLakeColocateTable(mv.getId()));
+        Assertions.assertFalse(index.isMetaGroupColocateTable(mv.getId()));
 
         starRocksAssert.dropMaterializedView("mv6");
         Assertions.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv6"));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -468,7 +468,7 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<ColocateTableIndex>() {
             @Mock
-            public boolean isLakeColocateTable(long tableId) {
+            public boolean isMetaGroupColocateTable(long tableId) {
                 return true;
             }
 
@@ -1048,7 +1048,7 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<ColocateTableIndex>() {
             @Mock
-            public boolean isLakeColocateTable(long tableId) {
+            public boolean isMetaGroupColocateTable(long tableId) {
                 return true;
             }
 


### PR DESCRIPTION
  ## Why I'm doing:                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                             
  Previous PRs added colocate metadata (ColocateRange, ColocateRangeMgr), DDL parsing                                                                                                                                                                                        
  (ColocatePropertyInfo), colocate group creation (ColocateTableIndex), StarOSAgent PACK                                                                                                                                                                                     
  shard group support, and ColocateRangeUtils. However, the colocate group still used a                                                                                                                                                                                      
  placeholder shard group ID (0), and tablet creation did not leverage the dual SPREAD+PACK
  shard group membership. This PR completes P1 by wiring everything together.                                                                                                                                                                                                

  ## What I'm doing:

  1. PACK shard group creation: Replace the TODO in ColocateTableIndex.addTableToGroup:
  call StarOSAgent.createShardGroup(PACK) to create an actual PACK shard group instead
  of using placeholder 0. Add !isReplay guard so that PACK shard group creation only
  happens on the leader node (consistent with MetaGroup pattern). Edit log persistence
  for colocateRangeMgr is deferred to P5.
  2. Range colocate tablet creation: Add createRangeColocateLakeTablets in
  LocalMetastore.createLakeTablets: when a range distribution lake table is in a
  colocate group, create one tablet per ColocateRange with dual shard group membership
  (SPREAD + PACK). Each tablet's range is expanded from the colocate range to a full
  sort key range via ColocateRangeUtils.expandToFullSortKey.
  3. afterTabletCreation routing: Rename addTableToGroup parameter from
  expectLakeTable to afterTabletCreation to clarify the timing semantics. Update
  routing logic so that range colocate lake tables are handled before tablet creation
  (afterTabletCreation=false), because PACK shard group must exist before
  createRangeColocateLakeTablets runs. Hash colocate lake tables are still handled
  after tablet creation (afterTabletCreation=true), because MetaGroup creation needs
  shard group IDs. The MV path does not need an extra call because
  PropertyAnalyzer.analyzeMVProperties already calls addTableToGroup(false)
  internally, which handles both non-lake MVs and range colocate lake MVs before tablet
  creation.
  4. Move colocate setup after setIndexMeta in OlapTableFactory: The colocate
  property check and addTableToGroup(false) call is moved from before setIndexMeta
  to after it, because range colocate needs baseIndexMeta to resolve sort key columns
  via getRangeColocateColumns. This is still before tablet creation, so PACK shard
  groups are set up in time for createRangeColocateLakeTablets.
  5. Exclude range colocate from MetaGroup paths: Range colocate uses PACK shard groups
  instead of MetaGroup. Guard all MetaGroup-related operations to skip range colocate
  groups:
  - updateLakeTableColocationInfo(): skip when schema.isRangeColocate(), preventing
  add partition / truncate / insert overwrite / merge partition / restart sync from
  calling updateMetaGroup on non-existent MetaGroup.
  - removeTable(): skip updateMetaGroup leave call for range colocate groups.
  - constructMetaGroups() (image restore): skip range colocate groups so they are not
  added to metaGroups.
  - Rename lakeGroups → metaGroups, isLakeColocateTable → isMetaGroupColocateTable,
  constructLakeGroups → constructMetaGroups to reflect that these only track hash
  colocate groups using MetaGroup.
  6. Defensive validation for missing range metadata: Add fail-fast checks to prevent
  silent failures when colocate range metadata is missing:
  - addTableToGroup: when joining an existing range colocate group, verify that
  colocateRangeMgr contains the group's range data; throw DdlException if missing.
  - createRangeColocateLakeTablets: verify that colocateRanges is non-empty before
  creating tablets; throw DdlException if empty, instead of silently creating a
  partition with zero tablets.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
