### PR TITLE
[Refactor] Remove legacy maintenance-plan state from FE MV objects

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -87,7 +87,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
-import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
@@ -627,9 +626,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     private List<ExpressionSerializedObject> serializedPartitionRefTableExprs;
     @Deprecated
     private List<Expr> partitionRefTableExprs;
-
-    // Maintenance plan for this MV
-    private transient ExecPlan maintenancePlan;
 
     // NOTE: The `maxMVRewriteStaleness` option helps you achieve consistently high performance
     // with controlled costs when processing large, frequently changing datasets.
@@ -2105,14 +2101,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     MvUtils.formatBaseTableInfos(baseTableInfos)));
         }
         return result;
-    }
-
-    public ExecPlan getMaintenancePlan() {
-        return maintenancePlan;
-    }
-
-    public void setMaintenancePlan(ExecPlan maintenancePlan) {
-        this.maintenancePlan = maintenancePlan;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
@@ -57,10 +57,13 @@ import java.util.stream.Collectors;
 class IMTCreator {
     private static final Logger LOG = LogManager.getLogger(IMTCreator.class);
 
-    public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) throws DdlException {
-        ExecPlan maintenancePlan = stmt.getMaintenancePlan();
+    static void createIMT(CreateMaterializedViewStatement stmt,
+                          MaterializedView view,
+                          ExecPlan maintenancePlan,
+                          ColumnRefFactory columnRefFactory) throws DdlException {
         OptExpression optExpr = maintenancePlan.getPhysicalPlan();
-        List<CreateTableStmt> createTables = IMTCreatorVisitor.createIMTForOperator(stmt, optExpr, view);
+        List<CreateTableStmt> createTables =
+                IMTCreatorVisitor.createIMTForOperator(stmt, optExpr, view, columnRefFactory);
 
         for (CreateTableStmt create : createTables) {
             LOG.info("creating IMT {} for MV {}", create.getTableName(), view.getName());
@@ -77,14 +80,17 @@ class IMTCreator {
     static class IMTCreatorVisitor extends OptExpressionVisitor<Void, Void> {
         private CreateMaterializedViewStatement stmt;
         private MaterializedView view;
+        private ColumnRefFactory columnRefFactory;
         private List<CreateTableStmt> result = new ArrayList<>();
 
         public static List<CreateTableStmt> createIMTForOperator(CreateMaterializedViewStatement stmt,
                                                                  OptExpression optExpr,
-                                                                 MaterializedView view) {
+                                                                 MaterializedView view,
+                                                                 ColumnRefFactory columnRefFactory) {
             IMTCreatorVisitor visitor = new IMTCreatorVisitor();
             visitor.stmt = stmt;
             visitor.view = view;
+            visitor.columnRefFactory = columnRefFactory;
             visitor.visit(visitor, optExpr);
             return visitor.result;
         }
@@ -117,7 +123,6 @@ class IMTCreator {
         @Override
         public Void visitPhysicalStreamAgg(OptExpression optExpr, Void ctx) {
             MVOperatorProperty property = optExpr.getMvOperatorProperty();
-            ColumnRefFactory columnRefFactory = stmt.getColumnRefFactory();
             Map<String, String> properties = view.getProperties();
 
             if (!property.getModify().isInsertOnly()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -100,7 +100,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
     private transient Map<Long, MVMaintenanceTask> taskMap;
     private transient BiMap<Long, TNetworkAddress> taskId2Addr;
 
-    public MVMaintenanceJob(MaterializedView view) {
+    MVMaintenanceJob(MaterializedView view, ExecPlan plan) {
         this.jobId = view.getId();
         this.dbId = view.getDbId();
         this.viewId = view.getId();
@@ -108,7 +108,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         this.epoch = new MVEpoch(view.getMvId());
         this.serializedState = JobState.INIT;
         this.state.set(JobState.INIT);
-        this.plan = Preconditions.checkNotNull(view.getMaintenancePlan());
+        this.plan = Preconditions.checkNotNull(plan);
     }
 
     // TODO recover the entire job state, include execution plan
@@ -227,11 +227,10 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         }
 
         // Build  query coordinator
-        ExecPlan execPlan = this.view.getMaintenancePlan();
-        List<PlanFragment> fragments = execPlan.getFragments();
-        List<ScanNode> scanNodes = execPlan.getScanNodes();
-        TDescriptorTable descTable = execPlan.getDescTbl().toThrift();
-        JobSpec jobSpec = JobSpec.Factory.fromMVMaintenanceJobSpec(connectContext, fragments, scanNodes, descTable, execPlan);
+        List<PlanFragment> fragments = plan.getFragments();
+        List<ScanNode> scanNodes = plan.getScanNodes();
+        TDescriptorTable descTable = plan.getDescTbl().toThrift();
+        JobSpec jobSpec = JobSpec.Factory.fromMVMaintenanceJobSpec(connectContext, fragments, scanNodes, descTable, plan);
         this.queryCoordinator = new CoordinatorPreprocessor(connectContext, jobSpec, false);
         this.epochCoordinator = new TxnBasedEpochCoordinator(this);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MaterializedViewMgr.java
@@ -32,6 +32,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TMVMaintenanceTasks;
 import com.starrocks.thrift.TMVReportEpochTask;
@@ -141,7 +142,10 @@ public class MaterializedViewMgr {
      * 3. Create job for MV maintenance
      * 4. Compute physical topology of MV job
      */
-    public void prepareMaintenanceWork(CreateMaterializedViewStatement stmt, MaterializedView view)
+    void prepareMaintenanceWork(CreateMaterializedViewStatement stmt,
+                                MaterializedView view,
+                                ExecPlan execPlan,
+                                ColumnRefFactory columnRefFactory)
             throws DdlException {
         if (!view.getRefreshScheme().isIncremental()) {
             return;
@@ -152,14 +156,13 @@ public class MaterializedViewMgr {
                 throw new DdlException("MV already existed");
             }
             // Prepare the table sink for exec-plan
-            ExecPlan execPlan = stmt.getMaintenancePlan();
             PlanFragment sinkFragment = execPlan.getTopFragment();
             OlapTableSink tableSink = (OlapTableSink) sinkFragment.getSink();
             tableSink.setDstTable(view);
             tableSink.setPartitionIds(view.getAllPartitionIds());
 
             // Create the job but not execute it
-            MVMaintenanceJob job = new MVMaintenanceJob(view);
+            MVMaintenanceJob job = new MVMaintenanceJob(view, execPlan);
             // TODO(murphy) atomic persist the meta of MV (IMT, MaintenancePlan) along with materialized view
             AtomicBoolean jobExist = new AtomicBoolean(false);
             GlobalStateMgr.getCurrentState().getEditLog().logMVJobState(job, wal -> {
@@ -168,7 +171,7 @@ public class MaterializedViewMgr {
                 }
             });
             if (!jobExist.get()) {
-                IMTCreator.createIMT(stmt, view);
+                IMTCreator.createIMT(stmt, view, execPlan, columnRefFactory);
             }
             LOG.info("create the maintenance job for MV: {}", view.getName());
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -23,9 +23,7 @@ import com.starrocks.catalog.Index;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.sql.plan.ExecPlan;
 
 import java.util.List;
 import java.util.Map;
@@ -83,10 +81,6 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private MaterializedView.RefreshMode currentRefreshMode = MaterializedView.RefreshMode.PCT;
     // the encode row id version deduced by analyzer
     private int encodeRowIdVersion = 0;
-
-    // Maintenance information
-    ExecPlan maintenancePlan;
-    ColumnRefFactory columnRefFactory;
 
     // Sink table information
     private List<Column> mvColumnItems = Lists.newArrayList();
@@ -341,25 +335,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.partitionRefTableExprs = partitionRefTableExprs;
     }
 
-    public ExecPlan getMaintenancePlan() {
-        return maintenancePlan;
-    }
-
-    public ColumnRefFactory getColumnRefFactory() {
-        return columnRefFactory;
-    }
-
     public List<Integer> getQueryOutputIndices() {
         return queryOutputIndices;
     }
 
     public void setQueryOutputIndices(List<Integer> queryOutputIndices) {
         this.queryOutputIndices = queryOutputIndices;
-    }
-
-    public void setMaintenancePlan(ExecPlan maintenancePlan, ColumnRefFactory columnRefFactory) {
-        this.maintenancePlan = maintenancePlan;
-        this.columnRefFactory = columnRefFactory;
     }
 
     public Map<Integer, Column> getGeneratedPartitionCols() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -30,6 +30,7 @@ import com.starrocks.catalog.LightWeightIcebergTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -58,6 +59,7 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.mv.MaterializedViewMgr;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -2973,7 +2975,9 @@ public class CreateMaterializedViewTest extends MVTestBase {
                     (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(testDb.getFullName(),
                             "async_mv_1");
             Assertions.assertFalse(mv.getRefreshScheme().isIncremental());
-            Assertions.assertNull(mv.getMaintenancePlan());
+            Method getJob = MaterializedViewMgr.class.getDeclaredMethod("getJob", MvId.class);
+            getJob.setAccessible(true);
+            Assertions.assertNull(getJob.invoke(GlobalStateMgr.getCurrentState().getMaterializedViewMgr(), mv.getMvId()));
             Assertions.assertTrue(mv.getFullSchema().get(0).isKey());
             Assertions.assertFalse(mv.getFullSchema().get(1).isKey());
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVMaintenanceJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVMaintenanceJobTest.java
@@ -45,7 +45,7 @@ public class MVMaintenanceJobTest extends PlanTestBase {
         MaterializedView view = new MaterializedView();
         view.setId(1024);
         view.setName("view1");
-        view.setMaintenancePlan(new ExecPlan());
+        ExecPlan plan = new ExecPlan();
 
         List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
         BaseTableInfo baseTableInfo1 = new BaseTableInfo(100L, "db", "tbl1", 1L);
@@ -57,7 +57,7 @@ public class MVMaintenanceJobTest extends PlanTestBase {
 
         view.setBaseTableInfos(baseTableInfos);
 
-        MVMaintenanceJob job = new MVMaintenanceJob(view);
+        MVMaintenanceJob job = new MVMaintenanceJob(view, plan);
         assertFalse(job.isRunnable());
 
         job.startJob();
@@ -108,9 +108,8 @@ public class MVMaintenanceJobTest extends PlanTestBase {
         view.setDbId(dbId);
         view.setId(1024);
         view.setName("view1");
-        view.setMaintenancePlan(pair.second);
 
-        MVMaintenanceJob job = new MVMaintenanceJob(view);
+        MVMaintenanceJob job = new MVMaintenanceJob(view, pair.second);
         job.buildContext();
         job.buildPhysicalTopology();
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MaterializedViewMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MaterializedViewMgrEditLogTest.java
@@ -71,6 +71,20 @@ public class MaterializedViewMgrEditLogTest {
     private static final long INDEX_ID = 80006L;
     private static final long TABLET_ID = 80007L;
 
+    private static final class MaintenanceWorkInput {
+        private final CreateMaterializedViewStatement stmt;
+        private final ExecPlan execPlan;
+        private final ColumnRefFactory columnRefFactory;
+
+        private MaintenanceWorkInput(CreateMaterializedViewStatement stmt,
+                                     ExecPlan execPlan,
+                                     ColumnRefFactory columnRefFactory) {
+            this.stmt = stmt;
+            this.execPlan = execPlan;
+            this.columnRefFactory = columnRefFactory;
+        }
+    }
+
     @BeforeEach
     public void setUp() throws Exception {
         UtFrameUtils.setUpForPersistTest();
@@ -125,15 +139,11 @@ public class MaterializedViewMgrEditLogTest {
         baseTableInfos.add(baseTableInfo);
         mv.setBaseTableInfos(baseTableInfos);
         
-        // Set maintenance plan (required for MVMaintenanceJob)
-        ExecPlan execPlan = new ExecPlan();
-        mv.setMaintenancePlan(execPlan);
-        
         return mv;
     }
 
-    private CreateMaterializedViewStatement createCreateMaterializedViewStatement(MaterializedView mv) throws Exception {
-        // Create a mock CreateMaterializedViewStatement with maintenance plan
+    private MaintenanceWorkInput createMaintenanceWorkInput(MaterializedView mv) throws Exception {
+        // Create a mock CreateMaterializedViewStatement with explicit maintenance inputs
         CreateMaterializedViewStatement stmt = new CreateMaterializedViewStatement(
                 null, false, null, null, null, null, null, null, null, null, null, 0, 0, null, null);
         
@@ -153,10 +163,8 @@ public class MaterializedViewMgrEditLogTest {
         physicalPlanField.setAccessible(true);
         physicalPlanField.set(execPlan, physicalPlan);
         
-        // Set maintenance plan with ColumnRefFactory
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-        stmt.setMaintenancePlan(execPlan, columnRefFactory);
-        return stmt;
+        return new MaintenanceWorkInput(stmt, execPlan, columnRefFactory);
     }
 
     @Test
@@ -164,7 +172,8 @@ public class MaterializedViewMgrEditLogTest {
         // Mock IMTCreator.createIMT to avoid exceptions during testing
         new MockUp<IMTCreator>() {
             @Mock
-            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view,
+                                         ExecPlan execPlan, ColumnRefFactory columnRefFactory) {
                 // Do nothing - skip IMT creation for testing
             }
         };
@@ -175,19 +184,19 @@ public class MaterializedViewMgrEditLogTest {
         db.registerTableUnlocked(mv);
 
         // 2. Create CreateMaterializedViewStatement with maintenance plan
-        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+        MaintenanceWorkInput input = createMaintenanceWorkInput(mv);
 
         // 3. Create job first time
         MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
         MvId mvId = new MvId(DB_ID, MV_ID);
-        mvMgr.prepareMaintenanceWork(stmt, mv);
+        mvMgr.prepareMaintenanceWork(input.stmt, mv, input.execPlan, input.columnRefFactory);
 
         // 4. Verify job was created
         Assertions.assertNotNull(mvMgr.getJob(mvId), "Job should be created after first call");
 
         // 5. Try to create job again - should fail silently (exception is caught)
         // The method catches DdlException and removes the job from jobMap
-        mvMgr.prepareMaintenanceWork(stmt, mv);
+        mvMgr.prepareMaintenanceWork(input.stmt, mv, input.execPlan, input.columnRefFactory);
     }
 
     @Test
@@ -202,11 +211,11 @@ public class MaterializedViewMgrEditLogTest {
         db.registerTableUnlocked(mv);
 
         // 2. Create CreateMaterializedViewStatement with maintenance plan
-        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+        MaintenanceWorkInput input = createMaintenanceWorkInput(mv);
 
         // 3. Call prepareMaintenanceWork - should return early for non-incremental MV
         MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
-        mvMgr.prepareMaintenanceWork(stmt, mv);
+        mvMgr.prepareMaintenanceWork(input.stmt, mv, input.execPlan, input.columnRefFactory);
 
         // 4. Verify no job was created
         MvId mvId = new MvId(DB_ID, MV_ID);
@@ -218,7 +227,8 @@ public class MaterializedViewMgrEditLogTest {
         // Mock IMTCreator.createIMT to avoid exceptions during testing
         new MockUp<IMTCreator>() {
             @Mock
-            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view,
+                                         ExecPlan execPlan, ColumnRefFactory columnRefFactory) {
                 // Do nothing - skip IMT creation for testing
             }
         };
@@ -229,12 +239,12 @@ public class MaterializedViewMgrEditLogTest {
         db.registerTableUnlocked(mv);
 
         // 2. Create CreateMaterializedViewStatement with maintenance plan
-        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+        MaintenanceWorkInput input = createMaintenanceWorkInput(mv);
 
         // 3. Call prepareMaintenanceWork on master
         MaterializedViewMgr masterMvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
         MvId mvId = new MvId(DB_ID, MV_ID);
-        masterMvMgr.prepareMaintenanceWork(stmt, mv);
+        masterMvMgr.prepareMaintenanceWork(input.stmt, mv, input.execPlan, input.columnRefFactory);
 
         // 4. Verify master state - job was created
         MVMaintenanceJob masterJob = masterMvMgr.getJob(mvId);
@@ -288,7 +298,8 @@ public class MaterializedViewMgrEditLogTest {
         // Mock IMTCreator.createIMT to avoid exceptions during testing
         new MockUp<IMTCreator>() {
             @Mock
-            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view,
+                                         ExecPlan execPlan, ColumnRefFactory columnRefFactory) {
                 // Do nothing - skip IMT creation for testing
             }
         };
@@ -299,7 +310,7 @@ public class MaterializedViewMgrEditLogTest {
         db.registerTableUnlocked(mv);
 
         // 2. Create CreateMaterializedViewStatement with maintenance plan
-        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+        MaintenanceWorkInput input = createMaintenanceWorkInput(mv);
 
         // 3. Mock EditLog.logMVJobState to throw exception
         EditLog currentEditLog = GlobalStateMgr.getCurrentState().getEditLog();
@@ -317,7 +328,7 @@ public class MaterializedViewMgrEditLogTest {
 
         // 5. Execute prepareMaintenanceWork - exception is caught internally, so it won't throw
         // But the job should not be added to jobMap if EditLog fails
-        mvMgr.prepareMaintenanceWork(stmt, mv);
+        mvMgr.prepareMaintenanceWork(input.stmt, mv, input.execPlan, input.columnRefFactory);
 
         Assertions.assertNull(mvMgr.getJob(mvId));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -105,7 +105,6 @@ import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
-import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.DmlStmt;
@@ -555,35 +554,6 @@ public class UtFrameUtils {
 
         Assertions.assertEquals(plan.getFragments().size(), visitedFragments.size(),
                 "Some fragments do not belong to the fragment tree");
-    }
-
-    /*
-     * Return analyzed statement and execution plan for MV maintenance
-     */
-    public static Pair<CreateMaterializedViewStatement, ExecPlan> planMVMaintenance(ConnectContext connectContext,
-                                                                                    String sql)
-            throws DdlException, CloneNotSupportedException {
-        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
-
-        List<StatementBase> statements =
-                com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode());
-        connectContext.getDumpInfo().setOriginStmt(sql);
-        SessionVariable oldSessionVariable = connectContext.getSessionVariable();
-        StatementBase statementBase = statements.get(0);
-
-        try {
-            // update session variable by adding optional hints.
-            if (statementBase.isExistQueryScopeHint()) {
-                processQueryScopeHint(statementBase, connectContext);
-            }
-
-            ExecPlan execPlan = StatementPlanner.plan(statementBase, connectContext);
-            Assertions.assertTrue(statementBase instanceof CreateMaterializedViewStatement);
-            CreateMaterializedViewStatement createMVStmt = (CreateMaterializedViewStatement) statementBase;
-            return Pair.create(createMVStmt, createMVStmt.getMaintenancePlan());
-        } finally {
-            clearQueryScopeHintContext(connectContext, oldSessionVariable);
-        }
     }
 
     private interface GetPlanHook<R> {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
