### PR TITLE
[BugFix] Validate Iceberg incremental snapshot lineage before IVM planning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -767,12 +767,20 @@ public class IcebergMetadata implements ConnectorMetadata {
             return Collections.emptyList();
         }
         // fromSnapshotExclusive can be empty, but toSnapshotInclusive must have a valid snapshot ID
-        final long fromSnapshotIdExclusive = fromSnapshotExclusive.getSnapshotId();
+        final Long fromSnapshotIdExclusive = fromSnapshotExclusive.isEmpty() ? null : fromSnapshotExclusive.getSnapshotId();
         final long toSnapshotIdInclusive =
                 toSnapshotInclusive.end().orElseThrow(() -> new StarRocksConnectorException(
                         "toSnapshotInclusive must have a valid snapshot ID"));
         final IcebergTable icebergTable = (IcebergTable) table;
         final org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+
+        if (fromSnapshotIdExclusive != null &&
+                !SnapshotUtil.isParentAncestorOf(nativeTable, toSnapshotIdInclusive, fromSnapshotIdExclusive)) {
+            throw new StarRocksConnectorException(
+                    "Starting snapshot (exclusive) %s is not a parent ancestor of end snapshot %s",
+                    fromSnapshotIdExclusive, toSnapshotIdInclusive);
+        }
+
         long lastSnapshotId = toSnapshotIdInclusive;
 
         final List<TvrTableDeltaTrait> tvrDeltaTraits = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -200,6 +200,11 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
             return maxTvrDelta;
         }
 
+        if (maxTvrDelta.start().isEmpty() && mv.getCurrentRefreshMode() == MaterializedView.RefreshMode.AUTO) {
+            throw new SemanticException("No checkpoint found for base table: %s.%s during AUTO IVM planning",
+                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
+        }
+
         // check the delta traits between the max delta
         List<TvrTableDeltaTrait> tableDeltaTraits = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -3633,4 +3633,61 @@ public class IcebergMetadataTest extends TableTestBase {
         // Only REPLACE in range — should return empty
         Assertions.assertTrue(traits.isEmpty());
     }
+
+    @Test
+    public void testListTableDeltaTraitsAllowsExpiredExclusiveStartSnapshot() {
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+
+        mockedNativeTableA.newAppend().appendFile(FILE_A_1).commit();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+
+        mockedNativeTableA.expireSnapshots().expireSnapshotId(snap1.snapshotId()).commit();
+        mockedNativeTableA.refresh();
+
+        IcebergTable icebergTable = new IcebergTable(1, "testTbl", CATALOG_NAME, CATALOG_NAME,
+                "db", "testTbl", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TvrTableSnapshot from = TvrTableSnapshot.of(Optional.of(snap1.snapshotId()));
+        TvrTableSnapshot to = TvrTableSnapshot.of(Optional.of(snap2.snapshotId()));
+
+        List<TvrTableDeltaTrait> traits = metadata.listTableDeltaTraits("db", icebergTable, from, to);
+        Assertions.assertEquals(1, traits.size());
+        Assertions.assertTrue(traits.get(0).isAppendOnly());
+        Assertions.assertEquals(snap2.snapshotId(), traits.get(0).getTvrDelta().start().get());
+        Assertions.assertEquals(snap2.snapshotId(), traits.get(0).getTvrDelta().end().get());
+    }
+
+    @Test
+    public void testListTableDeltaTraitsFailsWhenSnapshotLineageIsBroken() {
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+
+        mockedNativeTableA.newAppend().appendFile(FILE_A_1).commit();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+
+        mockedNativeTableA.newAppend().appendFile(FILE_A_2).commit();
+        Snapshot snap3 = mockedNativeTableA.currentSnapshot();
+
+        mockedNativeTableA.expireSnapshots().expireSnapshotId(snap2.snapshotId()).commit();
+        mockedNativeTableA.refresh();
+
+        IcebergTable icebergTable = new IcebergTable(1, "testTbl", CATALOG_NAME, CATALOG_NAME,
+                "db", "testTbl", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TvrTableSnapshot from = TvrTableSnapshot.of(Optional.of(snap1.snapshotId()));
+        TvrTableSnapshot to = TvrTableSnapshot.of(Optional.of(snap3.snapshotId()));
+
+        StarRocksConnectorException exception = assertThrows(StarRocksConnectorException.class,
+                () -> metadata.listTableDeltaTraits("db", icebergTable, from, to));
+        assertTrue(exception.getMessage().contains("Starting snapshot (exclusive)"));
+        assertTrue(exception.getMessage().contains(String.valueOf(snap1.snapshotId())));
+        assertTrue(exception.getMessage().contains(String.valueOf(snap3.snapshotId())));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -24,6 +24,7 @@ import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
@@ -531,23 +532,29 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
         Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
 
-        // if the base table has no retractable changes, the refresh processor should be full refresh
+        // Without a checkpoint, AUTO should bypass IVM planning and fall back to PCT.
         {
             advanceTableVersionTo(2);
             MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
             Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
             MVHybridBasedRefreshProcessor hybridBasedRefreshProcessor =
                     (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
         }
-        // if the base table has retractable changes, the refresh processor should be full refresh
+        // Once a checkpoint exists, append-only changes can switch AUTO back to IVM.
         {
-            mockListTableDeltaTraits();
-            MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+            MaterializedView refreshedMv = getMv("test_mv1");
+            advanceTableVersionTo(3);
+            mockListTableDeltaTraits(ImmutableList.of(
+                    TvrTableDeltaTrait.ofMonotonic(
+                            TvrTableDelta.of(2L, 3L),
+                            TvrDeltaStats.EMPTY)
+            ));
+            MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(refreshedMv);
             Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
             MVHybridBasedRefreshProcessor hybridBasedRefreshProcessor =
                     (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+            Assertions.assertTrue(hybridBasedRefreshProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
         }
     }
 
@@ -558,7 +565,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
 
         advanceTableVersionTo(2);
-        mockListTableDeltaTraits();
 
         MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
         Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
@@ -588,6 +594,30 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         MVHybridBasedRefreshProcessor hybrid2 =
                 (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
         Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+    }
+
+    @Test
+    public void testAutoRefreshFallsBackToPctWhenLineageValidationFails() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+        Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(run1.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid1 =
+                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid1.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        MaterializedView refreshedMv = getMv("test_mv1");
+        advanceTableVersionTo(3);
+        mockListTableDeltaTraitsThrows("Starting snapshot (exclusive) 2 is not a parent ancestor of end snapshot 3");
+
+        MVTaskRunProcessor run2 = getMVTaskRunProcessor(refreshedMv);
+        Assertions.assertTrue(run2.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybrid2 =
+                (MVHybridBasedRefreshProcessor) run2.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid2.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
     }
 
     @Test
@@ -758,43 +788,87 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
     }
 
     /**
-     * Test that IVM refresh records complete PCT metadata without batch truncation.
+     * Test that IVM records complete PCT metadata without truncation by
+     * partition_refresh_number.
      */
     @Test
     public void testIVMPCTMetadataNotTruncatedByPartitionRefreshNumber() throws Exception {
-        // Create a PARTITIONED MV on partitioned Iceberg table t1 (4 partitions: date=2020-01-01..04).
-        // partition_refresh_number=1 would truncate to 1 partition in the old code path.
+        // Create a PARTITIONED incremental MV on partitioned Iceberg table t1
+        // (4 partitions: date=2020-01-01..04). partition_refresh_number=1 would
+        // truncate to 1 partition in the old code path.
+        String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "incremental",
+                "`date`", Map.of("partition_refresh_number", "1"));
+        Assertions.assertEquals(MaterializedView.RefreshMode.INCREMENTAL, mv.getCurrentRefreshMode());
+
+        advanceTableVersionTo(2);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(mv);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVIVMBasedRefreshProcessor);
+
+        MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
+        MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
+        Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
+        Assertions.assertNotNull(mvPartitionsToRefresh, "mvPartitionsToRefresh should not be null");
+        Assertions.assertTrue(mvPartitionsToRefresh.size() > 1,
+                "IVM should record complete PCT metadata without truncation, but got: " + mvPartitionsToRefresh);
+    }
+
+    @Test
+    public void testAutoRecoveredIvmRecordsPCTMetadataWithoutBatchTruncation() throws Exception {
         String query = "SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t1`";
         MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto",
                 "`date`", Map.of("partition_refresh_number", "1"));
         Assertions.assertEquals(MaterializedView.RefreshMode.AUTO, mv.getCurrentRefreshMode());
 
-        // Initial refresh: all 4 partitions detected as new
-        {
-            advanceTableVersionTo(2);
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
-            TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
-            MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        advanceTableVersionTo(2);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mv.getDbId());
+        TaskRun taskRun = withMVRefreshTaskRun(db.getFullName(), mv);
+        MVTaskRunProcessor mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        MVHybridBasedRefreshProcessor hybridProcessor =
+                (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
 
-            // Verify IVM path was used (auto mode -> hybrid -> IVM)
-            Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
-            MVHybridBasedRefreshProcessor hybridProcessor =
-                    (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
-            Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
-
-            // Verify PCT metadata records ALL partitions, not truncated to 1.
-            // Before the fix, partition_refresh_number=1 would truncate mvPartitionsToRefresh to 1 partition.
-            // After the fix (skipBatchFilter=true), all detected partitions should be recorded.
-            MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
-            MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
-            Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
-            Assertions.assertNotNull(mvPartitionsToRefresh,
-                    "mvPartitionsToRefresh should not be null");
-            // t1 has 4 partitions -> MV should have 4 corresponding partitions, all recorded
-            Assertions.assertTrue(mvPartitionsToRefresh.size() > 1,
-                    "IVM should record all detected partitions in PCT metadata, " +
-                            "not truncated by partition_refresh_number. " +
-                            "Expected >1 but got: " + mvPartitionsToRefresh);
+        TaskRun nextTaskRun = hybridProcessor.getCurrentProcessor().getNextTaskRun();
+        while (nextTaskRun != null) {
+            initAndExecuteTaskRun(nextTaskRun);
+            MVTaskRunProcessor nextProcessor = getMVTaskRunProcessor(nextTaskRun);
+            BaseMVRefreshProcessor refreshProcessor = nextProcessor.getMVRefreshProcessor();
+            if (refreshProcessor instanceof MVHybridBasedRefreshProcessor) {
+                MVHybridBasedRefreshProcessor nextHybrid =
+                        (MVHybridBasedRefreshProcessor) refreshProcessor;
+                nextTaskRun = nextHybrid.getCurrentProcessor().getNextTaskRun();
+            } else if (refreshProcessor instanceof MVPCTBasedRefreshProcessor) {
+                nextTaskRun = ((MVPCTBasedRefreshProcessor) refreshProcessor).getNextTaskRun();
+            } else {
+                nextTaskRun = null;
+            }
         }
+
+        MaterializedView refreshedMv = getMv("test_mv1");
+        MockIcebergMetadata mockIcebergMetadata =
+                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr()
+                        .getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+        mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
+                ImmutableList.of("date=2020-01-02", "date=2020-01-03"));
+        advanceTableVersionTo(3);
+        mockListTableDeltaTraits(ImmutableList.of(
+                TvrTableDeltaTrait.ofMonotonic(
+                        TvrTableDelta.of(2L, 3L),
+                        TvrDeltaStats.EMPTY)
+        ));
+
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(refreshedMv.getDbId());
+        taskRun = withMVRefreshTaskRun(db.getFullName(), refreshedMv);
+        mvTaskRunProcessor = getMVTaskRunProcessor(taskRun);
+        Assertions.assertTrue(mvTaskRunProcessor.getMVRefreshProcessor() instanceof MVHybridBasedRefreshProcessor);
+        hybridProcessor = (MVHybridBasedRefreshProcessor) mvTaskRunProcessor.getMVRefreshProcessor();
+        Assertions.assertTrue(hybridProcessor.getCurrentProcessor() instanceof MVIVMBasedRefreshProcessor);
+
+        MvTaskRunContext mvContext = mvTaskRunProcessor.getMvTaskRunContext();
+        MVTaskRunExtraMessage extraMessage = mvContext.getStatus().getMvTaskRunExtraMessage();
+        Set<String> mvPartitionsToRefresh = extraMessage.getMvPartitionsToRefresh();
+        Assertions.assertEquals(Set.of("p20200102", "p20200103"), mvPartitionsToRefresh,
+                "Recovered IVM should record complete changed MV partitions without truncation");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMIcebergTestBase.java
@@ -21,6 +21,7 @@ import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import mockit.Mock;
 import mockit.MockUp;
@@ -68,5 +69,16 @@ public class MVIVMIcebergTestBase extends MVIVMTestBase {
                         TvrDeltaStats.EMPTY)
         );
         mockListTableDeltaTraits(deltas);
+    }
+
+    public void mockListTableDeltaTraitsThrows(String message) {
+        new MockUp<MockIcebergMetadata>() {
+            @Mock
+            public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, com.starrocks.catalog.Table table,
+                                                                 TvrTableSnapshot fromSnapshotExclusive,
+                                                                 TvrTableSnapshot toSnapshotInclusive) {
+                throw new SemanticException(message);
+            }
+        };
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When Iceberg snapshots between the MV's last-refresh checkpoint and the current table version have been expired (e.g., by Iceberg's snapshot expiration mechanism), the incremental snapshot lineage becomes broken. In this case, IVM (Incremental View Maintenance) cannot correctly compute the delta between the two snapshots, potentially leading to incorrect refresh results or errors. Additionally, when AUTO refresh mode has no checkpoint yet (first refresh), it should not attempt IVM planning since there is no valid starting snapshot to compute deltas from.

## What I'm doing:
Add snapshot lineage validation in IcebergMetadata.listTableDeltaTraits: Before walking the snapshot chain, validate that the starting snapshot (exclusive) is a parent ancestor of the ending snapshot using SnapshotUtil.isParentAncestorOf. If the lineage is broken (e.g., intermediate snapshots were expired), throw a StarRocksConnectorException to signal that incremental delta computation is not possible. Also fix the fromSnapshotIdExclusive type from long to Long to correctly handle the empty-snapshot case (first refresh with no checkpoint).

Add checkpoint guard in MVIVMBasedRefreshProcessor: When the MV is in AUTO refresh mode and the base table has no checkpoint (maxTvrDelta.start() is empty), throw a SemanticException to prevent IVM planning. This ensures the first refresh in AUTO mode falls back to PCT (Partition Change Tracking) refresh, which will establish the initial checkpoint for subsequent IVM refreshes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
