### PR TITLE
[Refactor] Remove TVR rewrite entry point from QueryOptimizer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -549,10 +549,9 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, new ApplyExceptionRule());
         CTEUtils.collectCteOperators(tree, context);
 
-        // IVM rule rewrite: try unified Delta/Version framework first, then TVR as fallback
+        // IVM rule rewrite
         if (context.getSessionVariable().isEnableIVMRefresh()) {
             IvmRewriter.rewrite(tree, rootTaskContext, scheduler, requiredColumns);
-            scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.TVR_REWRITE_RULES);
         }
 
         if (sessionVariable.isEnableFineGrainedRangePredicate()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
@@ -146,14 +146,13 @@ public class IvmDeltaAggregateRule extends TransformationRule {
 
         // Step 6: Build LEFT OUTER JOIN (intermediate agg ⋈ MV scan)
         // Delta is preserved on the aggregate's child for subsequent iterations.
-        // Use createWithoutTvr for join and MV scan to prevent TVR rules from re-matching.
         LogicalDeltaOperator childDelta = new LogicalDeltaOperator(false, delta.getActionColumn());
-        OptExpression intermediateAggExpr = OptExpression.createWithoutTvr(intermediateAgg,
+        OptExpression intermediateAggExpr = OptExpression.create(intermediateAgg,
                 OptExpression.create(childDelta, aggChild));
         LogicalJoinOperator joinOp = new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, eqPredicate);
-        OptExpression joinExpr = OptExpression.createWithoutTvr(joinOp,
+        OptExpression joinExpr = OptExpression.create(joinOp,
                 intermediateAggExpr,
-                OptExpression.createWithoutTvr(mvScan));
+                OptExpression.create(mvScan));
 
         // Step 7: Build state_union project
         Map<ColumnRefOperator, ScalarOperator> projMap = Maps.newHashMap();
@@ -186,7 +185,7 @@ public class IvmDeltaAggregateRule extends TransformationRule {
             projMap.put(actionColumn, ConstantOperator.createTinyInt((byte) 1));
         }
 
-        OptExpression result = OptExpression.createWithoutTvr(new LogicalProjectOperator(projMap), joinExpr);
+        OptExpression result = OptExpression.create(new LogicalProjectOperator(projMap), joinExpr);
         return List.of(result);
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Remove the TVR framework call from the optimizer pipeline. All Iceberg IVM patterns (scan, filter, project, join, aggregate, union) are now fully handled by the unified Delta/Version operator framework.

Changes:
- QueryOptimizer: remove scheduler.rewriteIterative(TVR_REWRITE_RULES)
- IvmDeltaAggregateRule: replace createWithoutTvr() with create(), since TVR no longer runs and the anti-matching guard is unnecessary

TVR rule code is retained for now but no longer executed. Full cleanup of the TVR codebase will follow in a separate PR after stability validation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
