### PR TITLE
[BugFix] Fix deadlock when warmup the lru cache for rowset metadata in share nothing mode

### DIFF
--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -277,7 +277,8 @@ void LRUCache::release(Cache::Handle* handle) {
 void LRUCache::touch(const CacheKey& key, uint32_t hash) {
     std::lock_guard l(_mutex);
     LRUHandle* e = _table.lookup(key, hash);
-    if (e != nullptr && e->in_cache && e->refs == 1) {
+    if (e != nullptr && e->refs == 1) {
+        DCHECK(e->in_cache);
         _lru_remove(e);
         _lru_append(&_lru, e);
     }

--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -274,6 +274,15 @@ void LRUCache::release(Cache::Handle* handle) {
     }
 }
 
+void LRUCache::touch(const CacheKey& key, uint32_t hash) {
+    std::lock_guard l(_mutex);
+    LRUHandle* e = _table.lookup(key, hash);
+    if (e != nullptr && e->in_cache && e->refs == 1) {
+        _lru_remove(e);
+        _lru_append(&_lru, e);
+    }
+}
+
 void LRUCache::_evict_from_lru(size_t charge, std::vector<LRUHandle*>* deleted) {
     LRUHandle* cur = &_lru;
     // 1. evict normal cache entries
@@ -464,6 +473,11 @@ Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
 void ShardedLRUCache::release(Handle* handle) {
     auto* h = reinterpret_cast<LRUHandle*>(handle);
     _shards[_shard(h->hash)].release(handle);
+}
+
+void ShardedLRUCache::touch(const CacheKey& key) {
+    const uint32_t hash = _hash_slice(key);
+    _shards[_shard(hash)].touch(key, hash);
 }
 
 void ShardedLRUCache::erase(const CacheKey& key) {

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -150,6 +150,11 @@ public:
     // REQUIRES: handle must have been returned by a method on *this.
     virtual void release(Handle* handle) = 0;
 
+    // Refresh the recency of an existing cache entry without taking or
+    // releasing a handle, so callers can update LRU order without triggering
+    // deleter side effects.
+    virtual void touch(const CacheKey& key) = 0;
+
     // Return the value encapsulated in a handle returned by a
     // successful lookup().
     // REQUIRES: handle must not have been released yet.
@@ -274,6 +279,7 @@ public:
                           CachePriority priority = CachePriority::NORMAL);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
     void release(Cache::Handle* handle);
+    void touch(const CacheKey& key, uint32_t hash);
     void erase(const CacheKey& key, uint32_t hash);
     int prune();
 
@@ -326,6 +332,7 @@ public:
                    CachePriority priority = CachePriority::NORMAL) override;
     Handle* lookup(const CacheKey& key) override;
     void release(Handle* handle) override;
+    void touch(const CacheKey& key) override;
     void erase(const CacheKey& key) override;
     void* value(Handle* handle) override;
     Slice value_slice(Handle* handle) override;

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -77,10 +77,7 @@ void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
 }
 
 void MetadataCache::_warmup(const std::string& key) {
-    Cache::Handle* handle = _cache->lookup(CacheKey(key));
-    if (handle != nullptr) {
-        _cache->release(handle);
-    }
+    _cache->touch(CacheKey(key));
 }
 
 } // namespace starrocks

--- a/be/test/base/lru_cache_test.cpp
+++ b/be/test/base/lru_cache_test.cpp
@@ -36,6 +36,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 using namespace starrocks;
@@ -234,9 +237,73 @@ static void deleter(const CacheKey& key, void* v) {
     std::cout << "delete key " << key.to_string() << std::endl;
 }
 
-static void insert_LRUCache(LRUCache& cache, const CacheKey& key, int value, CachePriority priority) {
-    uint32_t hash = key.hash(key.data(), key.size(), 0);
-    cache.release(cache.insert(key, hash, EncodeValue(value), value, &deleter, priority));
+static uint32_t hash_cache_key(const CacheKey& key) {
+    return key.hash(key.data(), key.size(), 0);
+}
+
+static int lookup_cache(Cache* cache, int key) {
+    std::string encoded;
+    Cache::Handle* handle = cache->lookup(EncodeKey(&encoded, key));
+    const int result = (handle == nullptr) ? -1 : DecodeValue(cache->value(handle));
+    if (handle != nullptr) {
+        cache->release(handle);
+    }
+    return result;
+}
+
+static void insert_cache(Cache* cache, int key, int value, size_t charge,
+                         CachePriority priority = CachePriority::NORMAL) {
+    std::string encoded;
+    cache->release(cache->insert(EncodeKey(&encoded, key), EncodeValue(value), charge, &CacheTest::Deleter, priority));
+}
+
+static void touch_cache(Cache* cache, int key) {
+    std::string encoded;
+    cache->touch(EncodeKey(&encoded, key));
+}
+
+static uint32_t shard_for_int_key(int key) {
+    std::string encoded;
+    return hash_cache_key(EncodeKey(&encoded, key)) >> (32 - kNumShardBits);
+}
+
+static std::array<int, 3> find_int_keys_in_same_shard() {
+    std::unordered_map<uint32_t, std::vector<int>> shard_keys;
+    for (int key = 0;; key++) {
+        auto& keys = shard_keys[shard_for_int_key(key)];
+        keys.push_back(key);
+        if (keys.size() == 3) {
+            return {keys[0], keys[1], keys[2]};
+        }
+    }
+}
+
+static void insert_LRUCache(LRUCache& cache, const CacheKey& key, int value, size_t charge,
+                            CachePriority priority = CachePriority::NORMAL) {
+    cache.release(cache.insert(key, hash_cache_key(key), EncodeValue(value), charge, &deleter, priority));
+}
+
+static int decode_LRUCache_value(Cache::Handle* handle) {
+    return DecodeValue(reinterpret_cast<LRUHandle*>(handle)->value);
+}
+
+static int lookup_LRUCache(LRUCache& cache, const CacheKey& key) {
+    Cache::Handle* handle = cache.lookup(key, hash_cache_key(key));
+    const int result = (handle == nullptr) ? -1 : decode_LRUCache_value(handle);
+    if (handle != nullptr) {
+        cache.release(handle);
+    }
+    return result;
+}
+
+static void touch_LRUCache(LRUCache& cache, const CacheKey& key) {
+    cache.touch(key, hash_cache_key(key));
+}
+
+static size_t entry_charge_for_int_key() {
+    std::string encoded;
+    CacheKey key = EncodeKey(&encoded, 0);
+    return 1 + LRUCache::key_handle_size(key);
 }
 
 TEST_F(CacheTest, Usage) {
@@ -245,39 +312,170 @@ TEST_F(CacheTest, Usage) {
 
     CacheKey key1("100");
     size_t key_mem_usage = sizeof(LRUHandle) - 1 + key1.size();
-    insert_LRUCache(cache, key1, 100, CachePriority::NORMAL);
+    insert_LRUCache(cache, key1, 100, 100, CachePriority::NORMAL);
     // 100 + 90
     ASSERT_EQ(100 + key_mem_usage, cache.get_usage());
 
     CacheKey key2("200");
-    insert_LRUCache(cache, key2, 200, CachePriority::DURABLE);
+    insert_LRUCache(cache, key2, 200, 200, CachePriority::DURABLE);
     // 300 + 180
     ASSERT_EQ(300 + key_mem_usage * 2, cache.get_usage());
 
     CacheKey key3("300");
-    insert_LRUCache(cache, key3, 300, CachePriority::NORMAL);
+    insert_LRUCache(cache, key3, 300, 300, CachePriority::NORMAL);
     // 600 + 270
     ASSERT_EQ(600 + key_mem_usage * 3, cache.get_usage());
 
     CacheKey key4("400");
-    insert_LRUCache(cache, key4, 400, CachePriority::NORMAL);
+    insert_LRUCache(cache, key4, 400, 400, CachePriority::NORMAL);
     // 600 + 180
     ASSERT_EQ(600 + key_mem_usage * 2, cache.get_usage());
 
     CacheKey key5("500");
-    insert_LRUCache(cache, key5, 500, CachePriority::NORMAL);
+    insert_LRUCache(cache, key5, 500, 500, CachePriority::NORMAL);
     // 700 + 180
     ASSERT_EQ(700 + key_mem_usage * 2, cache.get_usage());
 
     CacheKey key6("600");
-    insert_LRUCache(cache, key6, 600, CachePriority::NORMAL);
+    insert_LRUCache(cache, key6, 600, 600, CachePriority::NORMAL);
     // 800 + 180
     ASSERT_EQ(800 + key_mem_usage * 2, cache.get_usage());
 
     CacheKey key7("950");
     // 900 + 90
-    insert_LRUCache(cache, key7, 900, CachePriority::DURABLE);
+    insert_LRUCache(cache, key7, 900, 900, CachePriority::DURABLE);
     ASSERT_EQ(900 + key_mem_usage, cache.get_usage());
+}
+
+TEST_F(CacheTest, TouchUpdatesRecencyWithoutLookupSideEffects) {
+    const size_t entry_charge = entry_charge_for_int_key();
+
+    {
+        LRUCache cache;
+        cache.set_capacity(entry_charge * 2);
+
+        std::string k100_buf;
+        std::string k200_buf;
+        std::string k300_buf;
+        CacheKey k100 = EncodeKey(&k100_buf, 100);
+        CacheKey k200 = EncodeKey(&k200_buf, 200);
+        CacheKey k300 = EncodeKey(&k300_buf, 300);
+
+        insert_LRUCache(cache, k100, 101, 1);
+        insert_LRUCache(cache, k200, 201, 1);
+        insert_LRUCache(cache, k300, 301, 1);
+
+        ASSERT_EQ(-1, lookup_LRUCache(cache, k100));
+        ASSERT_EQ(201, lookup_LRUCache(cache, k200));
+        ASSERT_EQ(301, lookup_LRUCache(cache, k300));
+    }
+
+    {
+        LRUCache cache;
+        cache.set_capacity(entry_charge * 2);
+
+        std::string k100_buf;
+        std::string k200_buf;
+        std::string k300_buf;
+        CacheKey k100 = EncodeKey(&k100_buf, 100);
+        CacheKey k200 = EncodeKey(&k200_buf, 200);
+        CacheKey k300 = EncodeKey(&k300_buf, 300);
+
+        insert_LRUCache(cache, k100, 101, 1);
+        insert_LRUCache(cache, k200, 201, 1);
+        const uint64_t lookup_count_before_touch = cache.get_lookup_count();
+        const uint64_t hit_count_before_touch = cache.get_hit_count();
+        touch_LRUCache(cache, k100);
+        ASSERT_EQ(lookup_count_before_touch, cache.get_lookup_count());
+        ASSERT_EQ(hit_count_before_touch, cache.get_hit_count());
+        insert_LRUCache(cache, k300, 301, 1);
+
+        ASSERT_EQ(101, lookup_LRUCache(cache, k100));
+        ASSERT_EQ(-1, lookup_LRUCache(cache, k200));
+        ASSERT_EQ(301, lookup_LRUCache(cache, k300));
+    }
+}
+
+TEST_F(CacheTest, TouchUpdatesRecencyOnShardedCache) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    const auto keys = find_int_keys_in_same_shard();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * 2 * kNumShards));
+
+    insert_cache(cache.get(), keys[0], 1000, 1);
+    insert_cache(cache.get(), keys[1], 2000, 1);
+    touch_cache(cache.get(), keys[0]);
+    insert_cache(cache.get(), keys[2], 3000, 1);
+
+    ASSERT_EQ(1000, lookup_cache(cache.get(), keys[0]));
+    ASSERT_EQ(-1, lookup_cache(cache.get(), keys[1]));
+    ASSERT_EQ(3000, lookup_cache(cache.get(), keys[2]));
+}
+
+TEST_F(CacheTest, TouchMissingKeyDoesNotAffectRecencyOrStats) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    LRUCache cache;
+    cache.set_capacity(entry_charge * 2);
+
+    std::string k100_buf;
+    std::string k200_buf;
+    std::string k300_buf;
+    std::string k999_buf;
+    CacheKey k100 = EncodeKey(&k100_buf, 100);
+    CacheKey k200 = EncodeKey(&k200_buf, 200);
+    CacheKey k300 = EncodeKey(&k300_buf, 300);
+    CacheKey k999 = EncodeKey(&k999_buf, 999);
+
+    insert_LRUCache(cache, k100, 101, 1);
+    insert_LRUCache(cache, k200, 201, 1);
+
+    const uint64_t lookup_count_before = cache.get_lookup_count();
+    const uint64_t hit_count_before = cache.get_hit_count();
+    touch_LRUCache(cache, k999);
+
+    ASSERT_EQ(lookup_count_before, cache.get_lookup_count());
+    ASSERT_EQ(hit_count_before, cache.get_hit_count());
+
+    insert_LRUCache(cache, k300, 301, 1);
+
+    ASSERT_EQ(-1, lookup_LRUCache(cache, k100));
+    ASSERT_EQ(201, lookup_LRUCache(cache, k200));
+    ASSERT_EQ(301, lookup_LRUCache(cache, k300));
+}
+
+TEST_F(CacheTest, TouchPinnedEntryIsNoOpAndDoesNotChangeStats) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    LRUCache cache;
+    cache.set_capacity(entry_charge * 2);
+
+    std::string k100_buf;
+    std::string k200_buf;
+    std::string k300_buf;
+    CacheKey k100 = EncodeKey(&k100_buf, 100);
+    CacheKey k200 = EncodeKey(&k200_buf, 200);
+    CacheKey k300 = EncodeKey(&k300_buf, 300);
+
+    insert_LRUCache(cache, k100, 101, 1);
+    insert_LRUCache(cache, k200, 201, 1);
+
+    Cache::Handle* pinned = cache.lookup(k100, hash_cache_key(k100));
+    ASSERT_NE(nullptr, pinned);
+    ASSERT_EQ(101, decode_LRUCache_value(pinned));
+
+    const uint64_t lookup_count_after_pin = cache.get_lookup_count();
+    const uint64_t hit_count_after_pin = cache.get_hit_count();
+    touch_LRUCache(cache, k100);
+
+    ASSERT_EQ(lookup_count_after_pin, cache.get_lookup_count());
+    ASSERT_EQ(hit_count_after_pin, cache.get_hit_count());
+
+    insert_LRUCache(cache, k300, 301, 1);
+
+    ASSERT_EQ(-1, lookup_LRUCache(cache, k200));
+    ASSERT_EQ(301, lookup_LRUCache(cache, k300));
+    ASSERT_EQ(101, decode_LRUCache_value(pinned));
+
+    cache.release(pinned);
+    ASSERT_EQ(101, lookup_LRUCache(cache, k100));
 }
 
 TEST_F(CacheTest, HeavyEntries) {

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -35,7 +35,7 @@ namespace starrocks {
 class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                   void (* /*deleter*/)(const CacheKey& key, void* value),
+                   void (*/*deleter*/)(const CacheKey& key, void* value),
                    CachePriority /*priority*/ = CachePriority::NORMAL) override {
         return nullptr;
     }

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/rowset/metadata_cache.h"
-
 #include <gtest/gtest.h>
+
+#define private public
+#include "storage/rowset/metadata_cache.h"
+#undef private
 
 #include "runtime/starrocks_metrics.h"
 #include "storage/chunk_helper.h"
@@ -29,6 +31,74 @@
 #include "storage/tablet_schema_helper.h"
 
 namespace starrocks {
+
+class RecordingCache final : public Cache {
+public:
+    Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
+                   void (* /*deleter*/)(const CacheKey& key, void* value),
+                   CachePriority /*priority*/ = CachePriority::NORMAL) override {
+        return nullptr;
+    }
+
+    Handle* lookup(const CacheKey& key) override {
+        ++lookup_calls;
+        last_lookup_key = key.to_string();
+        return &_handle;
+    }
+
+    void release(Handle* /*handle*/) override { ++release_calls; }
+
+    void touch(const CacheKey& key) override {
+        ++touch_calls;
+        last_touch_key = key.to_string();
+    }
+
+    void* value(Handle* /*handle*/) override { return nullptr; }
+
+    Slice value_slice(Handle* /*handle*/) override { return {}; }
+
+    void erase(const CacheKey& /*key*/) override {}
+
+    uint64_t new_id() override { return 0; }
+
+    void get_cache_status(rapidjson::Document* /*document*/) override {}
+
+    void set_capacity(size_t capacity) override { _capacity = capacity; }
+
+    size_t get_capacity() const override { return _capacity; }
+
+    size_t get_memory_usage() const override { return 0; }
+
+    size_t get_lookup_count() const override { return lookup_calls; }
+
+    size_t get_hit_count() const override { return 0; }
+
+    size_t get_insert_count() const override { return 0; }
+
+    size_t get_insert_evict_count() const override { return 0; }
+
+    size_t get_release_evict_count() const override { return 0; }
+
+    bool adjust_capacity(int64_t delta, size_t min_capacity = 0) override {
+        int64_t new_capacity = static_cast<int64_t>(_capacity) + delta;
+        if (new_capacity < static_cast<int64_t>(min_capacity)) {
+            return false;
+        }
+        _capacity = static_cast<size_t>(new_capacity);
+        return true;
+    }
+
+    size_t lookup_calls = 0;
+    size_t release_calls = 0;
+    size_t touch_calls = 0;
+    std::string last_lookup_key;
+    std::string last_touch_key;
+
+private:
+    size_t _capacity = 0;
+    Handle _handle;
+};
+
 class MetadataCacheTest : public ::testing::Test {
 public:
     void SetUp() override {}
@@ -176,6 +246,19 @@ TEST_F(MetadataCacheTest, test_warmup) {
         metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 64);
         ASSERT_TRUE(rowsets[0]->segment_memory_usage() > 0);
     }
+}
+
+TEST_F(MetadataCacheTest, test_warmup_uses_touch_without_releasing_handle) {
+    MetadataCache metadata_cache(1);
+    auto* recording_cache = new RecordingCache();
+    metadata_cache._cache.reset(recording_cache);
+
+    metadata_cache._warmup("rowset_warmup_key");
+
+    ASSERT_EQ(1, recording_cache->touch_calls);
+    ASSERT_EQ("rowset_warmup_key", recording_cache->last_touch_key);
+    ASSERT_EQ(0, recording_cache->lookup_calls);
+    ASSERT_EQ(0, recording_cache->release_calls);
 }
 
 TEST_F(MetadataCacheTest, test_concurrency_issue) {


### PR DESCRIPTION
## Why I'm doing:
Dead lock when refresh_rowset lru cache in rowset::load in share nothing mode if the cache is full.
> 
    0x7f634be873ee  __GI___lll_lock_wait
    0x7f634be8d582  ___pthread_mutex_lock
    0x61216c9  starrocks::Rowset::close()
    0x625fa36  starrocks::MetadataCache::_cache_value_deleter(starrocks::CacheKey const&, void*)
    0x396c64c  starrocks::ShardedLRUCache::release(starrocks::Cache::Handle*)
    0x625f62b  starrocks::MetadataCache::refresh_rowset(starrocks::Rowset*)
    0x6b69c7c  starrocks::Rowset::load()
    0x6b6ef5c  starrocks::Rowset::get_segment_iterators(starrocks::Schema const&, starrocks::RowsetReadOptions const&, std::vector<std::shared_ptr<starrocks::ChunkIterator>, std::allocator<std::shared_ptr<starrocks::ChunkIterator> > >*)"
    0x62e76d7  starrocks::TabletReader::get_segment_iterators(starrocks::TabletReaderParams const&, std::vector<std::shared_ptr<starrocks::ChunkIterator>, std::allocator<std::shared_ptr<starrocks::ChunkIterator> > >*)
    0x62e7e31  starrocks::TabletReader::_init_collector(starrocks::TabletReaderParams const&)
    0x62e95c0  starrocks::TabletReader::open(starrocks::TabletReaderParams const&)
    0x6b59938  starrocks::VerticalCompactionTask::_compact_column_group(bool, int, std::vector<unsigned int, std::allocator<unsigned int> > const&, starrocks::RowsetWriter*, starrocks::RowSourceMaskBuffer*, std::vector<starrocks::RowSourceMask, std::allocator<starrocks::>
    0x6b5a0dc  starrocks::VerticalCompactionTask::_vertical_compaction_data(starrocks::Statistics*)
    0x6b5a924  starrocks::VerticalCompactionTask::run_impl()
    0x6b537ee  starrocks::CompactionTask::run()
    0x6357670  std::_Function_handler<void (), starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lambda()#1}>::_M_invoke(std::_Any_data const&)"
    0x395c6a3  starrocks::ThreadPool::dispatch_thread()
    0x39548e6  starrocks::Thread::supervise_thread(void*)
    0x7f634be8a19a  start_thread
    0x7f634bf0f210  __clone3
> 

## What I'm doing:
Use touch instead of lookup + release to refresh the cache to avoid the deconstruction.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
