### PR TITLE
[BugFix] Calculate statistics in SplitWindowSkewToUnionRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
@@ -34,4 +34,6 @@ public class OpRuleBit {
     public static final int OP_MV_AGG_PRUNE_COLUMNS = 4;
     // Operator has been push down topn below agg or not, if push down topn, no need to push down again.
     public static final int OP_PUSH_DOWN_TOPN_AGG = 5;
+    // Window operator has been split by the window skew rewrite, no need to split again.
+    public static final int OP_SPLIT_WINDOW_SKEW = 6;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -46,6 +47,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static com.starrocks.sql.optimizer.operator.OpRuleBit.OP_SPLIT_WINDOW_SKEW;
 
 /*
  * Rule Objective:
@@ -120,6 +123,10 @@ public class SplitWindowSkewToUnionRule extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         if (input.getOp() instanceof LogicalWindowOperator lwo) {
+            if (lwo.isOpRuleBitSet(OP_SPLIT_WINDOW_SKEW)) {
+                return false;
+            }
+
             List<ScalarOperator> partitionExprs = lwo.getPartitionExpressions();
 
             // Rule only applies if there is exactly one partition expression,
@@ -206,8 +213,14 @@ public class SplitWindowSkewToUnionRule extends TransformationRule {
 
         // 4. Build Union
         LogicalUnionOperator unionOp = buildUnionOperator(context, child, window, unskewedBranch);
+        OptExpression unionExpr = OptExpression.create(unionOp, skewedBranch.root, unskewedBranch.root);
+        // The split builds a fresh UNION subtree and the duplicated branch starts without logical properties or
+        // statistics. Derive logical properties first so statistics estimators can inspect output columns, then
+        // calculate fresh statistics for the duplicated branch.
+        deriveLogicalProperty(unionExpr);
+        Utils.calculateStatistics(unionExpr, context);
 
-        return Lists.newArrayList(OptExpression.create(unionOp, skewedBranch.root, unskewedBranch.root));
+        return Lists.newArrayList(unionExpr);
     }
 
     private LogicalUnionOperator buildUnionOperator(OptimizerContext context,
@@ -280,7 +293,20 @@ public class SplitWindowSkewToUnionRule extends TransformationRule {
             windowBuilder.setPartitionExpressions(partitionExprs);
         }
 
-        return new BranchResult(OptExpression.create(windowBuilder.build(), filterExpr), mapping);
+        LogicalWindowOperator branchWindow = windowBuilder.build();
+        branchWindow.setOpRuleBit(OP_SPLIT_WINDOW_SKEW);
+        return new BranchResult(OptExpression.create(branchWindow, filterExpr), mapping);
+    }
+
+    private void deriveLogicalProperty(OptExpression root) {
+        if (root.getLogicalProperty() != null) {
+            return;
+        }
+
+        for (OptExpression child : root.getInputs()) {
+            deriveLogicalProperty(child);
+        }
+        root.deriveLogicalPropertyItself();
     }
 
     private List<ScalarOperator> rewriteExpressions(List<ScalarOperator> exprs, OptExpressionDuplicator duplicator) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowSkewTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -42,6 +43,7 @@ class WindowSkewTest extends PlanTestBase {
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
+        Config.enable_sync_statistics_load = true;
         connectContext.getGlobalStateMgr().setStatisticStorage(new CachedStatisticStorage());
         starRocksAssert.withTable(
                 """
@@ -51,6 +53,22 @@ class WindowSkewTest extends PlanTestBase {
                           `x` int NULL
                         ) ENGINE=OLAP
                         DUPLICATE KEY(`p`, `s`, `x`)
+                        DISTRIBUTED BY HASH(`p`) BUCKETS 3
+                        PROPERTIES (
+                          "replication_num" = "1",
+                          "in_memory" = "false"
+                        );
+                        """
+        );
+        starRocksAssert.withTable(
+                """
+                        CREATE TABLE `window_skew_table_multi_part` (
+                          `p` int NULL,
+                          `p1` int NULL,
+                          `s` int NULL,
+                          `x` int NULL
+                        ) ENGINE=OLAP
+                        DUPLICATE KEY(`p`, `p1`, `s`, `x`)
                         DISTRIBUTED BY HASH(`p`) BUCKETS 3
                         PROPERTIES (
                           "replication_num" = "1",
@@ -97,11 +115,13 @@ class WindowSkewTest extends PlanTestBase {
     private StatisticStorage storage() {
         return connectContext.getGlobalStateMgr().getStatisticStorage();
     }
-
-    private void setColumnStatForP(double nullsFraction) {
+    private void setColumnStatFor(double nullsFraction, String col) {
         final var stat = ColumnStatistic.builder().setNullsFraction(nullsFraction).build();
-        storage().addColumnStatistic(table(), "p", stat);
+        storage().addColumnStatistic(table(), col, stat);
         storage().getColumnStatistics(table(), ALL_COLUMNS);
+    }
+    private void setColumnStatForP(double nullsFraction) {
+        setColumnStatFor(nullsFraction, "p");
     }
 
     private void refreshAndSetColumnStatForP(ColumnStatistic stat) {
@@ -118,7 +138,8 @@ class WindowSkewTest extends PlanTestBase {
         assertContains(plan, "UNION");
         long analyticCount = plan.lines().filter(l -> l.contains("ANALYTIC")).count();
         assertEquals(expectedAnalyticCount, analyticCount,
-                "Expected exactly 2 ANALYTIC operators after UNION split, but found " + analyticCount);
+                "Expected exactly " + expectedAnalyticCount
+                        + " ANALYTIC operators after UNION split, but found " + analyticCount);
     }
 
     private void assertPlanHasUnionAndAnalytic(String plan) {
@@ -656,7 +677,36 @@ class WindowSkewTest extends PlanTestBase {
         String plan = getCostPlan(sql);
         assertPlanHasUnionAndAnalytic(plan, 4);
     }
+    @Test
+    void testTwoWindowsWithDifferentPartitionColumn() throws Exception {
+        final String multiPartTable = "window_skew_table_multi_part";
+        final var table = getOlapTable(multiPartTable);
+        final var statP = ColumnStatistic.builder().setNullsFraction(0.8).build();
+        final var statP1 = ColumnStatistic.builder().setNullsFraction(0.8).build();
+        storage().addColumnStatistic(table, "p", statP);
+        storage().addColumnStatistic(table, "p1", statP1);
+        setTableStatistics(table, 1000);
+        String sql = "select p, s, " +
+                "sum(x) over (partition by p order by s), " +
+                "avg(x) over (partition by p1 order by s) " +
+                "from " + multiPartTable;
 
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan, 6);
+    }
+    @Test
+    void testTwoWindowsOneWithDifferentSortColumn() throws Exception {
+        setColumnStatFor(0.8, "p");
+        String sql = "select p, s, " +
+                "sum(x) over (partition by p order by s), " +
+                "avg(x) over (partition by p order by x) " +
+                "from " + TABLE_NAME;
+
+        String plan = getCostPlan(sql);
+        assertPlanHasUnionAndAnalytic(plan, 6);
+
+
+    }
     @Test
     void testWindowSkewDuplicatorRemapsSkewColumn() throws Exception {
 
@@ -669,8 +719,7 @@ class WindowSkewTest extends PlanTestBase {
 
         String plan = getCostPlan(sql);
 
-        assertContains(plan, "UNION");
-        assertContains(plan, "ANALYTIC");
+        assertPlanHasUnionAndAnalytic(plan, 6);
         assertNullSplit(plan);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When `OptExpressionDuplicator` duplicates a plan subtree (used by `SplitWindowSkewToUnionRule`), Statistics are not propagated to the duplicated OptExpression nodes. This causes downstream instances of the same rule to operate on duplicated branches that have no statistics, leading to incorrect plan choices.
## What I'm doing:
Recalculate statistics for the duplicated branch on each invocation of `SplitWindowSkewToUnionRule`. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
