### PR TITLE
[BugFix] Fix IVM-to-PCT fallback TVR drift and add pending TVR owner tracking

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -344,6 +344,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         @SerializedName("tempBaseTableInfoTvrVersionRangeMap")
         private final Map<BaseTableInfo, TvrVersionRange> tempBaseTableInfoTvrDeltaMap = Maps.newConcurrentMap();
 
+        // Identifies which refresh job (by START_TASK_RUN_ID) owns the current temp TVR data.
+        // Used by pinned PCT mode to detect stale batches from superseded jobs.
+        @SerializedName("tempTvrOwnerStartTaskRunId")
+        private String tempTvrOwnerStartTaskRunId;
+
         @SerializedName(value = "defineStartTime")
         private boolean defineStartTime;
 
@@ -391,8 +396,29 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return tempBaseTableInfoTvrDeltaMap;
         }
 
-        public void clearTempBaseTableInfoTvrDeltaMap() {
+        public String getTempTvrOwnerStartTaskRunId() {
+            return tempTvrOwnerStartTaskRunId;
+        }
+
+        /**
+         * Atomically replace the temp TVR delta map and set the owner tag.
+         * The owner identifies which refresh job (by START_TASK_RUN_ID) owns this pending state.
+         */
+        public void replaceTempBaseTableInfoTvrDeltaMap(
+                String ownerStartTaskRunId,
+                Map<BaseTableInfo, TvrVersionRange> tvrMap) {
             this.tempBaseTableInfoTvrDeltaMap.clear();
+            this.tempBaseTableInfoTvrDeltaMap.putAll(tvrMap);
+            this.tempTvrOwnerStartTaskRunId = ownerStartTaskRunId;
+        }
+
+        /**
+         * Clear both the temp TVR delta map and its owner tag.
+         * Replaces the old clearTempBaseTableInfoTvrDeltaMap() which only cleared the map.
+         */
+        public void clearTempBaseTableInfoTvrDeltaState() {
+            this.tempBaseTableInfoTvrDeltaMap.clear();
+            this.tempTvrOwnerStartTaskRunId = null;
         }
 
         public void clearVisibleVersionMap() {
@@ -484,6 +510,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             arc.baseTableInfoVisibleVersionMap.putAll(this.baseTableInfoVisibleVersionMap);
             arc.baseTableInfoTvrDeltaMap.putAll(this.baseTableInfoTvrDeltaMap);
             arc.tempBaseTableInfoTvrDeltaMap.putAll(this.tempBaseTableInfoTvrDeltaMap);
+            arc.tempTvrOwnerStartTaskRunId = this.tempTvrOwnerStartTaskRunId;
             arc.mvPartitionNameRefBaseTablePartitionMap.putAll(this.mvPartitionNameRefBaseTablePartitionMap);
             arc.defineStartTime = this.defineStartTime;
             arc.startTime = this.startTime;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/IVMInsertLoadTxnCallback.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/IVMInsertLoadTxnCallback.java
@@ -108,8 +108,8 @@ public class IVMInsertLoadTxnCallback implements InsertLoadTxnCallback {
 
         // update mv's base table info tvr version range map
         mvBaseTableInfoTvrDeltaMap.putAll(baseTableInfoTvrDeltaMap);
-        // clear the temp map
-        asyncRefreshContext.clearTempBaseTableInfoTvrDeltaMap();
+        // clear the temp map and owner tag together
+        asyncRefreshContext.clearTempBaseTableInfoTvrDeltaState();
 
         long maxChangedTableRefreshTime = mv.getRefreshScheme().getLastRefreshTime();
         copiedScheme.setLastRefreshTime(maxChangedTableRefreshTime);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -955,7 +955,7 @@ public abstract class BaseMVRefreshProcessor {
     public void updatePCTMeta(ExecPlan execPlan,
                               PCellSortedSet mvRefreshedPartitions,
                               Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames,
-                              Map<BaseTableInfo, TvrVersionRange> tempMvTvrVersionRangeMap) {
+                              Map<BaseTableInfo, TvrVersionRange> tvrDeltaToPromote) {
         // check
         Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), this.mv.getId());
         if (mv == null) {
@@ -988,7 +988,7 @@ public abstract class BaseMVRefreshProcessor {
         MVVersionManager mvVersionManager = new MVVersionManager(this.mv, mvContext);
         try {
             mvVersionManager.updateMVVersionInfo(snapshotBaseTables, mvRefreshedPartitions,
-                    refBaseTableIds, refTableAndPartitionNames, tempMvTvrVersionRangeMap);
+                    refBaseTableIds, refTableAndPartitionNames, tvrDeltaToPromote);
         } catch (Exception e) {
             logger.warn("update final meta failed after mv refreshed:", DebugUtil.getRootStackTrace(e));
             throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -60,13 +60,13 @@ public class MVVersionManager {
      * @param mvRefreshedPartitions mv refreshed partitions
      * @param refBaseTableIds  mv's ref base table ids
      * @param refTableAndPartitionNames mv's ref base table and partition names
-     * @param tempMvTvrVersionRangeMap temporary tvr version range map for each base table which is used for ivm refresh
+     * @param tvrDeltaToPromote TVR version ranges to promote into the persistent baseTableInfoTvrVersionRangeMap
      */
     public void updateMVVersionInfo(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
                                     PCellSortedSet mvRefreshedPartitions,
                                     Set<Long> refBaseTableIds,
                                     Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames,
-                                    Map<BaseTableInfo, TvrVersionRange> tempMvTvrVersionRangeMap) {
+                                    Map<BaseTableInfo, TvrVersionRange> tvrDeltaToPromote) {
         MaterializedView.MvRefreshScheme copiedScheme = mv.getRefreshScheme().copy(); // copy on write
         MaterializedView.AsyncRefreshContext refreshContext = copiedScheme.getAsyncRefreshContext();
         // update materialized view partition to ref base table partition names meta
@@ -83,11 +83,11 @@ public class MVVersionManager {
         if (!isOlapTableRefreshed && !isExternalTableRefreshed) {
             return;
         }
-        if (tempMvTvrVersionRangeMap != null) {
+        if (tvrDeltaToPromote != null) {
             // update the tvr version range map in mv context
             final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
                     refreshContext.getBaseTableInfoTvrVersionRangeMap();
-            for (Map.Entry<BaseTableInfo, TvrVersionRange> entry : tempMvTvrVersionRangeMap.entrySet()) {
+            for (Map.Entry<BaseTableInfo, TvrVersionRange> entry : tvrDeltaToPromote.entrySet()) {
                 TvrVersionRange versionRange = entry.getValue();
                 if (versionRange == null || versionRange.isEmpty()) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -100,6 +100,13 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         // reset the task run id for pct
         this.mvContext.getCtx().setQueryId(UUIDUtil.genUUID());
 
+        // Clear stale temp TVR state from any prior attempt (explain-only, failed run, etc.)
+        // before starting a fresh complete-refresh cycle. Without this, a SKIPPED result below
+        // would leave the stale map/owner intact, risking incorrect TVR promotion by a later run.
+        if (mvRefreshParams.isCompleteRefresh()) {
+            mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaState();
+        }
+
         // ① Execute PCT first — this calls syncAndCheckPCTPartitions() internally,
         //    which refreshes external tables and re-collects snapshotBaseTables.
         //    After this returns, snapshotBaseTables reflects the snapshot that PCT will actually process.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/hybrid/MVHybridBasedRefreshProcessor.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler.mv.hybrid;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -99,28 +100,33 @@ public final class MVHybridBasedRefreshProcessor extends BaseMVRefreshProcessor 
         // reset the task run id for pct
         this.mvContext.getCtx().setQueryId(UUIDUtil.genUUID());
 
-        // For complete refreshes (IVM fallback or force): collect TVR version ranges and write
-        // them into the persisted tempBaseTableInfoTvrDeltaMap so that subsequent batch task_runs
-        // can access the checkpoint via AsyncRefreshContext (serialized to editlog).
-        // For partial refreshes (subsequent batches): skip — the temp map was already populated
-        // by the first task_run and persisted via editlog.
-        if (mvRefreshParams.isCompleteRefresh()) {
+        // ① Execute PCT first — this calls syncAndCheckPCTPartitions() internally,
+        //    which refreshes external tables and re-collects snapshotBaseTables.
+        //    After this returns, snapshotBaseTables reflects the snapshot that PCT will actually process.
+        ProcessExecPlan result = pctProcessor.getProcessExecPlan(taskRunContext);
+
+        // ② Freeze TVR from the SAME snapshotBaseTables that PCT uses.
+        //    This guarantees the persisted TVR matches the snapshot that PCT will scan.
+        //    Skip freeze if PCT found nothing to refresh (SKIPPED) — no subsequent batches will follow.
+        if (mvRefreshParams.isCompleteRefresh()
+                && result.state() == Constants.TaskRunState.SUCCESS) {
             MaterializedView.AsyncRefreshContext refreshContext =
                     mv.getRefreshScheme().getAsyncRefreshContext();
-            refreshContext.clearTempBaseTableInfoTvrDeltaMap();
-            final Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap =
+            final Map<BaseTableInfo, TvrVersionRange> committedMap =
                     refreshContext.getBaseTableInfoTvrVersionRangeMap();
+            Map<BaseTableInfo, TvrVersionRange> frozen = Maps.newHashMap();
             for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
                 TvrVersionRange changedVersionRange = ivmProcessor.getBaseTableMaxChangedDelta(
-                        snapshotInfo, mvTvrVersionRangeMap);
+                        snapshotInfo, committedMap);
                 logger.info("Base table: {}, changed version range: {}",
                         snapshotInfo.getBaseTableInfo().getTableName(), changedVersionRange);
-                // persist to AsyncRefreshContext temp map (survives across task_runs via editlog)
-                refreshContext.getTempBaseTableInfoTvrDeltaMap().put(
-                        snapshotInfo.getBaseTableInfo(), changedVersionRange);
+                frozen.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
             }
+            String owner = mvContext.getStatus().getStartTaskRunId();
+            refreshContext.replaceTempBaseTableInfoTvrDeltaMap(owner, frozen);
         }
-        return pctProcessor.getProcessExecPlan(taskRunContext);
+
+        return result;
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -80,8 +80,9 @@ import static com.starrocks.scheduler.TaskRun.MV_UNCOPYABLE_PROPERTIES;
  * - Execute the refresh plan to update the materialized view.
  */
 public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
-    // This map is used to store the temporary tvr version range for each base table
-    private final Map<BaseTableInfo, TvrVersionRange> tempMvTvrVersionRangeMap = Maps.newConcurrentMap();
+    // Per-call buffer: stores TVR deltas computed in getProcessExecPlan(), consumed in execProcessExecPlan().
+    // NOT the editlog-persisted temp map (that is AsyncRefreshContext.tempBaseTableInfoTvrDeltaMap).
+    private final Map<BaseTableInfo, TvrVersionRange> stagedTvrDeltaMap = Maps.newConcurrentMap();
     // whether the next task run is needed
     private boolean hasNextTaskRun = false;
 
@@ -97,6 +98,9 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
         if (!mvRefreshParams.isCompleteRefresh()) {
             throw new SemanticException("IVM based refresh only supports complete refresh, but got partial refresh");
         }
+        // Reset per-call buffer to prevent accumulation across retries within the same task run
+        // (processor instance is reused by retryProcessTaskRun).
+        this.stagedTvrDeltaMap.clear();
         syncAndCheckPCTPartitions(taskRunContext);
 
         // collect change snapshots
@@ -111,7 +115,7 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
                 // collect changed version range
                 TvrTableSnapshotInfo tvrTableSnapshotInfo = (TvrTableSnapshotInfo) snapshotInfo;
 
-                tempMvTvrVersionRangeMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
+                stagedTvrDeltaMap.put(snapshotInfo.getBaseTableInfo(), changedVersionRange);
                 // update the snapshot info with the changed version range
                 tvrTableSnapshotInfo.setTvrSnapshot(changedVersionRange);
             }
@@ -160,8 +164,9 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
         try (Timer ignored = Tracers.watchScope("MVRefreshMaterializedView")) {
             MaterializedView.AsyncRefreshContext mvRefreshContext =
                     mv.getRefreshScheme().getAsyncRefreshContext();
-            logger.info("temp tvr version range map: {}", tempMvTvrVersionRangeMap);
-            mvRefreshContext.getTempBaseTableInfoTvrDeltaMap().putAll(tempMvTvrVersionRangeMap);
+            logger.info("staged tvr delta map: {}", stagedTvrDeltaMap);
+            String owner = mvContext.getStatus().getStartTaskRunId();
+            mvRefreshContext.replaceTempBaseTableInfoTvrDeltaMap(owner, stagedTvrDeltaMap);
             executor.executePlan(execPlan, insertStmt);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTBasedRefreshProcessor.java
@@ -332,7 +332,7 @@ public final class MVPCTBasedRefreshProcessor extends BaseMVRefreshProcessor {
         // reused by subsequent unrelated refreshes (e.g., user-initiated partial refresh or
         // explain-time planning that populates the temp map without executing).
         if (!mvContext.hasNextBatchPartition()) {
-            mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaMap();
+            mv.getRefreshScheme().getAsyncRefreshContext().clearTempBaseTableInfoTvrDeltaState();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -690,6 +690,13 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
             Assertions.assertFalse(tempTvr.isEmpty(),
                     "tempBaseTableInfoTvrDeltaMap should contain pending TVR for subsequent batches");
 
+            // Verify owner is set during intermediate batches
+            String intermediateOwner = intermediateMv.getRefreshScheme()
+                    .getAsyncRefreshContext()
+                    .getTempTvrOwnerStartTaskRunId();
+            Assertions.assertNotNull(intermediateOwner,
+                    "Owner should be set during intermediate batches");
+
             // Execute remaining batches
             while (nextTaskRun != null) {
                 initAndExecuteTaskRun(nextTaskRun);
@@ -718,6 +725,52 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         Assertions.assertTrue(checkpoint instanceof TvrTableSnapshot);
         Assertions.assertEquals(2L, checkpoint.to().getVersion(),
                 "TVR checkpoint should point to version 2");
+
+        // Verify owner is cleared after all batches complete
+        String finalOwner = finalMv.getRefreshScheme()
+                .getAsyncRefreshContext()
+                .getTempTvrOwnerStartTaskRunId();
+        Assertions.assertNull(finalOwner,
+                "Owner should be cleared after all batches complete and TVR is promoted");
+    }
+
+    /**
+     * Verify that after single-batch IVM→PCT fallback, the frozen TVR in
+     * tempBaseTableInfoTvrDeltaMap matches the snapshot that PCT synced to (Bug A fix).
+     * Owner should be cleared after TVR promotion on the single batch.
+     */
+    @Test
+    public void testFallbackTvrOwnerLifecycleSingleBatch() throws Exception {
+        String query = "SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0` as a;";
+        MaterializedView mv = createMaterializedViewWithRefreshMode(query, "auto");
+
+        advanceTableVersionTo(2);
+        mockListTableDeltaTraits();
+
+        // Run: IVM fails → fallback to PCT (single batch, unpartitioned MV)
+        MVTaskRunProcessor run1 = getMVTaskRunProcessor(mv);
+        MVHybridBasedRefreshProcessor hybrid =
+                (MVHybridBasedRefreshProcessor) run1.getMVRefreshProcessor();
+        Assertions.assertTrue(hybrid.getCurrentProcessor() instanceof MVPCTBasedRefreshProcessor);
+
+        // After single-batch completes: TVR promoted, owner cleared
+        MaterializedView refreshedMv = getMv("test_mv1");
+        MaterializedView.AsyncRefreshContext ctx = refreshedMv.getRefreshScheme().getAsyncRefreshContext();
+
+        // TVR should be promoted
+        Map<BaseTableInfo, TvrVersionRange> finalCheckpoint = ctx.getBaseTableInfoTvrVersionRangeMap();
+        Assertions.assertFalse(finalCheckpoint.isEmpty(),
+                "TVR should be promoted after single-batch fallback");
+        Assertions.assertEquals(2L, finalCheckpoint.values().iterator().next().to().getVersion(),
+                "TVR should match the PCT-synced snapshot version");
+
+        // Owner should be cleared (single batch = first batch = last batch)
+        Assertions.assertNull(ctx.getTempTvrOwnerStartTaskRunId(),
+                "Owner should be cleared after single-batch TVR promotion");
+
+        // Temp map should be cleared
+        Assertions.assertTrue(ctx.getTempBaseTableInfoTvrDeltaMap().isEmpty(),
+                "Temp TVR map should be cleared after promotion");
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Bug fix: switchToPCTRefresh() previously computed TVR from snapshotBaseTables collected during the IVM phase (snapshot S1), but PCT then re-synced to snapshot S2. The persisted TVR recorded S1 while PCT actually processed S2. Fix by reordering the TVR freeze to after pctProcessor.getProcessExecPlan(), so the frozen TVR matches what PCT will actually scan.

Owner tracking: add tempTvrOwnerStartTaskRunId to AsyncRefreshContext to identify which refresh job owns the pending TVR state. This is the foundation for pinned PCT mode (subsequent PRs), where subsequent batch task runs verify the owner matches before entering pinned mode.

Also:
- Rename MVIVMBasedRefreshProcessor.tempMvTvrVersionRangeMap to stagedTvrDeltaMap (per-call buffer, not the editlog-persisted map)
- Clear stagedTvrDeltaMap on getProcessExecPlan entry to prevent accumulation across retries within the same task run
- Rename updatePCTMeta/updateMVVersionInfo parameter to tvrDeltaToPromote for clarity
- Migrate all callers from clearTempBaseTableInfoTvrDeltaMap() to clearTempBaseTableInfoTvrDeltaState() which clears both map and owner
- Add test for owner lifecycle in single-batch and multi-batch fallback



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
