### PR TITLE
[Tool] add auto assign reviewer job to pr-checker workflow

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -254,3 +254,13 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/check-pr-changelist.sh
+
+  assign-reviewer:
+    runs-on: [self-hosted, normal]
+    if: >
+      github.event.action == 'opened' &&
+      !startsWith(github.head_ref, 'mergify/')
+    steps:
+      - name: Assign PR Reviewer
+        run: |
+          claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"


### PR DESCRIPTION
## Why I'm doing:

PR reviewer assignment is currently manual or limited to label-based team assignment. This adds an automated reviewer assignment step using Claude CLI with the `starrocks-assign-pr-reviewer` skill, which analyzes the PR's changed files and selects the most appropriate reviewer based on feature ownership and code history.

## What I'm doing:

Add a new `assign-reviewer` job to `pr-checker.yml` that:
- Triggers only on PR `opened` events (not backport/cherry-pick PRs created by Mergify)
- Calls `claude -p "/starrocks-assign-pr-reviewer <pr_url>"` on the self-hosted runner
- Claude analyzes the PR, recommends a reviewer, and automatically assigns via `gh pr edit --add-reviewer`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4