### PR TITLE
[Enhancement] Add aggregate rules for unified IVM framework

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -60,9 +60,11 @@ import com.starrocks.sql.optimizer.rule.implementation.WindowImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamAggregateImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamJoinImplementationRule;
 import com.starrocks.sql.optimizer.rule.implementation.stream.StreamScanImplementationRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaAggregateRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaFilterRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaIcebergScanRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaProjectRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmVersionAggregateRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionFilterRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionIcebergScanRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionProjectRule;
@@ -442,9 +444,11 @@ public class RuleSet {
     // Unified IVM delta/version rewrite rules.
     public static final Rule IVM_DELTA_REWRITE_RULES =
             new CombinationRule(RuleType.GP_IVM_DELTA_REWRITE, ImmutableList.of(
+                    new IvmDeltaAggregateRule(),
                     new IvmDeltaIcebergScanRule(),
                     new IvmDeltaFilterRule(),
                     new IvmDeltaProjectRule(),
+                    new IvmVersionAggregateRule(),
                     new IvmVersionIcebergScanRule(),
                     new IvmVersionFilterRule(),
                     new IvmVersionProjectRule()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
+import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves a {@link LogicalDeltaOperator} wrapping a {@link LogicalAggregationOperator} by building
+ * an incremental aggregate plan that merges delta changes with the existing MV aggregate state.
+ *
+ * <p>Pattern: {@code LogicalDeltaOperator -> LogicalAggregationOperator -> child}
+ *
+ * <p>Only matches when {@code isRootDelta=true} (IVMAnalyzer guarantees aggregate is at the root).
+ *
+ * <p>This rule is a "terminal" rule — it consumes the Delta marker at the aggregate level and
+ * restructures the plan tree. However, it preserves the Delta marker on the aggregate's child
+ * so that subsequent iterations can push it down through filter/project to the scan.
+ *
+ * <p>The output plan structure:
+ * <pre>
+ *   Project(state_union(intermediate, mv_state), original_projection...)
+ *     └── LeftOuterJoin(encode_row_id(group_keys) = mv.__ROW_ID__)
+ *           ├── Aggregate(intermediate _combine)
+ *           │     └── Delta(...)       ← preserved for subsequent iterations
+ *           │           └── child...
+ *           └── OlapScan(MV)           ← scan existing MV state
+ * </pre>
+ */
+public class IvmDeltaAggregateRule extends TransformationRule {
+    public IvmDeltaAggregateRule() {
+        super(RuleType.TF_IVM_DELTA_AGGREGATE,
+                Pattern.create(OperatorType.LOGICAL_DELTA)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_AGGR, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        if (!delta.isRootDelta()) {
+            return false;
+        }
+        LogicalAggregationOperator aggOp = input.inputAt(0).getOp().cast();
+        if (aggOp.getGroupingKeys().isEmpty()) {
+            return false;
+        }
+        if (aggOp.getAggregations().values().stream().anyMatch(CallOperator::isDistinct)) {
+            return false;
+        }
+        if (aggOp.getPredicate() != null) {
+            return false;
+        }
+        // Must be able to load the target MV for state merge
+        MaterializedView mv = IvmRewriter.loadTargetMv(context);
+        return mv != null && mv.getColumn(TvrOpUtils.COLUMN_ROW_ID) != null;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        LogicalAggregationOperator inputAggOp = input.inputAt(0).getOp().cast();
+        OptExpression aggChild = input.inputAt(0).inputAt(0);
+
+        MaterializedView mv = IvmRewriter.loadTargetMv(context);
+        Preconditions.checkState(mv != null, "Target MV must not be null");
+
+        ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
+
+        // Step 1: Get MV schema info
+        Column rowIdColumn = mv.getColumn(TvrOpUtils.COLUMN_ROW_ID);
+        Preconditions.checkState(rowIdColumn != null, "__ROW_ID__ column must exist in MV");
+        int encodeRowIdVersion = mv.getEncodeRowIdVersion();
+
+        List<Column> aggStateColumns = mv.getFullSchema().stream()
+                .filter(col -> col.getName().startsWith(TvrOpUtils.COLUMN_AGG_STATE_PREFIX))
+                .collect(Collectors.toList());
+
+        // Step 2: Create MV scan
+        LogicalOlapScanOperator mvScan = MvRewritePreprocessor.createScanMvOperator(
+                mv, columnRefFactory, PCellSortedSet.of(), true);
+        ColumnRefOperator mvRowIdRef = mvScan.getColumnMetaToColRefMap().get(rowIdColumn);
+        Map<Column, ColumnRefOperator> mvColMetaToRefMap = mvScan.getColumnMetaToColRefMap();
+        List<ColumnRefOperator> mvAggStateRefs = aggStateColumns.stream()
+                .map(mvColMetaToRefMap::get)
+                .collect(Collectors.toList());
+
+        // Step 3: Collect input aggregate info
+        List<ColumnRefOperator> groupingKeys = inputAggOp.getGroupingKeys();
+        Map<ColumnRefOperator, CallOperator> inputAggMap = inputAggOp.getAggregations();
+        Preconditions.checkState(aggStateColumns.size() == inputAggMap.size(),
+                "MV __AGG_STATE__ columns size %s must match aggregate map size %s",
+                aggStateColumns.size(), inputAggMap.size());
+
+        // Step 4: Build intermediate aggregate operator (same _combine funcs, new ColumnRefs)
+        Map<ScalarOperator, ColumnRefOperator> oldToNewRefMap = Maps.newHashMap();
+        LogicalAggregationOperator intermediateAgg = buildIntermediateAggOperator(
+                columnRefFactory, groupingKeys, inputAggMap, oldToNewRefMap);
+
+        // Step 5: Build __ROW_ID__ equality predicate
+        List<ScalarOperator> uniqueKeys = groupingKeys.stream()
+                .map(col -> (ScalarOperator) col)
+                .collect(Collectors.toList());
+        ScalarOperator eqPredicate = TvrOpUtils.buildRowIdEqBinaryPredicateOp(
+                encodeRowIdVersion, mvRowIdRef, uniqueKeys);
+
+        // Step 6: Build LEFT OUTER JOIN (intermediate agg ⋈ MV scan)
+        // Delta is preserved on the aggregate's child for subsequent iterations.
+        // Use createWithoutTvr for join and MV scan to prevent TVR rules from re-matching.
+        LogicalDeltaOperator childDelta = new LogicalDeltaOperator(false, delta.getActionColumn());
+        OptExpression intermediateAggExpr = OptExpression.createWithoutTvr(intermediateAgg,
+                OptExpression.create(childDelta, aggChild));
+        LogicalJoinOperator joinOp = new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, eqPredicate);
+        OptExpression joinExpr = OptExpression.createWithoutTvr(joinOp,
+                intermediateAggExpr,
+                OptExpression.createWithoutTvr(mvScan));
+
+        // Step 7: Build state_union project
+        Map<ColumnRefOperator, ScalarOperator> projMap = Maps.newHashMap();
+        if (inputAggOp.getProjection() != null) {
+            projMap.putAll(inputAggOp.getProjection().getColumnRefMap());
+        }
+
+        List<ColumnRefOperator> inputAggCallRefs = inputAggMap.keySet().stream()
+                .sorted(Comparator.comparingInt(ColumnRefOperator::getId))
+                .collect(Collectors.toList());
+        Preconditions.checkState(inputAggCallRefs.size() == mvAggStateRefs.size(),
+                "Input agg call refs size %s must match MV agg state refs size %s",
+                inputAggCallRefs.size(), mvAggStateRefs.size());
+        for (int i = 0; i < inputAggCallRefs.size(); i++) {
+            ColumnRefOperator origRef = inputAggCallRefs.get(i);
+            CallOperator origCall = inputAggMap.get(origRef);
+            ColumnRefOperator intermediateRef = oldToNewRefMap.get(origCall);
+            Preconditions.checkState(intermediateRef != null,
+                    "Intermediate ref should not be null for: %s", origCall);
+            ColumnRefOperator mvStateRef = mvAggStateRefs.get(i);
+            ScalarOperator stateUnion = TvrOpUtils.buildStateUnionScalarOperator(
+                    origCall, intermediateRef, mvStateRef);
+            projMap.put(origRef, stateUnion);
+        }
+
+        // Add __ACTION__ column so appendPkLoadOpColumn can derive __op from it.
+        // For aggregate MVs, all output rows are UPSERTs (action = INSERT = 1).
+        ColumnRefOperator actionColumn = delta.getActionColumn();
+        if (actionColumn != null) {
+            projMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 1));
+        }
+
+        OptExpression result = OptExpression.createWithoutTvr(new LogicalProjectOperator(projMap), joinExpr);
+        return List.of(result);
+    }
+
+    private LogicalAggregationOperator buildIntermediateAggOperator(
+            ColumnRefFactory columnRefFactory,
+            List<ColumnRefOperator> groupingKeys,
+            Map<ColumnRefOperator, CallOperator> inputAggMap,
+            Map<ScalarOperator, ColumnRefOperator> oldToNewRefMap) {
+        Map<ColumnRefOperator, CallOperator> intermediateAggMap = inputAggMap.entrySet().stream()
+                .map(e -> {
+                    ColumnRefOperator origRef = e.getKey();
+                    CallOperator origCall = e.getValue();
+                    CallOperator intermediateFunc =
+                            AggregateFunctionRollupUtils.getIntermediateStateAggregateFunc(origCall);
+                    Preconditions.checkArgument(intermediateFunc != null,
+                            "Intermediate state agg func should not be null for: %s", origCall);
+                    ColumnRefOperator newRef = columnRefFactory.create(
+                            origRef.getName(), origRef.getType(), origRef.isNullable());
+                    oldToNewRefMap.put(origCall, newRef);
+                    return Map.entry(newRef, intermediateFunc);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return new LogicalAggregationOperator(AggType.GLOBAL, groupingKeys, intermediateAggMap);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -14,10 +14,16 @@
 
 package com.starrocks.sql.optimizer.rule.ivm;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonSyntaxException;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
 import com.starrocks.load.Load;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.StatementBase;
@@ -165,6 +171,30 @@ public class IvmRewriter {
                 .setPerPipeline(true);
         LogicalTopNOperator topN = topNBuilder.build();
         return OptExpression.create(topN, projectExpr);
+    }
+
+    static MaterializedView loadTargetMv(OptimizerContext optimizerContext) {
+        String strMvId = optimizerContext.getSessionVariable().getTvrTargetMvId();
+        if (Strings.isNullOrEmpty(strMvId)) {
+            return null;
+        }
+        MvId mvId;
+        try {
+            mvId = GsonUtils.GSON.fromJson(strMvId, MvId.class);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
+        if (mvId == null) {
+            return null;
+        }
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
+        if (db == null) {
+            return null;
+        }
+        if (!(db.getTable(mvId.getId()) instanceof MaterializedView mv)) {
+            return null;
+        }
+        return mv;
     }
 
     static void deriveLogicalProperty(OptExpression root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionAggregateRule.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+
+/**
+ * Pushes {@link LogicalVersionOperator} below {@link LogicalAggregationOperator}.
+ *
+ * <p>Pattern: {@code LogicalVersionOperator -> LogicalAggregationOperator -> child}
+ *
+ * <p>Output: {@code LogicalAggregationOperator -> LogicalVersionOperator -> child}
+ */
+public class IvmVersionAggregateRule extends TransformationRule {
+    public IvmVersionAggregateRule() {
+        super(RuleType.TF_IVM_VERSION_AGGREGATE,
+                Pattern.create(OperatorType.LOGICAL_VERSION)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_AGGR, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalVersionOperator version = (LogicalVersionOperator) input.getOp();
+        LogicalAggregationOperator aggregate = input.inputAt(0).getOp().cast();
+        OptExpression aggChild = input.inputAt(0).inputAt(0);
+
+        OptExpression versionChild = OptExpression.create(
+                new LogicalVersionOperator(version.getVersionRefType()), aggChild);
+        return List.of(OptExpression.create(
+                LogicalAggregationOperator.builder().withOperator(aggregate).build(),
+                versionChild));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -797,4 +797,54 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                             "Expected >1 but got: " + mvPartitionsToRefresh);
         }
     }
+
+    @Test
+    public void testIVMAggregatePlanContainsStateUnionAndMvScan() throws Exception {
+        doTestWith3Runs("SELECT date, sum(id), approx_count_distinct(data) " +
+                        "FROM `iceberg0`.`partitioned_db`.`t1` as a group by date;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    // Verify incremental scan
+                    PlanTestBase.assertContains(planStr,
+                            "TABLE VERSION: Delta@[MIN,1]");
+                    // Verify LEFT/RIGHT OUTER JOIN with __ROW_ID__
+                    PlanTestBase.assertContains(planStr, "HASH JOIN");
+                    PlanTestBase.assertContains(planStr, "equal join conjunct:");
+                    PlanTestBase.assertContains(planStr, "from_binary");
+                    // Verify MV scan exists (scan existing aggregate state)
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    // Verify state_union is in the plan
+                    PlanTestBase.assertContains(planStr, "state_union");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    // Verify delta version advanced
+                    PlanTestBase.assertContains(planStr,
+                            "TABLE VERSION: Delta@[1,2]");
+                    // Verify state_union still present on incremental refresh
+                    PlanTestBase.assertContains(planStr, "state_union");
+                    // Verify MV scan still present
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                }
+        );
+    }
+
+    @Test
+    public void testIVMAggregatePlanWithMultiGroupByKeys() throws Exception {
+        doTestWith3RunsNoCheckRewrite("SELECT date, id, sum(id), count(data) " +
+                        "FROM `iceberg0`.`partitioned_db`.`t1` as a group by date, id;",
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "HASH JOIN");
+                    PlanTestBase.assertContains(planStr, "state_union");
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                },
+                plan -> {
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[1,2]");
+                    PlanTestBase.assertContains(planStr, "state_union");
+                }
+        );
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmAggregateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmAggregateRuleTest.java
@@ -1,0 +1,269 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link IvmDeltaAggregateRule} check conditions and
+ * {@link IvmVersionAggregateRule} transform logic.
+ *
+ * Note: IvmDeltaAggregateRule.transform() requires a real MaterializedView with
+ * __ROW_ID__ and __AGG_STATE__ columns, plus MvRewritePreprocessor. This is covered
+ * by the integration test IVMBasedMvRefreshProcessorIcebergTest.testPartitionedIVMWithAggregate1.
+ */
+public class IvmAggregateRuleTest {
+
+    // ==================== IvmDeltaAggregateRule check conditions ====================
+
+    @Test
+    public void testCheckRejectsNonRootDelta(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        OptExpression aggExpr = buildDeltaAggregate(factory, table, false);  // isRootDelta=false
+        deriveLogicalProperty(aggExpr);
+
+        Assertions.assertFalse(new IvmDeltaAggregateRule().check(aggExpr, context));
+    }
+
+    @Test
+    public void testCheckRejectsEmptyGroupBy(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+        ColumnRefOperator sumRef = factory.create("sum_combine", IntegerType.BIGINT, true);
+
+        // Aggregate with empty grouping keys
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(sumRef, new CallOperator("sum_combine", IntegerType.BIGINT, List.of()));
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(), aggMap);  // empty group by
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        OptExpression aggExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(agg, scanExpr));
+        deriveLogicalProperty(aggExpr);
+
+        Assertions.assertFalse(new IvmDeltaAggregateRule().check(aggExpr, context));
+    }
+
+    @Test
+    public void testCheckRejectsDistinct(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+        ColumnRefOperator dateRef = factory.create("date", IntegerType.INT, false);
+        ColumnRefOperator countRef = factory.create("count_distinct", IntegerType.BIGINT, true);
+
+        // Aggregate with DISTINCT
+        CallOperator distinctCall = new CallOperator("count", IntegerType.BIGINT, List.of(dateRef), null, true);
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(countRef, distinctCall);
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(dateRef), aggMap);
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        OptExpression aggExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(agg, scanExpr));
+        deriveLogicalProperty(aggExpr);
+
+        Assertions.assertFalse(new IvmDeltaAggregateRule().check(aggExpr, context));
+    }
+
+    @Test
+    public void testCheckRejectsHaving(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+        ColumnRefOperator dateRef = factory.create("date", IntegerType.INT, false);
+        ColumnRefOperator sumRef = factory.create("sum_combine", IntegerType.BIGINT, true);
+
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(sumRef, new CallOperator("sum_combine", IntegerType.BIGINT, List.of(dateRef)));
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(dateRef), aggMap);
+        // Set HAVING predicate
+        agg.setPredicate(new com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator(
+                com.starrocks.sql.ast.expression.BinaryType.GT, sumRef,
+                com.starrocks.sql.optimizer.operator.scalar.ConstantOperator.createInt(100)));
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        OptExpression aggExpr = OptExpression.create(new LogicalDeltaOperator(true, actionRef),
+                OptExpression.create(agg, scanExpr));
+        deriveLogicalProperty(aggExpr);
+
+        Assertions.assertFalse(new IvmDeltaAggregateRule().check(aggExpr, context));
+    }
+
+    @Test
+    public void testCheckRejectsWhenNoTargetMv(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+        // No statement set → loadTargetMv returns null
+
+        OptExpression aggExpr = buildDeltaAggregate(factory, table, true);
+        deriveLogicalProperty(aggExpr);
+
+        Assertions.assertFalse(new IvmDeltaAggregateRule().check(aggExpr, context));
+    }
+
+    // ==================== IvmVersionAggregateRule ====================
+
+    @Test
+    public void testVersionAggregatePushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator dateRef = factory.create("date", IntegerType.INT, false);
+        ColumnRefOperator sumRef = factory.create("sum_combine", IntegerType.BIGINT, true);
+
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(sumRef, new CallOperator("sum_combine", IntegerType.BIGINT, List.of(dateRef)));
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(dateRef), aggMap);
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        // Version → Aggregate → Scan
+        OptExpression versionAgg = OptExpression.create(LogicalVersionOperator.fromVersion(),
+                OptExpression.create(agg, scanExpr));
+        deriveLogicalProperty(versionAgg);
+
+        List<OptExpression> result = new IvmVersionAggregateRule().transform(versionAgg, context);
+
+        // Should produce: Aggregate → Version → Scan
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalAggregationOperator);
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, result.get(0).inputAt(0).getOp().getOpType());
+        LogicalVersionOperator newVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.FROM_VERSION, newVersion.getVersionRefType());
+        Assertions.assertTrue(result.get(0).inputAt(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    @Test
+    public void testVersionAggregatePreservesToVersion(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator dateRef = factory.create("date", IntegerType.INT, false);
+        ColumnRefOperator sumRef = factory.create("sum_combine", IntegerType.BIGINT, true);
+
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(sumRef, new CallOperator("sum_combine", IntegerType.BIGINT, List.of(dateRef)));
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(dateRef), aggMap);
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        // Version(TO) → Aggregate → Scan
+        OptExpression versionAgg = OptExpression.create(LogicalVersionOperator.toVersion(),
+                OptExpression.create(agg, scanExpr));
+        deriveLogicalProperty(versionAgg);
+
+        List<OptExpression> result = new IvmVersionAggregateRule().transform(versionAgg, context);
+
+        // Should preserve TO_VERSION
+        LogicalVersionOperator newVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.TO_VERSION, newVersion.getVersionRefType());
+    }
+
+    // ==================== Helpers ====================
+
+    private void mockIcebergTable(IcebergTable table) {
+        new Expectations() {
+            {
+                table.getType();
+                result = com.starrocks.catalog.Table.TableType.ICEBERG;
+                minTimes = 0;
+            }
+        };
+    }
+
+    private OptExpression buildDeltaAggregate(ColumnRefFactory factory, IcebergTable table, boolean isRootDelta) {
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+        ColumnRefOperator dateRef = factory.create("date", IntegerType.INT, false);
+        ColumnRefOperator sumRef = factory.create("sum_combine", IntegerType.BIGINT, true);
+
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(sumRef, new CallOperator("sum_combine", IntegerType.BIGINT, List.of(dateRef)));
+        LogicalAggregationOperator agg = new LogicalAggregationOperator(
+                AggType.GLOBAL, List.of(dateRef), aggMap);
+
+        OptExpression scanExpr = newIcebergScan(factory, table);
+        return OptExpression.create(new LogicalDeltaOperator(isRootDelta, actionRef),
+                OptExpression.create(agg, scanExpr));
+    }
+
+    private OptExpression newIcebergScan(ColumnRefFactory factory, IcebergTable table) {
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
+        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
+        Column idCol = new Column("id", IntegerType.INT, false);
+        Column dataCol = new Column("data", StringType.STRING, true);
+        Map<ColumnRefOperator, Column> colRefMap = Maps.newHashMap();
+        colRefMap.put(idRef, idCol);
+        colRefMap.put(dataRef, dataCol);
+        LogicalIcebergScanOperator scan = new LogicalIcebergScanOperator.Builder()
+                .setTable(table)
+                .setColRefToColumnMetaMap(colRefMap)
+                .setTableVersionRange(TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)))
+                .build();
+        return OptExpression.create(scan);
+    }
+
+    private static void deriveLogicalProperty(OptExpression expression) {
+        for (OptExpression child : expression.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        ExpressionContext ctx = new ExpressionContext(expression);
+        ctx.deriveLogicalProperty();
+        expression.setLogicalProperty(ctx.getRootProperty());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add IvmDeltaAggregateRule and IvmVersionAggregateRule to handle incremental aggregate MV refresh through the unified Delta/Version operator framework.

IvmDeltaAggregateRule (state-merge strategy):
- Matches Delta(isRootDelta=true) -> Aggregate -> child
- Builds intermediate aggregate, LEFT OUTER JOIN with existing MV state, and state_union merge project
- Preserves Delta(isRootDelta=false) on child for scan rule resolution
- Uses createWithoutTvr to prevent TVR rules from re-matching

IvmVersionAggregateRule:
- Pushes Version below Aggregate (simple position swap)

IvmRewriter:
- Restored loadTargetMv() using InsertStmt.getTargetTable() directly instead of session variable serialization

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
