### PR TITLE
[Tool] fix assign-reviewer: full path, synchronize/edited triggers, continue-on-error

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -263,4 +263,4 @@ jobs:
     steps:
       - name: Assign PR Reviewer
         run: |
-          claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
+          /usr/local/bin/claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -257,6 +257,7 @@ jobs:
 
   assign-reviewer:
     runs-on: [self-hosted, normal]
+    continue-on-error: true
     if: >
       (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited') &&
       !startsWith(github.head_ref, 'mergify/')

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -258,7 +258,7 @@ jobs:
   assign-reviewer:
     runs-on: [self-hosted, normal]
     if: >
-      github.event.action == 'opened' &&
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited') &&
       !startsWith(github.head_ref, 'mergify/')
     steps:
       - name: Assign PR Reviewer


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `assign-reviewer` job in `pr-checker.yml`:

1. Use full path `/usr/local/bin/claude` to fix `claude: command not found` on runner (runner PATH does not include `/usr/local/bin`)
2. Add `synchronize` and `edited` triggers temporarily for testing (will be removed after validation)
3. Add `continue-on-error: true` so reviewer assignment failures do not block other CI jobs or the overall workflow

## Why are the changes needed?

- The job was silently skipped because `claude` was not found in PATH
- Re-assignments on PR updates are useful during testing phase
- Reviewer assignment should never be a blocking gate for CI

## Does this PR introduce any behavior change?

- [ ] Yes, this PR will result in a change in behavior
- [x] No, this PR will not result in a change in behavior

## Checks

- [ ] I have written unit tests
- [x] I have checked the version labels which the pr will be auto-backported to the target branch

## Is this a backport pr?

- [ ] This is a backport pr