### PR TITLE
[Refactor] Eliminate redundant partition resolver calls via BaseToMVPartitionMapping

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -45,6 +46,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -289,10 +291,11 @@ public abstract class MVTimelinessArbiter {
         if (partitionInfo.isUnPartitioned()) {
             return null;
         }
-        Map<Table, PCellSortedSet> basePartitionNameToRangeMap = differ.syncBaseTablePartitionInfos();
-        if (CollectionUtils.sizeIsEmpty(basePartitionNameToRangeMap)) {
+        Map<Table, BaseToMVPartitionMapping> basePartitionMappings = differ.syncBaseTablePartitionInfos();
+        if (CollectionUtils.sizeIsEmpty(basePartitionMappings)) {
             return null;
         }
+        Map<Table, PCellSortedSet> basePartitionNameToRangeMap = BaseToMVPartitionMapping.extractCells(basePartitionMappings);
         // add into base table info
         mvUpdateInfo.addRefBaseTablePCells(basePartitionNameToRangeMap);
         return basePartitionNameToRangeMap;
@@ -305,8 +308,10 @@ public abstract class MVTimelinessArbiter {
             if (partitionInfo.isUnPartitioned()) {
                 return null;
             }
-            PartitionDiffResult result = differ.computePartitionDiff(null,
-                    basePartitionNameToRangeMap);
+            // Wrap into BaseToMVPartitionMapping (no source name mapping needed for timeliness check)
+            Map<Table, BaseToMVPartitionMapping> mappings = new HashMap<>();
+            basePartitionNameToRangeMap.forEach((k, v) -> mappings.put(k, BaseToMVPartitionMapping.of(v)));
+            PartitionDiffResult result = differ.computePartitionDiff(null, mappings);
             if (result == null) {
                 logMVPrepare(mv, "Partitioned mv compute list diff failed");
                 return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/MVPartitionCellBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MVPartitionCellBuilder.java
@@ -26,16 +26,17 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.iceberg.IcebergPartitionKeyResolver;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.PRangeCell;
-import com.starrocks.sql.common.PartitionNameSetMap;
 import com.starrocks.type.PrimitiveType;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,49 +64,54 @@ public class MVPartitionCellBuilder {
 
     /**
      * Build range cells [lower, upper) for non-JDBC external tables, or (lower, upper] for JDBC tables.
-     * Automatically selects the correct range boundary strategy based on table type.
+     * Resolves partition names to PartitionKeys, collects source name mapping, sorts, and builds cells.
      */
-    public static PCellSortedSet buildRangeCells(Table baseTable, Column baseTablePartitionColumn,
+    public static BaseToMVPartitionMapping buildRangeCells(Table baseTable, Column baseTablePartitionColumn,
                                                  Collection<String> basePartitionNames,
                                                  Expr mvPartitionExpr) throws AnalysisException {
-        PartitionUtil.DateTimeInterval basePartitionInterval =
-                PartitionUtil.getDateTimeInterval(baseTable, baseTablePartitionColumn);
-        return buildRangeCells(
-                baseTable, baseTablePartitionColumn, basePartitionNames, mvPartitionExpr, basePartitionInterval);
-    }
-
-    /**
-     * Overload with explicit interval — used by per-spec interval logic for Iceberg partition evolution.
-     */
-    public static PCellSortedSet buildRangeCells(Table baseTable, Column baseTablePartitionColumn,
-                                                 Collection<String> basePartitionNames,
-                                                 Expr mvPartitionExpr,
-                                                 PartitionUtil.DateTimeInterval basePartitionInterval)
-            throws AnalysisException {
         ExternalPartitionMappingContext mappingContext =
                 ExternalPartitionMappingContext.create(baseTable, baseTablePartitionColumn, mvPartitionExpr);
         ExternalPartitionKeyResolver partitionKeyResolver = getResolver(baseTable);
+        PartitionUtil.DateTimeInterval basePartitionInterval =
+                PartitionUtil.getDateTimeInterval(baseTable, baseTablePartitionColumn);
 
-        LinkedHashMap<String, PartitionKey> mvPartitionKeysByName =
-                resolveAndSort(mappingContext, partitionKeyResolver, basePartitionNames);
-        if (baseTable.isJDBCTable()) {
-            return buildOpenClosedRangeCells(
-                    mvPartitionKeysByName, baseTablePartitionColumn, mvPartitionExpr);
+        // Resolve partition names to PartitionKeys, collect source name mapping, then sort by key value
+        Map<String, PartitionKey> mvPartitionKeysByName = Maps.newHashMap();
+        Map<String, Set<String>> sourceMapping = new HashMap<>();
+        for (String basePartitionName : basePartitionNames) {
+            PartitionKeyResolutionResult resolutionResult =
+                    partitionKeyResolver.resolve(mappingContext, basePartitionName);
+            PartitionKey mvPartitionKey = resolutionResult.getSingleKey();
+            String mvPartitionName = generateMVPartitionName(mvPartitionKey);
+            mvPartitionKeysByName.put(mvPartitionName, mvPartitionKey);
+            sourceMapping.computeIfAbsent(mvPartitionName, k -> new java.util.HashSet<>()).add(basePartitionName);
         }
-        return buildClosedOpenRangeCells(
-                mvPartitionKeysByName, baseTablePartitionColumn, mvPartitionExpr, basePartitionInterval);
+        LinkedHashMap<String, PartitionKey> sortedKeys = mvPartitionKeysByName.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(PartitionKey::compareTo))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                        (e1, e2) -> e1, LinkedHashMap::new));
+
+        PCellSortedSet cells;
+        if (baseTable.isJDBCTable()) {
+            cells = buildOpenClosedRangeCells(sortedKeys, baseTablePartitionColumn, mvPartitionExpr);
+        } else {
+            cells = buildClosedOpenRangeCells(sortedKeys, baseTablePartitionColumn,
+                    mvPartitionExpr, basePartitionInterval);
+        }
+        return BaseToMVPartitionMapping.of(cells, sourceMapping);
     }
 
     /**
      * Build list partition cells from external base table partition names.
      */
-    public static PCellSortedSet buildListCells(Table baseTable, List<Column> mvRefBasePartitionColumns,
-                                                Collection<String> basePartitionNames) throws AnalysisException {
+    public static BaseToMVPartitionMapping buildListCells(Table baseTable, List<Column> mvRefBasePartitionColumns,
+                                                          Collection<String> basePartitionNames) throws AnalysisException {
         ExternalPartitionMappingContext mappingContext =
                 ExternalPartitionMappingContext.create(baseTable, mvRefBasePartitionColumns);
         ExternalPartitionKeyResolver partitionKeyResolver = getResolver(baseTable);
 
         PCellSortedSet mvPartitionListMap = PCellSortedSet.of();
+        Map<String, Set<String>> sourceMapping = new HashMap<>();
         for (String basePartitionName : basePartitionNames) {
             PartitionKeyResolutionResult resolutionResult =
                     partitionKeyResolver.resolve(mappingContext, basePartitionName);
@@ -113,34 +119,10 @@ public class MVPartitionCellBuilder {
                 String mvPartitionName = generateMVPartitionName(mvPartitionKey);
                 List<List<String>> mvPartitionItems = generateMVPartitionList(mvPartitionKey);
                 mvPartitionListMap.add(PCellWithName.of(mvPartitionName, new PListCell(mvPartitionItems)));
+                sourceMapping.computeIfAbsent(mvPartitionName, k -> new java.util.HashSet<>()).add(basePartitionName);
             }
         }
-        return mvPartitionListMap;
-    }
-
-    /**
-     * Map external base table partitions to MV partition names.
-     * Multiple external partitions may map to the same MV partition name
-     * (e.g., par_col=0/par_date=2020-01-01 and par_col=1/par_date=2020-01-01 both → p20200101).
-     */
-    public static PartitionNameSetMap buildMVPartitionNameMap(Table baseTable,
-                                                              List<Column> mvRefBasePartitionColumns,
-                                                              List<String> basePartitionNames)
-            throws AnalysisException {
-        ExternalPartitionMappingContext mappingContext =
-                ExternalPartitionMappingContext.create(baseTable, mvRefBasePartitionColumns);
-        ExternalPartitionKeyResolver partitionKeyResolver = getResolver(baseTable);
-
-        PartitionNameSetMap mvPartitionKeySetMap = PartitionNameSetMap.of();
-        for (String basePartitionName : basePartitionNames) {
-            PartitionKeyResolutionResult resolutionResult =
-                    partitionKeyResolver.resolve(mappingContext, basePartitionName);
-            for (PartitionKey mvPartitionKey : resolutionResult.getKeys()) {
-                String mvPartitionName = generateMVPartitionName(mvPartitionKey);
-                mvPartitionKeySetMap.put(mvPartitionName, basePartitionName);
-            }
-        }
-        return mvPartitionKeySetMap;
+        return BaseToMVPartitionMapping.of(mvPartitionListMap, sourceMapping);
     }
 
     /**
@@ -153,11 +135,11 @@ public class MVPartitionCellBuilder {
                                                   Expr mvPartitionExpr) throws AnalysisException {
         if (mvUsesListPartitioning) {
             PCellSortedSet mvPartitionNamesWithList = buildListCells(
-                    baseTable, ImmutableList.of(baseTablePartitionColumn), basePartitionNames);
+                    baseTable, ImmutableList.of(baseTablePartitionColumn), basePartitionNames).cells();
             return mvPartitionNamesWithList.getPartitionNames();
         } else {
             PCellSortedSet mvPartitionNamesWithRange = buildRangeCells(
-                    baseTable, baseTablePartitionColumn, basePartitionNames, mvPartitionExpr);
+                    baseTable, baseTablePartitionColumn, basePartitionNames, mvPartitionExpr).cells();
             return mvPartitionNamesWithRange.getPartitionNames();
         }
     }
@@ -169,10 +151,10 @@ public class MVPartitionCellBuilder {
      * For OLAP tables, reads directly from OlapTable's range partition map.
      * For external tables, resolves partition names via the resolver pipeline.
      */
-    public static PCellSortedSet getPartitionKeyRange(Table table, Column partitionColumn,
+    public static BaseToMVPartitionMapping getPartitionKeyRange(Table table, Column partitionColumn,
                                                        Expr partitionExpr) throws AnalysisException {
         if (table.isNativeTableOrMaterializedView()) {
-            return getOlapRangePartitionMap((OlapTable) table);
+            return BaseToMVPartitionMapping.of(getOlapRangePartitionMap((OlapTable) table));
         }
         return buildRangeCells(table, partitionColumn, getPartitionNames(table), partitionExpr);
     }
@@ -182,10 +164,10 @@ public class MVPartitionCellBuilder {
      * For OLAP tables, reads directly from OlapTable's partition cells.
      * For external tables, resolves partition names via the resolver pipeline.
      */
-    public static PCellSortedSet getPartitionCells(Table table, List<Column> partitionColumns)
+    public static BaseToMVPartitionMapping getPartitionCells(Table table, List<Column> partitionColumns)
             throws AnalysisException {
         if (table.isNativeTableOrMaterializedView()) {
-            return ((OlapTable) table).getPartitionCells(Optional.of(partitionColumns));
+            return BaseToMVPartitionMapping.of(((OlapTable) table).getPartitionCells(Optional.of(partitionColumns)));
         }
         return buildListCells(table, partitionColumns, getPartitionNames(table));
     }
@@ -294,30 +276,6 @@ public class MVPartitionCellBuilder {
         }
 
         return mvPartitionRangeMap;
-    }
-
-    // ========== Internal: resolve + sort ==========
-
-    /**
-     * Resolve all partition names to PartitionKeys via the resolver, then sort by key value.
-     */
-    private static LinkedHashMap<String, PartitionKey> resolveAndSort(
-            ExternalPartitionMappingContext mappingContext,
-            ExternalPartitionKeyResolver partitionKeyResolver,
-            Collection<String> basePartitionNames)
-            throws AnalysisException {
-        Map<String, PartitionKey> mvPartitionKeysByName = Maps.newHashMap();
-        for (String basePartitionName : basePartitionNames) {
-            PartitionKeyResolutionResult resolutionResult =
-                    partitionKeyResolver.resolve(mappingContext, basePartitionName);
-            PartitionKey mvPartitionKey = resolutionResult.getSingleKey();
-            String mvPartitionName = generateMVPartitionName(mvPartitionKey);
-            mvPartitionKeysByName.put(mvPartitionName, mvPartitionKey);
-        }
-        return mvPartitionKeysByName.entrySet().stream()
-                .sorted(Map.Entry.comparingByValue(PartitionKey::compareTo))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                        (e1, e2) -> e1, LinkedHashMap::new));
     }
 
     // ========== Internal: helpers ==========

--- a/fe/fe-core/src/main/java/com/starrocks/mv/pct/BaseToMVPartitionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/pct/BaseToMVPartitionMapping.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mv.pct;
+
+import com.starrocks.sql.common.PCellSortedSet;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Pairs a base table's partition cells (resolved into MV partition space) with
+ * an optional source name mapping that traces each MV partition name back to
+ * the original base table partition names.
+ * <p>
+ * For OLAP tables the source mapping is empty — their partition names are
+ * directly usable. For external tables (Hive, Iceberg, etc.) the mapping
+ * records which original partition names (e.g. {@code par_date=2024-01-01})
+ * were resolved into each normalized MV partition name (e.g. {@code p20240101}).
+ */
+public record BaseToMVPartitionMapping(
+        // Base table partitions resolved into MV partition granularity.
+        // Each entry's name is a generated MV partition name (e.g. "p20240101"),
+        // and its cell is the corresponding range/list value at MV granularity.
+        // The original base table partition names and their finer-grained cell
+        // values are NOT preserved here — only the MV-level projection.
+        PCellSortedSet cells,
+        // Reverse lookup: MV partition name → the original base table partition
+        // names that were resolved into it.
+        // e.g. "p20240101" → {"par_date=2024-01-01", "par_date=2024-01-02"}
+        //
+        // Empty for OLAP tables (their partition names are directly usable).
+        // Populated for external tables (Hive, Iceberg, etc.) where the original
+        // partition names differ from the generated MV partition names.
+        // Used by MvTaskRunContext.getExternalTableRealPartitionName() to tell
+        // connectors which partitions to refresh.
+        Map<String, Set<String>> sourceNameMapping
+) {
+    public static BaseToMVPartitionMapping of(PCellSortedSet cells) {
+        return new BaseToMVPartitionMapping(cells, Map.of());
+    }
+
+    public static BaseToMVPartitionMapping of(PCellSortedSet cells, Map<String, Set<String>> mapping) {
+        return new BaseToMVPartitionMapping(cells, mapping);
+    }
+
+    /**
+     * Get the original base partition names that were resolved into the given MV partition name.
+     * Returns empty set if no mapping exists (OLAP tables or unknown partition name).
+     */
+    public Set<String> getSourceNames(String mvPartitionName) {
+        return sourceNameMapping.getOrDefault(mvPartitionName, Set.of());
+    }
+
+    /**
+     * Extract a plain {@code Map<K, PCellSortedSet>} from a map of mappings.
+     * Used when callers only need the cells (e.g. {@code generateBaseRefMap}).
+     */
+    public static <K> Map<K, PCellSortedSet> extractCells(Map<K, BaseToMVPartitionMapping> map) {
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().cells()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -142,8 +142,8 @@ public class MvTaskRunContext extends TaskRunContext {
     public Set<String> getExternalTableRealPartitionName(Table table, String mvPartitionName) {
         if (!table.isNativeTableOrMaterializedView()) {
             Preconditions.checkState(partitionTopology != null
-                    && partitionTopology.getExternalRefBaseTableMVPartitionMap().containsKey(table));
-            return partitionTopology.getExternalRefBaseTableMVPartitionMap().get(table).get(mvPartitionName);
+                    && partitionTopology.getRefBaseTableToCellMap().containsKey(table));
+            return partitionTopology.getRefBaseTableToCellMap().get(table).getSourceNames(mvPartitionName);
         } else {
             return Sets.newHashSet(mvPartitionName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
@@ -18,15 +18,14 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.common.PartitionNameSetMap;
 import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,7 +39,7 @@ public class MVRefreshPartitionSelector {
     private final long maxBytesThreshold;
     private final int maxSelectedPartitions;
 
-    private final Map<Table, PartitionNameSetMap> externalPartitionMap;
+    private final Map<Table, BaseToMVPartitionMapping> externalPartitionMap;
     /**
      * Minimum required ratio of collected partition statistics.
      * If the collected stats are less than this ratio compared to the expected partitions,
@@ -59,7 +58,7 @@ public class MVRefreshPartitionSelector {
     public MVRefreshPartitionSelector(long maxRowsThreshold,
                                       long maxBytesThreshold,
                                       int maxPartitionNum,
-                                      Map<Table, PartitionNameSetMap> externalPartitionMap) {
+                                      Map<Table, BaseToMVPartitionMapping> externalPartitionMap) {
         this.maxRowsThreshold = maxRowsThreshold;
         this.maxBytesThreshold = maxBytesThreshold;
         this.maxSelectedPartitions = maxPartitionNum;
@@ -153,10 +152,11 @@ public class MVRefreshPartitionSelector {
         if (table.isNativeTableOrMaterializedView()) {
             return Collections.singleton(logicalPartitionNames);
         }
-        PartitionNameSetMap mapping = externalPartitionMap.get(table);
-        return Optional.ofNullable(mapping)
-                .map(m -> m.get(logicalPartitionNames))
-                .orElse(Collections.emptySet());
+        BaseToMVPartitionMapping mapping = externalPartitionMap.get(table);
+        if (mapping == null) {
+            return Collections.emptySet();
+        }
+        return mapping.getSourceNames(logicalPartitionNames);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
@@ -27,6 +27,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRunContext;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
@@ -148,15 +149,16 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
         // add into mv context
         result.mvPartitionToCells.addAll(adds);
-        final Map<Table, PCellSortedSet> refBaseTablePartitionMap = result.refBaseTablePartitionMap;
+        final Map<Table, PCellSortedSet> refBaseTableCells =
+                BaseToMVPartitionMapping.extractCells(result.refBaseTablePartitionMap);
         // base table -> Map<partition name -> mv partition names>
         final Map<Table, PCellSetMapping> baseToMvNameRef =
-                differ.generateBaseRefMap(refBaseTablePartitionMap, result.mvPartitionToCells);
+                differ.generateBaseRefMap(refBaseTableCells, result.mvPartitionToCells);
         // mv partition name -> Map<base table -> base partition names>
         final Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef =
-                differ.generateMvRefMap(result.mvPartitionToCells, refBaseTablePartitionMap);
-        publishTopology(new PCTPartitionTopology(result.mvPartitionToCells, refBaseTablePartitionMap,
-                baseToMvNameRef, mvToBaseNameRef, result.getRefBaseTableMVPartitionMap()));
+                differ.generateMvRefMap(result.mvPartitionToCells, refBaseTableCells);
+        publishTopology(new PCTPartitionTopology(result.mvPartitionToCells, result.refBaseTablePartitionMap,
+                baseToMvNameRef, mvToBaseNameRef));
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -31,6 +31,7 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.ConnectorPartitionTraits;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.MvTaskRunContext;
@@ -466,7 +467,7 @@ public abstract class MVPCTRefreshPartitioner {
         MVRefreshPartitionSelector mvRefreshPartitionSelector =
                 new MVRefreshPartitionSelector(Config.mv_max_rows_per_refresh, Config.mv_max_bytes_per_refresh,
                         Config.mv_max_partitions_num_per_refresh,
-                        partitionTopology.getExternalRefBaseTableMVPartitionMap());
+                        partitionTopology.getRefBaseTableToCellMap());
         int adaptiveRefreshNumber = 0;
         for (PCellWithName pCellWithName : toRefreshPartitions.getPartitions()) {
             String mvRefreshPartition = pCellWithName.name();
@@ -748,7 +749,7 @@ public abstract class MVPCTRefreshPartitioner {
     protected Map<Table, PCellSortedSet> toBaseTableWithSortedSet(Map<Table, PCellSortedSet> baseToPartitionNames) {
         Map<Table, PCellSortedSet> result = new HashMap<>();
         PCTPartitionTopology partitionTopology = mvContext.getPartitionTopology();
-        Map<Table, PCellSortedSet> refBaseTableRangePartitionMap =
+        Map<Table, BaseToMVPartitionMapping> refBaseTableRangePartitionMap =
                 partitionTopology == null ? Map.of() : partitionTopology.getRefBaseTableToCellMap();
         for (Map.Entry<Table, PCellSortedSet> entry : baseToPartitionNames.entrySet()) {
             Table baseTable = entry.getKey();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunContext;
@@ -146,13 +147,14 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mv.getName(), adds);
 
         // used to get partitions to refresh
+        Map<Table, PCellSortedSet> refBaseTableCells = BaseToMVPartitionMapping.extractCells(result.refBaseTablePartitionMap);
         Map<Table, PCellSetMapping> baseToMvNameRef =
-                differ.generateBaseRefMap(result.refBaseTablePartitionMap, mvPartitionToCells);
+                differ.generateBaseRefMap(refBaseTableCells, mvPartitionToCells);
         Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef =
-                differ.generateMvRefMap(mvPartitionToCells, result.refBaseTablePartitionMap);
+                differ.generateMvRefMap(mvPartitionToCells, refBaseTableCells);
 
         publishTopology(new PCTPartitionTopology(mvPartitionToCells, result.refBaseTablePartitionMap,
-                baseToMvNameRef, mvToBaseNameRef, result.getRefBaseTableMVPartitionMap()));
+                baseToMvNameRef, mvToBaseNameRef));
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPartitionTopology.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPartitionTopology.java
@@ -15,9 +15,9 @@
 package com.starrocks.scheduler.mv.pct;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.common.PartitionNameSetMap;
 
 import java.util.Map;
 import java.util.Objects;
@@ -37,13 +37,14 @@ public final class PCTPartitionTopology {
     private final PCellSortedSet mvToCellMap;
 
     /**
-     * For each ref base table, stores all of its normalized partition cells.
+     * For each ref base table, stores its partition mapping including both normalized partition cells
+     * and an optional source name mapping that traces MV partition names back to original base partition names.
      * <p>
-     * Key is the base table object, value is that table's partition-name to partition-cell mapping.
+     * Key is the base table object, value is the {@link BaseToMVPartitionMapping} for that table.
      * This lets the refresh pipeline recover the exact range/list cell behind a base-table partition name
      * when generating predicates or projecting refresh work back to base tables.
      */
-    private final Map<Table, PCellSortedSet> refBaseTableToCellMap;
+    private final Map<Table, BaseToMVPartitionMapping> refBaseTableToCellMap;
 
     /**
      * Forward intersection mapping from base-table partitions to MV partitions.
@@ -65,32 +66,21 @@ public final class PCTPartitionTopology {
      */
     private final Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions;
 
-    /**
-     * Mapping for external ref base tables from MV partition name back to the original external partition names.
-     * <p>
-     * External connectors may normalize one or more original partition names into a single MV partition name,
-     * especially for multi-column partitions. This structure preserves that reverse lookup so metadata refresh
-     * and partition-targeted external table refresh can recover the real connector-side partition names.
-     */
-    private final Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap;
-
     public PCTPartitionTopology(PCellSortedSet mvToCellMap,
-                                Map<Table, PCellSortedSet> refBaseTableToCellMap,
+                                Map<Table, BaseToMVPartitionMapping> refBaseTableToCellMap,
                                 Map<Table, PCellSetMapping> refBaseTableMVIntersectedPartitions,
-                                Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions,
-                                Map<Table, PartitionNameSetMap> externalRefBaseTableMVPartitionMap) {
+                                Map<String, Map<Table, PCellSortedSet>> mvRefBaseTableIntersectedPartitions) {
         this.mvToCellMap = mvToCellMap;
         this.refBaseTableToCellMap = refBaseTableToCellMap;
         this.refBaseTableMVIntersectedPartitions = refBaseTableMVIntersectedPartitions;
         this.mvRefBaseTableIntersectedPartitions = mvRefBaseTableIntersectedPartitions;
-        this.externalRefBaseTableMVPartitionMap = externalRefBaseTableMVPartitionMap;
     }
 
     public PCellSortedSet getMvToCellMap() {
         return mvToCellMap;
     }
 
-    public Map<Table, PCellSortedSet> getRefBaseTableToCellMap() {
+    public Map<Table, BaseToMVPartitionMapping> getRefBaseTableToCellMap() {
         return refBaseTableToCellMap;
     }
 
@@ -102,12 +92,8 @@ public final class PCTPartitionTopology {
         return mvRefBaseTableIntersectedPartitions;
     }
 
-    public Map<Table, PartitionNameSetMap> getExternalRefBaseTableMVPartitionMap() {
-        return externalRefBaseTableMVPartitionMap;
-    }
-
     public static PCTPartitionTopology empty() {
-        return new PCTPartitionTopology(PCellSortedSet.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        return new PCTPartitionTopology(PCellSortedSet.of(), Map.of(), Map.of(), Map.of());
     }
 
     @Override
@@ -122,14 +108,13 @@ public final class PCTPartitionTopology {
         return Objects.equals(mvToCellMap, that.mvToCellMap)
                 && Objects.equals(refBaseTableToCellMap, that.refBaseTableToCellMap)
                 && Objects.equals(refBaseTableMVIntersectedPartitions, that.refBaseTableMVIntersectedPartitions)
-                && Objects.equals(mvRefBaseTableIntersectedPartitions, that.mvRefBaseTableIntersectedPartitions)
-                && Objects.equals(externalRefBaseTableMVPartitionMap, that.externalRefBaseTableMVPartitionMap);
+                && Objects.equals(mvRefBaseTableIntersectedPartitions, that.mvRefBaseTableIntersectedPartitions);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(mvToCellMap, refBaseTableToCellMap, refBaseTableMVIntersectedPartitions,
-                mvRefBaseTableIntersectedPartitions, externalRefBaseTableMVPartitionMap);
+                mvRefBaseTableIntersectedPartitions);
     }
 
     @Override
@@ -139,7 +124,6 @@ public final class PCTPartitionTopology {
                 + ", refBaseTableToCellMap=" + refBaseTableToCellMap
                 + ", refBaseTableMVIntersectedPartitions=" + refBaseTableMVIntersectedPartitions
                 + ", mvRefBaseTableIntersectedPartitions=" + mvRefBaseTableIntersectedPartitions
-                + ", externalRefBaseTableMVPartitionMap=" + externalRefBaseTableMVPartitionMap
                 + '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPredicateBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTPredicateBuilder.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.Expr;
@@ -91,14 +92,15 @@ public class PCTPredicateBuilder {
                                               List<Expr> mvPartitionSlotRefs) throws AnalysisException {
         List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
         PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
-        Map<Table, PCellSortedSet> refBaseTablePartitionCells =
+        Map<Table, BaseToMVPartitionMapping> refBaseTableMappings =
                 partitionTopology == null ? null : partitionTopology.getRefBaseTableToCellMap();
-        if (refBaseTablePartitionCells == null || !refBaseTablePartitionCells.containsKey(table)) {
+        if (refBaseTableMappings == null || !refBaseTableMappings.containsKey(table)) {
             throw new AnalysisException("Cannot generate mv refresh partition predicate because cannot find "
                     + "the ref base table partition cells for table:" + table.getName());
         }
+        PCellSortedSet refBaseTablePartitionCells = refBaseTableMappings.get(table).cells();
         for (String partitionName : refBaseTablePartitionNames.getPartitionNames()) {
-            PRangeCell rangeCell = (PRangeCell) refBaseTablePartitionCells.get(table).getPCell(partitionName);
+            PRangeCell rangeCell = (PRangeCell) refBaseTablePartitionCells.getPCell(partitionName);
             sourceTablePartitionRange.add(rangeCell.getRange());
         }
         sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
@@ -197,15 +199,16 @@ public class PCTPredicateBuilder {
                                              PCellSortedSet refBaseTablePartitionNames,
                                              List<Expr> mvPartitionSlotRefs) throws AnalysisException {
         PCTPartitionTopology partitionTopology = partitioner.mvContext.getPartitionTopology();
-        Map<Table, PCellSortedSet> basePartitionMaps =
+        Map<Table, BaseToMVPartitionMapping> basePartitionMappings =
                 partitionTopology == null ? Map.of() : partitionTopology.getRefBaseTableToCellMap();
-        if (basePartitionMaps.isEmpty()) {
+        if (basePartitionMappings.isEmpty()) {
             return null;
         }
-        PCellSortedSet baseListPartitionMap = basePartitionMaps.get(refBaseTable);
+        BaseToMVPartitionMapping mapping = basePartitionMappings.get(refBaseTable);
+        PCellSortedSet baseListPartitionMap = mapping == null ? null : mapping.cells();
         if (baseListPartitionMap == null) {
             partitioner.logger.warn("Generate incremental partition predicate failed, "
-                    + "basePartitionMaps:{} contains no refBaseTable:{}", basePartitionMaps, refBaseTable);
+                    + "basePartitionMappings:{} contains no refBaseTable:{}", basePartitionMappings, refBaseTable);
             return null;
         }
         if (baseListPartitionMap.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -149,9 +149,9 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
             }
             Expr rangePartitionExpr = rangePartitionExprOpt.get();
             PCellSortedSet snapshotPartitionMap = MVPartitionCellBuilder.getPartitionKeyRange(
-                    baseTable, partitionColumn, rangePartitionExpr);
+                    baseTable, partitionColumn, rangePartitionExpr).cells();
             PCellSortedSet currentPartitionMap = MVPartitionCellBuilder.getPartitionKeyRange(
-                    table, partitionColumn, rangePartitionExpr);
+                    table, partitionColumn, rangePartitionExpr).cells();
             return SyncPartitionUtils.hasRangePartitionChanged(snapshotPartitionMap, currentPartitionMap);
         } else {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.connector.MVPartitionCellBuilder;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -317,17 +318,17 @@ public final class ListPartitionDiffer extends PartitionDiffer {
      * Collect base table's partition infos.
      */
     @Override
-    public Map<Table, PCellSortedSet> syncBaseTablePartitionInfos() {
-        Map<Table, PCellSortedSet> refBaseTablePartitionMap = Maps.newHashMap();
+    public Map<Table, BaseToMVPartitionMapping> syncBaseTablePartitionInfos() {
+        Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap = Maps.newHashMap();
         Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
         try {
             for (Map.Entry<Table, List<Column>> e : refBaseTablePartitionColumns.entrySet()) {
                 Table refBaseTable = e.getKey();
                 List<Column> refPartitionColumns = e.getValue();
                 // collect base table's partition cells by aligning with mv's partition column order
-                PCellSortedSet basePartitionCells = MVPartitionCellBuilder.getPartitionCells(refBaseTable,
+                BaseToMVPartitionMapping mapping = MVPartitionCellBuilder.getPartitionCells(refBaseTable,
                         refPartitionColumns);
-                refBaseTablePartitionMap.put(refBaseTable, basePartitionCells);
+                refBaseTablePartitionMap.put(refBaseTable, mapping);
             }
         } catch (Exception e) {
             LOG.warn("Materialized view compute partition difference with base table failed.",
@@ -361,7 +362,7 @@ public final class ListPartitionDiffer extends PartitionDiffer {
     @Override
     public PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude) {
         // table -> map<partition name -> partition cell>
-        Map<Table, PCellSortedSet> refBaseTablePartitionMap = syncBaseTablePartitionInfos();
+        Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap = syncBaseTablePartitionInfos();
         // merge all base table partition cells
         if (refBaseTablePartitionMap == null) {
             logMVPrepare(mv, "Partitioned mv collect base table infos failed");
@@ -372,27 +373,18 @@ public final class ListPartitionDiffer extends PartitionDiffer {
 
     @Override
     public PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude,
-                                                    Map<Table, PCellSortedSet> refBaseTablePartitionMap) {
+                                                    Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap) {
         // generate the reference map between the base table and the mv
         // TODO: prune the partitions based on ttl
         PCellSortedSet mvPartitionNameToListMap = mv.getPartitionCells(Optional.empty());
 
         // collect all base table partition cells
-        PCellSortedSet allBasePartitionItems = collectBasePartitionCells(refBaseTablePartitionMap);
+        Map<Table, PCellSortedSet> refBaseTableCells = BaseToMVPartitionMapping.extractCells(refBaseTablePartitionMap);
+        PCellSortedSet allBasePartitionItems = collectBasePartitionCells(refBaseTableCells);
 
         PartitionDiff diff = ListPartitionDiffer.getListPartitionDiff(allBasePartitionItems, mvPartitionNameToListMap);
 
-        // collect external partition column mapping
-        Map<Table, PartitionNameSetMap> externalPartitionMaps = Maps.newHashMap();
-        if (!queryRewriteParams.isQueryRewrite()) {
-            try {
-                collectExternalPartitionNameMapping(mv.getRefBaseTablePartitionColumns(), externalPartitionMaps);
-            } catch (Exception e) {
-                LOG.warn("Get external partition column mapping failed.", DebugUtil.getStackTrace(e));
-                return null;
-            }
-        }
-        return new PartitionDiffResult(externalPartitionMaps, refBaseTablePartitionMap, mvPartitionNameToListMap, diff);
+        return new PartitionDiffResult(refBaseTablePartitionMap, mvPartitionNameToListMap, diff);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellUtils.java
@@ -67,7 +67,7 @@ public class PCellUtils {
                 }
                 List<Column> refPartitionColumns = refBaseTablePartitionColumns.get(baseTable);
                 if (partitionInfo.isListPartition()) {
-                    return buildListCells(baseTable, refPartitionColumns, partitionNames);
+                    return buildListCells(baseTable, refPartitionColumns, partitionNames).cells();
                 } else if (partitionInfo.isRangePartition()) {
                     Preconditions.checkArgument(refPartitionColumns.size() == 1,
                             "Range partition column size must be 1");
@@ -76,7 +76,7 @@ public class PCellUtils {
                     Preconditions.checkArgument(partitionExprOpt.isPresent(),
                             "Range partition expr must be present");
                     return buildRangeCells(baseTable, partitionColumn,
-                            partitionNames, partitionExprOpt.get());
+                            partitionNames, partitionExprOpt.get()).cells();
                 } else if (partitionInfo.isUnPartitioned()) {
                     // For non-partitioned MV, any updated partition in the base table triggers a full refresh.
                     // Wrap each updated base-table partition name as a PCellNone so the caller can detect

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
@@ -15,50 +15,36 @@
 package com.starrocks.sql.common;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 
 import java.util.Map;
 
 public class PartitionDiffResult {
-    // For external table, the mapping of base table partition to mv partition:
-    // <base table, <base table partition name, mv partition name>>
-    public final Map<Table, PartitionNameSetMap> refBaseTableMVPartitionMap;
-    // The partition range of the base tables: <base table, partition cells>
-    public final Map<Table, PCellSortedSet> refBaseTablePartitionMap;
+    // The partition range of the base tables: <base table, partition mapping>
+    public final Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap;
     // The partition range of the materialized view
     public final PCellSortedSet mvPartitionToCells;
     // The diff result of partition range between materialized view and base tables
     public final PartitionDiff diff;
 
-    public PartitionDiffResult(Map<Table, PartitionNameSetMap> refBaseTableMVPartitionMap,
-                               Map<Table, PCellSortedSet> refBaseTablePartitionMap,
+    public PartitionDiffResult(Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap,
                                PCellSortedSet mvPartitionToCells,
                                PartitionDiff diff) {
-        this.refBaseTableMVPartitionMap = refBaseTableMVPartitionMap;
         this.refBaseTablePartitionMap = refBaseTablePartitionMap;
         this.diff = diff;
         this.mvPartitionToCells = mvPartitionToCells;
     }
 
-    public Map<Table, PartitionNameSetMap> getRefBaseTableMVPartitionMap() {
-        return refBaseTableMVPartitionMap;
-    }
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        String refBaseTableMVPartitionMapStr = refBaseTableMVPartitionMap.entrySet()
-                .stream()
-                .map(e -> e.getKey().getName() + "=" + e.getValue().toString())
-                .reduce((a, b) -> a + ", " + b)
-                .orElse("");
         String  refBaseTablePartitionMapStr = refBaseTablePartitionMap.entrySet()
                 .stream()
-                .map(e -> e.getKey().getName() + "=" + e.getValue().toString())
+                .map(e -> e.getKey().getName() + "=" + e.getValue().cells().toString())
                 .reduce((a, b) -> a + ", " + b)
                 .orElse("");
         sb.append("{")
-                .append("refBaseTableMVPartitionMap:[").append(refBaseTableMVPartitionMapStr).append("]")
-                .append(", refBaseTablePartitionMap:[").append(refBaseTablePartitionMapStr).append("]")
+                .append("refBaseTablePartitionMap:[").append(refBaseTablePartitionMapStr).append("]")
                 .append(", mvPartitionToCells:[").append(mvPartitionToCells).append("]")
                 .append(", diff:[").append(diff).append("]")
                 .append("}");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -15,16 +15,12 @@
 package com.starrocks.sql.common;
 
 import com.google.common.collect.Range;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
-import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.MVPartitionCellBuilder;
-import com.starrocks.connector.PartitionUtil;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,7 +42,7 @@ public abstract class PartitionDiffer {
      * Collect the ref base table's partition range map.
      * @return the ref base table's partition range map: <ref base table, <partition name, partition range>>
      */
-    public abstract Map<Table, PCellSortedSet> syncBaseTablePartitionInfos();
+    public abstract Map<Table, BaseToMVPartitionMapping> syncBaseTablePartitionInfos();
 
     /**
      * Compute the partition difference between materialized view and all ref base tables.
@@ -57,7 +53,7 @@ public abstract class PartitionDiffer {
     public abstract PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude);
 
     public abstract PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude,
-                                                             Map<Table, PCellSortedSet> refBaseTablePartitionMap);
+                                                             Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap);
     /**
      * Generate the reference map between the base table and the mv.
      *
@@ -83,37 +79,4 @@ public abstract class PartitionDiffer {
      */
     public abstract Map<String, Map<Table, PCellSortedSet>> generateMvRefMap(PCellSortedSet mvPCells,
                                                                              Map<Table, PCellSortedSet> baseTablePCells);
-    /**
-     * To solve multi partition columns' problem of external table, record the mv partition name to all the same
-     * partition names map here.
-     * @param partitionTableAndColumns the partition table and its partition column
-     * @param result the result map
-     */
-    public static void collectExternalPartitionNameMapping(Map<Table, List<Column>> partitionTableAndColumns,
-                                                           Map<Table, PartitionNameSetMap> result) throws AnalysisException {
-        for (Map.Entry<Table, List<Column>> e : partitionTableAndColumns.entrySet()) {
-            Table refBaseTable = e.getKey();
-            List<Column> refPartitionColumns = e.getValue();
-            collectExternalBaseTablePartitionMapping(refBaseTable, refPartitionColumns, result);
-        }
-    }
-
-    /**
-     * Collect the external base table's partition name to its intersected materialized view names.
-     * @param refBaseTable the base table
-     * @param refTablePartitionColumns the partition column of the base table
-     * @param result the result map
-     * @throws AnalysisException
-     */
-    private static void collectExternalBaseTablePartitionMapping(
-            Table refBaseTable,
-            List<Column> refTablePartitionColumns,
-            Map<Table, PartitionNameSetMap> result) throws AnalysisException {
-        if (refBaseTable.isNativeTableOrMaterializedView()) {
-            return;
-        }
-        PartitionNameSetMap mvPartitionNameMap = MVPartitionCellBuilder.buildMVPartitionNameMap(refBaseTable,
-                refTablePartitionColumns, PartitionUtil.getPartitionNames(refBaseTable));
-        result.put(refBaseTable, mvPartitionNameMap);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -33,6 +33,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.connector.MVPartitionCellBuilder;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.type.Type;
@@ -221,13 +222,13 @@ public final class RangePartitionDiffer extends PartitionDiffer {
      * @return the ref base table's partition range map: <ref base table, partition cells>
      */
     @Override
-    public Map<Table, PCellSortedSet> syncBaseTablePartitionInfos() {
+    public Map<Table, BaseToMVPartitionMapping> syncBaseTablePartitionInfos() {
         Map<Table, List<Column>> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         if (partitionTableAndColumn.isEmpty()) {
             return Maps.newHashMap();
         }
 
-        Map<Table, PCellSortedSet> refBaseTablePartitionMap = Maps.newHashMap();
+        Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap = Maps.newHashMap();
         Optional<Expr> mvPartitionExprOpt = mv.getRangePartitionFirstExpr();
         if (mvPartitionExprOpt.isEmpty()) {
             return Maps.newHashMap();
@@ -238,13 +239,13 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                 List<Column> refBTPartitionColumns = entry.getValue();
                 Preconditions.checkArgument(refBTPartitionColumns.size() == 1);
                 // Collect the ref base table's partition range map.
-                PCellSortedSet refTablePartitionKeyMap =
+                BaseToMVPartitionMapping mapping =
                         MVPartitionCellBuilder.getPartitionKeyRange(refBT, refBTPartitionColumns.get(0),
                                 mvPartitionExprOpt.get());
-                if (refTablePartitionKeyMap == null) {
+                if (mapping.cells() == null) {
                     return null;
                 }
-                refBaseTablePartitionMap.put(refBT, refTablePartitionKeyMap);
+                refBaseTablePartitionMap.put(refBT, mapping);
             }
         } catch (StarRocksException | SemanticException e) {
             LOG.warn("Partition differ collects ref base table partition failed.", e);
@@ -334,13 +335,13 @@ public final class RangePartitionDiffer extends PartitionDiffer {
      */
     @Override
     public PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude) {
-        Map<Table, PCellSortedSet> rBTPartitionMap = syncBaseTablePartitionInfos();
+        Map<Table, BaseToMVPartitionMapping> rBTPartitionMap = syncBaseTablePartitionInfos();
         return computePartitionDiff(rangeToInclude, rBTPartitionMap);
     }
 
     @Override
     public PartitionDiffResult computePartitionDiff(Range<PartitionKey> rangeToInclude,
-                                                    Map<Table, PCellSortedSet> refBaseTablePartitionMap) {
+                                                    Map<Table, BaseToMVPartitionMapping> refBaseTablePartitionMap) {
         Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
         Preconditions.checkArgument(!refBaseTablePartitionColumns.isEmpty());
         // get the materialized view's partition range map
@@ -352,7 +353,8 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             return null;
         }
         Expr mvPartitionExpr = mvPartitionExprOpt.get();
-        PCellSortedSet mergedRBTPartitionKeyMap = mergeRBTPartitionKeyMap(mvPartitionExpr, refBaseTablePartitionMap);
+        Map<Table, PCellSortedSet> refBaseTableCells = BaseToMVPartitionMapping.extractCells(refBaseTablePartitionMap);
+        PCellSortedSet mergedRBTPartitionKeyMap = mergeRBTPartitionKeyMap(mvPartitionExpr, refBaseTableCells);
         if (mergedRBTPartitionKeyMap == null) {
             LOG.warn("Merge materialized view {} with base tables failed.", mv.getName());
             return null;
@@ -364,42 +366,31 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             for (Table refBaseTable : refBaseTablePartitionColumns.keySet()) {
                 Preconditions.checkArgument(refBaseTablePartitionMap.containsKey(refBaseTable));
                 RangePartitionDiffer differ = new RangePartitionDiffer(mv, queryRewriteParams, rangeToInclude);
-                PCellSortedSet basePartitionMap = refBaseTablePartitionMap.get(refBaseTable);
+                PCellSortedSet basePartitionMap = refBaseTableCells.get(refBaseTable);
                 PartitionDiff diff = PartitionUtil.getPartitionDiff(mvPartitionExpr, basePartitionMap,
                         mvPartitionCells, differ);
                 rangePartitionDiffList.add(diff);
             }
             PartitionDiff.checkRangePartitionAligned(rangePartitionDiffList);
         }
-        try {
-            // NOTE: Use all refBaseTables' partition range to compute the partition difference between MV and refBaseTables.
-            // Merge all deletes of each refBaseTab's diff may cause dropping needed partitions, the deletes should use
-            // `bigcap` rather than `bigcup`.
-            // Diff_{adds} = P_{\bigcup_{baseTables}^{}} \setminus  P_{MV} \\
-            //             = \bigcup_{baseTables} P_{baseTable}\setminus P_{MV}
-            //
-            // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
-            //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
-            RangePartitionDiffer differ = queryRewriteParams.isQueryRewrite() ? null
-                    : new RangePartitionDiffer(mv, queryRewriteParams, rangeToInclude);
-            PartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(mvPartitionExpr, mergedRBTPartitionKeyMap,
-                    mvPartitionCells, differ);
-            if (rangePartitionDiff == null) {
-                LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
-                return null;
-            }
-            Map<Table, PartitionNameSetMap> extRBTMVPartitionNameMap = Maps.newHashMap();
-            if (!queryRewriteParams.isQueryRewrite()) {
-                // To solve multi partition columns' problem of external table, record the mv partition name to all the same
-                // partition names map here.
-                collectExternalPartitionNameMapping(refBaseTablePartitionColumns, extRBTMVPartitionNameMap);
-            }
-            return new PartitionDiffResult(extRBTMVPartitionNameMap, refBaseTablePartitionMap,
-                    mvPartitionCells, rangePartitionDiff);
-        } catch (AnalysisException e) {
-            LOG.warn("Materialized view compute partition difference with base table failed.", e);
+        // NOTE: Use all refBaseTables' partition range to compute the partition difference between MV and refBaseTables.
+        // Merge all deletes of each refBaseTab's diff may cause dropping needed partitions, the deletes should use
+        // `bigcap` rather than `bigcup`.
+        // Diff_{adds} = P_{\bigcup_{baseTables}^{}} \setminus  P_{MV} \\
+        //             = \bigcup_{baseTables} P_{baseTable}\setminus P_{MV}
+        //
+        // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
+        //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
+        RangePartitionDiffer differ = queryRewriteParams.isQueryRewrite() ? null
+                : new RangePartitionDiffer(mv, queryRewriteParams, rangeToInclude);
+        PartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(mvPartitionExpr, mergedRBTPartitionKeyMap,
+                mvPartitionCells, differ);
+        if (rangePartitionDiff == null) {
+            LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
             return null;
         }
+        return new PartitionDiffResult(refBaseTablePartitionMap,
+                mvPartitionCells, rangePartitionDiff);
     }
 
     public static void updatePartitionRefMap(Map<String, Map<Table, PCellSortedSet>> result,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -291,7 +291,7 @@ public class PartitionUtilTest {
         };
 
         PCellSortedSet partitionMap =
-                MVPartitionCellBuilder.getPartitionKeyRange(table, partitionColumn, null);
+                MVPartitionCellBuilder.getPartitionKeyRange(table, partitionColumn, null).cells();
         Assertions.assertEquals(partitionMap.size(), partitionNames.size());
         Assertions.assertTrue(partitionMap.containsName("p20221202"));
         PartitionKey upperBound = new PartitionKey();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MvTaskRunContextTest.java
@@ -16,13 +16,13 @@ package com.starrocks.scheduler;
 
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Table;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.scheduler.mv.pct.PCTPartitionTopology;
 import com.starrocks.scheduler.mv.pct.PCTRefreshScope;
 import com.starrocks.sql.common.PCellNone;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
-import com.starrocks.sql.common.PartitionNameSetMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -52,24 +52,23 @@ public class MvTaskRunContextTest {
 
         PCellSortedSet refBaseTableToCell = PCellSortedSet.of();
         refBaseTableToCell.add(PCellWithName.of("base_p1", new PCellNone()));
-        Map<Table, PCellSortedSet> refBaseTableToCellMap = Maps.newHashMap();
-        refBaseTableToCellMap.put(refBaseTable, refBaseTableToCell);
+        BaseToMVPartitionMapping refBaseTableMapping = BaseToMVPartitionMapping.of(
+                refBaseTableToCell, Map.of("mv_p1", Set.of("base_p1")));
+        Map<Table, BaseToMVPartitionMapping> refBaseTableToCellMap = Maps.newHashMap();
+        refBaseTableToCellMap.put(refBaseTable, refBaseTableMapping);
 
         PCellSetMapping refBaseTableMVIntersectedPartitions = PCellSetMapping.of();
         refBaseTableMVIntersectedPartitions.put("base_p1", PCellWithName.of("mv_p1", new PCellNone()));
         Map<Table, PCellSetMapping> baseToMvNameRef = Maps.newHashMap();
         baseToMvNameRef.put(refBaseTable, refBaseTableMVIntersectedPartitions);
 
+        Map<Table, PCellSortedSet> refBaseTableToCellMapRaw = Maps.newHashMap();
+        refBaseTableToCellMapRaw.put(refBaseTable, refBaseTableToCell);
         Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef = Maps.newHashMap();
-        mvToBaseNameRef.put("mv_p1", refBaseTableToCellMap);
-
-        PartitionNameSetMap externalRefBaseTableMVPartitionMap = PartitionNameSetMap.of();
-        externalRefBaseTableMVPartitionMap.put("mv_p1", "base_p1");
-        Map<Table, PartitionNameSetMap> externalMap = Maps.newHashMap();
-        externalMap.put(refBaseTable, externalRefBaseTableMVPartitionMap);
+        mvToBaseNameRef.put("mv_p1", refBaseTableToCellMapRaw);
 
         PCTPartitionTopology topology = new PCTPartitionTopology(mvToCellMap, refBaseTableToCellMap,
-                baseToMvNameRef, mvToBaseNameRef, externalMap);
+                baseToMvNameRef, mvToBaseNameRef);
 
         context.setPartitionTopology(topology);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -72,8 +72,7 @@ public class MVPCTRefreshRangePartitionerTest {
                 PCellSortedSet.of(),
                 Maps.newHashMap(),
                 Maps.<Table, PCellSetMapping>newHashMap(),
-                mvToBaseNameRefs,
-                Maps.newHashMap()));
+                mvToBaseNameRefs));
         // TODO: make range cells
         List<PCellWithName> partitions = Arrays.asList(PCellWithName.of("mv_p1", new PCellNone()),
                 PCellWithName.of("mv_p2", new PCellNone()));

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -18,10 +18,10 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.common.PCellNone;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
-import com.starrocks.sql.common.PartitionNameSetMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -121,15 +121,17 @@ public class MVRefreshPartitionSelectorTest {
 
     @Test
     public void testExternalTablePartitionsStatistics() throws Exception {
-        Map<Table, PartitionNameSetMap> externalPartitionMap = new HashMap<>();
-        PartitionNameSetMap partitionMap1 = PartitionNameSetMap.of();
-        partitionMap1.put("p1", Set.of("dt=p1"));
-        partitionMap1.put("p2", Set.of("dt=p2", "dt=p3"));
-        externalPartitionMap.put(mockExternalTable(), partitionMap1);
-        PartitionNameSetMap partitionMap2 = PartitionNameSetMap.of();
-        partitionMap2.put("p1", Set.of("dt=p1"));
-        partitionMap2.put("p2", Set.of("dt=p2"));
-        externalPartitionMap.put(mockExternalTable(), partitionMap2);
+        Map<Table, BaseToMVPartitionMapping> externalPartitionMap = new HashMap<>();
+        Map<String, Set<String>> sourceMapping1 = new HashMap<>();
+        sourceMapping1.put("p1", Set.of("dt=p1"));
+        sourceMapping1.put("p2", Set.of("dt=p2", "dt=p3"));
+        externalPartitionMap.put(mockExternalTable(),
+                BaseToMVPartitionMapping.of(PCellSortedSet.of(), sourceMapping1));
+        Map<String, Set<String>> sourceMapping2 = new HashMap<>();
+        sourceMapping2.put("p1", Set.of("dt=p1"));
+        sourceMapping2.put("p2", Set.of("dt=p2"));
+        externalPartitionMap.put(mockExternalTable(),
+                BaseToMVPartitionMapping.of(PCellSortedSet.of(), sourceMapping2));
 
         MVRefreshPartitionSelector selector = new MVRefreshPartitionSelector(1000, 10000,
                 10, externalPartitionMap);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/BaseToMVPartitionMappingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/BaseToMVPartitionMappingTest.java
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv.pct;
+
+import com.starrocks.mv.pct.BaseToMVPartitionMapping;
+import com.starrocks.sql.common.PCellNone;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+public class BaseToMVPartitionMappingTest {
+
+    @Test
+    public void testEmptyMapping() {
+        PCellSortedSet cells = PCellSortedSet.of();
+        cells.add(PCellWithName.of("p202401", new PCellNone()));
+        BaseToMVPartitionMapping mapping = BaseToMVPartitionMapping.of(cells);
+
+        Assertions.assertSame(cells, mapping.cells());
+        Assertions.assertTrue(mapping.sourceNameMapping().isEmpty());
+        Assertions.assertTrue(mapping.getSourceNames("p202401").isEmpty());
+    }
+
+    @Test
+    public void testWithSourceNames() {
+        PCellSortedSet cells = PCellSortedSet.of();
+        cells.add(PCellWithName.of("p202401", new PCellNone()));
+        Map<String, Set<String>> sourceMapping = Map.of(
+                "p202401", Set.of("par_date=2024-01-01", "par_date=2024-01-02"));
+        BaseToMVPartitionMapping mapping = BaseToMVPartitionMapping.of(cells, sourceMapping);
+
+        Assertions.assertEquals(Set.of("par_date=2024-01-01", "par_date=2024-01-02"),
+                mapping.getSourceNames("p202401"));
+        Assertions.assertTrue(mapping.getSourceNames("nonexistent").isEmpty());
+    }
+
+    @Test
+    public void testExtractCells() {
+        PCellSortedSet cells1 = PCellSortedSet.of();
+        cells1.add(PCellWithName.of("p1", new PCellNone()));
+        PCellSortedSet cells2 = PCellSortedSet.of();
+        cells2.add(PCellWithName.of("p2", new PCellNone()));
+
+        Map<String, BaseToMVPartitionMapping> map = Map.of(
+                "t1", BaseToMVPartitionMapping.of(cells1),
+                "t2", BaseToMVPartitionMapping.of(cells2));
+
+        Map<String, PCellSortedSet> extracted = BaseToMVPartitionMapping.extractCells(map);
+        Assertions.assertSame(cells1, extracted.get("t1"));
+        Assertions.assertSame(cells2, extracted.get("t2"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/pct/PCTRefreshScopeCalculatorTest.java
@@ -72,8 +72,7 @@ public class PCTRefreshScopeCalculatorTest {
                 PCellSortedSet.of(),
                 Maps.newHashMap(),
                 Maps.newHashMap(),
-                mvToBasePartitions,
-                Maps.newHashMap());
+                mvToBasePartitions);
 
         Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = new LinkedHashMap<>();
         snapshotBaseTables.put(1L, snapshotInfoA);
@@ -113,8 +112,7 @@ public class PCTRefreshScopeCalculatorTest {
                 PCellSortedSet.of(),
                 Maps.newHashMap(),
                 Maps.newHashMap(),
-                mvToBasePartitions,
-                Maps.newHashMap());
+                mvToBasePartitions);
 
         Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = Map.of(1L, snapshotInfo);
 
@@ -162,8 +160,7 @@ public class PCTRefreshScopeCalculatorTest {
                 PCellSortedSet.of(),
                 Maps.newHashMap(),
                 Maps.newHashMap(),
-                mvToBasePartitions,
-                Maps.newHashMap());
+                mvToBasePartitions);
 
         Map<Long, BaseTableSnapshotInfo> snapshotBaseTables = new LinkedHashMap<>();
         snapshotBaseTables.put(1L, snapshotInfoA);


### PR DESCRIPTION
## Why I'm doing:

The MV refresh flow resolves external base table partitions **twice**:
1. `syncBaseTablePartitionInfos` → `buildRangeCells` → `resolveAndSort` builds `PCellSortedSet` but discards original base partition names during deduplication.
2. `collectExternalPartitionNameMapping` → `buildMVPartitionNameMap` re-resolves every partition name just to build the name-level mapping.

Additionally, `PCTPartitionTopology` carries two overlapping mapping systems (cell-level and name-level) and the name mapping is stuffed into `PartitionDiffResult` which is the wrong abstraction layer.

## What I'm doing:

- Introduce `BaseToMVPartitionMapping` record that pairs `PCellSortedSet` with an optional source name mapping (`mvPartitionName → Set<originalBasePartitionName>`), produced in a single resolve pass.
- Change `MVPartitionCellBuilder.buildRangeCells/buildListCells/getPartitionKeyRange/getPartitionCells` to return `BaseToMVPartitionMapping`.
- Remove `collectExternalPartitionNameMapping`, `collectExternalBaseTablePartitionMapping`, and `buildMVPartitionNameMap` — they are no longer needed.
- Slim down `PartitionDiffResult` by removing the `refBaseTableMVPartitionMap` field.
- Slim down `PCTPartitionTopology` from 5 fields to 4 by removing `externalRefBaseTableMVPartitionMap` and changing `refBaseTableToCellMap` to carry `BaseToMVPartitionMapping`.
- Adapt all downstream consumers: `MvTaskRunContext`, `MVRefreshPartitionSelector`, `MVPCTRefreshPartitioner`, both partitioners, `PCTPredicateBuilder`, etc.

Net result: 22 files changed, 313 insertions, 286 deletions.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4