### PR TITLE
[BugFix] Fix information schema sink use-after-free

### DIFF
--- a/be/src/runtime/schema_table_sink.cpp
+++ b/be/src/runtime/schema_table_sink.cpp
@@ -84,6 +84,7 @@ static Status set_config_remote(const StarRocksNodesInfo& nodes_info, int64_t be
     auto* closure = new RefCountClosure<ExecuteCommandResultPB>();
     closure->cntl.set_timeout_ms(10000);
     closure->ref();
+    closure->ref();
     DeferOp op([&]() {
         if (closure->unref()) {
             delete closure;

--- a/test/sql/test_information_schema/R/test_be_configs
+++ b/test/sql/test_information_schema/R/test_be_configs
@@ -1,0 +1,7 @@
+-- name: test_update_be_configs
+UPDATE information_schema.be_configs SET VALUE = 'true' WHERE name = "abort_on_large_memory_allocation";
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = 'false' WHERE name = "abort_on_large_memory_allocation";
+-- result:
+-- !result

--- a/test/sql/test_information_schema/T/test_be_configs
+++ b/test/sql/test_information_schema/T/test_be_configs
@@ -1,0 +1,3 @@
+-- name: test_update_be_configs
+UPDATE information_schema.be_configs SET VALUE = 'true' WHERE name = "abort_on_large_memory_allocation";
+UPDATE information_schema.be_configs SET VALUE = 'false' WHERE name = "abort_on_large_memory_allocation";


### PR DESCRIPTION
## Why I'm doing:

1. Missing reference count increment in async RPC closure handling

## What I'm doing:

```
Thread 309 "fragment_mgr" hit Breakpoint 1, starrocks::write_be_configs_table (nodes_info=..., self_be_id=10004, 
    columns=std::vector of length 6, capacity 6 = {...}) at be/src/runtime/schema_table_sink.cpp:112
112     in be/src/runtime/schema_table_sink.cpp
(gdb) c
Continuing.
=================================================================
==3342150==ERROR: AddressSanitizer: heap-use-after-free on address 0x51800001df60 at pc 0x0000276880e3 bp 0x7ffee11555c0 sp 0x7ffee11555b8
READ of size 8 at 0x51800001df60 thread T308
    #0 0x276880e2 in starrocks::ExecuteCommandResultPB::_internal_status() const be/build_ASAN/gensrc/gen_cpp/internal_service.pb.h:33864
    #1 0x2768811b in starrocks::ExecuteCommandResultPB::status() const (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x2768811b)
    #2 0x27684dc2 in set_config_remote be/src/runtime/schema_table_sink.cpp:99
    #3 0x27685d64 in write_be_configs_table be/src/runtime/schema_table_sink.cpp:134
    #4 0x276869d7 in starrocks::SchemaTableSink::send_chunk(starrocks::RuntimeState*, starrocks::Chunk*) be/src/runtime/schema_table_sink.cpp:152
    #5 0x1e21ea1b in starrocks::PlanFragmentExecutor::_open_internal_vectorized() be/src/runtime/plan_fragment_executor.cpp:262
    #6 0x1e21da09 in starrocks::PlanFragmentExecutor::open() be/src/runtime/plan_fragment_executor.cpp:219
    #7 0x1df8a463 in starrocks::FragmentExecState::execute() be/src/runtime/fragment_mgr.cpp:219
    #8 0x1df8e8e6 in starrocks::FragmentMgr::exec_actual(std::shared_ptr<starrocks::FragmentExecState> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&) be/src/runtime/fragment_mgr.cpp:401
    #9 0x1df8f5e4 in operator() be/src/runtime/fragment_mgr.cpp:464
    #10 0x1df9d6ab in __invoke_impl<void, starrocks::FragmentMgr::exec_plan_fragment(const starrocks::TExecPlanFragmentParams&, const StartSuccCallback&, const FinishCallback&)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #11 0x1df9ce13 in __invoke_r<void, starrocks::FragmentMgr::exec_plan_fragment(const starrocks::TExecPlanFragmentParams&, const StartSuccCallback&, const FinishCallback&)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #12 0x1df9c122 in _M_invoke /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #13 0x1b695d8b in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #14 0x2b2fe9b3 in starrocks::FunctionRunnable::run() be/src/common/thread/threadpool.cpp:61
    #15 0x2b2f89fa in starrocks::ThreadPool::dispatch_thread() be/src/common/thread/threadpool.cpp:680
    #16 0x2b319d6b in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:74
    #17 0x2b31870a in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:96
    #18 0x2b31715b in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc-toolset-14/include/c++/14.3.0/functional:513
    #19 0x2b3157b7 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc-toolset-14/include/c++/14.3.0/functional:598
    #20 0x2b313a3d in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #21 0x2b311340 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #22 0x2b30cbd6 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #23 0x1b695d8b in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #24 0x2b2de910 in starrocks::Thread::supervise_thread(void*) be/src/common/thread/thread.cpp:412
    #25 0x14812395 in asan_thread_start(void*) (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x14812395)
    #26 0x7ffff6989ac2 in start_thread nptl/pthread_create.c:442
    #27 0x7ffff6a1b8cf in __clone3 (/lib/x86_64-linux-gnu/libc.so.6+0x1268cf) (BuildId: 095c7ba148aeca81668091f718047078d57efddb)

0x51800001df60 is located 736 bytes inside of 784-byte region [0x51800001dc80,0x51800001df90)
freed by thread T1823 (brpc_wkr:0-5) here:
    #0 0x148ad318 in operator delete(void*) (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x148ad318)

previously allocated by thread T308 here:
    #0 0x148ac8d8 in operator new(unsigned long) (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x148ac8d8)
    #1 0x27684aac in set_config_remote be/src/runtime/schema_table_sink.cpp:84
    #2 0x27685d64 in write_be_configs_table be/src/runtime/schema_table_sink.cpp:134
    #3 0x276869d7 in starrocks::SchemaTableSink::send_chunk(starrocks::RuntimeState*, starrocks::Chunk*) be/src/runtime/schema_table_sink.cpp:152
    #4 0x1e21ea1b in starrocks::PlanFragmentExecutor::_open_internal_vectorized() be/src/runtime/plan_fragment_executor.cpp:262
    #5 0x1e21da09 in starrocks::PlanFragmentExecutor::open() be/src/runtime/plan_fragment_executor.cpp:219
    #6 0x1df8a463 in starrocks::FragmentExecState::execute() be/src/runtime/fragment_mgr.cpp:219
    #7 0x1df8e8e6 in starrocks::FragmentMgr::exec_actual(std::shared_ptr<starrocks::FragmentExecState> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&) be/src/runtime/fragment_mgr.cpp:401
    #8 0x1df8f5e4 in operator() be/src/runtime/fragment_mgr.cpp:464
    #9 0x1df9d6ab in __invoke_impl<void, starrocks::FragmentMgr::exec_plan_fragment(const starrocks::TExecPlanFragmentParams&, const StartSuccCallback&, const FinishCallback&)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #10 0x1df9ce13 in __invoke_r<void, starrocks::FragmentMgr::exec_plan_fragment(const starrocks::TExecPlanFragmentParams&, const StartSuccCallback&, const FinishCallback&)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #11 0x1df9c122 in _M_invoke /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #12 0x1b695d8b in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #13 0x2b2fe9b3 in starrocks::FunctionRunnable::run() be/src/common/thread/threadpool.cpp:61
    #14 0x2b2f89fa in starrocks::ThreadPool::dispatch_thread() be/src/common/thread/threadpool.cpp:680
    #15 0x2b319d6b in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:74
    #16 0x2b31870a in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:96
    #17 0x2b31715b in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc-toolset-14/include/c++/14.3.0/functional:513
    #18 0x2b3157b7 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc-toolset-14/include/c++/14.3.0/functional:598
    #19 0x2b313a3d in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #20 0x2b311340 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #21 0x2b30cbd6 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #22 0x1b695d8b in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #23 0x2b2de910 in starrocks::Thread::supervise_thread(void*) be/src/common/thread/thread.cpp:412
    #24 0x14812395 in asan_thread_start(void*) (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x14812395)

Thread T308 created by T0 here:
    #0 0x148a3ca1 in pthread_create (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x148a3ca1)
    #1 0x2b2dde47 in starrocks::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<starrocks::Thread>*) be/src/common/thread/thread.cpp:363
    #2 0x2b3027f6 in starrocks::Status starrocks::Thread::create<void (starrocks::ThreadPool::*)(), starrocks::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (starrocks::ThreadPool::* const&)(), starrocks::ThreadPool* const&, scoped_refptr<starrocks::Thread>*) be/src/common/thread/thread.h:76
    #3 0x2b2fab0f in starrocks::ThreadPool::create_thread() be/src/common/thread/threadpool.cpp:764
    #4 0x2b2f1e76 in starrocks::ThreadPool::init() be/src/common/thread/threadpool.cpp:282
    #5 0x2b2ee6f5 in starrocks::ThreadPoolBuilder::build(std::unique_ptr<starrocks::ThreadPool, std::default_delete<starrocks::ThreadPool> >*) const be/src/common/thread/threadpool.cpp:108
    #6 0x1df8dd33 in starrocks::FragmentMgr::FragmentMgr(starrocks::ExecEnv*) be/src/runtime/fragment_mgr.cpp:368
    #7 0x1def4819 in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:474
    #8 0x1e35833f in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:129
    #9 0x1490621d in main be/src/service/starrocks_main.cpp:277
    #10 0x7ffff691ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Thread T1823 (brpc_wkr:0-5) created by T0 here:
    #0 0x148a3ca1 in pthread_create (/home/disk5/fha/opt/env/default/be/lib/starrocks_be+0x148a3ca1)
    #1 0x2f841abd in bthread::TaskControl::init(int) src/bthread/task_control.cpp:215
    #2 0x2f8343a9 in bthread::get_or_new_task_control() src/bthread/bthread.cpp:110
    #3 0x2f833514 in bthread::start_from_non_worker(unsigned long*, bthread_attr_t const*, void* (*)(void*), void*) src/bthread/bthread.cpp:174
    #4 0x2f833514 in bthread_start_background src/bthread/bthread.cpp:256
    #5 0x1dfd774b in starrocks::LoadChannelMgr::_start_bg_worker() be/src/runtime/load_channel_mgr.cpp:353
    #6 0x1dfd2844 in starrocks::LoadChannelMgr::init(starrocks::MemTracker*) be/src/runtime/load_channel_mgr.cpp:139
    #7 0x1defb81a in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:767
    #8 0x1e35833f in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:129
    #9 0x1490621d in main be/src/service/starrocks_main.cpp:277
    #10 0x7ffff691ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-use-after-free be/build_ASAN/gensrc/gen_cpp/internal_service.pb.h:33864 in starrocks::ExecuteCommandResultPB::_internal_status() const
Shadow bytes around the buggy address:
  0x51800001dc80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001dd00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001dd80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001de00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001de80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x51800001df00: fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd
  0x51800001df80: fd fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x51800001e000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x51800001e080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001e100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51800001e180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3342150==ABORTING

Thread 2372 "pip_poll_172100" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ff53ae6e640 (LWP 3346226)]
0x000000001a26a27c in std::__atomic_base<bool>::load (this=0x513001d209c9, __m=std::memory_order::acquire)
    at /opt/gcc-toolset-14/include/c++/14.3.0/bits/atomic_base.h:501
501     /opt/gcc-toolset-14/include/c++/14.3.0/bits/atomic_base.h: No such file or directory.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4