### PR TITLE
[UT] fix clang warning hex escape sequence out of range

### DIFF
--- a/be/test/exprs/http_request_functions_test.cpp
+++ b/be/test/exprs/http_request_functions_test.cpp
@@ -1318,7 +1318,7 @@ TEST_F(HttpRequestFunctionsTest, buildJsonResponse_TextBody) {
 
 TEST_F(HttpRequestFunctionsTest, buildJsonResponse_InvalidUtf8) {
     // Invalid UTF-8 should return error response
-    std::string result = build_json_response(200, "Bad\x80Data");
+    std::string result = build_json_response(200, std::string("Bad") + char(0x80) + "Data");
     EXPECT_TRUE(result.find("\"status\": -1") != std::string::npos);
     EXPECT_TRUE(result.find("invalid UTF-8") != std::string::npos);
 }


### PR DESCRIPTION
## Why I'm doing:

```
/home/disk4/zhangyan/StarRocks/be/test/exprs/http_request_functions_test.cpp:1321:55: error: hex escape sequence out of range
  1321 |     std::string result = build_json_response(200, "Bad\x80Data");
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
