### PR TITLE
[BugFix] Cache SpaceUsedLong() to prevent SIGSEGV in ColumnReader destructor

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -90,29 +90,33 @@ ColumnReader::ColumnReader(const private_type&, Segment* segment) : _segment(seg
 }
 
 ColumnReader::~ColumnReader() {
+    // Use cached SpaceUsedLong() values instead of calling the virtual method on the
+    // protobuf objects. If heap memory is corrupted by an external bug, the protobuf
+    // vtable may be zeroed/invalid, causing SIGSEGV in SpaceUsedLong().
+    // See POST-1334 / GitHub #71283 for details.
     if (_segment_zone_map != nullptr) {
         MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->segment_zonemap_mem_tracker(),
-                                 _segment_zone_map->SpaceUsedLong());
+                                 _cached_segment_zone_map_size);
         _segment_zone_map.reset(nullptr);
     }
     if (_ordinal_index_meta != nullptr) {
         MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(),
-                                 _ordinal_index_meta->SpaceUsedLong());
+                                 _cached_ordinal_index_meta_size);
         _ordinal_index_meta.reset(nullptr);
     }
     if (_zonemap_index_meta != nullptr) {
         MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(),
-                                 _zonemap_index_meta->SpaceUsedLong());
+                                 _cached_zonemap_index_meta_size);
         _zonemap_index_meta.reset(nullptr);
     }
     if (_bitmap_index_meta != nullptr) {
         MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
-                                 _bitmap_index_meta->SpaceUsedLong());
+                                 _cached_bitmap_index_meta_size);
         _bitmap_index_meta.reset(nullptr);
     }
     if (_bloom_filter_index_meta != nullptr) {
         MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(),
-                                 _bloom_filter_index_meta->SpaceUsedLong());
+                                 _cached_bloom_filter_index_meta_size);
         _bloom_filter_index_meta.reset(nullptr);
     }
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_metadata_mem_tracker(), sizeof(ColumnReader));
@@ -157,9 +161,10 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
             switch (index_meta->type()) {
             case ORDINAL_INDEX:
                 _ordinal_index_meta.reset(index_meta->release_ordinal_index());
+                _cached_ordinal_index_meta_size = _ordinal_index_meta->SpaceUsedLong();
                 MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(),
-                                         _ordinal_index_meta->SpaceUsedLong());
-                _meta_mem_usage.fetch_add(_ordinal_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
+                                         _cached_ordinal_index_meta_size);
+                _meta_mem_usage.fetch_add(_cached_ordinal_index_meta_size, std::memory_order_relaxed);
                 _ordinal_index = std::make_unique<OrdinalIndexReader>();
                 break;
             case ZONE_MAP_INDEX:
@@ -175,28 +180,32 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
                     delete _segment_zone_map->release_min();
                     delete _segment_zone_map->release_max();
                 }
+                _cached_zonemap_index_meta_size = _zonemap_index_meta->SpaceUsedLong();
                 MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(),
-                                         _zonemap_index_meta->SpaceUsedLong())
-                _meta_mem_usage.fetch_add(_zonemap_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
+                                         _cached_zonemap_index_meta_size)
+                _meta_mem_usage.fetch_add(_cached_zonemap_index_meta_size, std::memory_order_relaxed);
                 // the segment zone map will release from zonemap_index_map,
                 // so we should calc mem usage after release.
+                _cached_segment_zone_map_size = _segment_zone_map->SpaceUsedLong();
                 MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->segment_zonemap_mem_tracker(),
-                                         _segment_zone_map->SpaceUsedLong())
-                _meta_mem_usage.fetch_add(_segment_zone_map->SpaceUsedLong(), std::memory_order_relaxed);
+                                         _cached_segment_zone_map_size)
+                _meta_mem_usage.fetch_add(_cached_segment_zone_map_size, std::memory_order_relaxed);
                 _zonemap_index = std::make_unique<ZoneMapIndexReader>();
                 break;
             case BITMAP_INDEX:
                 _bitmap_index_meta.reset(index_meta->release_bitmap_index());
+                _cached_bitmap_index_meta_size = _bitmap_index_meta->SpaceUsedLong();
                 MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
-                                         _bitmap_index_meta->SpaceUsedLong());
-                _meta_mem_usage.fetch_add(_bitmap_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
+                                         _cached_bitmap_index_meta_size);
+                _meta_mem_usage.fetch_add(_cached_bitmap_index_meta_size, std::memory_order_relaxed);
                 _bitmap_index = std::make_unique<BitmapIndexReader>();
                 break;
             case BLOOM_FILTER_INDEX:
                 _bloom_filter_index_meta.reset(index_meta->release_bloom_filter_index());
+                _cached_bloom_filter_index_meta_size = _bloom_filter_index_meta->SpaceUsedLong();
                 MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(),
-                                         _bloom_filter_index_meta->SpaceUsedLong());
-                _meta_mem_usage.fetch_add(_bloom_filter_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
+                                         _cached_bloom_filter_index_meta_size);
+                _meta_mem_usage.fetch_add(_cached_bloom_filter_index_meta_size, std::memory_order_relaxed);
                 _bloom_filter_index = std::make_unique<BloomFilterIndexReader>();
                 break;
             case UNKNOWN_INDEX_TYPE:

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -110,8 +110,7 @@ ColumnReader::~ColumnReader() {
         _zonemap_index_meta.reset(nullptr);
     }
     if (_bitmap_index_meta != nullptr) {
-        MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
-                                 _cached_bitmap_index_meta_size);
+        MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), _cached_bitmap_index_meta_size);
         _bitmap_index_meta.reset(nullptr);
     }
     if (_bloom_filter_index_meta != nullptr) {

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -260,6 +260,16 @@ private:
     std::unique_ptr<BitmapIndexPB> _bitmap_index_meta;
     std::unique_ptr<BloomFilterIndexPB> _bloom_filter_index_meta;
 
+    // Cached SpaceUsedLong() values recorded at init time.
+    // Used in the destructor to release memory tracking without calling the virtual
+    // SpaceUsedLong() method, which can crash if the protobuf object's heap memory
+    // has been corrupted by an external bug (see POST-1334 / #71283).
+    size_t _cached_segment_zone_map_size = 0;
+    size_t _cached_ordinal_index_meta_size = 0;
+    size_t _cached_zonemap_index_meta_size = 0;
+    size_t _cached_bitmap_index_meta_size = 0;
+    size_t _cached_bloom_filter_index_meta_size = 0;
+
     std::unique_ptr<ZoneMapIndexReader> _zonemap_index;
     std::unique_ptr<OrdinalIndexReader> _ordinal_index;
     std::unique_ptr<BitmapIndexReader> _bitmap_index;


### PR DESCRIPTION
## Summary
- Cache protobuf `SpaceUsedLong()` values at `ColumnReader::_init()` time
- Use cached values in `~ColumnReader()` instead of calling the virtual method
- Prevents SIGSEGV when protobuf heap memory is corrupted by an external bug

## Background
Multiple customers (Demandbase 3.5.15, Sands 3.3.11, #71283 4.0.8, #71579 3.3.22) report SIGSEGV in `ColumnReader::~ColumnReader()` at `SpaceUsedLong()`. The crash occurs because the protobuf object's vtable pointer is zeroed (freed/corrupted heap memory), causing dereference at offsets 0x88/0x98.

This is a **defensive fix** — the root cause (heap memory corruption) still needs ASAN investigation. But this eliminates the crash in the destructor path.

## Test plan
- [ ] Verify memory tracking values are consistent (cached == runtime)
- [ ] Stress test with concurrent PK writes + table drops + garbage sweep
- [ ] Run ASAN build to verify no new issues introduced

Fixes: POST-1334
Related: #71283, #71579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
