### PR TITLE
[Performance] Reduce lake PK compaction max input rowsets from 500 to 100

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1326,7 +1326,7 @@ CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");
 CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
-CONF_mInt64(lake_pk_compaction_max_input_rowsets, "500");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "100");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Enable cleanup of orphan delvec entries during compaction.
 // Orphan delvecs are leaked metadata entries from a historical bug that reference


### PR DESCRIPTION
## Why I'm doing:

In shared-data (lake) mode with primary key tables, compaction publishes with 400-500 input rowsets take **1.3-3.5 seconds** due to delvec loading and persistent index updates. The compaction publish holds a **per-tablet lock** that blocks stream load publishes for the same tablet. During bulk loads (which trigger large compactions), this causes ingestion P99 to spike by **+1111%** (from 6.2s to 75.3s in a 30GB benchmark with 500M rows, 3 CN nodes).

### Trace evidence from CN publish logs:

| Input Rowsets | delvec_loader Latency | Total Publish Cost |
|---------------|----------------------|-------------------|
| 81 | 24ms | 1,252ms |
| 257 | 403ms | 1,915ms |
| 327 | 410ms | 3,011ms |
| 469 | 1,166ms | 3,419ms |
| 482 | 1,312ms | 3,444ms |

The delvec_loader latency scales super-linearly with input rowsets above ~300, because more remote delvec file reads exceed the cache capacity.

### Root cause chain:
1. Bulk load → many small rowsets accumulated on tablet
2. Compaction picks up to 500 rowsets (current default of `lake_pk_compaction_max_input_rowsets`)
3. Compaction publish loads delvec for all input rowsets: **1.3s** at 500 rowsets
4. Per-tablet lock blocks stream load publishes during compaction publish
5. Stream load publishes queue up → **P99 spike**

## What I'm doing:

Reduce `lake_pk_compaction_max_input_rowsets` default from **500** to **100**.

With 100 input rowsets, delvec_loader stays under **~100-200ms** per compaction publish, and total publish time drops from **3.5s to ~1-1.5s**. This allows stream load publishes to interleave between compactions instead of queueing behind long-running compaction publishes.

**Trade-off**: More frequent but shorter compactions. Each compaction processes fewer rowsets, so more compaction rounds are needed. But per-compaction overhead is low, and the latency tail is dramatically reduced. The config is mutable (`CONF_mInt64`), so users can tune it at runtime if needed.

## What type of PR is this:

- [x] Improvement

## Does this PR entail a change in behavior?

- [x] Yes

## If yes, please specify the type of change:

- [x] Default configuration value change (lake_pk_compaction_max_input_rowsets: 500 → 100)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs mass test (If no, leave it unchecked)

## Expected Impact:

Reduce compaction publish lock hold time by ~60-70%, reducing stream load ingestion P99 during bulk loads. Expected to reduce P99 spike during bulk loads from +1111% to ~+200-400%.