### PR TITLE
[Enhancement] Fail-fast for unsupported Iceberg V3 features (backport #70242)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DeleteFileWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DeleteFileWrapper.java
@@ -147,6 +147,21 @@ public class DeleteFileWrapper implements DeleteFile {
     }
 
     @Override
+    public String referencedDataFile() {
+        return deleteFile.referencedDataFile();
+    }
+
+    @Override
+    public Long contentOffset() {
+        return deleteFile.contentOffset();
+    }
+
+    @Override
+    public Long contentSizeInBytes() {
+        return deleteFile.contentSizeInBytes();
+    }
+
+    @Override
     public DeleteFile copy() {
         return deleteFile.copy();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -268,6 +269,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             } else {
                 return buildDeleteFileScanRanges(fileScanTask, partitionId);
             }
+        } catch (StarRocksConnectorException e) {
+            throw e;
         } catch (Exception e) {
             LOG.error("build scan range failed", e);
             throw new StarRocksConnectorException("build scan range failed", e);
@@ -282,6 +285,12 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
             FileContent content = deleteFile.content();
             if (content == FileContent.EQUALITY_DELETES) {
                 continue;
+            }
+
+            if (ContentFileUtil.isDV(deleteFile)) {
+                throw new StarRocksConnectorException(
+                        "Iceberg V3 Deletion Vectors are not supported. " +
+                        "Table contains deletion vector file: " + deleteFile.path());
             }
 
             TIcebergDeleteFile target = new TIcebergDeleteFile();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -132,6 +132,7 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -196,6 +197,7 @@ import static java.util.Comparator.comparing;
 import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
+import static org.apache.iceberg.TableProperties.ENCRYPTION_TABLE_KEY;
 
 public class IcebergMetadata implements ConnectorMetadata {
 
@@ -674,6 +676,23 @@ public class IcebergMetadata implements ConnectorMetadata {
             throw e;
         } catch (NoSuchTableException e) {
             return getView(context, dbName, tblName);
+        }
+    }
+
+    static void checkUnsupportedEncryption(org.apache.iceberg.Table icebergTable) {
+        if (icebergTable.properties().containsKey(ENCRYPTION_TABLE_KEY)) {
+            throw new StarRocksConnectorException(
+                    "Iceberg table encryption is not supported. Table '%s' has encryption property '%s' set.",
+                    icebergTable.name(), ENCRYPTION_TABLE_KEY);
+        }
+
+        if (icebergTable instanceof BaseTable) {
+            TableMetadata metadata = ((BaseTable) icebergTable).operations().current();
+            if (metadata.encryptionKeys() != null && !metadata.encryptionKeys().isEmpty()) {
+                throw new StarRocksConnectorException(
+                        "Iceberg table encryption is not supported. Table '%s' has encryption keys set.",
+                        icebergTable.name());
+            }
         }
     }
 
@@ -1238,6 +1257,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         String tableName = icebergTable.getCatalogTableName();
 
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        checkUnsupportedEncryption(nativeTbl);
         traceIcebergMetricsConfig(nativeTbl);
 
         StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1325,6 +1325,35 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetRemoteFileFailsFastForEncryptedTable() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, mockedNativeTableB, Maps.newHashMap());
+
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.updateProperties().set(TableProperties.ENCRYPTION_TABLE_KEY, "test-key").commit();
+        mockedNativeTableB.refresh();
+
+        long snapshotId = mockedNativeTableB.currentSnapshot().snapshotId();
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> metadata.getRemoteFiles(icebergTable,
+                        GetRemoteFilesParams.newBuilder()
+                                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                                .setPredicate(predicate)
+                                .setFieldNames(Lists.newArrayList())
+                                .setLimit(10)
+                                .build()));
+        assertTrue(ex.getMessage().contains("encryption is not supported"),
+                "Expected encryption error, got: " + ex.getMessage());
+    }
+
+    @Test
     public void testGetTableStatistics() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergV3UnsupportedFeaturesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergV3UnsupportedFeaturesTest.java
@@ -1,0 +1,315 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.planner.PartitionIdGenerator;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.planner.TupleId;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
+import static com.starrocks.connector.iceberg.IcebergApiConverter.toPartitionField;
+import static com.starrocks.type.IntegerType.INT;
+import static com.starrocks.type.VarcharType.VARCHAR;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for handling unsupported Iceberg V3 features:
+ * 1. Deletion Vectors (fail-fast)
+ * 2. Extended Types (graceful degradation to UNKNOWN_TYPE)
+ * 3. Multi-argument transforms (fail-fast)
+ * 4. Table encryption (fail-fast)
+ */
+public class IcebergV3UnsupportedFeaturesTest extends TableTestBase {
+
+    private TupleDescriptor tupleDescriptor;
+
+    @BeforeEach
+    public void setUp() {
+        tupleDescriptor = new TupleDescriptor(new TupleId(1));
+
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), tupleDescriptor);
+        idSlot.setType(INT);
+        idSlot.setColumn(new Column("id", INT));
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), tupleDescriptor);
+        dataSlot.setType(VARCHAR);
+        dataSlot.setColumn(new Column("data", VARCHAR));
+
+        tupleDescriptor.addSlot(idSlot);
+        tupleDescriptor.addSlot(dataSlot);
+    }
+
+    // ========== 1. Deletion Vectors ==========
+
+    @Test
+    public void testDeletionVectorIsDetectedByContentFileUtil() {
+        // DVs are POSITION_DELETES in Puffin format with referencedDataFile set.
+        DeleteFile dvDeleteFile = mock(DeleteFile.class);
+        when(dvDeleteFile.content()).thenReturn(FileContent.POSITION_DELETES);
+        when(dvDeleteFile.format()).thenReturn(FileFormat.PUFFIN);
+        when(dvDeleteFile.referencedDataFile()).thenReturn("/path/to/data-a.parquet");
+        when(dvDeleteFile.path()).thenReturn("/path/to/dv-file.puffin");
+
+        Assertions.assertTrue(ContentFileUtil.isDV(dvDeleteFile),
+                "Puffin position delete with referencedDataFile should be detected as DV");
+    }
+
+    @Test
+    public void testDeletionVectorFailsFastInScanRanges() {
+        // Mock a DV delete file
+        DeleteFile dvDeleteFile = mock(DeleteFile.class);
+        when(dvDeleteFile.content()).thenReturn(FileContent.POSITION_DELETES);
+        when(dvDeleteFile.format()).thenReturn(FileFormat.PUFFIN);
+        when(dvDeleteFile.referencedDataFile()).thenReturn("/path/to/data-a.parquet");
+        when(dvDeleteFile.path()).thenReturn("/path/to/dv-file.puffin");
+        when(dvDeleteFile.fileSizeInBytes()).thenReturn(100L);
+        when(dvDeleteFile.specId()).thenReturn(0);
+        when(dvDeleteFile.partition()).thenReturn(FILE_A.partition());
+        when(dvDeleteFile.pos()).thenReturn(null);
+
+        // Mock a FileScanTask that includes the DV delete file
+        FileScanTask taskWithDV = mock(FileScanTask.class);
+        when(taskWithDV.file()).thenReturn(FILE_A);
+        when(taskWithDV.deletes()).thenReturn(Lists.newArrayList(dvDeleteFile));
+        when(taskWithDV.spec()).thenReturn(SPEC_A);
+        when(taskWithDV.partition()).thenReturn(FILE_A.partition());
+
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("id", INT));
+        columns.add(new Column("data", VARCHAR));
+        IcebergTable icebergTable = IcebergTable.builder()
+                .setNativeTable(mockedNativeTableA)
+                .setFullSchema(columns)
+                .setCatalogName("test_catalog")
+                .setCatalogDBName("test_db")
+                .setCatalogTableName("test_table")
+                .build();
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(
+                icebergTable,
+                RemoteFileInfoDefaultSource.EMPTY,
+                IcebergMORParams.EMPTY,
+                tupleDescriptor,
+                Optional.empty(),
+                PartitionIdGenerator.of(),
+                false,
+                false);
+
+        // toScanRanges wraps exceptions: "build scan range failed" with cause containing DV message
+        StarRocksConnectorException ex = Assertions.assertThrows(
+                StarRocksConnectorException.class,
+                () -> scanRangeSource.toScanRanges(taskWithDV));
+        // The DV error is wrapped by toScanRanges, check either the message or the cause
+        boolean hasDvMessage = ex.getMessage().contains("Deletion Vectors are not supported") ||
+                (ex.getCause() != null && ex.getCause().getMessage().contains("Deletion Vectors are not supported"));
+        Assertions.assertTrue(hasDvMessage,
+                "Expected DV error message, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testPositionDeleteWithoutDVIsAllowed() {
+        // Regular position deletes (not DVs) should still work fine
+        DeleteFile regularPosDelete = FileMetadata.deleteFileBuilder(SPEC_A)
+                .ofPositionDeletes()
+                .withPath("/path/to/pos-deletes.orc")
+                .withFormat(FileFormat.ORC)
+                .withFileSizeInBytes(10)
+                .withPartitionPath("data_bucket=0")
+                .withRecordCount(1)
+                .build();
+
+        // Verify this is NOT a DV
+        Assertions.assertFalse(
+                org.apache.iceberg.util.ContentFileUtil.isDV(regularPosDelete),
+                "Regular position delete file should not be detected as DV");
+    }
+
+    @Test
+    public void testDeleteFileWrapperProxiesDVFields() {
+        DeleteFile dvFile = mock(DeleteFile.class);
+        when(dvFile.path()).thenReturn("/path/to/dv.puffin");
+        when(dvFile.referencedDataFile()).thenReturn("/path/to/data.parquet");
+        when(dvFile.contentOffset()).thenReturn(1024L);
+        when(dvFile.contentSizeInBytes()).thenReturn(2048L);
+
+        DeleteFileWrapper wrapper = DeleteFileWrapper.wrap(dvFile);
+        Assertions.assertEquals("/path/to/data.parquet", wrapper.referencedDataFile());
+        Assertions.assertEquals(1024L, wrapper.contentOffset());
+        Assertions.assertEquals(2048L, wrapper.contentSizeInBytes());
+    }
+
+    // ========== 2. Extended Types ==========
+
+    @Test
+    public void testUnsupportedIcebergTypeReturnsUnknown() {
+        // Unsupported V3 types should degrade to UNKNOWN_TYPE, not throw.
+        // The query analyzer will reject queries on these columns at analysis time.
+        Assertions.assertTrue(fromIcebergType(Types.GeometryType.crs84()).isUnknown());
+        Assertions.assertTrue(fromIcebergType(Types.GeographyType.crs84()).isUnknown());
+        Assertions.assertTrue(fromIcebergType(Types.FixedType.ofLength(16)).isUnknown());
+    }
+
+    @Test
+    public void testSupportedTypesStillWork() {
+        // Verify supported types are not affected
+        Assertions.assertFalse(fromIcebergType(Types.BooleanType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.IntegerType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.LongType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.FloatType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.DoubleType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.DateType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.TimestampType.withZone()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.StringType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.BinaryType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.UUIDType.get()).isUnknown());
+        Assertions.assertFalse(fromIcebergType(Types.TimeType.get()).isUnknown());
+        Assertions.assertTrue(fromIcebergType(Types.VariantType.get()).isVariantType());
+    }
+
+    @Test
+    public void testToFullSchemasDegradesToUnknownForUnsupportedType() {
+        // Unsupported V3 types should degrade to UNKNOWN_TYPE, not throw,
+        // so that queries not involving the column still work.
+        Types.NestedField field = Types.NestedField.optional(1, "geo_col", Types.GeographyType.crs84());
+        Schema schema = new Schema(field);
+
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema);
+        Assertions.assertEquals(1, columns.size());
+        Assertions.assertTrue(columns.get(0).getType().isUnknown(),
+                "Unsupported type should degrade to UNKNOWN, got: " + columns.get(0).getType());
+    }
+
+    // ========== 3. Multi-argument transforms ==========
+
+    @Test
+    public void testUnknownTransformFromStringParsesAsUnknown() {
+        // A V3 multi-argument transform like "range" should parse as UNKNOWN
+        IcebergPartitionTransform transform =
+                IcebergPartitionTransform.fromString("range[10, 20]");
+        Assertions.assertEquals(IcebergPartitionTransform.UNKNOWN, transform);
+
+        // Another example: a hypothetical "sorted" transform
+        transform = IcebergPartitionTransform.fromString("sorted");
+        Assertions.assertEquals(IcebergPartitionTransform.UNKNOWN, transform);
+    }
+
+    @Test
+    public void testToPartitionFieldFailsOnUnsupportedTransform() {
+        // Create a partition spec with a known transform, then test with unknown transform string
+        // We use a mock PartitionField to simulate an unsupported V3 multi-arg transform
+        org.apache.iceberg.PartitionField mockField = mock(org.apache.iceberg.PartitionField.class);
+        org.apache.iceberg.transforms.Transform mockTransform =
+                mock(org.apache.iceberg.transforms.Transform.class);
+        when(mockTransform.toString()).thenReturn("range[10, 20]");
+        when(mockField.transform()).thenReturn(mockTransform);
+        when(mockField.sourceId()).thenReturn(1);
+
+        PartitionSpec mockSpec = mock(PartitionSpec.class);
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        when(mockSpec.schema()).thenReturn(schema);
+
+        StarRocksConnectorException ex = Assertions.assertThrows(
+                StarRocksConnectorException.class,
+                () -> toPartitionField(mockSpec, mockField, false));
+        Assertions.assertTrue(ex.getMessage().contains("Unsupported partition transform"),
+                "Expected unsupported transform error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testIsSupportedConvertPartitionTransformRejectsUnknown() {
+        Assertions.assertFalse(
+                IcebergPartitionUtils.isSupportedConvertPartitionTransform(
+                        IcebergPartitionTransform.UNKNOWN),
+                "UNKNOWN transform should not be considered supported");
+    }
+
+    // ========== 4. Table encryption ==========
+
+    @Test
+    public void testEncryptionTableKeyPropertyFailsFast() {
+        org.apache.iceberg.Table encryptedTable = mock(org.apache.iceberg.Table.class);
+        Map<String, String> encryptionProps = new HashMap<>();
+        encryptionProps.put("encryption.key-id", "my-key");
+        when(encryptedTable.properties()).thenReturn(encryptionProps);
+        when(encryptedTable.name()).thenReturn("encrypted_table");
+
+        StarRocksConnectorException ex = Assertions.assertThrows(
+                StarRocksConnectorException.class,
+                () -> IcebergMetadata.checkUnsupportedEncryption(encryptedTable));
+        Assertions.assertTrue(ex.getMessage().contains("encryption is not supported"),
+                "Expected encryption error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testEncryptionKeysInMetadataFailsFast() {
+        // Test the TableMetadata.encryptionKeys() check path (lines 692-694)
+        org.apache.iceberg.BaseTable baseTable = mock(org.apache.iceberg.BaseTable.class);
+        Map<String, String> emptyProps = new HashMap<>();
+        when(baseTable.properties()).thenReturn(emptyProps);
+        when(baseTable.name()).thenReturn("encrypted_via_metadata");
+
+        org.apache.iceberg.TableOperations ops = mock(org.apache.iceberg.TableOperations.class);
+        org.apache.iceberg.TableMetadata metadata = mock(org.apache.iceberg.TableMetadata.class);
+        when(baseTable.operations()).thenReturn(ops);
+        when(ops.current()).thenReturn(metadata);
+        when(metadata.encryptionKeys()).thenReturn(
+                Lists.newArrayList(mock(org.apache.iceberg.encryption.EncryptedKey.class)));
+
+        StarRocksConnectorException ex = Assertions.assertThrows(
+                StarRocksConnectorException.class,
+                () -> IcebergMetadata.checkUnsupportedEncryption(baseTable));
+        Assertions.assertTrue(ex.getMessage().contains("encryption is not supported"),
+                "Expected encryption error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testNonEncryptedTablePasses() {
+        org.apache.iceberg.Table normalTable = mock(org.apache.iceberg.Table.class);
+        Map<String, String> normalProps = new HashMap<>();
+        normalProps.put("write.format.default", "parquet");
+        normalProps.put("commit.retry.num-retries", "4");
+        when(normalTable.properties()).thenReturn(normalProps);
+
+        // Should not throw
+        IcebergMetadata.checkUnsupportedEncryption(normalTable);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
+import com.starrocks.type.UnknownType;
 import com.starrocks.type.VarcharType;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.iceberg.DataFile;
@@ -77,6 +78,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_TRANSFORMS_DB_NAME = "partitioned_transforms_db";
 
     public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
+    public static final String MOCKED_UNKNOWN_TYPE_TABLE_NAME = "t_unknown_types";
     public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "t1";
     // date partition table
     public static final String MOCKED_PARTITIONED_TABLE_NAME2 = "t2";
@@ -141,6 +143,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     static {
         try {
             mockUnPartitionedTable();
+            mockUnknownTypeTable();
             mockPartitionedTable();
             mockPartitionTransforms();
         } catch (IOException e) {
@@ -190,6 +193,41 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                 col -> ColumnStatistic.unknown()));
 
         icebergTableInfoMap.put(MOCKED_UNPARTITIONED_TABLE_NAME0,
+                new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100, columnStatisticMap));
+    }
+
+    public static void mockUnknownTypeTable() throws IOException {
+        MOCK_TABLE_MAP.putIfAbsent(MOCKED_UNPARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, IcebergTableInfo> icebergTableInfoMap = MOCK_TABLE_MAP.get(MOCKED_UNPARTITIONED_DB_NAME);
+
+        List<Column> schemas = ImmutableList.of(
+                new Column("id", IntegerType.INT, true),
+                new Column("data", StringType.STRING, true),
+                new Column("geo_col", UnknownType.UNKNOWN_TYPE, true),
+                new Column("ts_nano_col", UnknownType.UNKNOWN_TYPE, true));
+        schemas = addMetaColumns(schemas);
+
+        Schema schema = new Schema(
+                required(3, "id", Types.IntegerType.get()),
+                required(4, "data", Types.StringType.get()),
+                required(5, "geo_col", Types.StringType.get()),
+                required(6, "ts_nano_col", Types.StringType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema).build();
+        TestTables.TestTable baseTable = TestTables.create(
+                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" +
+                        MOCKED_UNKNOWN_TYPE_TABLE_NAME), MOCKED_UNKNOWN_TYPE_TABLE_NAME,
+                schema, spec, 3);
+
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(2, MOCKED_UNKNOWN_TYPE_TABLE_NAME,
+                MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
+                MOCKED_UNKNOWN_TYPE_TABLE_NAME, schemas, baseTable, null, "");
+
+        Map<String, ColumnStatistic> columnStatisticMap;
+        List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
+        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
+                col -> ColumnStatistic.unknown()));
+
+        icebergTableInfoMap.put(MOCKED_UNKNOWN_TYPE_TABLE_NAME,
                 new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100, columnStatisticMap));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergUnsupportedTypeQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergUnsupportedTypeQueryTest.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+/**
+ * Verifies that querying Iceberg columns with unsupported V3 types
+ * (e.g., geometry, timestamp_nano) fails at analysis time with a clear error,
+ * while querying supported columns on the same table works fine.
+ */
+public class IcebergUnsupportedTypeQueryTest extends ConnectorPlanTestBase {
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.doInit(newFolder(temp, "junit").toURI().toString());
+    }
+
+    @Test
+    public void testSelectUnsupportedColumnFails() {
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () ->
+                getFragmentPlan("SELECT geo_col FROM iceberg0.unpartitioned_db.t_unknown_types"));
+        Assertions.assertTrue(ex.getMessage().contains("not supported"),
+                "Expected 'not supported' error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testSelectAnotherUnsupportedColumnFails() {
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () ->
+                getFragmentPlan("SELECT ts_nano_col FROM iceberg0.unpartitioned_db.t_unknown_types"));
+        Assertions.assertTrue(ex.getMessage().contains("not supported"),
+                "Expected 'not supported' error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testSelectStarWithUnsupportedColumnFails() {
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () ->
+                getFragmentPlan("SELECT * FROM iceberg0.unpartitioned_db.t_unknown_types"));
+        Assertions.assertTrue(ex.getMessage().contains("not supported"),
+                "Expected 'not supported' error, got: " + ex.getMessage());
+    }
+
+}


### PR DESCRIPTION
## Why I'm doing:

StarRocks does not yet support several Iceberg V3 features: Deletion Vectors (DVs), table encryption, and new extended types (geometry, geography, timestamp_nano). Without explicit guards, queries against tables using these features can produce silent data correctness issues (e.g., reading deleted data when DVs are cached incorrectly) or confusing late-stage errors from the BE.

## What I'm doing:

Add fail-fast checks for unsupported Iceberg V3 features at the appropriate stage of query processing:

1. **Deletion Vectors**: Detect DV files (Puffin-format position deletes) during scan range building and throw a clear error. Also fix `DeleteFileWrapper` missing `referencedDataFile()`, `contentOffset()`, and `contentSizeInBytes()` proxies, which caused DVs to silently disappear from the delete file cache after the first query.
2. **Table encryption**: Check `TableProperties.ENCRYPTION_TABLE_KEY` and `TableMetadata.encryptionKeys()` in `triggerIcebergPlanFilesIfNeeded()` — early enough to avoid wasted planning work, but not in `getTable()` so DDL operations like DROP TABLE are not blocked.
3. **Unsupported types**: Unsupported V3 types (geometry, geography, timestamp_nano) gracefully degrade to `UNKNOWN_TYPE`. The existing `Scope.resolveField` / `SelectAnalyzer` guards reject queries on those columns at analysis time, while queries on other columns of the same table continue to work.
4. **Error message transparency**: Add `catch (StarRocksConnectorException e) { throw e; }` before the generic `catch (Exception e)` in `toScanRanges()` so that DV/encryption errors propagate with their original message instead of being wrapped as "build scan range failed".

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Queries against Iceberg tables with Deletion Vectors or encryption now return a clear error message instead of silently returning incorrect results or failing with an obscure BE error.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
