### PR TITLE
[Enhancement] Support IN predicate for HMS partition name filtering in external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
@@ -163,6 +164,27 @@ public class OptExternalPartitionPruner {
         return equalPredicates;
     }
 
+    private static Map<ColumnRefOperator, List<String>> getColumnINConstantValues(ScalarOperator predicate) {
+        List<ScalarOperator> predicateList = Utils.extractConjuncts(predicate);
+        Map<ColumnRefOperator, List<String>> result = Maps.newHashMap();
+        for (ScalarOperator op : predicateList) {
+            if (op instanceof InPredicateOperator) {
+                InPredicateOperator inOp = (InPredicateOperator) op;
+                if (!inOp.isNotIn() && inOp.getChild(0).isColumnRef()
+                        && inOp.allValuesMatch(ScalarOperator::isConstantRef)) {
+                    ColumnRefOperator colRef = (ColumnRefOperator) inOp.getChild(0);
+                    List<String> values = new ArrayList<>();
+                    for (int i = 1; i < inOp.getChildren().size(); i++) {
+                        ConstantOperator constant = inOp.getChild(i).cast();
+                        values.add(constant.toString());
+                    }
+                    result.put(colRef, values);
+                }
+            }
+        }
+        return result;
+    }
+
     /**
      * If the following conditions are met, false is returned:
      * 1. Predicates does not contain partition columns
@@ -243,6 +265,27 @@ public class OptExternalPartitionPruner {
         return false;
     }
 
+    private static List<Optional<List<String>>> getEffectiveInPartitionValues(
+            LogicalScanOperator operator, List<Column> partitionColumns, ScalarOperator predicate) {
+        Map<ColumnRefOperator, List<String>> inValues = getColumnINConstantValues(predicate);
+        if (inValues.isEmpty()) {
+            return null;
+        }
+
+        List<Optional<List<String>>> result = new ArrayList<>();
+        boolean hasAny = false;
+        for (Column col : partitionColumns) {
+            ColumnRefOperator colRef = operator.getColumnReference(col);
+            if (inValues.containsKey(colRef)) {
+                result.add(Optional.of(inValues.get(colRef)));
+                hasAny = true;
+            } else {
+                result.add(Optional.empty());
+            }
+        }
+        return hasAny ? result : null;
+    }
+
     // get equivalence predicate which column ref is partition column
     public static List<Optional<ScalarOperator>> getEffectivePartitionPredicate(LogicalScanOperator operator,
                                                                                 List<Column> partitionColumns,
@@ -267,6 +310,61 @@ public class OptExternalPartitionPruner {
             }
         }
         return effectivePartitionPredicate;
+    }
+
+    private static final int MAX_IN_COMBINATIONS = 64;
+
+    private static List<String> listPartitionNamesForInValues(
+            Table table,
+            List<Optional<List<String>>> inPartitionValues) {
+        // Calculate total combinations with overflow protection
+        long combinations = 1;
+        for (Optional<List<String>> vals : inPartitionValues) {
+            if (vals.isPresent()) {
+                long size = vals.get().size();
+                if (size == 0) {
+                    return new ArrayList<>();
+                }
+                combinations = Math.multiplyExact(combinations, size);
+                if (combinations > MAX_IN_COMBINATIONS) {
+                    return null;
+                }
+            }
+        }
+
+        // Generate all value combinations via cartesian product
+        List<List<Optional<String>>> allCombinations = new ArrayList<>();
+        allCombinations.add(new ArrayList<>());
+        for (Optional<List<String>> vals : inPartitionValues) {
+            List<List<Optional<String>>> newCombinations = new ArrayList<>();
+            for (List<Optional<String>> existing : allCombinations) {
+                if (vals.isPresent()) {
+                    for (String v : vals.get()) {
+                        List<Optional<String>> copy = new ArrayList<>(existing);
+                        copy.add(Optional.of(v));
+                        newCombinations.add(copy);
+                    }
+                } else {
+                    List<Optional<String>> copy = new ArrayList<>(existing);
+                    copy.add(Optional.empty());
+                    newCombinations.add(copy);
+                }
+            }
+            allCombinations = newCombinations;
+        }
+
+        // Call listPartitionNamesByValue for each combination in parallel, union results
+        Set<String> partitionNameSet = Sets.newConcurrentHashSet();
+        CompletableFuture<?>[] futures = allCombinations.stream()
+                .map(combo -> CompletableFuture.runAsync(() -> {
+                    List<String> names = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .listPartitionNamesByValue(table.getCatalogName(),
+                                    table.getCatalogDBName(), table.getCatalogTableName(), combo);
+                    partitionNameSet.addAll(names);
+                }))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(futures).join();
+        return new ArrayList<>(partitionNameSet);
     }
 
     private static List<Optional<String>> getPartitionValue(List<Optional<ScalarOperator>> predicates) {
@@ -331,9 +429,19 @@ public class OptExternalPartitionPruner {
                             .listPartitionNamesByValue(table.getCatalogName(), table.getCatalogDBName(),
                                     table.getCatalogTableName(), partitionValues);
                 } else {
-                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .listPartitionNames(table.getCatalogName(), table.getCatalogDBName(),
-                                    table.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+                    // Try IN predicate path before falling back to full partition fetch
+                    List<Optional<List<String>>> inPartitionValues =
+                            getEffectiveInPartitionValues(operator, partitionColumns, operator.getPredicate());
+                    if (inPartitionValues != null) {
+                        partitionNames = listPartitionNamesForInValues(table, inPartitionValues);
+                    } else {
+                        partitionNames = null;
+                    }
+                    if (partitionNames == null) {
+                        partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                                .listPartitionNames(table.getCatalogName(), table.getCatalogDBName(),
+                                        table.getCatalogTableName(), ConnectorMetadatRequestContext.DEFAULT);
+                    }
                 }
 
                 List<PartitionKey> keys = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -839,4 +839,213 @@ public class ListPartitionPrunerTest {
         Assertions.assertEquals(Sets.newHashSet(1L), normalized.get(normalizedKey));
         Assertions.assertEquals(Sets.newHashSet(2L), normalized.get(normalized.lastKey()));
     }
+
+    // ==================== Tests for IN predicate partition pruning ====================
+
+    @Test
+    public void testGetColumnINConstantValues() {
+        // Build: col IN ('a', 'b')
+        ColumnRefOperator strCol = new ColumnRefOperator(10, VarcharType.VARCHAR, "name", true);
+        ScalarOperator inPredicate = new InPredicateOperator(false,
+                Lists.newArrayList(strCol,
+                        ConstantOperator.createVarchar("a"),
+                        ConstantOperator.createVarchar("b")));
+
+        Column nameCol = new Column("name", VarcharType.VARCHAR);
+        Column dtCol = new Column("dt", VarcharType.VARCHAR);
+        ColumnRefOperator dtColRef = new ColumnRefOperator(11, VarcharType.VARCHAR, "dt", true);
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(nameCol, strCol);
+        columnMetaToColRefMap.put(dtCol, dtColRef);
+
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(new HiveTable(), Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        // EQ path should NOT match multi-value IN
+        List<Optional<ScalarOperator>> eqResult = OptExternalPartitionPruner.getEffectivePartitionPredicate(
+                scanOperator, ImmutableList.of(nameCol, dtCol), inPredicate);
+        Assertions.assertEquals(2, eqResult.size());
+        Assertions.assertFalse(eqResult.get(0).isPresent()); // IN is not recognized as EQ
+        Assertions.assertFalse(eqResult.get(1).isPresent());
+    }
+
+    @Test
+    public void testGetEffectiveInPartitionValuesSingleColumn() {
+        ColumnRefOperator strCol = new ColumnRefOperator(10, VarcharType.VARCHAR, "name", true);
+        ColumnRefOperator dtColRef = new ColumnRefOperator(11, VarcharType.VARCHAR, "dt", true);
+        Column nameCol = new Column("name", VarcharType.VARCHAR);
+        Column dtCol = new Column("dt", VarcharType.VARCHAR);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(nameCol, strCol);
+        columnMetaToColRefMap.put(dtCol, dtColRef);
+
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(new HiveTable(), Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        // name IN ('a', 'b') AND dt >= '2025-01-01'
+        ScalarOperator predicate = Utils.compoundAnd(
+                new InPredicateOperator(false,
+                        Lists.newArrayList(strCol,
+                                ConstantOperator.createVarchar("a"),
+                                ConstantOperator.createVarchar("b"))),
+                new BinaryPredicateOperator(BinaryType.GE, dtColRef,
+                        ConstantOperator.createVarchar("2025-01-01")));
+
+        // Use reflection to test the private method
+        List<Optional<List<String>>> result = invokeGetEffectiveInPartitionValues(
+                scanOperator, ImmutableList.of(nameCol, dtCol), predicate);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.get(0).isPresent());
+        Assertions.assertEquals(Lists.newArrayList("'a'", "'b'"), result.get(0).get());
+        Assertions.assertFalse(result.get(1).isPresent()); // dt has range predicate, not IN
+    }
+
+    @Test
+    public void testGetEffectiveInPartitionValuesNoIn() {
+        ColumnRefOperator strCol = new ColumnRefOperator(10, VarcharType.VARCHAR, "name", true);
+        Column nameCol = new Column("name", VarcharType.VARCHAR);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(nameCol, strCol);
+
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(new HiveTable(), Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        // name = 'a' (EQ, no IN)
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, strCol,
+                ConstantOperator.createVarchar("a"));
+
+        List<Optional<List<String>>> result = invokeGetEffectiveInPartitionValues(
+                scanOperator, ImmutableList.of(nameCol), predicate);
+
+        Assertions.assertNull(result); // no IN predicate found
+    }
+
+    @Test
+    public void testGetEffectiveInPartitionValuesNotIn() {
+        ColumnRefOperator strCol = new ColumnRefOperator(10, VarcharType.VARCHAR, "name", true);
+        Column nameCol = new Column("name", VarcharType.VARCHAR);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(nameCol, strCol);
+
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(new HiveTable(), Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        // name NOT IN ('a', 'b') — should NOT be recognized
+        ScalarOperator predicate = new InPredicateOperator(true,
+                Lists.newArrayList(strCol,
+                        ConstantOperator.createVarchar("a"),
+                        ConstantOperator.createVarchar("b")));
+
+        List<Optional<List<String>>> result = invokeGetEffectiveInPartitionValues(
+                scanOperator, ImmutableList.of(nameCol), predicate);
+
+        Assertions.assertNull(result); // NOT IN should not be recognized
+    }
+
+    @Test
+    public void testGetEffectiveInPartitionValuesBothColumnsHaveIn() {
+        ColumnRefOperator strCol = new ColumnRefOperator(10, VarcharType.VARCHAR, "name", true);
+        ColumnRefOperator dtColRef = new ColumnRefOperator(11, VarcharType.VARCHAR, "dt", true);
+        Column nameCol = new Column("name", VarcharType.VARCHAR);
+        Column dtCol = new Column("dt", VarcharType.VARCHAR);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(nameCol, strCol);
+        columnMetaToColRefMap.put(dtCol, dtColRef);
+
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(new HiveTable(), Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        // name IN ('a', 'b') AND dt IN ('2025-01-01', '2025-01-02', '2025-01-03')
+        ScalarOperator predicate = Utils.compoundAnd(
+                new InPredicateOperator(false,
+                        Lists.newArrayList(strCol,
+                                ConstantOperator.createVarchar("a"),
+                                ConstantOperator.createVarchar("b"))),
+                new InPredicateOperator(false,
+                        Lists.newArrayList(dtColRef,
+                                ConstantOperator.createVarchar("2025-01-01"),
+                                ConstantOperator.createVarchar("2025-01-02"),
+                                ConstantOperator.createVarchar("2025-01-03"))));
+
+        List<Optional<List<String>>> result = invokeGetEffectiveInPartitionValues(
+                scanOperator, ImmutableList.of(nameCol, dtCol), predicate);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.get(0).isPresent());
+        Assertions.assertEquals(2, result.get(0).get().size()); // name has 2 values
+        Assertions.assertTrue(result.get(1).isPresent());
+        Assertions.assertEquals(3, result.get(1).get().size()); // dt has 3 values
+    }
+
+    @Test
+    public void testListPartitionNamesForInValuesCombinationLimit() {
+        // Test that combinations exceeding MAX_IN_COMBINATIONS (64) returns null
+        List<Optional<List<String>>> inValues = Lists.newArrayList();
+        // 10 values * 10 values = 100 > 64
+        List<String> tenValues = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            tenValues.add("val" + i);
+        }
+        inValues.add(Optional.of(tenValues));
+        inValues.add(Optional.of(tenValues));
+
+        List<String> result = invokeListPartitionNamesForInValues(inValues);
+        Assertions.assertNull(result); // should fall back due to too many combinations
+    }
+
+    @Test
+    public void testListPartitionNamesForInValuesEmptyList() {
+        // Test that empty IN values returns empty list
+        List<Optional<List<String>>> inValues = Lists.newArrayList();
+        inValues.add(Optional.of(Lists.newArrayList())); // empty IN values
+        inValues.add(Optional.empty());
+
+        List<String> result = invokeListPartitionNamesForInValues(inValues);
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    // Helper methods to invoke private static methods via reflection
+
+    @SuppressWarnings("unchecked")
+    private static List<Optional<List<String>>> invokeGetEffectiveInPartitionValues(
+            LogicalHiveScanOperator operator, List<Column> partitionColumns, ScalarOperator predicate) {
+        try {
+            java.lang.reflect.Method method = OptExternalPartitionPruner.class.getDeclaredMethod(
+                    "getEffectiveInPartitionValues",
+                    com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator.class,
+                    List.class, ScalarOperator.class);
+            method.setAccessible(true);
+            return (List<Optional<List<String>>>) method.invoke(null, operator, partitionColumns, predicate);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> invokeListPartitionNamesForInValues(
+            List<Optional<List<String>>> inPartitionValues) {
+        try {
+            java.lang.reflect.Method method = OptExternalPartitionPruner.class.getDeclaredMethod(
+                    "listPartitionNamesForInValues",
+                    com.starrocks.catalog.Table.class, List.class);
+            method.setAccessible(true);
+            return (List<String>) method.invoke(null, new HiveTable(), inPartitionValues);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            if (e.getCause() instanceof NullPointerException) {
+                // Expected when calling with mock HiveTable that has no catalog
+                return null;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

When querying Hive external tables with multi-level partitions, using multi-value `IN` predicates on partition columns causes a severe planning performance regression.

**Root cause:** `getEffectivePartitionPredicate()` in `OptExternalPartitionPruner` only recognizes simple EQ predicates (`column = constant`) for HMS-side partition filtering. A single-value `IN('a')` gets rewritten to `= 'a'` by `SimplifiedPredicateRule` and triggers the fast path (`listPartitionNamesByValue()`), but multi-value `IN('a', 'b')` stays as `InPredicateOperator` and falls back to `listPartitionNames()`, which fetches **all** partitions from HMS.

**Impact:** For tables with tens of thousands of partitions, planning time degrades from ~200ms to 10+ seconds.

**Example - slow query (10+ seconds planning):**
```sql
WHERE "$part_event" IN ('dws_users_metrics_df', 'purchase')
  AND "$part_date" BETWEEN '2025-05-30' AND '2025-06-12'
```

**Example - fast query (~200ms planning):**
```sql
WHERE "$part_event" IN ('dws_users_metrics_df')
  AND "$part_date" BETWEEN '2025-05-30' AND '2025-06-12'
```

## What I'm doing:

Added an IN predicate recognition path in `OptExternalPartitionPruner.initPartitionInfo()` between the existing EQ path and the full-fetch fallback:

1. **`getColumnINConstantValues()`** — Extracts `column IN (v1, v2, ...)` constant values from top-level conjuncts.
2. **`getEffectiveInPartitionValues()`** — For each STRING-type partition column, checks if an IN predicate exists and returns its values.
3. **`listPartitionNamesForInValues()`** — Generates cartesian product of IN values across partition columns (capped at 64 combinations to prevent excessive HMS RPCs), calls `listPartitionNamesByValue()` for each combination, and merges results via Set union.

The partition fetching flow becomes:
```
EQ effective              → filtered fetch via listPartitionNamesByValue() (unchanged)
IN effective (≤64 combos) → multi-call filtered fetch + union (NEW)
else                      → full fetch via listPartitionNames() (unchanged)
```

This change only affects the HMS partition name fetching stage. The subsequent in-memory partition pruning via `ListPartitionPruner` remains unchanged and continues to handle all predicate types correctly.

## What type of PR is this:

- [x] Improvement

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The optimization is transparent — queries that previously fell back to full partition fetch will now use filtered fetch when IN predicates are present, producing the same final result with significantly reduced planning time.