### PR TITLE
[Enhancement] Add join rules for unified IVM framework

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -63,10 +63,12 @@ import com.starrocks.sql.optimizer.rule.implementation.stream.StreamScanImplemen
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaAggregateRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaFilterRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaIcebergScanRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaJoinRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmDeltaProjectRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionAggregateRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionFilterRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionIcebergScanRule;
+import com.starrocks.sql.optimizer.rule.ivm.IvmVersionJoinRule;
 import com.starrocks.sql.optimizer.rule.ivm.IvmVersionProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.CastToEmptyRule;
 import com.starrocks.sql.optimizer.rule.transformation.CollectCTEConsumeRule;
@@ -445,10 +447,12 @@ public class RuleSet {
     public static final Rule IVM_DELTA_REWRITE_RULES =
             new CombinationRule(RuleType.GP_IVM_DELTA_REWRITE, ImmutableList.of(
                     new IvmDeltaAggregateRule(),
+                    new IvmDeltaJoinRule(),
                     new IvmDeltaIcebergScanRule(),
                     new IvmDeltaFilterRule(),
                     new IvmDeltaProjectRule(),
                     new IvmVersionAggregateRule(),
+                    new IvmVersionJoinRule(),
                     new IvmVersionIcebergScanRule(),
                     new IvmVersionFilterRule(),
                     new IvmVersionProjectRule()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaJoinRule.java
@@ -1,0 +1,190 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.OptExpressionDuplicator;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves a {@link LogicalDeltaOperator} wrapping a {@link LogicalJoinOperator} by applying
+ * the incremental join delta formula.
+ *
+ * <p>Pattern: {@code LogicalDeltaOperator -> LogicalJoinOperator(LEAF, LEAF)}
+ *
+ * <p>Only supports inner join and cross join. For inner join:
+ * <pre>
+ *   Delta(A ⋈ B) = (Delta_A ⋈ Version(FROM, B)) ∪ (Version(TO, A) ⋈ Delta_B)
+ * </pre>
+ *
+ * <p>Each branch gets its own cloned join subtree (via {@link OptExpressionDuplicator})
+ * with fresh ColumnRefs. The Delta marker is set to {@code isRootDelta=false} on each branch
+ * since these are child deltas, not the root delta created by IvmRewriter.
+ */
+public class IvmDeltaJoinRule extends TransformationRule {
+    public IvmDeltaJoinRule() {
+        super(RuleType.TF_IVM_DELTA_JOIN,
+                Pattern.create(OperatorType.LOGICAL_DELTA)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN,
+                                OperatorType.PATTERN_LEAF, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalJoinOperator join = (LogicalJoinOperator) input.inputAt(0).getOp();
+        return join.getJoinType().isInnerJoin() || join.getJoinType().isCrossJoin();
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalDeltaOperator delta = (LogicalDeltaOperator) input.getOp();
+        OptExpression joinExpr = input.inputAt(0);
+        ColumnRefFactory factory = context.getColumnRefFactory();
+        ColumnRefOperator actionColumn = delta.getActionColumn();
+
+        List<ColumnRefOperator> finalOutputColumns = input.getOutputColumns().getColumnRefOperators(factory);
+        List<ColumnRefOperator> joinOutputColumns = getJoinOutputsWithoutAction(finalOutputColumns, actionColumn);
+
+        List<OptExpression> unionChildren = Lists.newArrayList();
+        List<List<ColumnRefOperator>> unionChildOutputs = Lists.newArrayList();
+
+        // Branch 1: Delta_left ⋈ Version(FROM, right)
+        BranchResult branch1 = buildBranch(factory, context, joinExpr, joinOutputColumns, actionColumn, true);
+        // Branch 2: Version(TO, left) ⋈ Delta_right
+        BranchResult branch2 = buildBranch(factory, context, joinExpr, joinOutputColumns, actionColumn, false);
+        if (!appendBranch(unionChildren, unionChildOutputs, branch1)
+                || !appendBranch(unionChildren, unionChildOutputs, branch2)) {
+            return List.of();
+        }
+
+        LogicalUnionOperator unionOp = new LogicalUnionOperator(finalOutputColumns, unionChildOutputs, true);
+        return List.of(OptExpression.create(unionOp, unionChildren));
+    }
+
+    /**
+     * Build one branch of the join delta formula.
+     *
+     * @param isLeftDelta if true: Delta(left) ⋈ Version(FROM, right);
+     *                    if false: Version(TO, left) ⋈ Delta(right)
+     */
+    private BranchResult buildBranch(ColumnRefFactory factory,
+                                     OptimizerContext context,
+                                     OptExpression joinExpr,
+                                     List<ColumnRefOperator> joinOutputColumns,
+                                     ColumnRefOperator actionColumn,
+                                     boolean isLeftDelta) {
+        DuplicatedJoin dup = duplicateJoin(factory, context, joinExpr);
+        LogicalJoinOperator dupJoinOp = (LogicalJoinOperator) dup.joinExpr().getOp();
+        ColumnRefOperator branchAction = duplicateActionColumn(factory, actionColumn);
+
+        OptExpression left;
+        OptExpression right;
+        if (isLeftDelta) {
+            left = OptExpression.create(new LogicalDeltaOperator(false, branchAction),
+                    dup.joinExpr().inputAt(0));
+            right = OptExpression.create(LogicalVersionOperator.fromVersion(),
+                    dup.joinExpr().inputAt(1));
+        } else {
+            left = OptExpression.create(LogicalVersionOperator.toVersion(),
+                    dup.joinExpr().inputAt(0));
+            right = OptExpression.create(new LogicalDeltaOperator(false, branchAction),
+                    dup.joinExpr().inputAt(1));
+        }
+
+        List<ColumnRefOperator> outputs = deriveBranchOutputs(joinOutputColumns, branchAction, dup.columnMapping());
+        if (outputs == null) {
+            return null;
+        }
+
+        LogicalJoinOperator newJoin = LogicalJoinOperator.builder()
+                .withOperator(dupJoinOp)
+                .build();
+        return new BranchResult(OptExpression.create(newJoin, left, right), outputs);
+    }
+
+    private DuplicatedJoin duplicateJoin(ColumnRefFactory factory, OptimizerContext context,
+                                         OptExpression joinExpr) {
+        OptExpressionDuplicator duplicator = new OptExpressionDuplicator(factory, context);
+        return new DuplicatedJoin(duplicator.duplicate(joinExpr), duplicator.getColumnMapping());
+    }
+
+    private ColumnRefOperator duplicateActionColumn(ColumnRefFactory factory, ColumnRefOperator actionColumn) {
+        if (actionColumn == null) {
+            return null;
+        }
+        return factory.create(actionColumn.getName(), actionColumn.getType(), actionColumn.isNullable());
+    }
+
+    private List<ColumnRefOperator> getJoinOutputsWithoutAction(List<ColumnRefOperator> finalOutputColumns,
+                                                                 ColumnRefOperator actionColumn) {
+        List<ColumnRefOperator> result = Lists.newArrayList();
+        for (ColumnRefOperator col : finalOutputColumns) {
+            if (actionColumn == null || col.getId() != actionColumn.getId()) {
+                result.add(col);
+            }
+        }
+        return result;
+    }
+
+    private List<ColumnRefOperator> deriveBranchOutputs(List<ColumnRefOperator> joinOutputColumns,
+                                                         ColumnRefOperator actionColumn,
+                                                         Map<ColumnRefOperator, ColumnRefOperator> oldToNew) {
+        List<ColumnRefOperator> outputs =
+                Lists.newArrayListWithCapacity(joinOutputColumns.size() + (actionColumn == null ? 0 : 1));
+        for (ColumnRefOperator col : joinOutputColumns) {
+            ColumnRefOperator mapped = oldToNew.get(col);
+            if (mapped == null) {
+                return null;
+            }
+            outputs.add(mapped);
+        }
+        if (actionColumn != null) {
+            outputs.add(actionColumn);
+        }
+        return outputs;
+    }
+
+    private boolean appendBranch(List<OptExpression> unionChildren,
+                                 List<List<ColumnRefOperator>> unionChildOutputs,
+                                 BranchResult branch) {
+        if (branch == null || branch.outputs() == null) {
+            return false;
+        }
+        unionChildren.add(branch.branchExpr());
+        unionChildOutputs.add(branch.outputs());
+        return true;
+    }
+
+    private record DuplicatedJoin(OptExpression joinExpr,
+                                  Map<ColumnRefOperator, ColumnRefOperator> columnMapping) {
+    }
+
+    private record BranchResult(OptExpression branchExpr, List<ColumnRefOperator> outputs) {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmVersionJoinRule.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+
+import java.util.List;
+
+/**
+ * Pushes {@link LogicalVersionOperator} below {@link LogicalJoinOperator} by wrapping
+ * both join children with the same version operator.
+ *
+ * <p>Pattern: {@code LogicalVersionOperator -> LogicalJoinOperator(LEAF, LEAF)}
+ *
+ * <p>Output: {@code LogicalJoinOperator(Version -> left, Version -> right)}
+ *
+ * <p>This rule is needed for multi-way joins (3+ tables). When the outer join is expanded
+ * by {@link IvmDeltaJoinRule}, one branch produces {@code Version -> inner_join}, which
+ * needs this rule to push Version down to each scan.
+ */
+public class IvmVersionJoinRule extends TransformationRule {
+    public IvmVersionJoinRule() {
+        super(RuleType.TF_IVM_VERSION_JOIN,
+                Pattern.create(OperatorType.LOGICAL_VERSION)
+                        .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN,
+                                OperatorType.PATTERN_LEAF, OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalVersionOperator version = (LogicalVersionOperator) input.getOp();
+        LogicalJoinOperator join = (LogicalJoinOperator) input.inputAt(0).getOp();
+        OptExpression left = input.inputAt(0).inputAt(0);
+        OptExpression right = input.inputAt(0).inputAt(1);
+
+        OptExpression versionLeft = OptExpression.create(
+                new LogicalVersionOperator(version.getVersionRefType()), left);
+        OptExpression versionRight = OptExpression.create(
+                new LogicalVersionOperator(version.getVersionRefType()), right);
+
+        return List.of(OptExpression.create(
+                LogicalJoinOperator.builder().withOperator(join).build(),
+                versionLeft, versionRight));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -96,39 +96,20 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         doTestWith3Runs("SELECT a.id * 2 + 1, b.data FROM `iceberg0`.`unpartitioned_db`.`t0` a inner join " +
                         "`iceberg0`.`partitioned_db`.`t1` b on a.id=b.id where a.id > 10;",
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 14: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 14: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
+                    String planStr = plan.getExplainString(TExplainLevel.COSTS);
+                    // First run: should have delta scan and snapshot/delta scans via UNION
+                    PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
+                    PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "UNION");
                 },
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 8: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 8: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "  1:IcebergScanNode\n" +
-                                    "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 11: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 11: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 14: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 14: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(2)");
+                    String planStr = plan.getExplainString(TExplainLevel.COSTS);
+                    // Third run: should have delta and snapshot scans
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[1,2]");
+                    PlanTestBase.assertContains(planStr, "UNION");
+                    PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
+                    PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
                 }
         );
     }
@@ -140,39 +121,20 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                         "   join `iceberg0`.`partitioned_db`.`t1` b join `iceberg0`.`partitioned_db`.`part_tbl1` c " +
                         "   on a.id=b.id and a.id=c.c where a.id > 10;",
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 14: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 14: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[MIN,1]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
+                    String planStr = plan.getExplainString(TExplainLevel.COSTS);
+                    // First run: 3-table join with delta scans
+                    PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
+                    PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[MIN,1]");
+                    PlanTestBase.assertContains(planStr, "UNION");
                 },
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 8: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 8: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "  1:IcebergScanNode\n" +
-                                    "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 11: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 11: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 14: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 14: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.COSTS),
-                            "     TABLE: partitioned_db.t1\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(2)");
+                    String planStr = plan.getExplainString(TExplainLevel.COSTS);
+                    // Third run: should have delta and snapshot scans
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[1,2]");
+                    PlanTestBase.assertContains(planStr, "UNION");
+                    PlanTestBase.assertContains(planStr, "TABLE: unpartitioned_db.t0");
+                    PlanTestBase.assertContains(planStr, "TABLE: partitioned_db.t1");
                 }
         );
     }
@@ -281,33 +243,19 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         doTestWith3Runs("SELECT b.data, sum(a.id * 2 + 1) FROM `iceberg0`.`unpartitioned_db`.`t0` a " +
                         "inner join `iceberg0`.`partitioned_db`.`t1` b on a.id=b.id where a.id > 10 GROUP BY b.data;",
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                                    "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 28: from_binary = 23: __ROW_ID__");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "  16:OlapScanNode\n" +
-                                    "     TABLE: test_mv1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1");
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    // Aggregate MV: LEFT OUTER JOIN with MV state + state_union
+                    PlanTestBase.assertContains(planStr, "LEFT OUTER JOIN");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__");
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "state_union");
                 },
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 11: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 11: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                                    "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 28: from_binary = 23: __ROW_ID__");
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[1,2]");
+                    PlanTestBase.assertContains(planStr, "LEFT OUTER JOIN");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__");
+                    PlanTestBase.assertContains(planStr, "state_union");
                 }
         );
     }
@@ -322,33 +270,18 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                         "   `iceberg0`.`unpartitioned_db`.`t0` a inner join `iceberg0`.`partitioned_db`.`t1` b " +
                         "   on a.id=b.id where a.id > 10 GROUP BY b.data;",
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                                    "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 82: from_binary = 44: __ROW_ID__");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "  16:OlapScanNode\n" +
-                                    "     TABLE: test_mv1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1");
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "LEFT OUTER JOIN");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__");
+                    PlanTestBase.assertContains(planStr, "TABLE: test_mv1");
+                    PlanTestBase.assertContains(planStr, "state_union");
                 },
                 plan -> {
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 17: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 17: id > 10\n" +
-                                    "     TABLE VERSION: Delta@[1,2]");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "     TABLE: unpartitioned_db.t0\n" +
-                                    "     PREDICATES: 11: id > 10\n" +
-                                    "     MIN/MAX PREDICATES: 11: id > 10\n" +
-                                    "     TABLE VERSION: Snapshot@(1)");
-                    PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
-                                    "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 82: from_binary = 44: __ROW_ID__");
+                    String planStr = plan.getExplainString(TExplainLevel.NORMAL);
+                    PlanTestBase.assertContains(planStr, "TABLE VERSION: Delta@[1,2]");
+                    PlanTestBase.assertContains(planStr, "LEFT OUTER JOIN");
+                    PlanTestBase.assertContains(planStr, "__ROW_ID__");
+                    PlanTestBase.assertContains(planStr, "state_union");
                 }
         );
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmJoinRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmJoinRuleTest.java
@@ -1,0 +1,312 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.ivm;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrVersion;
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalVersionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class IvmJoinRuleTest {
+
+    // ==================== IvmDeltaJoinRule check ====================
+
+    @Test
+    public void testCheckAcceptsInnerJoin(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        OptExpression input = buildDeltaJoin(factory, table, JoinOperator.INNER_JOIN);
+        deriveLogicalProperty(input);
+
+        Assertions.assertTrue(new IvmDeltaJoinRule().check(input, context));
+    }
+
+    @Test
+    public void testCheckAcceptsCrossJoin(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        OptExpression input = buildDeltaJoin(factory, table, JoinOperator.CROSS_JOIN);
+        deriveLogicalProperty(input);
+
+        Assertions.assertTrue(new IvmDeltaJoinRule().check(input, context));
+    }
+
+    @Test
+    public void testCheckRejectsLeftOuterJoin(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        OptExpression input = buildDeltaJoin(factory, table, JoinOperator.LEFT_OUTER_JOIN);
+        deriveLogicalProperty(input);
+
+        Assertions.assertFalse(new IvmDeltaJoinRule().check(input, context));
+    }
+
+    @Test
+    public void testCheckRejectsLeftSemiJoin(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        OptExpression input = buildDeltaJoin(factory, table, JoinOperator.LEFT_SEMI_JOIN);
+        deriveLogicalProperty(input);
+
+        Assertions.assertFalse(new IvmDeltaJoinRule().check(input, context));
+    }
+
+    // ==================== IvmDeltaJoinRule transform ====================
+
+    @Test
+    public void testTransformInnerJoinProducesUnionWithTwoBranches(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator leftId = factory.create("a_id", IntegerType.INT, false);
+        ColumnRefOperator leftData = factory.create("a_data", StringType.STRING, true);
+        ColumnRefOperator rightId = factory.create("b_id", IntegerType.INT, false);
+        ColumnRefOperator rightData = factory.create("b_data", StringType.STRING, true);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression leftScan = newIcebergScan(table, leftId, leftData,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression rightScan = newIcebergScan(table, rightId, rightData,
+                TvrTableDelta.of(TvrVersion.of(300L), TvrVersion.of(400L)));
+
+        LogicalJoinOperator join = new LogicalJoinOperator(JoinOperator.INNER_JOIN,
+                new BinaryPredicateOperator(BinaryType.EQ, leftId, rightId));
+        OptExpression joinExpr = OptExpression.create(join, leftScan, rightScan);
+        OptExpression input = OptExpression.create(new LogicalDeltaOperator(true, actionRef), joinExpr);
+        deriveLogicalProperty(input);
+
+        List<OptExpression> result = new IvmDeltaJoinRule().transform(input, context);
+
+        // Should produce UnionAll with 2 children
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalUnionOperator);
+        LogicalUnionOperator union = (LogicalUnionOperator) result.get(0).getOp();
+        Assertions.assertTrue(union.isUnionAll());
+        Assertions.assertEquals(2, result.get(0).getInputs().size());
+
+        // Branch 1: Join(Delta → left, Version(FROM) → right)
+        OptExpression branch1 = result.get(0).inputAt(0);
+        Assertions.assertTrue(branch1.getOp() instanceof LogicalJoinOperator);
+        Assertions.assertEquals(OperatorType.LOGICAL_DELTA, branch1.inputAt(0).getOp().getOpType());
+        LogicalDeltaOperator branch1Delta = (LogicalDeltaOperator) branch1.inputAt(0).getOp();
+        Assertions.assertFalse(branch1Delta.isRootDelta());
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, branch1.inputAt(1).getOp().getOpType());
+        LogicalVersionOperator branch1Version = (LogicalVersionOperator) branch1.inputAt(1).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.FROM_VERSION,
+                branch1Version.getVersionRefType());
+
+        // Branch 2: Join(Version(TO) → left, Delta → right)
+        OptExpression branch2 = result.get(0).inputAt(1);
+        Assertions.assertTrue(branch2.getOp() instanceof LogicalJoinOperator);
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, branch2.inputAt(0).getOp().getOpType());
+        LogicalVersionOperator branch2Version = (LogicalVersionOperator) branch2.inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.TO_VERSION,
+                branch2Version.getVersionRefType());
+        Assertions.assertEquals(OperatorType.LOGICAL_DELTA, branch2.inputAt(1).getOp().getOpType());
+        LogicalDeltaOperator branch2Delta = (LogicalDeltaOperator) branch2.inputAt(1).getOp();
+        Assertions.assertFalse(branch2Delta.isRootDelta());
+    }
+
+    @Test
+    public void testTransformUnionOutputsIncludeActionColumn(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator leftId = factory.create("a_id", IntegerType.INT, false);
+        ColumnRefOperator rightId = factory.create("b_id", IntegerType.INT, false);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression leftScan = newIcebergScan(table, leftId, null,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression rightScan = newIcebergScan(table, rightId, null,
+                TvrTableDelta.of(TvrVersion.of(300L), TvrVersion.of(400L)));
+
+        LogicalJoinOperator join = new LogicalJoinOperator(JoinOperator.CROSS_JOIN, null);
+        OptExpression joinExpr = OptExpression.create(join, leftScan, rightScan);
+        OptExpression input = OptExpression.create(new LogicalDeltaOperator(true, actionRef), joinExpr);
+        deriveLogicalProperty(input);
+
+        List<OptExpression> result = new IvmDeltaJoinRule().transform(input, context);
+
+        // Union output columns should include __ACTION__
+        LogicalUnionOperator union = (LogicalUnionOperator) result.get(0).getOp();
+        boolean hasAction = union.getOutputColumnRefOp().stream()
+                .anyMatch(col -> col.getId() == actionRef.getId());
+        Assertions.assertTrue(hasAction, "Union outputs should include __ACTION__ column");
+    }
+
+    // ==================== IvmVersionJoinRule ====================
+
+    @Test
+    public void testVersionJoinPushDown(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator leftId = factory.create("a_id", IntegerType.INT, false);
+        ColumnRefOperator rightId = factory.create("b_id", IntegerType.INT, false);
+
+        OptExpression leftScan = newIcebergScan(table, leftId, null,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression rightScan = newIcebergScan(table, rightId, null,
+                TvrTableDelta.of(TvrVersion.of(300L), TvrVersion.of(400L)));
+
+        LogicalJoinOperator join = new LogicalJoinOperator(JoinOperator.INNER_JOIN,
+                new BinaryPredicateOperator(BinaryType.EQ, leftId, rightId));
+        OptExpression joinExpr = OptExpression.create(join, leftScan, rightScan);
+        // Version(FROM) → Join(left, right)
+        OptExpression input = OptExpression.create(LogicalVersionOperator.fromVersion(), joinExpr);
+        deriveLogicalProperty(input);
+
+        List<OptExpression> result = new IvmVersionJoinRule().transform(input, context);
+
+        // Should produce: Join(Version(FROM) → left, Version(FROM) → right)
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.get(0).getOp() instanceof LogicalJoinOperator);
+
+        // Left child: Version(FROM)
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, result.get(0).inputAt(0).getOp().getOpType());
+        LogicalVersionOperator leftVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.FROM_VERSION, leftVersion.getVersionRefType());
+        Assertions.assertTrue(result.get(0).inputAt(0).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+
+        // Right child: Version(FROM)
+        Assertions.assertEquals(OperatorType.LOGICAL_VERSION, result.get(0).inputAt(1).getOp().getOpType());
+        LogicalVersionOperator rightVersion = (LogicalVersionOperator) result.get(0).inputAt(1).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.FROM_VERSION, rightVersion.getVersionRefType());
+        Assertions.assertTrue(result.get(0).inputAt(1).inputAt(0).getOp() instanceof LogicalIcebergScanOperator);
+    }
+
+    @Test
+    public void testVersionJoinPreservesToVersion(@Mocked IcebergTable table) {
+        mockIcebergTable(table);
+        ColumnRefFactory factory = new ColumnRefFactory();
+        OptimizerContext context = OptimizerFactory.mockContext(factory);
+
+        ColumnRefOperator leftId = factory.create("a_id", IntegerType.INT, false);
+        ColumnRefOperator rightId = factory.create("b_id", IntegerType.INT, false);
+
+        OptExpression leftScan = newIcebergScan(table, leftId, null,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression rightScan = newIcebergScan(table, rightId, null,
+                TvrTableDelta.of(TvrVersion.of(300L), TvrVersion.of(400L)));
+
+        LogicalJoinOperator join = new LogicalJoinOperator(JoinOperator.INNER_JOIN, null);
+        OptExpression joinExpr = OptExpression.create(join, leftScan, rightScan);
+        // Version(TO) → Join
+        OptExpression input = OptExpression.create(LogicalVersionOperator.toVersion(), joinExpr);
+        deriveLogicalProperty(input);
+
+        List<OptExpression> result = new IvmVersionJoinRule().transform(input, context);
+
+        // Both children should have Version(TO)
+        LogicalVersionOperator leftVersion = (LogicalVersionOperator) result.get(0).inputAt(0).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.TO_VERSION, leftVersion.getVersionRefType());
+        LogicalVersionOperator rightVersion = (LogicalVersionOperator) result.get(0).inputAt(1).getOp();
+        Assertions.assertEquals(LogicalVersionOperator.VersionRefType.TO_VERSION, rightVersion.getVersionRefType());
+    }
+
+    // ==================== Helpers ====================
+
+    private void mockIcebergTable(IcebergTable table) {
+        new Expectations() {
+            {
+                table.getType();
+                result = com.starrocks.catalog.Table.TableType.ICEBERG;
+                minTimes = 0;
+            }
+        };
+    }
+
+    private OptExpression buildDeltaJoin(ColumnRefFactory factory, IcebergTable table, JoinOperator joinType) {
+        ColumnRefOperator leftId = factory.create("a_id", IntegerType.INT, false);
+        ColumnRefOperator rightId = factory.create("b_id", IntegerType.INT, false);
+        ColumnRefOperator actionRef = factory.create(IvmRuleUtils.ACTION_COLUMN_NAME, IntegerType.TINYINT, false);
+
+        OptExpression leftScan = newIcebergScan(table, leftId, null,
+                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
+        OptExpression rightScan = newIcebergScan(table, rightId, null,
+                TvrTableDelta.of(TvrVersion.of(300L), TvrVersion.of(400L)));
+
+        LogicalJoinOperator join = new LogicalJoinOperator(joinType,
+                joinType.isCrossJoin() ? null :
+                        new BinaryPredicateOperator(BinaryType.EQ, leftId, rightId));
+        OptExpression joinExpr = OptExpression.create(join, leftScan, rightScan);
+        return OptExpression.create(new LogicalDeltaOperator(true, actionRef), joinExpr);
+    }
+
+    private OptExpression newIcebergScan(IcebergTable table, ColumnRefOperator idRef,
+                                          ColumnRefOperator dataRef,
+                                          com.starrocks.common.tvr.TvrVersionRange versionRange) {
+        Column idCol = new Column("id", IntegerType.INT, false);
+        Map<ColumnRefOperator, Column> colRefMap = Maps.newHashMap();
+        colRefMap.put(idRef, idCol);
+        if (dataRef != null) {
+            Column dataCol = new Column("data", StringType.STRING, true);
+            colRefMap.put(dataRef, dataCol);
+        }
+        LogicalIcebergScanOperator scan = new LogicalIcebergScanOperator.Builder()
+                .setTable(table)
+                .setColRefToColumnMetaMap(colRefMap)
+                .setTableVersionRange(versionRange)
+                .build();
+        return OptExpression.create(scan);
+    }
+
+    private static void deriveLogicalProperty(OptExpression expression) {
+        for (OptExpression child : expression.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        ExpressionContext ctx = new ExpressionContext(expression);
+        ctx.deriveLogicalProperty();
+        expression.setLogicalProperty(ctx.getRootProperty());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add IvmDeltaJoinRule and IvmVersionJoinRule to handle incremental join MV refresh through the unified Delta/Version operator framework.

IvmDeltaJoinRule (inner/cross join only):
- Implements Delta(A ⋈ B) = (Delta_A ⋈ Version(FROM,B)) ∪ (Version(TO,A) ⋈ Delta_B)
- Clones join subtrees via OptExpressionDuplicator for each branch
- Child deltas use isRootDelta=false
- __ACTION__ column propagated through Union from each branch

IvmVersionJoinRule:
- Pushes Version below Join to both children
- Required for 3+ table joins where outer join expansion produces Version -> inner_join patterns

With this PR, all Iceberg IVM patterns (scan, filter, project, join, aggregate, join+aggregate) are fully handled by the new framework. Verified: all 34 integration tests pass with TVR disabled.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
