### PR TITLE
[BugFix] Align resource group user classifier with CREATE USER

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ResourceGroupClassifier {
-    public static final Pattern USER_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_]{1,63}/?[.a-zA-Z0-9_-]{0,63}$");
     public static final Pattern USE_ROLE_PATTERN = Pattern.compile("^\\w+$");
     public static final ImmutableSet<String> SUPPORTED_QUERY_TYPES =
             ImmutableSet.of(QueryType.SELECT.name(), QueryType.INSERT.name());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -65,7 +65,9 @@ public class ResourceGroupAnalyzer {
                 String key = ((SlotRef) lhs).getColumnName();
                 String value = ((StringLiteral) rhs).getValue();
                 if (key.equalsIgnoreCase(ResourceGroup.USER)) {
-                    if (!ResourceGroupClassifier.USER_PATTERN.matcher(value).matches()) {
+                    try {
+                        FeNameFormat.checkUserName(value);
+                    } catch (SemanticException e) {
                         throw new SemanticException(
                                 String.format("Illegal classifier specifier '%s': '%s'", ResourceGroup.USER,
                                         ExprToSql.toSql(eqPred)));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -384,6 +384,26 @@ public class ResourceGroupStmtTest {
     }
 
     @Test
+    public void testCreateResourceGroupClassifierAllowsDigitLeadingUserName() throws Exception {
+        String sql = "create resource group rg_digit_user\n" +
+                "to\n" +
+                "    (user='123abc')\n" +
+                "with (\n" +
+                "    'cpu_core_limit' = '10',\n" +
+                "    'mem_limit' = '20%',\n" +
+                "    'concurrency_limit' = '1',\n" +
+                "    'type' = 'normal'\n" +
+                ");";
+
+        starRocksAssert.executeResourceGroupDdlSql(sql);
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_digit_user");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(rows.get(0).size() - CLASSIFIER_COLUMN_IDX_REVERSE)).contains("user=123abc");
+
+        dropResourceGroup("rg_digit_user");
+    }
+
+    @Test
     public void testAlterResourceGroupDropManyClassifiers() throws Exception {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -404,10 +404,10 @@ public class ResourceGroupStmtTest {
     }
 
     @Test
-    public void testCreateResourceGroupClassifierAllowsSingleCharacterUserName() throws Exception {
-        String sql = "create resource group rg_single_char_user\n" +
+    public void testCreateResourceGroupClassifierRejectsInvalidUserName() {
+        String sql = "create resource group rg_invalid_user\n" +
                 "to\n" +
-                "    (user='1')\n" +
+                "    (user='aaa~bbb')\n" +
                 "with (\n" +
                 "    'cpu_core_limit' = '10',\n" +
                 "    'mem_limit' = '20%',\n" +
@@ -415,13 +415,9 @@ public class ResourceGroupStmtTest {
                 "    'type' = 'normal'\n" +
                 ");";
 
-        starRocksAssert.executeResourceGroupDdlSql(sql);
-        List<List<String>> rows =
-                starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_single_char_user");
-        assertThat(rows).hasSize(1);
-        assertThat(rows.get(0).get(rows.get(0).size() - CLASSIFIER_COLUMN_IDX_REVERSE)).contains("user=1");
-
-        dropResourceGroup("rg_single_char_user");
+        assertThatThrownBy(() -> starRocksAssert.executeResourceGroupDdlSql(sql))
+                .isInstanceOf(SemanticException.class)
+                .hasMessageContaining("Illegal classifier specifier 'user'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -404,6 +404,27 @@ public class ResourceGroupStmtTest {
     }
 
     @Test
+    public void testCreateResourceGroupClassifierAllowsSingleCharacterUserName() throws Exception {
+        String sql = "create resource group rg_single_char_user\n" +
+                "to\n" +
+                "    (user='1')\n" +
+                "with (\n" +
+                "    'cpu_core_limit' = '10',\n" +
+                "    'mem_limit' = '20%',\n" +
+                "    'concurrency_limit' = '1',\n" +
+                "    'type' = 'normal'\n" +
+                ");";
+
+        starRocksAssert.executeResourceGroupDdlSql(sql);
+        List<List<String>> rows =
+                starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_single_char_user");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get(rows.get(0).size() - CLASSIFIER_COLUMN_IDX_REVERSE)).contains("user=1");
+
+        dropResourceGroup("rg_single_char_user");
+    }
+
+    @Test
     public void testAlterResourceGroupDropManyClassifiers() throws Exception {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");


### PR DESCRIPTION

## Why I'm doing:
### Summary
- align resource group classifier `user` validation with `CREATE USER`
- remove the duplicated stricter regex from `ResourceGroupClassifier`
- add a FE regression test for digit-leading usernames in resource group classifiers

### Root Cause
`CREATE USER` and resource group classifier `user='...'` were validated by different rules. `CREATE USER` allowed digit-leading usernames, but resource groups used a separate stricter regex and rejected the same usernames.

### Validation
- `git diff --check -- fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java`
- attempted `./run-fe-ut.sh --test com.starrocks.analysis.ResourceGroupStmtTest`, but the build is currently blocked by unrelated generated thrift compilation errors in `fe/fe-core/target/generated-sources/thrift/BackendService.java` and `FrontendService.java`

## What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

