### PR TITLE
[BugFix] Fix link issue in dynamic link

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -561,17 +561,17 @@ set(STARROCKS_LINK_LIBS
     Cache
     orc
     ${WL_END_GROUP}
-    ${WL_WHOLE_ARCHIVE_PREFIX} ExprCore ${WL_WHOLE_ARCHIVE_SUFFIX}
+    ${WL_WHOLE_ARCHIVE_PREFIX} $<TARGET_FILE:ExprCore> ${WL_WHOLE_ARCHIVE_SUFFIX}
     RuntimeCore
-    ChunkCore
-    ColumnCore
-    TypesCore
-    FSCore
-    IOCore
-    Common
-    Base
-    Gutil
-    StarRocksGen
+    $<TARGET_FILE:ChunkCore>
+    $<TARGET_FILE:ColumnCore>
+    $<TARGET_FILE:TypesCore>
+    $<TARGET_FILE:FSCore>
+    $<TARGET_FILE:IOCore>
+    $<TARGET_FILE:Common>
+    $<TARGET_FILE:Base>
+    $<TARGET_FILE:Gutil>
+    $<TARGET_FILE:StarRocksGen>
 )
 
 set(STARROCKS_DEPENDENCIES ${STARROCKS_DEPENDENCIES}

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -41,7 +41,7 @@ ADD_BE_LIB(RuntimeCore
     ${RUNTIME_CORE_FILES}
 )
 
-target_link_libraries(RuntimeCore PUBLIC
+target_link_libraries(RuntimeCore PRIVATE
     ChunkCore
     ColumnCore
     TypesCore


### PR DESCRIPTION
## Why I'm doing:

```
[99%] Built target Exec
[100%] Linking CXX executable /worktree/starrocks/main/be/output/lib/starrocks_be
/worktree/starrocks/main/be/output/tmp/RELEASE/libColumnCore.so: error: undefined reference to 'arangodb::velocypack::Parser::parseInternal(bool)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'vtable for apache::thrift::server::TNonblockingServer'
/usr/bin/ld.gold: the vtable symbol may be undefined because the class is missing its key function
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::server::TNonblockingServer::setThreadManager(std::shared_ptr<apache::thrift::concurrency::ThreadManager>)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::transport::TServerSocket::TServerSocket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::server::TThreadedServer::TThreadedServer(std::shared_ptr<apache::thrift::TProcessor> const&, std::shared_ptr<apache::thrift::transport::TServerTransport> const&, std::shared_ptr<apache::thrift::transport::TTransportFactory> const&, std::shared_ptr<apache::thrift::protocol::TProtocolFactory> const&, std::shared_ptr<apache::thrift::concurrency::ThreadFactory> const&)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::concurrency::ThreadManager::newSimpleThreadManager(unsigned long, unsigned long)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::server::TThreadPoolServer::TThreadPoolServer(std::shared_ptr<apache::thrift::TProcessor> const&, std::shared_ptr<apache::thrift::transport::TServerTransport> const&, std::shared_ptr<apache::thrift::transport::TTransportFactory> const&, std::shared_ptr<apache::thrift::concurrency::ThreadManager> const&)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'apache::thrift::server::TNonblockingServerSocket::TNonblockingServerSocket(int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'opentelemetry::v1::exporter::jaeger::JaegerExporter::JaegerExporter(opentelemetry::v1::exporter::jaeger::JaegerExporterOptions const&)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'opentelemetry::v1::sdk::resource::Resource::Create(opentelemetry::v1::sdk::common::AttributeMap const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'vtable for opentelemetry::v1::sdk::trace::RandomIdGenerator'
/usr/bin/ld.gold: the vtable symbol may be undefined because the class is missing its key function
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'opentelemetry::v1::sdk::trace::TracerProvider::TracerProvider(std::unique_ptr<opentelemetry::v1::sdk::trace::SpanProcessor, std::default_delete<opentelemetry::v1::sdk::trace::SpanProcessor> >, opentelemetry::v1::sdk::resource::Resource, std::unique_ptr<opentelemetry::v1::sdk::trace::Sampler, std::default_delete<opentelemetry::v1::sdk::trace::Sampler> >, std::unique_ptr<opentelemetry::v1::sdk::trace::IdGenerator>, std::default_delete<opentelemetry::v1::sdk::trace::IdGenerator> >)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'my_strlen'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'google_breakpad::ExceptionHandler::~ExceptionHandler()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'google_breakpad::ExceptionHandler::ExceptionHandler(google_breakpad::MinidumpDescriptor const&, bool (*)(void*), bool (*)(google_breakpad::MinidumpDescriptor const&, void*, bool), void*, bool, int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libCommon.so: error: undefined reference to 'google_breakpad::ExceptionHandler::WriteMinidump()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentClientSyncInfo::generateSeqId()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentSendSentry::TConcurrentSendSentry(apache::thrift::async::TConcurrentClientSyncInfo*)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentSendSentry::commit()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentSendSentry::~TConcurrentSendSentry()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentRecvSentry::TConcurrentRecvSentry(apache::thrift::async::TConcurrentClientSyncInfo*, int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentClientSyncInfo::updatePending(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, apache::thrift::protocol::TMessageType, int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentClientSyncInfo::waitForWork(int)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentClientSyncInfo::getPending(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMessageType&, int&)'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentRecvSentry::commit()'
/worktree/starrocks/main/be/output/tmp/RELEASE/libStarRocksGen.so: error: undefined reference to 'apache::thrift::async::TConcurrentRecvSentry::~TConcurrentRecvSentry()'
collect2: error: ld returned 1 exit status
make[2]: *** [/worktree/starrocks/main/be/output/lib/starrocks_be] Error 1
make[1]: *** [src/service/CMakeFiles/starrocks_be.dir/all] Error 2
make: *** [all] Error 2
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
