### PR TITLE
[Enhancement] Add vector_index_ids  in SegmentMetadataPB

### DIFF
--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -139,6 +139,9 @@ message SegmentMetadataPB {
     // non-contiguous after operations such as partial compaction or batch merge.
     // Backward compatibility: if absent, consumers should fallback to positional index.
     optional uint32 segment_idx = 4;
+    // IDs of vector indexes that need .vi files for this segment.
+    // Only populated when the segment meets the build threshold.
+    repeated int64 vector_index_ids = 5;
 }
 
 message RowsetMetadataPB {


### PR DESCRIPTION
## Why I'm doing:
Add vector_index ids in SegmentMetadataPB for compatibility with celerdata(https://github.com/CelerData/celerdata-enterprise/pull/52101).


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
