### PR TITLE
[Tool] fix FE UT Clean ECI and Upload log steps failing when UT is skipped

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -805,16 +805,16 @@ jobs:
           ./bin/elastic-ut.sh --pr ${PR_NUMBER} --module fe --branch ${{steps.branch.outputs.branch}} --build Release --repository ${{ github.repository }} --linuxdistro ${LINUX_DISTRO}
 
       - name: Clean ECI
-        if: always() && steps.run_ut.outputs.ECI_ID != ''
+        if: always() && steps.run_ut.outputs.ECI_ID
         run: |
           echo ${{ steps.run_ut.outputs.ECI_ID }}
           echo "::group::>>> Dmesg info:"
           eci exec ${{ steps.run_ut.outputs.ECI_ID }} bash -c "dmesg -T"
           echo "::endgroup::"
-          eci rm ${{ steps.run_ut.outputs.ECI_ID }}
+          eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Upload log
-        if: always() && steps.run_ut.outputs.RES_LOG != ''
+        if: always() && steps.run_ut.outputs.RES_LOG
         uses: actions/upload-artifact@v6
         with:
           name: FE UT LOG


### PR DESCRIPTION
## Why I'm doing:

When `elastic-ut.sh` detects a version cache hit (same commit already tested), it exits early without writing any outputs to `$GITHUB_OUTPUT`. In GitHub Actions expression language, an unset output is `null`, and `null != ''` evaluates to `true`. This causes the **Clean ECI** and **Upload log** steps to run even though no ECI container was created, resulting in:

- `eci: The instanceId mismatch instance type` (exit 255) in Clean ECI
- `Input required and not supplied: path` in Upload log

Example failure: https://github.com/StarRocks/starrocks/actions/runs/24130145651/job/70541572143

## What I'm doing:

- Change `!= ''` conditions to truthy checks (`steps.run_ut.outputs.ECI_ID` and `steps.run_ut.outputs.RES_LOG`), which correctly evaluate to `false` for both `null` and empty string
- Add `|| true` to `eci rm` in Clean ECI step, consistent with the existing BE UT job

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4