### PR TITLE
[BugFix] disable insert only acid hive table in hive catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -129,6 +129,10 @@ public class HiveMetastore implements IHiveMetastore {
                 throw new StarRocksConnectorException(String.format(
                         "%s.%s is a hive transactional table(full acid), sr didn't support it yet", dbName, tableName));
             }
+            if (table.getParameters() != null && AcidUtils.isInsertOnlyTable(table.getParameters())) {
+                throw new StarRocksConnectorException(String.format(
+                        "%s.%s is a hive transactional table(insert only), sr didn't support it yet", dbName, tableName));
+            }
             if (table.getTableType().equalsIgnoreCase("VIRTUAL_VIEW")) {
                 return HiveMetastoreApiConverter.toHiveView(table, catalogName);
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -123,8 +123,8 @@ public class CachingHiveMetastoreTest {
                 metastore, executor, executor,
                 expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         // get insert only table
-        com.starrocks.catalog.Table table = cachingHiveMetastore.getTable("transactional_db", "insert_only");
-        Assertions.assertNotNull(table);
+        Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> cachingHiveMetastore.getTable("transactional_db", "insert_only"));
         // get full acid table
         Assertions.assertThrows(StarRocksConnectorException.class,
                 () -> cachingHiveMetastore.getTable("transactional_db", "full_acid"));


### PR DESCRIPTION
## Why I'm doing:
We can not recognize the insert overwrite operations for insert only acid hive table. So the query result may have more results than the real result.
## What I'm doing:
disable acid hive table.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
