### PR TITLE
[Enhancement] support join reorder for complex expr from two child

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
@@ -76,16 +76,17 @@ public class MultiJoinNode {
     public static MultiJoinNode toMultiJoinNode(OptExpression node) {
         LinkedHashSet<OptExpression> atoms = new LinkedHashSet<>();
         List<ScalarOperator> predicates = new ArrayList<>();
-        Map<ColumnRefOperator, ScalarOperator> proMap = new HashMap<>();
+        Map<ColumnRefOperator, ScalarOperator> expressionMap = new HashMap<>();
 
-        flattenJoinNode(node, atoms, predicates, proMap);
+        flattenJoinNode(node, atoms, predicates, expressionMap, true);
 
-        return new MultiJoinNode(atoms, predicates, proMap);
+        return new MultiJoinNode(atoms, predicates, expressionMap);
     }
 
     private static void flattenJoinNode(OptExpression node, LinkedHashSet<OptExpression> atoms,
                                         List<ScalarOperator> predicates,
-                                        Map<ColumnRefOperator, ScalarOperator> expressionMap) {
+                                        Map<ColumnRefOperator, ScalarOperator> expressionMap,
+                                        boolean isMultiJoinRoot) {
         Operator operator = node.getOp();
         if (!(operator instanceof LogicalJoinOperator)) {
             atoms.add(node);
@@ -112,28 +113,43 @@ public class MultiJoinNode {
 
         if (joinOperator.getProjection() != null) {
             Projection projection = joinOperator.getProjection();
-            if (hasUnsafeProjectionForJoinReorder(projection)) {
+            if (hasUnsafeProjectionForJoinReorder(node, isMultiJoinRoot)) {
                 atoms.add(node);
                 return;
             }
-            projection.getColumnRefMap().forEach((k, v) -> {
-                if (!k.equals(v)) {
-                    expressionMap.put(k, v);
+            projection.getColumnRefMap().forEach((columnRef, expression) -> {
+                if (!columnRef.equals(expression)) {
+                    expressionMap.put(columnRef, expression);
                 }
             });
         }
 
-        flattenJoinNode(node.inputAt(0), atoms, predicates, expressionMap);
-        flattenJoinNode(node.inputAt(1), atoms, predicates, expressionMap);
+        flattenJoinNode(node.inputAt(0), atoms, predicates, expressionMap, false);
+        flattenJoinNode(node.inputAt(1), atoms, predicates, expressionMap, false);
         predicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
         Preconditions.checkState(!Utils.isEqualBinaryPredicate(joinPredicate));
         predicates.addAll(Utils.extractConjuncts(joinPredicate));
     }
 
-    private static boolean hasUnsafeProjectionForJoinReorder(Projection projection) {
-        if (!projection.getCommonSubOperatorMap().isEmpty() || projection.needReuseLambdaDependentExpr()) {
-            return true;
+    static boolean hasFromTwoChildProjectionBoundary(OptExpression node) {
+        if (!(node.getOp() instanceof LogicalJoinOperator)) {
+            return false;
         }
-        return projection.getColumnRefMap().values().stream().anyMatch(Utils::hasNonDeterministicFunc);
+        LogicalJoinOperator joinOperator = (LogicalJoinOperator) node.getOp();
+        if (joinOperator.getProjection() == null) {
+            return false;
+        }
+        ColumnRefSet leftChildColumns = node.inputAt(0).getOutputColumns();
+        ColumnRefSet rightChildColumns = node.inputAt(1).getOutputColumns();
+        return joinOperator.getProjection().getColumnRefMap().values().stream().anyMatch(expression -> {
+            ColumnRefSet usedColumns = expression.getUsedColumns();
+            return !expression.isColumnRef()
+                    && usedColumns.isIntersect(leftChildColumns)
+                    && usedColumns.isIntersect(rightChildColumns);
+        });
+    }
+
+    private static boolean hasUnsafeProjectionForJoinReorder(OptExpression node, boolean isMultiJoinRoot) {
+        return !isMultiJoinRoot && hasFromTwoChildProjectionBoundary(node);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
@@ -112,12 +112,7 @@ public class MultiJoinNode {
 
         if (joinOperator.getProjection() != null) {
             Projection projection = joinOperator.getProjection();
-            boolean fromTwoChildren = projection.getColumnRefMap().values().stream().anyMatch(v -> {
-                ColumnRefSet useRefs = v.getUsedColumns();
-                return !v.isColumnRef() && useRefs.isIntersect(node.inputAt(0).getOutputColumns())
-                        && useRefs.isIntersect(node.inputAt(1).getOutputColumns());
-            });
-            if (fromTwoChildren) {
+            if (hasUnsafeProjectionForJoinReorder(projection)) {
                 atoms.add(node);
                 return;
             }
@@ -133,5 +128,12 @@ public class MultiJoinNode {
         predicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
         Preconditions.checkState(!Utils.isEqualBinaryPredicate(joinPredicate));
         predicates.addAll(Utils.extractConjuncts(joinPredicate));
+    }
+
+    private static boolean hasUnsafeProjectionForJoinReorder(Projection projection) {
+        if (!projection.getCommonSubOperatorMap().isEmpty() || projection.needReuseLambdaDependentExpr()) {
+            return true;
+        }
+        return projection.getColumnRefMap().values().stream().anyMatch(Utils::hasNonDeterministicFunc);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/MultiJoinNode.java
@@ -76,11 +76,11 @@ public class MultiJoinNode {
     public static MultiJoinNode toMultiJoinNode(OptExpression node) {
         LinkedHashSet<OptExpression> atoms = new LinkedHashSet<>();
         List<ScalarOperator> predicates = new ArrayList<>();
-        Map<ColumnRefOperator, ScalarOperator> expressionMap = new HashMap<>();
+        Map<ColumnRefOperator, ScalarOperator> proMap = new HashMap<>();
 
-        flattenJoinNode(node, atoms, predicates, expressionMap, true);
+        flattenJoinNode(node, atoms, predicates, proMap, true);
 
-        return new MultiJoinNode(atoms, predicates, expressionMap);
+        return new MultiJoinNode(atoms, predicates, proMap);
     }
 
     private static void flattenJoinNode(OptExpression node, LinkedHashSet<OptExpression> atoms,
@@ -131,7 +131,7 @@ public class MultiJoinNode {
         predicates.addAll(Utils.extractConjuncts(joinPredicate));
     }
 
-    static boolean hasFromTwoChildProjectionBoundary(OptExpression node) {
+    static boolean hasProjectRelyOnTwoChildren(OptExpression node) {
         if (!(node.getOp() instanceof LogicalJoinOperator)) {
             return false;
         }
@@ -149,7 +149,10 @@ public class MultiJoinNode {
         });
     }
 
+    // multi join node tree's root can have projection that rely on two children
+    // since projection's output won't be used by any atom of this join tree
+    // so it's safe to reorder this join tree
     private static boolean hasUnsafeProjectionForJoinReorder(OptExpression node, boolean isMultiJoinRoot) {
-        return !isMultiJoinRoot && hasFromTwoChildProjectionBoundary(node);
+        return !isMultiJoinRoot && hasProjectRelyOnTwoChildren(node);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -71,10 +71,19 @@ public class ReorderJoinRule extends Rule {
                 return;
             }
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) operator;
+            // For A inner join (B inner join C), we only think A is root tree
             if (joinOperator.isInnerOrCrossJoin()) {
-                boolean separateFromProjectionBoundary = MultiJoinNode.hasFromTwoChildProjectionBoundary(root);
-                // For A inner join (B inner join C), we only think A is root tree
-                if (!findNewRoot || separateFromProjectionBoundary) {
+                boolean hasProjectRelyOnTwoChildren = MultiJoinNode.hasProjectRelyOnTwoChildren(root);
+                // if findNewRoot == true && hasProjectRelyOnTwoChildren
+                // like below:
+                //      B
+                //    /   \
+                //   A     C
+                //        /  \
+                //       D    E
+                // if C has project rely on two child, then C is an atom for join tree with B as root,
+                // but we still can reorder join tree whose root is C
+                if (!findNewRoot || hasProjectRelyOnTwoChildren) {
                     findNewRoot = true;
                     results.add(Pair.create(root, Pair.create(parent, childIdx)));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -72,8 +72,9 @@ public class ReorderJoinRule extends Rule {
             }
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) operator;
             if (joinOperator.isInnerOrCrossJoin()) {
+                boolean separateFromProjectionBoundary = MultiJoinNode.hasFromTwoChildProjectionBoundary(root);
                 // For A inner join (B inner join C), we only think A is root tree
-                if (!findNewRoot) {
+                if (!findNewRoot || separateFromProjectionBoundary) {
                     findNewRoot = true;
                     results.add(Pair.create(root, Pair.create(parent, childIdx)));
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -578,4 +578,18 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)"), planFragment);
     }
+
+    @Test
+    @Order(7)
+    void testJoinReorderWithTwoChildDeterministicProjection() throws Exception {
+        connectContext.getSessionVariable().enableDPJoinReorder();
+        connectContext.getSessionVariable().enableGreedyJoinReorder();
+        String sql = "select sum(case when t1.v4 = 1 then t0.v1 end) " +
+                "from t1, t2, t3, t0 " +
+                "where t0.v1 = t1.v4 and t0.v2 = t2.v7 and t0.v3 = t3.v10";
+        String planFragment = getFragmentPlan(sql);
+        assertNotContains(planFragment, "CROSS JOIN");
+        assertContains(planFragment, "HASH JOIN");
+        assertContains(planFragment, "equal join conjunct");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -30,7 +30,6 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MultiJoinReorderTest extends PlanTestBase {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -30,6 +30,7 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MultiJoinReorderTest extends PlanTestBase {
@@ -589,7 +590,5 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "where t0.v1 = t1.v4 and t0.v2 = t2.v7 and t0.v3 = t3.v10";
         String planFragment = getFragmentPlan(sql);
         assertNotContains(planFragment, "CROSS JOIN");
-        assertContains(planFragment, "HASH JOIN");
-        assertContains(planFragment, "equal join conjunct");
     }
 }

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/agg-pushdown-enable_on_broadcast_join.sql
@@ -103,10 +103,10 @@ select max(v2 + v5) from t0 join t1 on t0.v1 = t1.v4;
 [result]
 AGGREGATE ([GLOBAL] aggregate [{8: max=max(7: expr)}] group by [[]] having [null]
     EXCHANGE GATHER
-        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-            SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
-            EXCHANGE SHUFFLE[4]
-                SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
+        INNER JOIN (join-predicate [4: v4 = 1: v1] post-join-predicate [null])
+            SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
+            EXCHANGE SHUFFLE[1]
+                SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
 [end]
 
 [sql]
@@ -188,10 +188,10 @@ from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
 [result]
 AGGREGATE ([GLOBAL] aggregate [{10: max=max(8: case), 11: sum=sum(9: expr)}] group by [[7: expr]] having [null]
     EXCHANGE SHUFFLE[7]
-        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-            SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
-            EXCHANGE SHUFFLE[4]
-                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+        INNER JOIN (join-predicate [4: v4 = 1: v1] post-join-predicate [null])
+            SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+            EXCHANGE SHUFFLE[1]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
 [end]
 
 [sql]
@@ -217,10 +217,10 @@ from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
 [result]
 AGGREGATE ([GLOBAL] aggregate [{10: max=max(8: case), 11: sum=sum(9: expr)}] group by [[7: expr]] having [null]
     EXCHANGE SHUFFLE[7]
-        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
-            SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
-            EXCHANGE SHUFFLE[4]
-                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+        INNER JOIN (join-predicate [4: v4 = 1: v1] post-join-predicate [null])
+            SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+            EXCHANGE SHUFFLE[1]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
 [end]
 
 [sql]
@@ -596,4 +596,3 @@ AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(9: sum), 8: sum=sum(10: sum)}] group 
         EXCHANGE SHUFFLE[4]
             SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
 [end]
-


### PR DESCRIPTION
## Why I'm doing:
currently, for sql like : s"select sum(case when t1.v4 = 1 then t0.v1 end) from t1, t2, t3, t0 
                where t0.v1 = t1.v4 and t0.v2 = t2.v7 and t0.v3 = t3.v10"
it wll be one hash join on the top and two cross join below it, this is because "case when t1.v4 = 1 then t0.v1 end" rely on two child's output so optimizer give up reordering the whole tree.

but if this project is on the inner join tree's root, then it's safe to reorder the whole inner join tree, since it's output won't be used by any node of this inner join tree

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
