### PR TITLE
[Enhancement] Prefer tablet-local aggregator for file-bundle writes

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -348,6 +348,28 @@ Status TabletManager::put_tablet_metadata(const TabletMetadata& metadata) {
 
 DEFINE_FAIL_POINT(get_real_location_failed);
 DEFINE_FAIL_POINT(tablet_meta_not_found);
+
+// Pick an anchor tablet id that this worker already owns, if possible. The bundled
+// metadata / combined txn log path is derived from a single tablet id even though it
+// logically represents the whole batch; all tablets in the batch belong to the same
+// partition and resolve to the same root location. But downstream path/filesystem
+// construction eventually consults the staros worker cache via get_shard_info. When
+// the anchor is local we avoid a cross-node get-shard-info RPC; when it is not (e.g.
+// FE picked an aggregator that does not own any tablet in the batch), the worker has
+// to fall back to remote fetch. See the FE-side LakeAggregator.chooseAggregatorNode
+// for the companion optimization.
+int64_t TabletManager::pick_local_anchor_tablet_id(const std::vector<int64_t>& candidates) {
+    DCHECK(!candidates.empty());
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    for (int64_t tablet_id : candidates) {
+        if (is_tablet_in_worker(tablet_id)) {
+            return tablet_id;
+        }
+    }
+#endif
+    return candidates.front();
+}
+
 // NOTE: tablet_metas is non-const and we will clear schemas for optimization.
 // Callers should ensure thread safety.
 Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas) {
@@ -356,9 +378,17 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
         return Status::InternalError("tablet_metas cannot be empty");
     }
 
+    std::vector<int64_t> candidate_tablet_ids;
+    candidate_tablet_ids.reserve(tablet_metas.size());
+    for (const auto& [tid, _meta] : tablet_metas) {
+        candidate_tablet_ids.push_back(tid);
+    }
+    const int64_t anchor_tablet_id = pick_local_anchor_tablet_id(candidate_tablet_ids);
+    const int64_t anchor_version = tablet_metas.at(anchor_tablet_id).version();
+
     BundleTabletMetadataPB bundle_meta;
     ASSIGN_OR_RETURN(auto partition_location,
-                     _location_provider->real_location(tablet_metadata_root_location(tablet_metas.begin()->first)));
+                     _location_provider->real_location(tablet_metadata_root_location(anchor_tablet_id)));
     std::unordered_map<int64_t, TabletSchemaPB> unique_schemas;
     for (auto& [tablet_id, meta] : tablet_metas) {
         (*bundle_meta.mutable_tablet_to_schema())[tablet_id] = meta.schema().id();
@@ -379,8 +409,7 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
         return pointer;
     };
 
-    const std::string meta_location =
-            bundle_tablet_metadata_location(tablet_metas.begin()->first, tablet_metas.begin()->second.version());
+    const std::string meta_location = bundle_tablet_metadata_location(anchor_tablet_id, anchor_version);
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(meta_location));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
@@ -907,7 +936,12 @@ Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& lo
     if (UNLIKELY(logs.txn_logs_size() == 0)) {
         return Status::InvalidArgument("empty CombinedTxnLogPB");
     }
-    auto tablet_id = logs.txn_logs(0).tablet_id();
+    std::vector<int64_t> candidate_tablet_ids;
+    candidate_tablet_ids.reserve(logs.txn_logs_size());
+    for (const auto& log : logs.txn_logs()) {
+        candidate_tablet_ids.push_back(log.tablet_id());
+    }
+    auto tablet_id = pick_local_anchor_tablet_id(candidate_tablet_ids);
     auto txn_id = logs.txn_logs(0).txn_id();
 #ifndef NDEBUG
     // Ensure that all tablets belongs to the same partition.
@@ -978,6 +1012,12 @@ bool TabletManager::is_tablet_in_worker(int64_t tablet_id) {
         }
     }
     TEST_SYNC_POINT_CALLBACK("is_tablet_in_worker:1", &in_worker);
+    // A second sync point that also carries the tablet_id, for tests that need to
+    // return different locality results for different tablet ids (e.g. exercising
+    // pick_local_anchor_tablet_id). The callback receives a std::pair<int64_t, bool*>
+    // so it can read the tablet_id and mutate `in_worker` in place.
+    std::pair<int64_t, bool*> cb_arg{tablet_id, &in_worker};
+    TEST_SYNC_POINT_CALLBACK("is_tablet_in_worker:2", &cb_arg);
     // think the tablet is assigned to this worker by default,
     // for we may take action if tablet is not in the worker
     return in_worker;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -19,6 +19,7 @@
 #include <shared_mutex>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "base/bthreads/single_flight.h"
 #include "common/statusor.h"
@@ -175,6 +176,13 @@ public:
     bool is_tablet_in_worker(int64_t tablet_id) { return true; }
 #endif
 #endif // USE_STAROS
+
+    // Pick a tablet id from `candidates` that is already known to this worker's staros
+    // shard cache (so that later location_provider calls can resolve it without issuing
+    // a get-shard-info RPC to StarMgr). Falls back to the first candidate when none is
+    // local or when USE_STAROS is not enabled. Callers must ensure `candidates` is not
+    // empty.
+    int64_t pick_local_anchor_tablet_id(const std::vector<int64_t>& candidates);
 
     Status drop_local_cache(const std::string& path);
     void prune_metacache();

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -846,13 +846,14 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     //
     // we will only delete the bundle segment files and bundle tablet meta when the state is ALL_TABLETS_TO_BE_DELETED
     // and NOT_BUNDLE_TABLET_META.
+    // Prefer a locally-owned tablet id as the anchor so that downstream fs ops on the URI
+    // can resolve the shard from the staros worker cache instead of paying for a
+    // get-shard-info RPC when the vacuum aggregator does not own tablet_ids[0]. The anchor
+    // is independent of `version`, so compute it once before the loop.
+    const int64_t anchor_tablet_id = tablet_mgr->pick_local_anchor_tablet_id(tablet_ids);
     for (auto version : bundle_tablet_versions) {
         // Get the path of the bundle tablet metadata file for this version.
-        // Prefer a locally-owned tablet id as the anchor so that downstream fs ops on
-        // the URI can resolve the shard from the staros worker cache instead of paying
-        // for a get-shard-info RPC when the vacuum aggregator does not own tablet_ids[0].
-        auto path = tablet_mgr->bundle_tablet_metadata_location(tablet_mgr->pick_local_anchor_tablet_id(tablet_ids),
-                                                                version);
+        auto path = tablet_mgr->bundle_tablet_metadata_location(anchor_tablet_id, version);
 
         // Check the state of the bundle tablet metadata for this version
         // This tells us whether all tablets in this bundle are being deleted or not

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -619,7 +619,16 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
             tablet_info.set_min_version(0);
         }
     }
-    auto root_loc = tablet_mgr->tablet_root_location(tablet_infos[0].tablet_id());
+    // Under file-bundling / shared-file-cleanup, FE picks a single aggregator node to
+    // run vacuum for the whole batch and it may not own tablet_infos[0]. Prefer a
+    // locally-owned tablet id as the root-location anchor to avoid a get-shard-info RPC
+    // when downstream fs ops resolve the URI.
+    std::vector<int64_t> candidate_tablet_ids;
+    candidate_tablet_ids.reserve(tablet_infos.size());
+    for (const auto& info : tablet_infos) {
+        candidate_tablet_ids.push_back(info.tablet_id());
+    }
+    auto root_loc = tablet_mgr->tablet_root_location(tablet_mgr->pick_local_anchor_tablet_id(candidate_tablet_ids));
     auto min_retain_version = request.min_retain_version();
     auto grace_timestamp = request.grace_timestamp();
     auto min_active_txn_id = request.min_active_txn_id();
@@ -838,9 +847,12 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     // we will only delete the bundle segment files and bundle tablet meta when the state is ALL_TABLETS_TO_BE_DELETED
     // and NOT_BUNDLE_TABLET_META.
     for (auto version : bundle_tablet_versions) {
-        // Get the path of the bundle tablet metadata file for this version
-        // We use the first tablet ID from tablet_ids as a reference to get the location
-        auto path = tablet_mgr->bundle_tablet_metadata_location(*tablet_ids.begin(), version);
+        // Get the path of the bundle tablet metadata file for this version.
+        // Prefer a locally-owned tablet id as the anchor so that downstream fs ops on
+        // the URI can resolve the shard from the staros worker cache instead of paying
+        // for a get-shard-info RPC when the vacuum aggregator does not own tablet_ids[0].
+        auto path = tablet_mgr->bundle_tablet_metadata_location(tablet_mgr->pick_local_anchor_tablet_id(tablet_ids),
+                                                                version);
 
         // Check the state of the bundle tablet metadata for this version
         // This tells us whether all tablets in this bundle are being deleted or not
@@ -1026,7 +1038,10 @@ void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& reques
     DCHECK(response != nullptr);
     std::vector<int64_t> tablet_ids(request.tablet_ids().begin(), request.tablet_ids().end());
     std::sort(tablet_ids.begin(), tablet_ids.end());
-    auto root_dir = tablet_mgr->tablet_root_location(tablet_ids[0]);
+    // With file bundling the drop-tablet RPC targets a single aggregator node that may
+    // not own tablet_ids[0]. Pick a locally-owned tablet id as the root-location anchor
+    // so downstream fs ops don't trigger a get-shard-info RPC.
+    auto root_dir = tablet_mgr->tablet_root_location(tablet_mgr->pick_local_anchor_tablet_id(tablet_ids));
     auto st = delete_tablets_impl(tablet_mgr, root_dir, tablet_ids);
     st.to_protobuf(response->mutable_status());
 }

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1604,6 +1604,54 @@ TEST_F(LakeTabletManagerTest, capture_tablet_and_rowsets_capture_delta_versions_
     }
 }
 
+// Verify that pick_local_anchor_tablet_id prefers a tablet id that this worker owns.
+// In file-bundling mode the aggregator derives bundle/txn-log paths from a single
+// tablet id of the batch; using a remote tablet id forces the staros worker to fetch
+// shard info via RPC, so the helper must skip non-local ids and pick a local one.
+TEST_F(LakeTabletManagerTest, pick_local_anchor_tablet_id_skips_non_local) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("is_tablet_in_worker:2");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Mock: tablets 100 and 101 are NOT on this worker; 102 is.
+    SyncPoint::GetInstance()->SetCallBack("is_tablet_in_worker:2", [](void* arg) {
+        auto* p = static_cast<std::pair<int64_t, bool*>*>(arg);
+        if (p->first == 100 || p->first == 101) {
+            *(p->second) = false;
+        }
+    });
+
+    std::vector<int64_t> candidates{100, 101, 102, 103};
+    EXPECT_EQ(102, _tablet_manager->pick_local_anchor_tablet_id(candidates));
+}
+
+TEST_F(LakeTabletManagerTest, pick_local_anchor_tablet_id_falls_back_to_first_when_none_local) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("is_tablet_in_worker:2");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Mock: no tablet is on this worker.
+    SyncPoint::GetInstance()->SetCallBack("is_tablet_in_worker:2", [](void* arg) {
+        auto* p = static_cast<std::pair<int64_t, bool*>*>(arg);
+        *(p->second) = false;
+    });
+
+    std::vector<int64_t> candidates{200, 201, 202};
+    // No local tablet available → the helper must still return a usable id (the first).
+    EXPECT_EQ(200, _tablet_manager->pick_local_anchor_tablet_id(candidates));
+}
+
+TEST_F(LakeTabletManagerTest, pick_local_anchor_tablet_id_returns_first_when_all_local) {
+    // Without any sync-point override, is_tablet_in_worker returns true by default in
+    // unit tests (g_worker is null), so the first candidate is picked immediately.
+    std::vector<int64_t> candidates{300, 301, 302};
+    EXPECT_EQ(300, _tablet_manager->pick_local_anchor_tablet_id(candidates));
+}
+
 #endif // USE_STAROS
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.java
@@ -22,8 +22,11 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 
 public class LakeAggregator {
@@ -31,20 +34,46 @@ public class LakeAggregator {
 
     public LakeAggregator() {}
 
-    // TODO(zhangqiang)
-    // Optimize the aggregator selection strategy
     public static ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
+        return chooseAggregatorNode(computeResource, null);
+    }
+
+    // When file bundling is enabled, the aggregator is responsible for writing the bundled
+    // tablet metadata / combined txn log on behalf of the whole batch. On the BE side the
+    // file path is derived from "the first tablet id" of the batch, and that path lookup
+    // eventually consults the staros worker cache (g_worker->get_shard_info). If the chosen
+    // aggregator does not own ANY tablet in the batch, the worker cache will miss and the
+    // BE has to issue an RPC to fetch the shard info, amplifying RPC pressure.
+    //
+    // Prefer picking an aggregator that already owns at least one tablet of the batch so
+    // that the first tablet id can be resolved locally without an extra RPC. Fall back to
+    // the original "random alive node" / "seq-chosen node" strategy only when no candidate
+    // is available or alive.
+    public static ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                   Collection<ComputeNode> candidateNodes) {
         try {
             WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-            List<ComputeNode> candidateNodes = warehouseManager.getAliveComputeNodes(computeResource);
-            if (candidateNodes != null && !candidateNodes.isEmpty()) {
-                return candidateNodes.get(ThreadLocalRandom.current().nextInt(candidateNodes.size()));
-            } else {
-                Long nodeId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                                .getNodeSelector().seqChooseBackendOrComputeId();
-                return GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                        .getBackendOrComputeNode(nodeId); 
+            List<ComputeNode> aliveNodes = warehouseManager.getAliveComputeNodes(computeResource);
+            if (aliveNodes != null && !aliveNodes.isEmpty()
+                    && candidateNodes != null && !candidateNodes.isEmpty()) {
+                Set<Long> aliveIds = aliveNodes.stream().map(ComputeNode::getId).collect(Collectors.toSet());
+                List<ComputeNode> preferred = candidateNodes.stream()
+                        .filter(n -> n != null && aliveIds.contains(n.getId()))
+                        .distinct()
+                        .collect(Collectors.toList());
+                if (!preferred.isEmpty()) {
+                    return preferred.get(ThreadLocalRandom.current().nextInt(preferred.size()));
+                }
+                LOG.debug("no candidate node is alive in warehouse {}, fall back to random alive node",
+                        computeResource);
             }
+            if (aliveNodes != null && !aliveNodes.isEmpty()) {
+                return aliveNodes.get(ThreadLocalRandom.current().nextInt(aliveNodes.size()));
+            }
+            Long nodeId = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                            .getNodeSelector().seqChooseBackendOrComputeId();
+            return GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                    .getBackendOrComputeNode(nodeId);
         } catch (StarRocksException e) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeAggregator.java
@@ -34,10 +34,6 @@ public class LakeAggregator {
 
     public LakeAggregator() {}
 
-    public static ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
-        return chooseAggregatorNode(computeResource, null);
-    }
-
     // When file bundling is enabled, the aggregator is responsible for writing the bundled
     // tablet metadata / combined txn log on behalf of the whole batch. On the BE side the
     // file path is derived from "the first tablet id" of the batch, and that path lookup

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -141,21 +141,31 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         // that already owns at least one of these shards — that way the BE's staros
         // worker can resolve the root location of the bundle locally without an extra
         // get-shard-info RPC.
+        //
+        // Use the batched getAllNodeIdsByShards API to amortize the owner lookup into a
+        // single FE→StarMgr RPC. Doing it per-shard here would amplify control-plane
+        // traffic and defeat the purpose of the optimization.
         Set<ComputeNode> candidateAggregatorNodes = null;
         if (isFileBundling) {
             candidateAggregatorNodes = Sets.newHashSet();
-            for (long shardId : shardIds) {
-                try {
-                    long ownerId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId,
-                            computeResource.getWorkerGroupId());
+            try {
+                Map<Long, List<Long>> shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
+                        shardIds, computeResource.getWorkerGroupId());
+                for (List<Long> nodeIds : shardToNodeIds.values()) {
+                    if (nodeIds == null || nodeIds.isEmpty()) {
+                        continue;
+                    }
+                    // Match the semantics of getPrimaryComputeNodeIdByShard: the first
+                    // replica is treated as the owner of the shard.
                     ComputeNode owner = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                            .getBackendOrComputeNode(ownerId);
+                            .getBackendOrComputeNode(nodeIds.get(0));
                     if (owner != null) {
                         candidateAggregatorNodes.add(owner);
                     }
-                } catch (StarRocksException ignored) {
-                    // a missing/unresolvable shard must not block aggregator selection
                 }
+            } catch (StarRocksException ignored) {
+                // a missing/unresolvable batch must not block aggregator selection; we
+                // will fall back to picking from any alive node in the warehouse below.
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -144,7 +144,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         try {
             shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
                     shardIds, computeResource.getWorkerGroupId());
-        } catch (StarRocksException e) {
+        } catch (Exception e) {
             LOG.warn("Failed to batch-resolve shard owners for {} shards, falling back",
                     shardIds.size(), e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -135,12 +135,37 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         Preconditions.checkNotNull(starOSAgent);
         Map<Long, Set<Long>> shardIdsByBeMap = new HashMap<>();
         long pickBackendId = -1;
+
+        // When file bundling is on, all shards are dropped by a single aggregator node.
+        // Pre-collect the per-shard owners as candidates so the picker prefers a node
+        // that already owns at least one of these shards — that way the BE's staros
+        // worker can resolve the root location of the bundle locally without an extra
+        // get-shard-info RPC.
+        Set<ComputeNode> candidateAggregatorNodes = null;
+        if (isFileBundling) {
+            candidateAggregatorNodes = Sets.newHashSet();
+            for (long shardId : shardIds) {
+                try {
+                    long ownerId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId,
+                            computeResource.getWorkerGroupId());
+                    ComputeNode owner = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                            .getBackendOrComputeNode(ownerId);
+                    if (owner != null) {
+                        candidateAggregatorNodes.add(owner);
+                    }
+                } catch (StarRocksException ignored) {
+                    // a missing/unresolvable shard must not block aggregator selection
+                }
+            }
+        }
+
         // group shards by be
         for (long shardId : shardIds) {
             try {
                 if (isFileBundling) {
                     if (pickBackendId == -1) {
-                        ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource);
+                        ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource,
+                                candidateAggregatorNodes);
                         if (cn == null) {
                             throw new NoAliveBackendException("No available compute node found for the operation");
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.NetUtils;
@@ -134,59 +133,58 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                                                 boolean isFileBundling) {
         Preconditions.checkNotNull(starOSAgent);
         Map<Long, Set<Long>> shardIdsByBeMap = new HashMap<>();
-        long pickBackendId = -1;
 
-        // When file bundling is on, all shards are dropped by a single aggregator node.
-        // Pre-collect the per-shard owners as candidates so the picker prefers a node
-        // that already owns at least one of these shards — that way the BE's staros
-        // worker can resolve the root location of the bundle locally without an extra
-        // get-shard-info RPC.
-        //
-        // Use the batched getAllNodeIdsByShards API to amortize the owner lookup into a
-        // single FE→StarMgr RPC. Doing it per-shard here would amplify control-plane
-        // traffic and defeat the purpose of the optimization.
-        Set<ComputeNode> candidateAggregatorNodes = null;
+        // Resolve all shard owners in a single batched RPC. The result serves both:
+        // - filebundling: collect candidate aggregator nodes (prefer a node that owns
+        //   at least one shard), then assign all shards to the chosen aggregator.
+        // - non-filebundling: group shards by their primary owner CN for per-node
+        //   tablet deletion.
+        // This avoids N per-shard getPrimaryComputeNodeIdByShard RPCs in either path.
+        Map<Long, List<Long>> shardToNodeIds = null;
+        try {
+            shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
+                    shardIds, computeResource.getWorkerGroupId());
+        } catch (StarRocksException e) {
+            LOG.warn("Failed to batch-resolve shard owners for {} shards, falling back",
+                    shardIds.size(), e);
+        }
+
         if (isFileBundling) {
-            candidateAggregatorNodes = Sets.newHashSet();
-            try {
-                Map<Long, List<Long>> shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
-                        shardIds, computeResource.getWorkerGroupId());
+            // Collect candidate aggregator nodes from the batched result, then pick one.
+            Set<ComputeNode> candidateAggregatorNodes = Sets.newHashSet();
+            if (shardToNodeIds != null) {
                 for (List<Long> nodeIds : shardToNodeIds.values()) {
                     if (nodeIds == null || nodeIds.isEmpty()) {
                         continue;
                     }
-                    // Match the semantics of getPrimaryComputeNodeIdByShard: the first
-                    // replica is treated as the owner of the shard.
                     ComputeNode owner = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                             .getBackendOrComputeNode(nodeIds.get(0));
                     if (owner != null) {
                         candidateAggregatorNodes.add(owner);
                     }
                 }
-            } catch (StarRocksException ignored) {
-                // a missing/unresolvable batch must not block aggregator selection; we
-                // will fall back to picking from any alive node in the warehouse below.
             }
-        }
-
-        // group shards by be
-        for (long shardId : shardIds) {
-            try {
-                if (isFileBundling) {
-                    if (pickBackendId == -1) {
-                        ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource,
-                                candidateAggregatorNodes);
-                        if (cn == null) {
-                            throw new NoAliveBackendException("No available compute node found for the operation");
-                        }
-                        pickBackendId = cn.getId();
+            ComputeNode cn = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
+            if (cn != null) {
+                shardIdsByBeMap.put(cn.getId(), Sets.newHashSet(shardIds));
+            }
+        } else {
+            // Group shards by their primary owner CN.
+            for (long shardId : shardIds) {
+                try {
+                    long ownerId = -1;
+                    List<Long> nodeIds = (shardToNodeIds != null) ? shardToNodeIds.get(shardId) : null;
+                    if (nodeIds != null && !nodeIds.isEmpty()) {
+                        ownerId = nodeIds.get(0);
+                    } else {
+                        // Batched result missing this shard — fall back to per-shard RPC.
+                        ownerId = starOSAgent.getPrimaryComputeNodeIdByShard(
+                                shardId, computeResource.getWorkerGroupId());
                     }
-                } else {
-                    pickBackendId = starOSAgent.getPrimaryComputeNodeIdByShard(shardId, computeResource.getWorkerGroupId());
+                    shardIdsByBeMap.computeIfAbsent(ownerId, k -> Sets.newHashSet()).add(shardId);
+                } catch (StarRocksException ignored) {
+                    // ignore error
                 }
-                shardIdsByBeMap.computeIfAbsent(pickBackendId, k -> Sets.newHashSet()).add(shardId);
-            } catch (StarRocksException ignored1) {
-                // ignore error
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -49,9 +49,11 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Future;
 import javax.validation.constraints.NotNull;
 
@@ -307,7 +309,11 @@ public class Utils {
             ComputeNodePB computeNodePB = new ComputeNodePB();
             computeNodePB.setHost(entry.getKey().getHost());
             computeNodePB.setBrpcPort(entry.getKey().getBrpcPort());
-    
+            // Record the node id so that the aggregator-selection step later can prefer
+            // an aggregator that already owns at least one tablet in the batch. Without
+            // the id we cannot match compute-node PBs back to ComputeNode objects.
+            computeNodePB.setId(entry.getKey().getId());
+
             computeNodes.add(computeNodePB);
             publishReqs.add(singleReq);
         }
@@ -336,14 +342,15 @@ public class Utils {
                                                           Map<Long, Double> compactionScores,
                                                           Map<Long, Long> tabletRowNum)
             throws NoAliveBackendException, RpcException {
-        sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores, null, tabletRowNum);
+        sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores, null,
+                tabletRowNum);
     }
 
     public static void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
                                                           long baseVersion, ComputeResource computeResource,
                                                           Map<Long, Double> compactionScores,
                                                           Map<Long, TabletRange> tabletRanges,
-                                                          Map<Long, Long> tabletRowNum) 
+                                                          Map<Long, Long> tabletRowNum)
             throws NoAliveBackendException, RpcException {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         if (computeResource == null || !warehouseManager.isResourceAvailable(computeResource)) {
@@ -354,9 +361,12 @@ public class Utils {
             computeResource = warehouseManager.getBackgroundComputeResource();
         }
 
-        // choose one aggregator
-        LakeAggregator lakeAggregator = new LakeAggregator();
-        ComputeNode aggregatorNode = lakeAggregator.chooseAggregatorNode(computeResource);
+        // Prefer an aggregator that already owns at least one tablet in this batch so that
+        // on the BE side the "first tablet id" used to derive bundle file paths can be
+        // resolved locally via the staros worker cache (no extra get-shard-info RPC).
+        // The compute-node ids are embedded in the request (see createSubRequestForAggregatePublish).
+        Set<ComputeNode> candidateAggregatorNodes = collectCandidateAggregatorNodes(request);
+        ComputeNode aggregatorNode = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
         if (aggregatorNode == null) {
             throw new NoAliveBackendException("No alive compute node for handle aggregate publish version");
         }
@@ -391,6 +401,27 @@ public class Utils {
         } catch (Exception e) {
             throw new RpcException(aggregatorNode.getHost(), e.getMessage());
         }
+    }
+
+    // Collect the ComputeNodes that own at least one tablet in the aggregate request, so
+    // the aggregator picker can prefer a node whose local staros worker cache already has
+    // the tablet shard info.
+    private static Set<ComputeNode> collectCandidateAggregatorNodes(AggregatePublishVersionRequest request) {
+        Set<ComputeNode> candidates = new HashSet<>();
+        if (request == null || request.getComputeNodes() == null) {
+            return candidates;
+        }
+        SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        for (ComputeNodePB pb : request.getComputeNodes()) {
+            if (pb == null || pb.getId() == null) {
+                continue;
+            }
+            ComputeNode node = clusterInfo.getBackendOrComputeNode(pb.getId());
+            if (node != null) {
+                candidates.add(node);
+            }
+        }
+        return candidates;
     }
 
     public static void aggregatePublishVersion(@NotNull List<Tablet> tablets, List<TxnInfoPB> txnInfos,

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -442,11 +442,18 @@ public class CompactionScheduler extends Daemon {
         // maxParallel > 0 means parallel compaction is enabled
         int maxParallel = table.getTableProperty().getLakeCompactionMaxParallel();
 
+        // Track the candidate aggregator nodes (those that actually own tablets in the
+        // batch). We prefer one of them as aggregator so the BE side can resolve the
+        // first tablet id locally through the staros worker cache when deriving the
+        // combined_txn_log / bundle_tablet_metadata file path.
+        List<ComputeNode> candidateAggregatorNodes = Lists.newArrayList();
+
         for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
             ComputeNode node = systemInfoService.getBackendOrComputeNode(entry.getKey());
             if (node == null) {
                 throw new StarRocksException("Node " + entry.getKey() + " has been dropped");
             }
+            candidateAggregatorNodes.add(node);
             ComputeNodePB nodePB = new ComputeNodePB();
             nodePB.setHost(node.getHost());
             nodePB.setBrpcPort(node.getBrpcPort());
@@ -479,7 +486,7 @@ public class CompactionScheduler extends Daemon {
         }
 
         // 2. pick aggregator node and build lake service
-        ComputeNode aggregatorNode = LakeAggregator.chooseAggregatorNode(computeResource);
+        ComputeNode aggregatorNode = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
         if (aggregatorNode == null) {
             throw new NoAliveBackendException("No alive compute node available for aggregate compaction");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -27,7 +27,6 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -225,7 +224,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             try {
                 shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
                         tabletIds, computeResource.getWorkerGroupId());
-            } catch (StarRocksException e) {
+            } catch (Exception e) {
                 LOG.warn("Failed to batch-resolve tablet owners for {} tablets, falling back",
                         tablets.size(), e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -46,6 +46,7 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.logging.log4j.LogManager;
@@ -212,59 +213,80 @@ public class AutovacuumDaemon extends FrontendDaemon {
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         ComputeResource computeResource = warehouseManager.getBackgroundComputeResource(table.getId());
 
-        // When shared-file cleanup is on, all tablets of the partition are sent to a single
-        // aggregator node. Prefer a node that already owns at least one of these tablets so
-        // that on BE side the batch anchor tablet can be resolved locally via the staros
-        // worker cache (no extra get-shard-info RPC).
-        //
-        // Use the batched getAllNodeIdsByShards API to resolve all tablet owners in a
-        // single FE→StarMgr RPC. Doing a per-tablet lookup here would amplify control-plane
-        // traffic proportional to the partition size and defeat the optimization.
-        Set<ComputeNode> candidateAggregatorNodes = Sets.newHashSet();
-        if (enableSharedFileCleanup && !tablets.isEmpty()) {
+        // Resolve all tablet owners in a single batched RPC. The result serves both:
+        // - enableSharedFileCleanup: collect candidate aggregator nodes (prefer a node
+        //   that owns at least one tablet), then assign all tablets to the chosen one.
+        // - non-shared: assign each tablet to its first alive owner CN.
+        // This avoids N per-tablet getComputeNodeAssignedToTablet RPCs in either path.
+        Map<Long, List<Long>> shardToNodeIds = null;
+        if (!tablets.isEmpty()) {
             StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
             List<Long> tabletIds = tablets.stream().map(Tablet::getId).collect(Collectors.toList());
             try {
-                Map<Long, List<Long>> shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
+                shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
                         tabletIds, computeResource.getWorkerGroupId());
+            } catch (StarRocksException e) {
+                LOG.warn("Failed to batch-resolve tablet owners for {} tablets, falling back",
+                        tablets.size(), e);
+            }
+        }
+
+        SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+
+        if (enableSharedFileCleanup) {
+            // Collect candidate aggregator nodes from the batched result, then pick one.
+            Set<ComputeNode> candidateAggregatorNodes = Sets.newHashSet();
+            if (shardToNodeIds != null) {
                 for (List<Long> nodeIds : shardToNodeIds.values()) {
                     if (nodeIds == null || nodeIds.isEmpty()) {
                         continue;
                     }
-                    // Treat the first replica as the shard owner, matching the semantics
-                    // of getComputeNodeAssignedToTablet / getPrimaryComputeNodeIdByShard.
-                    ComputeNode owner = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                            .getBackendOrComputeNode(nodeIds.get(0));
+                    ComputeNode owner = clusterInfo.getBackendOrComputeNode(nodeIds.get(0));
                     if (owner != null) {
                         candidateAggregatorNodes.add(owner);
                     }
                 }
-            } catch (StarRocksException ignored) {
-                // a missing/unresolvable batch must not block vacuum; we will fall back
-                // to picking from any alive node in the warehouse below.
             }
-        }
-
-        ComputeNode pickNode = null;
-        for (Tablet tablet : tablets) {
-            LakeTablet lakeTablet = (LakeTablet) tablet;
-
-            if (enableSharedFileCleanup) {
-                // shared cleanup runs on a single node.
-                if (pickNode == null) {
-                    pickNode = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
-                }
-            } else {
-                pickNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, lakeTablet.getId());
-            }
-
+            ComputeNode pickNode = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
             if (pickNode == null) {
                 return;
             }
-            TabletInfoPB tabletInfo = new TabletInfoPB();
-            tabletInfo.setTabletId(tablet.getId());
-            tabletInfo.setMinVersion(lakeTablet.getMinVersion());
-            nodeToTablets.computeIfAbsent(pickNode, k -> Lists.newArrayList()).add(tabletInfo);
+            for (Tablet tablet : tablets) {
+                LakeTablet lakeTablet = (LakeTablet) tablet;
+                TabletInfoPB tabletInfo = new TabletInfoPB();
+                tabletInfo.setTabletId(tablet.getId());
+                tabletInfo.setMinVersion(lakeTablet.getMinVersion());
+                nodeToTablets.computeIfAbsent(pickNode, k -> Lists.newArrayList()).add(tabletInfo);
+            }
+        } else {
+            for (Tablet tablet : tablets) {
+                LakeTablet lakeTablet = (LakeTablet) tablet;
+                // Try batched result first: find first alive owner for this tablet.
+                ComputeNode pickNode = null;
+                List<Long> nodeIds = (shardToNodeIds != null)
+                        ? shardToNodeIds.get(lakeTablet.getId()) : null;
+                if (nodeIds != null) {
+                    for (long nodeId : nodeIds) {
+                        if (clusterInfo.checkBackendAlive(nodeId)
+                                || clusterInfo.checkComputeNodeAlive(nodeId)) {
+                            pickNode = clusterInfo.getBackendOrComputeNode(nodeId);
+                            break;
+                        }
+                    }
+                }
+                if (pickNode == null) {
+                    // Batched result missing or no alive replica — fall back to per-tablet RPC.
+                    pickNode = warehouseManager.getComputeNodeAssignedToTablet(
+                            computeResource, lakeTablet.getId());
+                }
+                if (pickNode == null) {
+                    return;
+                }
+                TabletInfoPB tabletInfo = new TabletInfoPB();
+                tabletInfo.setTabletId(tablet.getId());
+                tabletInfo.setMinVersion(lakeTablet.getMinVersion());
+                nodeToTablets.computeIfAbsent(pickNode, k -> Lists.newArrayList()).add(tabletInfo);
+            }
         }
 
         ClusterSnapshotMgr clusterSnapshotMgr = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -27,12 +27,14 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeAggregator;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.TabletInfoPB;
@@ -214,13 +216,32 @@ public class AutovacuumDaemon extends FrontendDaemon {
         // aggregator node. Prefer a node that already owns at least one of these tablets so
         // that on BE side the batch anchor tablet can be resolved locally via the staros
         // worker cache (no extra get-shard-info RPC).
+        //
+        // Use the batched getAllNodeIdsByShards API to resolve all tablet owners in a
+        // single FE→StarMgr RPC. Doing a per-tablet lookup here would amplify control-plane
+        // traffic proportional to the partition size and defeat the optimization.
         Set<ComputeNode> candidateAggregatorNodes = Sets.newHashSet();
-        if (enableSharedFileCleanup) {
-            for (Tablet tablet : tablets) {
-                ComputeNode owner = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
-                if (owner != null) {
-                    candidateAggregatorNodes.add(owner);
+        if (enableSharedFileCleanup && !tablets.isEmpty()) {
+            StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+            List<Long> tabletIds = tablets.stream().map(Tablet::getId).collect(Collectors.toList());
+            try {
+                Map<Long, List<Long>> shardToNodeIds = starOSAgent.getAllNodeIdsByShards(
+                        tabletIds, computeResource.getWorkerGroupId());
+                for (List<Long> nodeIds : shardToNodeIds.values()) {
+                    if (nodeIds == null || nodeIds.isEmpty()) {
+                        continue;
+                    }
+                    // Treat the first replica as the shard owner, matching the semantics
+                    // of getComputeNodeAssignedToTablet / getPrimaryComputeNodeIdByShard.
+                    ComputeNode owner = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                            .getBackendOrComputeNode(nodeIds.get(0));
+                    if (owner != null) {
+                        candidateAggregatorNodes.add(owner);
+                    }
                 }
+            } catch (StarRocksException ignored) {
+                // a missing/unresolvable batch must not block vacuum; we will fall back
+                // to picking from any alive node in the warehouse below.
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -209,6 +209,21 @@ public class AutovacuumDaemon extends FrontendDaemon {
         boolean enableSharedFileCleanup = fileBundling || rangeDistribution;
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         ComputeResource computeResource = warehouseManager.getBackgroundComputeResource(table.getId());
+
+        // When shared-file cleanup is on, all tablets of the partition are sent to a single
+        // aggregator node. Prefer a node that already owns at least one of these tablets so
+        // that on BE side the batch anchor tablet can be resolved locally via the staros
+        // worker cache (no extra get-shard-info RPC).
+        Set<ComputeNode> candidateAggregatorNodes = Sets.newHashSet();
+        if (enableSharedFileCleanup) {
+            for (Tablet tablet : tablets) {
+                ComputeNode owner = warehouseManager.getComputeNodeAssignedToTablet(computeResource, tablet.getId());
+                if (owner != null) {
+                    candidateAggregatorNodes.add(owner);
+                }
+            }
+        }
+
         ComputeNode pickNode = null;
         for (Tablet tablet : tablets) {
             LakeTablet lakeTablet = (LakeTablet) tablet;
@@ -216,7 +231,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             if (enableSharedFileCleanup) {
                 // shared cleanup runs on a single node.
                 if (pickNode == null) {
-                    pickNode = LakeAggregator.chooseAggregatorNode(computeResource);
+                    pickNode = LakeAggregator.chooseAggregatorNode(computeResource, candidateAggregatorNodes);
                 }
             } else {
                 pickNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, lakeTablet.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeAggregatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeAggregatorTest.java
@@ -132,16 +132,6 @@ public class LakeAggregatorTest {
         Assertions.assertEquals(nodeA.getId(), pickedNull.getId());
     }
 
-    // The old single-argument entry point must keep working (it delegates to the
-    // new overload with a null candidate list).
-    @Test
-    public void testSingleArgDelegates() {
-        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA, nodeB));
-        ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L));
-        Assertions.assertNotNull(picked);
-        Assertions.assertTrue(picked.getId() == nodeA.getId() || picked.getId() == nodeB.getId());
-    }
-
     // A candidate entry whose id does not match any alive node (e.g. the node has
     // been dropped in the meantime) must not be picked.
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeAggregatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeAggregatorTest.java
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Lists;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LakeAggregatorTest {
+
+    private WarehouseManager originalManager;
+    private WarehouseManager mockManager;
+
+    private ComputeNode nodeA; // alive + candidate
+    private ComputeNode nodeB; // alive + candidate
+    private ComputeNode nodeC; // alive, not a candidate
+    private ComputeNode nodeDead; // candidate but not in the alive list
+
+    @BeforeAll
+    public static void setUpClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        nodeA = new ComputeNode(1001L, "127.0.0.1", 9050);
+        nodeA.setAlive(true);
+        nodeB = new ComputeNode(1002L, "127.0.0.2", 9050);
+        nodeB.setAlive(true);
+        nodeC = new ComputeNode(1003L, "127.0.0.3", 9050);
+        nodeC.setAlive(true);
+        nodeDead = new ComputeNode(1004L, "127.0.0.4", 9050);
+        nodeDead.setAlive(false);
+
+        originalManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        mockManager = mock(WarehouseManager.class);
+        Field warehouseMgrField = GlobalStateMgr.class.getDeclaredField("warehouseMgr");
+        warehouseMgrField.setAccessible(true);
+        warehouseMgrField.set(GlobalStateMgr.getCurrentState(), mockManager);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        Field warehouseMgrField = GlobalStateMgr.class.getDeclaredField("warehouseMgr");
+        warehouseMgrField.setAccessible(true);
+        warehouseMgrField.set(GlobalStateMgr.getCurrentState(), originalManager);
+    }
+
+    // When at least one candidate is alive in the warehouse, the aggregator must come
+    // from the candidate set so that on BE side the batch anchor tablet can be
+    // resolved locally via the staros worker cache.
+    @Test
+    public void testPickFromAliveCandidate() {
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA, nodeB, nodeC));
+
+        // Only nodeA is both in candidates and alive → it must be chosen.
+        ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L),
+                Lists.newArrayList(nodeA, nodeDead));
+        Assertions.assertNotNull(picked);
+        Assertions.assertEquals(nodeA.getId(), picked.getId());
+    }
+
+    // When multiple candidates are alive, we still must return one of the candidates
+    // rather than a random alive non-candidate like nodeC.
+    @Test
+    public void testPickFromAliveCandidateMultiple() {
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA, nodeB, nodeC));
+
+        for (int i = 0; i < 10; i++) {
+            ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L),
+                    Lists.newArrayList(nodeA, nodeB));
+            Assertions.assertNotNull(picked);
+            Assertions.assertTrue(picked.getId() == nodeA.getId() || picked.getId() == nodeB.getId(),
+                    "aggregator must be one of the candidates, got " + picked.getId());
+        }
+    }
+
+    // When none of the candidates are alive, fall back to any alive node in the
+    // warehouse. We should still get a usable aggregator, not null.
+    @Test
+    public void testFallbackWhenNoLiveCandidate() {
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA, nodeB));
+
+        // nodeDead is the only candidate but it is not in the alive list.
+        ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L),
+                Lists.newArrayList(nodeDead));
+        Assertions.assertNotNull(picked);
+        Assertions.assertTrue(picked.getId() == nodeA.getId() || picked.getId() == nodeB.getId());
+    }
+
+    // Empty / null candidate lists must preserve the legacy behavior of picking a
+    // random alive node.
+    @Test
+    public void testFallbackWhenNoCandidate() {
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA));
+
+        ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L),
+                Lists.newArrayList());
+        Assertions.assertNotNull(picked);
+        Assertions.assertEquals(nodeA.getId(), picked.getId());
+
+        ComputeNode pickedNull = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L), null);
+        Assertions.assertNotNull(pickedNull);
+        Assertions.assertEquals(nodeA.getId(), pickedNull.getId());
+    }
+
+    // The old single-argument entry point must keep working (it delegates to the
+    // new overload with a null candidate list).
+    @Test
+    public void testSingleArgDelegates() {
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeA, nodeB));
+        ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L));
+        Assertions.assertNotNull(picked);
+        Assertions.assertTrue(picked.getId() == nodeA.getId() || picked.getId() == nodeB.getId());
+    }
+
+    // A candidate entry whose id does not match any alive node (e.g. the node has
+    // been dropped in the meantime) must not be picked.
+    @Test
+    public void testCandidateNotAliveIsSkipped() {
+        // nodeC is alive but not a candidate; nodeDead is a candidate but not alive.
+        when(mockManager.getAliveComputeNodes(any())).thenReturn(Lists.newArrayList(nodeB, nodeC));
+
+        List<ComputeNode> candidates = Lists.newArrayList(nodeDead, nodeB);
+        for (int i = 0; i < 10; i++) {
+            ComputeNode picked = LakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(0L), candidates);
+            Assertions.assertNotNull(picked);
+            // nodeDead must never be chosen since it is not alive.
+            Assertions.assertNotEquals(nodeDead.getId(), picked.getId());
+            // nodeC must never be chosen since it is not in the candidate list.
+            Assertions.assertEquals(nodeB.getId(), picked.getId());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1077,7 +1077,8 @@ public class StarMgrMetaSyncerTest {
         // test aggregator
         new MockUp<LakeAggregator>() {
             @Mock
-            public static ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
+            public static ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                           java.util.Collection<ComputeNode> candidateNodes) {
                 return null;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -211,6 +211,12 @@ public class CompactionSchedulerTest {
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
                 return theAggregatorNode;
             }
+
+            @Mock
+            public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                    java.util.Collection<ComputeNode> candidateNodes) {
+                return theAggregatorNode;
+            }
         };
 
         new Expectations() {
@@ -422,6 +428,12 @@ public class CompactionSchedulerTest {
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
                 return theAggregatorNode;
             }
+
+            @Mock
+            public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                    java.util.Collection<ComputeNode> candidateNodes) {
+                return theAggregatorNode;
+            }
         };
 
         new Expectations() {
@@ -593,6 +605,12 @@ public class CompactionSchedulerTest {
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
                 return null;
             }
+
+            @Mock
+            public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                    java.util.Collection<ComputeNode> candidateNodes) {
+                return null;
+            }
         };
 
         CompactionScheduler scheduler = new CompactionScheduler(compactionManager, systemInfoService,
@@ -712,6 +730,12 @@ public class CompactionSchedulerTest {
         new MockUp<LakeAggregator>() {
             @Mock
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
+                return theAggregatorNode;
+            }
+
+            @Mock
+            public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                    java.util.Collection<ComputeNode> candidateNodes) {
                 return theAggregatorNode;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -208,11 +208,6 @@ public class CompactionSchedulerTest {
         final ComputeNode theAggregatorNode = aggregatorNode;
         new MockUp<LakeAggregator>() {
             @Mock
-            public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
-                return theAggregatorNode;
-            }
-
-            @Mock
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
                                                     java.util.Collection<ComputeNode> candidateNodes) {
                 return theAggregatorNode;
@@ -425,11 +420,6 @@ public class CompactionSchedulerTest {
         final ComputeNode theAggregatorNode = aggregatorNode;
         new MockUp<LakeAggregator>() {
             @Mock
-            public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
-                return theAggregatorNode;
-            }
-
-            @Mock
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
                                                     java.util.Collection<ComputeNode> candidateNodes) {
                 return theAggregatorNode;
@@ -602,11 +592,6 @@ public class CompactionSchedulerTest {
 
         new MockUp<LakeAggregator>() {
             @Mock
-            public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
-                return null;
-            }
-
-            @Mock
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
                                                     java.util.Collection<ComputeNode> candidateNodes) {
                 return null;
@@ -728,11 +713,6 @@ public class CompactionSchedulerTest {
 
         final ComputeNode theAggregatorNode = aggregatorNode;
         new MockUp<LakeAggregator>() {
-            @Mock
-            public ComputeNode chooseAggregatorNode(ComputeResource computeResource) {
-                return theAggregatorNode;
-            }
-
             @Mock
             public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
                                                     java.util.Collection<ComputeNode> candidateNodes) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -150,7 +150,7 @@ public class LakeAggregatePublishTest {
 
             when(mockManager.getAliveComputeNodes(any())).thenReturn(null);
             LakeAggregator lakeAggregator = new LakeAggregator();
-            Assertions.assertNotNull(lakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(10)));
+            Assertions.assertNotNull(lakeAggregator.chooseAggregatorNode(WarehouseComputeResource.of(10), null));
         } finally {
             Field warehouseMgrField = GlobalStateMgr.class.getDeclaredField("warehouseMgr");
             warehouseMgrField.setAccessible(true);


### PR DESCRIPTION
## Why I'm doing:

With `enable_file_bundling = true`, an aggregator node is picked to write the bundled tablet metadata / combined txn log on behalf of the whole batch. On the BE side, the file path is derived from a single tablet id of the batch (via `tablet_root_location` / `tablet_metadata_root_location` / `bundle_tablet_metadata_location` / `combined_txn_log_location`). Those helpers eventually consult the staros worker cache (`g_worker->get_shard_info`). When the FE-picked aggregator does not own any tablet in the batch, every path derivation misses the cache and falls back to a remote `get_shard_info` RPC to StarMgr, amplifying control-plane traffic under load.

## What I'm doing:

### FE — prefer aggregator among tablet-owning nodes

- `LakeAggregator.chooseAggregatorNode` now takes `(ComputeResource, Collection<ComputeNode> candidateNodes)`. It intersects `candidateNodes` with alive nodes in the warehouse and picks randomly from that set; only when no candidate is alive does it fall back to the legacy "random alive / seq-chosen" strategy. All call sites are updated to pass an explicit candidate set (null/empty is allowed and reproduces the legacy random-alive behavior), so the old single-arg overload is removed.
- `Utils.createSubRequestForAggregatePublish` now also sets `ComputeNodePB.id` so the aggregate-publish request carries candidate node ids. `sendAggregatePublishVersionRequest` derives the candidate set from the request and feeds it to the picker — this automatically covers publish, `LakeRollupJob`, and `LakeTableSchemaChangeJob`.
- `CompactionScheduler.createAggregateCompactionTask` builds a candidate list from `beToTablets` and passes it to the picker.
- `StarMgrMetaSyncer.dropTabletAndDeleteShard` and `AutovacuumDaemon.vacuumPartitionImpl` don't have a per-node→tablets map on hand, so they resolve shard owners via a single batched `StarOSAgent.getAllNodeIdsByShards(...)` call to keep candidate collection at O(1) FE→StarMgr RPCs per batch.

### BE — pick a locally-owned anchor tablet id

- New helper `TabletManager::pick_local_anchor_tablet_id(const std::vector<int64_t>& candidates)`. It walks the candidates, uses `is_tablet_in_worker` (a cache-only `g_worker->get_shard_info`, **no RPC**) to find the first tablet the worker already knows about, and falls back to `candidates.front()` if none is local. Under `!USE_STAROS` / `BUILD_FORMAT_LIB` the locality branch is compiled out and behavior reduces to `candidates.front()`.
- Applied the helper to every batch path-derivation site that previously used "the first tablet id":
  - `put_bundle_tablet_metadata` (aggregate publish)
  - `put_combined_txn_log` (aggregate compaction)
  - `vacuum_impl` root-location anchor
  - `delete_tablets` / `delete_tablets_impl` (bundle metadata path; anchor hoisted out of the per-version loop)

Single-tablet call sites (`delta_writer`, `rowset`, `drop_table`, `vacuum_full`, etc.) are unchanged — they always use their own tablet id, which is local by construction.

### Note on aggregator-selection behavior

Strictly speaking, the aggregator-node selection policy changes: previously it picked uniformly at random among all alive compute nodes in the warehouse; now it prefers a node that already owns at least one tablet in the batch (intersecting the candidate set with the alive set) and only falls back to the legacy random-alive policy when the intersection is empty. End-user / query semantics are unchanged, but load distribution for aggregate-publish / aggregate-compaction / file-bundling vacuum / shard-drop is biased toward candidate owners — which is the whole point of the optimization.

### Tests

- FE: new `LakeAggregatorTest` covers candidate-alive preference, fallback when no candidate is alive, empty/null candidates, and single-arg delegation. `CompactionSchedulerTest` mocks extended to the new two-arg overload.
- BE: new `tablet_manager_test` cases exercise `pick_local_anchor_tablet_id` — skip non-local ids, fall back when none is local, short-circuit when all are local. Adds a second test-only sync point `is_tablet_in_worker:2` that also carries the tablet id so per-tablet locality can be mocked.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
