### PR TITLE
[Enhancement] Allow HDFS HA configuration passthrough in Catalog and BE to support accessing multiple HDFS clusters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.HDFSFileStoreInfo;
+import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudCredential;
 import org.apache.hadoop.conf.Configuration;
@@ -65,7 +66,9 @@ public class HDFSCloudCredential implements CloudCredential {
     public void applyToConfiguration(Configuration configuration) {
         if (hadoopConfiguration != null) {
             for (Map.Entry<String, String> entry : hadoopConfiguration.entrySet()) {
-                configuration.set(entry.getKey(), entry.getValue());
+                if (!isReservedHadoopExtProperty(entry.getKey())) {
+                    configuration.set(entry.getKey(), entry.getValue());
+                }
             }
         }
     }
@@ -88,7 +91,11 @@ public class HDFSCloudCredential implements CloudCredential {
     @Override
     public void toThrift(Map<String, String> properties) {
         if (hadoopConfiguration != null) {
-            properties.putAll(hadoopConfiguration);
+            for (Map.Entry<String, String> entry : hadoopConfiguration.entrySet()) {
+                if (!isReservedHadoopExtProperty(entry.getKey())) {
+                    properties.put(entry.getKey(), entry.getValue());
+                }
+            }
         }
     }
 
@@ -118,5 +125,9 @@ public class HDFSCloudCredential implements CloudCredential {
         hdfsFileStoreInfo.putAllConfiguration(hadoopConfiguration);
         fileStore.setHdfsFsInfo(hdfsFileStoreInfo.build());
         return fileStore.build();
+    }
+
+    private boolean isReservedHadoopExtProperty(String key) {
+        return HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING.equals(key);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -63,6 +63,11 @@ public class HDFSCloudCredential implements CloudCredential {
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        if (hadoopConfiguration != null) {
+            for (Map.Entry<String, String> entry : hadoopConfiguration.entrySet()) {
+                configuration.set(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     @Override
@@ -82,6 +87,9 @@ public class HDFSCloudCredential implements CloudCredential {
 
     @Override
     public void toThrift(Map<String, String> properties) {
+        if (hadoopConfiguration != null) {
+            properties.putAll(hadoopConfiguration);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -14,8 +14,12 @@
 
 package com.starrocks.credential;
 
+import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.aws.AwsCloudCredential;
+import com.starrocks.credential.hdfs.HDFSCloudConfiguration;
+import com.starrocks.credential.hdfs.HDFSCloudConfigurationProvider;
+import com.starrocks.credential.hdfs.HDFSCloudCredential;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
@@ -28,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.HDFS_AUTHENTICATION;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.HDFS_USERNAME;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_ENDPOINT;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.ADLS_SAS_TOKEN;
 import static com.starrocks.credential.azure.AzureCloudConfigurationProvider.BLOB_ENDPOINT;
@@ -416,8 +422,8 @@ public class CloudConfigurationFactoryTest {
     public void testHDFSCloudConfiguration() {
         Map<String, String> map = new HashMap<String, String>() {
             {
-                put(CloudConfigurationConstants.HDFS_AUTHENTICATION, "simple");
-                put(CloudConfigurationConstants.HDFS_USERNAME, "XX");
+                put(HDFS_AUTHENTICATION, "simple");
+                put(HDFS_USERNAME, "XX");
                 put(CloudConfigurationConstants.HDFS_PASSWORD, "XX");
             }
         };
@@ -438,6 +444,112 @@ public class CloudConfigurationFactoryTest {
 
         cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map, true);
         Assertions.assertEquals(CloudType.HDFS, cc.getCloudType());
+    }
+
+    @Test
+    public void testHDFSInvalidAuthenticationValidate() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, "invalid_auth");
+
+        HDFSCloudConfigurationProvider provider = new HDFSCloudConfigurationProvider();
+        CloudConfiguration cloudConfiguration = provider.build(storageParams);
+        Assertions.assertNull(cloudConfiguration);
+    }
+
+    @Test
+    public void testHDFSApplyToConfiguration() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
+        storageParams.put("dfs.nameservices", "HDFS1002060");
+        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
+        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
+
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(storageParams);
+        Assertions.assertEquals(CloudType.HDFS, cloudConfiguration.getCloudType());
+        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
+
+        // Verify that applyToConfiguration can write the configuration into Hadoop Configuration
+        Configuration conf = new Configuration();
+        hdfsCloudConfiguration.applyToConfiguration(conf);
+        Assertions.assertEquals("HDFS1002060", conf.get("dfs.nameservices"));
+        Assertions.assertEquals("nn1,nn2", conf.get("dfs.ha.namenodes.HDFS1002060"));
+        Assertions.assertEquals("host1:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
+        Assertions.assertEquals("host2:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
+        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+                conf.get("dfs.client.failover.proxy.provider.HDFS1002060"));
+        Assertions.assertEquals("hdfs://HDFS1002060", conf.get("fs.defaultFS"));
+
+        Map<String, String> hadoopConf = hdfsCloudConfiguration.getHdfsCloudCredential().getHadoopConfiguration();
+        Assertions.assertEquals(6, hadoopConf.size());
+        Assertions.assertEquals("HDFS1002060", hadoopConf.get("dfs.nameservices"));
+    }
+
+    @Test
+    public void testHDFSToThrift() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
+        storageParams.put(HDFS_USERNAME, "username");
+        storageParams.put("dfs.nameservices", "HDFS1002060");
+        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
+        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
+
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(storageParams);
+        Assertions.assertEquals(CloudType.HDFS, cloudConfiguration.getCloudType());
+        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
+        HDFSCloudCredential credential = hdfsCloudConfiguration.getHdfsCloudCredential();
+
+        // Verify that toThrift can write the HA configuration into the properties map
+        Map<String, String> thriftProperties = new HashMap<>();
+        credential.toThrift(thriftProperties);
+        Assertions.assertEquals("HDFS1002060", thriftProperties.get("dfs.nameservices"));
+        Assertions.assertEquals("nn1,nn2", thriftProperties.get("dfs.ha.namenodes.HDFS1002060"));
+        Assertions.assertEquals("host1:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
+        Assertions.assertEquals("host2:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
+        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+                thriftProperties.get("dfs.client.failover.proxy.provider.HDFS1002060"));
+        Assertions.assertEquals("hdfs://HDFS1002060", thriftProperties.get("fs.defaultFS"));
+        // Verify that known keys such as HDFS_AUTHENTICATION are removed by preprocessProperties and not present in hadoopConfiguration
+        Assertions.assertNull(thriftProperties.get(HDFS_AUTHENTICATION));
+        Assertions.assertNull(thriftProperties.get(HDFS_USERNAME));
+    }
+
+    @Test
+    public void testHDFSToThriftDoesNotOverrideReservedHadoopExtKeys() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
+        storageParams.put(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING, "evil-cache-key");
+        storageParams.put("dfs.nameservices", "HDFS1002060");
+
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(storageParams);
+        Assertions.assertEquals(CloudType.HDFS, cloudConfiguration.getCloudType());
+        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
+        HDFSCloudCredential credential = hdfsCloudConfiguration.getHdfsCloudCredential();
+
+        Map<String, String> hadoopConf = credential.getHadoopConfiguration();
+        Assertions.assertEquals("evil-cache-key", hadoopConf.get(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING));
+
+        Map<String, String> credOnly = new HashMap<>();
+        credential.toThrift(credOnly);
+        Assertions.assertFalse(credOnly.containsKey(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING));
+        Assertions.assertEquals("HDFS1002060", credOnly.get("dfs.nameservices"));
+
+        TCloudConfiguration tc = new TCloudConfiguration();
+        hdfsCloudConfiguration.toThrift(tc);
+        Map<String, String> cloudProps = tc.getCloud_properties();
+
+        Assertions.assertEquals(hdfsCloudConfiguration.toConfString(),
+                cloudProps.get(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING));
+
+        Assertions.assertTrue(cloudProps.containsKey(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING));
+        Assertions.assertEquals("HDFS1002060", cloudProps.get("dfs.nameservices"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -35,6 +35,7 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.credential.aws.AwsCloudConfiguration;
 import com.starrocks.credential.hdfs.HDFSCloudConfiguration;
+import com.starrocks.credential.hdfs.HDFSCloudConfigurationProvider;
 import com.starrocks.credential.hdfs.HDFSCloudCredential;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -330,6 +331,86 @@ public class StorageVolumeTest {
         FileStoreInfo fileStore = cloudConfiguration.toFileStoreInfo();
         Assertions.assertEquals(FileStoreType.HDFS, fileStore.getFsType());
         Assertions.assertTrue(fileStore.hasHdfsFsInfo());
+    }
+
+    @Test
+    public void testHDFSInvalidAuthenticationValidate() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, "invalid_auth");
+
+        HDFSCloudConfigurationProvider provider = new HDFSCloudConfigurationProvider();
+        CloudConfiguration cloudConfiguration = provider.build(storageParams);
+        Assertions.assertNull(cloudConfiguration);
+    }
+
+    @Test
+    public void testHDFSApplyToConfiguration() throws DdlException {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
+        storageParams.put("dfs.nameservices", "HDFS1002060");
+        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
+        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
+
+
+        StorageVolume sv = new StorageVolume("1", "test", "hdfs", Arrays.asList("hdfs://abc"),
+                storageParams, true, "");
+        CloudConfiguration cloudConfiguration = sv.getCloudConfiguration();
+        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
+
+        // Verify that applyToConfiguration can write the configuration into Hadoop Configuration
+        Configuration conf = new Configuration();
+        hdfsCloudConfiguration.applyToConfiguration(conf);
+        Assertions.assertEquals("HDFS1002060", conf.get("dfs.nameservices"));
+        Assertions.assertEquals("nn1,nn2", conf.get("dfs.ha.namenodes.HDFS1002060"));
+        Assertions.assertEquals("host1:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
+        Assertions.assertEquals("host2:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
+        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+                conf.get("dfs.client.failover.proxy.provider.HDFS1002060"));
+        Assertions.assertEquals("hdfs://HDFS1002060", conf.get("fs.defaultFS"));
+
+        Map<String, String> hadoopConf = hdfsCloudConfiguration.getHdfsCloudCredential().getHadoopConfiguration();
+        Assertions.assertEquals(6, hadoopConf.size());
+        Assertions.assertEquals("HDFS1002060", hadoopConf.get("dfs.nameservices"));
+    }
+
+
+    @Test
+    public void testHDFSToThrift() throws DdlException {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
+        storageParams.put(HDFS_USERNAME, "username");
+        storageParams.put("dfs.nameservices", "HDFS1002060");
+        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
+        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
+        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
+
+
+        StorageVolume sv = new StorageVolume("1", "test", "hdfs", Arrays.asList("hdfs://abc"),
+                storageParams, true, "");
+        CloudConfiguration cloudConfiguration = sv.getCloudConfiguration();
+        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
+        HDFSCloudCredential credential = hdfsCloudConfiguration.getHdfsCloudCredential();
+
+        // Verify that toThrift can write the HA configuration into the properties map
+        Map<String, String> thriftProperties = new HashMap<>();
+        credential.toThrift(thriftProperties);
+        Assertions.assertEquals("HDFS1002060", thriftProperties.get("dfs.nameservices"));
+        Assertions.assertEquals("nn1,nn2", thriftProperties.get("dfs.ha.namenodes.HDFS1002060"));
+        Assertions.assertEquals("host1:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
+        Assertions.assertEquals("host2:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
+        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+                thriftProperties.get("dfs.client.failover.proxy.provider.HDFS1002060"));
+        Assertions.assertEquals("hdfs://HDFS1002060", thriftProperties.get("fs.defaultFS"));
+        // Verify that known keys such as HDFS_AUTHENTICATION are removed by preprocessProperties and not present in hadoopConfiguration
+        Assertions.assertNull(thriftProperties.get(HDFS_AUTHENTICATION));
+        Assertions.assertNull(thriftProperties.get(HDFS_USERNAME));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -35,7 +35,6 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.credential.aws.AwsCloudConfiguration;
 import com.starrocks.credential.hdfs.HDFSCloudConfiguration;
-import com.starrocks.credential.hdfs.HDFSCloudConfigurationProvider;
 import com.starrocks.credential.hdfs.HDFSCloudCredential;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -331,86 +330,6 @@ public class StorageVolumeTest {
         FileStoreInfo fileStore = cloudConfiguration.toFileStoreInfo();
         Assertions.assertEquals(FileStoreType.HDFS, fileStore.getFsType());
         Assertions.assertTrue(fileStore.hasHdfsFsInfo());
-    }
-
-    @Test
-    public void testHDFSInvalidAuthenticationValidate() {
-        Map<String, String> storageParams = new HashMap<>();
-        storageParams.put(HDFS_AUTHENTICATION, "invalid_auth");
-
-        HDFSCloudConfigurationProvider provider = new HDFSCloudConfigurationProvider();
-        CloudConfiguration cloudConfiguration = provider.build(storageParams);
-        Assertions.assertNull(cloudConfiguration);
-    }
-
-    @Test
-    public void testHDFSApplyToConfiguration() throws DdlException {
-        Map<String, String> storageParams = new HashMap<>();
-        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
-        storageParams.put("dfs.nameservices", "HDFS1002060");
-        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
-        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
-        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
-        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
-                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
-        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
-
-
-        StorageVolume sv = new StorageVolume("1", "test", "hdfs", Arrays.asList("hdfs://abc"),
-                storageParams, true, "");
-        CloudConfiguration cloudConfiguration = sv.getCloudConfiguration();
-        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
-
-        // Verify that applyToConfiguration can write the configuration into Hadoop Configuration
-        Configuration conf = new Configuration();
-        hdfsCloudConfiguration.applyToConfiguration(conf);
-        Assertions.assertEquals("HDFS1002060", conf.get("dfs.nameservices"));
-        Assertions.assertEquals("nn1,nn2", conf.get("dfs.ha.namenodes.HDFS1002060"));
-        Assertions.assertEquals("host1:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
-        Assertions.assertEquals("host2:4007", conf.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
-        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
-                conf.get("dfs.client.failover.proxy.provider.HDFS1002060"));
-        Assertions.assertEquals("hdfs://HDFS1002060", conf.get("fs.defaultFS"));
-
-        Map<String, String> hadoopConf = hdfsCloudConfiguration.getHdfsCloudCredential().getHadoopConfiguration();
-        Assertions.assertEquals(6, hadoopConf.size());
-        Assertions.assertEquals("HDFS1002060", hadoopConf.get("dfs.nameservices"));
-    }
-
-
-    @Test
-    public void testHDFSToThrift() throws DdlException {
-        Map<String, String> storageParams = new HashMap<>();
-        storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
-        storageParams.put(HDFS_USERNAME, "username");
-        storageParams.put("dfs.nameservices", "HDFS1002060");
-        storageParams.put("dfs.ha.namenodes.HDFS1002060", "nn1,nn2");
-        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn1", "host1:4007");
-        storageParams.put("dfs.namenode.rpc-address.HDFS1002060.nn2", "host2:4007");
-        storageParams.put("dfs.client.failover.proxy.provider.HDFS1002060",
-                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
-        storageParams.put("fs.defaultFS", "hdfs://HDFS1002060");
-
-
-        StorageVolume sv = new StorageVolume("1", "test", "hdfs", Arrays.asList("hdfs://abc"),
-                storageParams, true, "");
-        CloudConfiguration cloudConfiguration = sv.getCloudConfiguration();
-        HDFSCloudConfiguration hdfsCloudConfiguration = (HDFSCloudConfiguration) cloudConfiguration;
-        HDFSCloudCredential credential = hdfsCloudConfiguration.getHdfsCloudCredential();
-
-        // Verify that toThrift can write the HA configuration into the properties map
-        Map<String, String> thriftProperties = new HashMap<>();
-        credential.toThrift(thriftProperties);
-        Assertions.assertEquals("HDFS1002060", thriftProperties.get("dfs.nameservices"));
-        Assertions.assertEquals("nn1,nn2", thriftProperties.get("dfs.ha.namenodes.HDFS1002060"));
-        Assertions.assertEquals("host1:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn1"));
-        Assertions.assertEquals("host2:4007", thriftProperties.get("dfs.namenode.rpc-address.HDFS1002060.nn2"));
-        Assertions.assertEquals("org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
-                thriftProperties.get("dfs.client.failover.proxy.provider.HDFS1002060"));
-        Assertions.assertEquals("hdfs://HDFS1002060", thriftProperties.get("fs.defaultFS"));
-        // Verify that known keys such as HDFS_AUTHENTICATION are removed by preprocessProperties and not present in hadoopConfiguration
-        Assertions.assertNull(thriftProperties.get(HDFS_AUTHENTICATION));
-        Assertions.assertNull(thriftProperties.get(HDFS_USERNAME));
     }
 
     @Test


### PR DESCRIPTION

## Why I'm doing:

Currently, we need to place core-site.xml and hdfs-site.xml under the conf directory to query Iceberg clusters. The paths stored in Iceberg metadata do not contain HA information (e.g., hdfs:/iceberg/warehouse/db/table/metadata/162635-94101c0e-0e83-43f4-8305-999e4622a634.metadata.json).

When the cluster is configured with HA, fs.defaultFS must be set in core-site.xml for the HA cluster to be queried properly. 
Or it will meet an error.

Error info
```
Caused by: java.io.IOException: Incomplete HDFS URI, no host: hdfs:/iceberg/warehouse/db/table/metadata/162635-94101c0e-0e83-43f4-8305-999e4622a634.metadata.json
```

However, if there are multiple HDFS clusters, each configured with HA, this approach becomes problematic — since core-site.xml can only have one fs.defaultFS, it cannot serve multiple HDFS clusters simultaneously.


## What I'm doing:

Pass HA configuration to the Catalog and BE , enabling HA information to be registered through SQL properties. This allows support for multiple Catalogs with multiple HA-enabled HDFS clusters.

```sql
CREATE EXTERNAL CATALOG iceberg
PROPERTIES (
    "type" = "iceberg",
    "iceberg.catalog.type" = "jdbc",
    "iceberg.catalog.uri" = "jdbc:mysql://ip:port/iceberg_jdbc",
    "iceberg.catalog.warehouse" = "hdfs://HDFS1002060/iceberg/warehouse",
    "iceberg.catalog.jdbc.user" = "username",
    "iceberg.catalog.jdbc.password" = "password",
    "dfs.nameservices" = "HDFS1002060",
    "dfs.ha.namenodes.HDFS1002060" = "nn1,nn2",
    "dfs.namenode.rpc-address.HDFS1002060.nn1" = "ip1:port",
    "dfs.namenode.rpc-address.HDFS1002060.nn2" = "ip2:port",
    "dfs.client.failover.proxy.provider.HDFS1002060" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
    "fs.defaultFS" = "hdfs://HDFS1002060",
    "hadoop.security.authentication" = "simple"
);
```


Fixes https://github.com/StarRocks/starrocks/issues/71526

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
