### PR TITLE
[Refactor] Migrate TvrOpUtils to IvmOpUtils

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -110,8 +110,8 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
-import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.OptExprBuilder;
@@ -655,12 +655,12 @@ public class MaterializedViewAnalyzer {
                     colName = colWithComments.get(i).getColName();
                 }
                 Column column = new Column(colName, type, colNullable);
-                if (TvrOpUtils.COLUMN_ROW_ID.equalsIgnoreCase(colName)) {
+                if (IvmOpUtils.COLUMN_ROW_ID.equalsIgnoreCase(colName)) {
                     column.setIsKey(true);
                     column.setIsAllowNull(false);
                     column.setIsHidden(true);
                 }
-                if (colName.startsWith(TvrOpUtils.COLUMN_AGG_STATE_PREFIX)) {
+                if (colName.startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX)) {
                     column.setIsHidden(true);
                 }
                 if (colWithComments != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -47,7 +47,7 @@ import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IsNullPredicate;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
-import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
@@ -295,7 +295,7 @@ public class IVMAnalyzer {
             String aggFuncName = aggFuncExpr.getFunctionName();
             // build intermediate aggregate function
             FunctionCallExpr intermediateAggFuncExpr = buildIntermediateAggregateFunc(aggFuncExpr);
-            String newAggFuncName = TvrOpUtils.getTvrAggStateColumnName(aggFuncExpr);
+            String newAggFuncName = IvmOpUtils.getIvmAggStateColumnName(aggFuncExpr);
 
             IVMAggFunctionInfo aggFunctionInfo = new IVMAggFunctionInfo(aggFuncExpr, aggFuncName,
                     intermediateAggFuncExpr, newAggFuncName);
@@ -311,15 +311,15 @@ public class IVMAnalyzer {
         selectRelation.setAggregate(newAggFuncs);
 
         // Build the row ID function expression
-        int encodeRowIdVersion = TvrOpUtils.deduceEncodeRowIdVersion(groupByExprs);
+        int encodeRowIdVersion = IvmOpUtils.deduceEncodeRowIdVersion(groupByExprs);
         if (statement != null) {
             statement.setEncodeRowIdVersion(encodeRowIdVersion);
         }
-        FunctionCallExpr rowIdFuncExpr = TvrOpUtils.buildRowIdFuncExpr(encodeRowIdVersion, groupByExprs);
+        FunctionCallExpr rowIdFuncExpr = IvmOpUtils.buildRowIdFuncExpr(encodeRowIdVersion, groupByExprs);
         SelectList selectList = selectRelation.getSelectList();
         List<SelectListItem> newItems = Lists.newArrayList();
         // add row_id func expr
-        newItems.add(new SelectListItem(rowIdFuncExpr, TvrOpUtils.COLUMN_ROW_ID));
+        newItems.add(new SelectListItem(rowIdFuncExpr, IvmOpUtils.COLUMN_ROW_ID));
         // add original items
         selectList.getItems()
                 .stream()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
@@ -37,9 +37,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
-import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -93,7 +93,7 @@ public class IvmDeltaAggregateRule extends TransformationRule {
         }
         // Must be able to load the target MV for state merge
         MaterializedView mv = IvmRewriter.loadTargetMv(context);
-        return mv != null && mv.getColumn(TvrOpUtils.COLUMN_ROW_ID) != null;
+        return mv != null && mv.getColumn(IvmOpUtils.COLUMN_ROW_ID) != null;
     }
 
     @Override
@@ -108,12 +108,12 @@ public class IvmDeltaAggregateRule extends TransformationRule {
         ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
 
         // Step 1: Get MV schema info
-        Column rowIdColumn = mv.getColumn(TvrOpUtils.COLUMN_ROW_ID);
+        Column rowIdColumn = mv.getColumn(IvmOpUtils.COLUMN_ROW_ID);
         Preconditions.checkState(rowIdColumn != null, "__ROW_ID__ column must exist in MV");
         int encodeRowIdVersion = mv.getEncodeRowIdVersion();
 
         List<Column> aggStateColumns = mv.getFullSchema().stream()
-                .filter(col -> col.getName().startsWith(TvrOpUtils.COLUMN_AGG_STATE_PREFIX))
+                .filter(col -> col.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX))
                 .collect(Collectors.toList());
 
         // Step 2: Create MV scan
@@ -141,7 +141,7 @@ public class IvmDeltaAggregateRule extends TransformationRule {
         List<ScalarOperator> uniqueKeys = groupingKeys.stream()
                 .map(col -> (ScalarOperator) col)
                 .collect(Collectors.toList());
-        ScalarOperator eqPredicate = TvrOpUtils.buildRowIdEqBinaryPredicateOp(
+        ScalarOperator eqPredicate = IvmOpUtils.buildRowIdEqBinaryPredicateOp(
                 encodeRowIdVersion, mvRowIdRef, uniqueKeys);
 
         // Step 6: Build LEFT OUTER JOIN (intermediate agg ⋈ MV scan)
@@ -174,7 +174,7 @@ public class IvmDeltaAggregateRule extends TransformationRule {
             Preconditions.checkState(intermediateRef != null,
                     "Intermediate ref should not be null for: %s", origCall);
             ColumnRefOperator mvStateRef = mvAggStateRefs.get(i);
-            ScalarOperator stateUnion = TvrOpUtils.buildStateUnionScalarOperator(
+            ScalarOperator stateUnion = IvmOpUtils.buildStateUnionScalarOperator(
                     origCall, intermediateRef, mvStateRef);
             projMap.put(origRef, stateUnion);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -10,9 +10,9 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.tvr.common;
+package com.starrocks.sql.optimizer.rule.ivm.common;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -39,9 +39,16 @@ import com.starrocks.type.VarcharType;
 import java.util.List;
 
 /**
- * Utility class for TVR operations.
+ * Utility class for IVM (Incremental View Maintenance) operations.
+ *
+ * <p>Contains helpers for:
+ * <ul>
+ *   <li>Aggregate state column naming ({@code __AGG_STATE_*})</li>
+ *   <li>Row-id encoding ({@code encode_sort_key} / {@code encode_fingerprint_sha256})</li>
+ *   <li>Row-id equality predicate and state_union scalar operator construction</li>
+ * </ul>
  */
-public class TvrOpUtils {
+public class IvmOpUtils {
     public static final String COLUMN_ROW_ID = "__ROW_ID__";
     public static final String COLUMN_AGG_STATE_PREFIX = "__AGG_STATE";
     public static final ImmutableMap<Integer, String> ENCODE_ROW_ID_FUNCTION_MAP =
@@ -50,23 +57,20 @@ public class TvrOpUtils {
                     .put(1, FunctionSet.ENCODE_FINGERPRINT_SHA256)
                     .build();
 
-    public static String getTvrAggStateColumnName(FunctionCallExpr functionCallExpr) {
-        // TODO: format functionCallExpr to a more readable name
+    private IvmOpUtils() {
+    }
+
+    public static String getIvmAggStateColumnName(FunctionCallExpr functionCallExpr) {
         // agg_state column name is like __AGG_STATE_<agg_func_name>
-        String exprFuncName = AstToStringBuilder.getAliasName(functionCallExpr, false,
-                false);
+        String exprFuncName = AstToStringBuilder.getAliasName(functionCallExpr, false, false);
         return String.format("%s_%s", COLUMN_AGG_STATE_PREFIX, exprFuncName);
     }
 
     /**
      * encode_row_id(...) -> encode_sort_key(...) if all args are fixed-length and total size <= 32 bytes
      *                    -> encode_fingerprint_sha256(...) otherwise
-     * Note: Since syntax sugars are applied during parsing (before type analysis),
-     * types are not yet available. For now, we always use encode_fingerprint_sha256.
-     * TODO: Implement type-based optimization during semantic analysis phase.
      */
     public static int deduceEncodeRowIdVersion(List<Expr> children) {
-        // Check if all children have types available (they should be analyzed)
         boolean allTypesAvailable = true;
         int totalSize = 0;
 
@@ -76,7 +80,6 @@ public class TvrOpUtils {
                 break;
             }
 
-            // Check if it's a variable-length type
             if (child.getType().isScalarType()) {
                 ScalarType scalarType = (ScalarType) child.getType();
                 if (scalarType.getPrimitiveType().isVariableLengthType()) {
@@ -85,17 +88,14 @@ public class TvrOpUtils {
                 }
                 totalSize += scalarType.getPrimitiveType().getTypeSize();
             } else if (child.getType().isComplexType()) {
-                // Complex types (ARRAY, MAP, STRUCT) are variable-length
                 allTypesAvailable = false;
                 break;
             }
         }
 
-        // If all types are fixed-length and total size <= 32 bytes, use encode_sort_key
         if (allTypesAvailable && totalSize > 0 && totalSize <= 32) {
             return 0;
         }
-        // Otherwise, use encode_fingerprint_sha256 (default for variable-length or large data)
         return 1;
     }
 
@@ -114,52 +114,39 @@ public class TvrOpUtils {
 
     /**
      * Build the row id function expression for IVM.
-     * - For multi unique keys, use ENCODE_SORT_KEY to encode them to a varbinary and use FROM_BINARY to convert it into
-     * varchar:
-     *  `FROM_BINARY(ENCODE_ROW_ID(k1, k2, ..., kn), 'encode64')
-     * TODO: Since binary type is not supported to be used for primary keys, we can remove from_binary in the future.
+     * For multi unique keys, use ENCODE_ROW_ID to encode them to a varbinary and use FROM_BINARY to convert it into
+     * varchar: {@code FROM_BINARY(ENCODE_ROW_ID(k1, k2, ..., kn), 'encode64')}
      */
-    public static FunctionCallExpr buildRowIdFuncExpr(int encodeRowIdVersion,
-                                                      List<Expr> uniqueKeys) {
+    public static FunctionCallExpr buildRowIdFuncExpr(int encodeRowIdVersion, List<Expr> uniqueKeys) {
         final String encodeRowIdFuncName = getEncodeRowIdFunctionNameChecked(encodeRowIdVersion);
-        // This method is a placeholder for the actual implementation of building a row ID function.
-        // The implementation would typically create a FunctionCallExpr that represents the row ID function
-        // used in incremental view maintenance (IVM).
         FunctionCallExpr encodeSortKeyFunc = new FunctionCallExpr(encodeRowIdFuncName, uniqueKeys);
         List<Expr> fromBinaryArgs = Lists.newArrayList(encodeSortKeyFunc, new StringLiteral("encode64"));
-        FunctionCallExpr fromBinaryFunc = new FunctionCallExpr(FunctionSet.FROM_BINARY, fromBinaryArgs);
-        return fromBinaryFunc;
+        return new FunctionCallExpr(FunctionSet.FROM_BINARY, fromBinaryArgs);
     }
 
     public static ScalarOperator buildRowIdEqBinaryPredicateOp(int encodeRowIdVersion,
-                                                               ColumnRefOperator aggStateRowIdScalarOp,
-                                                               List<ScalarOperator> uniqueKeys) {
-        // build row id operator for agg state table
+                                                                ColumnRefOperator aggStateRowIdScalarOp,
+                                                                List<ScalarOperator> uniqueKeys) {
         ScalarOperator deltaInputRowIdScalarOp = buildRowIdColumnOperator(encodeRowIdVersion, uniqueKeys);
-        BinaryPredicateOperator eqBinaryPredicateOperator =
-                new BinaryPredicateOperator(BinaryType.EQ, aggStateRowIdScalarOp, deltaInputRowIdScalarOp);
-        return eqBinaryPredicateOperator;
+        return new BinaryPredicateOperator(BinaryType.EQ, aggStateRowIdScalarOp, deltaInputRowIdScalarOp);
     }
 
     public static ScalarOperator buildRowIdColumnOperator(int encodeRowIdVersion,
-                                                          List<ScalarOperator> uniqueKeys) {
-        // build row id operator for agg state table
-        Type[] argTypes = uniqueKeys.stream()
-                .map(ScalarOperator::getType)
-                .toArray(Type[]::new);
+                                                           List<ScalarOperator> uniqueKeys) {
+        Type[] argTypes = uniqueKeys.stream().map(ScalarOperator::getType).toArray(Type[]::new);
         final String encodeRowIdFuncName = getEncodeRowIdFunctionNameChecked(encodeRowIdVersion);
         Function newFunc = ExprUtils.getBuiltinFunction(encodeRowIdFuncName, argTypes,
                 Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         if (newFunc == null) {
             throw new IllegalArgumentException("Function " + encodeRowIdFuncName + " not found");
         }
-        ScalarOperator rowIdScalarOp = new CallOperator(encodeRowIdFuncName, VarbinaryType.VARBINARY, uniqueKeys, newFunc);
-        // varbinary to varchar
+        ScalarOperator rowIdScalarOp =
+                new CallOperator(encodeRowIdFuncName, VarbinaryType.VARBINARY, uniqueKeys, newFunc);
         return fromBinaryToVarchar(rowIdScalarOp);
     }
 
     private static ScalarOperator fromBinaryToVarchar(ScalarOperator rowIdScalarOp) {
-        Type[] argTypes = new Type[] { rowIdScalarOp.getType(), VarcharType.VARCHAR };
+        Type[] argTypes = new Type[] {rowIdScalarOp.getType(), VarcharType.VARCHAR};
         Function newFunc = ExprUtils.getBuiltinFunction(FunctionSet.FROM_BINARY, argTypes,
                 Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         if (newFunc == null) {
@@ -170,13 +157,11 @@ public class TvrOpUtils {
     }
 
     public static ScalarOperator buildStateUnionScalarOperator(CallOperator aggFunc,
-                                                               ScalarOperator intermediateAggScalarOp,
-                                                               ScalarOperator aggStateAggStateColumnRef) {
+                                                                ScalarOperator intermediateAggScalarOp,
+                                                                ScalarOperator aggStateAggStateColumnRef) {
         Preconditions.checkArgument(intermediateAggScalarOp.getType().equals(aggStateAggStateColumnRef.getType()),
                 "The type of intermediateAggScalarOp and aggStateTableRowIdScalarOp must be the same");
-        // build row id operator for agg state table
-        Type[] argTypes = new Type[] { intermediateAggScalarOp.getType(), aggStateAggStateColumnRef.getType() };
-        // get the state union function name
+        Type[] argTypes = new Type[] {intermediateAggScalarOp.getType(), aggStateAggStateColumnRef.getType()};
         String origAggFuncName = AggStateUtils.getAggFuncNameOfCombinator(aggFunc.getFnName());
         String stateUnionFunctionName = AggStateUtils.stateUnionFunctionName(origAggFuncName);
         Function newFunc = ExprUtils.getBuiltinFunction(stateUnionFunctionName, argTypes,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tvr/TvrAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tvr/TvrAggregateRule.java
@@ -35,8 +35,8 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
-import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
 import com.starrocks.sql.optimizer.rule.tvr.common.TvrOptContext;
 import com.starrocks.sql.optimizer.rule.tvr.common.TvrOptMeta;
 import org.apache.hadoop.util.Lists;
@@ -80,7 +80,7 @@ public class TvrAggregateRule extends TvrTransformationRule {
                                                      OptExpression input) {
         Preconditions.checkArgument(aggStateTable != null,
                 "Aggregate state table must not be null for TVR aggregate rule");
-        final Column tvrColumnRowId = aggStateTable.getColumn(TvrOpUtils.COLUMN_ROW_ID);
+        final Column tvrColumnRowId = aggStateTable.getColumn(IvmOpUtils.COLUMN_ROW_ID);
         Preconditions.checkArgument(tvrColumnRowId != null,
                 "TVR column row id must exist in agg state table");
         final ColumnRefFactory columnRefFactory = optimizerContext.getColumnRefFactory();
@@ -90,7 +90,7 @@ public class TvrAggregateRule extends TvrTransformationRule {
                 aggStateOlapScanOperator.getColumnMetaToColRefMap().get(tvrColumnRowId);
         List<Column> aggStateTableFullColumns = aggStateTable.getFullSchema();
         List<Column> aggStateTableColumns = aggStateTableFullColumns.stream()
-                .filter(col -> col.getName().startsWith(TvrOpUtils.COLUMN_AGG_STATE_PREFIX))
+                .filter(col -> col.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX))
                 .collect(Collectors.toList());
         // collect agg state table's aggregate agg state columns
         Map<Column, ColumnRefOperator> aggStateTableColumnMetaToColRefMap =
@@ -112,7 +112,7 @@ public class TvrAggregateRule extends TvrTransformationRule {
                 .map(col -> (ScalarOperator) col)
                 .collect(Collectors.toList());
         final int encodeRowIdVersion = aggStateTable.getEncodeRowIdVersion();
-        ScalarOperator eqRowIdOperator = TvrOpUtils.buildRowIdEqBinaryPredicateOp(encodeRowIdVersion,
+        ScalarOperator eqRowIdOperator = IvmOpUtils.buildRowIdEqBinaryPredicateOp(encodeRowIdVersion,
                 aggStateRowIdColumnRef, inputAggUniqueKeys);
 
         // old aggregate function to new column ref operator map
@@ -151,7 +151,7 @@ public class TvrAggregateRule extends TvrTransformationRule {
             Preconditions.checkState(intermediateAggColumnRef != null,
                     "New column ref operator should not be null for: %s", callOperator);
             ColumnRefOperator aggStateAggStateColumnRef = aggStateTableColumnRefs.get(i);
-            ScalarOperator stateUnionScalarOperator = TvrOpUtils.buildStateUnionScalarOperator(
+            ScalarOperator stateUnionScalarOperator = IvmOpUtils.buildStateUnionScalarOperator(
                     callOperator, intermediateAggColumnRef, aggStateAggStateColumnRef);
             projColumnRefMap.put(oldColumnRef, stateUnionScalarOperator);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.combinator.AggStateUtils;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
-import com.starrocks.sql.optimizer.rule.tvr.common.TvrOpUtils;
+import com.starrocks.sql.optimizer.rule.ivm.common.IvmOpUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -108,7 +108,7 @@ public class SyntaxSugars {
     }
 
     private static FunctionCallExpr encodeRowId(FunctionCallExpr call) {
-        final String encodeRowIdFuncName = TvrOpUtils.getEncodeRowIdFunctionNameChecked(
+        final String encodeRowIdFuncName = IvmOpUtils.getEncodeRowIdFunctionNameChecked(
                 call.getChildren());
         return new FunctionCallExpr(encodeRowIdFuncName, call.getChildren());
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Move TvrOpUtils from rule/tvr/common/ to rule/ivm/common/IvmOpUtils.java as part of preparing to remove the TVR framework. The content is moved as-is with these renames:

- Class: TvrOpUtils -> IvmOpUtils
- Method: getTvrAggStateColumnName -> getIvmAggStateColumnName
- Added private constructor to prevent instantiation

Updated imports in 5 files:
- IvmDeltaAggregateRule (IVM rule)
- IVMAnalyzer (CREATE MV time rewrite)
- MaterializedViewAnalyzer (hidden column detection)
- SyntaxSugars (parser syntax sugar expansion)
- TvrAggregateRule (TVR rule, still functional until PR6b deletes it)

Remaining TVR cleanup (deleting rule/tvr/ directory, OptExpression tvrOptMeta, QueryOptimizer TVR call, RuleSet.TVR_REWRITE_RULES, etc.) will be done in a follow-up PR.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
