### PR TITLE
[BugFix] Align builtin inverted MATCH_ALL/MATCH_ANY tokenization with parser settings

### DIFF
--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -330,13 +330,7 @@ Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string&
         for (const auto& predicate : predicates) {
             roaring.clear();
             Slice s(predicate);
-            // After parser-aware tokenization, '%' is typically preserved only for parser=none.
-            // Keep this branch so MATCH_ALL/MATCH_ANY can still reuse wildcard semantics in that mode.
-            if (predicate.find('%') != std::string::npos) {
-                RETURN_IF_ERROR(_wildcard_query(&s, &roaring));
-            } else {
-                RETURN_IF_ERROR(_equal_query(&s, &roaring));
-            }
+            RETURN_IF_ERROR(_equal_query(&s, &roaring));
 
             if (first) {
                 *bitmap = std::move(roaring);

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -15,8 +15,13 @@
 #include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
 
 #include <CLucene.h>
+#include <CLucene/analysis/LanguageBasedAnalyzer.h>
+#include <fmt/format.h>
 
+#include <boost/locale/encoding_errors.hpp>
+#include <boost/locale/encoding_utf.hpp>
 #include <memory>
+#include <vector>
 
 #include "common/runtime_profile.h"
 #include "exprs/function_context.h"
@@ -24,6 +29,77 @@
 #include "storage/chunk_helper.h"
 
 namespace starrocks {
+BuiltinInvertedIndexIterator::BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta,
+                                                           InvertedReader* reader, OlapReaderStatistics* stats,
+                                                           std::unique_ptr<BitmapIndexIterator>& bitmap_itr,
+                                                           const size_t& segment_rows)
+        : InvertedIndexIterator(index_meta, reader, stats),
+          _bitmap_itr(std::move(bitmap_itr)),
+          _segment_rows(segment_rows) {
+    if (_analyser_type == InvertedIndexParserType::PARSER_ENGLISH) {
+        _builtin_query_analyzer = std::make_unique<SimpleAnalyzer>();
+    } else if (_analyser_type == InvertedIndexParserType::PARSER_STANDARD) {
+        _query_analyzer = std::make_unique<lucene::analysis::standard::StandardAnalyzer>();
+    } else if (_analyser_type == InvertedIndexParserType::PARSER_CHINESE) {
+        auto chinese_analyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
+        chinese_analyzer->setLanguage(L"cjk");
+        _query_analyzer.reset(chinese_analyzer);
+    }
+
+    if (_query_analyzer != nullptr) {
+        _query_string_reader = std::make_unique<lucene::util::StringReader>(L"");
+    }
+}
+
+Status BuiltinInvertedIndexIterator::_tokenize_query_by_parser(const Slice& query, std::vector<std::string>* tokens) {
+    tokens->clear();
+    std::string query_str = query.to_string();
+    if (query_str.empty()) {
+        return Status::OK();
+    }
+
+    switch (_analyser_type) {
+    case InvertedIndexParserType::PARSER_NONE:
+        tokens->emplace_back(std::move(query_str));
+        return Status::OK();
+    case InvertedIndexParserType::PARSER_ENGLISH: {
+        std::vector<SliceToken> slice_tokens;
+        _builtin_query_analyzer->tokenize(query_str.data(), query_str.size(), slice_tokens);
+        tokens->reserve(slice_tokens.size());
+        for (const auto& token : slice_tokens) {
+            if (!token.empty()) {
+                tokens->emplace_back(token.text.to_string());
+            }
+        }
+        return Status::OK();
+    }
+    case InvertedIndexParserType::PARSER_STANDARD:
+    case InvertedIndexParserType::PARSER_CHINESE: {
+        try {
+            std::wstring wquery = boost::locale::conv::utf_to_utf<TCHAR>(query_str);
+            _query_string_reader->init(wquery.c_str(), wquery.size(), false);
+            auto stream = _query_analyzer->reusableTokenStream(L"", _query_string_reader.get());
+            lucene::analysis::Token token;
+            while (stream->next(&token)) {
+                if (token.termLength() == 0) {
+                    continue;
+                }
+                tokens->emplace_back(boost::locale::conv::utf_to_utf<char>(token.termBuffer(),
+                                                                           token.termBuffer() + token.termLength()));
+            }
+        } catch (const boost::locale::conv::conversion_error& e) {
+            return Status::InvalidArgument(fmt::format("Invalid UTF-8 query for inverted index: {}", e.what()));
+        } catch (const std::exception& e) {
+            return Status::InternalError(fmt::format("Failed to tokenize inverted index query with parser {}: {}",
+                                                     inverted_index_parser_type_to_string(_analyser_type), e.what()));
+        }
+        return Status::OK();
+    }
+    default:
+        return Status::NotSupported("Unsupported parser type for builtin inverted query tokenization");
+    }
+}
+
 std::string get_next_prefix(const Slice& prefix_s) {
     std::string next_prefix = prefix_s.to_string();
 
@@ -232,6 +308,7 @@ Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string&
                                                               InvertedIndexQueryType query_type,
                                                               roaring::Roaring* bitmap) {
     const auto* search_query = reinterpret_cast<const Slice*>(query_value);
+    bitmap->clear();
     switch (query_type) {
     case InvertedIndexQueryType::EQUAL_QUERY: {
         RETURN_IF_ERROR(_equal_query(search_query, bitmap));
@@ -243,15 +320,19 @@ Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string&
     }
     case InvertedIndexQueryType::MATCH_ALL_QUERY:
     case InvertedIndexQueryType::MATCH_ANY_QUERY: {
-        std::string search_query_str = search_query->to_string();
-        std::istringstream iss(search_query_str);
-        std::string cur_predicate;
+        std::vector<std::string> predicates;
+        RETURN_IF_ERROR(_tokenize_query_by_parser(*search_query, &predicates));
+        if (predicates.empty()) {
+            return Status::OK();
+        }
         bool first = true;
         roaring::Roaring roaring;
-        while (iss >> cur_predicate) {
+        for (const auto& predicate : predicates) {
             roaring.clear();
-            Slice s(cur_predicate);
-            if (cur_predicate.find('%') != std::string::npos) {
+            Slice s(predicate);
+            // After parser-aware tokenization, '%' is typically preserved only for parser=none.
+            // Keep this branch so MATCH_ALL/MATCH_ANY can still reuse wildcard semantics in that mode.
+            if (predicate.find('%') != std::string::npos) {
                 RETURN_IF_ERROR(_wildcard_query(&s, &roaring));
             } else {
                 RETURN_IF_ERROR(_equal_query(&s, &roaring));
@@ -267,7 +348,6 @@ Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string&
             } else {
                 DCHECK(false) << "do not support query type";
             }
-            cur_predicate.clear();
         }
         break;
     }

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -14,7 +14,13 @@
 
 #pragma once
 
+#include <CLucene.h>
+
+#include <memory>
+#include <vector>
+
 #include "base/string/slice.h"
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
 #include "storage/index/inverted/inverted_index_iterator.h"
 #include "storage/rowset/bitmap_index_reader.h"
 
@@ -27,10 +33,7 @@ class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
 public:
     BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
                                  OlapReaderStatistics* stats, std::unique_ptr<BitmapIndexIterator>& bitmap_itr,
-                                 const size_t& segment_rows)
-            : InvertedIndexIterator(index_meta, reader, stats),
-              _bitmap_itr(std::move(bitmap_itr)),
-              _segment_rows(segment_rows) {}
+                                 const size_t& segment_rows);
 
     ~BuiltinInvertedIndexIterator() override = default;
 
@@ -40,10 +43,18 @@ public:
     Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
 
 private:
+    Status _tokenize_query_by_parser(const Slice& query, std::vector<std::string>* tokens);
+
     Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
 
     Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
 
+    // Reused CLucene analyzer for parser=standard/chinese query tokenization.
+    std::unique_ptr<lucene::analysis::Analyzer> _query_analyzer;
+    // Reused input buffer paired with _query_analyzer to avoid per-query allocations.
+    std::unique_ptr<lucene::util::StringReader> _query_string_reader;
+    // Reused builtin analyzer for parser=english query tokenization.
+    std::unique_ptr<SimpleAnalyzer> _builtin_query_analyzer;
     std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
     size_t _segment_rows;
 };

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -123,6 +123,55 @@ TEST_F(BuiltinInvertedIndexTest, test_parser_none_equal_query) {
     delete iter;
 }
 
+TEST_F(BuiltinInvertedIndexTest, test_parser_none_match_all_uses_whole_query) {
+    std::vector<std::string> values = {"hello world", "hello", "world"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/parser_none_match_all";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    roaring::Roaring bitmap;
+    Slice query("hello world");
+    ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
+    ASSERT_EQ(1, bitmap.cardinality());
+    ASSERT_TRUE(bitmap.contains(0));
+
+    delete iter;
+}
+
 // Test tokenized english parser: verify equality and prefix wildcard behaviour.
 TEST_F(BuiltinInvertedIndexTest, test_english_parser_queries) {
     // Values:
@@ -276,10 +325,10 @@ TEST_F(BuiltinInvertedIndexTest, test_english_parser_match_any_all_queries) {
         ASSERT_FALSE(bitmap.contains(3));
     }
 
-    // MATCH_ANY with wildcard tokens "he% wor%" should behave the same as above.
+    // MATCH_ANY with punctuation-delimited tokens should use the configured parser instead of space splitting.
     {
         roaring::Roaring bitmap;
-        std::string pattern = std::string("he% wor%");
+        std::string pattern = std::string("hello,world");
         Slice query(pattern);
         ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ANY_QUERY, &bitmap));
         ASSERT_EQ(3, bitmap.cardinality());
@@ -289,10 +338,10 @@ TEST_F(BuiltinInvertedIndexTest, test_english_parser_match_any_all_queries) {
         ASSERT_FALSE(bitmap.contains(3));
     }
 
-    // MATCH_ALL with wildcard tokens "he% wor%" should also hit only row 0.
+    // MATCH_ALL with punctuation-delimited tokens should also follow parser tokenization.
     {
         roaring::Roaring bitmap;
-        std::string pattern = std::string("he% wor%");
+        std::string pattern = std::string("hello,world");
         Slice query(pattern);
         ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
         ASSERT_EQ(1, bitmap.cardinality());
@@ -685,22 +734,71 @@ TEST_F(BuiltinInvertedIndexTest, test_mixed_token_queries) {
     InvertedIndexIterator* iter = nullptr;
     ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
 
-    // MATCH_ANY: "apple banan%" should hit all 3 rows
+    // MATCH_ANY follows parser tokenization, so use plain tokens here.
     {
         roaring::Roaring bitmap;
-        Slice query("apple banan%");
+        Slice query("apple banana");
         ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ANY_QUERY, &bitmap));
         ASSERT_EQ(3, bitmap.cardinality());
     }
 
-    // MATCH_ALL: "apple fru%" should hit only row 1
+    // MATCH_ALL follows parser tokenization, so use plain tokens here.
     {
         roaring::Roaring bitmap;
-        Slice query("apple fru%");
+        Slice query("apple fruit");
         ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
         ASSERT_EQ(1, bitmap.cardinality());
         ASSERT_TRUE(bitmap.contains(1));
     }
+
+    delete iter;
+}
+
+TEST_F(BuiltinInvertedIndexTest, test_chinese_parser_low_cardinality_match_all) {
+    std::vector<std::string> values = {"低基数", "低基数", "高基数", "高基数", "低基数优化"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_CHINESE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/chinese_low_cardinality";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = slices.size();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    roaring::Roaring bitmap;
+    Slice query("低基数");
+    ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
+    ASSERT_EQ(3, bitmap.cardinality());
+    ASSERT_TRUE(bitmap.contains(0));
+    ASSERT_TRUE(bitmap.contains(1));
+    ASSERT_TRUE(bitmap.contains(4));
+    ASSERT_FALSE(bitmap.contains(2));
+    ASSERT_FALSE(bitmap.contains(3));
 
     delete iter;
 }


### PR DESCRIPTION
## Why I'm doing:

  Builtin inverted index uses parser-specific tokenization when building the index,
  but `MATCH_ALL/MATCH_ANY` still split query text by whitespace only at read time.

  This makes query behavior inconsistent with index write semantics. For example:
  - `parser = none`: `match_all('hello world')` is split into `hello` and `world`
  - `parser = english/standard/chinese`: query text with punctuation or CJK content
    is not tokenized by the configured parser

## What I'm doing:

  Use parser-aware tokenization for builtin inverted `MATCH_ALL/MATCH_ANY`:
  - `parser = none`: keep the whole query as one term
  - `parser = english`: use builtin `SimpleAnalyzer`
  - `parser = standard/chinese`: use the corresponding `CLucene analyzer`

  This makes builtin inverted index query behavior consistent with its write path
  and closer to the existing clucene implementation.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
