### PR TITLE
[Enhancement] Expose MV lastRefreshTime in information_schema.materialized_views and SHOW MATERIALIZED VIEWS

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -53,6 +53,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         {"CREATOR", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"LAST_REFRESH_PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"LAST_REFRESH_JOB_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"LAST_REFRESH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -420,6 +421,21 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
                 const std::string* str = &info.last_refresh_job_id;
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&value);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 28: {
+            // LAST_REFRESH_TIME
+            if (info.__isset.last_refresh_time) {
+                auto* nullable_column = down_cast<NullableColumn*>(column);
+                DateTimeValue t;
+                if (!t.from_date_str(info.last_refresh_time.data(), info.last_refresh_time.size())) {
+                    nullable_column->append_nulls(1);
+                } else {
+                    fill_column_with_slot<TYPE_DATETIME>(column, (void*)&t);
+                }
             } else {
                 fill_data_column_with_null(column);
             }

--- a/be/test/exec/schema_materialized_views_scanner_test.cpp
+++ b/be/test/exec/schema_materialized_views_scanner_test.cpp
@@ -54,7 +54,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
 
     // Test that scanner has the correct number of columns
     auto slot_descs = scanner.get_slot_descs();
-    EXPECT_EQ(27, slot_descs.size());
+    EXPECT_EQ(28, slot_descs.size());
 
     // Test column names and types
     EXPECT_EQ("MATERIALIZED_VIEW_ID", slot_descs[0]->col_name());
@@ -84,6 +84,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
     EXPECT_EQ("CREATOR", slot_descs[24]->col_name());
     EXPECT_EQ("LAST_REFRESH_PROCESS_TIME", slot_descs[25]->col_name());
     EXPECT_EQ("LAST_REFRESH_JOB_ID", slot_descs[26]->col_name());
+    EXPECT_EQ("LAST_REFRESH_TIME", slot_descs[27]->col_name());
 }
 
 TEST_F(SchemaMaterializedViewsScannerTest, test_uninitialized_scanner) {
@@ -186,6 +187,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     mv.__set_creator("admin");
     mv.__set_last_refresh_process_time("2025-01-01 10:04:30");
     mv.__set_last_refresh_job_id("job_001");
+    mv.__set_last_refresh_time("2025-01-01 10:05:00");
 
     scanner._mv_results.materialized_views = {mv};
 
@@ -217,6 +219,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     EXPECT_TRUE(row.find("admin") != std::string::npos);                    // CREATOR
     EXPECT_TRUE(row.find("2025-01-01 10:04:30") != std::string::npos);      // LAST_REFRESH_PROCESS_TIME
     EXPECT_TRUE(row.find("job_001") != std::string::npos);                  // LAST_REFRESH_JOB_ID
+    EXPECT_TRUE(row.find("2025-01-01 10:05:00") != std::string::npos);      // LAST_REFRESH_TIME
 
     chunk->reset();
     EXPECT_OK(scanner.get_next(&chunk, &eos));
@@ -264,6 +267,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_multiple_materialized_views) {
         mv.__set_creator("user_" + std::to_string(i));
         mv.__set_last_refresh_process_time("2025-01-01 10:04:30");
         mv.__set_last_refresh_job_id("job_" + std::to_string(i));
+        mv.__set_last_refresh_time("2025-01-01 10:05:0" + std::to_string(i));
 
         mvs.push_back(mv);
     }

--- a/docs/en/sql-reference/information_schema/materialized_views.md
+++ b/docs/en/sql-reference/information_schema/materialized_views.md
@@ -37,3 +37,4 @@ The following fields are provided in `materialized_views`:
 | CREATOR                              | Creator of the materialized view.                            |
 | LAST_REFRESH_PROCESS_TIME            | Process time of the most recent refresh task.                |
 | LAST_REFRESH_JOB_ID                  | Job ID of the most recent refresh task.                      |
+| LAST_REFRESH_TIME                    | Time up to which base table updates are reflected in the materialized view. |

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -47,6 +47,7 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | name                       | The name of the materialized view.                           |
 | refresh_type               | The refresh type of the materialized view, including ROLLUP, MANUAL, ASYNC, and INCREMENTAL. |
 | is_active                  | Whether the materialized view state is active. Valid Value: `true` and `false`. |
+| inactive_reason            | The reason why the materialized view is inactive.            |
 | partition_type             | The partition type of the materialized view, including RANGE and UNPARTITIONED.                |
 | task_id                    | ID of the materialized view refresh task.                  |
 | task_name                  | Name of the materialized view refresh task.                |
@@ -63,6 +64,12 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | last_refresh_error_message | The reason why the last refresh failed (if the materialized view state is not active). |
 | rows                       | The number of data rows in the materialized view.            |
 | text                       | The statement used to create the materialized view.          |
+| extra_message              | Extra information about the latest refresh task.             |
+| query_rewrite_status       | Query rewrite status of the materialized view.               |
+| creator                    | Creator of the materialized view refresh task.               |
+| last_refresh_process_time  | The process start time of the latest refresh task.           |
+| last_refresh_job_id        | Job ID of the latest refresh task.                           |
+| last_refresh_time          | Time up to which base table updates are reflected in the materialized view. |
 
 ## Examples
 

--- a/docs/zh/sql-reference/information_schema/materialized_views.md
+++ b/docs/zh/sql-reference/information_schema/materialized_views.md
@@ -37,3 +37,4 @@ displayed_sidebar: docs
 | CREATOR                              | 物化视图的创建者。                               |
 | LAST_REFRESH_PROCESS_TIME            | 最近一次刷新任务的处理时间。                     |
 | LAST_REFRESH_JOB_ID                  | 最近一次刷新任务的作业 ID。                      |
+| LAST_REFRESH_TIME                    | 物化视图已反映基表更新的最新时间。               |

--- a/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -56,11 +56,11 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | last_refresh_finished_time | 物化视图上一次刷新结束时间。                                    |
 | last_refresh_duration      | 物化视图上一次刷新耗时（单位秒）。                               |
 | last_refresh_state         | 物化视图上一次刷新的状态，包括 PENDING、RUNNING、FAILED、SUCCESS。 |
-| last_refresh_force_refresh | 物化视图上一次刷新是否为强制（FORCE）刷新。                      ｜
-| last_refresh_start_partition | 上一次刷新开始的物化视图分区。                                ｜
-| last_refresh_end_partition | 上一次刷新结束的物化视图分区。                                  ｜
-| last_refresh_base_refresh_partitions | 上一次刷新基表更新的分区。                            ｜
-| last_refresh_mv_refresh_partitions | 上一次刷新物化视图刷新的分区。                          ｜
+| last_refresh_force_refresh | 物化视图上一次刷新是否为强制（FORCE）刷新。                      |
+| last_refresh_start_partition | 上一次刷新开始的物化视图分区。                                |
+| last_refresh_end_partition | 上一次刷新结束的物化视图分区。                                  |
+| last_refresh_base_refresh_partitions | 上一次刷新基表更新的分区。                            |
+| last_refresh_mv_refresh_partitions | 上一次刷新物化视图刷新的分区。                          |
 | last_refresh_error_code    | 物化视图上一次刷新失败的 ErrorCode（如果物化视图状态不为 active）。 |
 | last_refresh_error_message | 物化视图上一次刷新失败的 ErrorMessage（如果物化视图状态不为 active）。 |
 | rows                       | 物化视图中数据行数。                                           |

--- a/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -48,6 +48,7 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | name                       | 物化视图名称。                                               |
 | refresh_type               | 物化视图的更新方式，包括 ROLLUP、MANUAL、ASYNC、INCREMENTAL。   |
 | is_active                  | 物化视图状态是否为 active。有效值：`true` 和 `false`。          |
+| inactive_reason            | 物化视图失效的原因。                                          |
 | partition_type             | 物化视图的分区类型，包括 RANGE 和 UNPARTITIONED。|
 | task_id                    | 物化视图的刷新任务 ID。                                       |
 | task_name                  | 物化视图的刷新任务名称。                                       |
@@ -64,6 +65,12 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | last_refresh_error_message | 物化视图上一次刷新失败的 ErrorMessage（如果物化视图状态不为 active）。 |
 | rows                       | 物化视图中数据行数。                                           |
 | text                       | 创建物化视图的查询语句。                                        |
+| extra_message              | 最近一次刷新任务的额外信息。                                    |
+| query_rewrite_status       | 物化视图的查询改写状态。                                        |
+| creator                    | 最近一次刷新任务的创建者。                                      |
+| last_refresh_process_time  | 最近一次刷新任务的处理开始时间。                                |
+| last_refresh_job_id        | 最近一次刷新任务的作业 ID。                                     |
+| last_refresh_time          | 物化视图已反映基表更新的最新时间。                              |
 
 ## 示例
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -106,6 +106,7 @@ public class MaterializedViewsSystemTable extends SystemTable {
                         .column("CREATOR", TypeFactory.createVarcharType(64))
                         .column("LAST_REFRESH_PROCESS_TIME", DateType.DATETIME)
                         .column("LAST_REFRESH_JOB_ID", TypeFactory.createVarcharType(64))
+                        .column("LAST_REFRESH_TIME", DateType.DATETIME)
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -74,6 +74,7 @@ public class ShowMaterializedViewStatus {
     private String queryRewriteStatus;
     private long taskId;
     private String taskName;
+    private long lastRefreshTime;
     private List<TaskRunStatus> lastJobTaskRunStatus;
 
     /**
@@ -353,6 +354,10 @@ public class ShowMaterializedViewStatus {
             status.setTaskId(task.getId());
             status.setTaskName(task.getName());
         }
+        // last refresh time (data version timestamp used for staleness check)
+        if (refreshScheme != null) {
+            status.setLastRefreshTime(refreshScheme.getLastRefreshTime());
+        }
         status.setLastJobTaskRunStatus(taskTaskStatusJob);
         return status;
     }
@@ -600,6 +605,14 @@ public class ShowMaterializedViewStatus {
         this.queryRewriteStatus = queryRewriteStatus;
     }
 
+    public long getLastRefreshTime() {
+        return lastRefreshTime;
+    }
+
+    public void setLastRefreshTime(long lastRefreshTime) {
+        this.lastRefreshTime = lastRefreshTime;
+    }
+
     /**
      * Return the thrift of show materialized views command from be's request.
      */
@@ -658,6 +671,10 @@ public class ShowMaterializedViewStatus {
         status.setQuery_rewrite_status(queryRewriteStatus);
         // creator
         status.setCreator(refreshJobStatus.getTaskOwner());
+        // last refresh time (data version timestamp used for staleness check)
+        if (this.lastRefreshTime > 0) {
+            status.setLast_refresh_time(TimeUtils.longToTimeString(this.lastRefreshTime));
+        }
 
         return status;
     }
@@ -731,6 +748,8 @@ public class ShowMaterializedViewStatus {
         addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshProcessTime()));
         // last refresh job id
         addField(resultRow, refreshJobStatus.getJobId());
+        // last refresh time (data version timestamp used for staleness check)
+        addField(resultRow, this.lastRefreshTime > 0 ? TimeUtils.longToTimeString(this.lastRefreshTime) : "");
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -354,7 +354,6 @@ public class ShowMaterializedViewStatus {
             status.setTaskId(task.getId());
             status.setTaskName(task.getName());
         }
-        // last refresh time (data version timestamp used for staleness check)
         if (refreshScheme != null) {
             status.setLastRefreshTime(refreshScheme.getLastRefreshTime());
         }
@@ -488,6 +487,14 @@ public class ShowMaterializedViewStatus {
         this.taskName = taskName;
     }
 
+    public long getLastRefreshTime() {
+        return lastRefreshTime;
+    }
+
+    public void setLastRefreshTime(long lastRefreshTime) {
+        this.lastRefreshTime = lastRefreshTime;
+    }
+
     public void setLastJobTaskRunStatus(List<TaskRunStatus> lastJobTaskRunStatus) {
         if (lastJobTaskRunStatus != null) {
             // sort by process start time
@@ -605,14 +612,6 @@ public class ShowMaterializedViewStatus {
         this.queryRewriteStatus = queryRewriteStatus;
     }
 
-    public long getLastRefreshTime() {
-        return lastRefreshTime;
-    }
-
-    public void setLastRefreshTime(long lastRefreshTime) {
-        this.lastRefreshTime = lastRefreshTime;
-    }
-
     /**
      * Return the thrift of show materialized views command from be's request.
      */
@@ -672,8 +671,8 @@ public class ShowMaterializedViewStatus {
         // creator
         status.setCreator(refreshJobStatus.getTaskOwner());
         // last refresh time (data version timestamp used for staleness check)
-        if (this.lastRefreshTime > 0) {
-            status.setLast_refresh_time(TimeUtils.longToTimeString(this.lastRefreshTime));
+        if (lastRefreshTime > 0) {
+            status.setLast_refresh_time(TimeUtils.longToTimeString(lastRefreshTime));
         }
 
         return status;
@@ -749,7 +748,7 @@ public class ShowMaterializedViewStatus {
         // last refresh job id
         addField(resultRow, refreshJobStatus.getJobId());
         // last refresh time (data version timestamp used for staleness check)
-        addField(resultRow, this.lastRefreshTime > 0 ? TimeUtils.longToTimeString(this.lastRefreshTime) : "");
+        addField(resultRow, lastRefreshTime > 0 ? TimeUtils.longToTimeString(lastRefreshTime) : "");
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -869,6 +869,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .column("creator", TypeFactory.createVarcharType(64))
                 .column("last_refresh_process_time", DATETIME)
                 .column("last_refresh_job_id", TypeFactory.createVarcharType(64))
+                .column("last_refresh_time", DATETIME)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtToSelectStmtConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtToSelectStmtConverter.java
@@ -88,7 +88,8 @@ public final class ShowStmtToSelectStmtConverter {
             "query_rewrite_status",
             "creator",
             "last_refresh_process_time",
-            "last_refresh_job_id"
+            "last_refresh_job_id",
+            "last_refresh_time"
     );
 
     private static final Map<String, String> MATERIALIZED_VIEW_ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -124,7 +124,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status, " +
                         "information_schema.materialized_views.creator AS creator, " +
                         "information_schema.materialized_views.last_refresh_process_time AS last_refresh_process_time, " +
-                        "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id" +
+                        "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id, " +
+                        "information_schema.materialized_views.last_refresh_time AS last_refresh_time" +
                         " FROM " +
                         "information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND " +

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -1001,7 +1001,7 @@ public class ShowStmtMetaTest {
     public void testShowMaterializedViewsStmt() {
         ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("test_db", null);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(27, metaData.getColumnCount());
+        Assertions.assertEquals(28, metaData.getColumnCount());
         Assertions.assertEquals("id", metaData.getColumn(0).getName());
         Assertions.assertEquals("database_name", metaData.getColumn(1).getName());
         Assertions.assertEquals("name", metaData.getColumn(2).getName());
@@ -1029,6 +1029,7 @@ public class ShowStmtMetaTest {
         Assertions.assertEquals("creator", metaData.getColumn(24).getName());
         Assertions.assertEquals("last_refresh_process_time", metaData.getColumn(25).getName());
         Assertions.assertEquals("last_refresh_job_id", metaData.getColumn(26).getName());
+        Assertions.assertEquals("last_refresh_time", metaData.getColumn(27).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -56,6 +56,7 @@ public class ShowMaterializedViewStatusTest {
 
         List<String> resultSet = viewStatus.toResultSet();
 
+        Assertions.assertEquals(28, resultSet.size());
         Assertions.assertEquals("", resultSet.get(3)); // refresh type
         Assertions.assertEquals("false", resultSet.get(4)); // is active
         Assertions.assertEquals("", resultSet.get(5)); // inactive reason
@@ -78,5 +79,16 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertEquals("", resultSet.get(22)); // owner
         Assertions.assertEquals("", resultSet.get(23)); // process start time
         Assertions.assertEquals("", resultSet.get(24)); // last refresh job id
+        Assertions.assertEquals("", resultSet.get(27)); // last refresh time
+    }
+
+    @Test
+    public void toThriftIncludesLastRefreshTimeWhenPresent() {
+        ShowMaterializedViewStatus viewStatus = new ShowMaterializedViewStatus(1L, "testDb", "testView");
+        viewStatus.setLastRefreshTime(1735697100000L);
+
+        TMaterializedViewStatus thriftStatus = viewStatus.toThrift();
+
+        Assertions.assertEquals("2025-01-01 10:05:00", thriftStatus.getLast_refresh_time());
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -409,6 +409,7 @@ struct TMaterializedViewStatus {
     28: optional string creator
     29: optional string last_refresh_process_time
     30: optional string last_refresh_job_id
+    31: optional string last_refresh_time
 }
 
 struct TListPipesParams {

--- a/test/sql/test_information_schema/R/test_materialized_views
+++ b/test/sql/test_information_schema/R/test_materialized_views
@@ -28,6 +28,10 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_vi
 -- result:
 OK
 -- !result
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
@@ -36,6 +40,10 @@ set enable_evaluate_schema_scan_rule=false;
 1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 -- result:
 OK
 -- !result

--- a/test/sql/test_information_schema/T/test_materialized_views
+++ b/test/sql/test_information_schema/T/test_materialized_views
@@ -14,9 +14,11 @@ AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
 set enable_evaluate_schema_scan_rule=true;
 [UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 set enable_evaluate_schema_scan_rule=false;
 [UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 
 create database if not exists test_information_schema_materialized_views;
 use test_information_schema_materialized_views;

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -147,6 +147,10 @@ user_tags_mv1	0	true	None
 select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%' ORDER BY LAST_REFRESH_START_TIME DESC;
 -- result:
 -- !result
+select TABLE_NAME, if(LAST_REFRESH_TIME is null, 'null', 'not_null') as LAST_REFRESH_TIME_STATUS from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%' ORDER BY LAST_REFRESH_START_TIME DESC;
+-- result:
+user_tags_mv1	not_null
+-- !result
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
 -- result:
 10598	test_show_materialized_view	user_tags_mv1	MANUAL	true	None	UNPARTITIONED	10606	mv-10598	2025-11-14 17:38:45	2025-11-14 17:38:46	0.264	SUCCESS	true	NULL	NULL	{}	[user_tags_mv1]	0		0	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union(to_bitmap(tag_id))`)

--- a/test/sql/test_materialized_view/T/test_show_materialized_view
+++ b/test/sql/test_materialized_view/T/test_show_materialized_view
@@ -55,6 +55,7 @@ select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from info
 select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%' ORDER BY LAST_REFRESH_START_TIME DESC;
 select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%%' ORDER BY LAST_REFRESH_START_TIME DESC;
 select TABLE_NAME, LAST_REFRESH_ERROR_CODE, IS_ACTIVE, INACTIVE_REASON from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%bad_name%' ORDER BY LAST_REFRESH_START_TIME DESC;
+select TABLE_NAME, if(LAST_REFRESH_TIME is null, 'null', 'not_null') as LAST_REFRESH_TIME_STATUS from information_schema.materialized_views where TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%' ORDER BY LAST_REFRESH_START_TIME DESC;
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name = 'user_tags_mv1';
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like 'user_tags_mv1';
 [UC] SELECT * FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'test_show_materialized_view' and table_name like '%user_tags_mv1%';


### PR DESCRIPTION
## Why I'm doing:

The internal lastRefreshTime from MvRefreshScheme is the timestamp used to determine staleness of the MV compared to the base table, and is the value used in the staleness formula for mv_rewrite_staleness_second. This value is not currently exposed externally.

The existing LAST_REFRESH_FINISHED_TIME comes from TaskRunStatus and represents when the refresh job finished executing -- an operational metric, not a data-freshness metric.

## What I'm doing:

Added a new LAST_REFRESH_TIME column to information_schema.materialized_views and SHOW MATERIALIZED VIEWS that reads from MvRefreshScheme.getLastRefreshTime() on the MaterializedView object. This enables external monitoring and alerting on MV data freshness using the same value that the query optimizer uses internally for staleness decisions.

Note: the column name LAST_REFRESH_TIME was chosen as a direct mapping to the internal variable name. Open to renaming if a more descriptive name is preferred (e.g. LAST_REFRESH_DATA_TIME).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.