### PR TITLE
[Enhancement] Support csv.enclose and csv.escape in INSERT INTO FILES CSV export

### DIFF
--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -18,12 +18,14 @@
 #include <utility>
 
 #include "base/utility/defer_op.h"
+#include "column/column_helper.h"
 #include "common/http/content_type.h"
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
 #include "formats/column_evaluator.h"
 #include "formats/csv/csv_escape.h"
 #include "formats/utils.h"
 #include "io/formatted_output_stream_file.h"
+#include "io/formatted_output_stream_string.h"
 #include "runtime/current_thread.h"
 #include "util/compression/compression_utils.h"
 
@@ -83,11 +85,17 @@ Status CSVFileWriter::_write_header() {
             LOG(WARNING)
                     << "include_header is enabled but column_names is empty, this may indicate an upstream logic issue";
         } else {
+            const bool use_enclose = (_writer_options->enclose != 0);
             for (size_t i = 0; i < _column_names.size(); i++) {
-                // Escape column names that contain special characters (delimiter, quotes, newlines)
-                std::string escaped_name =
-                        csv::escape_csv_field(_column_names[i], _writer_options->column_terminated_by);
-                RETURN_IF_ERROR(_output_stream->write(escaped_name));
+                if (use_enclose) {
+                    // Enclose the column name with the same escape semantics as data fields
+                    RETURN_IF_ERROR(_write_enclosed_string(_column_names[i]));
+                } else {
+                    // Escape column names that contain special characters (delimiter, quotes, newlines)
+                    std::string escaped_name =
+                            csv::escape_csv_field(_column_names[i], _writer_options->column_terminated_by);
+                    RETURN_IF_ERROR(_output_stream->write(escaped_name));
+                }
                 if (i + 1 != _column_names.size()) {
                     RETURN_IF_ERROR(_output_stream->write(_writer_options->column_terminated_by));
                 }
@@ -125,6 +133,16 @@ Status CSVFileWriter::write(Chunk* chunk) {
         columns.push_back(std::move(column));
     }
 
+    // Expression evaluation can produce ConstColumn (e.g. `SELECT NULL AS c, ...`),
+    // whose `is_nullable()` may be true but whose dynamic type is not NullableColumn.
+    // Unpack those here so downstream converters can safely rely on concrete column
+    // types without every per-type `down_cast` having to handle ConstColumn.
+    for (auto& column : columns) {
+        column = ColumnHelper::unpack_and_duplicate_const_column(chunk->num_rows(), column);
+    }
+
+    const bool use_enclose = (_writer_options->enclose != 0);
+
     for (size_t r = 0; r < chunk->num_rows(); r++) {
         for (size_t c = 0; c < columns.size(); c++) {
             csv::Converter* converter;
@@ -133,7 +151,25 @@ Status CSVFileWriter::write(Chunk* chunk) {
             } else {
                 converter = _column_converters[c].second.get();
             }
-            RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r, *_converter_options));
+
+            if (use_enclose) {
+                // Use the polymorphic Column::is_null() to decide on enclosure. After
+                // unpack_and_duplicate_const_column above, this safely handles both
+                // regular and previously-const nullable columns.
+                if (columns[c]->is_null(r)) {
+                    // NULL values go through the NullableConverter, which emits "\N"
+                    // without enclosing (matches Redshift / Postgres COPY behavior).
+                    RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r,
+                                                            *_converter_options));
+                } else {
+                    // Non-NULL: wrap with enclose char and escape internal enclose/escape chars.
+                    RETURN_IF_ERROR(_write_enclosed_field(converter, *columns[c], r, *_converter_options));
+                }
+            } else {
+                RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r,
+                                                        *_converter_options));
+            }
+
             if (c + 1 != columns.size()) {
                 RETURN_IF_ERROR(_output_stream->write(_writer_options->column_terminated_by));
             }
@@ -142,6 +178,51 @@ Status CSVFileWriter::write(Chunk* chunk) {
     }
 
     return Status::OK();
+}
+
+Status CSVFileWriter::_write_enclosed_string(const std::string& value) {
+    const char enclose = _writer_options->enclose;
+    const char escape = _writer_options->escape;
+
+    // Write opening enclose
+    RETURN_IF_ERROR(_output_stream->write(enclose));
+
+    if (escape != 0) {
+        const char* data = value.data();
+        size_t size = value.size();
+        size_t start = 0;
+        for (size_t i = 0; i < size; i++) {
+            // When escape == enclose, both conditions refer to the same char,
+            // so we handle it once (doubling). The first branch covers it.
+            if (data[i] == enclose) {
+                RETURN_IF_ERROR(_output_stream->write(Slice(data + start, i - start)));
+                RETURN_IF_ERROR(_output_stream->write(escape));
+                start = i; // the enclose char itself will be written in the next segment
+            } else if (data[i] == escape && escape != enclose) {
+                // Escape the escape character itself so the CSV reader's ESCAPE state
+                // (csv_reader.cpp lines 282-294) doesn't strip it on re-import.
+                RETURN_IF_ERROR(_output_stream->write(Slice(data + start, i - start)));
+                RETURN_IF_ERROR(_output_stream->write(escape));
+                start = i;
+            }
+        }
+        RETURN_IF_ERROR(_output_stream->write(Slice(data + start, size - start)));
+    } else {
+        RETURN_IF_ERROR(_output_stream->write(Slice(value)));
+    }
+
+    // Write closing enclose
+    return _output_stream->write(enclose);
+}
+
+Status CSVFileWriter::_write_enclosed_field(csv::Converter* converter, const Column& column, size_t row_num,
+                                            const csv::Converter::Options& options) {
+    // Write the field content into a temporary in-memory string buffer, then scan
+    // and escape via _write_enclosed_string.
+    io::FormattedOutputStreamString field_buf(256);
+    RETURN_IF_ERROR(converter->write_string(&field_buf, column, row_num, options));
+    RETURN_IF_ERROR(field_buf.finalize()); // flush internal buffer to string
+    return _write_enclosed_string(field_buf.as_string());
 }
 
 FileWriter::CommitResult CSVFileWriter::close() {
@@ -200,6 +281,12 @@ Status CSVFileWriterFactory::init() {
     }
     if (_options.contains(CSVWriterOptions::INCLUDE_HEADER)) {
         _parsed_options->include_header = boost::iequals(_options[CSVWriterOptions::INCLUDE_HEADER], "true");
+    }
+    if (_options.contains(CSVWriterOptions::ENCLOSE) && !_options[CSVWriterOptions::ENCLOSE].empty()) {
+        _parsed_options->enclose = _options[CSVWriterOptions::ENCLOSE][0];
+    }
+    if (_options.contains(CSVWriterOptions::ESCAPE) && !_options[CSVWriterOptions::ESCAPE].empty()) {
+        _parsed_options->escape = _options[CSVWriterOptions::ESCAPE][0];
     }
     return Status::OK();
 }

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -159,15 +159,13 @@ Status CSVFileWriter::write(Chunk* chunk) {
                 if (columns[c]->is_null(r)) {
                     // NULL values go through the NullableConverter, which emits "\N"
                     // without enclosing (matches Redshift / Postgres COPY behavior).
-                    RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r,
-                                                            *_converter_options));
+                    RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r, *_converter_options));
                 } else {
                     // Non-NULL: wrap with enclose char and escape internal enclose/escape chars.
                     RETURN_IF_ERROR(_write_enclosed_field(converter, *columns[c], r, *_converter_options));
                 }
             } else {
-                RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r,
-                                                        *_converter_options));
+                RETURN_IF_ERROR(converter->write_string(_output_stream.get(), *columns[c], r, *_converter_options));
             }
 
             if (c + 1 != columns.size()) {

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -35,6 +35,10 @@ struct CSVWriterOptions : FileWriterOptions {
     std::string mapkey_delim = ",";
     bool is_hive = false;
     bool include_header = false;
+    // 0 = disabled. When set, all non-NULL fields are wrapped with this char.
+    char enclose = 0;
+    // 0 = disabled. Used together with enclose to escape enclose/escape chars inside fields.
+    char escape = 0;
 
     inline static std::string COLUMN_TERMINATED_BY = "column_terminated_by";
     inline static std::string LINE_TERMINATED_BY = "line_terminated_by";
@@ -42,6 +46,8 @@ struct CSVWriterOptions : FileWriterOptions {
     inline static std::string MAPKEY_DELIM = "mapkey_delim";
     inline static std::string IS_HIVE = "is_hive";
     inline static std::string INCLUDE_HEADER = "include_header";
+    inline static std::string ENCLOSE = "enclose";
+    inline static std::string ESCAPE = "escape";
 };
 
 // The primary purpose of this class is to support hive + csv. Use with caution in other cases.
@@ -83,6 +89,16 @@ private:
     std::vector<std::pair<std::unique_ptr<csv::Converter>, std::unique_ptr<csv::Converter>>> _column_converters;
 
     Status _write_header();
+
+    // Write a field value enclosed with enclose char, escaping internal enclose and escape
+    // chars. The converter writes into a temporary in-memory buffer, then this method scans
+    // the buffer and writes escaped content to the real output stream.
+    Status _write_enclosed_field(csv::Converter* converter, const Column& column, size_t row_num,
+                                 const csv::Converter::Options& options);
+
+    // Write a string value enclosed with enclose char, escaping internal enclose and escape
+    // chars. Shared by header and field writing paths.
+    Status _write_enclosed_string(const std::string& value);
 };
 
 class CSVFileWriterFactory : public FileWriterFactory {

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -117,6 +117,14 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     if (target_table.__isset.csv_include_header && target_table.csv_include_header) {
         sink_ctx->options[formats::CSVWriterOptions::INCLUDE_HEADER] = "true";
     }
+    if (target_table.__isset.csv_enclose) {
+        sink_ctx->options[formats::CSVWriterOptions::ENCLOSE] =
+                std::string(1, static_cast<char>(target_table.csv_enclose));
+    }
+    if (target_table.__isset.csv_escape) {
+        sink_ctx->options[formats::CSVWriterOptions::ESCAPE] =
+                std::string(1, static_cast<char>(target_table.csv_escape));
+    }
     if (target_table.__isset.parquet_use_legacy_encoding && target_table.parquet_use_legacy_encoding) {
         sink_ctx->options[formats::ParquetWriterOptions::USE_LEGACY_DECIMAL_ENCODING] = "true";
         sink_ctx->options[formats::ParquetWriterOptions::USE_INT96_TIMESTAMP_ENCODING] = "true";

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -1291,8 +1291,7 @@ TEST_F(CSVFileWriterTest, TestFactoryWithGzipCompression) {
 // Returns writer options pre-configured with given enclose/escape.
 namespace {
 
-std::shared_ptr<Chunk> _build_enclose_test_chunk(const std::vector<int32_t>& ids,
-                                                 const std::vector<std::string>& names,
+std::shared_ptr<Chunk> _build_enclose_test_chunk(const std::vector<int32_t>& ids, const std::vector<std::string>& names,
                                                  const std::vector<std::string>& nullable_values,
                                                  const std::vector<uint8_t>& nullable_nulls) {
     auto chunk = std::make_shared<Chunk>();
@@ -1354,11 +1353,8 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeRFC4180) {
     //   (1, "hello",        "not null")    -- plain
     //   (2, "hello,world",  NULL)          -- comma + NULL
     //   (3, "say \"hi\"",   "val")         -- internal double quotes
-    auto chunk = _build_enclose_test_chunk(
-            {1, 2, 3},
-            {"hello", "hello,world", "say \"hi\""},
-            {"not null", "", "val"},
-            {0, 1, 0});
+    auto chunk = _build_enclose_test_chunk({1, 2, 3}, {"hello", "hello,world", "say \"hi\""}, {"not null", "", "val"},
+                                           {0, 1, 0});
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_OK(writer->close().io_status);
 
@@ -1368,9 +1364,10 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeRFC4180) {
     //   "1","hello","not null"\n
     //   "2","hello,world",\N\n
     //   "3","say ""hi""","val"\n
-    std::string expect = "\"1\",\"hello\",\"not null\"\n"
-                         "\"2\",\"hello,world\",\\N\n"
-                         "\"3\",\"say \"\"hi\"\"\",\"val\"\n";
+    std::string expect =
+            "\"1\",\"hello\",\"not null\"\n"
+            "\"2\",\"hello,world\",\\N\n"
+            "\"3\",\"say \"\"hi\"\"\",\"val\"\n";
     ASSERT_EQ(content, expect);
 }
 
@@ -1404,11 +1401,8 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeBackslash) {
     //   (2, "path\\to",   NULL)           -- escape char inside
     //   (3, "end\\",      "val")          -- trailing escape char
     //   (4, "a\\\"b",     "x")            -- both escape and enclose chars
-    auto chunk = _build_enclose_test_chunk(
-            {1, 2, 3, 4},
-            {"say \"hi\"", "path\\to", "end\\", "a\\\"b"},
-            {"not null", "", "val", "x"},
-            {0, 1, 0, 0});
+    auto chunk = _build_enclose_test_chunk({1, 2, 3, 4}, {"say \"hi\"", "path\\to", "end\\", "a\\\"b"},
+                                           {"not null", "", "val", "x"}, {0, 1, 0, 0});
     ASSERT_OK(writer->write(chunk.get()));
     ASSERT_OK(writer->close().io_status);
 
@@ -1419,10 +1413,11 @@ TEST_F(CSVFileWriterTest, TestEncloseEscapeBackslash) {
     //   "2","path\\to",\N\n
     //   "3","end\\","val"\n
     //   "4","a\\\"b","x"\n
-    std::string expect = "\"1\",\"say \\\"hi\\\"\",\"not null\"\n"
-                         "\"2\",\"path\\\\to\",\\N\n"
-                         "\"3\",\"end\\\\\",\"val\"\n"
-                         "\"4\",\"a\\\\\\\"b\",\"x\"\n";
+    std::string expect =
+            "\"1\",\"say \\\"hi\\\"\",\"not null\"\n"
+            "\"2\",\"path\\\\to\",\\N\n"
+            "\"3\",\"end\\\\\",\"val\"\n"
+            "\"4\",\"a\\\\\\\"b\",\"x\"\n";
     ASSERT_EQ(content, expect);
 }
 
@@ -1697,9 +1692,10 @@ TEST_F(CSVFileWriterTest, TestEncloseConstStringColumn) {
     std::string content;
     ASSERT_OK(_fs.read_file(_file_path, &content));
     // Each row: enclosed id, enclosed constant string with doubled quotes.
-    std::string expect = "\"1\",\"hello,\"\"world\"\"\"\n"
-                         "\"2\",\"hello,\"\"world\"\"\"\n"
-                         "\"3\",\"hello,\"\"world\"\"\"\n";
+    std::string expect =
+            "\"1\",\"hello,\"\"world\"\"\"\n"
+            "\"2\",\"hello,\"\"world\"\"\"\n"
+            "\"3\",\"hello,\"\"world\"\"\"\n";
     ASSERT_EQ(content, expect);
 }
 

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -25,6 +25,7 @@
 #include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "common/object_pool.h"
@@ -1282,6 +1283,443 @@ TEST_F(CSVFileWriterTest, TestFactoryWithGzipCompression) {
     std::string content = test::decompress_gzip(compressed_content);
     EXPECT_TRUE(content.find("1,test1\n") != std::string::npos);
     EXPECT_TRUE(content.find("2,test2\n") != std::string::npos);
+}
+
+// ==================== Enclose / Escape Tests ====================
+
+// Helper: build a simple INT + VARCHAR + nullable-VARCHAR chunk for enclose tests.
+// Returns writer options pre-configured with given enclose/escape.
+namespace {
+
+std::shared_ptr<Chunk> _build_enclose_test_chunk(const std::vector<int32_t>& ids,
+                                                 const std::vector<std::string>& names,
+                                                 const std::vector<std::string>& nullable_values,
+                                                 const std::vector<uint8_t>& nullable_nulls) {
+    auto chunk = std::make_shared<Chunk>();
+
+    // Column 0: non-nullable INT
+    auto id_col = Int32Column::create();
+    for (auto v : ids) {
+        id_col->append(v);
+    }
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    // Column 1: nullable VARCHAR (never-null values)
+    auto name_data = BinaryColumn::create();
+    for (auto& s : names) {
+        name_data->append(s);
+    }
+    auto name_null = UInt8Column::create();
+    name_null->append_numbers(std::vector<uint8_t>(names.size(), 0).data(), names.size());
+    auto name_col = NullableColumn::create(std::move(name_data), std::move(name_null));
+    chunk->append_column(std::move(name_col), chunk->num_columns());
+
+    // Column 2: nullable VARCHAR (with actual NULLs)
+    auto nullable_data = BinaryColumn::create();
+    for (auto& s : nullable_values) {
+        nullable_data->append(s);
+    }
+    auto nullable_null = UInt8Column::create();
+    nullable_null->append_numbers(nullable_nulls.data(), nullable_nulls.size());
+    auto nullable_col = NullableColumn::create(std::move(nullable_data), std::move(nullable_null));
+    chunk->append_column(std::move(nullable_col), chunk->num_columns());
+
+    return chunk;
+}
+
+} // namespace
+
+// Case: enclose == escape == '"'  (RFC 4180 doubling style)
+TEST_F(CSVFileWriterTest, TestEncloseEscapeRFC4180) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "name", "val"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    writer_options->escape = '"';
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    // Rows:
+    //   (1, "hello",        "not null")    -- plain
+    //   (2, "hello,world",  NULL)          -- comma + NULL
+    //   (3, "say \"hi\"",   "val")         -- internal double quotes
+    auto chunk = _build_enclose_test_chunk(
+            {1, 2, 3},
+            {"hello", "hello,world", "say \"hi\""},
+            {"not null", "", "val"},
+            {0, 1, 0});
+    ASSERT_OK(writer->write(chunk.get()));
+    ASSERT_OK(writer->close().io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Expected:
+    //   "1","hello","not null"\n
+    //   "2","hello,world",\N\n
+    //   "3","say ""hi""","val"\n
+    std::string expect = "\"1\",\"hello\",\"not null\"\n"
+                         "\"2\",\"hello,world\",\\N\n"
+                         "\"3\",\"say \"\"hi\"\"\",\"val\"\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Case: enclose == '"', escape == '\\'  (backslash escape style)
+// Verifies:
+//   - internal enclose char ('"') is escaped with '\\'
+//   - internal escape char ('\\') itself is also escaped (for reader roundtrip)
+//   - NULL stays as \N (unenclosed)
+TEST_F(CSVFileWriterTest, TestEncloseEscapeBackslash) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "name", "val"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    writer_options->escape = '\\';
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    // Rows:
+    //   (1, "say \"hi\"", "not null")     -- enclose char inside
+    //   (2, "path\\to",   NULL)           -- escape char inside
+    //   (3, "end\\",      "val")          -- trailing escape char
+    //   (4, "a\\\"b",     "x")            -- both escape and enclose chars
+    auto chunk = _build_enclose_test_chunk(
+            {1, 2, 3, 4},
+            {"say \"hi\"", "path\\to", "end\\", "a\\\"b"},
+            {"not null", "", "val", "x"},
+            {0, 1, 0, 0});
+    ASSERT_OK(writer->write(chunk.get()));
+    ASSERT_OK(writer->close().io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Expected (C++ escaped):
+    //   "1","say \"hi\"","not null"\n
+    //   "2","path\\to",\N\n
+    //   "3","end\\","val"\n
+    //   "4","a\\\"b","x"\n
+    std::string expect = "\"1\",\"say \\\"hi\\\"\",\"not null\"\n"
+                         "\"2\",\"path\\\\to\",\\N\n"
+                         "\"3\",\"end\\\\\",\"val\"\n"
+                         "\"4\",\"a\\\\\\\"b\",\"x\"\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Case: enclose set but escape not set (escape == 0).
+// Fields are wrapped but internal enclose chars are NOT escaped (caller's responsibility).
+TEST_F(CSVFileWriterTest, TestEncloseWithoutEscape) {
+    std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    std::vector<std::string> column_names = {"name"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    // escape intentionally left as 0
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    auto data = BinaryColumn::create();
+    data->append("hello");
+    data->append("a,b");
+    auto nulls = UInt8Column::create();
+    nulls->append_numbers(std::vector<uint8_t>{0, 0}.data(), 2);
+    chunk->append_column(NullableColumn::create(std::move(data), std::move(nulls)), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    ASSERT_OK(writer->close().io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Enclose only, no escape applied
+    std::string expect = "\"hello\"\n\"a,b\"\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Case: enclose with include_header=true.
+// Header column names are also enclosed & escaped using the same rules.
+TEST_F(CSVFileWriterTest, TestEncloseWithHeader) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    // Column name with enclose char inside
+    std::vector<std::string> column_names = {"id", "my\"col"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    writer_options->escape = '"';
+    writer_options->include_header = true;
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    auto id_col = Int32Column::create();
+    id_col->append(1);
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    auto name_data = BinaryColumn::create();
+    name_data->append("alice");
+    auto name_nulls = UInt8Column::create();
+    name_nulls->append(0);
+    chunk->append_column(NullableColumn::create(std::move(name_data), std::move(name_nulls)), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    ASSERT_OK(writer->close().io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Header: "id","my""col"\n
+    // Row:    "1","alice"\n
+    std::string expect = "\"id\",\"my\"\"col\"\n\"1\",\"alice\"\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Case: enclose disabled (default). Behavior must be unchanged.
+TEST_F(CSVFileWriterTest, TestEncloseDisabled) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "name"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    // enclose / escape default to 0
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    auto id_col = Int32Column::create();
+    id_col->append(1);
+    id_col->append(2);
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    auto name_data = BinaryColumn::create();
+    name_data->append("alice");
+    name_data->append("bob");
+    auto name_nulls = UInt8Column::create();
+    name_nulls->append_numbers(std::vector<uint8_t>{0, 0}.data(), 2);
+    chunk->append_column(NullableColumn::create(std::move(name_data), std::move(name_nulls)), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    ASSERT_OK(writer->close().io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Original raw output
+    std::string expect = "1,alice\n2,bob\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Regression: enclose path must tolerate ConstColumn(Nullable) inputs, which can
+// arise from expression evaluation (e.g. `SELECT NULL ...`). An unconditional
+// down_cast<NullableColumn*> previously asserted here. With the polymorphic
+// is_null() check, the writer should treat the row as NULL and emit \N.
+TEST_F(CSVFileWriterTest, TestEncloseConstNullableColumn) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "const_col"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    writer_options->escape = '"';
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    constexpr size_t kNumRows = 3;
+
+    // Column 0: regular INT column.
+    auto id_col = Int32Column::create();
+    id_col->append(1);
+    id_col->append(2);
+    id_col->append(3);
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    // Column 1: ConstColumn wrapping a NullableColumn that holds a single NULL.
+    // This mimics what ExprContext produces for a `SELECT NULL` literal.
+    auto data_col = BinaryColumn::create();
+    data_col->append(""); // placeholder; null bitmap marks it null
+    auto null_col = UInt8Column::create();
+    null_col->append(1);
+    auto nullable_inner = NullableColumn::create(std::move(data_col), std::move(null_col));
+    auto const_null_col = ConstColumn::create(std::move(nullable_inner), kNumRows);
+    chunk->append_column(std::move(const_null_col), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+    ASSERT_OK(result.io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Each row: enclosed id, unenclosed \N for the const null column.
+    std::string expect = "\"1\",\\N\n\"2\",\\N\n\"3\",\\N\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Regression: even with enclose disabled (the default / pre-existing path),
+// the writer must tolerate ConstColumn inputs. Before the
+// unpack_and_duplicate_const_column fix, every converter (BinaryConverter,
+// NullableConverter, etc.) would crash on its own down_cast.
+TEST_F(CSVFileWriterTest, TestConstColumnWithoutEnclose) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "const_str"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    // enclose/escape left at default (disabled)
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    constexpr size_t kNumRows = 2;
+
+    auto id_col = Int32Column::create();
+    id_col->append(10);
+    id_col->append(20);
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    auto data_col = BinaryColumn::create();
+    data_col->append("hello");
+    auto const_str_col = ConstColumn::create(std::move(data_col), kNumRows);
+    chunk->append_column(std::move(const_str_col), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+    ASSERT_OK(result.io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    std::string expect = "10,hello\n20,hello\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Regression: enclose path must tolerate non-nullable ConstColumn(BinaryColumn)
+// inputs, which can arise from constant literal expressions (e.g.
+// `SELECT 'hello,world' ...`). Previously such columns would bypass the writer
+// NULL check and hit a NullableColumn/BinaryColumn down_cast inside the
+// converter. With unpack_and_duplicate_const_column at the top of write(), the
+// converter always sees a concrete column type.
+TEST_F(CSVFileWriterTest, TestEncloseConstStringColumn) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+    };
+    std::vector<std::string> column_names = {"id", "const_str"};
+    auto output_file = std::move(_fs.new_writable_file(_file_path).value());
+    auto output_stream = std::make_unique<io::FormattedOutputStreamFile>(std::move(output_file), 1024);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->enclose = '"';
+    writer_options->escape = '"';
+
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    constexpr size_t kNumRows = 3;
+
+    // Column 0: regular INT.
+    auto id_col = Int32Column::create();
+    id_col->append(1);
+    id_col->append(2);
+    id_col->append(3);
+    chunk->append_column(std::move(id_col), chunk->num_columns());
+
+    // Column 1: ConstColumn wrapping a non-null BinaryColumn — a value that also
+    // contains the column separator and the enclose char, to exercise escaping.
+    auto data_col = BinaryColumn::create();
+    data_col->append("hello,\"world\"");
+    auto const_str_col = ConstColumn::create(std::move(data_col), kNumRows);
+    chunk->append_column(std::move(const_str_col), chunk->num_columns());
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->close();
+    ASSERT_OK(result.io_status);
+
+    std::string content;
+    ASSERT_OK(_fs.read_file(_file_path, &content));
+    // Each row: enclosed id, enclosed constant string with doubled quotes.
+    std::string expect = "\"1\",\"hello,\"\"world\"\"\"\n"
+                         "\"2\",\"hello,\"\"world\"\"\"\n"
+                         "\"3\",\"hello,\"\"world\"\"\"\n";
+    ASSERT_EQ(content, expect);
+}
+
+// Factory: verify enclose/escape options are parsed from map.
+TEST_F(CSVFileWriterTest, TestFactoryWithEncloseEscapeOptions) {
+    auto type_varchar = TypeDescriptor::from_logical_type(TYPE_VARCHAR);
+    std::vector<TypeDescriptor> type_descs{type_varchar};
+    std::vector<std::string> column_names = {"name"};
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto fs = std::make_shared<MemoryFileSystem>();
+
+    std::map<std::string, std::string> options;
+    options[formats::CSVWriterOptions::ENCLOSE] = "\"";
+    options[formats::CSVWriterOptions::ESCAPE] = "\\";
+
+    auto factory = formats::CSVFileWriterFactory(fs, TCompressionType::NO_COMPRESSION, options, column_names,
+                                                 std::move(column_evaluators), nullptr, nullptr);
+    ASSERT_OK(factory.init());
+    auto maybe_writer = factory.create("/test_enclose.csv");
+    ASSERT_OK(maybe_writer.status());
 }
 
 TEST_F(CSVFileWriterTest, TestCompressionWithCustomDelimiters) {

--- a/docs/en/loading/loading_introduction/feature-support-loading-and-unloading.md
+++ b/docs/en/loading/loading_introduction/feature-support-loading-and-unloading.md
@@ -308,13 +308,28 @@ This document outlines the features of various data loading and unloading method
         <th>EXPORT</th>
     </tr>
     <tr>
-        <td rowspan="2">CSV</td>
+        <td rowspan="5">CSV</td>
         <td>column_separator</td>
         <td rowspan="2">Yes (v3.3+)</td>
         <td rowspan="2">Yes</td>
     </tr>
     <tr>
         <td>line_delimiter [1]</td>
+    </tr>
+    <tr>
+        <td>enclose</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>escape</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>include_header</td>
+        <td>Yes</td>
+        <td>No</td>
     </tr>
 </table>
 

--- a/docs/en/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/en/sql-reference/sql-functions/table-functions/files.md
@@ -927,7 +927,12 @@ unload_data_param ::=
     "compression" = { "uncompressed" | "gzip" | "snappy" | "zstd | "lz4" },
     "partition_by" = "<column_name> [, ...]",
     "single" = { "true" | "false" } ,
-    "target_max_file_size" = "<int>"
+    "target_max_file_size" = "<int>",
+    "csv.column_separator" = "<column_separator>",
+    "csv.row_delimiter" = "<row_delimiter>",
+    "csv.include_header" = { "true" | "false" },
+    "csv.enclose" = "<enclose_character>",
+    "csv.escape" = "<escape_character>"
 ```
 
 | **Key**          | **Required** | **Description**                                              |
@@ -936,6 +941,11 @@ unload_data_param ::=
 | `partition_by`     | No           | The list of columns that are used to partition data files into different storage paths. Multiple columns are separated by commas (,). `FILES()` extracts the key/value information of the specified columns and stores the data files under the storage paths featured with the extracted key/value pair. For further instructions, see Example 7. |
 | `single`           | No           | Whether to unload the data into a single file. Valid values:<ul><li>`true`: The data is stored in a single data file.</li><li>`false` (Default): The data is stored in multiple files if the amount of data unloaded exceeds 512 MB.</li></ul>                  |
 | `target_max_file_size` | No           | The best-effort maximum size of each file in the batch to be unloaded. Unit: Bytes. Default value: 1073741824 (1 GB). When the size of data to be unloaded exceeds this value, the data will be divided into multiple files, and the size of each file will not significantly exceed this value. Introduced in v3.2.7. |
+| `csv.column_separator` | No       | The column separator used in CSV-format output files. Default value: `\t`. Only applicable when `format` is `csv`.                       |
+| `csv.row_delimiter` | No          | The row delimiter used in CSV-format output files. Default value: `\n`. Only applicable when `format` is `csv`.                          |
+| `csv.include_header` | No         | Whether to include column names as the first row of CSV-format output files. Valid values: `true`, `false` (default). Only applicable when `format` is `csv`. |
+| `csv.enclose`      | No           | The character used to enclose each field value in CSV-format output files. When specified, all non-NULL fields are wrapped with this character, and occurrences of the enclose/escape characters within field values are escaped using the `csv.escape` character. NULL values are output as `\N` without enclosing. Type: single-byte ASCII character. Multi-character or multi-byte (non-ASCII) values are rejected with a semantic error. Default: `NONE` (disabled). Only applicable when `format` is `csv`. |
+| `csv.escape`       | No           | The character used to escape the enclose character and the escape character itself within field values. Type: single-byte ASCII character. Multi-character or multi-byte (non-ASCII) values are rejected with a semantic error. Default: `NONE`. Common combinations:<ul><li>`"csv.enclose"="\""`, `"csv.escape"="\""`: RFC 4180 style (doubled quotes).</li><li>`"csv.enclose"="\""`, `"csv.escape"="\\"`: backslash escape style.</li></ul>**NOTE**<br />When re-importing RFC 4180 doubled-quote output (where `escape` equals `enclose`) back into StarRocks, set only `csv.enclose` without `csv.escape` on the read side. StarRocks' CSV reader natively handles doubled quotes via its ENCLOSE state. |
 
 ## Examples
 

--- a/docs/en/unloading/unload_using_insert_into_files.md
+++ b/docs/en/unloading/unload_using_insert_into_files.md
@@ -210,10 +210,26 @@ Example:
 ```SQL
 -- Unload data into CSV files.
 INSERT INTO FILES(
-  'path' = 'file:///home/ubuntu/csvfile/', 
-  'format' = 'csv', 
-  'csv.column_separator' = ',', 
+  'path' = 'file:///home/ubuntu/csvfile/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
   'csv.row_delimitor' = '\n'
+)
+SELECT * FROM sales_records;
+
+-- Unload data into CSV files with field enclosing (RFC 4180 style).
+-- Field values containing commas or quotes are wrapped with the enclose
+-- character, and internal quotes are escaped by doubling (because
+-- csv.escape is the same as csv.enclose). NULL values are output as \N
+-- without enclosing.
+INSERT INTO FILES(
+  'path' = 'file:///home/ubuntu/csvfile_enclosed/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
+  'csv.row_delimiter' = '\n',
+  'csv.enclose' = '"',
+  'csv.escape' = '"',
+  'csv.include_header' = 'true'
 )
 SELECT * FROM sales_records;
 
@@ -225,6 +241,25 @@ INSERT INTO FILES(
 )
 SELECT * FROM sales_records;
 ```
+
+:::note
+
+When `csv.enclose` is set, every non-NULL field value is wrapped with the enclose character,
+and occurrences of the enclose character (and the escape character itself, when different)
+inside field values are escaped with the `csv.escape` character. NULL values are output as
+`\N` without enclosing.
+
+If you need to re-import RFC 4180-style doubled-quote output (where `csv.escape` equals
+`csv.enclose`) back into StarRocks, set only `csv.enclose` on the read side and do NOT set
+`csv.escape`. StarRocks' CSV reader natively handles doubled quotes via its ENCLOSE state.
+
+Also note that NULL values round-trip cleanly **only** when `csv.escape` is not
+backslash (`\`). The NULL marker `\N` is fixed, and when `csv.escape = '\\'` the reader's
+ESCAPE state strips the leading backslash and reads `\N` as the literal character `N`
+instead of NULL. Use `csv.escape = '"'` (RFC 4180 doubling) for datasets that need
+NULL roundtrip.
+
+:::
 
 ## See also
 

--- a/docs/ja/loading/loading_introduction/feature-support-loading-and-unloading.md
+++ b/docs/ja/loading/loading_introduction/feature-support-loading-and-unloading.md
@@ -308,13 +308,28 @@ sidebar_label: 機能サポート
         <th>EXPORT</th>
     </tr>
     <tr>
-        <td rowspan="2">CSV</td>
+        <td rowspan="5">CSV</td>
         <td>column_separator</td>
         <td rowspan="2">Yes (v3.3+)</td>
         <td rowspan="2">Yes</td>
     </tr>
     <tr>
         <td>line_delimiter [1]</td>
+    </tr>
+    <tr>
+        <td>enclose</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>escape</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>include_header</td>
+        <td>Yes</td>
+        <td>No</td>
     </tr>
 </table>
 

--- a/docs/ja/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/ja/sql-reference/sql-functions/table-functions/files.md
@@ -926,7 +926,12 @@ unload_data_param ::=
     "compression" = { "uncompressed" | "gzip" | "snappy" | "zstd | "lz4" },
     "partition_by" = "<column_name> [, ...]",
     "single" = { "true" | "false" } ,
-    "target_max_file_size" = "<int>"
+    "target_max_file_size" = "<int>",
+    "csv.column_separator" = "<column_separator>",
+    "csv.row_delimiter" = "<row_delimiter>",
+    "csv.include_header" = { "true" | "false" },
+    "csv.enclose" = "<enclose_character>",
+    "csv.escape" = "<escape_character>"
 ```
 
 | **キー**          | **必須** | **説明**                                              |
@@ -935,6 +940,11 @@ unload_data_param ::=
 | `partition_by`     | いいえ           | データファイルを異なるストレージパスにパーティション分割するために使用される列のリスト。複数の列はカンマ (,) で区切られます。`FILES()` は指定された列のキー/値情報を抽出し、抽出されたキー/値ペアを特徴とするストレージパスの下にデータファイルを保存します。詳細な指示については、例 7 を参照してください。 |
 | `single`           | いいえ           | データを単一のファイルにアンロードするかどうか。 有効な値:<ul><li>`true`: データは単一のデータファイルに保存されます。</li><li>`false` (デフォルト): アンロードされたデータ量が 512 MB を超える場合、データは複数のファイルに保存されます。</li></ul>                  |
 | `target_max_file_size` | いいえ           | バッチでアンロードされる各ファイルの最大サイズのベストエフォート。単位: バイト。デフォルト値: 1073741824 (1 GB)。アンロードするデータのサイズがこの値を超える場合、データは複数のファイルに分割され、各ファイルのサイズはこの値を大幅に超えません。v3.2.7 で導入されました。 |
+| `csv.column_separator` | いいえ       | CSV 形式の出力ファイルで使用される列区切り文字。デフォルト値: `\t`。`format` が `csv` の場合にのみ適用されます。                         |
+| `csv.row_delimiter` | いいえ          | CSV 形式の出力ファイルで使用される行区切り文字。デフォルト値: `\n`。`format` が `csv` の場合にのみ適用されます。                          |
+| `csv.include_header` | いいえ         | CSV 形式の出力ファイルの最初の行に列名を含めるかどうか。有効な値: `true`, `false` (デフォルト)。`format` が `csv` の場合にのみ適用されます。 |
+| `csv.enclose`      | いいえ           | CSV 形式の出力ファイルで各フィールド値を囲む文字。指定されると、すべての非 NULL フィールドがこの文字で囲まれ、フィールド値内に現れる enclose/escape 文字は `csv.escape` 文字でエスケープされます。NULL 値は囲まずに `\N` として出力されます。型: 単一バイト ASCII 文字。複数文字またはマルチバイト (非 ASCII) の値はセマンティックエラーで拒否されます。デフォルト: `NONE` (無効)。`format` が `csv` の場合にのみ適用されます。 |
+| `csv.escape`       | いいえ           | フィールド値内の enclose 文字および escape 文字自身をエスケープするために使用される文字。型: 単一バイト ASCII 文字。複数文字またはマルチバイト (非 ASCII) の値はセマンティックエラーで拒否されます。デフォルト: `NONE`。一般的な組み合わせ:<ul><li>`"csv.enclose"="\""`, `"csv.escape"="\""`: RFC 4180 スタイル (二重引用符)。</li><li>`"csv.enclose"="\""`, `"csv.escape"="\\"`: バックスラッシュエスケープスタイル。</li></ul>**注意**<br />RFC 4180 の二重引用符形式の出力 (`escape` と `enclose` が同じ) を StarRocks に再インポートする場合、読み取り側では `csv.enclose` のみを設定し、`csv.escape` は設定しないでください。StarRocks の CSV reader は ENCLOSE 状態を通じて二重引用符をネイティブに処理します。 |
 
 ## 例
 

--- a/docs/ja/unloading/unload_using_insert_into_files.md
+++ b/docs/ja/unloading/unload_using_insert_into_files.md
@@ -210,10 +210,25 @@ SELECT * FROM sales_records;
 ```SQL
 -- CSV ファイルへのデータのアンロード。
 INSERT INTO FILES(
-  'path' = 'file:///home/ubuntu/csvfile/', 
-  'format' = 'csv', 
-  'csv.column_separator' = ',', 
+  'path' = 'file:///home/ubuntu/csvfile/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
   'csv.row_delimitor' = '\n'
+)
+SELECT * FROM sales_records;
+
+-- フィールド囲み (RFC 4180 スタイル) で CSV ファイルにアンロード。
+-- カンマや引用符を含むフィールド値は enclose 文字で囲まれ、内部の
+-- 引用符は重複によってエスケープされます (csv.escape と csv.enclose が
+-- 同じため)。NULL 値は囲まずに \N として出力されます。
+INSERT INTO FILES(
+  'path' = 'file:///home/ubuntu/csvfile_enclosed/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
+  'csv.row_delimiter' = '\n',
+  'csv.enclose' = '"',
+  'csv.escape' = '"',
+  'csv.include_header' = 'true'
 )
 SELECT * FROM sales_records;
 
@@ -225,6 +240,26 @@ INSERT INTO FILES(
 )
 SELECT * FROM sales_records;
 ```
+
+:::note
+
+`csv.enclose` が設定されると、すべての非 NULL フィールド値は enclose 文字で囲まれ、
+フィールド値内に現れる enclose 文字 (および `csv.escape` が異なる場合は escape 文字
+自身) は `csv.escape` 文字でエスケープされます。NULL 値は囲まずに `\N` として出力
+されます。
+
+RFC 4180 形式の二重引用符出力 (`csv.escape` が `csv.enclose` と等しい) を StarRocks
+に再インポートする場合、読み取り側では `csv.enclose` のみを設定し、`csv.escape` は
+設定しないでください。StarRocks の CSV reader は ENCLOSE 状態を通じて二重引用符を
+ネイティブに処理します。
+
+また、NULL 値が正しく roundtrip するのは `csv.escape` がバックスラッシュ (`\`) で
+ない場合に限られます。NULL マーカーは `\N` に固定されており、`csv.escape = '\\'` の
+場合、読み取り側の ESCAPE 状態が先頭のバックスラッシュを取り除くため、`\N` は NULL
+ではなく文字リテラル `N` として解釈されます。NULL の roundtrip が必要なデータセット
+では `csv.escape = '"'` (RFC 4180 の二重引用符) を使用してください。
+
+:::
 
 ## 参照
 

--- a/docs/zh/loading/loading_introduction/feature-support-loading-and-unloading.md
+++ b/docs/zh/loading/loading_introduction/feature-support-loading-and-unloading.md
@@ -308,13 +308,28 @@ sidebar_label: "能力边界"
         <th>EXPORT</th>
     </tr>
     <tr>
-        <td rowspan="2">CSV</td>
+        <td rowspan="5">CSV</td>
         <td>column_separator</td>
         <td rowspan="2">Yes (v3.3+)</td>
         <td rowspan="2">Yes</td>
     </tr>
     <tr>
         <td>line_delimiter [1]</td>
+    </tr>
+    <tr>
+        <td>enclose</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>escape</td>
+        <td>Yes</td>
+        <td>No</td>
+    </tr>
+    <tr>
+        <td>include_header</td>
+        <td>Yes</td>
+        <td>No</td>
     </tr>
 </table>
 

--- a/docs/zh/sql-reference/sql-functions/table-functions/files.md
+++ b/docs/zh/sql-reference/sql-functions/table-functions/files.md
@@ -926,7 +926,12 @@ unload_data_param ::=
     "compression" = { "uncompressed" | "gzip" | "snappy" | "zstd | "lz4" },
     "partition_by" = "<column_name> [, ...]",
     "single" = { "true" | "false" } ,
-    "target_max_file_size" = "<int>"
+    "target_max_file_size" = "<int>",
+    "csv.column_separator" = "<column_separator>",
+    "csv.row_delimiter" = "<row_delimiter>",
+    "csv.include_header" = { "true" | "false" },
+    "csv.enclose" = "<enclose_character>",
+    "csv.escape" = "<escape_character>"
 ```
 
 | **Key**          | **Required** | **Description**                                              |
@@ -935,6 +940,11 @@ unload_data_param ::=
 | `partition_by`     | No           | 用于将数据文件分区到不同存储路径的列列表。多个列用逗号（,）分隔。`FILES()` 提取指定列的键/值信息，并将数据文件存储在具有提取键/值对的存储路径下。有关进一步说明，请参见示例 7。 |
 | `single`           | No           | 是否将数据导出到单个文件。有效值：<ul><li>`true`：数据存储在单个数据文件中。</li><li>`false`（默认）：如果导出数据量超过 512 MB，数据将存储在多个文件中。</li></ul>                  |
 | `target_max_file_size` | No           | 要导出的批次中每个文件的最大大小（此值仅为系统尽力达成的目标，不代表实际结果）。单位：字节。默认值：1073741824（1 GB）。当要导出的数据大小超过此值时，数据将被分割成多个文件，并且每个文件的大小不会显著超过此值。引入于 v3.2.7。 |
+| `csv.column_separator` | No       | CSV 格式导出文件中使用的列分隔符。默认值：`\t`。仅在 `format` 为 `csv` 时生效。                           |
+| `csv.row_delimiter` | No          | CSV 格式导出文件中使用的行分隔符。默认值：`\n`。仅在 `format` 为 `csv` 时生效。                          |
+| `csv.include_header` | No         | 是否在 CSV 格式导出文件的首行输出列名。有效值：`true`、`false`（默认）。仅在 `format` 为 `csv` 时生效。 |
+| `csv.enclose`      | No           | CSV 格式导出文件中用于包裹每个字段值的字符。指定该参数后，所有非 NULL 字段值将被该字符包裹，字段值内出现的 enclose/escape 字符将使用 `csv.escape` 字符进行转义。NULL 值输出为 `\N`，不进行包裹。类型：单字节 ASCII 字符。多字符或多字节（非 ASCII）的值会被语义层拒绝。默认值：`NONE`（禁用）。仅在 `format` 为 `csv` 时生效。 |
+| `csv.escape`       | No           | 用于转义 enclose 字符和 escape 字符自身的字符。类型：单字节 ASCII 字符。多字符或多字节（非 ASCII）的值会被语义层拒绝。默认值：`NONE`。常见组合：<ul><li>`"csv.enclose"="\""`, `"csv.escape"="\""`：RFC 4180 风格（双引号重复）。</li><li>`"csv.enclose"="\""`, `"csv.escape"="\\"`：反斜杠转义风格。</li></ul>**注意**<br />将 RFC 4180 双引号重复格式的输出（即 `escape` 与 `enclose` 相同）重新导入到 StarRocks 时，读端只需设置 `csv.enclose`，不要设置 `csv.escape`。StarRocks 的 CSV reader 通过其 ENCLOSE 状态原生处理双引号重复。 |
 
 ## 示例
 

--- a/docs/zh/unloading/unload_using_insert_into_files.md
+++ b/docs/zh/unloading/unload_using_insert_into_files.md
@@ -206,10 +206,25 @@ SELECT * FROM sales_records;
 ```SQL
 -- 导出为 CSV 文件。
 INSERT INTO FILES(
-  'path' = 'file:///home/ubuntu/csvfile/', 
-  'format' = 'csv', 
-  'csv.column_separator' = ',', 
+  'path' = 'file:///home/ubuntu/csvfile/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
   'csv.row_delimitor' = '\n'
+)
+SELECT * FROM sales_records;
+
+-- 导出为 CSV 文件，并使用 enclose/escape（RFC 4180 风格）。
+-- 包含逗号或双引号的字段值会被 enclose 字符包裹，内部出现的双引号
+-- 会被重复转义（因为 csv.escape 与 csv.enclose 相同）。NULL 值输出为
+-- \N，不进行包裹。
+INSERT INTO FILES(
+  'path' = 'file:///home/ubuntu/csvfile_enclosed/',
+  'format' = 'csv',
+  'csv.column_separator' = ',',
+  'csv.row_delimiter' = '\n',
+  'csv.enclose' = '"',
+  'csv.escape' = '"',
+  'csv.include_header' = 'true'
 )
 SELECT * FROM sales_records;
 
@@ -221,6 +236,23 @@ INSERT INTO FILES(
 )
 SELECT * FROM sales_records;
 ```
+
+:::note
+
+设置 `csv.enclose` 后，每个非 NULL 字段值都会被 enclose 字符包裹，字段值内出现的
+enclose 字符（以及当 `csv.escape` 不同时，escape 字符自身）会使用 `csv.escape` 字符
+转义。NULL 值输出为 `\N`，不进行包裹。
+
+若需要将 RFC 4180 双引号重复格式的输出（即 `csv.escape` 等于 `csv.enclose`）重新导入
+到 StarRocks，请在读端只设置 `csv.enclose`，不要设置 `csv.escape`。StarRocks 的 CSV
+reader 通过其 ENCLOSE 状态原生处理双引号重复。
+
+此外，NULL 值仅在 `csv.escape` 不是反斜杠（`\`）时才能正确 roundtrip。NULL 标记
+固定为 `\N`，当 `csv.escape = '\\'` 时，读端的 ESCAPE 状态会吃掉前导反斜杠，把 `\N`
+解析为字面字符 `N`，而不是 NULL。需要 NULL roundtrip 的数据集请使用 `csv.escape = '"'`
+（RFC 4180 双引号重复）。
+
+:::
 
 ## 另请参阅
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -398,6 +398,12 @@ public class TableFunctionTable extends Table {
             tTableFunctionTable.setCsv_column_seperator(csvColumnSeparator);
             tTableFunctionTable.setCsv_row_delimiter(csvRowDelimiter);
             tTableFunctionTable.setCsv_include_header(csvIncludeHeader);
+            if (csvEnclose != 0) {
+                tTableFunctionTable.setCsv_enclose(csvEnclose);
+            }
+            if (csvEscape != 0) {
+                tTableFunctionTable.setCsv_escape(csvEscape);
+            }
         }
         tTableFunctionTable.setParquet_use_legacy_encoding(parquetUseLegacyEncoding);
         TParquetOptions parquetOptions = new TParquetOptions();
@@ -926,6 +932,29 @@ public class TableFunctionTable extends Table {
                         "expect a boolean value (true or false).", includeHeader);
             }
             this.csvIncludeHeader = includeHeader.equalsIgnoreCase("true");
+        }
+
+        // csv enclose & escape options: accept exactly one single-byte ASCII character.
+        // Reject empty, multi-character, or multi-byte (non-ASCII) values so that the
+        // byte transmitted to BE unambiguously represents the user's intent.
+        if (properties.containsKey(PROPERTY_CSV_ENCLOSE)) {
+            byte[] bs = properties.get(PROPERTY_CSV_ENCLOSE).getBytes(StandardCharsets.UTF_8);
+            if (bs.length != 1) {
+                throw new SemanticException(
+                        "csv.enclose must be a single-byte ASCII character, got \"%s\" (%d bytes)",
+                        properties.get(PROPERTY_CSV_ENCLOSE), bs.length);
+            }
+            this.csvEnclose = bs[0];
+        }
+
+        if (properties.containsKey(PROPERTY_CSV_ESCAPE)) {
+            byte[] bs = properties.get(PROPERTY_CSV_ESCAPE).getBytes(StandardCharsets.UTF_8);
+            if (bs.length != 1) {
+                throw new SemanticException(
+                        "csv.escape must be a single-byte ASCII character, got \"%s\" (%d bytes)",
+                        properties.get(PROPERTY_CSV_ESCAPE), bs.length);
+            }
+            this.csvEscape = bs[0];
         }
 
         // parquet options

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -418,6 +418,124 @@ public class TableFunctionTableTest {
     }
 
     @Test
+    public void testCSVEncloseEscapeForUnload() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "file:///test_dir");
+        properties.put("format", "csv");
+
+        // default: neither specified, both are 0 (disabled)
+        {
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertEquals((byte) 0, (byte) Deencapsulation.getField(table, "csvEnclose"));
+            Assertions.assertEquals((byte) 0, (byte) Deencapsulation.getField(table, "csvEscape"));
+            // toTTableFunctionTable should not set these fields when disabled
+            Assertions.assertFalse(table.toTTableFunctionTable().isSetCsv_enclose());
+            Assertions.assertFalse(table.toTTableFunctionTable().isSetCsv_escape());
+        }
+
+        // enclose='"' and escape='"' (RFC 4180 style)
+        {
+            properties.put("csv.enclose", "\"");
+            properties.put("csv.escape", "\"");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertEquals((byte) '"', (byte) Deencapsulation.getField(table, "csvEnclose"));
+            Assertions.assertEquals((byte) '"', (byte) Deencapsulation.getField(table, "csvEscape"));
+            Assertions.assertTrue(table.toTTableFunctionTable().isSetCsv_enclose());
+            Assertions.assertEquals((byte) '"', table.toTTableFunctionTable().getCsv_enclose());
+            Assertions.assertTrue(table.toTTableFunctionTable().isSetCsv_escape());
+            Assertions.assertEquals((byte) '"', table.toTTableFunctionTable().getCsv_escape());
+        }
+
+        // enclose='"' and escape='\\' (backslash escape style)
+        {
+            properties.put("csv.enclose", "\"");
+            properties.put("csv.escape", "\\");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertEquals((byte) '"', (byte) Deencapsulation.getField(table, "csvEnclose"));
+            Assertions.assertEquals((byte) '\\', (byte) Deencapsulation.getField(table, "csvEscape"));
+            Assertions.assertEquals((byte) '"', table.toTTableFunctionTable().getCsv_enclose());
+            Assertions.assertEquals((byte) '\\', table.toTTableFunctionTable().getCsv_escape());
+        }
+
+        // only enclose specified (escape disabled)
+        {
+            properties.remove("csv.escape");
+            properties.put("csv.enclose", "|");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertEquals((byte) '|', (byte) Deencapsulation.getField(table, "csvEnclose"));
+            Assertions.assertEquals((byte) 0, (byte) Deencapsulation.getField(table, "csvEscape"));
+            Assertions.assertTrue(table.toTTableFunctionTable().isSetCsv_enclose());
+            Assertions.assertFalse(table.toTTableFunctionTable().isSetCsv_escape());
+        }
+
+        // abnormal: empty csv.enclose
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.enclose", "");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.enclose must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+
+        // abnormal: empty csv.escape
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.escape", "");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.escape must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+
+        // abnormal: multi-character csv.enclose (would previously silently take first byte)
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.enclose", "ab");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.enclose must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+
+        // abnormal: multi-character csv.escape
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.escape", "\\\\");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.escape must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+
+        // abnormal: multi-byte (non-ASCII) csv.enclose (Chinese char is 3 UTF-8 bytes)
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.enclose", "中");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.enclose must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+
+        // abnormal: multi-byte (non-ASCII) csv.escape
+        {
+            properties.clear();
+            properties.put("path", "file:///test_dir");
+            properties.put("format", "csv");
+            properties.put("csv.escape", "中");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "csv.escape must be a single-byte ASCII character",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+    }
+
+    @Test
     public void testAutoDetectTypes() throws NoSuchFieldException {
         Map<String, String> properties = new HashMap<>();
         properties.put(TableFunctionTable.PROPERTY_PATH, "fake://test/path");

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -544,6 +544,14 @@ struct TTableFunctionTable {
     11: optional Types.TParquetOptions parquet_options
 
     12: optional bool csv_include_header
+
+    // enclose character for CSV unload. When set, all non-NULL field values are
+    // wrapped with this character; occurrences of the enclose character (and the
+    // escape character itself) within field content are escaped using csv_escape.
+    13: optional i8 csv_enclose
+
+    // escape character for CSV unload. Used together with csv_enclose.
+    14: optional i8 csv_escape
 }
 
 struct TIcebergSchemaField {

--- a/test/sql/test_sink/R/test_csv_enclose_escape
+++ b/test/sql/test_sink/R/test_csv_enclose_escape
@@ -1,0 +1,155 @@
+-- name: testCsvEncloseEscapeRFC4180
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1 (id int, name varchar(200), nullable_col varchar(50)) distributed by hash(id) buckets 1;
+-- result:
+-- !result
+insert into t1 values (1, 'hello', 'not null'), (2, 'hello,world', NULL), (3, 'say "hi"', 'val');
+-- result:
+-- !result
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\"",
+    "single" = "true"
+)
+select * from t1 order by id;
+-- result:
+-- !result
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\""
+) order by 1;
+-- result:
+1	hello	not null
+2	hello,world	None
+3	say "hi"	val
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+
+-- name: testCsvEncloseEscapeBackslash
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t2 (id int, name varchar(200), extra varchar(50)) distributed by hash(id) buckets 1;
+-- result:
+-- !result
+insert into t2 values (1, 'hello', 'plain'), (2, 'say "hi"', 'val'), (3, 'path\\to', 'val'), (4, 'a\\"b', 'x');
+-- result:
+-- !result
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\\",
+    "single" = "true"
+)
+select * from t2 order by id;
+-- result:
+-- !result
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\\"
+) order by 1;
+-- result:
+1	hello	plain
+2	say "hi"	val
+3	path\to	val
+4	a\"b	x
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+
+-- name: testCsvEncloseWithHeader
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t3 (id int, name varchar(200)) distributed by hash(id) buckets 1;
+-- result:
+-- !result
+insert into t3 values (1, 'alice'), (2, 'bob,comma');
+-- result:
+-- !result
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\"",
+    "csv.include_header" = "true",
+    "single" = "true"
+)
+select * from t3 order by id;
+-- result:
+-- !result
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.skip_header" = "1",
+    "csv.enclose" = "\""
+) order by 1;
+-- result:
+1	alice
+2	bob,comma
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_sink/T/test_csv_enclose_escape
+++ b/test/sql/test_sink/T/test_csv_enclose_escape
@@ -1,0 +1,97 @@
+-- name: testCsvEncloseEscapeRFC4180
+create database db_${uuid0};
+use db_${uuid0};
+create table t1 (id int, name varchar(200), nullable_col varchar(50)) distributed by hash(id) buckets 1;
+insert into t1 values (1, 'hello', 'not null'), (2, 'hello,world', NULL), (3, 'say "hi"', 'val');
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\"",
+    "single" = "true"
+)
+select * from t1 order by id;
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\""
+) order by 1;
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseRFC/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+drop database db_${uuid0};
+
+-- name: testCsvEncloseEscapeBackslash
+create database db_${uuid0};
+use db_${uuid0};
+create table t2 (id int, name varchar(200), extra varchar(50)) distributed by hash(id) buckets 1;
+-- NOTE: avoid NULL here. With csv.escape='\\', the fixed NULL marker "\N" is
+-- indistinguishable from an escaped literal N on re-import (the reader's
+-- ESCAPE state strips the backslash), so NULL does not roundtrip under this
+-- escape mode. NULL roundtrip is covered by the RFC4180 case above, which
+-- uses csv.escape='"' and keeps \N intact.
+insert into t2 values (1, 'hello', 'plain'), (2, 'say "hi"', 'val'), (3, 'path\\to', 'val'), (4, 'a\\"b', 'x');
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\\",
+    "single" = "true"
+)
+select * from t2 order by id;
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\\"
+) order by 1;
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseBS/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+drop database db_${uuid0};
+
+-- name: testCsvEncloseWithHeader
+create database db_${uuid0};
+use db_${uuid0};
+create table t3 (id int, name varchar(200)) distributed by hash(id) buckets 1;
+insert into t3 values (1, 'alice'), (2, 'bob,comma');
+insert into files (
+    "path" = "s3://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "format" = "csv",
+    "compression" = "uncompressed",
+    "csv.column_separator" = ",",
+    "csv.enclose" = "\"",
+    "csv.escape" = "\"",
+    "csv.include_header" = "true",
+    "single" = "true"
+)
+select * from t3 order by id;
+select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0}/*",
+    "fs.oss.endpoint" = "${oss_endpoint}",
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.skip_header" = "1",
+    "csv.enclose" = "\""
+) order by 1;
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvEncloseHeader/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+drop database db_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing:                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                             
  When exporting data via `INSERT INTO FILES ... format = "csv"`, string/JSON columns                                                                                                                                                                                        
  containing commas produce malformed CSV — the comma inside the field value is                                                                                                                                                                                              
  indistinguishable from the column delimiter, causing column mismatch when
  downstream tools (Redshift, Excel, pandas, etc.) read the file.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                             
  StarRocks already supports `csv.enclose`/`csv.escape` on the **LOAD** (read) path,                                                                                                                                                                                         
  but silently ignores them on the **UNLOAD** (export/write) path. User-provided                                                                                                                                                                                             
  properties are parsed but never serialized to BE, and the writer emits raw, unescaped bytes.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                             
  Example of the current broken behavior:

  ```sql
  INSERT INTO FILES (
      "path" = "s3://bucket/csv/",
      "format" = "csv",
      "csv.column_separator" = ",",
      "csv.enclose" = '"',
      "csv.escape"  = '"'
  ) SELECT id, name FROM t;

  -- Row: (1, "hello,world")
  -- Current output (broken): 1,hello,world        <- parsed as 3 columns
  -- Expected output:         1,"hello,world"      <- comma preserved
  ```

  ## What I'm doing:

  End-to-end support for csv.enclose and csv.escape in the CSV unload path.

  ### Behavior

  - When csv.enclose is set, every non-NULL field value is wrapped with the
  enclose character.
  - Occurrences of the enclose character and the escape character itself within
  field content are prefixed with the escape character. Escaping the escape
  character is required for roundtrip correctness because the CSV reader's
  ESCAPE state (be/src/formats/csv/csv_reader.cpp:282-294) strips escape
  characters during parsing.
  - Special case: when escape == enclose, a single occurrence is emitted (RFC 4180 doubling).
  - NULL values are output as \N without enclosing (matches Redshift / Postgres COPY).
  - csv.enclose / csv.escape accept a single-byte ASCII character only; multi-character or multi-byte (non-ASCII) values are rejected with a semantic error (tightened from the load-path contract, intentionally scoped to this new unload surface).
  - When csv.enclose is not set, behavior is unchanged.

  StarRocks reader roundtrip caveat

  RFC 4180 output (escape == enclose == '"') cannot be re-imported with
  csv.escape='"' because the reader's START state checks escape before
  enclose (see csv_reader.cpp:217-234). When re-importing, set only
  csv.enclose='"' without csv.escape; the reader's ENCLOSE state natively
  handles doubled quotes. Documented in all three languages (en/zh/ja).

  ### Implementation

  - gensrc/thrift/Descriptors.thrift: add csv_enclose and csv_escape to
  TTableFunctionTable (fields 13/14, optional i8 to match existing
  enclose/escape fields in TBrokerScanRangeParams).
  - fe/.../TableFunctionTable.java: parse in parsePropertiesForUnload() with
  single-byte ASCII validation via getBytes(StandardCharsets.UTF_8);
  serialize in toTTableFunctionTable().
  - be/src/runtime/table_function_table_sink.cpp: propagate thrift fields into
  sink context options.
  - be/src/formats/csv/csv_file_writer.{h,cpp}:
    - Add enclose/escape to CSVWriterOptions and factory option parsing.
    - _write_enclosed_string() writes a string wrapped with the enclose char,
  escaping both enclose and escape occurrences (with escape == enclose
  handled once).
    - _write_enclosed_field() captures converter output into a
  FormattedOutputStreamString in-memory buffer, then calls the escape
  routine. This keeps enclose/escape logic out of every converter and covers
  all data types (string, JSON, numeric, etc.) uniformly.
    - write() calls ColumnHelper::unpack_and_duplicate_const_column() on
  every evaluated column before per-row iteration. This removes a latent
  crash path where ConstColumn inputs (e.g. from SELECT NULL ... or
  SELECT 'literal' ...) would hit down_cast<NullableColumn*> /
  down_cast<BinaryColumn*> assertions inside the per-type converters.
  The fix matches the Chunk::unpack_and_duplicate_const_columns() pattern
  already used elsewhere in the codebase.
    - write() uses the polymorphic Column::is_null(r) (not a down_cast) to
  branch between enclosed and \N emission.
    - _write_header() applies the same enclose/escape rules to header names
  when enabled.

  Note: the ConstColumn crash is a pre-existing issue in the CSV writer (not
  introduced by this PR), but is fixed here because the new enclose path made it
  easier to reproduce and because the fix is a 3-line addition.

  ### Tests

  - FE (TableFunctionTableTest.testCSVEncloseEscapeForUnload): covers
  default, RFC 4180, backslash-escape, only-enclose cases, plus empty /
  multi-character / multi-byte (Chinese) rejection for both enclose and escape.
  Tests run: 13, Failures: 0, Errors: 0.
  - BE (CSVFileWriterTest): new tests cover
    - TestEncloseEscapeRFC4180 — enclose==escape doubling
    - TestEncloseEscapeBackslash — enclose!=escape including trailing \,  mixed \"
    - TestEncloseWithoutEscape, TestEncloseWithHeader, TestEncloseDisabled
    - TestEncloseConstNullableColumn — regression for SELECT NULL crash
    - TestEncloseConstStringColumn — regression for SELECT 'literal' crash
    - TestConstColumnWithoutEnclose — pre-existing const-column crash on the  enclose-disabled path
    - TestFactoryWithEncloseEscapeOptions 9/9 PASSED.
  - SQL integration (test/sql/test_sink/T/test_csv_enclose_escape +
  matching R file): three OSS-based roundtrip cases following the
  test_csv_file_sink pattern (RFC 4180, backslash escape, include-header).

  ### Docs

  Updated docs/en, docs/zh, docs/ja for:

  - sql-reference/sql-functions/table-functions/files.md — unload_data_param
  table (added csv.column_separator, csv.row_delimiter,
  csv.include_header, csv.enclose, csv.escape) with explicit
  single-byte ASCII contract and re-import caveat.
  - loading/loading_introduction/feature-support-loading-and-unloading.md —
  unloading CSV feature table (added enclose, escape, include_header).
  - unloading/unload_using_insert_into_files.md — new CSV export example with
  csv.enclose/csv.escape and a note about the re-import caveat.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4