### PR TITLE
[Enhancement] Add decimal type support for variant virtual column rewrite

### DIFF
--- a/be/src/column/variant_converter.h
+++ b/be/src/column/variant_converter.h
@@ -72,8 +72,8 @@ public:
         }
 
         RunTimeCppType<ResultType> decimal_value{};
-        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(
-                                                &decimal_value, variant, precision, scale));
+        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(&decimal_value, variant,
+                                                                                            precision, scale));
         if (overflow) {
             result.append_null();
         } else {

--- a/be/src/column/variant_converter.h
+++ b/be/src/column/variant_converter.h
@@ -19,6 +19,7 @@
 #include "base/statusor.h"
 #include "column/column_builder.h"
 #include "column/runtime_type_traits.h"
+#include "exprs/decimal_cast_expr.h"
 #include "types/date_value.h"
 #include "types/logical_type.h"
 #include "types/time_types.h"
@@ -58,6 +59,28 @@ public:
 
     static Status cast_to_datetime(const VariantRowRef& row, const cctz::time_zone& zone,
                                    ColumnBuilder<TYPE_DATETIME>& result);
+
+    template <LogicalType ResultType>
+    static Status cast_to_decimal(const VariantRowRef& row, int precision, int scale,
+                                  ColumnBuilder<ResultType>& result) {
+        static_assert(lt_is_decimal<ResultType>, "ResultType must be decimal");
+
+        const VariantValue& variant = row.get_value();
+        if (variant.type() == VariantType::NULL_TYPE) {
+            result.append_null();
+            return Status::OK();
+        }
+
+        RunTimeCppType<ResultType> decimal_value{};
+        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(
+                                                &decimal_value, variant, precision, scale));
+        if (overflow) {
+            result.append_null();
+        } else {
+            result.append(decimal_value);
+        }
+        return Status::OK();
+    }
 
     template <LogicalType ResultType>
     static Status cast_to_arithmetic(const VariantRowRef& row, ColumnBuilder<ResultType>& result) {

--- a/be/src/column/variant_converter.h
+++ b/be/src/column/variant_converter.h
@@ -19,7 +19,6 @@
 #include "base/statusor.h"
 #include "column/column_builder.h"
 #include "column/runtime_type_traits.h"
-#include "exprs/decimal_cast_expr.h"
 #include "types/date_value.h"
 #include "types/logical_type.h"
 #include "types/time_types.h"
@@ -59,28 +58,6 @@ public:
 
     static Status cast_to_datetime(const VariantRowRef& row, const cctz::time_zone& zone,
                                    ColumnBuilder<TYPE_DATETIME>& result);
-
-    template <LogicalType ResultType>
-    static Status cast_to_decimal(const VariantRowRef& row, int precision, int scale,
-                                  ColumnBuilder<ResultType>& result) {
-        static_assert(lt_is_decimal<ResultType>, "ResultType must be decimal");
-
-        const VariantValue& variant = row.get_value();
-        if (variant.type() == VariantType::NULL_TYPE) {
-            result.append_null();
-            return Status::OK();
-        }
-
-        RunTimeCppType<ResultType> decimal_value{};
-        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(&decimal_value, variant,
-                                                                                            precision, scale));
-        if (overflow) {
-            result.append_null();
-        } else {
-            result.append(decimal_value);
-        }
-        return Status::OK();
-    }
 
     template <LogicalType ResultType>
     static Status cast_to_arithmetic(const VariantRowRef& row, ColumnBuilder<ResultType>& result) {

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -184,12 +184,14 @@ bool ColumnReader::check_type_can_apply_bloom_filter(const TypeDescriptor& col_t
         //      And any convert should be disabled, because the length cannot change.
     } else if (type == LogicalType::TYPE_DECIMAL32 || type == LogicalType::TYPE_DECIMAL64 ||
                type == LogicalType::TYPE_DECIMAL128 || type == LogicalType::TYPE_DECIMALV2) {
-        //TODO: Decimal can be stored as INT32, INT64, BYTE_ARRAY, FLBA in parquet
-        //      SR stores the decimalxx as intxx with precision and scale,
-        //      First the int type should match the parquet's physical type
-        //      And the logical type of sr and parquet's scale and precision should also be the same
-        //      Ohterwise, we need to convert the value.
-        //      But we should notice that if the convert will cause precision loss, otherwise it should be disabled.
+        const bool exact_decimal_layout = field.precision == col_type.precision && field.scale == col_type.scale;
+        if (exact_decimal_layout) {
+            if (type == LogicalType::TYPE_DECIMAL32 && parquet_type == tparquet::Type::type::INT32) {
+                appliable = true;
+            } else if (type == LogicalType::TYPE_DECIMAL64 && parquet_type == tparquet::Type::type::INT64) {
+                appliable = true;
+            }
+        }
     } else {
         //TODO: Other types like TYPE_TIME, TYPE_DATE_V1, TYPE_DATETIME, TYPE_DATETIME_V1 is stored different with int type in sr
         //    should be converted as int32_t or int64_t.

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -274,9 +274,9 @@ StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn*
             continue;
         }
         RunTimeCppType<ResultType> decimal_value{};
-        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(
-                                                &decimal_value, variant_value, target_type.precision,
-                                                target_type.scale));
+        ASSIGN_OR_RETURN(bool overflow,
+                         cast_variant_to_decimal<RunTimeCppType<ResultType>>(&decimal_value, variant_value,
+                                                                             target_type.precision, target_type.scale));
         if (overflow) {
             builder.append_null();
         } else {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -174,6 +174,18 @@ StatusOr<ColumnPtr> build_exact_typed_variant_projection(const VariantColumn* va
     return result;
 }
 
+// Cast a typed-shredded decimal column to a (possibly different) decimal target type.
+//
+// This function is needed because the shredded typed column already holds native decimal
+// storage (int32 / int64 / int128 physical values with precision+scale baked into the
+// TypeDescriptor). That is NOT a variant-binary-encoded value, so VariantRowConverter::cast_to
+// cannot be used: that path decodes variant binary wire format and explicitly excludes
+// decimal targets (see the "VARIANT -> Decimal types: DecimalNonDecimalCast" comment in
+// variant_row_converter.cpp). Instead we go through TypeConverter::convert_column, which
+// understands native decimal storage and handles precision/scale widening correctly.
+//
+// If source_type == target_type (same precision and scale) no conversion is necessary and the
+// column is returned as-is.
 StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_column, const TypeDescriptor& source_type,
                                                    const TypeDescriptor& target_type) {
     if (source_type == target_type) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -39,6 +39,7 @@
 #include "common/system/master_info.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/chunk_predicate_evaluator.h"
+#include "exprs/decimal_cast_expr.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/variant_path_reader.h"
@@ -267,8 +268,20 @@ StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn*
             builder.append_null();
             continue;
         }
-        RETURN_IF_ERROR(VariantRowConverter::cast_to_decimal<ResultType>(read.value.as_ref(), target_type.precision,
-                                                                         target_type.scale, builder));
+        const VariantValue& variant_value = read.value.as_ref().get_value();
+        if (variant_value.type() == VariantType::NULL_TYPE) {
+            builder.append_null();
+            continue;
+        }
+        RunTimeCppType<ResultType> decimal_value{};
+        ASSIGN_OR_RETURN(bool overflow, cast_variant_to_decimal<RunTimeCppType<ResultType>>(
+                                                &decimal_value, variant_value, target_type.precision,
+                                                target_type.scale));
+        if (overflow) {
+            builder.append_null();
+        } else {
+            builder.append(decimal_value);
+        }
     }
 
     return builder.build(false);

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -192,14 +192,14 @@ StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_colum
 
     auto result = ColumnHelper::create_column(target_type, true);
     MemPool mem_pool;
-    RETURN_IF_ERROR(
-            converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(), result.get(),
-                                      &mem_pool));
+    RETURN_IF_ERROR(converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(),
+                                              result.get(), &mem_pool));
     return result;
 }
 
-StatusOr<ColumnPtr> build_decimal_typed_variant_projection(const VariantColumn* variant_column, const ColumnPtr& variant_src,
-                                                           const VariantPath& path, const TypeDescriptor& target_type) {
+StatusOr<ColumnPtr> build_decimal_typed_variant_projection(const VariantColumn* variant_column,
+                                                           const ColumnPtr& variant_src, const VariantPath& path,
+                                                           const TypeDescriptor& target_type) {
     VariantPathReader reader;
     reader.prepare(variant_column, &path);
     if (!reader.is_typed_exact()) {
@@ -246,8 +246,9 @@ StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant
 }
 
 template <LogicalType ResultType>
-StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
-                                                            const VariantPath& path, const TypeDescriptor& target_type) {
+StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn* variant_column,
+                                                            const ColumnPtr& variant_src, const VariantPath& path,
+                                                            const TypeDescriptor& target_type) {
     const size_t num_rows = variant_src->size();
 
     ColumnBuilder<ResultType> builder(num_rows, target_type.precision, target_type.scale);
@@ -266,9 +267,8 @@ StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn*
             builder.append_null();
             continue;
         }
-        RETURN_IF_ERROR(
-                VariantRowConverter::cast_to_decimal<ResultType>(read.value.as_ref(), target_type.precision,
-                                                                 target_type.scale, builder));
+        RETURN_IF_ERROR(VariantRowConverter::cast_to_decimal<ResultType>(read.value.as_ref(), target_type.precision,
+                                                                         target_type.scale, builder));
     }
 
     return builder.build(false);
@@ -286,7 +286,8 @@ StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, co
         return exact_typed_result;
     }
     if (target_type.is_decimalv3_type()) {
-        auto decimal_typed_result = build_decimal_typed_variant_projection(variant_column, variant_src, path, target_type);
+        auto decimal_typed_result =
+                build_decimal_typed_variant_projection(variant_column, variant_src, path, target_type);
         if (decimal_typed_result.ok()) {
             return decimal_typed_result;
         }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -52,7 +52,9 @@
 #include "formats/parquet/scalar_column_reader.h"
 #include "formats/parquet/schema.h"
 #include "gen_cpp/Exprs_types.h"
+#include "runtime/mem_pool.h"
 #include "storage/chunk_helper.h"
+#include "storage/convert_helper.h"
 #include "types/type_descriptor.h"
 #include "utils.h"
 
@@ -171,6 +173,49 @@ StatusOr<ColumnPtr> build_exact_typed_variant_projection(const VariantColumn* va
     return result;
 }
 
+StatusOr<ColumnPtr> cast_decimal_projection_column(const ColumnPtr& source_column, const TypeDescriptor& source_type,
+                                                   const TypeDescriptor& target_type) {
+    if (source_type == target_type) {
+        return source_column;
+    }
+
+    const TypeConverter* converter = get_type_converter(source_type.type, target_type.type);
+    if (converter == nullptr) {
+        return Status::NotFound("no decimal converter for variant typed projection");
+    }
+
+    TypeInfoPtr source_type_info = get_type_info(source_type);
+    TypeInfoPtr target_type_info = get_type_info(target_type);
+    if (source_type_info == nullptr || target_type_info == nullptr) {
+        return Status::NotSupported("missing type info for decimal variant projection");
+    }
+
+    auto result = ColumnHelper::create_column(target_type, true);
+    MemPool mem_pool;
+    RETURN_IF_ERROR(
+            converter->convert_column(source_type_info.get(), *source_column, target_type_info.get(), result.get(),
+                                      &mem_pool));
+    return result;
+}
+
+StatusOr<ColumnPtr> build_decimal_typed_variant_projection(const VariantColumn* variant_column, const ColumnPtr& variant_src,
+                                                           const VariantPath& path, const TypeDescriptor& target_type) {
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+    if (!reader.is_typed_exact()) {
+        return Status::NotFound("variant path is not an exact typed leaf");
+    }
+
+    const TypeDescriptor& source_type = reader.typed_type_desc();
+    if (!source_type.is_decimalv3_type() || !target_type.is_decimalv3_type()) {
+        return Status::NotFound("variant typed leaf is not decimal");
+    }
+
+    ASSIGN_OR_RETURN(auto exact_source_projection,
+                     build_exact_typed_variant_projection(variant_column, variant_src, path, source_type));
+    return cast_decimal_projection_column(exact_source_projection, source_type, target_type);
+}
+
 template <LogicalType ResultType>
 StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
                                                     const VariantPath& path, const cctz::time_zone& zone) {
@@ -200,6 +245,35 @@ StatusOr<ColumnPtr> build_variant_projection_column(const VariantColumn* variant
     return builder.build(false);
 }
 
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> build_decimal_variant_projection_column(const VariantColumn* variant_column, const ColumnPtr& variant_src,
+                                                            const VariantPath& path, const TypeDescriptor& target_type) {
+    const size_t num_rows = variant_src->size();
+
+    ColumnBuilder<ResultType> builder(num_rows, target_type.precision, target_type.scale);
+    VariantPathReader reader;
+    reader.prepare(variant_column, &path);
+
+    const bool src_is_const = variant_src->is_constant();
+    for (size_t row = 0; row < num_rows; ++row) {
+        if (variant_src->is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+        size_t variant_row = src_is_const ? 0 : row;
+        VariantReadResult read = reader.read_row(variant_row);
+        if (read.state != VariantReadState::kValue) {
+            builder.append_null();
+            continue;
+        }
+        RETURN_IF_ERROR(
+                VariantRowConverter::cast_to_decimal<ResultType>(read.value.as_ref(), target_type.precision,
+                                                                 target_type.scale, builder));
+    }
+
+    return builder.build(false);
+}
+
 StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, const VariantPath& path,
                                                 const TypeDescriptor& target_type, const cctz::time_zone& zone) {
     auto* variant_column = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(variant_src.get()));
@@ -210,6 +284,12 @@ StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, co
     auto exact_typed_result = build_exact_typed_variant_projection(variant_column, variant_src, path, target_type);
     if (exact_typed_result.ok()) {
         return exact_typed_result;
+    }
+    if (target_type.is_decimalv3_type()) {
+        auto decimal_typed_result = build_decimal_typed_variant_projection(variant_column, variant_src, path, target_type);
+        if (decimal_typed_result.ok()) {
+            return decimal_typed_result;
+        }
     }
 
     switch (target_type.type) {
@@ -237,6 +317,12 @@ StatusOr<ColumnPtr> project_variant_leaf_column(const ColumnPtr& variant_src, co
         return build_variant_projection_column<TYPE_DATETIME>(variant_column, variant_src, path, zone);
     case TYPE_TIME:
         return build_variant_projection_column<TYPE_TIME>(variant_column, variant_src, path, zone);
+    case TYPE_DECIMAL32:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL32>(variant_column, variant_src, path, target_type);
+    case TYPE_DECIMAL64:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL64>(variant_column, variant_src, path, target_type);
+    case TYPE_DECIMAL128:
+        return build_decimal_variant_projection_column<TYPE_DECIMAL128>(variant_column, variant_src, path, target_type);
     case TYPE_VARIANT:
         return build_variant_projection_column<TYPE_VARIANT>(variant_column, variant_src, path, zone);
     default:

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -558,9 +558,11 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tpar
     return ColumnReaderFactory::create(opts, &field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
-static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(
-        tparquet::RowGroup& rg, ColumnReaderOptions& opts, bool stats_on_leaf_chunk = false,
-        bool leaf_value_all_null = false, bool include_leaf_value = true) {
+static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(tparquet::RowGroup& rg,
+                                                                                    ColumnReaderOptions& opts,
+                                                                                    bool stats_on_leaf_chunk = false,
+                                                                                    bool leaf_value_all_null = false,
+                                                                                    bool include_leaf_value = true) {
     ParquetField meta_f;
     meta_f.name = "metadata";
     meta_f.type = ColumnType::SCALAR;

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -558,6 +558,86 @@ static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_variant_reader(tpar
     return ColumnReaderFactory::create(opts, &field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
 }
 
+static StatusOr<std::unique_ptr<ColumnReader>> make_shredded_decimal_variant_reader(
+        tparquet::RowGroup& rg, ColumnReaderOptions& opts, bool stats_on_leaf_chunk = false,
+        bool leaf_value_all_null = false, bool include_leaf_value = true) {
+    ParquetField meta_f;
+    meta_f.name = "metadata";
+    meta_f.type = ColumnType::SCALAR;
+    meta_f.physical_type = tparquet::Type::BYTE_ARRAY;
+    meta_f.physical_column_index = 0;
+
+    ParquetField val_f;
+    val_f.name = "value";
+    val_f.type = ColumnType::SCALAR;
+    val_f.physical_type = tparquet::Type::BYTE_ARRAY;
+    val_f.physical_column_index = 1;
+
+    ParquetField price_val_f;
+    price_val_f.name = "value";
+    price_val_f.type = ColumnType::SCALAR;
+    price_val_f.physical_type = tparquet::Type::BYTE_ARRAY;
+    price_val_f.physical_column_index = 2;
+
+    ParquetField price_typed_f;
+    price_typed_f.name = "typed_value";
+    price_typed_f.type = ColumnType::SCALAR;
+    price_typed_f.physical_type = tparquet::Type::INT32;
+    price_typed_f.physical_column_index = 3;
+    {
+        tparquet::DecimalType decimal_type;
+        decimal_type.__set_precision(5);
+        decimal_type.__set_scale(2);
+        tparquet::LogicalType logical_type;
+        logical_type.__set_DECIMAL(decimal_type);
+        price_typed_f.schema_element.__set_logicalType(logical_type);
+        price_typed_f.precision = 5;
+        price_typed_f.scale = 2;
+    }
+
+    ParquetField tv_struct;
+    tv_struct.name = "typed_value";
+    tv_struct.type = ColumnType::STRUCT;
+    ParquetField price_node;
+    price_node.name = "price";
+    price_node.type = ColumnType::STRUCT;
+    price_node.children = include_leaf_value ? std::vector<ParquetField>{price_val_f, price_typed_f}
+                                             : std::vector<ParquetField>{price_typed_f};
+    tv_struct.children = {price_node};
+
+    ParquetField field;
+    field.name = "data";
+    field.type = ColumnType::STRUCT;
+    field.children = {meta_f, val_f, tv_struct};
+
+    for (int i = 0; i <= 3; ++i) {
+        tparquet::ColumnChunk chunk;
+        chunk.__set_file_path("col" + std::to_string(i));
+        chunk.file_offset = 0;
+        chunk.meta_data.data_page_offset = 4;
+        chunk.meta_data.__set_type(i == 3 ? tparquet::Type::INT32 : tparquet::Type::BYTE_ARRAY);
+        if ((i == 1 || i == 2) && leaf_value_all_null) {
+            tparquet::Statistics stats;
+            stats.__set_null_count(5);
+            chunk.meta_data.__set_statistics(stats);
+        }
+        if (i == 3 && stats_on_leaf_chunk) {
+            int32_t min_val = 1050;
+            int32_t max_val = 1250;
+            tparquet::Statistics stats;
+            stats.__set_null_count(0);
+            stats.__set_min_value(std::string(reinterpret_cast<const char*>(&min_val), sizeof(min_val)));
+            stats.__set_max_value(std::string(reinterpret_cast<const char*>(&max_val), sizeof(max_val)));
+            chunk.meta_data.__set_statistics(stats);
+        }
+        rg.columns.emplace_back(std::move(chunk));
+    }
+    rg.__set_num_rows(5);
+    opts.row_group_meta = &rg;
+
+    return ColumnReaderFactory::create(opts, &field, TypeDescriptor::from_logical_type(LogicalType::TYPE_VARIANT));
+}
+
 // Build a minimal FileMetaData (writer version "unknown") so that
 // has_correct_min_max_stats does not dereference a null pointer.
 // For INT32 with SIGNED sort order HasCorrectStatistics returns true regardless of version.
@@ -766,6 +846,39 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesPredicatesToLeafType) {
     auto bloom_result = zm_reader.row_group_bloom_filter({pred}, CompoundNodeType::AND, 0, 5);
     ASSERT_OK(bloom_result);
     EXPECT_FALSE(bloom_result.value());
+}
+
+TEST(VariantZoneMapTest, ZoneMapReaderRewritesDecimalPredicatesToLeafType) {
+    auto file_meta = make_minimal_file_meta();
+    ASSERT_NE(file_meta, nullptr);
+
+    tparquet::RowGroup rg;
+    ColumnReaderOptions opts;
+    opts.file_meta_data = file_meta.get();
+    ASSIGN_OR_ABORT(auto reader,
+                    make_shredded_decimal_variant_reader(rg, opts, /*stats_on_leaf_chunk=*/true,
+                                                         /*leaf_value_all_null=*/true, /*include_leaf_value=*/true));
+    auto* vr = down_cast<VariantColumnReader*>(reader.get());
+
+    auto path = VariantPathParser::parse_shredded_path(std::string_view("price"));
+    ASSERT_OK(path);
+    auto virtual_slot_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2);
+    VariantVirtualZoneMapReader zm_reader(vr, *path, virtual_slot_type);
+
+    ObjectPool pool;
+    TypeInfoPtr ti = get_type_info(virtual_slot_type);
+    ASSERT_NE(ti, nullptr);
+    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int64_t(2000))));
+
+    auto row_group_result = zm_reader.row_group_zone_map_filter({pred}, CompoundNodeType::AND, 0, 5);
+    ASSERT_OK(row_group_result);
+    EXPECT_TRUE(row_group_result.value());
+
+    SparseRange<uint64_t> row_ranges;
+    auto page_result = zm_reader.page_index_zone_map_filter({pred}, &row_ranges, CompoundNodeType::AND, 0, 5);
+    ASSERT_OK(page_result);
+    EXPECT_FALSE(page_result.value());
+    EXPECT_TRUE(row_ranges.empty());
 }
 
 TEST(VariantZoneMapTest, ZoneMapReaderSkipsPushdownWhenPredicateRewriteFails) {

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -3052,24 +3052,24 @@ TEST(GroupReaderBloomFilterTest, DecimalBloomFilterApplicabilityRequiresExactLay
     decimal32_field.physical_type = tparquet::Type::INT32;
     decimal32_field.precision = 5;
     decimal32_field.scale = 2;
-    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(
-            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2), decimal32_field));
-    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(
-            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 6, 2), decimal32_field));
+    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2),
+                                                         decimal32_field));
+    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 6, 2),
+                                                          decimal32_field));
 
     ParquetField decimal64_field;
     decimal64_field.physical_type = tparquet::Type::INT64;
     decimal64_field.precision = 16;
     decimal64_field.scale = 2;
-    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(
-            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 16, 2), decimal64_field));
+    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 16, 2),
+                                                         decimal64_field));
 
     ParquetField decimal128_field;
     decimal128_field.physical_type = tparquet::Type::FIXED_LEN_BYTE_ARRAY;
     decimal128_field.precision = 22;
     decimal128_field.scale = 4;
-    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(
-            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 22, 4), decimal128_field));
+    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 22, 4),
+                                                          decimal128_field));
 }
 
 // ── Hidden variant source active/lazy classification ─────────────────────────

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -22,6 +22,7 @@
 
 #include "column/column_helper.h"
 #include "column/const_column.h"
+#include "column/variant_encoder.h"
 #include "common/config_exec_fwd.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exprs/chunk_predicate_evaluator.h"
@@ -348,6 +349,21 @@ static ColumnPtr make_typed_decimal32_variant_column_for_virtual_column_test() {
     typed_col->append_datum(Datum(int32_t(1250)));
     typed_columns.emplace_back(typed_col->as_mutable_ptr());
     variant->set_shredded_columns({"a.b.c"}, {decimal_type}, std::move(typed_columns), nullptr, nullptr);
+    return variant;
+}
+
+// Build a raw (non-shredded) VariantColumn from JSON strings.
+// The path "a.b.c" is embedded in each row's binary variant encoding; there is no typed
+// shredded column.  This forces project_variant_leaf_column to use the row-by-row fallback
+// path (build_decimal_variant_projection_column / build_variant_projection_column).
+static ColumnPtr make_raw_json_variant_column_for_virtual_column_test(
+        std::initializer_list<std::string_view> json_rows) {
+    auto variant = VariantColumn::create();
+    for (auto json : json_rows) {
+        auto encoded = VariantEncoder::encode_json_text_to_variant(json);
+        DCHECK(encoded.ok()) << encoded.status().to_string();
+        variant->append(&encoded.value());
+    }
     return variant;
 }
 
@@ -3382,6 +3398,145 @@ TEST_F(GroupReaderTest, FillDstChunkReturnsErrorWhenSourceSlotMissingFromActiveC
     auto status = group_reader->_fill_dst_chunk(active_chunk, &dst_chunk);
     EXPECT_FALSE(status.ok());
     EXPECT_TRUE(status.is_internal_error());
+}
+
+// ── Decimal virtual column fallback tests ──────────────────────────────────────
+//
+// These tests exercise the row-by-row decimal fallback path that is reached when
+// neither build_exact_typed_variant_projection nor build_decimal_typed_variant_projection
+// succeeds (i.e. the shredded leaf is absent or is a non-decimal type).
+//
+// Covered lines in group_reader.cpp (build_decimal_typed_variant_projection early
+// returns + build_decimal_variant_projection_column body):
+//   line 219: !reader.is_typed_exact() → no shredded leaf at path, decimal target
+//   line 224: source leaf is not decimal (e.g. INT64) with decimal target
+//   lines 262-300: build_decimal_variant_projection_column (normal + overflow rows)
+//   lines 346-351: TYPE_DECIMAL32/64/128 switch cases in project_variant_leaf_column
+
+// Test: raw JSON variant data (no typed shredded leaf) with a DECIMAL32 target.
+// build_decimal_typed_variant_projection returns NotFound at line 219 (no typed exact
+// leaf), then build_decimal_variant_projection_column is invoked for the row-by-row cast.
+TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnFromRawVariantFallback) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2);
+    auto* virtual_slot = _pool.add(new SlotDescriptor(400, "data.price", decimal_type));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    // Project path "a.b.c" → DECIMAL32(5,2). The raw variant rows hold integer values
+    // at that path; they must be cast row-by-row via cast_variant_to_decimal.
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(401)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    // Raw variant: {"a":{"b":{"c":10}}} and {"a":{"b":{"c":20}}} — no typed shredded leaf.
+    auto variant_src = make_raw_json_variant_column_for_virtual_column_test(
+            {R"({"a":{"b":{"c":10}}})", R"({"a":{"b":{"c":20}}})"});
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_src, SlotId(401));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    // 10 → 10.00 in DECIMAL32(5,2) stored as 1000; 20 → 2000.
+    EXPECT_EQ(1000, result->get(0).get_int32());
+    EXPECT_EQ(2000, result->get(1).get_int32());
+}
+
+// Test: variant with an INT64 typed shredded leaf at "a.b.c" but a DECIMAL32 target.
+// build_decimal_typed_variant_projection returns NotFound at line 224 (source is INT64,
+// not a decimal type), then build_decimal_variant_projection_column does the row-by-row
+// cast reading from the typed INT64 column.
+TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnFromBigintTypedLeafFallback) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 7, 2);
+    auto* virtual_slot = _pool.add(new SlotDescriptor(402, "data.price", decimal_type));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(403)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    // Typed INT64 leaf at "a.b.c" (values 11 and 22).
+    // Target DECIMAL32(7,2): exact match fails (INT64 ≠ DECIMAL32); decimal typed match
+    // fails at line 224 (INT64 is not a decimal type); row-by-row cast follows.
+    auto variant_src = make_typed_only_variant_column_for_virtual_column_test(); // INT64 values 11, 22
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_src, SlotId(403));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    // 11 → 11.00 stored as 1100; 22 → 2200.
+    EXPECT_EQ(1100, result->get(0).get_int32());
+    EXPECT_EQ(2200, result->get(1).get_int32());
+}
+
+// Test: raw JSON variant with a value that overflows DECIMAL32 storage.
+// cast_variant_to_decimal uses DecimalV3Cast::from_integer which checks for int32_t overflow
+// (value × scale_factor > INT32_MAX).  For scale=2, scale_factor=100; integer 21474837 ×
+// 100 = 2147483700 exceeds INT32_MAX (2147483647), so overflow=true and the row is NULL
+// (lines 292-293 in build_decimal_variant_projection_column).
+TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnOverflowBecomesNull) {
+    auto* param = _create_group_reader_param();
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 9, 2);
+    auto* virtual_slot = _pool.add(new SlotDescriptor(404, "data.price", decimal_type));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(405)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    // Row 0: integer 5 → 5 × 100 = 500, fits in int32_t → non-null.
+    // Row 1: integer 21474837 → 21474837 × 100 = 2147483700 > INT32_MAX → overflow → NULL.
+    auto variant_src = make_raw_json_variant_column_for_virtual_column_test(
+            {R"({"a":{"b":{"c":5}}})", R"({"a":{"b":{"c":21474837}}})"});
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(variant_src, SlotId(405));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ(500, result->get(0).get_int32()); // 5 × 100 = 500
+    EXPECT_TRUE(result->is_null(1));            // 21474837 × 100 overflows int32_t → NULL
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -339,6 +339,18 @@ static ColumnPtr make_typed_only_variant_column_for_virtual_column_test() {
     return variant;
 }
 
+static ColumnPtr make_typed_decimal32_variant_column_for_virtual_column_test() {
+    auto variant = VariantColumn::create();
+    MutableColumns typed_columns;
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2);
+    auto typed_col = ColumnHelper::create_column(decimal_type, true);
+    typed_col->append_datum(Datum(int32_t(1050)));
+    typed_col->append_datum(Datum(int32_t(1250)));
+    typed_columns.emplace_back(typed_col->as_mutable_ptr());
+    variant->set_shredded_columns({"a.b.c"}, {decimal_type}, std::move(typed_columns), nullptr, nullptr);
+    return variant;
+}
+
 static ColumnPtr make_nullable_typed_variant_column_for_virtual_column_test() {
     auto data = make_typed_only_variant_column_for_virtual_column_test();
     auto nulls = NullColumn::create();
@@ -2680,6 +2692,72 @@ TEST_F(GroupReaderTest, FillDstChunkProjectsExactTypedVirtualColumnRespectsSourc
     EXPECT_EQ(22, result->get(1).get_int64());
 }
 
+TEST_F(GroupReaderTest, FillDstChunkProjectsExactTypedDecimalVirtualColumn) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2);
+    auto* virtual_slot = _pool.add(new SlotDescriptor(106, "data.id", decimal_type));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(303)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_typed_decimal32_variant_column_for_virtual_column_test(), SlotId(303));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ(1050, result->get(0).get_int32());
+    EXPECT_EQ(1250, result->get(1).get_int32());
+}
+
+TEST_F(GroupReaderTest, FillDstChunkProjectsDecimalVirtualColumnWithWidening) {
+    auto* param = _create_group_reader_param();
+
+    FileMetaData* file_meta;
+    ASSERT_OK(_create_filemeta(&file_meta, param));
+    param->file_metadata = file_meta;
+
+    auto decimal_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2);
+    auto* virtual_slot = _pool.add(new SlotDescriptor(107, "data.id", decimal_type));
+    param->read_cols.clear();
+    GroupReaderParam::Column virtual_col{};
+    virtual_col.slot_desc = virtual_slot;
+    param->read_cols.emplace_back(virtual_col);
+
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
+
+    ASSIGN_OR_ABORT(auto projection, make_virtual_projection_for_test("a.b.c", virtual_slot->type(), SlotId(304)));
+    group_reader->_variant_virtual_projections.emplace(virtual_slot->id(), std::move(projection));
+
+    auto read_chunk = std::make_shared<Chunk>();
+    read_chunk->append_column(make_typed_decimal32_variant_column_for_virtual_column_test(), SlotId(304));
+
+    auto dst_chunk = std::make_shared<Chunk>();
+    dst_chunk->append_column(ColumnHelper::create_column(virtual_slot->type(), true), virtual_slot->id());
+
+    ASSERT_OK(group_reader->_fill_dst_chunk(read_chunk, &dst_chunk));
+    const auto& result = dst_chunk->get_column_by_slot_id(virtual_slot->id());
+    ASSERT_EQ(2, result->size());
+    EXPECT_EQ(1050, result->get(0).get_int64());
+    EXPECT_EQ(1250, result->get(1).get_int64());
+}
+
 TEST_F(GroupReaderTest, FillDstChunkProjectsVirtualVarcharColumnFromPhysicalSourceSlot) {
     auto* param = _create_group_reader_param();
 
@@ -2965,6 +3043,33 @@ TEST_F(GroupReaderTest, CreateColumnReadersRegistersVirtualZoneMapReaderForPhysi
     auto it = group_reader->_column_readers.find(virtual_slot->id());
     ASSERT_NE(it, group_reader->_column_readers.end());
     EXPECT_NE(nullptr, down_cast<VariantVirtualZoneMapReader*>(it->second.get()));
+}
+
+TEST(GroupReaderBloomFilterTest, DecimalBloomFilterApplicabilityRequiresExactLayoutMatch) {
+    MockColumnReader reader(tparquet::Type::INT32);
+
+    ParquetField decimal32_field;
+    decimal32_field.physical_type = tparquet::Type::INT32;
+    decimal32_field.precision = 5;
+    decimal32_field.scale = 2;
+    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(
+            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2), decimal32_field));
+    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(
+            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 6, 2), decimal32_field));
+
+    ParquetField decimal64_field;
+    decimal64_field.physical_type = tparquet::Type::INT64;
+    decimal64_field.precision = 16;
+    decimal64_field.scale = 2;
+    EXPECT_TRUE(reader.check_type_can_apply_bloom_filter(
+            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 16, 2), decimal64_field));
+
+    ParquetField decimal128_field;
+    decimal128_field.physical_type = tparquet::Type::FIXED_LEN_BYTE_ARRAY;
+    decimal128_field.precision = 22;
+    decimal128_field.scale = 4;
+    EXPECT_FALSE(reader.check_type_can_apply_bloom_filter(
+            TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 22, 4), decimal128_field));
 }
 
 // ── Hidden variant source active/lazy classification ─────────────────────────

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
@@ -346,6 +346,7 @@ public class VariantPathRewriteRule extends TransformationRule {
             return type.isBoolean()
                     || type.isIntegerType()
                     || type.isFloatingPointType()
+                    || type.isDecimalV3()
                     || type.isStringType()
                     || type.isDate()
                     || type.isDatetime()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/VariantPathRewriteRule.java
@@ -346,7 +346,7 @@ public class VariantPathRewriteRule extends TransformationRule {
             return type.isBoolean()
                     || type.isIntegerType()
                     || type.isFloatingPointType()
-                    || type.isDecimalV3()
+                    || (type.isDecimalV3() && !type.isDecimal256())
                     || type.isStringType()
                     || type.isDate()
                     || type.isDatetime()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VariantPathRewriteTest.java
@@ -111,6 +111,19 @@ public class VariantPathRewriteTest extends ConnectorPlanTestBase {
     }
 
     @Test
+    public void testCastVariantQueryRewriteToDecimal() throws Exception {
+        connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
+        String sql = "select cast(variant_query(v, '$.profile.rank') as decimal(10, 2)) from " + VARIANT_TABLE;
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "v.profile.rank");
+
+        String verbose = getVerboseExplain(sql);
+        assertContains(verbose, "ExtendedColumnAccessPath");
+        assertContains(verbose,
+                "/v(decimal(10, 2))/profile(decimal(10, 2))/rank(decimal(10, 2))");
+    }
+
+    @Test
     public void testAggregateRewrite() throws Exception {
         connectContext.getSessionVariable().setEnableVariantPathRewrite(true);
         String sql = "select sum(get_variant_int(v, '$.metrics.views')) from " + VARIANT_TABLE;

--- a/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
@@ -57,17 +57,19 @@ function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.p
 -- result:
 True
 -- !result
--- DECIMAL cast is not a supported rewrite target (FE isSupportedCastTarget excludes DECIMAL).
--- These will become assert_explain_verbose_contains once FE DECIMAL rewrite is implemented.
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(5, 2))/profile(decimal(5, 2))/price(decimal(5, 2))]")
 -- result:
 True
 -- !result
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(16, 2))/profile(decimal(16, 2))/amount(decimal(16, 2))]")
 -- result:
 True
 -- !result
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(22, 4))/profile(decimal(22, 4))/balance(decimal(22, 4))]")
+-- result:
+True
+-- !result
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(10, 2))/profile(decimal(10, 2))/price(decimal(10, 2))]")
 -- result:
 True
 -- !result
@@ -235,7 +237,7 @@ order by id;
 1003
 1004
 -- !result
--- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), no rewrite, row-level eval
+-- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), with virtual-column rewrite
 select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) as price
 from test_variant_virtual_column
 order by price;
@@ -266,7 +268,18 @@ order by balance;
 4000000000000000.0004
 5000000000000000.0005
 -- !result
--- DECIMAL predicate correctness (row-level, no pushdown yet)
+-- DECIMAL widening correctness: typed decimal leaf widened to a compatible target decimal
+select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) as price_wide
+from test_variant_virtual_column
+order by price_wide;
+-- result:
+10.50
+11.00
+11.50
+12.00
+12.50
+-- !result
+-- DECIMAL predicate correctness with variant virtual predicate pushdown
 select count(*) from test_variant_virtual_column
 where cast(variant_query(data, '$.profile.price') as decimal(5, 2)) >= 11.50;
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -30,10 +30,10 @@ function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') 
 function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/id(bigint(20))]")
 function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.rank') as bigint) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/rank(bigint(20))]")
 function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.profile.metrics.views')) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/metrics(bigint(20))/views(bigint(20))]")
-function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(5,2))/profile(decimal(5,2))/price(decimal(5,2))]")
-function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(16,2))/profile(decimal(16,2))/amount(decimal(16,2))]")
-function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(22,4))/profile(decimal(22,4))/balance(decimal(22,4))]")
-function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(10,2))/profile(decimal(10,2))/price(decimal(10,2))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(5, 2))/profile(decimal(5, 2))/price(decimal(5, 2))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(16, 2))/profile(decimal(16, 2))/amount(decimal(16, 2))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(22, 4))/profile(decimal(22, 4))/balance(decimal(22, 4))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(10, 2))/profile(decimal(10, 2))/price(decimal(10, 2))]")
 
 set cbo_variant_path_rewrite = true;
 

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -30,11 +30,10 @@ function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') 
 function: assert_explain_verbose_contains("select get_variant_int(data, '$.id') from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/id(bigint(20))]")
 function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.rank') as bigint) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/rank(bigint(20))]")
 function: assert_explain_verbose_contains("select sum(get_variant_int(data, '$.profile.metrics.views')) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(bigint(20))/profile(bigint(20))/metrics(bigint(20))/views(bigint(20))]")
--- DECIMAL cast is not a supported rewrite target (FE isSupportedCastTarget excludes DECIMAL).
--- These will become assert_explain_verbose_contains once FE DECIMAL rewrite is implemented.
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
-function: assert_explain_not_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(5,2))/profile(decimal(5,2))/price(decimal(5,2))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.amount') as decimal(16, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(16,2))/profile(decimal(16,2))/amount(decimal(16,2))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(22,4))/profile(decimal(22,4))/balance(decimal(22,4))]")
+function: assert_explain_verbose_contains("select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) from test_variant_virtual_column", "ExtendedColumnAccessPath: [/data(decimal(10,2))/profile(decimal(10,2))/price(decimal(10,2))]")
 
 set cbo_variant_path_rewrite = true;
 
@@ -131,7 +130,7 @@ from test_variant_virtual_column
 where get_variant_int(data, '$.profile.salary') >= 52000
 order by id;
 
--- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), no rewrite, row-level eval
+-- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), with virtual-column rewrite
 select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) as price
 from test_variant_virtual_column
 order by price;
@@ -144,7 +143,12 @@ select cast(variant_query(data, '$.profile.balance') as decimal(22, 4)) as balan
 from test_variant_virtual_column
 order by balance;
 
--- DECIMAL predicate correctness (row-level, no pushdown yet)
+-- DECIMAL widening correctness: typed decimal leaf widened to a compatible target decimal
+select cast(variant_query(data, '$.profile.price') as decimal(10, 2)) as price_wide
+from test_variant_virtual_column
+order by price_wide;
+
+-- DECIMAL predicate correctness with variant virtual predicate pushdown
 select count(*) from test_variant_virtual_column
 where cast(variant_query(data, '$.profile.price') as decimal(5, 2)) >= 11.50;
 


### PR DESCRIPTION
## Why I'm doing:

Variant virtual columns can hold typed decimal leaves extracted from shredded Parquet files. Without this change, casting a variant path expression to a decimal type bypassed the virtual-column rewrite path entirely, forcing row-level evaluation and missing potential predicate-pushdown and statistics-based optimizations.

## What I'm doing:

FE (VariantPathRewriteRule.java)
- Extended isSupportedCastTarget to include DECIMAL_V3 types, enabling the optimizer to rewrite cast(variant_query(...) as decimal(...)) into a virtual-column access path.

BE – projection (group_reader.cpp, variant_converter.h)
- Added build_decimal_variant_projection_column to read variant values and cast them to a target decimal type (DECIMAL32 / DECIMAL64 / DECIMAL128) via VariantRowConverter::cast_to_decimal.
- Added build_decimal_typed_variant_projection to fast-path the case where the shredded column already stores an exact decimal leaf, using TypeConverter to widen/rescale without re-parsing.
- Wired both paths into project_variant_leaf_column.

BE – bloom filter (column_reader.cpp)
- Enabled bloom-filter applicability for DECIMAL32/INT32 and DECIMAL64/INT64 pairs when precision and scale match exactly (replaces a TODO comment).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
