### PR TITLE
[Refactor] Replace raw_data() with type-safe visitors in primary key index and encoder

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -622,6 +622,18 @@ public:
         return down_cast<const BinaryColumn*>(get_data_column(column));
     }
 
+    // Build a slice buffer from a binary/large-binary column.
+    // Unwraps NullableColumn and ConstColumn before dispatch.
+    // Supports BinaryColumn (uint32_t offsets) and LargeBinaryColumn (uint64_t offsets).
+    static void build_slices(const Column* column, Buffer<Slice>& slices) {
+        const Column* data_col = get_data_column(column);
+        if (data_col->is_large_binary()) {
+            down_cast<const LargeBinaryColumn*>(data_col)->build_slices(slices);
+        } else {
+            down_cast<const BinaryColumn*>(data_col)->build_slices(slices);
+        }
+    }
+
     // If column[row] is not null and is a binary column, writes the slice to *out and returns true.
     // Handles ConstColumn (normalises row to 0) and NullableColumn (null check).
     static bool get_binary_slice_at(const Column* column, size_t row, Slice* out);

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -23,6 +23,7 @@
 
 #include "column/chunk.h"
 #include "column/column.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -606,7 +607,9 @@ Status DeltaWriterImpl::check_partial_update_with_sort_key(const Chunk& chunk) {
         if (_slots != nullptr && _slots->back()->col_name() == "__op") {
             size_t op_column_id = chunk.num_columns() - 1;
             const auto& op_column = chunk.get_column_by_index(op_column_id);
-            auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
+            RawDataVisitor visitor;
+            RETURN_IF_ERROR(op_column->accept(&visitor));
+            const auto* ops = visitor.result();
             ok = !std::any_of(ops, ops + chunk.num_rows(), [](auto op) { return op == TOpType::UPSERT; });
         } else {
             ok = false;

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -306,9 +306,9 @@ Status LakePrimaryIndex::erase(const TabletMetadataPtr& metadata, const Column& 
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            std::vector<Slice> keys;
+            Buffer<Slice> keys;
             std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-            const Slice* vkeys = build_persistent_keys(pks, _key_size, 0, pks.size(), &keys);
+            ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
             // Cloud native index need to setup rowset id as rebuild point when erase.
             RETURN_IF_ERROR(lake_persistent_index->erase(pks.size(), vkeys,
                                                          reinterpret_cast<IndexValue*>(old_values.data()), rowset_id));

--- a/be/src/storage/lake/pk_tablet_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_sst_writer.cpp
@@ -51,9 +51,9 @@ Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
     auto clone_pk_column = _pk_column->clone_empty();
     TRY_CATCH_BAD_ALLOC(
             PrimaryKeyEncoder::encode(_pkey_schema, data, 0, data.num_rows(), clone_pk_column.get(), pk_encoding_type));
-    std::vector<Slice> keys;
-    const Slice* vkeys =
-            PrimaryIndex::build_persistent_keys(*clone_pk_column, _key_size, 0, clone_pk_column->size(), &keys);
+    Buffer<Slice> keys;
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(*clone_pk_column, _key_size, 0,
+                                                                             clone_pk_column->size(), &keys));
     for (size_t i = 0; i < clone_pk_column->size(); i++) {
         RETURN_IF_ERROR(_pk_sst_builder->add(vkeys[i]));
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -19,6 +19,7 @@
 #include "base/time/time.h"
 #include "column/binary_column.h"
 #include "column/json_column.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/logging.h"
@@ -483,7 +484,9 @@ Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, Mutabl
     auto op_column = src->get_column_by_index(op_column_id);
     src->remove_column_by_index(op_column_id);
     size_t nrows = src->num_rows();
-    auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
+    RawDataVisitor visitor;
+    RETURN_IF_ERROR(op_column->accept(&visitor));
+    const auto* ops = visitor.result();
     size_t ndel = 0;
     for (size_t i = 0; i < nrows; i++) {
         ndel += (ops[i] == TOpType::DELETE);

--- a/be/src/storage/persistent_index_parallel_publish_context.h
+++ b/be/src/storage/persistent_index_parallel_publish_context.h
@@ -29,7 +29,7 @@ class ThreadPoolToken;
 // avoiding data races between concurrent tasks.
 struct ParallelPublishSlot {
     MutableColumnPtr pk_column;       // Encoded primary key column for this batch
-    Buffer<Slice> keys;          // Primary keys for this task, data inside slices owned by `pk_column`.
+    Buffer<Slice> keys;               // Primary keys for this task, data inside slices owned by `pk_column`.
     std::vector<uint64_t> values;     // New row IDs (rssid + segment row id) to be inserted/updated
     std::vector<uint64_t> old_values; // Existing row IDs found in the index (for get operations)
 };

--- a/be/src/storage/persistent_index_parallel_publish_context.h
+++ b/be/src/storage/persistent_index_parallel_publish_context.h
@@ -29,7 +29,7 @@ class ThreadPoolToken;
 // avoiding data races between concurrent tasks.
 struct ParallelPublishSlot {
     MutableColumnPtr pk_column;       // Encoded primary key column for this batch
-    std::vector<Slice> keys;          // Primary keys for this task, data inside slices owned by `pk_column`.
+    Buffer<Slice> keys;          // Primary keys for this task, data inside slices owned by `pk_column`.
     std::vector<uint64_t> values;     // New row IDs (rssid + segment row id) to be inserted/updated
     std::vector<uint64_t> old_values; // Existing row IDs found in the index (for get operations)
 };

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1434,8 +1434,8 @@ Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vect
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
-    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace,
-                                               reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
+    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace, reinterpret_cast<IndexValue*>(values.data()),
+                                               src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
@@ -1449,8 +1449,8 @@ Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_st
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
-    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace,
-                                               reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
+    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace, reinterpret_cast<IndexValue*>(values.data()),
+                                               max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
@@ -1520,8 +1520,8 @@ Status PrimaryIndex::_replace_persistent_index_by_indexes(uint32_t rssid, uint32
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
-    Status st = _persistent_index->replace(pks.size(), vkeys_replace,
-                                           reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
+    Status st = _persistent_index->replace(pks.size(), vkeys_replace, reinterpret_cast<IndexValue*>(values.data()),
+                                           replace_indexes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -19,6 +19,8 @@
 
 #include "base/hash/xxh3.h"
 #include "base/types/int128.h"
+#include "column/column_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/tracer.h"
 #include "gutil/strings/substitute.h"
 #include "io/io_profiler.h"
@@ -108,7 +110,7 @@ const uint32_t PREFETCHN = 8;
 
 template <typename Key>
 class HashIndexImpl : public HashIndex {
-private:
+    static_assert(!std::is_same_v<Key, Slice>, "HashIndexImpl does not support string/binary types");
     phmap::parallel_flat_hash_map<Key, RowIdPack4, StdHashWithSeed<Key, PhmapSeed1>, phmap::priv::hash_default_eq<Key>,
                                   TraceAlloc<phmap::priv::Pair<const Key, RowIdPack4>>, 4, phmap::NullMutex, true>
             _map;
@@ -126,7 +128,9 @@ public:
     Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks, uint32_t idx_begin,
                   uint32_t idx_end) override {
         CHECK_MEM_LIMIT("HashIndexImpl::insert");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         DCHECK(idx_end <= rowids.size());
         uint64_t base = (((uint64_t)rssid) << 32);
         for (auto i = idx_begin; i < idx_end; i++) {
@@ -150,7 +154,9 @@ public:
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
                    uint32_t idx_end, const Column& pks) override {
         CHECK_MEM_LIMIT("HashIndexImpl::insert");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
@@ -166,7 +172,9 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("HashIndexImpl::upsert");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             uint32_t prefetch_i = i + PREFETCHN;
@@ -186,7 +194,9 @@ public:
                                         const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
                                         vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("HashIndexImpl::try_replace");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             uint32_t prefetch_i = i + PREFETCHN;
@@ -206,7 +216,9 @@ public:
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
                        uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("HashIndexImpl::try_replace");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             uint32_t prefetch_i = i + PREFETCHN;
@@ -223,7 +235,9 @@ public:
 
     Status erase(const Column& pks, uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("HashIndexImpl::erase");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         for (auto i = idx_begin; i < idx_end; i++) {
             uint32_t prefetch_i = i + PREFETCHN;
             if (LIKELY(prefetch_i < idx_end)) _map.prefetch(keys[prefetch_i]);
@@ -239,7 +253,9 @@ public:
 
     Status get(const Column& pks, uint32_t idx_begin, uint32_t idx_end, std::vector<uint64_t>* rowids) override {
         CHECK_MEM_LIMIT("HashIndexImpl::get");
-        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const auto* keys = reinterpret_cast<const Key*>(visitor.result());
         for (auto i = idx_begin; i < idx_end; i++) {
             uint32_t prefetch_i = i + PREFETCHN;
             if (LIKELY(prefetch_i < idx_end)) _map.prefetch(keys[prefetch_i]);
@@ -306,7 +322,7 @@ public:
     Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks, uint32_t idx_begin,
                   uint32_t idx_end) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::insert");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         DCHECK(idx_end <= rowids.size());
         uint64_t base = (((uint64_t)rssid) << 32);
         uint32_t n = idx_end - idx_begin;
@@ -361,7 +377,7 @@ public:
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
                    uint32_t idx_end, const Column& pks) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::replace");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
@@ -376,7 +392,7 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::upsert");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         uint32_t n = idx_end - idx_begin;
         if (n >= PREFETCHN * 2) {
@@ -420,7 +436,7 @@ public:
                                         const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
                                         vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::try_replace");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         uint32_t n = idx_end - idx_begin;
         if (n >= PREFETCHN * 2) {
@@ -466,7 +482,7 @@ public:
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
                        uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::try_replace");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         uint32_t n = idx_end - idx_begin;
         if (n >= PREFETCHN * 2) {
@@ -511,7 +527,7 @@ public:
 
     Status erase(const Column& pks, uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::erase");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint32_t n = idx_end - idx_begin;
         if (n >= PREFETCHN * 2) {
             FixSlice<S> prefetch_keys[PREFETCHN];
@@ -551,7 +567,7 @@ public:
 
     Status get(const Column& pks, uint32_t idx_begin, uint32_t idx_end, std::vector<uint64_t>* rowids) override {
         CHECK_MEM_LIMIT("FixSliceHashIndex::get");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint32_t n = idx_end - idx_begin;
         if (n >= PREFETCHN * 2) {
             FixSlice<S> prefetch_keys[PREFETCHN];
@@ -626,7 +642,7 @@ public:
     Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks, uint32_t idx_begin,
                   uint32_t idx_end) override {
         CHECK_MEM_LIMIT("SliceHashIndex::insert");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         DCHECK(idx_end <= rowids.size());
         uint64_t base = (((uint64_t)rssid) << 32);
         for (uint32_t i = idx_begin; i < idx_end; i++) {
@@ -650,7 +666,7 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("SliceHashIndex::upsert");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        auto keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             uint64_t v = base + i;
@@ -669,7 +685,7 @@ public:
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
                    uint32_t idx_end, const Column& pks) override {
         CHECK_MEM_LIMIT("SliceHashIndex::replace");
-        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
@@ -687,7 +703,7 @@ public:
                                         const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
                                         vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("SliceHashIndex::try_replace");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             auto p = _map.find(keys[i].to_string());
@@ -705,7 +721,7 @@ public:
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
                        uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
         CHECK_MEM_LIMIT("SliceHashIndex::try_replace");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             auto p = _map.find(keys[i].to_string());
@@ -722,7 +738,7 @@ public:
 
     Status erase(const Column& pks, uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) override {
         CHECK_MEM_LIMIT("SliceHashIndex::erase");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             auto p = _map.find(keys[i].to_string());
             if (p != _map.end()) {
@@ -737,7 +753,7 @@ public:
 
     Status get(const Column& pks, uint32_t idx_begin, uint32_t idx_end, std::vector<uint64_t>* rowids) override {
         CHECK_MEM_LIMIT("SliceHashIndex::get");
-        auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
         for (uint32_t i = idx_begin; i < idx_end; i++) {
             auto p = _map.find(keys[i].to_string());
             if (p != _map.end()) {
@@ -864,7 +880,7 @@ public:
     Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks, uint32_t idx_begin,
                   uint32_t idx_end) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(
@@ -880,7 +896,7 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(get_index_by_length(keys[idx_begin].size)
@@ -897,7 +913,7 @@ public:
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
                    uint32_t idx_end, const Column& pks) override {
         if (!indexes.empty() && idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[indexes[i]].size != keys[indexes[idx_begin]].size) {
                     RETURN_IF_ERROR(get_index_by_length(keys[indexes[idx_begin]].size)
@@ -915,7 +931,7 @@ public:
                                         const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
                                         vector<uint32_t>* failed) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(get_index_by_length(keys[idx_begin].size)
@@ -932,7 +948,7 @@ public:
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
                        uint32_t idx_begin, uint32_t idx_end, vector<uint32_t>* failed) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(
@@ -949,7 +965,7 @@ public:
 
     Status erase(const Column& pks, uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(get_index_by_length(keys[idx_begin].size)->erase(pks, idx_begin, i, deletes));
@@ -963,7 +979,7 @@ public:
 
     Status get(const Column& pks, uint32_t idx_begin, uint32_t idx_end, std::vector<uint64_t>* rowids) override {
         if (idx_begin < idx_end) {
-            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(&pks);
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
                 if (keys[i].size != keys[idx_begin].size) {
                     RETURN_IF_ERROR(get_index_by_length(keys[idx_begin].size)->get(pks, idx_begin, i, rowids));
@@ -1320,28 +1336,31 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint3
     return Status::OK();
 }
 
-const Slice* PrimaryIndex::build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin,
-                                                 uint32_t idx_end, std::vector<Slice>* key_slices) {
+StatusOr<const Slice*> PrimaryIndex::build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin,
+                                                           uint32_t idx_end, Buffer<Slice>* key_slices) {
     if (pks.is_binary() || pks.is_large_binary()) {
-        const Slice* vkeys = reinterpret_cast<const Slice*>(pks.raw_data());
-        return vkeys + idx_begin;
+        ColumnHelper::build_slices(&pks, *key_slices);
+        return key_slices->data() + idx_begin;
     } else {
         DCHECK(key_size > 0);
-        const uint8_t* keys = pks.raw_data() + idx_begin * key_size;
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(pks.accept(&visitor));
+        const uint8_t* keys = visitor.result() + idx_begin * key_size;
         for (size_t i = idx_begin; i < idx_end; i++) {
             key_slices->emplace_back(keys, key_size);
             keys += key_size;
         }
-        return reinterpret_cast<const Slice*>(key_slices->data());
+        return key_slices->data();
     }
 }
 
 Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks) {
-    std::vector<Slice> keys;
+    // TODO: remove slice buffers
+    Buffer<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowids, 0, pks.size(), &values));
-    const Slice* vkeys = build_persistent_keys(pks, _key_size, 0, pks.size(), &keys);
+    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
     RETURN_IF_ERROR(_persistent_index->insert(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), true));
     return Status::OK();
 }
@@ -1356,7 +1375,7 @@ Status PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowi
     auto slot = ctx->slots.back().get();
     slot->values.reserve(n);
     slot->old_values.resize(n, NullIndexValue);
-    const Slice* vkeys = build_persistent_keys(pks, _key_size, idx_begin, idx_end, &slot->keys);
+    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, idx_begin, idx_end, &slot->keys));
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &slot->values));
     RETURN_IF_ERROR(_persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(slot->values.data()),
                                               reinterpret_cast<IndexValue*>(slot->old_values.data()), stat, ctx));
@@ -1380,9 +1399,10 @@ Status PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowi
 
 Status PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* deletes) {
     Status st;
-    std::vector<Slice> keys;
+    // TODO: remove slice buffers
+    Buffer<Slice> keys;
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
-    const Slice* vkeys = build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys);
+    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys));
     st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
@@ -1396,8 +1416,8 @@ Status PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* 
 }
 
 Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const {
-    std::vector<Slice> keys;
-    const Slice* vkeys = build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys);
+    Buffer<Slice> keys;
+    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(key_col, _key_size, 0, key_col.size(), &keys));
     Status st = _persistent_index->get(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
@@ -1409,11 +1429,12 @@ Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vect
                                                                 const vector<uint32_t>& src_rssid,
                                                                 vector<uint32_t>* deletes) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
-    std::vector<Slice> keys;
+    Buffer<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->try_replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
+    ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace,
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
@@ -1423,11 +1444,12 @@ Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vect
 
 Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
                                                const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
-    std::vector<Slice> keys;
+    Buffer<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->try_replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
+    ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    Status st = _persistent_index->try_replace(pks.size(), vkeys_replace,
                                                reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
@@ -1493,11 +1515,12 @@ Status PrimaryIndex::_replace_persistent_index_by_indexes(uint32_t rssid, uint32
                                                           const std::vector<uint32_t>& replace_indexes,
                                                           const Column& pks) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
-    std::vector<Slice> keys;
+    Buffer<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
     RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
-    Status st = _persistent_index->replace(pks.size(), build_persistent_keys(pks, _key_size, 0, pks.size(), &keys),
+    ASSIGN_OR_RETURN(const Slice* vkeys_replace, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    Status st = _persistent_index->replace(pks.size(), vkeys_replace,
                                            reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -173,8 +173,8 @@ public:
     }
 
     // Return the pointer of specific position of slice array.
-    static const Slice* build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin, uint32_t idx_end,
-                                              std::vector<Slice>* key_slices);
+    static StatusOr<const Slice*> build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin,
+                                                        uint32_t idx_end, Buffer<Slice>* key_slices);
 
     bool need_rebuild() const;
 

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -36,12 +36,14 @@
 #include "storage/primary_key_encoder.h"
 
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <numeric>
 #include <type_traits>
 
 #include "column/binary_column.h"
 #include "column/chunk.h"
+#include "column/raw_data_visitor.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "gutil/endian.h"
@@ -312,7 +314,7 @@ Status PrimaryKeyEncoder::create_column(const Schema& schema, MutableColumnPtr* 
     return Status::OK();
 }
 
-typedef void (*EncodeOp)(const void*, int, std::string*);
+using EncodeOp = std::function<void(int, std::string*)>;
 
 template <LogicalType LT>
 void encode_pk_fixed_value(const void* data, int idx, std::string* buff) {
@@ -325,35 +327,33 @@ void encode_pk_fixed_value(const void* data, int idx, std::string* buff) {
     }
 }
 
-static void prepare_ops_datas(const Schema& schema, const std::vector<ColumnId>& sort_key_idxes, const Chunk& chunk,
-                              std::vector<EncodeOp>* pops, std::vector<const void*>* pdatas) {
-    DCHECK_EQ(pops->size(), pdatas->size());
+static void prepare_ops(const Schema& schema, const std::vector<ColumnId>& sort_key_idxes, const Chunk& chunk,
+                        std::vector<EncodeOp>* pops) {
     int ncol = sort_key_idxes.size();
     auto& ops = *pops;
-    auto& datas = *pdatas;
     for (int j = 0; j < ncol; j++) {
-        datas[j] = chunk.get_column_by_index(sort_key_idxes[j])->raw_data();
         switch (schema.field(sort_key_idxes[j])->type()->type()) {
-#define M(LT)                               \
-    case LT:                                \
-        ops[j] = encode_pk_fixed_value<LT>; \
-        break;
+#define M(LT)                                                                              \
+    case LT: {                                                                             \
+        RawDataVisitor visitor;                                                            \
+        CHECK(chunk.get_column_by_index(sort_key_idxes[j])->accept(&visitor).ok());       \
+        const void* data = visitor.result();                                               \
+        ops[j] = [data](int idx, std::string* buff) { encode_pk_fixed_value<LT>(data, idx, buff); }; \
+        break;                                                                             \
+    }
             APPLY_FOR_ALL_PK_SUPPORT_FIXED_TYPE(M)
 #undef M
-        case TYPE_VARCHAR:
-            if (j + 1 == ncol) {
-                ops[j] = [](const void* data, int idx, std::string* buff) {
-                    encode_slice(((const Slice*)data)[idx], buff, true);
-                };
-            } else {
-                ops[j] = [](const void* data, int idx, std::string* buff) {
-                    encode_slice(((const Slice*)data)[idx], buff, false);
-                };
-            }
+        case TYPE_VARCHAR: {
+            auto container = GetContainer<TYPE_VARCHAR>::get_data(chunk.get_column_by_index(sort_key_idxes[j]));
+            bool is_last = (j + 1 == ncol);
+            ops[j] = [container, is_last](int idx, std::string* buff) {
+                encode_slice(container[idx], buff, is_last);
+            };
             break;
+        }
         default:
             DCHECK(false) << "type not supported for primary key encoding "
-                          << logical_type_to_string(schema.field(j)->type()->type());
+                          << logical_type_to_string(schema.field(sort_key_idxes[j])->type()->type());
         }
     }
 }
@@ -383,10 +383,9 @@ void PrimaryKeyEncoder::encode(const Schema& schema, const Chunk& chunk, size_t 
         DCHECK(dest->is_binary() || dest->is_large_binary()) << "dest column should be binary";
         int ncol = schema.num_key_fields();
         std::vector<EncodeOp> ops(ncol);
-        std::vector<const void*> datas(ncol);
         std::vector<ColumnId> primary_key_iota_idxes(ncol);
         std::iota(primary_key_iota_idxes.begin(), primary_key_iota_idxes.end(), 0);
-        prepare_ops_datas(schema, primary_key_iota_idxes, chunk, &ops, &datas);
+        prepare_ops(schema, primary_key_iota_idxes, chunk, &ops);
         if (dest->is_binary()) {
             auto& bdest = down_cast<BinaryColumn&>(*dest);
             bdest.reserve(bdest.size() + len);
@@ -394,7 +393,7 @@ void PrimaryKeyEncoder::encode(const Schema& schema, const Chunk& chunk, size_t 
             for (size_t i = 0; i < len; i++) {
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], offset + i, &buff);
+                    ops[j](offset + i, &buff);
                 }
                 bdest.append(buff);
             }
@@ -405,7 +404,7 @@ void PrimaryKeyEncoder::encode(const Schema& schema, const Chunk& chunk, size_t 
             for (size_t i = 0; i < len; i++) {
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], offset + i, &buff);
+                    ops[j](offset + i, &buff);
                 }
                 bdest.append(buff);
             }
@@ -418,8 +417,7 @@ Status PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chu
     RETURN_ERROR_IF_FALSE(dest->is_binary() || dest->is_large_binary());
     int ncol = schema.sort_key_idxes().size();
     std::vector<EncodeOp> ops(ncol);
-    std::vector<const void*> datas(ncol);
-    prepare_ops_datas(schema, schema.sort_key_idxes(), chunk, &ops, &datas);
+    prepare_ops(schema, schema.sort_key_idxes(), chunk, &ops);
     Columns cols(ncol);
     for (int i = 0; i < ncol; i++) {
         cols[i] = chunk.get_column_by_index(schema.sort_key_idxes()[i]);
@@ -439,7 +437,7 @@ Status PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chu
             for (size_t i = 0; i < len; i++) {
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], offset + i, &buff);
+                    ops[j](offset + i, &buff);
                 }
                 bdest.append(buff);
             }
@@ -451,7 +449,7 @@ Status PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chu
                         buff.push_back(SORT_KEY_NULL_FIRST_MARKER);
                     } else {
                         buff.push_back(SORT_KEY_NORMAL_MARKER);
-                        ops[j](datas[j], offset + i, &buff);
+                        ops[j](offset + i, &buff);
                     }
                 }
                 bdest.append(buff);
@@ -465,7 +463,7 @@ Status PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chu
             for (size_t i = 0; i < len; i++) {
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], offset + i, &buff);
+                    ops[j](offset + i, &buff);
                 }
                 bdest.append(buff);
             }
@@ -477,7 +475,7 @@ Status PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chu
                         buff.push_back(SORT_KEY_NULL_FIRST_MARKER);
                     } else {
                         buff.push_back(SORT_KEY_NORMAL_MARKER);
-                        ops[j](datas[j], offset + i, &buff);
+                        ops[j](offset + i, &buff);
                     }
                 }
                 bdest.append(buff);
@@ -498,10 +496,9 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
         DCHECK(dest->is_binary() || dest->is_large_binary()) << "dest column should be binary";
         int ncol = schema.num_key_fields();
         std::vector<EncodeOp> ops(ncol);
-        std::vector<const void*> datas(ncol);
         std::vector<ColumnId> primary_key_iota_idxes(ncol);
         std::iota(primary_key_iota_idxes.begin(), primary_key_iota_idxes.end(), 0);
-        prepare_ops_datas(schema, primary_key_iota_idxes, chunk, &ops, &datas);
+        prepare_ops(schema, primary_key_iota_idxes, chunk, &ops);
         if (dest->is_binary()) {
             auto& bdest = down_cast<BinaryColumn&>(*dest);
             bdest.reserve(bdest.size() + len);
@@ -510,7 +507,7 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
                 uint32_t idx = indexes[i];
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], idx, &buff);
+                    ops[j](idx, &buff);
                 }
                 bdest.append(buff);
             }
@@ -522,7 +519,7 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
                 uint32_t idx = indexes[i];
                 buff.clear();
                 for (int j = 0; j < ncol; j++) {
-                    ops[j](datas[j], idx, &buff);
+                    ops[j](idx, &buff);
                 }
                 bdest.append(buff);
             }
@@ -533,11 +530,9 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
 bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
                                             const size_t limit_size, PrimaryKeyEncodingType encoding_type) {
     int ncol = schema.num_key_fields();
-    std::vector<const void*> datas(ncol, nullptr);
     if (ncol == 1 && encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1) {
         if (schema.field(0)->type()->type() == TYPE_VARCHAR) {
-            const Slice* keys =
-                    static_cast<const Slice*>(static_cast<const void*>(chunk.get_column_by_index(0)->raw_data()));
+            const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(chunk.get_column_by_index(0));
             for (size_t i = 0; i < len; i++) {
                 if (keys[offset + i].size > limit_size) {
                     return true;
@@ -548,28 +543,30 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& c
         size_t size = 0;
 
         std::vector<int> varchar_indexes;
+        std::vector<BinaryImmContainer> varchar_containers;
 
         for (int i = 0; i < ncol; i++) {
-            datas[i] = chunk.get_column_by_index(i)->raw_data();
-            if (schema.field(i)->type()->type() == TYPE_VARCHAR) {
+            auto t = schema.field(i)->type()->type();
+            if (t == TYPE_VARCHAR) {
+                varchar_containers.push_back(GetContainer<TYPE_VARCHAR>::get_data(chunk.get_column_by_index(i)));
                 varchar_indexes.push_back(i);
             } else {
-                size += TabletColumn::get_field_length_by_type(schema.field(i)->type()->type(), 0);
+                size += TabletColumn::get_field_length_by_type(t, 0);
             }
             if (size > limit_size) {
                 return true;
             }
         }
 
-        const int accumulated_fixed_size = size;
+        const size_t accumulated_fixed_size = size;
 
         for (size_t i = 0; i < len; i++) {
             size = accumulated_fixed_size;
-            for (const auto varchar_index : varchar_indexes) {
-                if (varchar_index + 1 == ncol) {
-                    size += static_cast<const Slice*>(datas[varchar_index])[offset + i].get_size();
+            for (size_t k = 0; k < varchar_indexes.size(); k++) {
+                auto s = varchar_containers[k][offset + i];
+                if (varchar_indexes[k] + 1 == ncol) {
+                    size += s.get_size();
                 } else {
-                    auto s = static_cast<const Slice*>(datas[varchar_index])[offset + i];
                     std::string_view sv(s.get_data(), s.get_size());
                     size += s.get_size() + std::count(sv.begin(), sv.end(), 0) + 2;
                 }

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -43,8 +43,8 @@
 
 #include "column/binary_column.h"
 #include "column/chunk.h"
-#include "column/raw_data_visitor.h"
 #include "column/fixed_length_column.h"
+#include "column/raw_data_visitor.h"
 #include "column/schema.h"
 #include "gutil/endian.h"
 #include "gutil/stringprintf.h"
@@ -333,22 +333,20 @@ static void prepare_ops(const Schema& schema, const std::vector<ColumnId>& sort_
     auto& ops = *pops;
     for (int j = 0; j < ncol; j++) {
         switch (schema.field(sort_key_idxes[j])->type()->type()) {
-#define M(LT)                                                                              \
-    case LT: {                                                                             \
-        RawDataVisitor visitor;                                                            \
-        CHECK(chunk.get_column_by_index(sort_key_idxes[j])->accept(&visitor).ok());       \
-        const void* data = visitor.result();                                               \
+#define M(LT)                                                                                        \
+    case LT: {                                                                                       \
+        RawDataVisitor visitor;                                                                      \
+        CHECK(chunk.get_column_by_index(sort_key_idxes[j])->accept(&visitor).ok());                  \
+        const void* data = visitor.result();                                                         \
         ops[j] = [data](int idx, std::string* buff) { encode_pk_fixed_value<LT>(data, idx, buff); }; \
-        break;                                                                             \
+        break;                                                                                       \
     }
             APPLY_FOR_ALL_PK_SUPPORT_FIXED_TYPE(M)
 #undef M
         case TYPE_VARCHAR: {
             auto container = GetContainer<TYPE_VARCHAR>::get_data(chunk.get_column_by_index(sort_key_idxes[j]));
             bool is_last = (j + 1 == ncol);
-            ops[j] = [container, is_last](int idx, std::string* buff) {
-                encode_slice(container[idx], buff, is_last);
-            };
+            ops[j] = [container, is_last](int idx, std::string* buff) { encode_slice(container[idx], buff, is_last); };
             break;
         }
         default:

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -19,6 +19,8 @@
 
 #include "base/utility/pretty_printer.h"
 #include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "gutil/stl_util.h"
@@ -63,6 +65,8 @@ struct MergeEntry {
     // rssid_rowids will be empty, when `need_rssid_rowids` is false.
     bool need_rssid_rowids = false;
     std::vector<uint64_t> rssid_rowids;
+    // TODO: Remove slice buf
+    Buffer<Slice> _slice_buf; // used only when T == Slice
 
     MergeEntry() = default;
     ~MergeEntry() { close(); }
@@ -128,7 +132,14 @@ struct MergeEntry {
             DCHECK(chunk_pk_column->size() > 0);
             DCHECK(chunk_pk_column->size() == chunk->num_rows());
             // 2. setup pk cursor
-            pk_start = reinterpret_cast<const T*>(chunk_pk_column->raw_data());
+            if constexpr (std::is_same_v<T, Slice>) {
+                ColumnHelper::build_slices(chunk_pk_column.get(), _slice_buf);
+                pk_start = _slice_buf.data();
+            } else {
+                RawDataVisitor visitor;
+                CHECK(chunk_pk_column->accept(&visitor).ok());
+                pk_start = reinterpret_cast<const T*>(visitor.result());
+            }
             pk_cur = pk_start;
             pk_last = pk_start + chunk_pk_column->size() - 1;
             return Status::OK();

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -137,7 +137,7 @@ struct MergeEntry {
                 pk_start = _slice_buf.data();
             } else {
                 RawDataVisitor visitor;
-                CHECK(chunk_pk_column->accept(&visitor).ok());
+                RETURN_IF_ERROR(chunk_pk_column->accept(&visitor));
                 pk_start = reinterpret_cast<const T*>(visitor.result());
             }
             pk_cur = pk_start;

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -19,6 +19,7 @@
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/binary_column.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/tracer.h"
 #include "fs/fs_factory.h"
@@ -552,8 +553,9 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
     */
     _auto_increment_partial_update_states[idx].delete_pks = _upserts[idx]->clone_empty();
     std::vector<uint32_t> delete_idxes;
-    const auto* data =
-            reinterpret_cast<const int64*>(_auto_increment_partial_update_states[idx].write_column->raw_data());
+    RawDataVisitor visitor;
+    RETURN_IF_ERROR(_auto_increment_partial_update_states[idx].write_column->accept(&visitor));
+    const auto* data = reinterpret_cast<const int64*>(visitor.result());
 
     // just check the rows which are not exist in the previous version
     // because the rows exist in the previous version may contain 0 which are specified by the user

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -191,4 +191,49 @@ TEST_F(ColumnHelperTest, append_column_value_large_binary) {
     EXPECT_EQ(col->debug_string(), "['foo', 'bar']");
 }
 
+// ColumnHelper::build_slices
+TEST_F(ColumnHelperTest, build_slices_binary_column) {
+    auto col = ColumnTestHelper::build_column<Slice>({"foo", "bar", "baz"});
+
+    Buffer<Slice> slices;
+    ColumnHelper::build_slices(col.get(), slices);
+    ASSERT_EQ(slices.size(), 3);
+    EXPECT_EQ(slices[0].to_string(), "foo");
+    EXPECT_EQ(slices[1].to_string(), "bar");
+    EXPECT_EQ(slices[2].to_string(), "baz");
+}
+
+TEST_F(ColumnHelperTest, build_slices_large_binary_column) {
+    auto col = LargeBinaryColumn::create();
+    col->append_string("hello");
+    col->append_string("world");
+
+    Buffer<Slice> slices;
+    ColumnHelper::build_slices(col.get(), slices);
+    ASSERT_EQ(slices.size(), 2);
+    EXPECT_EQ(slices[0].to_string(), "hello");
+    EXPECT_EQ(slices[1].to_string(), "world");
+}
+
+TEST_F(ColumnHelperTest, build_slices_nullable_column) {
+    auto nullable = ColumnTestHelper::build_nullable_column<Slice>({"a", "bb"});
+
+    Buffer<Slice> slices;
+    ColumnHelper::build_slices(nullable.get(), slices);
+    ASSERT_EQ(slices.size(), 2);
+    EXPECT_EQ(slices[0].to_string(), "a");
+    EXPECT_EQ(slices[1].to_string(), "bb");
+}
+
+TEST_F(ColumnHelperTest, build_slices_const_column) {
+    auto inner = BinaryColumn::create();
+    inner->append(Slice("const"));
+    ColumnPtr const_col = ConstColumn::create(std::move(inner), 3);
+
+    Buffer<Slice> slices;
+    ColumnHelper::build_slices(const_col.get(), slices);
+    ASSERT_EQ(slices.size(), 1);
+    EXPECT_EQ(slices[0].to_string(), "const");
+}
+
 } // namespace starrocks

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -24,6 +24,8 @@
 #include "base/testutil/assert.h"
 #include "base/testutil/parallel_test.h"
 #include "base/utility/defer_op.h"
+#include "column/column_helper.h"
+#include "column/raw_data_visitor.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "fs/fs_factory.h"
@@ -1559,19 +1561,23 @@ void build_persistent_index_from_tablet(size_t N) {
         std::vector<uint64_t> persistent_results;
         primary_results.resize(pks.size());
         persistent_results.resize(pks.size());
-        primary_index.get(pks, &primary_results);
+        ASSERT_OK(primary_index.get(pks, &primary_results));
         if (pks.is_binary()) {
-            persistent_index.get(pks.size(), reinterpret_cast<const Slice*>(pks.raw_data()),
-                                 reinterpret_cast<IndexValue*>(persistent_results.data()));
+            Buffer<Slice> slices;
+            ColumnHelper::build_slices(&pks, slices);
+            ASSERT_OK(persistent_index.get(pks.size(), slices.data(),
+                                           reinterpret_cast<IndexValue*>(persistent_results.data())));
         } else {
             size_t key_size = primary_index.key_size();
             ASSERT_TRUE(key_size == sizeof(uint64_t));
+            RawDataVisitor visitor;
+            ASSERT_OK(pks.accept(&visitor));
             std::vector<Slice> col_key_slices;
-            for (size_t i = 0; i < pks.size(); ++i) {
-                col_key_slices.emplace_back(pks.raw_data() + i * key_size, key_size);
+            for (size_t j = 0; j < pks.size(); ++j) {
+                col_key_slices.emplace_back(visitor.result() + j * key_size, key_size);
             }
-            persistent_index.get(pks.size(), col_key_slices.data(),
-                                 reinterpret_cast<IndexValue*>(persistent_results.data()));
+            ASSERT_OK(persistent_index.get(pks.size(), col_key_slices.data(),
+                                           reinterpret_cast<IndexValue*>(persistent_results.data())));
         }
 
         ASSERT_EQ(primary_results.size(), persistent_results.size());
@@ -1596,18 +1602,22 @@ void build_persistent_index_from_tablet(size_t N) {
             std::vector<uint64_t> persistent_results;
             primary_results.resize(pks.size());
             persistent_results.resize(pks.size());
-            primary_index.get(pks, &primary_results);
+            ASSERT_OK(primary_index.get(pks, &primary_results));
             if (pks.is_binary()) {
-                persistent_index.get(pks.size(), reinterpret_cast<const Slice*>(pks.raw_data()),
-                                     reinterpret_cast<IndexValue*>(persistent_results.data()));
+                Buffer<Slice> slices;
+                ColumnHelper::build_slices(&pks, slices);
+                ASSERT_OK(persistent_index.get(pks.size(), slices.data(),
+                                               reinterpret_cast<IndexValue*>(persistent_results.data())));
             } else {
                 size_t key_size = primary_index.key_size();
+                RawDataVisitor visitor;
+                ASSERT_OK(pks.accept(&visitor));
                 std::vector<Slice> col_key_slices;
-                for (size_t i = 0; i < pks.size(); ++i) {
-                    col_key_slices.emplace_back(pks.raw_data() + i * key_size, key_size);
+                for (size_t j = 0; j < pks.size(); ++j) {
+                    col_key_slices.emplace_back(visitor.result() + j * key_size, key_size);
                 }
-                persistent_index.get(pks.size(), col_key_slices.data(),
-                                     reinterpret_cast<IndexValue*>(persistent_results.data()));
+                ASSERT_OK(persistent_index.get(pks.size(), col_key_slices.data(),
+                                               reinterpret_cast<IndexValue*>(persistent_results.data())));
             }
             ASSERT_EQ(primary_results.size(), persistent_results.size());
             for (size_t j = 0; j < primary_results.size(); ++j) {


### PR DESCRIPTION
## Why I'm doing:

This is the 16th step for https://github.com/StarRocks/starrocks/issues/69589

`BinaryColumn::raw_data()` will be removed in a future cleanup. This PR migrates all primary key–related call sites away from it before that happens.

## What I'm doing:

  - **`primary_index.cpp`**: Replace `raw_data()` + `reinterpret_cast` with `RawDataVisitor` in all `HashIndexImpl` methods (`insert`, `upsert`, `replace`, `try_replace`, `erase`, `get`). Use                
  `GetContainer<TYPE_VARCHAR>` in `SliceHashIndex`. Change `build_persistent_keys` to return `StatusOr<const Slice*>` for proper error propagation; update all 6 call sites with `ASSIGN_OR_RETURN`.
                                                                                                                                                                                                               
  - **`primary_key_encoder.cpp`**: Refactor `prepare_ops_datas` into `prepare_ops` using `std::function` lambdas. Fixed-length columns capture the raw pointer via `RawDataVisitor`; VARCHAR columns capture   
  `BinaryImmContainer` by value. Replace `raw_data()` in `encode_exceed_limit` with `BinaryImmContainer`.
                                                                                                                                                                                                               
  - **`rowset_merger.cpp`**: `MergeEntry<Slice>` now owns a `Buffer<Slice>` rebuilt each `next()` call via `ColumnHelper::build_slices`, instead of relying on `BinaryColumn`'s internal slice cache.          
   
  - **`column_helper.h`**: Add `ColumnHelper::build_slices(const Column*, Buffer<Slice>&)` — unwraps `NullableColumn`/`ConstColumn` and dispatches to `BinaryColumn` or `LargeBinaryColumn`.                   
                  
  - **`rowset_update_state.cpp`, `lake/delta_writer.cpp`, `memtable.cpp`**: Replace remaining `raw_data()` calls with `RawDataVisitor`.            

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
