### PR TITLE
[Trace] Add multiget_t3 breakdown for PK index publish diagnosis

### DIFF
--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -29,6 +29,7 @@
 
 #include "base/concurrency/stopwatch.hpp"
 #include "base/container/lru_cache.h"
+#include "base/debug/trace.h"
 #include "base/string/string_parser.hpp"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
@@ -632,7 +633,10 @@ private:
         if (_shard_fs != nullptr) {
             return _shard_fs;
         }
-        return g_worker->get_shard_filesystem(shard_id, _conf);
+        int64_t t_start = butil::gettimeofday_us();
+        auto fs_st = g_worker->get_shard_filesystem(shard_id, _conf);
+        TRACE_COUNTER_INCREMENT("get_shard_filesystem_us", butil::gettimeofday_us() - t_start);
+        return fs_st;
     }
 
 private:

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -18,7 +18,6 @@
 
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
-#include "storage/olap_common.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_starlet_fwd.h"
 #include "fs/fs.h"
@@ -28,6 +27,7 @@
 #include "runtime/starrocks_metrics.h"
 #include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/utils.h"
+#include "storage/olap_common.h"
 #include "storage/sstable/table_builder.h"
 
 namespace starrocks::lake {

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -18,6 +18,7 @@
 
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
+#include "storage/olap_common.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_starlet_fwd.h"
 #include "fs/fs.h"
@@ -164,6 +165,10 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     // only used for sstable compaction to filter out some keys for tablet split purpose and such keys can not
     // be read by the persistent index by designed. So even we provide a predicate, all keys read by multi_get
     // will always meet the condition.
+    // Capture IO stats before MultiGet to compute delta
+    auto* stat_file = rf ? rf.get() : _rf.get();
+    auto pre_stats = stat_file->get_numeric_statistics();
+
     auto start_ts = butil::gettimeofday_us();
     auto multiget_st = _sst->MultiGet(options, keys, key_indexes.begin(), key_indexes.end(), &index_value_with_vers);
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::multi_get:error", &multiget_st);
@@ -184,6 +189,27 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     TRACE_COUNTER_INCREMENT("multi_get_us", end_ts - start_ts);
     TRACE_COUNTER_INCREMENT("read_block_hit_cache_cnt", stat.block_cnt_from_cache);
     TRACE_COUNTER_INCREMENT("read_block_miss_cache_cnt", stat.block_cnt_from_file);
+    // Compute datacache vs remote IO delta from file-level statistics
+    auto post_stats = stat_file->get_numeric_statistics();
+    if (pre_stats.ok() && pre_stats.value() && post_stats.ok() && post_stats.value()) {
+        auto get_val = [](const io::NumericStatistics& s, const char* key) -> int64_t {
+            for (int64_t i = 0; i < s.size(); i++) {
+                if (s.name(i) == key) return s.value(i);
+            }
+            return 0;
+        };
+        auto get_delta = [&](const char* key) -> int64_t {
+            return get_val(*post_stats.value(), key) - get_val(*pre_stats.value(), key);
+        };
+        TRACE_COUNTER_INCREMENT("sst_io_count_local_disk", get_delta(kIOCountLocalDisk));
+        TRACE_COUNTER_INCREMENT("sst_io_count_remote", get_delta(kIOCountRemote));
+        TRACE_COUNTER_INCREMENT("sst_io_ns_read_local_disk", get_delta(kIONsReadLocalDisk));
+        TRACE_COUNTER_INCREMENT("sst_io_ns_read_remote", get_delta(kIONsReadRemote));
+        TRACE_COUNTER_INCREMENT("sst_io_ns_write_local_disk", get_delta(kIONsWriteLocalDisk));
+        TRACE_COUNTER_INCREMENT("sst_prefetch_hit_count", get_delta(kPrefetchHitCount));
+        TRACE_COUNTER_INCREMENT("sst_prefetch_wait_finish_ns", get_delta(kPrefetchWaitFinishNs));
+        TRACE_COUNTER_INCREMENT("sst_prefetch_pending_ns", get_delta(kPrefetchPendingNs));
+    }
     size_t i = 0;
     for (auto& key_index : key_indexes) {
         // Index_value_with_vers is empty means key is not found in sst.

--- a/be/src/storage/sstable/options.h
+++ b/be/src/storage/sstable/options.h
@@ -113,6 +113,13 @@ struct ReadIOStat {
 
     // Read block cnt from page cache
     uint32_t block_cnt_from_cache = 0;
+
+    // BlockReader internal timing (us)
+    int64_t block_cache_lookup_us = 0;
+    int64_t block_read_io_us = 0;
+    int64_t block_cache_insert_us = 0;
+    int64_t block_alloc_us = 0;
+    int64_t block_read_max_io_us = 0;  // single slowest ReadBlock
 };
 
 // Options that control read operations

--- a/be/src/storage/sstable/options.h
+++ b/be/src/storage/sstable/options.h
@@ -119,7 +119,7 @@ struct ReadIOStat {
     int64_t block_read_io_us = 0;
     int64_t block_cache_insert_us = 0;
     int64_t block_alloc_us = 0;
-    int64_t block_read_max_io_us = 0;  // single slowest ReadBlock
+    int64_t block_read_max_io_us = 0; // single slowest ReadBlock
 };
 
 // Options that control read operations

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -217,33 +217,57 @@ Iterator* Table::BlockReader(void* arg, const ReadOptions& options, const Slice&
             encode_fixed64_le(reinterpret_cast<uint8_t*>(cache_key_buffer), table->rep_->cache_id);
             encode_fixed64_le(reinterpret_cast<uint8_t*>(cache_key_buffer + 8), handle.offset());
             CacheKey key(cache_key_buffer, sizeof(cache_key_buffer));
+            int64_t t_lookup = butil::gettimeofday_us();
             cache_handle = block_cache->lookup(key);
+            int64_t t_after_lookup = butil::gettimeofday_us();
+            if (options.stat != nullptr) {
+                options.stat->block_cache_lookup_us += t_after_lookup - t_lookup;
+            }
             if (cache_handle != nullptr) {
                 block = reinterpret_cast<Block*>(block_cache->value(cache_handle));
                 if (options.stat != nullptr) {
                     options.stat->block_cnt_from_cache++;
                 }
             } else {
+                int64_t t_io = butil::gettimeofday_us();
                 s = ReadBlock(table->rep_->file, options, handle, &contents);
+                int64_t t_after_io = butil::gettimeofday_us();
+                int64_t io_latency = t_after_io - t_io;
                 if (s.ok()) {
                     block = new Block(contents);
+                    int64_t t_after_alloc = butil::gettimeofday_us();
                     if (contents.cachable && options.fill_cache) {
                         size_t block_size = block->size();
                         cache_handle = block_cache->insert(key, block, block_size, &DeleteCachedBlock);
                     }
+                    int64_t t_after_insert = butil::gettimeofday_us();
+                    if (options.stat != nullptr) {
+                        options.stat->block_alloc_us += t_after_alloc - t_after_io;
+                        options.stat->block_cache_insert_us += t_after_insert - t_after_alloc;
+                    }
                 }
                 if (options.stat != nullptr) {
                     options.stat->block_cnt_from_file++;
+                    options.stat->block_read_io_us += io_latency;
+                    if (io_latency > options.stat->block_read_max_io_us) {
+                        options.stat->block_read_max_io_us = io_latency;
+                    }
                 }
             }
         } else {
             BlockContents contents;
+            int64_t t_io = butil::gettimeofday_us();
             s = ReadBlock(table->rep_->file, options, handle, &contents);
+            int64_t io_latency = butil::gettimeofday_us() - t_io;
             if (s.ok()) {
                 block = new Block(contents);
             }
             if (options.stat != nullptr) {
                 options.stat->block_cnt_from_file++;
+                options.stat->block_read_io_us += io_latency;
+                if (io_latency > options.stat->block_read_max_io_us) {
+                    options.stat->block_read_max_io_us = io_latency;
+                }
             }
         }
     }
@@ -292,6 +316,8 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     int64_t multiget_t1_us = 0;
     int64_t multiget_t2_us = 0;
     int64_t multiget_t3_us = 0;
+    int64_t multiget_t3_block_reader_us = 0;
+    int64_t multiget_t3_search_us = 0;
     size_t i = 0;
     bool founded = false;
     for (auto it = begin; it != end; ++it, ++i) {
@@ -319,8 +345,13 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
                 // Not found
                 sst_bloom_filter_rows++;
             } else {
+                int64_t t_br = butil::gettimeofday_us();
                 current_block_itr_ptr.reset(BlockReader(this, options, iiter->value()));
+                int64_t t_after_br = butil::gettimeofday_us();
                 ASSIGN_OR_RETURN(founded, search_in_block(k, &(*values)[i], current_block_itr_ptr.get()));
+                int64_t t_after_search = butil::gettimeofday_us();
+                multiget_t3_block_reader_us += t_after_br - t_br;
+                multiget_t3_search_us += t_after_search - t_after_br;
             }
         }
         int64_t t3 = butil::gettimeofday_us();
@@ -337,6 +368,15 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     TRACE_COUNTER_INCREMENT("multiget_t1_us", multiget_t1_us);
     TRACE_COUNTER_INCREMENT("multiget_t2_us", multiget_t2_us);
     TRACE_COUNTER_INCREMENT("multiget_t3_us", multiget_t3_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_block_reader_us", multiget_t3_block_reader_us);
+    TRACE_COUNTER_INCREMENT("multiget_t3_search_us", multiget_t3_search_us);
+    if (options.stat != nullptr) {
+        TRACE_COUNTER_INCREMENT("block_cache_lookup_us", options.stat->block_cache_lookup_us);
+        TRACE_COUNTER_INCREMENT("block_read_io_us", options.stat->block_read_io_us);
+        TRACE_COUNTER_INCREMENT("block_cache_insert_us", options.stat->block_cache_insert_us);
+        TRACE_COUNTER_INCREMENT("block_alloc_us", options.stat->block_alloc_us);
+        TRACE_COUNTER_INCREMENT("block_read_max_io_us", options.stat->block_read_max_io_us);
+    }
     return s;
 }
 


### PR DESCRIPTION
## Why

In the 1000-table concurrent ingestion benchmark (1 TXN/s per table, 5M rows/table), 
`multiget_t3` in SST MultiGet shows P90=3.4s, max=9.7s with only 2-6 cache misses.

This implies ~1.5s per cache miss block read, which is unreasonable for OSS (~10-50ms expected).
We need finer-grained tracing to identify where the time is actually spent.

## What

Add breakdown counters inside `Table::MultiGet()`:

| Counter | Description |
|---------|-------------|
| `multiget_t3_block_read_us` | Time in BlockReader() (cache lookup + ReadBlock IO) |
| `multiget_t3_block_search_us` | Time in search_in_block() after block loaded |
| `read_block_hit_cache_cnt` | Cache hits per MultiGet call |
| `read_block_miss_cache_cnt` | Cache misses per MultiGet call |
| `read_block_max_latency_us` | Single slowest BlockReader() call |

These appear in the existing publish version trace log under PublishTablet metrics.

## Context

Benchmark doc: https://docs.google.com/document/d/1u-UPEv8zjBxj7Xdh-AroWsMvTz99GG39ixwjEHl35kQ/edit

Current best results with 1GB/table:
- Upsert P50 = 70ms (target < 1s)
- Upsert P99 = 4,862ms (target < 3s)
- P99 bottleneck: multiget_t3 in SST block read during publish