### PR TITLE
[BugFix] Fix incorrect update for parallel_clone_task_per_path

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -96,6 +96,11 @@ static int32_t calc_real_num_threads(int32_t num_threads, int32_t cpu_cores_mult
     return num_threads;
 }
 
+static int32_t calc_clone_thread_pool_size(size_t num_store_paths, int32_t parallel_clone_task_per_path) {
+    return std::max(static_cast<int32_t>(num_store_paths) * parallel_clone_task_per_path,
+                    static_cast<int32_t>(MIN_CLONE_TASK_THREADS_IN_POOL));
+}
+
 class AgentServer::Impl {
 public:
     explicit Impl(ExecEnv* exec_env, bool is_compute_node) : _exec_env(exec_env), _is_compute_node(is_compute_node) {}
@@ -272,8 +277,8 @@ Status AgentServer::Impl::init() {
         // only a single worker thread, then we use dynamic thread pool to handle the task concurrently in clone task
         // callback, so that we can match the dop of FE clone task scheduling.
         BUILD_DYNAMIC_TASK_THREAD_POOL(clone, 0,
-                                       std::max(_exec_env->store_paths().size() * config::parallel_clone_task_per_path,
-                                                MIN_CLONE_TASK_THREADS_IN_POOL),
+                                       calc_clone_thread_pool_size(_exec_env->store_paths().size(),
+                                                                   config::parallel_clone_task_per_path),
                                        DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_clone);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL(
@@ -657,6 +662,10 @@ void AgentServer::Impl::update_max_thread_by_type(int type, int new_val) {
     case TTaskType::REPLICATE_SNAPSHOT:
         st = _thread_pool_replicate_snapshot->update_max_threads(
                 calc_real_num_threads(new_val, REPLICATION_CPU_CORES_MULTIPLIER));
+        break;
+    case TTaskType::CLONE:
+        st = _thread_pool_clone->update_max_threads(
+                calc_clone_thread_pool_size(_exec_env->store_paths().size(), new_val));
         break;
     default: {
         ThreadPool* thread_pool = get_thread_pool(type);

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -663,10 +663,16 @@ void AgentServer::Impl::update_max_thread_by_type(int type, int new_val) {
         st = _thread_pool_replicate_snapshot->update_max_threads(
                 calc_real_num_threads(new_val, REPLICATION_CPU_CORES_MULTIPLIER));
         break;
-    case TTaskType::CLONE:
-        st = _thread_pool_clone->update_max_threads(
-                calc_clone_thread_pool_size(_exec_env->store_paths().size(), new_val));
+    case TTaskType::CLONE: {
+        ThreadPool* thread_pool = get_thread_pool(type);
+        if (thread_pool) {
+            st = thread_pool->update_max_threads(calc_clone_thread_pool_size(_exec_env->store_paths().size(), new_val));
+        } else {
+            LOG(WARNING) << "Failed to update max thread, cannot get thread pool by task type: "
+                         << to_string((TTaskType::type)type);
+        }
         break;
+    }
     default: {
         ThreadPool* thread_pool = get_thread_pool(type);
         if (thread_pool) {

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -276,10 +276,10 @@ Status AgentServer::Impl::init() {
         // need to modify many interfaces. So for now we still use TaskThreadPool to submit clone tasks, but with
         // only a single worker thread, then we use dynamic thread pool to handle the task concurrently in clone task
         // callback, so that we can match the dop of FE clone task scheduling.
-        BUILD_DYNAMIC_TASK_THREAD_POOL(clone, 0,
-                                       calc_clone_thread_pool_size(_exec_env->store_paths().size(),
-                                                                   config::parallel_clone_task_per_path),
-                                       DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_clone);
+        BUILD_DYNAMIC_TASK_THREAD_POOL(
+                clone, 0,
+                calc_clone_thread_pool_size(_exec_env->store_paths().size(), config::parallel_clone_task_per_path),
+                DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_clone);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL(
                 remote_snapshot, 0,

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -14,9 +14,9 @@
 
 #include "agent/agent_task.h"
 
-#include <algorithm>
-
 #include <gtest/gtest.h>
+
+#include <algorithm>
 
 #include "agent/agent_server.h"
 #include "agent/publish_version.h"

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -14,6 +14,8 @@
 
 #include "agent/agent_task.h"
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "agent/agent_server.h"
@@ -21,6 +23,7 @@
 #include "agent/task_signatures_manager.h"
 #include "agent/task_worker_pool.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "base/uuid/uuid_generator.h"
 #include "common/config_storage_fwd.h"
@@ -255,6 +258,40 @@ TEST_F(AgentTaskTest, clone_task_under_dropping) {
     Status st = task.execute();
     ASSERT_TRUE(st.is_corruption());
     tablet->set_is_dropping(false);
+}
+
+TEST_F(AgentTaskTest, update_clone_thread_pool_size_by_task_type) {
+    auto* agent_server = ExecEnv::GetInstance()->agent_server();
+    auto* thread_pool = agent_server->get_thread_pool(TTaskType::CLONE);
+    ASSERT_NE(nullptr, thread_pool);
+
+    constexpr int new_parallelism = 4;
+    const int expected_max_threads =
+            std::max(static_cast<int>(ExecEnv::GetInstance()->store_paths().size()) * new_parallelism, 2);
+
+    agent_server->update_max_thread_by_type(TTaskType::CLONE, new_parallelism);
+
+    ASSERT_EQ(expected_max_threads, thread_pool->max_threads());
+}
+
+TEST_F(AgentTaskTest, update_clone_thread_pool_size_skips_missing_pool) {
+    auto* agent_server = ExecEnv::GetInstance()->agent_server();
+    auto* thread_pool = agent_server->get_thread_pool(TTaskType::CLONE);
+    ASSERT_NE(nullptr, thread_pool);
+
+    const int original_max_threads = thread_pool->max_threads();
+
+    SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
+                                          [](void* arg) { *static_cast<ThreadPool**>(arg) = nullptr; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    agent_server->update_max_thread_by_type(TTaskType::CLONE, 4);
+
+    ASSERT_EQ(original_max_threads, thread_pool->max_threads());
 }
 
 TEST_F(AgentTaskTest, create_tablet_task_timeout) {

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -122,6 +122,20 @@ TEST_F(UpdateConfigActionTest, test_update_tablet_meta_info_worker_count) {
     ASSERT_EQ(1, thread_pool->max_threads());
 }
 
+TEST_F(UpdateConfigActionTest, test_update_parallel_clone_task_per_path) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    auto* thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::CLONE);
+    ASSERT_NE(nullptr, thread_pool);
+
+    auto st = action.update_config("parallel_clone_task_per_path", "4");
+    CHECK_OK(st);
+
+    int expected_max_threads = static_cast<int>(ExecEnv::GetInstance()->store_paths().size()) * 4;
+    expected_max_threads = std::max(expected_max_threads, 2);
+    ASSERT_EQ(expected_max_threads, thread_pool->max_threads());
+}
+
 TEST_F(UpdateConfigActionTest, test_update_lake_metadata_fetch_thread_count) {
     UpdateConfigAction action(ExecEnv::GetInstance());
 

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -19,6 +19,7 @@
 #include "agent/agent_server.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/scoped_updater.h"
+#include "base/testutil/sync_point.h"
 #include "cache/datacache.h"
 #include "cache/disk_cache/starcache_engine.h"
 #include "cache/disk_cache/test_cache_utils.h"
@@ -134,6 +135,21 @@ TEST_F(UpdateConfigActionTest, test_update_parallel_clone_task_per_path) {
     int expected_max_threads = static_cast<int>(ExecEnv::GetInstance()->store_paths().size()) * 4;
     expected_max_threads = std::max(expected_max_threads, 2);
     ASSERT_EQ(expected_max_threads, thread_pool->max_threads());
+}
+
+TEST_F(UpdateConfigActionTest, test_update_parallel_clone_task_per_path_with_missing_clone_pool) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
+                                          [](void* arg) { *(ThreadPool**)arg = nullptr; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    auto st = action.update_config("parallel_clone_task_per_path", "4");
+    CHECK_OK(st);
 }
 
 TEST_F(UpdateConfigActionTest, test_update_lake_metadata_fetch_thread_count) {


### PR DESCRIPTION
## Why I'm doing:
When update parallel_clone_task_per_path, it miss the store path num as a factor to update the thread pool size for CLONE thread pool

## What I'm doing:
Fix it

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
