### PR TITLE
[Enhancement] Enabling dictification for eq_for_null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -97,7 +97,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.ast.expression.BinaryType.EQ_FOR_NULL;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 
@@ -1623,9 +1622,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         @Override
         public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
-            if (predicate.getBinaryType() == EQ_FOR_NULL) {
-                return forbidden(visitChildren(predicate, context), predicate);
-            }
             return merge(visitChildren(predicate, context), predicate);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1438,7 +1438,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
 
         sql = "select count(t.a) from(select S_ADDRESS <=> 'kks' as a from supplier) as t";
         plan = getVerboseExplain(sql);
-        Assertions.assertTrue(plan.contains("[3: S_ADDRESS, VARCHAR, false] <=> 'kks'"));
+        Assertions.assertTrue(plan.contains("DictDecode([11: S_ADDRESS, INT, false], [<place-holder> <=> 'kks'])"), plan);
 
         sql = "select S_ADDRESS not like '%key%' from supplier";
         plan = getVerboseExplain(sql);

--- a/test/sql/test_global_dict/R/dict_basic_query
+++ b/test/sql/test_global_dict/R/dict_basic_query
@@ -142,3 +142,8 @@ select * from (select max(v1) over (partition by v2) mv1 from t1) t where mv1 !=
 -- result:
 98
 -- !result
+select v1, v1 <=> 'a', v1 <=> 'b', v1 <=> null from t4 order by v1;
+-- result:
+None	0	0	1
+a	1	0	0
+-- !result

--- a/test/sql/test_global_dict/T/dict_basic_query
+++ b/test/sql/test_global_dict/T/dict_basic_query
@@ -66,3 +66,5 @@ select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1
 select v1, if(v1='a', null, 'b') from t4 order by 1;
 
 select * from (select max(v1) over (partition by v2) mv1 from t1) t where mv1 != '99' order by mv1 desc limit 1;
+
+select v1, v1 <=> 'a', v1 <=> 'b', v1 <=> null from t4 order by v1;


### PR DESCRIPTION
## Why I'm doing:
Currently eq_for_null (<=>) is not getting dictified (it might have been due to the bug fixed in https://github.com/StarRocks/starrocks/pull/69376). We can safely dictify it now. 

## What I'm doing:
Enabling dictification for eq_for_null.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
