### PR TITLE
[Refactor] Replace unordered std::map<std::string,...> with phmap::flat_hash_map

### DIFF
--- a/be/src/base/metrics.h
+++ b/be/src/base/metrics.h
@@ -406,7 +406,7 @@ private:
     mutable std::shared_mutex _collector_mutex;
     mutable std::shared_mutex _hooks_mutex;
     std::map<std::string, MetricCollector*> _collectors;
-    std::map<std::string, std::function<void()>> _hooks;
+    phmap::flat_hash_map<std::string, std::function<void()>> _hooks;
 
     std::atomic<bool> _collect_hook_enabled{false};
 };

--- a/be/src/common/runtime_profile.h
+++ b/be/src/common/runtime_profile.h
@@ -51,6 +51,7 @@
 #include "common/logging.h"
 #include "common/object_pool.h"
 #include "gen_cpp/RuntimeProfile_types.h"
+#include "base/phmap/phmap.h"
 #include "gutil/casts.h"
 
 namespace starrocks {
@@ -602,7 +603,7 @@ private:
 
     // Map from parent counter name to a set of child counter name.
     // All top level counters are the child of "" (root).
-    typedef std::map<std::string, std::set<std::string>> ChildCounterMap;
+    typedef phmap::flat_hash_map<std::string, std::set<std::string>> ChildCounterMap;
     ChildCounterMap _child_counter_map;
 
     // A set of bucket counters registered in this runtime profile.
@@ -620,7 +621,7 @@ private:
     ChildVector _children;
     mutable std::mutex _children_lock; // protects _child_map and _children
 
-    typedef std::map<std::string, std::string> InfoStrings;
+    typedef phmap::flat_hash_map<std::string, std::string> InfoStrings;
     InfoStrings _info_strings;
 
     // Keeps track of the order in which InfoStrings are displayed when printed

--- a/be/src/common/runtime_profile.h
+++ b/be/src/common/runtime_profile.h
@@ -47,11 +47,11 @@
 #include <utility>
 
 #include "base/concurrency/stopwatch.hpp"
+#include "base/phmap/phmap.h"
 #include "common/compiler_util.h"
 #include "common/logging.h"
 #include "common/object_pool.h"
 #include "gen_cpp/RuntimeProfile_types.h"
-#include "base/phmap/phmap.h"
 #include "gutil/casts.h"
 
 namespace starrocks {

--- a/be/src/common/system/disk_info.cpp
+++ b/be/src/common/system/disk_info.cpp
@@ -41,7 +41,7 @@ namespace starrocks {
 bool DiskInfo::_s_initialized;
 std::vector<DiskInfo::Disk> DiskInfo::_s_disks;
 std::map<dev_t, int> DiskInfo::_s_device_id_to_disk_id;
-std::map<std::string, int> DiskInfo::_s_disk_name_to_disk_id;
+phmap::flat_hash_map<std::string, int> DiskInfo::_s_disk_name_to_disk_id;
 int DiskInfo::_s_num_datanode_dirs;
 
 // Parses /proc/partitions to get the number of disks.  A bit of looking around

--- a/be/src/common/system/disk_info.h
+++ b/be/src/common/system/disk_info.h
@@ -37,11 +37,10 @@
 #include <cstdint>
 #include <map>
 #include <string>
-
-#include "base/phmap/phmap.h"
 #include <utility>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "common/logging.h"
 
 namespace starrocks {

--- a/be/src/common/system/disk_info.h
+++ b/be/src/common/system/disk_info.h
@@ -37,6 +37,8 @@
 #include <cstdint>
 #include <map>
 #include <string>
+
+#include "base/phmap/phmap.h"
 #include <utility>
 #include <vector>
 
@@ -122,7 +124,7 @@ private:
     static std::map<dev_t, int> _s_device_id_to_disk_id;
 
     // mapping of devices names to disk ids
-    static std::map<std::string, int> _s_disk_name_to_disk_id;
+    static phmap::flat_hash_map<std::string, int> _s_disk_name_to_disk_id;
 
     static int _s_num_datanode_dirs;
 

--- a/be/src/connector/es_connector.h
+++ b/be/src/connector/es_connector.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/phmap/phmap.h"
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
 
@@ -76,9 +77,9 @@ private:
     ObjectPool _obj_pool;
     ObjectPool* _pool = &_obj_pool;
 
-    std::map<std::string, std::string> _properties;
-    std::map<std::string, std::string> _docvalue_context;
-    std::map<std::string, std::string> _fields_context;
+    phmap::flat_hash_map<std::string, std::string> _properties;
+    phmap::flat_hash_map<std::string, std::string> _docvalue_context;
+    phmap::flat_hash_map<std::string, std::string> _fields_context;
     std::vector<std::string> _column_names;
     std::string _timezone;
 

--- a/be/src/connector/file_chunk_sink.h
+++ b/be/src/connector/file_chunk_sink.h
@@ -19,6 +19,7 @@
 #include <boost/thread/future.hpp>
 #include <future>
 
+#include "base/phmap/phmap.h"
 #include "common/status.h"
 #include "connector/connector.h"
 #include "connector_chunk_sink.h"
@@ -50,7 +51,7 @@ struct FileChunkSinkContext : public ConnectorChunkSinkContext {
     int64_t max_file_size = 128L * 1024 * 1024;
     std::string format;
     TCompressionType::type compression_type = TCompressionType::UNKNOWN_COMPRESSION;
-    std::map<std::string, std::string> options;
+    phmap::flat_hash_map<std::string, std::string> options;
     PriorityThreadPool* executor = nullptr;
     TCloudConfiguration cloud_conf;
     pipeline::FragmentContext* fragment_context = nullptr;

--- a/be/src/connector/hive_chunk_sink.h
+++ b/be/src/connector/hive_chunk_sink.h
@@ -19,6 +19,7 @@
 #include <boost/thread/future.hpp>
 #include <future>
 
+#include "base/phmap/phmap.h"
 #include "common/status.h"
 #include "connector/async_flush_stream_poller.h"
 #include "connector/connector.h"
@@ -53,7 +54,7 @@ struct HiveChunkSinkContext : public ConnectorChunkSinkContext {
     int64_t max_file_size = 128L * 1024 * 1024;
     std::string format;
     TCompressionType::type compression_type = TCompressionType::UNKNOWN_COMPRESSION;
-    std::map<std::string, std::string> options;
+    phmap::flat_hash_map<std::string, std::string> options;
     PriorityThreadPool* executor = nullptr;
     TCloudConfiguration cloud_conf;
     pipeline::FragmentContext* fragment_context = nullptr;

--- a/be/src/connector/iceberg_chunk_sink.h
+++ b/be/src/connector/iceberg_chunk_sink.h
@@ -19,6 +19,7 @@
 #include <boost/thread/future.hpp>
 #include <future>
 
+#include "base/phmap/phmap.h"
 #include "common/status.h"
 #include "connector/connector.h"
 #include "connector_chunk_sink.h"
@@ -60,7 +61,7 @@ struct IcebergChunkSinkContext : public ConnectorChunkSinkContext {
     int64_t max_file_size = 128L * 1024 * 1024;
     std::string format;
     TCompressionType::type compression_type = TCompressionType::UNKNOWN_COMPRESSION;
-    std::map<std::string, std::string> options;
+    phmap::flat_hash_map<std::string, std::string> options;
     std::vector<formats::FileColumnId> parquet_field_ids;
     PriorityThreadPool* executor = nullptr;
     TCloudConfiguration cloud_conf;

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "base/phmap/phmap.h"
 #include "column/chunk.h"
 #include "common/status.h"
 #include "connector/connector.h"
@@ -40,7 +41,7 @@ struct IcebergDeleteSinkContext : public ConnectorChunkSinkContext {
 
     // Compression type for Parquet files
     starrocks::TCompressionType::type compression_type;
-    std::map<std::string, std::string> options;
+    phmap::flat_hash_map<std::string, std::string> options;
 
     // Maximum size of delete files before rolling to new file
     int64_t max_file_size = 128L * 1024 * 1024; // 128MB default

--- a/be/src/connector/utils.h
+++ b/be/src/connector/utils.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "common/statusor.h"
 #include "exprs/expr_context.h"
 #include "fmt/format.h"
@@ -126,7 +127,7 @@ private:
     const std::string _file_name_prefix;
     const std::string _file_name_suffix;
     int _index = 0;
-    std::map<std::string, int> _partition2index;
+    phmap::flat_hash_map<std::string, int> _partition2index;
 };
 
 } // namespace starrocks::connector

--- a/be/src/exec/es/es_predicate.h
+++ b/be/src/exec/es/es_predicate.h
@@ -38,6 +38,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "base/time/timezone_utils.h"
 #include "cctz/time_zone.h"
 #include "column/column.h"
@@ -177,7 +178,7 @@ private:
     Status _es_query_status;
     const std::string _timezone;
     ObjectPool* _pool = nullptr;
-    std::map<std::string, std::string> _field_context;
+    phmap::flat_hash_map<std::string, std::string> _field_context;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner/jni_scanner.h
+++ b/be/src/exec/hdfs_scanner/jni_scanner.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/phmap/phmap.h"
 #include "column/chunk.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -100,7 +101,7 @@ private:
     jmethodID _jni_scanner_release_column = nullptr;
     jmethodID _jni_scanner_release_table = nullptr;
 
-    std::map<std::string, std::string> _jni_scanner_params;
+    phmap::flat_hash_map<std::string, std::string> _jni_scanner_params;
     std::string _jni_scanner_factory_class;
 
     const std::set<std::string> _skipped_log_jni_scanner_params = {"native_table", "split_info", "predicate_info",

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -29,7 +29,6 @@
 #include <string>
 
 #include "base/phmap/phmap.h"
-
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exprs/expr.h"

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -26,8 +26,9 @@
 #include <parquet/exception.h>
 
 #include <cstdint>
-#include <map>
 #include <string>
+
+#include "base/phmap/phmap.h"
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
@@ -96,7 +97,7 @@ private:
     std::shared_ptr<::parquet::FileMetaData> _file_metadata;
 
     // For nested column type, it's consisting of multiple physical-columns
-    std::map<std::string, std::vector<int>> _map_column_nested;
+    phmap::flat_hash_map<std::string, std::vector<int>> _map_column_nested;
     std::vector<int> _parquet_column_ids;
     int _total_groups{0}; // groups in a parquet file
     int _current_group{0};

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <cstdint>
+
+#include "base/phmap/phmap.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -51,7 +53,7 @@ struct OlapTableIndexSchema {
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
-    std::map<std::string, std::string> column_to_expr_value;
+    phmap::flat_hash_map<std::string, std::string> column_to_expr_value;
     bool is_shadow = false;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -15,13 +15,12 @@
 #pragma once
 
 #include <cstdint>
-
-#include "base/phmap/phmap.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "base/random/random.h"
 #include "column/column.h"
 #include "column/column_helper.h"

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -166,7 +166,7 @@ FileWriter::CommitResult CSVFileWriter::close() {
 }
 
 CSVFileWriterFactory::CSVFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                                           std::map<std::string, std::string> options,
+                                           phmap::flat_hash_map<std::string, std::string> options,
                                            std::vector<std::string> column_names,
                                            std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                                            PriorityThreadPool* executors, RuntimeState* runtime_state)

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/phmap/phmap.h"
 #include "formats/csv/converter.h"
 #include "formats/file_writer.h"
 #include "gen_cpp/Types_types.h"
@@ -88,7 +89,7 @@ private:
 class CSVFileWriterFactory : public FileWriterFactory {
 public:
     CSVFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                         std::map<std::string, std::string> options, std::vector<std::string> column_names,
+                         phmap::flat_hash_map<std::string, std::string> options, std::vector<std::string> column_names,
                          std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                          PriorityThreadPool* executors, RuntimeState* runtime_state);
 
@@ -99,7 +100,7 @@ public:
 private:
     std::shared_ptr<FileSystem> _fs;
     TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
-    std::map<std::string, std::string> _options;
+    phmap::flat_hash_map<std::string, std::string> _options;
     std::shared_ptr<CSVWriterOptions> _parsed_options;
 
     std::vector<std::string> _column_names;

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -477,7 +477,7 @@ void ORCFileWriter::_populate_orc_notnull(orc::ColumnVectorBatch& orc_column, co
 }
 
 ORCFileWriterFactory::ORCFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                                           std::map<std::string, std::string> options,
+                                           phmap::flat_hash_map<std::string, std::string> options,
                                            std::vector<std::string> column_names,
                                            std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                                            PriorityThreadPool* executors, RuntimeState* runtime_state)

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -18,6 +18,7 @@
 #include <orc/Writer.hh>
 #include <util/priority_thread_pool.hpp>
 
+#include "base/phmap/phmap.h"
 #include "column/column.h"
 #include "formats/file_writer.h"
 #include "formats/orc/orc_memory_pool.h"
@@ -128,7 +129,7 @@ private:
 class ORCFileWriterFactory : public FileWriterFactory {
 public:
     ORCFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                         std::map<std::string, std::string> options, std::vector<std::string> column_names,
+                         phmap::flat_hash_map<std::string, std::string> options, std::vector<std::string> column_names,
                          std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                          PriorityThreadPool* executors, RuntimeState* runtime_state);
 
@@ -139,7 +140,7 @@ public:
 private:
     std::shared_ptr<FileSystem> _fs;
     TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
-    std::map<std::string, std::string> _options;
+    phmap::flat_hash_map<std::string, std::string> _options;
     std::shared_ptr<ORCWriterOptions> _parsed_options;
 
     std::vector<std::string> _column_names;

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "column/variant_path_parser.h"
 #include "formats/parquet/column_reader.h"
 #include "scalar_column_reader.h"
@@ -248,7 +249,7 @@ private:
     void _handle_null_rows(uint8_t* is_nulls, bool* has_null, size_t num_rows);
 
     // _children_readers order is the same as TypeDescriptor children order.
-    std::map<std::string, ColumnReaderPtr> _child_readers;
+    phmap::flat_hash_map<std::string, ColumnReaderPtr> _child_readers;
     // First non-nullptr child ColumnReader, used to get def & rep levels
     const std::unique_ptr<ColumnReader>* _def_rep_level_child_reader = nullptr;
 };

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -318,7 +318,7 @@ ParquetFileWriter::~ParquetFileWriter() = default;
 
 ParquetFileWriterFactory::ParquetFileWriterFactory(
         std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-        std::map<std::string, std::string> options, std::vector<std::string> column_names,
+        phmap::flat_hash_map<std::string, std::string> options, std::vector<std::string> column_names,
         std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
         std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
         RuntimeState* runtime_state, std::vector<bool> nullable)

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -156,7 +156,8 @@ private:
 class ParquetFileWriterFactory : public FileWriterFactory {
 public:
     ParquetFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                             phmap::flat_hash_map<std::string, std::string> options, std::vector<std::string> column_names,
+                             phmap::flat_hash_map<std::string, std::string> options,
+                             std::vector<std::string> column_names,
                              std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
                              std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
                              RuntimeState* runtime_state, std::vector<bool> nullable = {});

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -35,7 +35,6 @@
 #include <condition_variable>
 #include <functional>
 #include <future>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -45,6 +44,7 @@
 #include <vector>
 
 #include "arrow_memory_pool.h"
+#include "base/phmap/phmap.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
@@ -156,7 +156,7 @@ private:
 class ParquetFileWriterFactory : public FileWriterFactory {
 public:
     ParquetFileWriterFactory(std::shared_ptr<FileSystem> fs, TCompressionType::type compression_type,
-                             std::map<std::string, std::string> options, std::vector<std::string> column_names,
+                             phmap::flat_hash_map<std::string, std::string> options, std::vector<std::string> column_names,
                              std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
                              std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
                              RuntimeState* runtime_state, std::vector<bool> nullable = {});
@@ -175,7 +175,7 @@ private:
     std::shared_ptr<FileSystem> _fs;
     TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
     std::optional<std::vector<formats::FileColumnId>> _field_ids;
-    std::map<std::string, std::string> _options;
+    phmap::flat_hash_map<std::string, std::string> _options;
     std::shared_ptr<ParquetWriterOptions> _parsed_options;
 
     std::vector<std::string> _column_names;

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -290,7 +290,7 @@ private:
     lake::DeltaWriterFinishMode _finish_mode{lake::DeltaWriterFinishMode::kWriteTxnLog};
     TxnLogCollector _txn_log_collector;
 
-    std::map<string, string> _column_to_expr_value;
+    phmap::flat_hash_map<string, string> _column_to_expr_value;
 
     // Profile counters
     // Number of times that update_profile() is called

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -19,6 +19,7 @@
 #include <bthread/mutex.h>
 
 #include "base/brpc/reusable_closure.h"
+#include "base/phmap/phmap.h"
 #include "base/concurrency/bthread_shared_mutex.h"
 #include "base/concurrency/countdown_latch.h"
 #include "common/compiler_util.h"
@@ -261,7 +262,7 @@ private:
     // so a TabletsChannel needs to be created, such that _is_incremental_channel=true
     bool _is_incremental_channel = false;
 
-    std::map<string, string> _column_to_expr_value;
+    phmap::flat_hash_map<string, string> _column_to_expr_value;
 
     // Profile counters
     // Number of times that update_profile() is called

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -19,9 +19,9 @@
 #include <bthread/mutex.h>
 
 #include "base/brpc/reusable_closure.h"
-#include "base/phmap/phmap.h"
 #include "base/concurrency/bthread_shared_mutex.h"
 #include "base/concurrency/countdown_latch.h"
+#include "base/phmap/phmap.h"
 #include "common/compiler_util.h"
 #include "common/system/backend_options.h"
 #include "runtime/tablets_channel.h"

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/phmap/phmap.h"
 #include "column/vectorized_fwd.h"
 #include "common/tracer_fwd.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -70,7 +71,7 @@ struct DeltaWriterOptions {
     // If you need to access it after intialization, please make sure the pointer is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
-    std::map<string, string>* column_to_expr_value = nullptr;
+    phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr;
 };
 
 enum State {

--- a/be/src/storage/index/vector/vector_search_option.h
+++ b/be/src/storage/index/vector/vector_search_option.h
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include <map>
 #include <string>
+
+#include "base/phmap/phmap.h"
 #include <vector>
 
 #include "common/global_types.h"
@@ -39,7 +40,7 @@ public:
 
     SlotId vector_slot_id;
 
-    std::map<std::string, std::string> query_params;
+    phmap::flat_hash_map<std::string, std::string> query_params;
 
     double vector_range;
 

--- a/be/src/storage/index/vector/vector_search_option.h
+++ b/be/src/storage/index/vector/vector_search_option.h
@@ -15,10 +15,9 @@
 #pragma once
 
 #include <string>
-
-#include "base/phmap/phmap.h"
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "common/global_types.h"
 
 namespace starrocks {

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -15,13 +15,12 @@
 #pragma once
 
 #include <functional>
-
-#include "base/phmap/phmap.h"
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "common/runtime_profile.h"
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -208,7 +207,8 @@ public:
         return *this;
     }
 
-    AsyncDeltaWriterBuilder& set_column_to_expr_value(const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
+    AsyncDeltaWriterBuilder& set_column_to_expr_value(
+            const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
         _column_to_expr_value = column_to_expr_value;
         return *this;
     }

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <functional>
+
+#include "base/phmap/phmap.h"
 #include <memory>
 #include <string>
 #include <utility>
@@ -206,7 +208,7 @@ public:
         return *this;
     }
 
-    AsyncDeltaWriterBuilder& set_column_to_expr_value(const std::map<std::string, std::string>* column_to_expr_value) {
+    AsyncDeltaWriterBuilder& set_column_to_expr_value(const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
         _column_to_expr_value = column_to_expr_value;
         return *this;
     }
@@ -252,7 +254,7 @@ private:
     std::string _merge_condition{};
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
-    const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
+    const phmap::flat_hash_map<std::string, std::string>* _column_to_expr_value{nullptr};
     PUniqueId _load_id;
     RuntimeProfile* _profile{nullptr};
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -109,7 +109,7 @@ public:
                              bool miss_auto_increment_column, int64_t db_id, int64_t table_id,
                              int64_t immutable_tablet_size, MemTracker* mem_tracker, int64_t max_buffer_size,
                              int64_t schema_id, const PartialUpdateMode& partial_update_mode,
-                             const std::map<string, string>* column_to_expr_value, PUniqueId load_id,
+                             const phmap::flat_hash_map<string, string>* column_to_expr_value, PUniqueId load_id,
                              RuntimeProfile* profile, BundleWritableFileContext* bundle_writable_file_context,
                              GlobalDictByNameMaps* global_dicts, bool is_multi_statements_txn)
             : _tablet_manager(tablet_manager),
@@ -290,7 +290,7 @@ private:
 
     int64_t _last_write_ts = 0;
 
-    const std::map<string, string>* _column_to_expr_value = nullptr;
+    const phmap::flat_hash_map<string, string>* _column_to_expr_value = nullptr;
 
     PUniqueId _load_id;
     RuntimeProfile* _profile = nullptr;

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -15,11 +15,10 @@
 #pragma once
 
 #include <atomic>
-
-#include "base/phmap/phmap.h"
 #include <memory>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "common/runtime_profile.h"
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -269,7 +268,8 @@ public:
         return *this;
     }
 
-    DeltaWriterBuilder& set_column_to_expr_value(const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
+    DeltaWriterBuilder& set_column_to_expr_value(
+            const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
         _column_to_expr_value = column_to_expr_value;
         return *this;
     }

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <atomic>
+
+#include "base/phmap/phmap.h"
 #include <memory>
 #include <vector>
 
@@ -267,7 +269,7 @@ public:
         return *this;
     }
 
-    DeltaWriterBuilder& set_column_to_expr_value(const std::map<std::string, std::string>* column_to_expr_value) {
+    DeltaWriterBuilder& set_column_to_expr_value(const phmap::flat_hash_map<std::string, std::string>* column_to_expr_value) {
         _column_to_expr_value = column_to_expr_value;
         return *this;
     }
@@ -314,7 +316,7 @@ private:
     int64_t _max_buffer_size{0};
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
-    const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
+    const phmap::flat_hash_map<std::string, std::string>* _column_to_expr_value{nullptr};
     PUniqueId _load_id;
     RuntimeProfile* _profile{nullptr};
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "base/phmap/phmap.h"
 #include "gutil/macros.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
@@ -244,7 +245,7 @@ private:
     // to be destructed after segment iters
     OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;
-    std::map<string, string> _column_to_expr_value;
+    phmap::flat_hash_map<string, string> _column_to_expr_value;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1264,7 +1264,8 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_lake_dcg_column_iterator(
 Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,
                                         bool with_default,
                                         const std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                                        MutableColumns* columns, const phmap::flat_hash_map<string, string>* column_to_expr_value,
+                                        MutableColumns* columns,
+                                        const phmap::flat_hash_map<string, string>* column_to_expr_value,
                                         AutoIncrementPartialUpdateState* auto_increment_state) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_column_values_latency_us");
     std::stringstream cost_str;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1264,7 +1264,7 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_lake_dcg_column_iterator(
 Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,
                                         bool with_default,
                                         const std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                                        MutableColumns* columns, const std::map<string, string>* column_to_expr_value,
+                                        MutableColumns* columns, const phmap::flat_hash_map<string, string>* column_to_expr_value,
                                         AutoIncrementPartialUpdateState* auto_increment_state) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_column_values_latency_us");
     std::stringstream cost_str;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -15,10 +15,9 @@
 #pragma once
 
 #include <string>
-
-#include "base/phmap/phmap.h"
 #include <unordered_map>
 
+#include "base/phmap/phmap.h"
 #include "runtime/runtime_fwd.h"
 #include "storage/del_vector.h"
 #include "storage/lake/lake_primary_index.h"
@@ -119,7 +118,8 @@ public:
     // get column data by rssid and rowids
     Status get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,
                              bool with_default, const std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                             MutableColumns* columns, const phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr,
+                             MutableColumns* columns,
+                             const phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr,
                              AutoIncrementPartialUpdateState* auto_increment_state = nullptr);
     // get delvec by version
     Status get_del_vec(const TabletSegmentId& tsid, int64_t version, const MetaFileBuilder* builder, bool fill_cache,

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <string>
+
+#include "base/phmap/phmap.h"
 #include <unordered_map>
 
 #include "runtime/runtime_fwd.h"
@@ -117,7 +119,7 @@ public:
     // get column data by rssid and rowids
     Status get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,
                              bool with_default, const std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
-                             MutableColumns* columns, const std::map<string, string>* column_to_expr_value = nullptr,
+                             MutableColumns* columns, const phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr,
                              AutoIncrementPartialUpdateState* auto_increment_state = nullptr);
     // get delvec by version
     Status get_del_vec(const TabletSegmentId& tsid, int64_t version, const MetaFileBuilder* builder, bool fill_cache,

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -243,7 +243,7 @@ Status FlatJsonColumnWriter::_write_flat_column() {
     return Status::OK();
 }
 
-const std::map<std::string, bool>& FlatJsonColumnWriter::get_subcolumn_dict_valid() const {
+const phmap::flat_hash_map<std::string, bool>& FlatJsonColumnWriter::get_subcolumn_dict_valid() const {
     return _subcolumn_dict_valid;
 }
 

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#include <map>
-
+#include "base/phmap/phmap.h"
 #include "storage/rowset/column_writer.h"
 #include "storage/rowset/object_column_writer.h"
 
@@ -53,7 +52,7 @@ public:
     bool is_global_dict_valid() override;
 
     // Get global dict validity status for each sub-column
-    const std::map<std::string, bool>& get_subcolumn_dict_valid() const;
+    const phmap::flat_hash_map<std::string, bool>& get_subcolumn_dict_valid() const;
 
     uint64_t total_mem_footprint() const override;
 
@@ -88,6 +87,6 @@ protected:
     std::string _column_name;
 
     // Track global dict validity for each sub-column
-    std::map<std::string, bool> _subcolumn_dict_valid;
+    phmap::flat_hash_map<std::string, bool> _subcolumn_dict_valid;
 };
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -36,6 +36,8 @@
 
 #include <storage/flat_json_config.h>
 
+#include "base/phmap/phmap.h"
+
 #include "fs/fs.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "runtime/global_dict/types_fwd_decl.h"
@@ -100,7 +102,7 @@ public:
     // is compaction job
     bool is_compaction = false;
 
-    std::map<string, string>* column_to_expr_value = nullptr;
+    phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr;
 
     std::shared_ptr<FlatJsonConfig> flat_json_config = nullptr;
 };

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -37,7 +37,6 @@
 #include <storage/flat_json_config.h>
 
 #include "base/phmap/phmap.h"
-
 #include "fs/fs.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "runtime/global_dict/types_fwd_decl.h"

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "base/phmap/phmap.h"
 #include "storage/olap_common.h"
 #include "storage/primary_index.h"
 #include "storage/rowset/column_iterator.h"
@@ -253,7 +254,7 @@ private:
     // when generate delta column group finish, these fields will be filled
     bool _finalize_finished = false;
     std::map<uint32_t, DeltaColumnGroupPtr> _rssid_to_delta_column_group;
-    std::map<string, string> _column_to_expr_value;
+    phmap::flat_hash_map<string, string> _column_to_expr_value;
 };
 
 void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<uint32_t>* sorted_source_rowids,

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "base/phmap/phmap.h"
 #include "storage/olap_common.h"
 #include "storage/primary_index.h"
 #include "storage/tablet_updates.h"
@@ -191,7 +192,7 @@ private:
     std::vector<PartialUpdateState> _partial_update_states;
 
     std::vector<AutoIncrementPartialUpdateState> _auto_increment_partial_update_states;
-    std::map<string, string> _column_to_expr_value;
+    phmap::flat_hash_map<string, string> _column_to_expr_value;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -50,6 +50,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/phmap/phmap.h"
 #include "agent/status.h"
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
@@ -422,7 +423,7 @@ private:
 private:
     EngineOptions _options;
     std::mutex _store_lock;
-    std::map<std::string, std::unique_ptr<DataDir>> _store_map;
+    phmap::flat_hash_map<std::string, std::unique_ptr<DataDir>> _store_map;
     uint32_t _available_storage_medium_type_count{0};
     bool _is_all_cluster_id_exist{true};
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -50,8 +50,8 @@
 #include <utility>
 #include <vector>
 
-#include "base/phmap/phmap.h"
 #include "agent/status.h"
+#include "base/phmap/phmap.h"
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/BackendService_types.h"

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5305,7 +5305,7 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                                         bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         MutableColumns* columns, void* state,
                                         const TabletSchemaCSPtr& read_tablet_schema,
-                                        const std::map<string, string>* column_to_expr_value) {
+                                        const phmap::flat_hash_map<string, string>* column_to_expr_value) {
     std::vector<uint32_t> unique_column_ids;
     for (unsigned int column_id : column_ids) {
         const TabletColumn& tablet_column = read_tablet_schema->column(column_id);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <atomic>
+
+#include "base/phmap/phmap.h"
 #include <condition_variable>
 #include <mutex>
 #include <shared_mutex>
@@ -308,7 +310,7 @@ public:
     Status get_column_values(const std::vector<uint32_t>& column_ids, int64_t read_version, bool with_default,
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid, MutableColumns* columns,
                              void* state, const TabletSchemaCSPtr& tablet_schema,
-                             const std::map<string, string>* column_to_expr_value = nullptr);
+                             const phmap::flat_hash_map<string, string>* column_to_expr_value = nullptr);
 
     Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
                                 std::vector<uint64_t>* rss_rowids, int64_t timeout_ms = 0);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -15,14 +15,13 @@
 #pragma once
 
 #include <atomic>
-
-#include "base/phmap/phmap.h"
 #include <condition_variable>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 
 #include "base/concurrency/blocking_queue.hpp"
+#include "base/phmap/phmap.h"
 #include "base/time/time.h"
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"

--- a/be/src/util/metrics/catalog_scan_metrics.h
+++ b/be/src/util/metrics/catalog_scan_metrics.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <shared_mutex>
 #include <string>
@@ -45,7 +44,7 @@ private:
 
     MetricRegistry* _registry;
     std::shared_mutex _mutex;
-    std::map<std::string, std::unique_ptr<SingleCatalogMetrics>> _metrics_map;
+    phmap::flat_hash_map<std::string, std::unique_ptr<SingleCatalogMetrics>> _metrics_map;
 };
 
 } // namespace starrocks

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -152,12 +152,12 @@ private:
 
     std::unique_ptr<CpuMetrics> _cpu_metrics;
     std::unique_ptr<MemoryMetrics> _memory_metrics;
-    std::map<std::string, DiskMetrics*> _disk_metrics;
-    std::map<std::string, NetMetrics*> _net_metrics;
+    phmap::flat_hash_map<std::string, DiskMetrics*> _disk_metrics;
+    phmap::flat_hash_map<std::string, NetMetrics*> _net_metrics;
     std::unique_ptr<FileDescriptorMetrics> _fd_metrics;
     std::unique_ptr<QueryCacheMetrics> _query_cache_metrics;
     std::unique_ptr<VectorIndexCacheMetrics> _vector_index_cache_metrics;
-    std::map<std::string, RuntimeFilterMetrics*> _runtime_filter_metrics;
+    phmap::flat_hash_map<std::string, RuntimeFilterMetrics*> _runtime_filter_metrics;
     int _proc_net_dev_version = 0;
     std::unique_ptr<SnmpMetrics> _snmp_metrics;
     std::vector<IOMetrics*> _io_metrics;


### PR DESCRIPTION
## Why I'm doing:

Replace std::map<std::string, V> with phmap::flat_hash_map<std::string, V> for maps that don't require key ordering. This provides O(1) average lookup instead of O(log n), and phmap's built-in transparent HashEq<std::string> enables heterogeneous lookup with std::string_view without constructing temporary std::string objects.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
