### PR TITLE
[BugFix] Fix Iceberg ScanReport `projectedFieldIds` showing all columns instead of projected columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
@@ -14,10 +14,12 @@
 
 package com.starrocks.connector;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.List;
 import java.util.StringJoiner;
 
 public class MetaPreparationItem {
@@ -25,12 +27,19 @@ public class MetaPreparationItem {
     private final ScalarOperator predicate;
     private final long limit;
     private final TvrVersionRange version;
+    private final List<String> fieldNames;
 
     public MetaPreparationItem(Table table, ScalarOperator predicate, long limit, TvrVersionRange version) {
+        this(table, predicate, limit, version, null);
+    }
+
+    public MetaPreparationItem(Table table, ScalarOperator predicate, long limit, TvrVersionRange version,
+                               List<String> fieldNames) {
         this.table = table;
         this.predicate = predicate;
         this.limit = limit;
         this.version = version;
+        this.fieldNames = fieldNames == null ? null : ImmutableList.copyOf(fieldNames);
     }
 
     public Table getTable() {
@@ -49,6 +58,10 @@ public class MetaPreparationItem {
         return version;
     }
 
+    public List<String> getFieldNames() {
+        return fieldNames;
+    }
+
     @Override
     public String toString() {
         return new StringJoiner(", ", MetaPreparationItem.class.getSimpleName() + "[", "]")
@@ -56,6 +69,7 @@ public class MetaPreparationItem {
                 .add("predicate=" + predicate)
                 .add("limit=" + limit)
                 .add("version=" + version)
+                .add("fieldNames=" + fieldNames)
                 .toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1245,28 +1245,40 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     private ScanReport withProjectedFields(IcebergTable icebergTable, ScanReport baseReport, List<String> fieldNames) {
-        List<String> projectedFieldNames = fieldNames == null
-                ? icebergTable.getNativeTable().schema().columns().stream()
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        List<String> candidates = fieldNames == null
+                ? nativeTbl.schema().columns().stream()
                 .map(Types.NestedField::name)
-                .collect(toImmutableList())
-                : fieldNames.stream().collect(toImmutableList());
+                .collect(Collectors.toList())
+                : filterToIcebergColumns(nativeTbl, fieldNames);
 
-        List<Integer> projectedFieldIds = projectedFieldNames.stream()
-                .map(fieldName -> {
-                    Types.NestedField field = icebergTable.getNativeTable().schema().findField(fieldName);
-                    if (field == null) {
-                        throw new StarRocksConnectorException("Failed to resolve projected field %s for table %s.%s",
-                                fieldName, icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName());
-                    }
-                    return field.fieldId();
-                })
-                .collect(toImmutableList());
+        List<String> resolvedNames = new ArrayList<>();
+        List<Integer> resolvedIds = new ArrayList<>();
+        for (String name : candidates) {
+            Types.NestedField field = nativeTbl.schema().findField(name);
+            if (field == null) {
+                LOG.warn("Skip unresolved projected field '{}' for table {}.{}",
+                        name, icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName());
+                continue;
+            }
+            resolvedNames.add(name);
+            resolvedIds.add(field.fieldId());
+        }
 
         return ImmutableScanReport.builder()
                 .from(baseReport)
-                .projectedFieldIds(projectedFieldIds)
-                .projectedFieldNames(projectedFieldNames)
+                .projectedFieldIds(resolvedIds)
+                .projectedFieldNames(resolvedNames)
                 .build();
+    }
+
+    private static List<String> filterToIcebergColumns(org.apache.iceberg.Table nativeTable, List<String> fieldNames) {
+        Set<String> schemaColumns = nativeTable.schema().columns().stream()
+                .map(Types.NestedField::name)
+                .collect(Collectors.toSet());
+        return fieldNames.stream()
+                .filter(schemaColumns::contains)
+                .collect(Collectors.toList());
     }
 
     private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
@@ -1340,9 +1352,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         if (fieldNames != null) {
-            // Preserve zero-column projections such as count(*) so ScanReport.projectedFieldIds
-            // reflects the actual scan projection instead of the full table schema.
-            scan = (Scan) scan.select(fieldNames);
+            // Filter out pseudo-columns (e.g. _row_id, $data_sequence_number, _file) that exist
+            // in StarRocks metadata but not in the Iceberg native schema.
+            List<String> icebergFieldNames = filterToIcebergColumns(nativeTbl, fieldNames);
+            scan = (Scan) scan.select(icebergFieldNames);
         }
 
         if (enableCollectColumnStats) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -150,6 +150,8 @@ import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializationUtil;
@@ -217,6 +219,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final Map<TableIdentifier, org.apache.iceberg.Table> tables = new ConcurrentHashMap<>();
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<PredicateSearchKey, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
+    private final Map<PredicateSearchKey, ScanReport> scanReports = new ConcurrentHashMap<>();
     private final Set<PredicateSearchKey> scannedTables = new HashSet<>();
     private final Set<PredicateSearchKey> preparedTables = ConcurrentHashMap.newKeySet();
 
@@ -832,11 +835,12 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
+        IcebergTable icebergTable = (IcebergTable) table;
         String dbName = table.getCatalogDBName();
         String tableName = table.getCatalogTableName();
 
         PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
-        triggerIcebergPlanFilesIfNeeded(key, table);
+        boolean plannedNow = triggerIcebergPlanFilesIfNeeded(key, icebergTable);
 
         List<FileScanTask> icebergScanTasks = splitTasks.get(key);
         if (icebergScanTasks == null) {
@@ -844,6 +848,9 @@ public class IcebergMetadata implements ConnectorMetadata {
                     dbName, tableName, params.getPredicate());
         }
 
+        if (!plannedNow) {
+            publishCachedScanReport(icebergTable, key);
+        }
         return icebergScanTasks.stream().map(IcebergRemoteFileInfo::new).collect(Collectors.toList());
     }
 
@@ -869,6 +876,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 .setPredicate(item.getPredicate())
                 .setLimit(item.getLimit())
                 .setTableVersionRange(versionRange)
+                .setFieldNames(item.getFieldNames())
                 .build();
 
         PredicateSearchKey key = PredicateSearchKey.of(dbName, tableName, params);
@@ -954,18 +962,20 @@ public class IcebergMetadata implements ConnectorMetadata {
         return new IcebergMetaSpec(serializedTable, remoteMetaSplits, loadColumnStats);
     }
 
-    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table) {
-        triggerIcebergPlanFilesIfNeeded(key, table, null, ConnectContext.get());
+    private boolean triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table) {
+        return triggerIcebergPlanFilesIfNeeded(key, table, null, ConnectContext.get());
     }
 
-    private void triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table,
-                                                 Tracers tracers, ConnectContext connectContext) {
+    private boolean triggerIcebergPlanFilesIfNeeded(PredicateSearchKey key, Table table,
+                                                    Tracers tracers, ConnectContext connectContext) {
         if (!scannedTables.contains(key)) {
             tracers = tracers == null ? Tracers.get() : tracers;
             try (Timer ignored = Tracers.watchScope(tracers, EXTERNAL, "ICEBERG.processSplit." + key)) {
                 collectTableStatisticsAndCacheIcebergSplit(key, table, tracers, connectContext);
             }
+            return true;
         }
+        return false;
     }
 
     public List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit, TvrVersionRange version) {
@@ -1074,7 +1084,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         List<FileScanTask> icebergScanTasks = Lists.newArrayList();
         try (CloseableIterator<FileScanTask> iterator =
                      buildFileScanTaskIterator((IcebergTable) table, icebergPredicate, tvrVersionRange,
-                             connectContext, enableCollectColumnStatistics)) {
+                             connectContext, enableCollectColumnStatistics, params.getFieldNames())) {
             while (iterator.hasNext()) {
                 FileScanTask scanTask = iterator.next();
 
@@ -1110,6 +1120,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             throw new StarRocksConnectorException("Failed to iter iceberg file scan iterator", e);
         }
 
+        cacheScanReport(icebergTable, key);
         splitTasks.put(key, icebergScanTasks);
         scannedTables.add(key);
     }
@@ -1128,6 +1139,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, params);
         RemoteFileInfoSource baseSource;
         if (splitTasks.containsKey(predicateSearchKey)) {
+            publishCachedScanReport(icebergTable, predicateSearchKey);
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey), params);
         } else {
             List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
@@ -1169,7 +1181,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                        GetRemoteFilesParams params) {
         CloseableIterator<FileScanTask> iterator =
                 buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, ConnectContext.get(),
-                        params.isEnableColumnStats());
+                        params.isEnableColumnStats(), params.getFieldNames());
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {
@@ -1210,11 +1222,68 @@ public class IcebergMetadata implements ConnectorMetadata {
         };
     }
 
+    private void cacheScanReport(IcebergTable icebergTable, PredicateSearchKey key) {
+        IcebergMetricsReporter metricsReporter = icebergTable.getIcebergMetricsReporter();
+        if (metricsReporter == null || metricsReporter.getScanReport() == null) {
+            return;
+        }
+
+        scanReports.put(key, ImmutableScanReport.copyOf(metricsReporter.getScanReport()));
+    }
+
+    private void publishCachedScanReport(IcebergTable icebergTable, PredicateSearchKey key) {
+        IcebergMetricsReporter metricsReporter = icebergTable.getIcebergMetricsReporter();
+        ScanReport cachedReport = scanReports.get(key);
+        if (metricsReporter == null || cachedReport == null) {
+            return;
+        }
+
+        ScanReport projectedReport = withProjectedFields(icebergTable, cachedReport, key.getParams().getFieldNames());
+        metricsReporter.report(projectedReport);
+        recordScanMetrics(new CachingIcebergCatalog.IcebergTableName(
+                icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName()), projectedReport);
+    }
+
+    private ScanReport withProjectedFields(IcebergTable icebergTable, ScanReport baseReport, List<String> fieldNames) {
+        List<String> projectedFieldNames = fieldNames == null
+                ? icebergTable.getNativeTable().schema().columns().stream()
+                .map(Types.NestedField::name)
+                .collect(toImmutableList())
+                : fieldNames.stream().collect(toImmutableList());
+
+        List<Integer> projectedFieldIds = projectedFieldNames.stream()
+                .map(fieldName -> {
+                    Types.NestedField field = icebergTable.getNativeTable().schema().findField(fieldName);
+                    if (field == null) {
+                        throw new StarRocksConnectorException("Failed to resolve projected field %s for table %s.%s",
+                                fieldName, icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName());
+                    }
+                    return field.fieldId();
+                })
+                .collect(toImmutableList());
+
+        return ImmutableScanReport.builder()
+                .from(baseReport)
+                .projectedFieldIds(projectedFieldIds)
+                .projectedFieldNames(projectedFieldNames)
+                .build();
+    }
+
     private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
                                                                       Expression icebergPredicate,
                                                                       TvrVersionRange tvrVersionRange,
                                                                       ConnectContext connectContext,
                                                                       boolean enableCollectColumnStats) {
+        return buildFileScanTaskIterator(icebergTable, icebergPredicate, tvrVersionRange, connectContext,
+                enableCollectColumnStats, null);
+    }
+
+    private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
+                                                                      Expression icebergPredicate,
+                                                                      TvrVersionRange tvrVersionRange,
+                                                                      ConnectContext connectContext,
+                                                                      boolean enableCollectColumnStats,
+                                                                      List<String> fieldNames) {
         if (tvrVersionRange.isEmpty()) {
             return new CloseableIterator<>() {
                 @Override
@@ -1268,6 +1337,12 @@ public class IcebergMetadata implements ConnectorMetadata {
                     .useSnapshot(snapshotId)
                     .metricsReporter(metricsReporter)
                     .planWith(jobPlanningExecutor);
+        }
+
+        if (fieldNames != null) {
+            // Preserve zero-column projections such as count(*) so ScanReport.projectedFieldIds
+            // reflects the actual scan projection instead of the full table schema.
+            scan = (Scan) scan.select(fieldNames);
         }
 
         if (enableCollectColumnStats) {
@@ -1445,12 +1520,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         IcebergMetricsReporter metricsReporter = ((StarRocksIcebergTableScan) tableScan).getMetricsReporter();
-        if (metricsReporter.getScanReport() == null) {
+        recordScanMetrics(((StarRocksIcebergTableScan) tableScan).getIcebergTableName(), metricsReporter.getScanReport());
+    }
+
+    private void recordScanMetrics(CachingIcebergCatalog.IcebergTableName icebergTableName, ScanReport scanReport) {
+        if (scanReport == null) {
             return;
         }
 
-        String name = "ICEBERG.ScanMetrics." + ((StarRocksIcebergTableScan) tableScan).getIcebergTableName();
-        String value = metricsReporter.getScanReport().toString();
+        String name = "ICEBERG.ScanMetrics." + icebergTableName;
+        String value = scanReport.toString();
         Tracers.record(EXTERNAL, name, value);
     }
 
@@ -2056,6 +2135,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     @Override
     public void clear() {
         splitTasks.clear();
+        scanReports.clear();
         databases.clear();
         tables.clear();
         scannedTables.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -16,6 +16,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
@@ -72,6 +73,7 @@ public class IcebergScanNode extends ScanNode {
     private int selectedPartitionCount = -1;
     private Optional<List<BucketProperty>> bucketProperties = Optional.empty();
     private PartitionIdGenerator partitionIdGenerator = null;
+    private final List<String> fieldNames;
     private IcebergMetricsReporter icebergScanMetricsReporter;
     private boolean usedForDelete = false;
     private boolean enableGlobalLateMaterialization = false;
@@ -80,11 +82,18 @@ public class IcebergScanNode extends ScanNode {
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
                            IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
                            PartitionIdGenerator partitionIdGenerator) {
+        this(id, desc, planNodeName, tableFullMORParams, morParams, partitionIdGenerator, null);
+    }
+
+    public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
+                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
+                           PartitionIdGenerator partitionIdGenerator, List<String> fieldNames) {
         super(id, desc, planNodeName);
         this.icebergTable = (IcebergTable) desc.getTable();
         this.tableFullMORParams = tableFullMORParams;
         this.morParams = morParams;
         this.partitionIdGenerator = partitionIdGenerator;
+        this.fieldNames = fieldNames == null ? null : ImmutableList.copyOf(fieldNames);
         this.icebergScanMetricsReporter = new IcebergMetricsReporter();
         this.icebergTable.setIcebergMetricsReporter(icebergScanMetricsReporter);
         setupCloudCredential();
@@ -180,6 +189,7 @@ public class IcebergScanNode extends ScanNode {
                         .setParams(morParams)
                         .setTableVersionRange(tvrVersionRange)
                         .setPredicate(icebergJobPlanningPredicate)
+                        .setFieldNames(fieldNames)
                         .setEnableColumnStats(scanOptimizeOption.getCanUseMinMaxOpt())
                         .setUsedForDelete(usedForDelete)
                         .build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -24,6 +24,7 @@ import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,7 +73,10 @@ public class PrepareCollectMetaTask extends OptimizerTask {
                     .map(op -> CompletableFuture.supplyAsync(() ->
                                     metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
                                             new MetaPreparationItem(op.getTable(), op.getPredicate(),
-                                                    op.getLimit(), op.getTvrVersionRange()),
+                                                    op.getLimit(), op.getTvrVersionRange(),
+                                                    op.getColRefToColumnMetaMap().keySet().stream()
+                                                            .map(ColumnRefOperator::getName)
+                                                            .collect(Collectors.toList())),
                                             tracers, connectContext),
                             executorService)).toArray(CompletableFuture[]::new));
             allFutures.join();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1605,6 +1605,9 @@ public class PlanFragmentBuilder {
 
             // partition id generator
             PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
+            List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
+                    .map(ColumnRefOperator::getName)
+                    .collect(Collectors.toList());
 
             boolean isEqDeleteScan = node.getOpType() != OperatorType.PHYSICAL_ICEBERG_SCAN;
             IcebergScanNode icebergScanNode;
@@ -1612,14 +1615,14 @@ public class PlanFragmentBuilder {
             if (!isEqDeleteScan) {
                 PhysicalIcebergScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator, fieldNames);
                 icebergScanNode.updateAppliedDictStringColumns(
                         ((PhysicalIcebergScanOperator) node).getGlobalDicts().stream()
                                 .map(entry -> entry.first).collect(Collectors.toSet()));
             } else {
                 PhysicalIcebergEqualityDeleteScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator, fieldNames);
             }
 
             icebergScanNode.setScanOptimizeOption(node.getScanOptimizeOption());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -67,9 +67,13 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ScanMetricsResult;
 import org.apache.iceberg.util.TableScanUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,6 +93,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Resource cleanup tests shared by Iceberg and Delta Lake connectors / scan nodes.
@@ -590,6 +595,143 @@ public class ExternalResourceCleanupTest {
         // iterator should be created and be consumable without exception
         iter.hasNext();
         iter.close();
+    }
+
+    @Test
+    public void testIcebergMetadataGetRemoteFilesAsyncSelectsEmptyProjection() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        IcebergMetricsReporter reporter = new IcebergMetricsReporter();
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(table.getIcebergMetricsReporter()).thenReturn(reporter);
+
+        StarRocksIcebergTableScan scan = Mockito.mock(StarRocksIcebergTableScan.class);
+        Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.useSnapshot(Mockito.anyLong())).thenReturn(scan);
+        Mockito.when(scan.metricsReporter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.planWith(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.select(Mockito.anyList())).thenReturn(scan);
+        Mockito.when(scan.includeColumnStats()).thenReturn(scan);
+        Mockito.when(scan.filter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.targetSplitSize()).thenReturn(128L);
+        Mockito.when(scan.planFiles()).thenReturn(CloseableIterable.withNoopClose(List.of()));
+
+        IcebergGetRemoteFilesParams.Builder builder = IcebergGetRemoteFilesParams.newBuilder();
+        builder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        builder.setPredicate(ConstantOperator.TRUE);
+        builder.setFieldNames(List.of());
+        builder.setAllParams(IcebergTableMORParams.EMPTY);
+        builder.setParams(IcebergMORParams.EMPTY);
+
+        RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, builder.build());
+        Assertions.assertFalse(source.hasMoreOutput());
+        Mockito.verify(scan).select(List.of());
+        source.close();
+    }
+
+    @Test
+    public void testIcebergCacheHitUpdatesProjectionReport() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        Schema schema = new Schema(
+                org.apache.iceberg.types.Types.NestedField.required(1, "id", org.apache.iceberg.types.Types.IntegerType.get()),
+                org.apache.iceberg.types.Types.NestedField.optional(2, "data", org.apache.iceberg.types.Types.StringType.get()));
+        IcebergMetricsReporter firstReporter = new IcebergMetricsReporter();
+        AtomicReference<IcebergMetricsReporter> reporterRef = new AtomicReference<>(firstReporter);
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(table.getIcebergMetricsReporter()).thenAnswer(invocation -> reporterRef.get());
+
+        StarRocksIcebergTableScan scan = Mockito.mock(StarRocksIcebergTableScan.class);
+        Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.useSnapshot(Mockito.anyLong())).thenReturn(scan);
+        Mockito.when(scan.metricsReporter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.planWith(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.select(Mockito.anyList())).thenReturn(scan);
+        Mockito.when(scan.includeColumnStats()).thenReturn(scan);
+        Mockito.when(scan.filter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.targetSplitSize()).thenReturn(128L);
+        Mockito.when(scan.planFiles()).thenReturn(CloseableIterable.withNoopClose(List.of()));
+        Mockito.when(scan.getMetricsReporter()).thenAnswer(invocation -> reporterRef.get());
+        Mockito.when(scan.getIcebergTableName())
+                .thenReturn(new com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName("db", "tbl"));
+
+        firstReporter.report(ImmutableScanReport.builder()
+                .tableName("db.tbl")
+                .snapshotId(1L)
+                .filter(Expressions.alwaysTrue())
+                .schemaId(schema.schemaId())
+                .projectedFieldIds(List.of(1))
+                .projectedFieldNames(List.of("id"))
+                .scanMetrics(Mockito.mock(ScanMetricsResult.class))
+                .metadata(Map.of())
+                .build());
+
+        MetaPreparationItem item = new MetaPreparationItem(table, ConstantOperator.TRUE, -1L,
+                TvrTableSnapshot.of(Optional.of(1L)), List.of("id"));
+
+        Assertions.assertTrue(metadata.prepareMetadata(item, null, null));
+        Mockito.verify(scan).select(List.of("id"));
+
+        IcebergMetricsReporter secondReporter = new IcebergMetricsReporter();
+        reporterRef.set(secondReporter);
+
+        IcebergGetRemoteFilesParams.Builder dataBuilder = IcebergGetRemoteFilesParams.newBuilder();
+        dataBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        dataBuilder.setPredicate(ConstantOperator.TRUE);
+        dataBuilder.setFieldNames(List.of("data"));
+        dataBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+        dataBuilder.setParams(IcebergMORParams.EMPTY);
+
+        RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, dataBuilder.build());
+        Assertions.assertFalse(source.hasMoreOutput());
+        Assertions.assertNotNull(secondReporter.getScanReport());
+        Assertions.assertEquals(List.of(2), secondReporter.getScanReport().projectedFieldIds());
+        Assertions.assertEquals(List.of("data"), secondReporter.getScanReport().projectedFieldNames());
+        source.close();
+
+        Field splitField = IcebergMetadata.class.getDeclaredField("splitTasks");
+        splitField.setAccessible(true);
+        Map<PredicateSearchKey, List<FileScanTask>> splitTasks =
+                (Map<PredicateSearchKey, List<FileScanTask>>) splitField.get(metadata);
+
+        IcebergGetRemoteFilesParams.Builder idBuilder = IcebergGetRemoteFilesParams.newBuilder();
+        idBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        idBuilder.setPredicate(ConstantOperator.TRUE);
+        idBuilder.setFieldNames(List.of("id"));
+        idBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+        idBuilder.setParams(IcebergMORParams.EMPTY);
+
+        IcebergGetRemoteFilesParams.Builder fullBuilder = IcebergGetRemoteFilesParams.newBuilder();
+        fullBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        fullBuilder.setPredicate(ConstantOperator.TRUE);
+        fullBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+        fullBuilder.setParams(IcebergMORParams.EMPTY);
+
+        Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", idBuilder.build())));
+        Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", fullBuilder.build())));
+        Assertions.assertEquals(1, splitTasks.size());
+        Mockito.verify(scan, Mockito.times(1)).planFiles();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.Pair;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
@@ -46,6 +47,7 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.type.IntegerType;
@@ -626,6 +628,7 @@ public class ExternalResourceCleanupTest {
         Mockito.when(scan.filter(Mockito.any())).thenReturn(scan);
         Mockito.when(scan.targetSplitSize()).thenReturn(128L);
         Mockito.when(scan.planFiles()).thenReturn(CloseableIterable.withNoopClose(List.of()));
+        Mockito.when(scan.getMetricsReporter()).thenReturn(reporter);
 
         IcebergGetRemoteFilesParams.Builder builder = IcebergGetRemoteFilesParams.newBuilder();
         builder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
@@ -634,10 +637,17 @@ public class ExternalResourceCleanupTest {
         builder.setAllParams(IcebergTableMORParams.EMPTY);
         builder.setParams(IcebergMORParams.EMPTY);
 
-        RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, builder.build());
-        Assertions.assertFalse(source.hasMoreOutput());
-        Mockito.verify(scan).select(List.of());
-        source.close();
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        Tracers.register(ctx);
+        try {
+            RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, builder.build());
+            Assertions.assertFalse(source.hasMoreOutput());
+            Mockito.verify(scan).select(List.of());
+            source.close();
+        } finally {
+            Tracers.close();
+        }
     }
 
     @Test
@@ -690,48 +700,55 @@ public class ExternalResourceCleanupTest {
         MetaPreparationItem item = new MetaPreparationItem(table, ConstantOperator.TRUE, -1L,
                 TvrTableSnapshot.of(Optional.of(1L)), List.of("id"));
 
-        Assertions.assertTrue(metadata.prepareMetadata(item, null, null));
-        Mockito.verify(scan).select(List.of("id"));
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        Tracers.register(ctx);
+        try {
+            Assertions.assertTrue(metadata.prepareMetadata(item, Tracers.get(), ctx));
+            Mockito.verify(scan).select(List.of("id"));
 
-        IcebergMetricsReporter secondReporter = new IcebergMetricsReporter();
-        reporterRef.set(secondReporter);
+            IcebergMetricsReporter secondReporter = new IcebergMetricsReporter();
+            reporterRef.set(secondReporter);
 
-        IcebergGetRemoteFilesParams.Builder dataBuilder = IcebergGetRemoteFilesParams.newBuilder();
-        dataBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
-        dataBuilder.setPredicate(ConstantOperator.TRUE);
-        dataBuilder.setFieldNames(List.of("data"));
-        dataBuilder.setAllParams(IcebergTableMORParams.EMPTY);
-        dataBuilder.setParams(IcebergMORParams.EMPTY);
+            IcebergGetRemoteFilesParams.Builder dataBuilder = IcebergGetRemoteFilesParams.newBuilder();
+            dataBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+            dataBuilder.setPredicate(ConstantOperator.TRUE);
+            dataBuilder.setFieldNames(List.of("data"));
+            dataBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+            dataBuilder.setParams(IcebergMORParams.EMPTY);
 
-        RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, dataBuilder.build());
-        Assertions.assertFalse(source.hasMoreOutput());
-        Assertions.assertNotNull(secondReporter.getScanReport());
-        Assertions.assertEquals(List.of(2), secondReporter.getScanReport().projectedFieldIds());
-        Assertions.assertEquals(List.of("data"), secondReporter.getScanReport().projectedFieldNames());
-        source.close();
+            RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, dataBuilder.build());
+            Assertions.assertFalse(source.hasMoreOutput());
+            Assertions.assertNotNull(secondReporter.getScanReport());
+            Assertions.assertEquals(List.of(2), secondReporter.getScanReport().projectedFieldIds());
+            Assertions.assertEquals(List.of("data"), secondReporter.getScanReport().projectedFieldNames());
+            source.close();
 
-        Field splitField = IcebergMetadata.class.getDeclaredField("splitTasks");
-        splitField.setAccessible(true);
-        Map<PredicateSearchKey, List<FileScanTask>> splitTasks =
-                (Map<PredicateSearchKey, List<FileScanTask>>) splitField.get(metadata);
+            Field splitField = IcebergMetadata.class.getDeclaredField("splitTasks");
+            splitField.setAccessible(true);
+            Map<PredicateSearchKey, List<FileScanTask>> splitTasks =
+                    (Map<PredicateSearchKey, List<FileScanTask>>) splitField.get(metadata);
 
-        IcebergGetRemoteFilesParams.Builder idBuilder = IcebergGetRemoteFilesParams.newBuilder();
-        idBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
-        idBuilder.setPredicate(ConstantOperator.TRUE);
-        idBuilder.setFieldNames(List.of("id"));
-        idBuilder.setAllParams(IcebergTableMORParams.EMPTY);
-        idBuilder.setParams(IcebergMORParams.EMPTY);
+            IcebergGetRemoteFilesParams.Builder idBuilder = IcebergGetRemoteFilesParams.newBuilder();
+            idBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+            idBuilder.setPredicate(ConstantOperator.TRUE);
+            idBuilder.setFieldNames(List.of("id"));
+            idBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+            idBuilder.setParams(IcebergMORParams.EMPTY);
 
-        IcebergGetRemoteFilesParams.Builder fullBuilder = IcebergGetRemoteFilesParams.newBuilder();
-        fullBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
-        fullBuilder.setPredicate(ConstantOperator.TRUE);
-        fullBuilder.setAllParams(IcebergTableMORParams.EMPTY);
-        fullBuilder.setParams(IcebergMORParams.EMPTY);
+            IcebergGetRemoteFilesParams.Builder fullBuilder = IcebergGetRemoteFilesParams.newBuilder();
+            fullBuilder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+            fullBuilder.setPredicate(ConstantOperator.TRUE);
+            fullBuilder.setAllParams(IcebergTableMORParams.EMPTY);
+            fullBuilder.setParams(IcebergMORParams.EMPTY);
 
-        Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", idBuilder.build())));
-        Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", fullBuilder.build())));
-        Assertions.assertEquals(1, splitTasks.size());
-        Mockito.verify(scan, Mockito.times(1)).planFiles();
+            Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", idBuilder.build())));
+            Assertions.assertTrue(splitTasks.containsKey(PredicateSearchKey.of("db", "tbl", fullBuilder.build())));
+            Assertions.assertEquals(1, splitTasks.size());
+            Mockito.verify(scan, Mockito.times(1)).planFiles();
+        } finally {
+            Tracers.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1604,8 +1604,23 @@ public class IcebergMetadataTest extends TableTestBase {
         PredicateSearchKey newFilter = PredicateSearchKey.of("db", "table", newCallParams);
         Assertions.assertEquals(filter, newFilter);
 
+        GetRemoteFilesParams projectedParams = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                .setPredicate(newCallOperator)
+                .setFieldNames(Lists.newArrayList("date_col"))
+                .setLimit(10)
+                .build();
+        GetRemoteFilesParams fullSchemaParams = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                .setPredicate(newCallOperator)
+                .setLimit(10)
+                .build();
+
         Assertions.assertEquals(newFilter, PredicateSearchKey.of("db", "table", newCallParams));
         Assertions.assertNotEquals(newFilter, PredicateSearchKey.of("db", "table", emptyParams));
+        Assertions.assertEquals(newFilter, PredicateSearchKey.of("db", "table", projectedParams));
+        Assertions.assertEquals(PredicateSearchKey.of("db", "table", projectedParams),
+                PredicateSearchKey.of("db", "table", fullSchemaParams));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -10,6 +10,7 @@ import com.starrocks.connector.CatalogConnectorMetadata;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
+import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -61,6 +62,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
@@ -981,6 +983,45 @@ public class IcebergScanNodeTest {
                 "reachLimit should be reset to false");
         Assertions.assertNull(Deencapsulation.getField(scanNode, "scanRangeSource"),
                 "scanRangeSource should be cleared");
+    }
+
+    @Test
+    public void testSetupScanRangeLocationsPassesEmptyProjection(@Mocked GlobalStateMgr globalStateMgr,
+                                                                 @Mocked MetadataMgr metadataMgr,
+                                                                 @Mocked IcebergTable table) throws Exception {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        IcebergScanNode scanNode = new IcebergScanNode(
+                new PlanNodeId(0), desc, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null, List.of());
+        scanNode.setTvrVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        scanNode.setScanOptimizeOption(new ScanOptimizeOption());
+
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getMetadataMgr();
+            result = metadataMgr;
+            minTimes = 0;
+
+            metadataMgr.getRemoteFiles(table, (GetRemoteFilesParams) any);
+            result = List.of();
+            minTimes = 0;
+
+            table.getCatalogDBName();
+            result = "db";
+            minTimes = 0;
+
+            table.getCatalogTableName();
+            result = "tbl";
+            minTimes = 0;
+        }};
+
+        scanNode.setupScanRangeLocations(false);
+
+        new Verifications() {{
+            GetRemoteFilesParams params;
+            metadataMgr.getRemoteFiles(table, params = withCapture());
+            Assertions.assertEquals(List.of(), params.getFieldNames());
+        }};
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The Iceberg ScanReport's `projectedFieldIds` incorrectly reports all table columns instead of only the columns referenced by the query. This misleads users into thinking all columns are being scanned, even when the BE only reads the projected columns.

For example, a query selecting 4-5 columns from a wide Iceberg table would show `projectedFieldIds: [1, 2, 3, ..., N]` in the ScanReport instead of just the 4-5 referenced column IDs.

## What I'm doing:

**Root cause**: The Iceberg `TableScan` is created without calling `.select()` to specify projected columns, so `scanMetrics()` initializes with the full table schema. Additionally, when file planning results are cached and reused by subsequent queries with different column projections, the ScanReport is never updated to reflect the actual projection.

**Fix** (two-part):

1. **Propagate projected column names to `scan.select()`**:
   - Extract projected column names from the optimizer's `colRefToColumnMetaMap` in both `PlanFragmentBuilder` (physical plan) and `PrepareCollectMetaTask` (parallel metadata preparation)
   - Pass `fieldNames` through `IcebergScanNode` → `GetRemoteFilesParams` → `IcebergMetadata.buildFileScanTaskIterator()`
   - Call `scan.select(fieldNames)` on the Iceberg `TableScan`/`IncrementalAppendScan` so the first query's `ScanReport` has correct `projectedFieldIds`

2. **Rewrite ScanReport on cache hit**:
   - Cache the `ScanReport` after file planning in a separate `scanReports` map
   - On cache hit (when `splitTasks` already contains results for the same table/predicate), reconstruct the `ScanReport` with the current query's `projectedFieldIds` and `projectedFieldNames` via `withProjectedFields()`
   - Publish the rewritten report to the current query's `IcebergMetricsReporter`

**Key design decisions**:
- `PredicateSearchKey` does NOT include `fieldNames` in `equals/hashCode` — different column projections share the same file planning cache, since file planning (which files to read) is independent of column projection
- The `ScanReport` is cheaply rewritten at read time to reflect the actual projection, avoiding redundant manifest scans
- `scan.select()` only affects `scanMetrics()` and the scan's projected schema — `BaseFileScanTask` always receives the full table schema via `tableSchema()`, so file planning and partition key resolution are unaffected

**Files changed**:
- `MetaPreparationItem`: added `fieldNames` for parallel metadata preparation path
- `PredicateSearchKey`: improved `hashCode` to use `predicateDigest` instead of `ScalarOperator` reference
- `IcebergMetadata`: added `scanReports` cache, `cacheScanReport()`, `publishCachedScanReport()`, `withProjectedFields()`, and 6-param `buildFileScanTaskIterator` overload
- `IcebergScanNode`: added `fieldNames` constructor parameter
- `PlanFragmentBuilder` / `PrepareCollectMetaTask`: extract `fieldNames` from `colRefToColumnMetaMap`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4