### PR TITLE
[Tool] fix assign-reviewer job: full path and add synchronize/edited triggers

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -263,4 +263,4 @@ jobs:
     steps:
       - name: Assign PR Reviewer
         run: |
-          claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
+          /usr/local/bin/claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -258,7 +258,7 @@ jobs:
   assign-reviewer:
     runs-on: [self-hosted, normal]
     if: >
-      github.event.action == 'opened' &&
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited') &&
       !startsWith(github.head_ref, 'mergify/')
     steps:
       - name: Assign PR Reviewer


### PR DESCRIPTION
## Why I'm doing:

Follow-up fixes for the `assign-reviewer` job added in #71593:
1. `claude` command not found — runner PATH doesn't include `/usr/local/bin`
2. Job was skipped on `synchronize`/`edited` events — only `opened` was in the condition

## What I'm doing:

- Use full path `/usr/local/bin/claude` instead of `claude`
- Add `synchronize` and `edited` to the trigger condition

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4