### PR TITLE
[BugFix] Fix AGG TopN runtime filter exprOrder mismatch causing crash and wrong results

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -594,9 +594,33 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         if (sv.getEnableTopNRuntimeFilter() && topNSortInfo != null
                 && !topNSortInfo.getOrderingExprs().isEmpty()) {
             Expr topnExpr = topNSortInfo.getOrderingExprs().get(0);
-            pushDownUnaryTopNRuntimeFilter(generator, topnExpr, descTbl, execGroupSets, 0);
+            int topnExprOrder = getGroupByExprOrder(topnExpr);
+            if (topnExprOrder >= 0) {
+                pushDownUnaryTopNRuntimeFilter(generator, topnExpr, descTbl, execGroupSets, topnExprOrder);
+            }
         }
         withRuntimeFilters = !buildRuntimeFilters.isEmpty();
+    }
+
+    // Find the index of the topN expression in the group-by expression list by matching SlotId.
+    // The topN ordering expression and group-by expressions are SlotRefs from different tuples
+    // (sort tuple vs input tuple), but they share the same SlotId (ColumnRefOperator ID).
+    // Find the index of the topN expression in the group-by expression list by matching SlotId.
+    // The topN ordering expression and group-by expressions are SlotRefs from different tuples
+    // (sort tuple vs input tuple), but they share the same SlotId (ColumnRefOperator ID).
+    private int getGroupByExprOrder(Expr topnExpr) {
+        if (!(topnExpr instanceof SlotRef)) {
+            return -1;
+        }
+        int topnSlotId = ((SlotRef) topnExpr).getSlotId().asInt();
+        List<Expr> groupingExprs = aggInfo.getGroupingExprs();
+        for (int i = 0; i < groupingExprs.size(); i++) {
+            Expr gexpr = groupingExprs.get(i);
+            if (gexpr instanceof SlotRef && ((SlotRef) gexpr).getSlotId().asInt() == topnSlotId) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private int getProbeExprOrder(List<Expr> exprs, Expr probeExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -177,11 +177,13 @@ public class RuntimeFilterDescription {
     }
 
     public boolean isTopNSortAsc() {
-        return sortInfo != null && sortInfo.getIsAscOrder().get(exprOrder);
+        // Always use index 0: we only support the first ordering column for TopN RF,
+        // and exprOrder refers to the group-by position, not the sort column position.
+        return sortInfo != null && sortInfo.getIsAscOrder().get(0);
     }
 
     public boolean isTopNullsFirst() {
-        return sortInfo != null && sortInfo.getNullsFirst().get(exprOrder);
+        return sortInfo != null && sortInfo.getNullsFirst().get(0);
     }
 
     public PlanNode getBuildPlanNode() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -622,6 +622,35 @@ class OrderByTest extends PlanTestBase {
     }
 
     @Test
+    void testTopNFilterWithDifferentGroupByOrder() throws Exception {
+        // When ORDER BY column differs from the first GROUP BY column,
+        // the TopN runtime filter must use the correct exprOrder to match
+        // the group-by column index. Previously exprOrder was hardcoded to 0,
+        // causing a type mismatch crash (DATE vs DATETIME) or wrong results.
+        String sql;
+        String plan;
+
+        // ORDER BY second group-by column (id_datetime) which has different type from first (id_date)
+        sql = "select id_date, id_datetime, count(*) from test_all_type_not_null " +
+                "group by id_date, id_datetime order by id_datetime limit 10;";
+        plan = getVerboseExplain(sql);
+        // The TopN filter should probe on id_datetime, not id_date
+        assertContains(plan, "probe_expr = (8: id_datetime)");
+
+        // ORDER BY first group-by column should still work
+        sql = "select id_date, id_datetime, count(*) from test_all_type_not_null " +
+                "group by id_date, id_datetime order by id_date limit 10;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "probe_expr = (9: id_date)");
+
+        // ORDER BY a column not in GROUP BY should not generate TopN RF
+        sql = "select t1a, count(*) cnt from test_all_type_not_null " +
+                "group by t1a order by cnt limit 10;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "build runtime filters");
+    }
+
+    @Test
     public void testTopNRuntimeFilterWithFilter() throws Exception {
         String sql = "select * from t0 where v1 > 1 order by v1 limit 10";
         String plan = getVerboseExplain(sql);


### PR DESCRIPTION
## Why I'm doing:

`AggregationNode.buildRuntimeFilters()` hardcodes `exprOrder=0` for the TopN runtime filter. When `ORDER BY` targets a column that is not the first `GROUP BY` column, `exprOrder=0` points to the wrong group-by column on the BE side, causing:

1. **Type mismatch crash** (e.g., `GROUP BY date_col, datetime_col ORDER BY datetime_col`): BE builds `MinMaxRuntimeFilter<DATE>` but probe side expects `<DATETIME>`, triggering a `down_cast` assertion failure (`SIGABRT` in ASAN builds). This is the crash reported in StarRocksTest#11224.

2. **Silent wrong results** when types match: BE builds the filter from the wrong column's data, producing incorrect min/max bounds that cause storage-level zone-map pruning to drop correct rows.

## What I'm doing:

- Resolve the TopN ordering expression's position in the group-by list via SlotId matching (`getGroupByExprOrder`) instead of hardcoding 0.
- Fix `RuntimeFilterDescription.isTopNSortAsc()`/`isTopNullsFirst()` to use index 0 (the sort column position) instead of `exprOrder` (which now represents the group-by position).
- Add UT covering `GROUP BY col_a, col_b ORDER BY col_b LIMIT N` scenarios with different column types.

Fixes StarRocksTest#11224

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4