### PR TITLE
[Enhancement] Add Plan Advisor metrics for guide generation, application, and time savings

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/i-p.md
+++ b/docs/en/administration/management/monitoring/metric_details/i-p.md
@@ -469,6 +469,26 @@ Latency metrics expose percentile series such as `merge_commit_request_latency_9
 - Unit: Count
 - Description: Total number of SST file write failures in the lake Primary Key persistent index. Incremented when SST file build fails.
 
+## `plan_advisor_guide_applied_total`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `operator_type` (`join` or `agg`)
+- Description: Total number of Plan Advisor guides applied during query optimization. The metric is incremented once for each guide that successfully rewrites a plan node. `join` covers join estimation error guides, and `agg` covers streaming aggregation guides.
+
+## `plan_advisor_guide_generated_total`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `operator_type` (`join` or `agg`)
+- Description: Total number of Plan Advisor guides generated and inserted into the local FE cache. The metric is incremented only when the analyzed guides are non-empty and stored as a new cache entry. `join` covers join estimation error guides, and `agg` covers streaming aggregation guides.
+
+## `plan_advisor_optimization_duration_ms_total`
+
+- Unit: Milliseconds
+- Type: Cumulative
+- Description: Total execution time saved by Plan Advisor, in milliseconds. When a query that used a cached guide finishes faster than the original query that produced the guide, the saved time is added to this counter.
+
 ## `plan_fragment_count`
 
 - Unit: Count

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1248,6 +1248,26 @@ starrocks_be_catalog_query_scan_bytes{catalog_type!="default"}
 - 单位：个
 - 描述：当前运行的查询计划 Fragment 数量。
 
+### plan_advisor_guide_applied_total
+
+- 单位：个
+- 类型：累积值
+- 标签：`operator_type`（`join` 或 `agg`）
+- 描述：Plan Advisor 在查询优化阶段成功应用的 guide 总数。每当某个 guide 成功改写一个计划节点时，该指标加 1。`join` 表示 Join 估算误差相关 guide，`agg` 表示 Streaming Agg 相关 guide。
+
+### plan_advisor_guide_generated_total
+
+- 单位：个
+- 类型：累积值
+- 标签：`operator_type`（`join` 或 `agg`）
+- 描述：Plan Advisor 成功生成并写入当前 FE 本地缓存的 guide 总数。只有分析结果非空且作为新的缓存项写入时才会累加。`join` 表示 Join 估算误差相关 guide，`agg` 表示 Streaming Agg 相关 guide。
+
+### plan_advisor_optimization_duration_ms_total
+
+- 单位：毫秒
+- 类型：累积值
+- 描述：Plan Advisor 累计节省的查询执行耗时（毫秒）。当一个使用了缓存 guide 的查询执行时间短于生成该 guide 的原始查询时，节省的时间会累加到该指标。
+
 ### page_cache_lookup_count
 
 - 单位：个

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -121,6 +121,16 @@ public final class MetricRepo {
     public static final String TABLET_MAX_COMPACTION_SCORE = "tablet_max_compaction_score";
     private static final String ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_NAME = "iceberg_time_travel_query_total";
     private static final String ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_DESC = "total iceberg time travel query";
+    private static final String PLAN_ADVISOR_GUIDE_GENERATED_TOTAL_METRIC_NAME = "plan_advisor_guide_generated_total";
+    private static final String PLAN_ADVISOR_GUIDE_GENERATED_TOTAL_METRIC_DESC =
+            "total generated plan advisor guides";
+    private static final String PLAN_ADVISOR_GUIDE_APPLIED_TOTAL_METRIC_NAME = "plan_advisor_guide_applied_total";
+    private static final String PLAN_ADVISOR_GUIDE_APPLIED_TOTAL_METRIC_DESC =
+            "total applied plan advisor guides";
+    private static final String PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL_METRIC_NAME =
+            "plan_advisor_optimization_duration_ms_total";
+    private static final String PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL_METRIC_DESC =
+            "total execution time saved by plan advisor in milliseconds";
 
     public static LongCounterMetric COUNTER_REQUEST_ALL;
     public static LongCounterMetric COUNTER_QUERY_ALL;
@@ -129,6 +139,7 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_SUCCESS;
     public static LongCounterMetric COUNTER_SLOW_QUERY;
     public static LongCounterMetric COUNTER_ICEBERG_TIME_TRAVEL_QUERY_TOTAL;
+    public static LongCounterMetric COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_PENDING;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_TOTAL;
     public static LongCounterMetric COUNTER_QUERY_QUEUE_TIMEOUT;
@@ -143,6 +154,14 @@ public final class MetricRepo {
             new MetricWithLabelGroup<>("time_travel_type",
                     () -> new LongCounterMetric(ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_NAME, MetricUnit.REQUESTS,
                             ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_DESC));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_PLAN_ADVISOR_GUIDE_GENERATED_TOTAL =
+            new MetricWithLabelGroup<>("operator_type",
+                    () -> new LongCounterMetric(PLAN_ADVISOR_GUIDE_GENERATED_TOTAL_METRIC_NAME, MetricUnit.REQUESTS,
+                            PLAN_ADVISOR_GUIDE_GENERATED_TOTAL_METRIC_DESC));
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_PLAN_ADVISOR_GUIDE_APPLIED_TOTAL =
+            new MetricWithLabelGroup<>("operator_type",
+                    () -> new LongCounterMetric(PLAN_ADVISOR_GUIDE_APPLIED_TOTAL_METRIC_NAME, MetricUnit.REQUESTS,
+                            PLAN_ADVISOR_GUIDE_APPLIED_TOTAL_METRIC_DESC));
 
     // Per-catalog-type query counters
     public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_CATALOG_QUERY_TOTAL =
@@ -708,6 +727,11 @@ public final class MetricRepo {
         COUNTER_ICEBERG_TIME_TRAVEL_QUERY_TOTAL = new LongCounterMetric(ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_NAME,
                 MetricUnit.REQUESTS, ICEBERG_TIME_TRAVEL_QUERY_TOTAL_METRIC_DESC);
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_ICEBERG_TIME_TRAVEL_QUERY_TOTAL);
+        COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL = new LongCounterMetric(
+                PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL_METRIC_NAME,
+                MetricUnit.MILLISECONDS,
+                PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL_METRIC_DESC);
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL);
         COUNTER_QUERY_QUEUE_PENDING = new LongCounterMetric("query_queue_pending", MetricUnit.REQUESTS,
                 "total pending query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_QUEUE_PENDING);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -91,6 +91,17 @@ public class OperatorTuningGuides {
 
     public void addOptimizedRecord(UUID queryId, long timeCost) {
         optimizedRecords.put(queryId, timeCost);
+        if (timeCost < originalTimeCost) {
+            PlanAdvisorMetrics.increaseOptimizationDuration(originalTimeCost - timeCost);
+        }
+    }
+
+    public List<TuningGuide> getAllTuningGuides() {
+        List<TuningGuide> guides = Lists.newArrayList();
+        for (OperatorGuideInfo operatorGuideInfo : operatorIdToTuningGuideInfo.values()) {
+            guides.addAll(operatorGuideInfo.tuningGuides);
+        }
+        return guides;
     }
 
     public boolean isUseful() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorMetrics.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.feedback;
+
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.feedback.guide.JoinTuningGuide;
+import com.starrocks.qe.feedback.guide.StreamingAggTuningGuide;
+import com.starrocks.qe.feedback.guide.TuningGuide;
+
+public final class PlanAdvisorMetrics {
+    public static final String JOIN_OPERATOR_TYPE = "join";
+    public static final String AGG_OPERATOR_TYPE = "agg";
+
+    private PlanAdvisorMetrics() {
+    }
+
+    public static void increaseGuideGenerated(TuningGuide guide) {
+        String operatorType = resolveOperatorType(guide);
+        if (operatorType != null) {
+            MetricRepo.COUNTER_PLAN_ADVISOR_GUIDE_GENERATED_TOTAL.getMetric(operatorType).increase(1L);
+        }
+    }
+
+    public static void increaseGuideApplied(TuningGuide guide) {
+        String operatorType = resolveOperatorType(guide);
+        if (operatorType != null) {
+            MetricRepo.COUNTER_PLAN_ADVISOR_GUIDE_APPLIED_TOTAL.getMetric(operatorType).increase(1L);
+        }
+    }
+
+    public static void increaseOptimizationDuration(long durationMs) {
+        if (durationMs > 0) {
+            MetricRepo.COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL.increase(durationMs);
+        }
+    }
+
+    private static String resolveOperatorType(TuningGuide guide) {
+        if (guide instanceof JoinTuningGuide) {
+            return JOIN_OPERATOR_TYPE;
+        }
+        if (guide instanceof StreamingAggTuningGuide) {
+            return AGG_OPERATOR_TYPE;
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
@@ -92,6 +92,7 @@ public class PlanTuningAdvisor {
 
         if (matchingKeys.isEmpty()) {
             cache.put(key, tuningGuides);
+            tuningGuides.getAllTuningGuides().forEach(PlanAdvisorMetrics::increaseGuideGenerated);
         } else {
             for (PlanTuningCacheKey matchingKey : matchingKeys) {
                 OperatorTuningGuides existingGuides = cache.getIfPresent(matchingKey);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyTuningGuideRule.java
@@ -21,6 +21,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.feedback.OperatorTuningGuides;
+import com.starrocks.qe.feedback.PlanAdvisorMetrics;
 import com.starrocks.qe.feedback.PlanTuningAdvisor;
 import com.starrocks.qe.feedback.guide.TuningGuide;
 import com.starrocks.qe.feedback.skeleton.SkeletonBuilder;
@@ -127,6 +128,7 @@ public class ApplyTuningGuideRule implements TreeRewriteRule {
                     if (newOpt.isPresent()) {
                         res = newOpt.get();
                         usedGuides.add(guide);
+                        PlanAdvisorMetrics.increaseGuideApplied(guide);
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -79,6 +79,24 @@ public class MetricRepoTest extends PlanTestBase {
     }
 
     @Test
+    public void testPlanAdvisorMetricsExposure() {
+        MetricRepo.COUNTER_PLAN_ADVISOR_GUIDE_GENERATED_TOTAL.getMetric("join").increase(1L);
+        MetricRepo.COUNTER_PLAN_ADVISOR_GUIDE_APPLIED_TOTAL.getMetric("agg").increase(2L);
+        MetricRepo.COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL.increase(3L);
+
+        MetricVisitor visitor = new PrometheusMetricVisitor("");
+        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true, true);
+        MetricRepo.getMetric(visitor, params);
+        String output = visitor.build();
+
+        Assertions.assertTrue(output.contains("plan_advisor_guide_generated_total"));
+        Assertions.assertTrue(output.contains("plan_advisor_guide_applied_total"));
+        Assertions.assertTrue(output.contains("plan_advisor_optimization_duration_ms_total"));
+        Assertions.assertTrue(output.contains("operator_type=\"join\""));
+        Assertions.assertTrue(output.contains("operator_type=\"agg\""));
+    }
+
+    @Test
     public void testLeaderAwarenessMetric() {
         Assertions.assertTrue(GlobalStateMgr.getCurrentState().isLeader());
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/feedback/analyzer/PlanTuningAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/feedback/analyzer/PlanTuningAnalyzerTest.java
@@ -18,8 +18,13 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.metric.Metric;
+import com.starrocks.metric.MetricLabel;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.qe.feedback.NodeExecStats;
 import com.starrocks.qe.feedback.OperatorTuningGuides;
+import com.starrocks.qe.feedback.PlanAdvisorMetrics;
 import com.starrocks.qe.feedback.PlanTuningAdvisor;
 import com.starrocks.qe.feedback.guide.LeftChildEstimationErrorTuningGuide;
 import com.starrocks.qe.feedback.guide.RightChildEstimationErrorTuningGuide;
@@ -27,9 +32,11 @@ import com.starrocks.qe.feedback.guide.StreamingAggTuningGuide;
 import com.starrocks.qe.feedback.skeleton.ScanNode;
 import com.starrocks.qe.feedback.skeleton.SkeletonBuilder;
 import com.starrocks.qe.feedback.skeleton.SkeletonNode;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.plan.DistributedEnvPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -48,6 +55,17 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
         FeConstants.runningUnitTest = true;
     }
 
+    private long getMetricValue(String name, String operatorType) {
+        for (Metric<?> metric : MetricRepo.getMetricsByName(name)) {
+            for (MetricLabel label : metric.getLabels()) {
+                if ("operator_type".equals(label.getKey()) && operatorType.equals(label.getValue())) {
+                    return (Long) metric.getValue();
+                }
+            }
+        }
+        return 0L;
+    }
+
     @Test
     void testStreamingAnalyzer() throws Exception {
         String sql = "select count(*) from lineitem group by l_shipmode";
@@ -64,6 +82,75 @@ class PlanTuningAnalyzerTest extends DistributedEnvPlanTestBase {
         OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
         PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
         Assertions.assertTrue(tuningGuides.getTuningGuides(2).get(0) instanceof StreamingAggTuningGuide);
+    }
+
+    @Test
+    void testPlanAdvisorGeneratedMetric() throws Exception {
+        PlanTuningAdvisor.getInstance().clearAllAdvisor();
+
+        String aggSql = "select count(*) from lineitem group by l_shipmode";
+        ExecPlan aggExecPlan = getExecPlan(aggSql);
+        Map<Integer, NodeExecStats> aggExecStats = Maps.newHashMap();
+        aggExecStats.put(1, new NodeExecStats(1, 3000000000L, 2000000000L, 0, 0, 0));
+        aggExecStats.put(3, new NodeExecStats(3, 500000, 7, 0, 0, 0));
+        Pair<SkeletonNode, Map<Integer, SkeletonNode>> aggPair =
+                new SkeletonBuilder(aggExecStats).buildSkeleton(aggExecPlan.getPhysicalPlan());
+        OperatorTuningGuides aggGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
+        PlanTuningAnalyzer.getInstance().analyzePlan(aggExecPlan.getPhysicalPlan(), aggPair.second, aggGuides);
+
+        long aggBefore = getMetricValue("plan_advisor_guide_generated_total", PlanAdvisorMetrics.AGG_OPERATOR_TYPE);
+        PlanTuningAdvisor.getInstance().putTuningGuides(aggSql, aggPair.first, aggGuides);
+        long aggAfter = getMetricValue("plan_advisor_guide_generated_total", PlanAdvisorMetrics.AGG_OPERATOR_TYPE);
+        Assertions.assertEquals(aggBefore + 1, aggAfter);
+
+        String joinSql = "select * from (select * from customer) c " +
+                "join (select * from supplier) s on abs(c_custkey) = abs(s_suppkey)";
+        ExecPlan joinExecPlan = getExecPlan(joinSql);
+        Map<Integer, NodeExecStats> joinExecStats = Maps.newHashMap();
+        joinExecStats.put(0, new NodeExecStats(0, 500, 500, 0, 0, 0));
+        joinExecStats.put(4, new NodeExecStats(4, 20000000, 20000000, 0, 0, 0));
+        Pair<SkeletonNode, Map<Integer, SkeletonNode>> joinPair =
+                new SkeletonBuilder(joinExecStats).buildSkeleton(joinExecPlan.getPhysicalPlan());
+        OperatorTuningGuides joinGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
+        PlanTuningAnalyzer.getInstance().analyzePlan(joinExecPlan.getPhysicalPlan(), joinPair.second, joinGuides);
+
+        long joinBefore = getMetricValue("plan_advisor_guide_generated_total", PlanAdvisorMetrics.JOIN_OPERATOR_TYPE);
+        PlanTuningAdvisor.getInstance().putTuningGuides(joinSql, joinPair.first, joinGuides);
+        long joinAfter = getMetricValue("plan_advisor_guide_generated_total", PlanAdvisorMetrics.JOIN_OPERATOR_TYPE);
+        Assertions.assertEquals(joinBefore + 1, joinAfter);
+    }
+
+    @Test
+    void testPlanAdvisorAppliedAndOptimizationMetrics() throws Exception {
+        PlanTuningAdvisor.getInstance().clearAllAdvisor();
+
+        String sql = "select count(*) from lineitem group by l_shipmode";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        connectContext.setExecutor(new StmtExecutor(connectContext, stmt));
+
+        ExecPlan execPlan = getExecPlan(sql);
+        Map<Integer, NodeExecStats> execStats = Maps.newHashMap();
+        execStats.put(1, new NodeExecStats(1, 3000000000L, 2000000000L, 0, 0, 0));
+        execStats.put(3, new NodeExecStats(3, 500000, 7, 0, 0, 0));
+        Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair =
+                new SkeletonBuilder(execStats).buildSkeleton(execPlan.getPhysicalPlan());
+        OperatorTuningGuides tuningGuides = new OperatorTuningGuides(UUID.randomUUID(), 50);
+        PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
+        PlanTuningAdvisor.getInstance().putTuningGuides(sql, pair.first, tuningGuides);
+
+        long appliedBefore = getMetricValue("plan_advisor_guide_applied_total", PlanAdvisorMetrics.AGG_OPERATOR_TYPE);
+        getExecPlan(sql);
+        long appliedAfter = getMetricValue("plan_advisor_guide_applied_total", PlanAdvisorMetrics.AGG_OPERATOR_TYPE);
+        Assertions.assertEquals(appliedBefore + 1, appliedAfter);
+
+        OperatorTuningGuides usedTuningGuides =
+                PlanTuningAdvisor.getInstance().getOperatorTuningGuides(connectContext.getQueryId());
+        Assertions.assertNotNull(usedTuningGuides);
+
+        long durationBefore = MetricRepo.COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL.getValue();
+        usedTuningGuides.addOptimizedRecord(connectContext.getQueryId(), usedTuningGuides.getOriginalTimeCost() - 1);
+        long durationAfter = MetricRepo.COUNTER_PLAN_ADVISOR_OPTIMIZATION_DURATION_MS_TOTAL.getValue();
+        Assertions.assertEquals(durationBefore + 1, durationAfter);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Plan Advisor currently has no dedicated FE metrics, which makes it hard to understand whether tuning guides are being generated and applied, and whether they are actually bringing execution-time benefits to users. Adding these metrics improves observability for both feature adoption and user-perceived value.

## What I'm doing:

This PR adds three FE metrics for Plan Advisor:
- `plan_advisor_guide_generated_total` to count generated and cached tuning guides by operator type (`join` / `agg`)
- `plan_advisor_guide_applied_total` to count successfully applied tuning guides by operator type (`join` / `agg`)
- `plan_advisor_optimization_duration_ms_total` to accumulate execution time savings from queries that benefit from applied tuning guides


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4