### PR TITLE
[BugFix] Add mem_tracker to AsyncDeltaWriter ExecutionQueue callbacks

### DIFF
--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -33,6 +33,10 @@ int AsyncDeltaWriter::_execute(void* meta, bthread::TaskIterator<AsyncDeltaWrite
         return 0;
     }
     auto writer = static_cast<DeltaWriter*>(meta);
+    // Track all memory allocated in this ExecutionQueue callback under the DeltaWriter's
+    // mem_tracker. Without this, allocations between write/flush/commit calls escape tracking
+    // because the ExecutionQueue thread has no default mem_tracker set.
+    SCOPED_THREAD_LOCAL_MEM_SETTER(writer->mem_tracker(), false);
     bool flush_after_write = false;
     int num_tasks = 0;
     int64_t pending_time_ns = 0;

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -23,6 +23,7 @@
 #include "base/testutil/sync_point.h"
 #include "common/compiler_util.h"
 #include "common/util/stack_trace_mutex.h"
+#include "runtime/current_thread.h"
 #include "runtime/starrocks_metrics.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/load_spill_block_manager.h"
@@ -177,6 +178,13 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
         delta_writer->close();
         return 0;
     }
+    // Track all memory allocated in this ExecutionQueue callback under the DeltaWriter's
+    // mem_tracker. Without this, allocations between write/flush/finish calls (e.g., task
+    // management, shared_ptr operations) escape tracking entirely because the ExecutionQueue
+    // thread has no default mem_tracker set. Individual operations like DeltaWriter::write()
+    // set SCOPED_THREAD_LOCAL_MEM_SETTER internally, but this outer scope ensures complete
+    // coverage and consistent tracking for the entire callback duration.
+    SCOPED_THREAD_LOCAL_MEM_SETTER(delta_writer->mem_tracker(), false);
     int num_tasks = 0;
     auto st = Status{};
     int64_t pending_time_ns = 0;


### PR DESCRIPTION
## Why I'm doing:

During investigation of an OOM in INSERT INTO SELECT with `pipeline_dop=16`, we found that the `AsyncDeltaWriter`'s `ExecutionQueue` callback (`execute()` / `_execute()`) runs without any default mem_tracker set on the thread.

While individual operations like `DeltaWriter::write()` / `flush()` / `finish()` set `SCOPED_THREAD_LOCAL_MEM_SETTER` internally, memory allocations happening **between** these calls — task iteration, `shared_ptr` operations, error handling, task stat updates — escape tracking entirely because the `ExecutionQueue` thread has no default mem_tracker.

This is a defensive fix to ensure complete memory tracking coverage for the entire `ExecutionQueue` callback duration, consistent with the pattern used in `SinkIOBuffer::_process_chunk()`.

## What I'm doing:

Add `SCOPED_THREAD_LOCAL_MEM_SETTER(delta_writer->mem_tracker(), false)` at the top of:
- `be/src/storage/lake/async_delta_writer.cpp` `AsyncDeltaWriterImpl::execute()` (cloud-native path)
- `be/src/storage/async_delta_writer.cpp` `AsyncDeltaWriter::_execute()` (local path)

The `false` parameter disables memory limit checking, matching the behavior inside `DeltaWriter::write()` where the SCOPED setter is already used with check=false.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4