### PR TITLE
[Refactor] Use PMR memory resource for table descriptor allocations

### DIFF
--- a/be/src/common/runtime_profile.cpp
+++ b/be/src/common/runtime_profile.cpp
@@ -206,7 +206,7 @@ void RuntimeProfile::update(const std::vector<TRuntimeProfileNode>& nodes, int* 
 
     if (!is_node_old) {
         std::lock_guard<std::mutex> l(_info_strings_lock);
-        const InfoStrings& info_strings = node.info_strings;
+        const auto& info_strings = node.info_strings;
         for (const std::string& key : node.info_strings_display_order) {
             // Look for existing info strings and update in place. If there
             // are new strings, add them to the end of the display order.
@@ -408,27 +408,37 @@ void RuntimeProfile::get_all_children(std::vector<RuntimeProfile*>* children) {
     }
 }
 
-void RuntimeProfile::add_info_string(const std::string& key, const std::string& value) {
+void RuntimeProfile::add_info_string(std::string_view key, std::string_view value) {
     std::lock_guard<std::mutex> l(_info_strings_lock);
     auto it = _info_strings.find(key);
 
     if (it == _info_strings.end()) {
         _info_strings.emplace(key, value);
-        _info_strings_display_order.push_back(key);
+        _info_strings_display_order.push_back(std::string(key));
     } else {
         it->second = value;
     }
 }
 
-std::string* RuntimeProfile::get_info_string(const std::string& key) {
+void RuntimeProfile::add_info_string_if_not_exists(std::string_view key, std::string_view value) {
     std::lock_guard<std::mutex> l(_info_strings_lock);
     auto it = _info_strings.find(key);
 
     if (it == _info_strings.end()) {
-        return nullptr;
+        _info_strings.emplace(key, value);
+        _info_strings_display_order.push_back(std::string(key));
+    }
+}
+
+std::optional<std::string> RuntimeProfile::get_info_string(std::string_view key) {
+    std::lock_guard<std::mutex> l(_info_strings_lock);
+    auto it = _info_strings.find(key);
+
+    if (it == _info_strings.end()) {
+        return std::nullopt;
     }
 
-    return &it->second;
+    return std::string(it->second);
 }
 
 void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
@@ -439,10 +449,10 @@ void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
 
     std::lock_guard<std::mutex> l(src_profile->_info_strings_lock);
     for (const auto& [key, value] : src_profile->_info_strings) {
-        const std::string* exist_ptr = get_info_string(key);
-        if (exist_ptr == nullptr) {
+        const auto info = get_info_string(key);
+        if (!info.has_value()) {
             add_info_string(key, value);
-        } else if (value != *exist_ptr) {
+        } else if (value != *info) {
             std::string original_key = key;
             if (size_t pos; (pos = key.find("__DUP(")) != std::string::npos) {
                 original_key = key.substr(0, pos);
@@ -454,7 +464,7 @@ void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
                 previous_offset = offset;
                 offset += step;
                 const std::string indexed_key = strings::Substitute("$0__DUP($1)", original_key, offset);
-                if (get_info_string(indexed_key) == nullptr) {
+                if (!get_info_string(indexed_key).has_value()) {
                     if (step == 1) {
                         add_info_string(indexed_key, value);
                         break;
@@ -826,7 +836,7 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
 
     {
         std::lock_guard<std::mutex> l(_info_strings_lock);
-        node.info_strings = _info_strings;
+        node.info_strings.insert(_info_strings.begin(), _info_strings.end());
         node.info_strings_display_order = _info_strings_display_order;
     }
 

--- a/be/src/common/runtime_profile.h
+++ b/be/src/common/runtime_profile.h
@@ -42,11 +42,11 @@
 #include <iostream>
 #include <mutex>
 #include <optional>
-#include <thread>
 #include <unordered_set>
 #include <utility>
 
 #include "base/concurrency/stopwatch.hpp"
+#include "base/phmap/phmap.h"
 #include "common/compiler_util.h"
 #include "common/logging.h"
 #include "common/object_pool.h"
@@ -466,12 +466,10 @@ public:
     // Clean all the counters except saved_names
     void remove_counters(const std::set<std::string>& saved_names);
 
-    // Helper to append to the "ExecOption" info string.
-    void append_exec_option(const std::string& option) { add_info_string("ExecOption", option); }
-
     // Adds a string to the runtime profile.  If a value already exists for 'key',
     // the value will be updated.
-    void add_info_string(const std::string& key, const std::string& value = "");
+    void add_info_string(std::string_view key, std::string_view value = {});
+    void add_info_string_if_not_exists(std::string_view key, std::string_view value);
 
     // Creates and returns a new EventSequence (owned by the runtime
     // profile) - unless a timer with the same 'key' already exists, in
@@ -479,9 +477,9 @@ public:
     // TODO: EventSequences are not merged by Merge()
     EventSequence* add_event_sequence(const std::string& key);
 
-    // Returns a pointer to the info string value for 'key'.  Returns NULL if
+    // Returns a pointer to the info string value for 'key'.  Returns std::nullopt if
     // the key does not exist.
-    std::string* get_info_string(const std::string& key);
+    std::optional<std::string> get_info_string(std::string_view key);
 
     // Copy all the string infos from src profile
     void copy_all_info_strings_from(RuntimeProfile* src_profile);
@@ -620,7 +618,7 @@ private:
     ChildVector _children;
     mutable std::mutex _children_lock; // protects _child_map and _children
 
-    typedef std::map<std::string, std::string> InfoStrings;
+    using InfoStrings = phmap::flat_hash_map<std::string, std::string>;
     InfoStrings _info_strings;
 
     // Keeps track of the order in which InfoStrings are displayed when printed

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -732,7 +732,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     }
     if (native_file_path.empty()) {
         bool start_with_slash = !scan_range.relative_path.empty() && scan_range.relative_path.at(0) == '/';
-        native_file_path = _hive_table->get_base_path() +
+        native_file_path = std::string(_hive_table->get_base_path()) +
                            (start_with_slash ? scan_range.relative_path : "/" + scan_range.relative_path);
     }
 

--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -132,10 +132,10 @@ Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     const auto* jdbc_table = down_cast<const JDBCTableDescriptor*>(_tuple_desc->table_desc());
 
     Status status;
-    std::string driver_name = jdbc_table->jdbc_driver_name();
-    std::string driver_url = jdbc_table->jdbc_driver_url();
-    std::string driver_checksum = jdbc_table->jdbc_driver_checksum();
-    std::string driver_class = jdbc_table->jdbc_driver_class();
+    std::string driver_name(jdbc_table->jdbc_driver_name());
+    std::string driver_url(jdbc_table->jdbc_driver_url());
+    std::string driver_checksum(jdbc_table->jdbc_driver_checksum());
+    std::string driver_class(jdbc_table->jdbc_driver_class());
     std::string driver_location;
 
     status = JDBCDriverManager::getInstance()->get_driver_location(driver_name, driver_url, driver_checksum,

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -53,6 +53,7 @@ void HashJoinProbeMetrics::prepare(RuntimeProfile* runtime_profile) {
 }
 
 void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
+    this->runtime_profile = runtime_profile;
     copy_right_table_chunk_timer = ADD_TIMER(runtime_profile, "CopyRightTableChunkTime");
     build_ht_timer = ADD_TIMER(runtime_profile, "BuildHashTableTime");
     build_runtime_filter_timer = ADD_TIMER(runtime_profile, "RuntimeFilterBuildTime");
@@ -64,8 +65,6 @@ void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
     partial_runtime_bloom_filter_bytes =
             ADD_COUNTER(runtime_profile, "PartialRuntimeMembershipFilterBytes", TUnit::BYTES);
     partition_nums = ADD_COUNTER(runtime_profile, "PartitionNums", TUnit::UNIT);
-    runtime_profile->add_info_string("HashMapType", "NONE");
-    hash_map_type_info = runtime_profile->get_info_string("HashMapType");
 }
 
 HashJoiner::HashJoiner(const HashJoinerParam& param)
@@ -255,7 +254,7 @@ Status HashJoiner::build_ht(RuntimeState* state) {
         _hash_join_builder->get_build_info(&bucket_size, &avg_keys_per_bucket, &hash_map_type);
         COUNTER_SET(build_metrics().build_buckets_counter, static_cast<int64_t>(bucket_size));
         COUNTER_SET(build_metrics().build_keys_per_bucket, static_cast<int64_t>(100 * avg_keys_per_bucket));
-        *(build_metrics().hash_map_type_info) = std::move(hash_map_type);
+        build_metrics().runtime_profile->add_info_string_if_not_exists("HashMapType", hash_map_type);
     }
 
     return Status::OK();

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -172,6 +172,7 @@ struct HashJoinProbeMetrics {
 };
 
 struct HashJoinBuildMetrics {
+    RuntimeProfile* runtime_profile = nullptr;
     RuntimeProfile::Counter* build_ht_timer = nullptr;
     RuntimeProfile::Counter* copy_right_table_chunk_timer = nullptr;
     RuntimeProfile::Counter* build_runtime_filter_timer = nullptr;
@@ -182,7 +183,6 @@ struct HashJoinBuildMetrics {
     RuntimeProfile::Counter* hash_table_memory_usage = nullptr;
     RuntimeProfile::Counter* partial_runtime_bloom_filter_bytes = nullptr;
     RuntimeProfile::Counter* partition_nums = nullptr;
-    std::string* hash_map_type_info = nullptr;
 
     void prepare(RuntimeProfile* runtime_profile);
 };

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -528,7 +528,7 @@ std::unique_ptr<JniScanner> create_hive_jni_scanner(const JniScanner::CreateOpti
     } else if (dynamic_cast<const HdfsTableDescriptor*>(hive_table)) {
         const auto* hdfs_table = down_cast<const HdfsTableDescriptor*>(hive_table);
         auto* partition_desc = hdfs_table->get_partition(scan_range.partition_id);
-        std::string partition_full_path = partition_desc->location();
+        std::string partition_full_path(partition_desc->location());
         data_file_path = fmt::format("{}/{}", partition_full_path, scan_range.relative_path);
 
         hive_column_names = hdfs_table->get_hive_column_names();
@@ -583,7 +583,7 @@ std::unique_ptr<JniScanner> create_hudi_jni_scanner(const JniScanner::CreateOpti
     const auto& scan_range = *(options.scan_range);
     const auto* hudi_table = dynamic_cast<const HudiTableDescriptor*>(options.hive_table);
     auto* partition_desc = hudi_table->get_partition(scan_range.partition_id);
-    std::string partition_full_path = partition_desc->location();
+    std::string partition_full_path(partition_desc->location());
 
     std::string delta_file_paths;
     if (!scan_range.hudi_logs.empty()) {

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -27,11 +27,11 @@
 
 namespace starrocks {
 const int RowDescriptor::INVALID_IDX = -1;
-SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type)
+SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type, std::pmr::memory_resource* mr)
         : _id(id),
           _type(std::move(type)),
           _parent(0),
-          _col_name(std::move(name)),
+          _col_name(name, mr),
           _col_unique_id(-1),
           _slot_idx(0),
           _slot_size(_type.get_slot_size()),
@@ -40,13 +40,13 @@ SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type)
           _is_nullable(true),
           _is_virtual(false) {}
 
-SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
+SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc, std::pmr::memory_resource* mr)
         : _id(tdesc.id),
           _type(TypeDescriptor::from_thrift(tdesc.slotType)),
           _parent(tdesc.parent),
-          _col_name(tdesc.colName),
+          _col_name(tdesc.colName, mr),
           _col_unique_id(tdesc.col_unique_id),
-          _col_physical_name(tdesc.col_physical_name),
+          _col_physical_name(tdesc.col_physical_name, mr),
           _slot_idx(tdesc.slotIdx),
           _slot_size(_type.get_slot_size()),
           _is_materialized(tdesc.isMaterialized),
@@ -56,11 +56,11 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
                                : (tdesc.__isset.nullIndicatorBit ? tdesc.nullIndicatorBit != -1 : true)),
           _is_virtual(tdesc.__isset.is_virtual_column ? tdesc.is_virtual_column : false) {}
 
-SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
+SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc, std::pmr::memory_resource* mr)
         : _id(pdesc.id()),
           _type(TypeDescriptor::from_protobuf(pdesc.slot_type())),
           _parent(pdesc.parent()),
-          _col_name(pdesc.col_name()),
+          _col_name(pdesc.col_name(), mr),
           _col_unique_id(-1),
           _slot_idx(pdesc.slot_idx()),
           _slot_size(_type.get_slot_size()),
@@ -79,7 +79,7 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_byte_offset(0);
     pslot->set_null_indicator_byte(0);
     pslot->set_null_indicator_bit(_is_nullable ? 0 : -1);
-    pslot->set_col_name(_col_name);
+    pslot->set_col_name(_col_name.data(), _col_name.size());
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);
     pslot->set_is_nullable(_is_nullable);
@@ -93,8 +93,8 @@ std::string SlotDescriptor::debug_string() const {
     return out.str();
 }
 
-TableDescriptor::TableDescriptor(const TTableDescriptor& tdesc)
-        : _name(tdesc.tableName), _database(tdesc.dbName), _id(tdesc.id) {}
+TableDescriptor::TableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : _name(tdesc.tableName, mr), _database(tdesc.dbName, mr), _id(tdesc.id) {}
 
 std::string TableDescriptor::debug_string() const {
     std::stringstream out;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -18,6 +18,7 @@
 #include <google/protobuf/stubs/common.h>
 
 #include <cstdint>
+#include <memory_resource>
 #include <optional>
 #include <string_view>
 #include <unordered_map>
@@ -48,7 +49,8 @@ class RowPositionDescriptor;
 
 class SlotDescriptor {
 public:
-    SlotDescriptor(SlotId id, std::string name, TypeDescriptor type);
+    SlotDescriptor(SlotId id, std::string name, TypeDescriptor type,
+                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
 
     SlotId id() const { return _id; }
     const TypeDescriptor& type() const { return _type; }
@@ -70,7 +72,8 @@ public:
     int32_t col_unique_id() const { return _col_unique_id; }
     std::string_view col_physical_name() const { return _col_physical_name; }
 
-    SlotDescriptor(const TSlotDescriptor& tdesc);
+    SlotDescriptor(const TSlotDescriptor& tdesc,
+                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
 
 private:
     friend class DescriptorTbl;
@@ -82,9 +85,9 @@ private:
     const SlotId _id;
     TypeDescriptor _type;
     const TupleId _parent;
-    const std::string _col_name;
+    const std::pmr::string _col_name;
     const int32_t _col_unique_id;
-    const std::string _col_physical_name;
+    const std::pmr::string _col_physical_name;
 
     // the idx of the slot in the tuple descriptor (0-based).
     // this is provided by the FE
@@ -100,23 +103,25 @@ private:
 
     const bool _is_virtual;
 
-    SlotDescriptor(const PSlotDescriptor& pdesc);
+    SlotDescriptor(const PSlotDescriptor& pdesc,
+                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
 };
 
 // Base class for table descriptors.
 class TableDescriptor {
 public:
-    TableDescriptor(const TTableDescriptor& tdesc);
+    TableDescriptor(const TTableDescriptor& tdesc,
+                    std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     virtual ~TableDescriptor() = default;
     TableId table_id() const { return _id; }
     virtual std::string debug_string() const;
 
-    const std::string& name() const { return _name; }
-    const std::string& database() const { return _database; }
+    std::string_view name() const { return _name; }
+    std::string_view database() const { return _database; }
 
 private:
-    std::string _name;
-    std::string _database;
+    std::pmr::string _name;
+    std::pmr::string _database;
     TableId _id;
 };
 
@@ -181,16 +186,30 @@ public:
     std::string debug_string() const;
 
 private:
-    typedef std::unordered_map<TableId, TableDescriptor*> TableDescriptorMap;
-    typedef std::unordered_map<TupleId, TupleDescriptor*> TupleDescriptorMap;
-    typedef std::unordered_map<SlotId, SlotDescriptor*> SlotDescriptorMap;
+    using TableDescriptorMap = std::pmr::unordered_map<TableId, TableDescriptor*>;
+    using TupleDescriptorMap = std::pmr::unordered_map<TupleId, TupleDescriptor*>;
+    using SlotDescriptorMap = std::pmr::unordered_map<SlotId, SlotDescriptor*>;
+
+    std::pmr::memory_resource* _mr;
 
     TableDescriptorMap _tbl_desc_map;
     TupleDescriptorMap _tuple_desc_map;
     SlotDescriptorMap _slot_desc_map;
     SlotDescriptorMap _slot_with_column_name_map;
 
-    DescriptorTbl() = default;
+    DescriptorTbl()
+            : _mr(std::pmr::get_default_resource()),
+              _tbl_desc_map(_mr),
+              _tuple_desc_map(_mr),
+              _slot_desc_map(_mr),
+              _slot_with_column_name_map(_mr) {}
+
+    explicit DescriptorTbl(std::pmr::memory_resource* mr)
+            : _mr(mr),
+              _tbl_desc_map(_mr),
+              _tuple_desc_map(_mr),
+              _slot_desc_map(_mr),
+              _slot_with_column_name_map(_mr) {}
 
     friend class ObjectPool;
 };

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -72,8 +72,7 @@ public:
     int32_t col_unique_id() const { return _col_unique_id; }
     std::string_view col_physical_name() const { return _col_physical_name; }
 
-    SlotDescriptor(const TSlotDescriptor& tdesc,
-                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
+    SlotDescriptor(const TSlotDescriptor& tdesc, std::pmr::memory_resource* mr = std::pmr::get_default_resource());
 
 private:
     friend class DescriptorTbl;
@@ -103,15 +102,13 @@ private:
 
     const bool _is_virtual;
 
-    SlotDescriptor(const PSlotDescriptor& pdesc,
-                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
+    SlotDescriptor(const PSlotDescriptor& pdesc, std::pmr::memory_resource* mr = std::pmr::get_default_resource());
 };
 
 // Base class for table descriptors.
 class TableDescriptor {
 public:
-    TableDescriptor(const TTableDescriptor& tdesc,
-                    std::pmr::memory_resource* mr = std::pmr::get_default_resource());
+    TableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     virtual ~TableDescriptor() = default;
     TableId table_id() const { return _id; }
     virtual std::string debug_string() const;
@@ -205,11 +202,7 @@ private:
               _slot_with_column_name_map(_mr) {}
 
     explicit DescriptorTbl(std::pmr::memory_resource* mr)
-            : _mr(mr),
-              _tbl_desc_map(_mr),
-              _tuple_desc_map(_mr),
-              _slot_desc_map(_mr),
-              _slot_with_column_name_map(_mr) {}
+            : _mr(mr), _tbl_desc_map(_mr), _tuple_desc_map(_mr), _slot_desc_map(_mr), _slot_with_column_name_map(_mr) {}
 
     friend class ObjectPool;
 };

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -57,8 +57,7 @@ std::string HdfsPartitionDescriptor::debug_string() const {
     return out.str();
 }
 
-HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
+HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
         : HiveTableDescriptor(tdesc, pool, mr),
           _serde_lib(tdesc.hdfsTable.serde_lib, mr),
           _input_format(tdesc.hdfsTable.input_format, mr),
@@ -99,8 +98,7 @@ std::string_view HdfsTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
+FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
         : HiveTableDescriptor(tdesc, pool, mr),
           _serde_lib(tdesc.fileTable.serde_lib, mr),
           _input_format(tdesc.fileTable.input_format, mr),
@@ -220,8 +218,7 @@ DeltaLakeTableDescriptor::DeltaLakeTableDescriptor(const TTableDescriptor& tdesc
     }
 }
 
-HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
+HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
         : HiveTableDescriptor(tdesc, pool, mr),
           _hudi_instant_time(tdesc.hudiTable.instant_time, mr),
           _hive_column_names(tdesc.hudiTable.hive_column_names, mr),
@@ -277,8 +274,7 @@ std::string_view PaimonTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
+OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
         : HiveTableDescriptor(tdesc, pool, mr),
           _database_name(tdesc.dbName, mr),
           _table_name(tdesc.tableName, mr),
@@ -299,16 +295,11 @@ std::string_view OdpsTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-KuduTableDescriptor::KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
+KuduTableDescriptor::KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
         : HiveTableDescriptor(tdesc, pool, mr) {}
 
-HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
-                                         std::pmr::memory_resource* mr)
-        : TableDescriptor(tdesc, mr),
-          _hdfs_base_path(mr),
-          _table_location(mr),
-          _mr(mr) {}
+HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr), _hdfs_base_path(mr), _table_location(mr), _mr(mr) {}
 
 bool HiveTableDescriptor::is_partition_col(const SlotDescriptor* slot) const {
     return get_partition_col_index(slot) >= 0;

--- a/be/src/runtime/descriptors_ext.cpp
+++ b/be/src/runtime/descriptors_ext.cpp
@@ -29,6 +29,7 @@
 #include "exprs/expr_factory.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "runtime/arena_allocator.h"
 #include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
 #include "util/compression/block_compression.h"
@@ -36,9 +37,9 @@
 namespace starrocks {
 // ============== HDFS Table Descriptor ============
 
-HdfsPartitionDescriptor::HdfsPartitionDescriptor(const THdfsPartition& thrift_partition)
+HdfsPartitionDescriptor::HdfsPartitionDescriptor(const THdfsPartition& thrift_partition, std::pmr::memory_resource* mr)
         : _file_format(thrift_partition.file_format),
-          _location(thrift_partition.location.suffix),
+          _location(thrift_partition.location.suffix, mr),
           _thrift_partition_key_exprs(thrift_partition.partition_key_exprs) {}
 
 Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, ObjectPool* pool) {
@@ -56,36 +57,37 @@ std::string HdfsPartitionDescriptor::debug_string() const {
     return out.str();
 }
 
-HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _hdfs_base_path = tdesc.hdfsTable.hdfs_base_dir;
+HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _serde_lib(tdesc.hdfsTable.serde_lib, mr),
+          _input_format(tdesc.hdfsTable.input_format, mr),
+          _hive_column_names(tdesc.hdfsTable.hive_column_names, mr),
+          _hive_column_types(tdesc.hdfsTable.hive_column_types, mr),
+          _serde_properties(tdesc.hdfsTable.serde_properties),
+          _time_zone(tdesc.hdfsTable.time_zone, mr) {
+    _hdfs_base_path.assign(tdesc.hdfsTable.hdfs_base_dir);
     _columns = tdesc.hdfsTable.columns;
     _partition_columns = tdesc.hdfsTable.partition_columns;
     for (const auto& entry : tdesc.hdfsTable.partitions) {
-        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second));
+        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second, mr));
         _partition_id_to_desc_map[entry.first] = partition;
     }
-    _hive_column_names = tdesc.hdfsTable.hive_column_names;
-    _hive_column_types = tdesc.hdfsTable.hive_column_types;
-    _input_format = tdesc.hdfsTable.input_format;
-    _serde_lib = tdesc.hdfsTable.serde_lib;
-    _serde_properties = tdesc.hdfsTable.serde_properties;
-    _time_zone = tdesc.hdfsTable.time_zone;
 }
 
-const std::string& HdfsTableDescriptor::get_hive_column_names() const {
+std::string_view HdfsTableDescriptor::get_hive_column_names() const {
     return _hive_column_names;
 }
 
-const std::string& HdfsTableDescriptor::get_hive_column_types() const {
+std::string_view HdfsTableDescriptor::get_hive_column_types() const {
     return _hive_column_types;
 }
 
-const std::string& HdfsTableDescriptor::get_input_format() const {
+std::string_view HdfsTableDescriptor::get_input_format() const {
     return _input_format;
 }
 
-const std::string& HdfsTableDescriptor::get_serde_lib() const {
+std::string_view HdfsTableDescriptor::get_serde_lib() const {
     return _serde_lib;
 }
 
@@ -93,44 +95,50 @@ const std::map<std::string, std::string> HdfsTableDescriptor::get_serde_properti
     return _serde_properties;
 }
 
-const std::string& HdfsTableDescriptor::get_time_zone() const {
+std::string_view HdfsTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _table_location = tdesc.fileTable.location;
+FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _serde_lib(tdesc.fileTable.serde_lib, mr),
+          _input_format(tdesc.fileTable.input_format, mr),
+          _hive_column_names(tdesc.fileTable.hive_column_names, mr),
+          _hive_column_types(tdesc.fileTable.hive_column_types, mr),
+          _time_zone(tdesc.fileTable.time_zone, mr) {
+    _table_location.assign(tdesc.fileTable.location);
     _columns = tdesc.fileTable.columns;
-    _hive_column_names = tdesc.fileTable.hive_column_names;
-    _hive_column_types = tdesc.fileTable.hive_column_types;
-    _input_format = tdesc.fileTable.input_format;
-    _serde_lib = tdesc.fileTable.serde_lib;
-    _time_zone = tdesc.fileTable.time_zone;
 }
 
-const std::string& FileTableDescriptor::get_hive_column_names() const {
+std::string_view FileTableDescriptor::get_table_locations() const {
+    return _table_location;
+}
+
+std::string_view FileTableDescriptor::get_hive_column_names() const {
     return _hive_column_names;
 }
 
-const std::string& FileTableDescriptor::get_hive_column_types() const {
+std::string_view FileTableDescriptor::get_hive_column_types() const {
     return _hive_column_types;
 }
 
-const std::string& FileTableDescriptor::get_input_format() const {
+std::string_view FileTableDescriptor::get_input_format() const {
     return _input_format;
 }
 
-const std::string& FileTableDescriptor::get_serde_lib() const {
+std::string_view FileTableDescriptor::get_serde_lib() const {
     return _serde_lib;
 }
 
-const std::string& FileTableDescriptor::get_time_zone() const {
+std::string_view FileTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _table_location = tdesc.icebergTable.location;
+IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                               std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr) {
+    _table_location.assign(tdesc.icebergTable.location);
     _columns = tdesc.icebergTable.columns;
     _t_iceberg_schema = tdesc.icebergTable.iceberg_schema;
     if (tdesc.icebergTable.__isset.partition_info) {
@@ -188,110 +196,119 @@ Status IcebergTableDescriptor::set_partition_desc_map(const starrocks::TIcebergT
         ASSIGN_OR_RETURN(TPartitionMap * tPartitionMap,
                          deserialize_partition_map(thrift_table.compressed_partitions, pool));
         for (const auto& entry : tPartitionMap->partitions) {
-            auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second));
+            auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second, _mr));
             _partition_id_to_desc_map[entry.first] = partition;
         }
     } else {
         for (const auto& entry : thrift_table.partitions) {
-            auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second));
+            auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second, _mr));
             _partition_id_to_desc_map[entry.first] = partition;
         }
     }
     return Status::OK();
 }
 
-DeltaLakeTableDescriptor::DeltaLakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _table_location = tdesc.deltaLakeTable.location;
+DeltaLakeTableDescriptor::DeltaLakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                                   std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr) {
+    _table_location.assign(tdesc.deltaLakeTable.location);
     _columns = tdesc.deltaLakeTable.columns;
     _partition_columns = tdesc.deltaLakeTable.partition_columns;
     for (const auto& entry : tdesc.deltaLakeTable.partitions) {
-        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second));
+        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second, mr));
         _partition_id_to_desc_map[entry.first] = partition;
     }
 }
 
-HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _table_location = tdesc.hudiTable.location;
+HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _hudi_instant_time(tdesc.hudiTable.instant_time, mr),
+          _hive_column_names(tdesc.hudiTable.hive_column_names, mr),
+          _hive_column_types(tdesc.hudiTable.hive_column_types, mr),
+          _input_format(tdesc.hudiTable.input_format, mr),
+          _serde_lib(tdesc.hudiTable.serde_lib, mr),
+          _time_zone(tdesc.hudiTable.time_zone, mr) {
+    _table_location.assign(tdesc.hudiTable.location);
     _columns = tdesc.hudiTable.columns;
     _partition_columns = tdesc.hudiTable.partition_columns;
     for (const auto& entry : tdesc.hudiTable.partitions) {
-        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second));
+        auto* partition = pool->add(new HdfsPartitionDescriptor(entry.second, mr));
         _partition_id_to_desc_map[entry.first] = partition;
     }
-    _hudi_instant_time = tdesc.hudiTable.instant_time;
-    _hive_column_names = tdesc.hudiTable.hive_column_names;
-    _hive_column_types = tdesc.hudiTable.hive_column_types;
-    _input_format = tdesc.hudiTable.input_format;
-    _serde_lib = tdesc.hudiTable.serde_lib;
-    _time_zone = tdesc.hudiTable.time_zone;
 }
 
-const std::string& HudiTableDescriptor::get_instant_time() const {
+std::string_view HudiTableDescriptor::get_instant_time() const {
     return _hudi_instant_time;
 }
 
-const std::string& HudiTableDescriptor::get_hive_column_names() const {
+std::string_view HudiTableDescriptor::get_hive_column_names() const {
     return _hive_column_names;
 }
 
-const std::string& HudiTableDescriptor::get_hive_column_types() const {
+std::string_view HudiTableDescriptor::get_hive_column_types() const {
     return _hive_column_types;
 }
 
-const std::string& HudiTableDescriptor::get_input_format() const {
+std::string_view HudiTableDescriptor::get_input_format() const {
     return _input_format;
 }
 
-const std::string& HudiTableDescriptor::get_serde_lib() const {
+std::string_view HudiTableDescriptor::get_serde_lib() const {
     return _serde_lib;
 }
 
-const std::string& HudiTableDescriptor::get_time_zone() const {
+std::string_view HudiTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-PaimonTableDescriptor::PaimonTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _paimon_native_table = tdesc.paimonTable.paimon_native_table;
-    _time_zone = tdesc.paimonTable.time_zone;
-    _t_paimon_schema = tdesc.paimonTable.paimon_schema;
-}
+PaimonTableDescriptor::PaimonTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                             std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _paimon_native_table(tdesc.paimonTable.paimon_native_table, mr),
+          _time_zone(tdesc.paimonTable.time_zone, mr),
+          _t_paimon_schema(tdesc.paimonTable.paimon_schema) {}
 
-const std::string& PaimonTableDescriptor::get_paimon_native_table() const {
+std::string_view PaimonTableDescriptor::get_paimon_native_table() const {
     return _paimon_native_table;
 }
 
-const std::string& PaimonTableDescriptor::get_time_zone() const {
+std::string_view PaimonTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
+OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _database_name(tdesc.dbName, mr),
+          _table_name(tdesc.tableName, mr),
+          _time_zone(tdesc.hdfsTable.time_zone, mr) {
     _columns = tdesc.hdfsTable.columns;
     _partition_columns = tdesc.hdfsTable.partition_columns;
-    _database_name = tdesc.dbName;
-    _table_name = tdesc.tableName;
-    _time_zone = tdesc.hdfsTable.time_zone;
 }
 
-const std::string& OdpsTableDescriptor::get_database_name() const {
+std::string_view OdpsTableDescriptor::get_database_name() const {
     return _database_name;
 }
 
-const std::string& OdpsTableDescriptor::get_table_name() const {
+std::string_view OdpsTableDescriptor::get_table_name() const {
     return _table_name;
 }
 
-const std::string& OdpsTableDescriptor::get_time_zone() const {
+std::string_view OdpsTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
-KuduTableDescriptor::KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {}
+KuduTableDescriptor::KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr) {}
 
-HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool) : TableDescriptor(tdesc) {}
+HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                         std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr),
+          _hdfs_base_path(mr),
+          _table_location(mr),
+          _mr(mr) {}
 
 bool HiveTableDescriptor::is_partition_col(const SlotDescriptor* slot) const {
     return get_partition_col_index(slot) >= 0;
@@ -330,22 +347,23 @@ std::optional<std::string> HiveTableDescriptor::get_column_default_value(const S
     return std::nullopt;
 }
 
-IcebergMetadataTableDescriptor::IcebergMetadataTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
-        : HiveTableDescriptor(tdesc, pool) {
-    _hive_column_names = tdesc.hdfsTable.hive_column_names;
-    _hive_column_types = tdesc.hdfsTable.hive_column_types;
-    _time_zone = tdesc.hdfsTable.__isset.time_zone ? tdesc.hdfsTable.time_zone : TimezoneUtils::default_time_zone;
-}
+IcebergMetadataTableDescriptor::IcebergMetadataTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                                               std::pmr::memory_resource* mr)
+        : HiveTableDescriptor(tdesc, pool, mr),
+          _hive_column_names(tdesc.hdfsTable.hive_column_names, mr),
+          _hive_column_types(tdesc.hdfsTable.hive_column_types, mr),
+          _time_zone(tdesc.hdfsTable.__isset.time_zone ? std::pmr::string(tdesc.hdfsTable.time_zone, mr)
+                                                       : std::pmr::string(TimezoneUtils::default_time_zone, mr)) {}
 
-const std::string& IcebergMetadataTableDescriptor::get_hive_column_names() const {
+std::string_view IcebergMetadataTableDescriptor::get_hive_column_names() const {
     return _hive_column_names;
 }
 
-const std::string& IcebergMetadataTableDescriptor::get_hive_column_types() const {
+std::string_view IcebergMetadataTableDescriptor::get_hive_column_types() const {
     return _hive_column_types;
 }
 
-const std::string& IcebergMetadataTableDescriptor::get_time_zone() const {
+std::string_view IcebergMetadataTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 
@@ -374,7 +392,7 @@ StatusOr<TPartitionMap*> HiveTableDescriptor::deserialize_partition_map(
 
 Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, ObjectPool* pool, int64_t id,
                                                 const THdfsPartition& thrift_partition) {
-    auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition));
+    auto* partition = pool->add(new HdfsPartitionDescriptor(thrift_partition, _mr));
     RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
     {
         std::unique_lock lock(_map_mutex);
@@ -395,7 +413,8 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
 
 // =============================================
 
-OlapTableDescriptor::OlapTableDescriptor(const TTableDescriptor& tdesc) : TableDescriptor(tdesc) {}
+OlapTableDescriptor::OlapTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr) {}
 
 std::string OlapTableDescriptor::debug_string() const {
     std::stringstream out;
@@ -403,8 +422,8 @@ std::string OlapTableDescriptor::debug_string() const {
     return out.str();
 }
 
-SchemaTableDescriptor::SchemaTableDescriptor(const TTableDescriptor& tdesc)
-        : TableDescriptor(tdesc), _schema_table_type(tdesc.schemaTable.tableType) {}
+SchemaTableDescriptor::SchemaTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr), _schema_table_type(tdesc.schemaTable.tableType) {}
 SchemaTableDescriptor::~SchemaTableDescriptor() = default;
 
 std::string SchemaTableDescriptor::debug_string() const {
@@ -413,7 +432,8 @@ std::string SchemaTableDescriptor::debug_string() const {
     return out.str();
 }
 
-BrokerTableDescriptor::BrokerTableDescriptor(const TTableDescriptor& tdesc) : TableDescriptor(tdesc) {}
+BrokerTableDescriptor::BrokerTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr) {}
 
 BrokerTableDescriptor::~BrokerTableDescriptor() = default;
 
@@ -423,7 +443,8 @@ std::string BrokerTableDescriptor::debug_string() const {
     return out.str();
 }
 
-EsTableDescriptor::EsTableDescriptor(const TTableDescriptor& tdesc) : TableDescriptor(tdesc) {}
+EsTableDescriptor::EsTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr) {}
 
 EsTableDescriptor::~EsTableDescriptor() = default;
 
@@ -433,14 +454,14 @@ std::string EsTableDescriptor::debug_string() const {
     return out.str();
 }
 
-MySQLTableDescriptor::MySQLTableDescriptor(const TTableDescriptor& tdesc)
-        : TableDescriptor(tdesc),
-          _mysql_db(tdesc.mysqlTable.db),
-          _mysql_table(tdesc.mysqlTable.table),
-          _host(tdesc.mysqlTable.host),
-          _port(tdesc.mysqlTable.port),
-          _user(tdesc.mysqlTable.user),
-          _passwd(tdesc.mysqlTable.passwd) {}
+MySQLTableDescriptor::MySQLTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr),
+          _mysql_db(tdesc.mysqlTable.db, mr),
+          _mysql_table(tdesc.mysqlTable.table, mr),
+          _host(tdesc.mysqlTable.host, mr),
+          _port(tdesc.mysqlTable.port, mr),
+          _user(tdesc.mysqlTable.user, mr),
+          _passwd(tdesc.mysqlTable.passwd, mr) {}
 
 std::string MySQLTableDescriptor::debug_string() const {
     std::stringstream out;
@@ -449,16 +470,16 @@ std::string MySQLTableDescriptor::debug_string() const {
     return out.str();
 }
 
-JDBCTableDescriptor::JDBCTableDescriptor(const TTableDescriptor& tdesc)
-        : TableDescriptor(tdesc),
-          _jdbc_driver_name(tdesc.jdbcTable.jdbc_driver_name),
-          _jdbc_driver_url(tdesc.jdbcTable.jdbc_driver_url),
-          _jdbc_driver_checksum(tdesc.jdbcTable.jdbc_driver_checksum),
-          _jdbc_driver_class(tdesc.jdbcTable.jdbc_driver_class),
-          _jdbc_url(tdesc.jdbcTable.jdbc_url),
-          _jdbc_table(tdesc.jdbcTable.jdbc_table),
-          _jdbc_user(tdesc.jdbcTable.jdbc_user),
-          _jdbc_passwd(tdesc.jdbcTable.jdbc_passwd) {}
+JDBCTableDescriptor::JDBCTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr)
+        : TableDescriptor(tdesc, mr),
+          _jdbc_driver_name(tdesc.jdbcTable.jdbc_driver_name, mr),
+          _jdbc_driver_url(tdesc.jdbcTable.jdbc_driver_url, mr),
+          _jdbc_driver_checksum(tdesc.jdbcTable.jdbc_driver_checksum, mr),
+          _jdbc_driver_class(tdesc.jdbcTable.jdbc_driver_class, mr),
+          _jdbc_url(tdesc.jdbcTable.jdbc_url, mr),
+          _jdbc_table(tdesc.jdbcTable.jdbc_table, mr),
+          _jdbc_user(tdesc.jdbcTable.jdbc_user, mr),
+          _jdbc_passwd(tdesc.jdbcTable.jdbc_passwd, mr) {}
 
 std::string JDBCTableDescriptor::debug_string() const {
     std::stringstream out;
@@ -476,13 +497,21 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
     // outlive the fragment, so they must be heap-allocated to avoid use-after-free.
     MemPool* mp = (state != nullptr && pool == state->obj_pool()) ? state->fragment_mem_pool() : nullptr;
 
+    // Build a pmr memory_resource backed by the MemPool (when available).
+    // The MemPoolResource is itself arena-allocated so it outlives the pmr
+    // containers that reference it (MemPool deallocation is a no-op).
+    std::pmr::memory_resource* mr = std::pmr::get_default_resource();
+    if (mp != nullptr) {
+        mr = new (mp->allocate_aligned(sizeof(MemPoolResource), alignof(MemPoolResource))) MemPoolResource(mp);
+    }
+
 // Placement-new T into fragment MemPool; fall back to heap when unavailable.
 #define ALLOC_DESC(T, ...)                                                                      \
     (mp != nullptr ? pool->emplace<T>(mp->allocate_aligned(sizeof(T), alignof(T)), __VA_ARGS__) \
                    : pool->add(new T(__VA_ARGS__)))
 
     if (mp != nullptr) {
-        *tbl = pool->emplace<DescriptorTbl>(mp->allocate_aligned(sizeof(DescriptorTbl), alignof(DescriptorTbl)));
+        *tbl = pool->emplace<DescriptorTbl>(mp->allocate_aligned(sizeof(DescriptorTbl), alignof(DescriptorTbl)), mr);
     } else {
         *tbl = pool->add(new DescriptorTbl());
     }
@@ -493,57 +522,57 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
 
         switch (tdesc.tableType) {
         case TTableType::MYSQL_TABLE:
-            desc = ALLOC_DESC(MySQLTableDescriptor, tdesc);
+            desc = ALLOC_DESC(MySQLTableDescriptor, tdesc, mr);
             break;
         case TTableType::OLAP_TABLE:
         case TTableType::MATERIALIZED_VIEW:
-            desc = ALLOC_DESC(OlapTableDescriptor, tdesc);
+            desc = ALLOC_DESC(OlapTableDescriptor, tdesc, mr);
             break;
         case TTableType::SCHEMA_TABLE:
-            desc = ALLOC_DESC(SchemaTableDescriptor, tdesc);
+            desc = ALLOC_DESC(SchemaTableDescriptor, tdesc, mr);
             break;
         case TTableType::BROKER_TABLE:
-            desc = ALLOC_DESC(BrokerTableDescriptor, tdesc);
+            desc = ALLOC_DESC(BrokerTableDescriptor, tdesc, mr);
             break;
         case TTableType::ES_TABLE:
-            desc = ALLOC_DESC(EsTableDescriptor, tdesc);
+            desc = ALLOC_DESC(EsTableDescriptor, tdesc, mr);
             break;
         case TTableType::HDFS_TABLE: {
-            auto* hdfs_desc = ALLOC_DESC(HdfsTableDescriptor, tdesc, pool);
+            auto* hdfs_desc = ALLOC_DESC(HdfsTableDescriptor, tdesc, pool, mr);
             RETURN_IF_ERROR(hdfs_desc->create_key_exprs(state, pool));
             desc = hdfs_desc;
             break;
         }
         case TTableType::FILE_TABLE:
-            desc = ALLOC_DESC(FileTableDescriptor, tdesc, pool);
+            desc = ALLOC_DESC(FileTableDescriptor, tdesc, pool, mr);
             break;
         case TTableType::ICEBERG_TABLE: {
-            auto* iceberg_desc = ALLOC_DESC(IcebergTableDescriptor, tdesc, pool);
+            auto* iceberg_desc = ALLOC_DESC(IcebergTableDescriptor, tdesc, pool, mr);
             RETURN_IF_ERROR(iceberg_desc->set_partition_desc_map(tdesc.icebergTable, pool));
             RETURN_IF_ERROR(iceberg_desc->create_key_exprs(state, pool));
             desc = iceberg_desc;
             break;
         }
         case TTableType::DELTALAKE_TABLE: {
-            auto* delta_lake_desc = ALLOC_DESC(DeltaLakeTableDescriptor, tdesc, pool);
+            auto* delta_lake_desc = ALLOC_DESC(DeltaLakeTableDescriptor, tdesc, pool, mr);
             RETURN_IF_ERROR(delta_lake_desc->create_key_exprs(state, pool));
             desc = delta_lake_desc;
             break;
         }
         case TTableType::HUDI_TABLE: {
-            auto* hudi_desc = ALLOC_DESC(HudiTableDescriptor, tdesc, pool);
+            auto* hudi_desc = ALLOC_DESC(HudiTableDescriptor, tdesc, pool, mr);
             RETURN_IF_ERROR(hudi_desc->create_key_exprs(state, pool));
             desc = hudi_desc;
             break;
         }
         case TTableType::PAIMON_TABLE:
-            desc = ALLOC_DESC(PaimonTableDescriptor, tdesc, pool);
+            desc = ALLOC_DESC(PaimonTableDescriptor, tdesc, pool, mr);
             break;
         case TTableType::JDBC_TABLE:
-            desc = ALLOC_DESC(JDBCTableDescriptor, tdesc);
+            desc = ALLOC_DESC(JDBCTableDescriptor, tdesc, mr);
             break;
         case TTableType::ODPS_TABLE:
-            desc = ALLOC_DESC(OdpsTableDescriptor, tdesc, pool);
+            desc = ALLOC_DESC(OdpsTableDescriptor, tdesc, pool, mr);
             break;
         case TTableType::LOGICAL_ICEBERG_METADATA_TABLE:
         case TTableType::ICEBERG_REFS_TABLE:
@@ -554,10 +583,10 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
         case TTableType::ICEBERG_FILES_TABLE:
         case TTableType::ICEBERG_PARTITIONS_TABLE:
         case TTableType::ICEBERG_PROPERTIES_TABLE:
-            desc = ALLOC_DESC(IcebergMetadataTableDescriptor, tdesc, pool);
+            desc = ALLOC_DESC(IcebergMetadataTableDescriptor, tdesc, pool, mr);
             break;
         case TTableType::KUDU_TABLE:
-            desc = ALLOC_DESC(KuduTableDescriptor, tdesc, pool);
+            desc = ALLOC_DESC(KuduTableDescriptor, tdesc, pool, mr);
             break;
         default:
             DCHECK(false) << "invalid table type: " << tdesc.tableType;
@@ -579,7 +608,7 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
     }
 
     for (const auto& tdesc : thrift_tbl.slotDescriptors) {
-        SlotDescriptor* slot_d = ALLOC_DESC(SlotDescriptor, tdesc);
+        SlotDescriptor* slot_d = ALLOC_DESC(SlotDescriptor, tdesc, mr);
         (*tbl)->_slot_desc_map[tdesc.id] = slot_d;
         if (!slot_d->col_name().empty()) {
             (*tbl)->_slot_with_column_name_map[tdesc.id] = slot_d;

--- a/be/src/runtime/descriptors_ext.h
+++ b/be/src/runtime/descriptors_ext.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <map>
+#include <memory_resource>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -30,10 +31,11 @@ class ExprContext;
 
 class HdfsPartitionDescriptor {
 public:
-    HdfsPartitionDescriptor(const THdfsPartition& thrift_partition);
+    HdfsPartitionDescriptor(const THdfsPartition& thrift_partition,
+                            std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     int64_t id() const { return _id; }
     THdfsFileFormat::type file_format() { return _file_format; }
-    std::string& location() { return _location; }
+    std::string_view location() { return _location; }
     // ExprContext is constant/literal for sure
     // such as hdfs://path/x=1/y=2/zzz, then
     // partition slots would be [x, y]
@@ -46,7 +48,7 @@ public:
 private:
     int64_t _id = 0;
     THdfsFileFormat::type _file_format;
-    std::string _location;
+    std::pmr::string _location;
 
     // holding thrift exprs for partition keys for duplication check during runtime
     const std::vector<TExpr> _thrift_partition_key_exprs;
@@ -55,13 +57,14 @@ private:
 
 class HiveTableDescriptor : public TableDescriptor {
 public:
-    HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     virtual bool has_partition() const = 0;
     virtual bool is_partition_col(const SlotDescriptor* slot) const;
     virtual int get_partition_col_index(const SlotDescriptor* slot) const;
     virtual HdfsPartitionDescriptor* get_partition(int64_t partition_id) const;
     virtual bool has_base_path() const { return false; }
-    virtual const std::string& get_base_path() const { return _table_location; }
+    virtual std::string_view get_base_path() const { return _table_location; }
 
     Status create_key_exprs(RuntimeState* state, ObjectPool* pool) {
         for (auto& part : _partition_id_to_desc_map) {
@@ -78,38 +81,41 @@ public:
     std::optional<std::string> get_column_default_value(const SlotDescriptor* slot) const;
 
 protected:
-    std::string _hdfs_base_path;
+    std::pmr::string _hdfs_base_path;
     std::vector<TColumn> _columns;
     std::vector<TColumn> _partition_columns;
     mutable std::shared_mutex _map_mutex;
     std::map<int64_t, HdfsPartitionDescriptor*> _partition_id_to_desc_map;
-    std::string _table_location;
+    std::pmr::string _table_location;
+    std::pmr::memory_resource* _mr;
 };
 
 class HdfsTableDescriptor : public HiveTableDescriptor {
 public:
-    HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~HdfsTableDescriptor() override = default;
     bool has_partition() const override { return true; }
-    const std::string& get_hive_column_names() const;
-    const std::string& get_hive_column_types() const;
-    const std::string& get_input_format() const;
-    const std::string& get_serde_lib() const;
+    std::string_view get_hive_column_names() const;
+    std::string_view get_hive_column_types() const;
+    std::string_view get_input_format() const;
+    std::string_view get_serde_lib() const;
     const std::map<std::string, std::string> get_serde_properties() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_time_zone() const;
 
 private:
-    std::string _serde_lib;
-    std::string _input_format;
-    std::string _hive_column_names;
-    std::string _hive_column_types;
+    std::pmr::string _serde_lib;
+    std::pmr::string _input_format;
+    std::pmr::string _hive_column_names;
+    std::pmr::string _hive_column_types;
     std::map<std::string, std::string> _serde_properties;
-    std::string _time_zone;
+    std::pmr::string _time_zone;
 };
 
 class IcebergTableDescriptor : public HiveTableDescriptor {
 public:
-    IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                           std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~IcebergTableDescriptor() override = default;
     bool has_partition() const override { return false; }
     const TIcebergSchema* get_iceberg_schema() const { return &_t_iceberg_schema; }
@@ -137,27 +143,29 @@ private:
 
 class FileTableDescriptor : public HiveTableDescriptor {
 public:
-    FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~FileTableDescriptor() override = default;
     bool has_partition() const override { return false; }
-    const std::string& get_table_locations() const;
-    const std::string& get_hive_column_names() const;
-    const std::string& get_hive_column_types() const;
-    const std::string& get_input_format() const;
-    const std::string& get_serde_lib() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_table_locations() const;
+    std::string_view get_hive_column_names() const;
+    std::string_view get_hive_column_types() const;
+    std::string_view get_input_format() const;
+    std::string_view get_serde_lib() const;
+    std::string_view get_time_zone() const;
 
 private:
-    std::string _serde_lib;
-    std::string _input_format;
-    std::string _hive_column_names;
-    std::string _hive_column_types;
-    std::string _time_zone;
+    std::pmr::string _serde_lib;
+    std::pmr::string _input_format;
+    std::pmr::string _hive_column_names;
+    std::pmr::string _hive_column_types;
+    std::pmr::string _time_zone;
 };
 
 class DeltaLakeTableDescriptor : public HiveTableDescriptor {
 public:
-    DeltaLakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    DeltaLakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                             std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~DeltaLakeTableDescriptor() override = default;
     bool has_partition() const override { return true; }
     bool has_base_path() const override { return true; }
@@ -165,86 +173,93 @@ public:
 
 class HudiTableDescriptor : public HiveTableDescriptor {
 public:
-    HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~HudiTableDescriptor() override = default;
     bool has_partition() const override { return true; }
-    const std::string& get_instant_time() const;
-    const std::string& get_hive_column_names() const;
-    const std::string& get_hive_column_types() const;
-    const std::string& get_input_format() const;
-    const std::string& get_serde_lib() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_instant_time() const;
+    std::string_view get_hive_column_names() const;
+    std::string_view get_hive_column_types() const;
+    std::string_view get_input_format() const;
+    std::string_view get_serde_lib() const;
+    std::string_view get_time_zone() const;
 
 private:
-    std::string _hudi_instant_time;
-    std::string _hive_column_names;
-    std::string _hive_column_types;
-    std::string _input_format;
-    std::string _serde_lib;
-    std::string _time_zone;
+    std::pmr::string _hudi_instant_time;
+    std::pmr::string _hive_column_names;
+    std::pmr::string _hive_column_types;
+    std::pmr::string _input_format;
+    std::pmr::string _serde_lib;
+    std::pmr::string _time_zone;
 };
 
 class PaimonTableDescriptor : public HiveTableDescriptor {
 public:
-    PaimonTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    PaimonTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                          std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~PaimonTableDescriptor() override = default;
     bool has_partition() const override { return false; }
-    const std::string& get_paimon_native_table() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_paimon_native_table() const;
+    std::string_view get_time_zone() const;
     const TIcebergSchema* get_paimon_schema() const { return &_t_paimon_schema; }
 
 private:
-    std::string _paimon_native_table;
-    std::string _time_zone;
+    std::pmr::string _paimon_native_table;
+    std::pmr::string _time_zone;
     TIcebergSchema _t_paimon_schema;
 };
 
 class OdpsTableDescriptor : public HiveTableDescriptor {
 public:
-    OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~OdpsTableDescriptor() override = default;
     bool has_partition() const override { return false; }
-    const std::string& get_database_name() const;
-    const std::string& get_table_name() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_database_name() const;
+    std::string_view get_table_name() const;
+    std::string_view get_time_zone() const;
 
 private:
-    std::string _database_name;
-    std::string _table_name;
-    std::string _time_zone;
+    std::pmr::string _database_name;
+    std::pmr::string _table_name;
+    std::pmr::string _time_zone;
 };
 
 class IcebergMetadataTableDescriptor : public HiveTableDescriptor {
 public:
-    IcebergMetadataTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    IcebergMetadataTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                                   std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~IcebergMetadataTableDescriptor() override = default;
-    const std::string& get_hive_column_names() const;
-    const std::string& get_hive_column_types() const;
-    const std::string& get_time_zone() const;
+    std::string_view get_hive_column_names() const;
+    std::string_view get_hive_column_types() const;
+    std::string_view get_time_zone() const;
     bool has_partition() const override { return false; }
 
 private:
-    std::string _hive_column_names;
-    std::string _hive_column_types;
-    std::string _time_zone;
+    std::pmr::string _hive_column_names;
+    std::pmr::string _hive_column_types;
+    std::pmr::string _time_zone;
 };
 
 class KuduTableDescriptor : public HiveTableDescriptor {
 public:
-    KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
+    KuduTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~KuduTableDescriptor() override = default;
     bool has_partition() const override { return false; }
 };
 
 class OlapTableDescriptor : public TableDescriptor {
 public:
-    OlapTableDescriptor(const TTableDescriptor& tdesc);
+    OlapTableDescriptor(const TTableDescriptor& tdesc,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     std::string debug_string() const override;
 };
 
 class SchemaTableDescriptor : public TableDescriptor {
 public:
-    SchemaTableDescriptor(const TTableDescriptor& tdesc);
+    SchemaTableDescriptor(const TTableDescriptor& tdesc,
+                          std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~SchemaTableDescriptor() override;
     std::string debug_string() const override;
     TSchemaTableType::type schema_table_type() const { return _schema_table_type; }
@@ -255,61 +270,65 @@ private:
 
 class BrokerTableDescriptor : public TableDescriptor {
 public:
-    BrokerTableDescriptor(const TTableDescriptor& tdesc);
+    BrokerTableDescriptor(const TTableDescriptor& tdesc,
+                          std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~BrokerTableDescriptor() override;
     std::string debug_string() const override;
 };
 
 class EsTableDescriptor : public TableDescriptor {
 public:
-    EsTableDescriptor(const TTableDescriptor& tdesc);
+    EsTableDescriptor(const TTableDescriptor& tdesc,
+                      std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~EsTableDescriptor() override;
     std::string debug_string() const override;
 };
 
 class MySQLTableDescriptor : public TableDescriptor {
 public:
-    MySQLTableDescriptor(const TTableDescriptor& tdesc);
+    MySQLTableDescriptor(const TTableDescriptor& tdesc,
+                         std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     std::string debug_string() const override;
-    const std::string mysql_db() const { return _mysql_db; }
-    const std::string mysql_table() const { return _mysql_table; }
-    const std::string host() const { return _host; }
-    const std::string port() const { return _port; }
-    const std::string user() const { return _user; }
-    const std::string passwd() const { return _passwd; }
+    std::string_view mysql_db() const { return _mysql_db; }
+    std::string_view mysql_table() const { return _mysql_table; }
+    std::string_view host() const { return _host; }
+    std::string_view port() const { return _port; }
+    std::string_view user() const { return _user; }
+    std::string_view passwd() const { return _passwd; }
 
 private:
-    std::string _mysql_db;
-    std::string _mysql_table;
-    std::string _host;
-    std::string _port;
-    std::string _user;
-    std::string _passwd;
+    std::pmr::string _mysql_db;
+    std::pmr::string _mysql_table;
+    std::pmr::string _host;
+    std::pmr::string _port;
+    std::pmr::string _user;
+    std::pmr::string _passwd;
 };
 
 class JDBCTableDescriptor : public TableDescriptor {
 public:
-    JDBCTableDescriptor(const TTableDescriptor& tdesc);
+    JDBCTableDescriptor(const TTableDescriptor& tdesc,
+                        std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     std::string debug_string() const override;
-    const std::string jdbc_driver_name() const { return _jdbc_driver_name; }
-    const std::string jdbc_driver_url() const { return _jdbc_driver_url; }
-    const std::string jdbc_driver_checksum() const { return _jdbc_driver_checksum; }
-    const std::string jdbc_driver_class() const { return _jdbc_driver_class; }
-    const std::string jdbc_url() const { return _jdbc_url; }
-    const std::string jdbc_table() const { return _jdbc_table; }
-    const std::string jdbc_user() const { return _jdbc_user; }
-    const std::string jdbc_passwd() const { return _jdbc_passwd; }
+    std::string_view jdbc_driver_name() const { return _jdbc_driver_name; }
+    std::string_view jdbc_driver_url() const { return _jdbc_driver_url; }
+    std::string_view jdbc_driver_checksum() const { return _jdbc_driver_checksum; }
+    std::string_view jdbc_driver_class() const { return _jdbc_driver_class; }
+    std::string_view jdbc_url() const { return _jdbc_url; }
+    std::string_view jdbc_table() const { return _jdbc_table; }
+    std::string_view jdbc_user() const { return _jdbc_user; }
+    std::string_view jdbc_passwd() const { return _jdbc_passwd; }
 
 private:
-    std::string _jdbc_driver_name;
-    std::string _jdbc_driver_url;
-    std::string _jdbc_driver_checksum;
-    std::string _jdbc_driver_class;
+    std::pmr::string _jdbc_driver_name;
+    std::pmr::string _jdbc_driver_url;
+    std::pmr::string _jdbc_driver_checksum;
+    std::pmr::string _jdbc_driver_class;
 
-    std::string _jdbc_url;
-    std::string _jdbc_table;
-    std::string _jdbc_user;
-    std::string _jdbc_passwd;
+    std::pmr::string _jdbc_url;
+    std::pmr::string _jdbc_table;
+    std::pmr::string _jdbc_user;
+    std::pmr::string _jdbc_passwd;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/descriptors_ext.h
+++ b/be/src/runtime/descriptors_ext.h
@@ -278,8 +278,7 @@ public:
 
 class EsTableDescriptor : public TableDescriptor {
 public:
-    EsTableDescriptor(const TTableDescriptor& tdesc,
-                      std::pmr::memory_resource* mr = std::pmr::get_default_resource());
+    EsTableDescriptor(const TTableDescriptor& tdesc, std::pmr::memory_resource* mr = std::pmr::get_default_resource());
     ~EsTableDescriptor() override;
     std::string debug_string() const override;
 };

--- a/be/test/common/runtime_profile_test.cpp
+++ b/be/test/common/runtime_profile_test.cpp
@@ -263,17 +263,17 @@ TEST(TestRuntimeProfile, testConflictInfoString) {
     auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
     const std::set<std::string> expected_values{"value1", "value2", "value3", "value4", "value5", "value6"};
     std::set<std::string> actual_values;
-    ASSERT_TRUE(merged_profile->get_info_string("key1") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1")));
-    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(0)") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(0)").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1__DUP(0)")));
-    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(1)") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(1)").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1__DUP(1)")));
-    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(2)") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(2)").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1__DUP(2)")));
-    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(3)") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(3)").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1__DUP(3)")));
-    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(4)") != nullptr);
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(4)").has_value());
     actual_values.insert(*(merged_profile->get_info_string("key1__DUP(4)")));
 
     ASSERT_EQ(expected_values, actual_values);
@@ -292,7 +292,7 @@ static void test_mass_conflict_info_string(int num) {
 
     auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
     for (int i = 0; i < num - 1; ++i) {
-        ASSERT_TRUE(merged_profile->get_info_string("key__DUP(" + std::to_string(i) + ")") != nullptr);
+        ASSERT_TRUE(merged_profile->get_info_string("key__DUP(" + std::to_string(i) + ")").has_value());
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

Table descriptors are created during query planning and can persist for the lifetime of a query execution. Currently, they use standard `std::string` which allocates from the global heap. By using polymorphic memory resources (PMR) backed by fragment memory pools, we can improve memory locality and reduce fragmentation for descriptor allocations.

## What I'm doing:

This change refactors table descriptor classes to use `std::pmr::string` and `std::pmr::memory_resource*` for memory allocation:

1. **Added PMR support to descriptor constructors**: All table descriptor constructors now accept an optional `std::pmr::memory_resource*` parameter that defaults to the global resource.

2. **Converted string members to PMR strings**: Changed `std::string` members to `std::pmr::string` in:
   - `HdfsPartitionDescriptor`
   - `HiveTableDescriptor` and all subclasses (HdfsTableDescriptor, FileTableDescriptor, IcebergTableDescriptor, DeltaLakeTableDescriptor, HudiTableDescriptor, PaimonTableDescriptor, OdpsTableDescriptor, IcebergMetadataTableDescriptor, KuduTableDescriptor)
   - `TableDescriptor` and all subclasses (OlapTableDescriptor, SchemaTableDescriptor, BrokerTableDescriptor, EsTableDescriptor, MySQLTableDescriptor, JDBCTableDescriptor)

3. **Updated return types to `std::string_view`**: Changed getter methods from returning `const std::string&` to `std::string_view` for better API design and to avoid unnecessary copies.

4. **Integrated MemPoolResource**: In `DescriptorTbl::create()`, when a fragment memory pool is available, a `MemPoolResource` is created and passed to all descriptor constructors, enabling PMR-backed allocations.

5. **Updated PMR container types**: Changed descriptor table maps from `std::unordered_map` to `std::pmr::unordered_map` to use the same memory resource.

6. **Updated call sites**: Modified code that constructs descriptors and uses their string accessors to work with the new PMR-based API.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

https://claude.ai/code/session_01D97m4rF588DLBHRKCXq7Ad