### PR TITLE
[BugFix] Fix batch publish deadlock caused by partition version gap

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -79,6 +79,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -87,6 +88,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 public class PublishVersionDaemon extends FrontendDaemon {
@@ -468,6 +470,17 @@ public class PublishVersionDaemon extends FrontendDaemon {
         Set<Long> publishingLakeTransactionsBatchTableId = getPublishingLakeTransactionsBatchTableId();
         Set<Long> publishingTransactions = getPublishingTransactions();
         for (TransactionStateBatch txnStateBatch : readyTransactionStatesBatch) {
+            // Trim batch at version gap boundary to avoid deadlock with SplitTabletJob.
+            // See trimBatchAtVersionGap() javadoc for details.
+            try {
+                txnStateBatch = trimBatchAtVersionGap(txnStateBatch);
+            } catch (Exception e) {
+                LOG.warn("Failed to trim batch at version gap, proceeding with original batch", e);
+            }
+            if (txnStateBatch == null) {
+                continue; // entire batch unpublishable (head txn has gap), skip this cycle
+            }
+
             if (txnStateBatch.size() == 1) {
                 // there are two situations:
                 // 1. the transactionState in txnStateBatch is with multi-tables
@@ -771,6 +784,103 @@ public class PublishVersionDaemon extends FrontendDaemon {
         } catch (Exception e) {
             LOG.warn("delete txn log error: " + e.getMessage());
         }
+    }
+
+    /**
+     * Trim a transaction batch to its publishable prefix by checking each partition's
+     * first commit version against the partition's current visibleVersion.
+     *
+     * If a partition has visibleVersion + 1 != firstCommitVersion (a version gap, typically
+     * caused by SplitTabletJob reserving a phantom version), the batch is truncated before
+     * the first transaction that touches the gap-affected partition.
+     *
+     * @return the original batch if no gap is found, or a new trimmed batch containing
+     *         only the publishable prefix. Returns null if the entire batch is unpublishable
+     *         (first transaction already touches a gap partition).
+     */
+    @VisibleForTesting
+    @Nullable
+    TransactionStateBatch trimBatchAtVersionGap(TransactionStateBatch txnStateBatch) {
+        if (txnStateBatch.size() <= 1) {
+            return txnStateBatch;
+        }
+
+        long dbId = txnStateBatch.getDbId();
+        long tableId = txnStateBatch.getTableId();
+        List<TransactionState> states = txnStateBatch.getTransactionStates();
+
+        // Step 1: Collect first version per partition across the batch
+        // partitionId -> firstVersion (from the earliest txn in the batch that touches it)
+        Map<Long, Long> partitionFirstVersions = new LinkedHashMap<>();
+        for (TransactionState state : states) {
+            TableCommitInfo tableCommitInfo = state.getTableCommitInfo(tableId);
+            if (tableCommitInfo == null) {
+                continue;
+            }
+            for (Map.Entry<Long, PartitionCommitInfo> entry :
+                    tableCommitInfo.getIdToPartitionCommitInfo().entrySet()) {
+                partitionFirstVersions.putIfAbsent(entry.getKey(), entry.getValue().getVersion());
+            }
+        }
+
+        // Step 2: Check each partition's first version against visibleVersion
+        Set<Long> gapPartitions = new HashSet<>();
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable(dbId, tableId);
+        if (table == null) {
+            return txnStateBatch;
+        }
+
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(dbId, List.of(tableId), LockType.READ);
+        try {
+            for (Map.Entry<Long, Long> entry : partitionFirstVersions.entrySet()) {
+                long partitionId = entry.getKey();
+                long firstVersion = entry.getValue();
+                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
+                if (partition != null
+                        && partition.getVisibleVersion() + 1 != firstVersion
+                        // REPLICATION txns may have non-consecutive versions, skip check
+                        && states.get(0).getSourceType()
+                                != TransactionState.LoadJobSourceType.REPLICATION) {
+                    gapPartitions.add(partitionId);
+                }
+            }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(dbId, List.of(tableId), LockType.READ);
+        }
+
+        if (gapPartitions.isEmpty()) {
+            return txnStateBatch; // no gap, return original batch unchanged
+        }
+
+        // Step 3: Find the first transaction that touches any gap-affected partition
+        for (int i = 0; i < states.size(); i++) {
+            TableCommitInfo tableCommitInfo = states.get(i).getTableCommitInfo(tableId);
+            if (tableCommitInfo != null) {
+                for (long partitionId : tableCommitInfo.getIdToPartitionCommitInfo().keySet()) {
+                    if (gapPartitions.contains(partitionId)) {
+                        if (i == 0) {
+                            LOG.debug("Skipping publish batch for table {}: head txn {}"
+                                    + " touches gap partition {}. Gap partitions: {}",
+                                    tableId, states.get(0).getTransactionId(),
+                                    partitionId, gapPartitions);
+                            return null; // entire batch unpublishable
+                        }
+                        LOG.info("Trimming publish batch for table {} from {} to {} txns"
+                                + " due to version gap on partitions {}."
+                                + " First gap txn: {}, all txns: {}",
+                                tableId, states.size(), i, gapPartitions,
+                                states.get(i).getTransactionId(),
+                                states.stream().map(s -> String.valueOf(s.getTransactionId()))
+                                        .collect(Collectors.joining(",")));
+                        return new TransactionStateBatch(
+                                new ArrayList<>(states.subList(0, i)));
+                    }
+                }
+            }
+        }
+        return txnStateBatch; // gap partitions not touched by any txn (shouldn't happen)
     }
 
     private CompletableFuture<Void> publishLakeTransactionBatchAsync(TransactionStateBatch txnStateBatch) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -719,6 +719,130 @@ public class LakePublishBatchTest {
         assertEquals(txn3, request.getTxnInfos().get(1).getTxnId());
     }
 
+    private List<TabletCommitInfo> getPartitionTabletCommitInfos(Partition partition) {
+        List<TabletCommitInfo> commitInfos = Lists.newArrayList();
+        MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+        for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+            for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
+                commitInfos.add(new TabletCommitInfo(tabletId, backendId));
+            }
+        }
+        return commitInfos;
+    }
+
+    @Test
+    public void testTrimBatchAtVersionGapMidBatch() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE_AGG_OFF);
+
+        // Pick two partitions: one without gap, one that will have a gap
+        List<Partition> allPartitions = Lists.newArrayList(table.getPartitions());
+        Partition partNoGap = allPartitions.get(0);
+        Partition partWithGap = allPartitions.get(2);
+
+        List<TabletCommitInfo> tabletsNoGap = getPartitionTabletCommitInfos(partNoGap);
+        List<TabletCommitInfo> tabletsWithGap = getPartitionTabletCommitInfos(partWithGap);
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        // Commit txn1 touching partNoGap only
+        long txnId1 = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                "trim_mid_1_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId1, tabletsNoGap, Lists.newArrayList(), null);
+
+        // Commit txn2 touching partNoGap only
+        long txnId2 = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                "trim_mid_2_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId2, tabletsNoGap, Lists.newArrayList(), null);
+
+        // Create version gap on partWithGap (simulates SplitTabletJob.updateNextVersions)
+        PhysicalPartition physWithGap = partWithGap.getDefaultPhysicalPartition();
+        long savedNextVersion = physWithGap.getNextVersion();
+        physWithGap.setNextVersion(savedNextVersion + 1); // skip one version
+
+        // Commit txn3 touching partWithGap (will have version gap)
+        long txnId3 = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                "trim_mid_3_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter3 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId3, tabletsWithGap, Lists.newArrayList(), null);
+
+        // Build batch manually: [txn1, txn2, txn3]
+        DatabaseTransactionMgr dbTxnMgr = globalTransactionMgr.getDatabaseTransactionMgr(db.getId());
+        TransactionStateBatch batch = new TransactionStateBatch(Lists.newArrayList(
+                dbTxnMgr.getTransactionState(txnId1),
+                dbTxnMgr.getTransactionState(txnId2),
+                dbTxnMgr.getTransactionState(txnId3)));
+
+        // Call trimBatchAtVersionGap
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        TransactionStateBatch trimmed = daemon.trimBatchAtVersionGap(batch);
+
+        // Verify: txn3 touches gap partition, so batch is trimmed to [txn1, txn2]
+        assertNotNull(trimmed);
+        assertEquals(2, trimmed.size());
+        assertEquals(txnId1, trimmed.getTransactionStates().get(0).getTransactionId());
+        assertEquals(txnId2, trimmed.getTransactionStates().get(1).getTransactionId());
+
+        // Cleanup: fill the phantom version gap and publish all transactions
+        physWithGap.updateVisibleVersion(physWithGap.getVisibleVersion() + 1);
+        awaitPublish(daemon, waiter1, waiter2, waiter3);
+    }
+
+    @Test
+    public void testTrimBatchAtVersionGapHeadTxn() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), TABLE_AGG_OFF);
+
+        // Pick two partitions
+        List<Partition> allPartitions = Lists.newArrayList(table.getPartitions());
+        Partition partWithGap = allPartitions.get(0);
+        Partition partNoGap = allPartitions.get(1);
+
+        List<TabletCommitInfo> tabletsWithGap = getPartitionTabletCommitInfos(partWithGap);
+        List<TabletCommitInfo> tabletsNoGap = getPartitionTabletCommitInfos(partNoGap);
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        // Create version gap on partWithGap (simulates SplitTabletJob.updateNextVersions)
+        PhysicalPartition physWithGap = partWithGap.getDefaultPhysicalPartition();
+        long savedNextVersion = physWithGap.getNextVersion();
+        physWithGap.setNextVersion(savedNextVersion + 1);
+
+        // Commit txn1 touching partWithGap (HEAD txn with gap)
+        long txnId1 = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                "trim_head_1_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId1, tabletsWithGap, Lists.newArrayList(), null);
+
+        // Commit txn2 touching partNoGap
+        long txnId2 = globalTransactionMgr.beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
+                "trim_head_2_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId2, tabletsNoGap, Lists.newArrayList(), null);
+
+        // Build batch: [txn1 (gap), txn2 (no gap)]
+        DatabaseTransactionMgr dbTxnMgr = globalTransactionMgr.getDatabaseTransactionMgr(db.getId());
+        TransactionStateBatch batch = new TransactionStateBatch(Lists.newArrayList(
+                dbTxnMgr.getTransactionState(txnId1),
+                dbTxnMgr.getTransactionState(txnId2)));
+
+        // Call trimBatchAtVersionGap: head txn touches gap → returns null
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        TransactionStateBatch trimmed = daemon.trimBatchAtVersionGap(batch);
+        Assertions.assertNull(trimmed);
+
+        // Cleanup: fill the gap and publish all transactions
+        physWithGap.updateVisibleVersion(physWithGap.getVisibleVersion() + 1);
+        awaitPublish(daemon, waiter1, waiter2);
+    }
+
     private List<TabletCommitInfo> commitAllTablets(List<LakeTablet> tablets) {
         List<TabletCommitInfo> commitInfos = Lists.newArrayList();
         List<Long> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds();


### PR DESCRIPTION
## Why I'm doing:

  Several operations (tablet split, schema change, alter job, etc.) reserve phantom versions for
  partitions by advancing `nextVersion` without a corresponding publish, creating a version gap
  (e.g., `visibleVersion=8` but the next committed version is `10` instead of `9`).

  If a transaction touching a gap-affected partition is included in a batch publish,
  `publishPartitionBatch()` fails the version check (`visibleVersion + 1 != versions.get(0)`),
  and the ALL-or-nothing batch semantics (`allMatch`) cause the **entire batch** to fail — blocking
  all transactions in the batch, including those not affected by the gap. This creates a permanent
  deadlock because the job that reserved the phantom version is waiting for other partitions'
  visibleVersions to advance, while those partitions' transactions are blocked by the failed batch.

## What I'm doing:

  Add `trimBatchAtVersionGap()` in `PublishVersionDaemon` to detect version gaps before publishing.
  For each partition touched by the batch, the method checks whether `visibleVersion + 1` matches
  the first committed version. If a gap is detected, the batch is truncated before the first
  transaction that touches the gap-affected partition, so only the publishable prefix is sent.

  Key properties:
  - A single trimmed `TransactionStateBatch` object flows through publish → finish → deleteLog,
    avoiding inconsistency between original and trimmed batch references.
  - If trimmed to size 1, the batch naturally enters the single-txn `publishLakeTransactionAsync()`
    path with full `versionTime` backoff support.
  - Only publishable txns are marked `hasSendTask`.
  - If the head txn touches a gap partition (entire batch unpublishable), returns `null` and the
    batch is skipped with `continue`, no publish attempted.
  - REPLICATION txns are excluded from the gap check (non-consecutive versions by design).

  Once the publishable prefix is finished, the job that reserved the phantom version becomes
  unblocked and publishes it, filling the gap. Subsequent publish cycles then pick up the
  remaining transactions normally.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
