### PR TITLE
[Tool] move assign-reviewer to standalone ai-sr-skills.yml workflow

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -1,0 +1,31 @@
+name: AI SR SKILLS
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - "branch*"
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency:
+  group: AI-SR-SKILLS-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewer:
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    if: >
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited') &&
+      !startsWith(github.head_ref, 'mergify/')
+    steps:
+      - name: Assign PR Reviewer
+        run: |
+          /usr/local/bin/claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -255,13 +255,3 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/check-pr-changelist.sh
 
-  assign-reviewer:
-    runs-on: [self-hosted, normal]
-    continue-on-error: true
-    if: >
-      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'edited') &&
-      !startsWith(github.head_ref, 'mergify/')
-    steps:
-      - name: Assign PR Reviewer
-        run: |
-          /usr/local/bin/claude -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove `assign-reviewer` job from `pr-checker.yml`
- Create new standalone workflow `ai-sr-skills.yml` with the same job

## Why are the changes needed?

AI skill jobs should be fully isolated from the main PR checker pipeline. A failure (or any behavior) in an AI skill must never affect existing CI gates. `ai-sr-skills.yml` is the single place to add future AI/LLM-driven automation jobs.

Key properties of `ai-sr-skills.yml`:
- Independent `concurrency` group (`AI-SR-SKILLS-{pr}`)
- Minimal permissions (`pull-requests: write` only)
- All jobs have `continue-on-error: true`

## Does this PR introduce any behavior change?

- [ ] Yes, this PR will result in a change in behavior
- [x] No, this PR will not result in a change in behavior

## Checks

- [ ] I have written unit tests
- [x] I have checked the version labels which the pr will be auto-backported to the target branch

## Is this a backport pr?

- [ ] This is a backport pr