### PR TITLE
[Enhancement] Allow creating CTE when merging complex projects

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -593,6 +593,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum number of rollup jobs can run in parallel for a table.
 - Introduced in: -
 
+### `merge_project_cte_rewrite_max_flat_children`
+
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: When merging two logical projects, the lower project is materialized as a CTE instead of inlining only when a merged expression's flat children count exceeds this threshold, actually increases compared to before the merge, and exceeds the maximum complexity of the lower project; otherwise, existing behavior is preserved. 0 or negative means disabled and existing behavior is preserved.
+- Introduced in: -
+
 ### `max_scalar_operator_flat_children`
 
 - Default：10000

--- a/docs/ja/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/management/FE_parameters/user_query_loading.md
@@ -593,6 +593,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：テーブルに対して並行して実行できるロールアップジョブの最大数。
 - 導入時期：-
 
+### `merge_project_cte_rewrite_max_flat_children`
+
+- Default：0
+- Type：Int
+- Unit：-
+- 変更可能：Yes
+- Description：2つの論理プロジェクトをマージする際、マージ後の式のフラット子ノード数がこの閾値を超えると、下位プロジェクトのインライン化ではなくCTE実体化を検討します。実際にCTE化されるのは、閾値超過に加えて、マージによって複雑度が増加し、かつ下位 Project 側の最大複雑度も上回るなど、実装上の追加条件を満たす場合です。0または負の値は無効を意味し、既存の動作が維持されます。
+- 導入時期：-
+
 ### `max_scalar_operator_flat_children`
 
 - Default：10000

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -593,6 +593,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 每张表可以并行运行的 rollup 作业的最大数量。
 - 引入版本: -
 
+### `merge_project_cte_rewrite_max_flat_children`
+
+- 默认值: 0
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: 合并两个逻辑 Project 时，只有在合并后表达式的扁平子节点数超过此阈值，且相较合并前确实增加，并且超过下层 Project 的最大复杂度时，才会将下层 Project 物化为 CTE 而非内联；否则保留现有行为。0 或负值表示禁用，保留现有行为。
+- 引入版本: -
+
 ### `max_scalar_operator_flat_children`
 
 - 默认值: 10000

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2236,6 +2236,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "scalar operator maximum number of flat children.")
     public static int max_scalar_operator_flat_children = 10000;
 
+    @ConfField(mutable = true, comment = "When merging two logical projects, the lower project is materialized as a "
+            + "CTE instead of inlining only when a merged expression's flat children count exceeds this threshold, "
+            + "actually increases compared to before the merge, and exceeds the maximum complexity of the lower "
+            + "project; otherwise, existing behavior is preserved. 0 or negative disables this behavior.")
+    public static int merge_project_cte_rewrite_max_flat_children = 0;
+
     @ConfField(mutable = true)
     public static int minmax_n_max_size = 10000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
@@ -54,6 +54,14 @@ public class ReplaceColumnRefRewriter {
         return result;
     }
 
+    public ScalarOperator rewriteWithoutCheck(ScalarOperator origin) {
+        if (origin == null) {
+            return null;
+        }
+
+        return origin.clone().accept(rewriter, null);
+    }
+
     public ScalarOperator rewriteWithoutClone(ScalarOperator origin) {
         if (origin == null) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
@@ -17,9 +17,14 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.common.Config;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -44,11 +49,42 @@ public class MergeTwoProjectRule extends TransformationRule {
         LogicalProjectOperator firstProject = (LogicalProjectOperator) input.getOp();
         LogicalProjectOperator secondProject = (LogicalProjectOperator) input.getInputs().get(0).getOp();
 
+        // cteRewriteMaxFlatChildren > 0 means to enable CTE rewrite if the merged project has an expression whose flat children
+        // count is above cteRewriteMaxFlatChildren.
+        int cteRewriteMaxFlatChildren = Config.merge_project_cte_rewrite_max_flat_children;
+        // We want to perform CTE rewrites only when the merged expression is more complicated than existing expressions. So we
+        // calculate the max count of flat children from bottom project first.
+        int maxBottomFlatChildren = 0;
+        if (cteRewriteMaxFlatChildren > 0) {
+            for (ScalarOperator expr : secondProject.getColumnRefMap().values()) {
+                maxBottomFlatChildren = Math.max(maxBottomFlatChildren, expr.getNumFlatChildren());
+            }
+        }
+
         ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(secondProject.getColumnRefMap());
         Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : firstProject.getColumnRefMap().entrySet()) {
-            ScalarOperator result = rewriter.rewrite(entry.getValue());
+            ScalarOperator result;
+            result = rewriter.rewriteWithoutCheck(entry.getValue());
+            // Create CTEs to avoid creating overly-complex expressions. Overly-complex expression may 1. fail the query
+            // because of expression complexity limit; 2. result in long planning time; 3. consume more FE memory.
+            // These conditions must be met:
+            // - merge_project_cte_rewrite_max_flat_children is set to > 0
+            // - result's flat children count exceeds merge_project_cte_rewrite_max_flat_children
+            // - result's flat children count does increase after the merge
+            // - result's flat children count is larger than max flat children count from bottom projects
+            // These additional checks avoid creating unnecessary CTEs when an identity projection is chained with an already-
+            // complex projection.
+            int resultNumFlatChildren = result.getNumFlatChildren();
+            if (cteRewriteMaxFlatChildren > 0
+                    && resultNumFlatChildren > cteRewriteMaxFlatChildren
+                    && resultNumFlatChildren > entry.getValue().getNumFlatChildren()
+                    && resultNumFlatChildren > maxBottomFlatChildren) {
+                return createCTEForComplexMerge(input, context, firstProject, secondProject);
+            } else {
+                result.checkMaxFlatChildren(true);
+            }
             if (result.isConstant()) {
                 // better to rewrite all expression, but it's unnecessary
                 result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
@@ -76,5 +112,47 @@ public class MergeTwoProjectRule extends TransformationRule {
                 new LogicalProjectOperator(resultMap, limit));
         optExpression.getInputs().addAll(input.getInputs().get(0).getInputs());
         return Lists.newArrayList(optExpression);
+    }
+
+    private List<OptExpression> createCTEForComplexMerge(OptExpression input, OptimizerContext context,
+                                                          LogicalProjectOperator firstProject,
+                                                          LogicalProjectOperator secondProject) {
+        ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
+        int cteId = context.getCteContext().getNextCteId();
+
+        OptExpression bottomTree = input.getInputs().get(0);
+        OptExpression cteProduce = OptExpression.create(new LogicalCTEProduceOperator(cteId),
+                Lists.newArrayList(bottomTree));
+
+        // CTE consume: create new column refs that map to the bottom project's output columns
+        Map<ColumnRefOperator, ColumnRefOperator> consumeOutputMap = Maps.newHashMap();
+        Map<ColumnRefOperator, ScalarOperator> columnRefRewriteMap = Maps.newHashMap();
+
+        for (ColumnRefOperator outputCol : secondProject.getColumnRefMap().keySet()) {
+            ColumnRefOperator newCol = columnRefFactory.create(outputCol, outputCol.getType(), outputCol.isNullable());
+            consumeOutputMap.put(newCol, outputCol);
+            columnRefRewriteMap.put(outputCol, newCol);
+        }
+
+        LogicalCTEConsumeOperator cteConsume = new LogicalCTEConsumeOperator(cteId, consumeOutputMap);
+
+        // Rewrite the top project to reference the CTE consume's output columns
+        ReplaceColumnRefRewriter consumeRewriter = new ReplaceColumnRefRewriter(columnRefRewriteMap);
+        Map<ColumnRefOperator, ScalarOperator> newFirstProjectMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : firstProject.getColumnRefMap().entrySet()) {
+            newFirstProjectMap.put(entry.getKey(), consumeRewriter.rewrite(entry.getValue()));
+        }
+
+        LogicalProjectOperator newFirstProject = new LogicalProjectOperator(newFirstProjectMap, firstProject.getLimit());
+
+        OptExpression consumeExpr = OptExpression.create(cteConsume);
+        OptExpression topProjectExpr = OptExpression.create(newFirstProject, consumeExpr);
+
+        LogicalCTEAnchorOperator cteAnchor = new LogicalCTEAnchorOperator(cteId);
+        OptExpression result = OptExpression.create(cteAnchor, cteProduce, topProjectExpr);
+
+        context.getCteContext().addForceCTE(cteId);
+
+        return Lists.newArrayList(result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OperatorMaxFlatChildTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OperatorMaxFlatChildTest.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OperatorMaxFlatChildTest extends PlanTestBase {
@@ -86,4 +87,53 @@ public class OperatorMaxFlatChildTest extends PlanTestBase {
         });
     }
 
+    @Test
+    public void testMergeProjectCTEFallbackAvoidsTooComplexError() {
+        final int prevFlat = Config.max_scalar_operator_flat_children;
+        final int prevMerge = Config.merge_project_cte_rewrite_max_flat_children;
+        try {
+            String sql =
+                    "WITH cte1 AS (\n" +
+                            "  SELECT\n" +
+                            "    t1a,\n" +
+                            "    (CASE\n" +
+                            "      WHEN t1b < 10 THEN 'small'\n" +
+                            "      WHEN t1b >= 10 AND t1b < 50 THEN 'medium'\n" +
+                            "      WHEN t1b >= 50 AND t1b < 100 THEN 'large'\n" +
+                            "      WHEN t1b >= 100 AND t1b < 500 THEN 'xlarge'\n" +
+                            "      ELSE NULL\n" +
+                            "    END) AS size_label\n" +
+                            "  FROM test_all_type\n" +
+                            "),\n" +
+                            "cte2 AS (\n" +
+                            "  SELECT\n" +
+                            "    t1a,\n" +
+                            "    (CASE\n" +
+                            "      WHEN size_label = 'small' AND t1a = 'X1' THEN concat(t1a, '_s')\n" +
+                            "      WHEN size_label = 'medium' AND t1a = 'X1' THEN concat(t1a, '_m')\n" +
+                            "      WHEN size_label = 'large' AND t1a = 'X1' THEN concat(t1a, '_l')\n" +
+                            "      WHEN size_label = 'xlarge' AND t1a = 'X1' THEN concat(t1a, '_x')\n" +
+                            "      ELSE NULL\n" +
+                            "    END) AS category\n" +
+                            "  FROM cte1\n" +
+                            ")\n" +
+                            "SELECT t1a, category FROM cte2";
+
+            // Individual CASE WHEN expressions have ~20 flat children each (passes 50).
+            // Merging two levels inlines the inner into the outer, creating ~120+ flat children (exceeds 50).
+            Config.max_scalar_operator_flat_children = 50;
+            Config.merge_project_cte_rewrite_max_flat_children = 0;
+
+            // Without CTE fallback, the merge causes the expression to exceed max_scalar_operator_flat_children
+            assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+
+            // With CTE fallback enabled, the lower project is materialized as a CTE instead of inlining
+            Config.merge_project_cte_rewrite_max_flat_children = 30;
+            String plan = assertDoesNotThrow(() -> getFragmentPlan(sql));
+            assertContains(plan, "MultiCastDataSinks");
+        } finally {
+            Config.max_scalar_operator_flat_children = prevFlat;
+            Config.merge_project_cte_rewrite_max_flat_children = prevMerge;
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
@@ -15,10 +15,15 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -27,12 +32,17 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MergeTwoProjectRuleTest {
 
@@ -143,5 +153,94 @@ public class MergeTwoProjectRuleTest {
         // And the original b -> ASSERT_TRUE(a) mapping from the lower project must be preserved per rule
         assertInstanceOf(CallOperator.class, resMap.get(b));
         assertEquals(com.starrocks.catalog.FunctionSet.ASSERT_TRUE, ((CallOperator) resMap.get(b)).getFnName());
+    }
+
+    @Test
+    public void testCTEFallbackWhenMergedExpressionExceedsBottomComplexity() {
+        final int prev = Config.merge_project_cte_rewrite_max_flat_children;
+        try {
+            Config.merge_project_cte_rewrite_max_flat_children = 5;
+
+            ColumnRefOperator a = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+            ColumnRefOperator b = new ColumnRefOperator(2, IntegerType.INT, "b", true);
+            ColumnRefOperator x = new ColumnRefOperator(3, IntegerType.INT, "x", true);
+
+            // Bottom: b -> complex_func(a,a,a) → 4 flat children
+            // Top: x -> wrap_func(b,b,b) → after merge 1+3*4 = 13 > maxBottom(4) → CTE
+            Map<ColumnRefOperator, ScalarOperator> bottomMap = Maps.newHashMap();
+            bottomMap.put(b, makeCall("complex_func", a, 3));
+            Map<ColumnRefOperator, ScalarOperator> topMap = Maps.newHashMap();
+            topMap.put(x, makeCall("wrap_func", b, 3));
+
+            OptimizerContext context = OptimizerFactory.mockContext(new ColumnRefFactory());
+            List<OptExpression> out =
+                    new MergeTwoProjectRule().transform(makeTwoProjectTree(topMap, bottomMap), context);
+
+            assertEquals(1, out.size());
+            OptExpression result = out.get(0);
+
+            // Root: CTEAnchor -> [CTEProduce -> Project, Project -> CTEConsume]
+            assertInstanceOf(LogicalCTEAnchorOperator.class, result.getOp());
+            int cteId = ((LogicalCTEAnchorOperator) result.getOp()).getCteId();
+
+            assertEquals(2, result.getInputs().size());
+            assertInstanceOf(LogicalCTEProduceOperator.class, result.inputAt(0).getOp());
+            assertEquals(cteId, ((LogicalCTEProduceOperator) result.inputAt(0).getOp()).getCteId());
+            assertInstanceOf(LogicalProjectOperator.class, result.inputAt(0).inputAt(0).getOp());
+
+            OptExpression topProjectExpr = result.inputAt(1);
+            LogicalProjectOperator rewrittenProject =
+                    assertInstanceOf(LogicalProjectOperator.class, topProjectExpr.getOp());
+            assertTrue(rewrittenProject.getColumnRefMap().containsKey(x));
+            assertInstanceOf(CallOperator.class, rewrittenProject.getColumnRefMap().get(x));
+
+            LogicalCTEConsumeOperator consume =
+                    assertInstanceOf(LogicalCTEConsumeOperator.class, topProjectExpr.inputAt(0).getOp());
+            assertEquals(cteId, consume.getCteId());
+            assertTrue(consume.getCteOutputColumnRefMap().values().contains(b));
+        } finally {
+            Config.merge_project_cte_rewrite_max_flat_children = prev;
+        }
+    }
+
+    @ParameterizedTest(name = "maxMergeProjectFlatChildren={0}")
+    @ValueSource(ints = {5, 100, 0})
+    public void mergesNormallyWhenBelowThresholdOrConfigDisabled(int maxMergeProjectFlatChildren) {
+        // Identity top over complex bottom: merged expression doesn't exceed bottom's max
+        // flat children (threshold=5) or the threshold itself (100), or feature is disabled (0).
+        final int prev = Config.merge_project_cte_rewrite_max_flat_children;
+        try {
+            Config.merge_project_cte_rewrite_max_flat_children = maxMergeProjectFlatChildren;
+
+            ColumnRefOperator a = new ColumnRefOperator(1, IntegerType.INT, "a", true);
+            ColumnRefOperator b = new ColumnRefOperator(2, IntegerType.INT, "b", true);
+            ColumnRefOperator x = new ColumnRefOperator(3, IntegerType.INT, "x", true);
+
+            Map<ColumnRefOperator, ScalarOperator> bottomMap = Maps.newHashMap();
+            bottomMap.put(b, makeCall("complex_func", a, 10));
+            Map<ColumnRefOperator, ScalarOperator> topMap = Maps.newHashMap();
+            topMap.put(x, b);
+
+            List<OptExpression> out = new MergeTwoProjectRule()
+                    .transform(makeTwoProjectTree(topMap, bottomMap), OptimizerFactory.mockContext(new ColumnRefFactory()));
+
+            assertEquals(1, out.size());
+            LogicalProjectOperator result = assertInstanceOf(LogicalProjectOperator.class, out.get(0).getOp());
+            CallOperator merged = assertInstanceOf(CallOperator.class, result.getColumnRefMap().get(x));
+            assertEquals("complex_func", merged.getFnName());
+        } finally {
+            Config.merge_project_cte_rewrite_max_flat_children = prev;
+        }
+    }
+
+    private static CallOperator makeCall(String name, ScalarOperator arg, int repeatCount) {
+        return new CallOperator(name, IntegerType.INT, new ArrayList<>(Collections.nCopies(repeatCount, arg)));
+    }
+
+    private static OptExpression makeTwoProjectTree(Map<ColumnRefOperator, ScalarOperator> topMap,
+                                                    Map<ColumnRefOperator, ScalarOperator> bottomMap) {
+        OptExpression top = new OptExpression(new LogicalProjectOperator(topMap, -1));
+        top.getInputs().add(OptExpression.create(new LogicalProjectOperator(bottomMap, -1)));
+        return top;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When `MergeTwoProjectRule` inlines the lower project's expressions into the upper project, the result can exceed the `max_scalar_operator_flat_children` limit and fail with "Expression too complex". A new config `merge_project_cte_rewrite_max_flat_children` (default 0 / disabled) controls a softer threshold: when enabled, the lower project is materialized as a forced CTE instead of being inlined only when
- a merged expression's flat children count exceeds this threshold,
- actually increases compared to before the merge, and
- exceeds the maximum complexity of the lower project;

otherwise, existing behavior is preserved.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
