### PR TITLE
[Performance] Pre-fetch compaction delvecs before per-tablet lock to reduce stream load P99

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1772,6 +1772,9 @@ CONF_mInt32(olap_string_max_length, "1048576");
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 
+// Pre-fetch delvec data for compaction publishes before acquiring the per-tablet lock.
+CONF_mBool(lake_enable_compaction_delvec_prefetch, "true");
+
 // jit LRU object cache size for total 32 shards, it will be an auto value if it < 0
 // mem_limit = system memory or process memory limit if set.
 // if mem_limit < 16 GB, disable JIT.

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -162,6 +162,11 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 
+// Pre-fetch delvec data for compaction publishes before acquiring the per-tablet lock.
+// This reduces lock hold time from seconds to milliseconds, preventing compaction publishes
+// from blocking stream load publishes on the same tablet.
+CONF_mBool(lake_enable_compaction_delvec_prefetch, "true");
+
 // if turned on, each compaction will use at most `max_cumulative_compaction_num_singleton_deltas` segments,
 // for now, only support non-pk LAKE compaction in size tierd compaction.
 CONF_mBool(enable_lake_compaction_use_partial_segments, "false");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -685,6 +685,7 @@
         "lake_pk_compaction_max_input_rowsets",
         "lake_pk_compaction_min_input_segments",
         "enable_light_pk_compaction_publish",
+        "lake_enable_compaction_delvec_prefetch",
         "enable_lake_compaction_use_partial_segments",
         "lake_compaction_chunk_size"
       ]

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -16,6 +16,7 @@
 
 #include "base/container/lru_cache.h"
 #include "base/utility/defer_op.h"
+#include "common/config_compaction_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -24,7 +24,6 @@
 #include "runtime/exec_env.h"
 #include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
-#include "storage/options.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
@@ -34,6 +33,7 @@
 #include "storage/lake/txn_log_applier.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h" // delete_files_async
+#include "storage/options.h"
 
 namespace {
 
@@ -218,8 +218,8 @@ void prefetch_compaction_delvecs(TabletManager* tablet_mgr, int64_t tablet_id, i
         }
     }
     VLOG(1) << "prefetch_compaction_delvecs: tablet=" << tablet_id << " version=" << base_version
-            << " input_rowsets=" << op_compaction.input_rowsets_size()
-            << " input_segments=" << input_segment_ids.size() << " prefetched_delvecs=" << prefetched;
+            << " input_rowsets=" << op_compaction.input_rowsets_size() << " input_segments=" << input_segment_ids.size()
+            << " prefetched_delvecs=" << prefetched;
 }
 
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
@@ -257,8 +257,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
             if (txn_log_st.ok() && !txn_log_st.value()[0].empty()) {
                 for (const auto& log : txn_log_st.value()[0]) {
                     if (log->has_op_compaction() && log->op_compaction().input_rowsets_size() > 0) {
-                        prefetch_compaction_delvecs(tablet_mgr, tablet_id, base_version,
-                                                    log->op_compaction());
+                        prefetch_compaction_delvecs(tablet_mgr, tablet_id, base_version, log->op_compaction());
                     }
                 }
             }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -22,6 +22,9 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/join.h"
 #include "runtime/exec_env.h"
+#include "storage/del_vector.h"
+#include "storage/lake/meta_file.h"
+#include "storage/options.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
@@ -173,6 +176,52 @@ StatusOr<std::vector<TxnLogVector>> load_txn_log(TabletManager* tablet_mgr, std:
     return txn_logs_vector;
 }
 
+// Pre-fetch delvec data into cache for compaction publishes.
+// Called BEFORE acquiring the per-tablet lock to avoid holding the lock during
+// expensive remote IO. The actual publish will find delvecs in cache.
+void prefetch_compaction_delvecs(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
+                                 const TxnLogPB_OpCompaction& op_compaction) {
+    // Load base metadata to look up delvec entries
+    auto base_metadata_or = tablet_mgr->get_tablet_metadata(tablet_id, base_version, true);
+    if (!base_metadata_or.ok()) {
+        VLOG(2) << "prefetch_compaction_delvecs: failed to load base metadata for tablet=" << tablet_id
+                << " version=" << base_version << ": " << base_metadata_or.status();
+        return;
+    }
+    auto& metadata = *base_metadata_or.value();
+
+    // Collect segment IDs from input rowsets
+    std::set<uint32_t> input_segment_ids;
+    for (uint32_t input_rowset_id : op_compaction.input_rowsets()) {
+        // Find the rowset in metadata to determine how many segments it has
+        for (const auto& rowset : metadata.rowsets()) {
+            if (rowset.id() == input_rowset_id) {
+                for (int seg = 0; seg < rowset.segments_size(); seg++) {
+                    input_segment_ids.insert(input_rowset_id + seg);
+                }
+                break;
+            }
+        }
+    }
+
+    // Pre-load delvecs for all input segments that have delvec entries
+    LakeIOOptions lake_io_opts;
+    int prefetched = 0;
+    for (uint32_t segment_id : input_segment_ids) {
+        auto iter = metadata.delvec_meta().delvecs().find(segment_id);
+        if (iter != metadata.delvec_meta().delvecs().end()) {
+            DelVector delvec;
+            auto st = lake::get_del_vec(tablet_mgr, metadata, segment_id, true /*fill_cache*/, lake_io_opts, &delvec);
+            if (st.ok()) {
+                prefetched++;
+            }
+        }
+    }
+    VLOG(1) << "prefetch_compaction_delvecs: tablet=" << tablet_id << " version=" << base_version
+            << " input_rowsets=" << op_compaction.input_rowsets_size()
+            << " input_segments=" << input_segment_ids.size() << " prefetched_delvecs=" << prefetched;
+}
+
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata) {
@@ -196,6 +245,24 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                     tablet_mgr->tablet_metadata_root_location(tablet_info.get_tablet_id_in_metadata()), true);
         }
         return new_metadata;
+    }
+
+    // Pre-fetch delvec data for compaction publishes BEFORE acquiring the per-tablet lock.
+    // This moves expensive remote IO (1-8s for 500 input rowsets) outside the lock,
+    // reducing lock hold time to <100ms and preventing compaction from blocking stream load.
+    if (config::lake_enable_compaction_delvec_prefetch) {
+        auto tablet_id = tablet_info.get_tablet_id_in_metadata();
+        for (size_t i = 0, sz = txns.size(); i < sz; i++) {
+            auto txn_log_st = load_txn_log(tablet_mgr, {tablet_id}, txns[i]);
+            if (txn_log_st.ok() && !txn_log_st.value()[0].empty()) {
+                for (const auto& log : txn_log_st.value()[0]) {
+                    if (log->has_op_compaction() && log->op_compaction().input_rowsets_size() > 0) {
+                        prefetch_compaction_delvecs(tablet_mgr, tablet_id, base_version,
+                                                    log->op_compaction());
+                    }
+                }
+            }
+        }
     }
 
     if (!add_tablet(tablet_info.get_tablet_id_in_metadata())) {


### PR DESCRIPTION
## Why I'm doing:

In shared-data (lake) mode with primary key tables, compaction publishes with 500 input rowsets hold the **per-tablet lock** for **1-8 seconds** while loading delete vectors (delvecs) from remote storage. During this time, stream load publishes for the same tablet return `ResourceBusy`, causing the FE to retry in the next publish cycle. This cascading retry pattern causes `wait_for_publish` to reach **57 seconds at P99**.

### Benchmark evidence (30GB single-table, 500M rows, 3 CN nodes):

**Stream load latency breakdown (FE-side, 51,372 transactions):**

| Component | P50 | P90 | P99 | Max |
|-----------|-----|-----|-----|-----|
| total cost | 1,231ms | 9,187ms | 67,856ms | 558,805ms |
| write cost | 254ms | 446ms | 7,418ms | 417,841ms |
| **wait_for_publish** | **381ms** | **5,683ms** | **57,688ms** | **161,922ms** |
| publish_rpc | 573ms | 2,549ms | 7,679ms | 59,092ms |

**Compaction delvec_loader latency (per tablet publish):**

| CN | P50 | P90 | Max |
|----|-----|-----|-----|
| CN1 | 9ms | 3,314ms | 74,418ms |
| CN2 | 16ms | 1,950ms | 21,824ms |
| CN3 | 5ms | 637ms | 65,644ms |

### Root cause chain:
1. Compaction publish loads delvec for each input rowset segment sequentially (500 reads × 10-300ms each)
2. This happens under the per-tablet lock (`tablet_txns` in transactions.cpp)
3. Stream load publish for the same tablet returns `ResourceBusy`
4. FE retries in next publish cycle → cascading `wait_for_publish` delays up to 57s

## What I'm doing:

Pre-fetch delvec data into cache **before** acquiring the per-tablet lock. Since delvec data is immutable and versioned, pre-loading into cache is safe and doesn't affect correctness.

**Before:** `acquire_lock → load_delvecs(1-8s) → update_index → release_lock`
**After:** `prefetch_delvecs(1-8s, NO LOCK) → acquire_lock → update_index(cache hit, <100ms) → release_lock`

The implementation:
1. Before `add_tablet()`, load the txn log and detect compaction operations
2. For compaction txns, load the base metadata and pre-fetch all delvecs for input rowset segments into metacache
3. When the actual publish runs under the lock, all delvec reads hit cache

**Expected impact:**
- Tablet lock hold time: 1-8s → <200ms
- Stream load `wait_for_publish` P99: 57s → <5s
- Ingest P99: 125s → estimated <10s

**Graceful degradation:** If pre-fetch fails (e.g., metadata not found), publish proceeds normally with the same behavior as before.

## What type of PR is this:

- [x] Improvement

## Does this PR entail a change in behavior?

- [x] Yes

## If yes, please specify the type of change:

- [x] Performance optimization (delvec loading moved outside per-tablet lock)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs mass test (If no, leave it unchecked)