### PR TITLE
[Enhancement] Parallelize row-mode partial update publish for lake PK tables

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -480,7 +480,7 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // Max threads for lake partial update segment-level parallelism.
-// <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
+// <= 0 means use half of CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
 CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 // Queue size for the lake partial update threadpool.
 CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -479,9 +479,8 @@ CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
-// Max threads for lake partial update segment-level parallelism. 0 means use CPU core count.
-// Negative values disable threadpool creation. Requires restart to take effect.
-// Runtime on/off is controlled by enable_pk_index_parallel_execution.
+// Max threads for lake partial update segment-level parallelism.
+// <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
 CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -479,10 +479,10 @@ CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
-// Whether enable parallel row-mode partial update publish for lake PK tables.
-CONF_mBool(lake_enable_parallel_row_mode_partial_update, "true");
-// Max threads for partial update segment-level parallelism (controls concurrency and memory).
-CONF_mInt32(lake_partial_update_thread_pool_max_threads, "4");
+// Max threads for parallel row-mode partial update publish in lake PK tables.
+// Controls segment-level parallelism concurrency and memory. 0 means use CPU core count.
+// Negative values (e.g., -1) disable parallel execution.
+CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -481,7 +481,7 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // Max threads for lake partial update segment-level parallelism.
 // <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
-CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
+CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 // Queue size for the lake partial update threadpool.
 CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -482,6 +482,8 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 // Max threads for lake partial update segment-level parallelism.
 // <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
 CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
+// Queue size for the lake partial update threadpool.
+CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -479,6 +479,10 @@ CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
+// Whether enable parallel row-mode partial update publish for lake PK tables.
+CONF_mBool(lake_enable_parallel_row_mode_partial_update, "true");
+// Max threads for partial update segment-level parallelism (controls concurrency and memory).
+CONF_mInt32(lake_partial_update_thread_pool_max_threads, "4");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -479,10 +479,10 @@ CONF_mInt32(pk_index_parallel_execution_threadpool_size, "1048576");
 CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
-// Max threads for parallel row-mode partial update publish in lake PK tables.
-// Controls segment-level parallelism concurrency and memory. 0 means use CPU core count.
-// Negative values (e.g., -1) disable parallel execution.
-CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
+// Max threads for lake partial update segment-level parallelism. 0 means use CPU core count.
+// Negative values disable threadpool creation. Requires restart to take effect.
+// Runtime on/off is controlled by enable_pk_index_parallel_execution.
+CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 // The maximum wait flush timeout for pk index memtable in shared-data mode, in milliseconds.

--- a/be/src/common/config_exec_env_fwd.h
+++ b/be/src/common/config_exec_env_fwd.h
@@ -51,6 +51,13 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_max_threads, "0");
 // The queue size for pk index memtable flush threadpool in shared-data mode.
 CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 
+// Max threads for lake partial update segment-level parallelism.
+// <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
+CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
+
+// Queue size for the lake partial update threadpool.
+CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
+
 CONF_Int32(streaming_load_thread_pool_num_min, "0");
 
 CONF_Int32(streaming_load_thread_pool_idle_time_ms, "2000");

--- a/be/src/common/config_exec_env_fwd.h
+++ b/be/src/common/config_exec_env_fwd.h
@@ -53,7 +53,7 @@ CONF_mInt32(pk_index_memtable_flush_threadpool_size, "2048");
 
 // Max threads for lake partial update segment-level parallelism.
 // <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
-CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
+CONF_mInt32(lake_partial_update_thread_pool_max_threads, "0");
 
 // Queue size for the lake partial update threadpool.
 CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -242,6 +242,8 @@
         "pipeline_scan_thread_pool_thread_num",
         "pipeline_sink_io_thread_pool_queue_size",
         "pipeline_sink_io_thread_pool_thread_num",
+        "lake_partial_update_thread_pool_max_threads",
+        "lake_partial_update_thread_pool_queue_size",
         "pk_index_memtable_flush_threadpool_max_threads",
         "pk_index_memtable_flush_threadpool_size",
         "pk_index_parallel_execution_threadpool_max_threads",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -709,6 +709,7 @@
         "pk_index_early_sst_compaction_threshold",
         "enable_pk_index_parallel_execution",
         "pk_index_parallel_execution_min_rows",
+        "lake_partial_update_thread_pool_max_threads",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
         "pk_index_size_tiered_min_level_size",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -710,6 +710,7 @@
         "enable_pk_index_parallel_execution",
         "pk_index_parallel_execution_min_rows",
         "lake_partial_update_thread_pool_max_threads",
+        "lake_partial_update_thread_pool_queue_size",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
         "pk_index_size_tiered_min_level_size",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -711,8 +711,6 @@
         "pk_index_early_sst_compaction_threshold",
         "enable_pk_index_parallel_execution",
         "pk_index_parallel_execution_min_rows",
-        "lake_partial_update_thread_pool_max_threads",
-        "lake_partial_update_thread_pool_queue_size",
         "pk_index_memtable_max_count",
         "pk_index_memtable_max_wait_flush_timeout_ms",
         "pk_index_size_tiered_min_level_size",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -74,6 +74,10 @@ CONF_mBool(enable_pk_index_parallel_execution, "true");
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 
+// Max threads for lake partial update segment-level parallelism.
+// <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
+CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
+
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -78,6 +78,9 @@ CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 // <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
 CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
 
+// Queue size for the lake partial update threadpool.
+CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
+
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -74,13 +74,6 @@ CONF_mBool(enable_pk_index_parallel_execution, "true");
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 
-// Max threads for lake partial update segment-level parallelism.
-// <= 0 means use CPU core count. Runtime on/off is controlled by enable_pk_index_parallel_execution.
-CONF_Int32(lake_partial_update_thread_pool_max_threads, "0");
-
-// Queue size for the lake partial update threadpool.
-CONF_mInt32(lake_partial_update_thread_pool_queue_size, "2048");
-
 // The maximum number of memtables for pk index in shared-data mode.
 CONF_mInt32(pk_index_memtable_max_count, "2");
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -306,7 +306,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         _config_callback.emplace("lake_partial_update_thread_pool_max_threads", [&]() -> Status {
             auto thread_pool = _exec_env->lake_partial_update_thread_pool();
             if (thread_pool != nullptr) {
-                return thread_pool->update_max_threads(config::lake_partial_update_thread_pool_max_threads);
+                int max_thread_count = config::lake_partial_update_thread_pool_max_threads;
+                if (max_thread_count <= 0) {
+                    max_thread_count = CpuInfo::num_cores() / 2;
+                }
+                return thread_pool->update_max_threads(std::max(1, max_thread_count));
             }
             return Status::OK();
         });

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -303,6 +303,13 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
             return Status::OK();
         });
+        _config_callback.emplace("lake_partial_update_thread_pool_max_threads", [&]() -> Status {
+            auto thread_pool = _exec_env->lake_partial_update_thread_pool();
+            if (thread_pool != nullptr) {
+                return thread_pool->update_max_threads(config::lake_partial_update_thread_pool_max_threads);
+            }
+            return Status::OK();
+        });
         _config_callback.emplace("pk_index_memtable_flush_threadpool_max_threads", [&]() -> Status {
             auto thread_pool = _exec_env->pk_index_memtable_flush_thread_pool();
             if (thread_pool != nullptr) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -724,11 +724,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
     max_thread_count = config::lake_partial_update_thread_pool_max_threads;
     if (max_thread_count <= 0) {
-        max_thread_count = CpuInfo::num_cores();
+        max_thread_count = CpuInfo::num_cores() / 2;
     }
     RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
                             .set_min_threads(0)
-                            .set_max_threads(max_thread_count)
+                            .set_max_threads(std::max(1, max_thread_count))
                             .set_max_queue_size(config::lake_partial_update_thread_pool_queue_size)
                             .build(&_lake_partial_update_thread_pool));
     REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -729,7 +729,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
                             .set_min_threads(0)
                             .set_max_threads(max_thread_count)
-                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .set_max_queue_size(config::lake_partial_update_thread_pool_queue_size)
                             .build(&_lake_partial_update_thread_pool));
     REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -723,17 +723,15 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .build(&_pk_index_memtable_flush_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
     max_thread_count = config::lake_partial_update_thread_pool_max_threads;
-    if (max_thread_count == 0) {
+    if (max_thread_count <= 0) {
         max_thread_count = CpuInfo::num_cores();
     }
-    if (max_thread_count > 0) {
-        RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
-                                .set_min_threads(0)
-                                .set_max_threads(max_thread_count)
-                                .set_max_queue_size(std::numeric_limits<int>::max())
-                                .build(&_lake_partial_update_thread_pool));
-        REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
-    }
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+                            .set_min_threads(0)
+                            .set_max_threads(max_thread_count)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_lake_partial_update_thread_pool));
+    REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -723,15 +723,17 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .build(&_pk_index_memtable_flush_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
     max_thread_count = config::lake_partial_update_thread_pool_max_threads;
-    if (max_thread_count <= 0) {
-        max_thread_count = 4;
+    if (max_thread_count == 0) {
+        max_thread_count = CpuInfo::num_cores();
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
-                            .set_min_threads(0)
-                            .set_max_threads(std::max(1, max_thread_count))
-                            .set_max_queue_size(std::numeric_limits<int>::max())
-                            .build(&_lake_partial_update_thread_pool));
-    REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
+    if (max_thread_count > 0) {
+        RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+                                .set_min_threads(0)
+                                .set_max_threads(max_thread_count)
+                                .set_max_queue_size(std::numeric_limits<int>::max())
+                                .build(&_lake_partial_update_thread_pool));
+        REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
+    }
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -395,6 +395,7 @@ void ExecEnv::_refresh_service_contexts() {
     _lake_services.parallel_compact_mgr = _parallel_compact_mgr.get();
     _lake_services.pk_index_execution_thread_pool = _pk_index_execution_thread_pool.get();
     _lake_services.pk_index_memtable_flush_thread_pool = _pk_index_memtable_flush_thread_pool.get();
+    _lake_services.lake_partial_update_thread_pool = _lake_partial_update_thread_pool.get();
 
     _runtime_services.external_scan_context_mgr = _external_scan_context_mgr;
     _runtime_services.stream_mgr = _stream_mgr;
@@ -721,6 +722,16 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(config::pk_index_memtable_flush_threadpool_size)
                             .build(&_pk_index_memtable_flush_thread_pool));
     REGISTER_THREAD_POOL_METRICS(cloud_native_pk_index_memtable_flush, _pk_index_memtable_flush_thread_pool);
+    max_thread_count = config::lake_partial_update_thread_pool_max_threads;
+    if (max_thread_count <= 0) {
+        max_thread_count = 4;
+    }
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+                            .set_min_threads(0)
+                            .set_max_threads(std::max(1, max_thread_count))
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_lake_partial_update_thread_pool));
+    REGISTER_THREAD_POOL_METRICS(lake_partial_update, _lake_partial_update_thread_pool);
 
 #elif defined(BE_TEST)
     _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
@@ -746,6 +757,11 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_memtable_flush_thread_pool));
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_partial_update")
+                            .set_min_threads(0)
+                            .set_max_threads(4)
+                            .set_max_queue_size(std::numeric_limits<int>::max())
+                            .build(&_lake_partial_update_thread_pool));
 #endif
 
     _load_channel_mgr = new LoadChannelMgr(_lake_tablet_manager);
@@ -879,6 +895,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _pk_index_memtable_flush_thread_pool->shutdown();
         component_times.emplace_back("pk_index_memtable_flush_thread_pool", MonotonicMillis() - start);
+    }
+
+    if (_lake_partial_update_thread_pool) {
+        start = MonotonicMillis();
+        _lake_partial_update_thread_pool->shutdown();
+        component_times.emplace_back("lake_partial_update_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -1076,6 +1098,7 @@ void ExecEnv::destroy() {
     _parallel_compact_mgr.reset();
     _pk_index_execution_thread_pool.reset();
     _pk_index_memtable_flush_thread_pool.reset();
+    _lake_partial_update_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -375,6 +375,8 @@ public:
 
     ThreadPool* pk_index_memtable_flush_thread_pool() { return _pk_index_memtable_flush_thread_pool.get(); }
 
+    ThreadPool* lake_partial_update_thread_pool() { return _lake_partial_update_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -451,6 +453,7 @@ private:
     std::unique_ptr<lake::LakePersistentIndexParallelCompactMgr> _parallel_compact_mgr;
     std::unique_ptr<ThreadPool> _pk_index_execution_thread_pool = nullptr;
     std::unique_ptr<ThreadPool> _pk_index_memtable_flush_thread_pool = nullptr;
+    std::unique_ptr<ThreadPool> _lake_partial_update_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr = nullptr;

--- a/be/src/runtime/service_contexts.h
+++ b/be/src/runtime/service_contexts.h
@@ -116,6 +116,7 @@ struct LakeServices {
     lake::LakePersistentIndexParallelCompactMgr* parallel_compact_mgr = nullptr;
     ThreadPool* pk_index_execution_thread_pool = nullptr;
     ThreadPool* pk_index_memtable_flush_thread_pool = nullptr;
+    ThreadPool* lake_partial_update_thread_pool = nullptr;
 };
 
 struct RuntimeServices {

--- a/be/src/runtime/starrocks_metrics.h
+++ b/be/src/runtime/starrocks_metrics.h
@@ -360,6 +360,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_execution);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_memtable_flush);
     METRICS_DEFINE_THREAD_POOL(cloud_native_pk_index_compact);
+    METRICS_DEFINE_THREAD_POOL(lake_partial_update);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
     METRICS_DEFINE_THREAD_POOL(pip_prepare);

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -352,7 +352,7 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
         // Create thread pool token for segment-level parallelism
         std::unique_ptr<ThreadPoolToken> token;
         if (config::enable_pk_index_parallel_execution) {
-            token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+            token = ExecEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
                     ThreadPool::ExecutionMode::CONCURRENT);
         }
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -208,26 +208,8 @@ static bool should_enable_lazy_load(const RowsetUpdateStateParams& params) {
 Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
                                        bool need_resolve_conflict, bool need_lock) {
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segment_us");
-    // Shared state initialization must be serialized across concurrent load_segment calls
-    // in the parallel path. prepare_for_parallel() normally does this single-threaded before
-    // parallel tasks start, but the mutex guarantees correctness even under concurrent init.
-    {
-        std::lock_guard<std::mutex> l(_shared_init_mutex);
-        if (_rowset_ptr == nullptr) {
-            _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
-            _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(),
-                                                   _rowset_meta_ptr.get(), -1 /*unused*/, params.tablet_schema);
-        }
-        if (_upserts.size() != _rowset_ptr->num_segments()) {
-            TRY_CATCH_BAD_ALLOC({
-                _upserts.resize(_rowset_ptr->num_segments());
-                _base_versions.resize(_rowset_ptr->num_segments());
-                _partial_update_states.resize(_rowset_ptr->num_segments());
-                _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
-                _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
-            });
-        }
-    }
+    // prepare() must have been called before load_segment.
+    DCHECK(_rowset_ptr != nullptr);
 
     if (_upserts.size() == 0) {
         // Empty rowset
@@ -338,20 +320,8 @@ void RowsetUpdateState::plan_read_by_rssid(const std::vector<uint64_t>& rowids, 
 Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params) {
     CHECK_MEM_LIMIT("RowsetUpdateState::_do_load_upserts");
     TRACE_COUNTER_SCOPE_LATENCY_US("do_load_upserts_us");
-    vector<uint32_t> pk_columns;
-    pk_columns.reserve(params.tablet_schema->num_key_columns());
-    for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
-        pk_columns.push_back((uint32_t)i);
-    }
-    Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
-
-    {
-        // Serialize segment iterator init against concurrent load_segment calls.
-        std::lock_guard<std::mutex> l(_shared_init_mutex);
-        if (_segment_iters.empty()) {
-            ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
-        }
-    }
+    // prepare() must have initialized _segment_iters already.
+    DCHECK(!_segment_iters.empty());
     RETURN_ERROR_IF_FALSE(_segment_iters.size() == _rowset_ptr->num_segments());
     ASSIGN_OR_RETURN(auto pk_encoding_type, params.tablet_schema->primary_key_encoding_type_or_error());
     auto& iter = _segment_iters[segment_id];
@@ -508,16 +478,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     CHECK_MEM_LIMIT("RowsetUpdateState::_prepare_partial_update_states");
     std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
-    const auto& txn_meta = params.op_write.txn_meta();
-    {
-        // Serialize _column_to_expr_value init against concurrent parallel calls.
-        std::lock_guard<std::mutex> l(_shared_init_mutex);
-        if (_column_to_expr_value.empty()) {
-            for (auto& entry : txn_meta.column_to_expr_value()) {
-                _column_to_expr_value.insert({entry.first, entry.second});
-            }
-        }
-    }
+    // _column_to_expr_value is already populated by prepare().
     auto read_column_schema = ChunkHelper::convert_schema(params.tablet_schema, read_column_ids);
     // column list that need to read from source segment
     MutableColumns read_columns;
@@ -879,11 +840,9 @@ void RowsetUpdateState::release_segment_partial_state(uint32_t segment_id) {
     _auto_increment_partial_update_states[segment_id].reset();
 }
 
-Status RowsetUpdateState::prepare_for_parallel(const RowsetUpdateStateParams& params) {
-    // Pre-initialize all shared state so that load_segment can be called in parallel.
-    // Runs single-threaded before parallel tasks start, but take the mutex anyway for
-    // consistency with the protected init sections in load_segment.
-    std::lock_guard<std::mutex> l(_shared_init_mutex);
+Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
+    // Initialize shared state: rowset, per-segment vectors, segment iterators, column expr values.
+    // Must be called once on the main thread before any load_segment call.
     if (_rowset_ptr == nullptr) {
         _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
         _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -208,21 +208,25 @@ static bool should_enable_lazy_load(const RowsetUpdateStateParams& params) {
 Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
                                        bool need_resolve_conflict, bool need_lock) {
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segment_us");
-    if (_rowset_ptr == nullptr) {
-        _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
-        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
-                                               -1 /*unused*/, params.tablet_schema);
-    }
-    // Idempotent resize: skip if already done by prepare_for_parallel() or a previous call.
-    // This guarantees thread-safety when load_segment is called concurrently for different segments.
-    if (_upserts.size() != _rowset_ptr->num_segments()) {
-        TRY_CATCH_BAD_ALLOC({
-            _upserts.resize(_rowset_ptr->num_segments());
-            _base_versions.resize(_rowset_ptr->num_segments());
-            _partial_update_states.resize(_rowset_ptr->num_segments());
-            _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
-            _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
-        });
+    // Shared state initialization must be serialized across concurrent load_segment calls
+    // in the parallel path. prepare_for_parallel() normally does this single-threaded before
+    // parallel tasks start, but the mutex guarantees correctness even under concurrent init.
+    {
+        std::lock_guard<std::mutex> l(_shared_init_mutex);
+        if (_rowset_ptr == nullptr) {
+            _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
+            _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(),
+                                                   _rowset_meta_ptr.get(), -1 /*unused*/, params.tablet_schema);
+        }
+        if (_upserts.size() != _rowset_ptr->num_segments()) {
+            TRY_CATCH_BAD_ALLOC({
+                _upserts.resize(_rowset_ptr->num_segments());
+                _base_versions.resize(_rowset_ptr->num_segments());
+                _partial_update_states.resize(_rowset_ptr->num_segments());
+                _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+                _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+            });
+        }
     }
 
     if (_upserts.size() == 0) {
@@ -341,8 +345,12 @@ Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpda
     }
     Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
 
-    if (_segment_iters.empty()) {
-        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
+    {
+        // Serialize segment iterator init against concurrent load_segment calls.
+        std::lock_guard<std::mutex> l(_shared_init_mutex);
+        if (_segment_iters.empty()) {
+            ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
+        }
     }
     RETURN_ERROR_IF_FALSE(_segment_iters.size() == _rowset_ptr->num_segments());
     ASSIGN_OR_RETURN(auto pk_encoding_type, params.tablet_schema->primary_key_encoding_type_or_error());
@@ -501,12 +509,13 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
     const auto& txn_meta = params.op_write.txn_meta();
-    // Idempotent: skip if already populated by prepare_for_parallel() or a previous call.
-    // Multiple parallel threads may enter here concurrently, but the empty check ensures
-    // only one (or none, if pre-populated) actually mutates the map.
-    if (_column_to_expr_value.empty()) {
-        for (auto& entry : txn_meta.column_to_expr_value()) {
-            _column_to_expr_value.insert({entry.first, entry.second});
+    {
+        // Serialize _column_to_expr_value init against concurrent parallel calls.
+        std::lock_guard<std::mutex> l(_shared_init_mutex);
+        if (_column_to_expr_value.empty()) {
+            for (auto& entry : txn_meta.column_to_expr_value()) {
+                _column_to_expr_value.insert({entry.first, entry.second});
+            }
         }
     }
     auto read_column_schema = ChunkHelper::convert_schema(params.tablet_schema, read_column_ids);
@@ -872,20 +881,23 @@ void RowsetUpdateState::release_segment_partial_state(uint32_t segment_id) {
 
 Status RowsetUpdateState::prepare_for_parallel(const RowsetUpdateStateParams& params) {
     // Pre-initialize all shared state so that load_segment can be called in parallel.
-    // After this, load_segment's guard checks will skip initialization and go directly
-    // to per-segment logic.
+    // Runs single-threaded before parallel tasks start, but take the mutex anyway for
+    // consistency with the protected init sections in load_segment.
+    std::lock_guard<std::mutex> l(_shared_init_mutex);
     if (_rowset_ptr == nullptr) {
         _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
         _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
                                                -1 /*unused*/, params.tablet_schema);
     }
-    TRY_CATCH_BAD_ALLOC({
-        _upserts.resize(_rowset_ptr->num_segments());
-        _base_versions.resize(_rowset_ptr->num_segments());
-        _partial_update_states.resize(_rowset_ptr->num_segments());
-        _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
-        _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
-    });
+    if (_upserts.size() != _rowset_ptr->num_segments()) {
+        TRY_CATCH_BAD_ALLOC({
+            _upserts.resize(_rowset_ptr->num_segments());
+            _base_versions.resize(_rowset_ptr->num_segments());
+            _partial_update_states.resize(_rowset_ptr->num_segments());
+            _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+            _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+        });
+    }
     if (_segment_iters.empty()) {
         vector<uint32_t> pk_columns;
         pk_columns.reserve(params.tablet_schema->num_key_columns());
@@ -895,7 +907,7 @@ Status RowsetUpdateState::prepare_for_parallel(const RowsetUpdateStateParams& pa
         Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
         ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
     }
-    if (params.op_write.has_txn_meta()) {
+    if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {
         for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {
             _column_to_expr_value.insert({entry.first, entry.second});
         }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -852,6 +852,50 @@ void RowsetUpdateState::release_segment(uint32_t segment_id) {
     _auto_increment_delete_pks[segment_id].reset();
 }
 
+void RowsetUpdateState::release_segment_partial_state(uint32_t segment_id) {
+    // Release write_columns and auto-increment state, but keep _upserts for Phase 2 (_do_update).
+    _memory_usage -= _partial_update_states[segment_id].memory_usage();
+    _partial_update_states[segment_id].reset();
+    _memory_usage -= _auto_increment_partial_update_states[segment_id].memory_usage();
+    _auto_increment_partial_update_states[segment_id].reset();
+    _memory_usage -=
+            _auto_increment_delete_pks[segment_id] ? _auto_increment_delete_pks[segment_id]->memory_usage() : 0;
+    _auto_increment_delete_pks[segment_id].reset();
+}
+
+Status RowsetUpdateState::prepare_for_parallel(const RowsetUpdateStateParams& params) {
+    // Pre-initialize all shared state so that load_segment can be called in parallel.
+    // After this, load_segment's guard checks will skip initialization and go directly
+    // to per-segment logic.
+    if (_rowset_ptr == nullptr) {
+        _rowset_meta_ptr = std::make_unique<const RowsetMetadata>(params.op_write.rowset());
+        _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
+                                               -1 /*unused*/, params.tablet_schema);
+    }
+    TRY_CATCH_BAD_ALLOC({
+        _upserts.resize(_rowset_ptr->num_segments());
+        _base_versions.resize(_rowset_ptr->num_segments());
+        _partial_update_states.resize(_rowset_ptr->num_segments());
+        _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+        _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+    });
+    if (_segment_iters.empty()) {
+        vector<uint32_t> pk_columns;
+        pk_columns.reserve(params.tablet_schema->num_key_columns());
+        for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
+            pk_columns.push_back((uint32_t)i);
+        }
+        Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
+        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
+    }
+    if (params.op_write.has_txn_meta()) {
+        for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {
+            _column_to_expr_value.insert({entry.first, entry.second});
+        }
+    }
+    return Status::OK();
+}
+
 Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStateParams& params) {
     CHECK_MEM_LIMIT("RowsetUpdateState::load_delete");
     // always one file for now.

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -213,13 +213,17 @@ Status RowsetUpdateState::load_segment(uint32_t segment_id, const RowsetUpdateSt
         _rowset_ptr = std::make_unique<Rowset>(params.tablet->tablet_mgr(), params.tablet->id(), _rowset_meta_ptr.get(),
                                                -1 /*unused*/, params.tablet_schema);
     }
-    TRY_CATCH_BAD_ALLOC({
-        _upserts.resize(_rowset_ptr->num_segments());
-        _base_versions.resize(_rowset_ptr->num_segments());
-        _partial_update_states.resize(_rowset_ptr->num_segments());
-        _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
-        _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
-    });
+    // Idempotent resize: skip if already done by prepare_for_parallel() or a previous call.
+    // This guarantees thread-safety when load_segment is called concurrently for different segments.
+    if (_upserts.size() != _rowset_ptr->num_segments()) {
+        TRY_CATCH_BAD_ALLOC({
+            _upserts.resize(_rowset_ptr->num_segments());
+            _base_versions.resize(_rowset_ptr->num_segments());
+            _partial_update_states.resize(_rowset_ptr->num_segments());
+            _auto_increment_partial_update_states.resize(_rowset_ptr->num_segments());
+            _auto_increment_delete_pks.resize(_rowset_ptr->num_segments());
+        });
+    }
 
     if (_upserts.size() == 0) {
         // Empty rowset
@@ -497,8 +501,13 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     std::vector<ColumnId> read_column_ids = get_read_columns_ids(params.op_write, params.tablet_schema);
 
     const auto& txn_meta = params.op_write.txn_meta();
-    for (auto& entry : txn_meta.column_to_expr_value()) {
-        _column_to_expr_value.insert({entry.first, entry.second});
+    // Idempotent: skip if already populated by prepare_for_parallel() or a previous call.
+    // Multiple parallel threads may enter here concurrently, but the empty check ensures
+    // only one (or none, if pre-populated) actually mutates the map.
+    if (_column_to_expr_value.empty()) {
+        for (auto& entry : txn_meta.column_to_expr_value()) {
+            _column_to_expr_value.insert({entry.first, entry.second});
+        }
     }
     auto read_column_schema = ChunkHelper::convert_schema(params.tablet_schema, read_column_ids);
     // column list that need to read from source segment
@@ -853,14 +862,12 @@ void RowsetUpdateState::release_segment(uint32_t segment_id) {
 }
 
 void RowsetUpdateState::release_segment_partial_state(uint32_t segment_id) {
-    // Release write_columns and auto-increment state, but keep _upserts for Phase 2 (_do_update).
+    // Release write_columns and auto-increment partial state used only by rewrite_segment.
+    // Keep _upserts and _auto_increment_delete_pks for Phase 2 (_do_update + index.erase).
     _memory_usage -= _partial_update_states[segment_id].memory_usage();
     _partial_update_states[segment_id].reset();
     _memory_usage -= _auto_increment_partial_update_states[segment_id].memory_usage();
     _auto_increment_partial_update_states[segment_id].reset();
-    _memory_usage -=
-            _auto_increment_delete_pks[segment_id] ? _auto_increment_delete_pks[segment_id]->memory_usage() : 0;
-    _auto_increment_delete_pks[segment_id].reset();
 }
 
 Status RowsetUpdateState::prepare_for_parallel(const RowsetUpdateStateParams& params) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -320,15 +320,13 @@ void RowsetUpdateState::plan_read_by_rssid(const std::vector<uint64_t>& rowids, 
 Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpdateStateParams& params) {
     CHECK_MEM_LIMIT("RowsetUpdateState::_do_load_upserts");
     TRACE_COUNTER_SCOPE_LATENCY_US("do_load_upserts_us");
-    // prepare() must have initialized _segment_iters already.
+    // prepare() must have initialized _segment_iters and _pkey_schema already.
     DCHECK(!_segment_iters.empty());
     RETURN_ERROR_IF_FALSE(_segment_iters.size() == _rowset_ptr->num_segments());
     ASSIGN_OR_RETURN(auto pk_encoding_type, params.tablet_schema->primary_key_encoding_type_or_error());
     auto& iter = _segment_iters[segment_id];
     SegmentPKIteratorPtr result = std::make_unique<SegmentPKIterator>();
-    // Initialize PK iterator with lazy loading if conditions allow (see should_enable_lazy_load for details).
-    // Lazy loading can significantly reduce memory usage for large segments at the cost of deferred I/O.
-    RETURN_IF_ERROR(result->init(iter, pkey_schema, should_enable_lazy_load(params), pk_encoding_type));
+    RETURN_IF_ERROR(result->init(iter, _pkey_schema, should_enable_lazy_load(params), pk_encoding_type));
     _upserts[segment_id] = std::move(result);
     _memory_usage += _upserts[segment_id]->memory_usage();
 
@@ -863,8 +861,8 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
         for (size_t i = 0; i < params.tablet_schema->num_key_columns(); i++) {
             pk_columns.push_back((uint32_t)i);
         }
-        Schema pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
-        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, false, &_stats));
+        _pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
+        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats));
     }
     if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {
         for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <unordered_map>
 
@@ -177,6 +178,12 @@ public:
     // Release `segment_id`-th segment file's state.
     void release_segment(uint32_t segment_id);
 
+    // Release partial update state (write_columns) for a segment, but keep upserts for Phase 2.
+    void release_segment_partial_state(uint32_t segment_id);
+
+    // Pre-initialize shared state so that load_segment can be called in parallel for different segments.
+    Status prepare_for_parallel(const RowsetUpdateStateParams& params);
+
     // Load `del_id`-th delete file's state.
     Status load_delete(uint32_t del_id, const RowsetUpdateStateParams& params);
 
@@ -186,7 +193,7 @@ public:
     const SegmentPKIteratorPtr& upserts(uint32_t segment_id) const { return _upserts[segment_id]; }
     const MutableColumnPtr& deletes(uint32_t segment_id) const { return _deletes[segment_id]; }
 
-    std::size_t memory_usage() const { return _memory_usage; }
+    std::size_t memory_usage() const { return _memory_usage.load(std::memory_order_relaxed); }
 
     std::string to_string() const;
 
@@ -229,7 +236,7 @@ private:
     std::vector<SegmentPKIteratorPtr> _upserts;
     // one for each delete file
     MutableColumns _deletes;
-    size_t _memory_usage = 0;
+    std::atomic<size_t> _memory_usage{0};
     int64_t _tablet_id = 0;
     // Because we can load partial segments when preload, so need vector to track their version.
     std::vector<int64_t> _base_versions;

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -257,6 +258,10 @@ private:
     OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;
     std::map<string, string> _column_to_expr_value;
+
+    // Protects shared state initialization (_rowset_ptr, per-segment vectors, _segment_iters,
+    // _column_to_expr_value) against concurrent load_segment calls in the parallel path.
+    std::mutex _shared_init_mutex;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -153,6 +152,7 @@ public:
     // How to use `RowsetUpdateState` when publish:
     //
     // init()
+    // prepare()
     //
     // for each segment:
     //      load_segment()
@@ -168,7 +168,11 @@ public:
     // init params in RowsetUpdateState.
     void init(const RowsetUpdateStateParams& params);
 
-    // Load `segment_id`-th segment file's state.
+    // Initialize shared state (rowset, segment iterators, per-segment vectors, column expr values).
+    // Must be called once before any load_segment call, for both serial and parallel paths.
+    Status prepare(const RowsetUpdateStateParams& params);
+
+    // Load `segment_id`-th segment file's state. Requires prepare() called first.
     Status load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
                         bool need_resolve_conflict, bool need_lock);
 
@@ -181,9 +185,6 @@ public:
 
     // Release partial update state (write_columns) for a segment, but keep upserts for Phase 2.
     void release_segment_partial_state(uint32_t segment_id);
-
-    // Pre-initialize shared state so that load_segment can be called in parallel for different segments.
-    Status prepare_for_parallel(const RowsetUpdateStateParams& params);
 
     // Load `del_id`-th delete file's state.
     Status load_delete(uint32_t del_id, const RowsetUpdateStateParams& params);
@@ -258,10 +259,6 @@ private:
     OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;
     std::map<string, string> _column_to_expr_value;
-
-    // Protects shared state initialization (_rowset_ptr, per-segment vectors, _segment_iters,
-    // _column_to_expr_value) against concurrent load_segment calls in the parallel path.
-    std::mutex _shared_init_mutex;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -173,17 +173,21 @@ public:
     Status prepare(const RowsetUpdateStateParams& params);
 
     // Load `segment_id`-th segment file's state. Requires prepare() called first.
+    // Thread-safe for concurrent calls with DIFFERENT segment_id values.
     Status load_segment(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version,
                         bool need_resolve_conflict, bool need_lock);
 
     // Handle `segment_id`-th segment file's partial update request.
+    // Thread-safe for concurrent calls with DIFFERENT segment_id values,
+    // provided each call uses its own replace_segments/orphan_files containers.
     Status rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
                            std::map<int, FileInfo>* replace_segments, std::vector<FileMetaPB>* orphan_files);
 
-    // Release `segment_id`-th segment file's state.
+    // Release `segment_id`-th segment file's state (upserts + partial state).
     void release_segment(uint32_t segment_id);
 
     // Release partial update state (write_columns) for a segment, but keep upserts for Phase 2.
+    // Thread-safe for concurrent calls with DIFFERENT segment_id values.
     void release_segment_partial_state(uint32_t segment_id);
 
     // Load `del_id`-th delete file's state.
@@ -255,6 +259,8 @@ private:
     RowsetMetadataUniquePtr _rowset_meta_ptr;
     std::unique_ptr<Rowset> _rowset_ptr;
 
+    // Initialized by prepare(), reused by _do_load_upserts for each segment.
+    Schema _pkey_schema;
     // to be destructed after segment iters
     OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -316,8 +316,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool is_row_mode_partial_update = op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 &&
                                             op_write.rowset().num_rows() > 0;
     const bool use_parallel_partial_update =
-            is_row_mode_partial_update && !has_condition_update && local_segments > 1 &&
-            ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
+            config::enable_pk_index_parallel_execution && is_row_mode_partial_update && !has_condition_update &&
+            local_segments > 1 && ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
 
     if (use_parallel_partial_update) {
         // ==================== Parallel row-mode partial update ====================

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -316,8 +316,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool is_row_mode_partial_update = op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 &&
                                             op_write.rowset().num_rows() > 0;
     const bool use_parallel_partial_update =
-            config::lake_enable_parallel_row_mode_partial_update && is_row_mode_partial_update &&
-            !has_condition_update && local_segments > 1 &&
+            is_row_mode_partial_update && !has_condition_update && local_segments > 1 &&
             ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
 
     if (use_parallel_partial_update) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -330,8 +330,9 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
 
         // Phase 1: parallel load + rewrite for this batch.
         if (use_parallel_partial_update && batch_end - batch_start > 1) {
-            std::vector<std::map<int, FileInfo>> per_seg_replace(local_segments);
-            std::vector<std::vector<FileMetaPB>> per_seg_orphans(local_segments);
+            uint32_t batch_count = batch_end - batch_start;
+            std::vector<std::map<int, FileInfo>> per_seg_replace(batch_count);
+            std::vector<std::vector<FileMetaPB>> per_seg_orphans(batch_count);
 
             std::mutex status_mutex;
             Status shared_status;
@@ -340,11 +341,12 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
 
             for (uint32_t i = batch_start; i < batch_end; i++) {
                 auto func = [&, i]() {
+                    uint32_t idx = i - batch_start;
                     auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
                                                  false /*no need lock*/);
                     _update_state_cache.update_object_size(state_entry, state.memory_usage());
                     if (st.ok()) {
-                        st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
+                        st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[idx], &per_seg_orphans[idx]);
                     }
                     state.release_segment_partial_state(i);
                     _update_state_cache.update_object_size(state_entry, state.memory_usage());
@@ -362,9 +364,10 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             RETURN_IF_ERROR(shared_status);
 
             for (uint32_t i = batch_start; i < batch_end; i++) {
-                replace_segments.merge(per_seg_replace[i]);
-                orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[i].begin()),
-                                    std::make_move_iterator(per_seg_orphans[i].end()));
+                uint32_t idx = i - batch_start;
+                replace_segments.merge(per_seg_replace[idx]);
+                orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[idx].begin()),
+                                    std::make_move_iterator(per_seg_orphans[idx].end()));
                 rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), i,
                                                            replace_segments);
             }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -315,9 +315,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool has_condition_update = (condition_column >= 0);
     const bool is_row_mode_partial_update =
             op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 && op_write.rowset().num_rows() > 0;
-    const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution &&
-                                             is_row_mode_partial_update && local_segments > 1 &&
-                                             use_cloud_native_pk_index(*metadata);
+    const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution && is_row_mode_partial_update &&
+                                             local_segments > 1 && use_cloud_native_pk_index(*metadata);
 
     // 2. Process segments in batches. In parallel mode, each batch runs Phase 1 (parallel
     // load+rewrite) then Phase 2 (sequential _do_update), releasing upserts per batch to
@@ -326,9 +325,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         RETURN_IF_ERROR(state.prepare_for_parallel(params));
     }
     const uint32_t batch_size =
-            use_parallel_partial_update
-                    ? ExecEnv::GetInstance()->lake_partial_update_thread_pool()->max_threads()
-                    : 1;
+            use_parallel_partial_update ? ExecEnv::GetInstance()->lake_partial_update_thread_pool()->max_threads() : 1;
 
     for (uint32_t batch_start = 0; batch_start < local_segments; batch_start += batch_size) {
         uint32_t batch_end = std::min(batch_start + batch_size, local_segments);
@@ -384,8 +381,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
                                                    false /*no need lock*/));
                 _update_state_cache.update_object_size(state_entry, state.memory_usage());
-                RETURN_IF_ERROR(
-                        state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
+                RETURN_IF_ERROR(state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
                 rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
                                                            replace_segments);
             }
@@ -403,8 +399,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 auto itr = new_deletes.find(rowset_id + global_segment_id);
                 if (itr != new_deletes.end() && itr->second.size() > 0) {
                     dv_generated_during_merge_update = std::make_shared<DelVector>();
-                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
-                                                           itr->second.size());
+                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
                     builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
                 }
             } else {
@@ -431,10 +426,10 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 bool succ = true;
                 ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
                 if (succ) {
-                    LOG(INFO) << fmt::format(
-                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
-                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
-                            async_compact_cb->trace()->MetricsAsJSON());
+                    LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
+                                             tablet->id(), txn_id,
+                                             index.current_fileset_index() - current_fileset_start_idx,
+                                             async_compact_cb->trace()->MetricsAsJSON());
                     async_compact_cb = nullptr;
                 }
             }
@@ -447,7 +442,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                                          metadata, current_fileset_start_idx + 1 /* new fileset*/));
             }
         } // end Phase 2 per-segment loop
-    } // end batch loop
+    }     // end batch loop
     if (async_compact_cb) {
         TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
         RETURN_IF_ERROR(async_compact_cb->wait_for());

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -310,105 +310,152 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // When too many sst files, we need to compact them early.
     int32_t current_fileset_start_idx = index.current_fileset_index();
     AsyncCompactCBPtr async_compact_cb;
-    // 2. Process segments sequentially to minimize peak memory usage.
-    // IMPORTANT: Each segment is fully processed before moving to next, allowing earlier segments
-    // to be released from memory while still handling large rowsets.
-    for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
-        // Track deletion vector generated during condition merge (if any).
-        // This is needed when parallel condition merge deletes rows from the newly ingested SST files.
-        std::shared_ptr<DelVector> dv_generated_during_merge_update;
-        uint32_t global_segment_id = rowset_segment_ids[local_id];
-        // Load update state of the current segment, resolving conflicts but without taking index lock.
-        RETURN_IF_ERROR(
-                state.load_segment(local_id, params, base_version, true /*reslove conflict*/, false /*no need lock*/));
+    // Check if parallel row-mode partial update is applicable.
+    int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
+    const bool has_condition_update = (condition_column >= 0);
+    const bool is_row_mode_partial_update = op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 &&
+                                            op_write.rowset().num_rows() > 0;
+    const bool use_parallel_partial_update =
+            config::lake_enable_parallel_row_mode_partial_update && is_row_mode_partial_update &&
+            !has_condition_update && local_segments > 1 &&
+            ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
+
+    if (use_parallel_partial_update) {
+        // ==================== Parallel row-mode partial update ====================
+        // Phase 1: Parallel load + rewrite segments (I/O heavy).
+        // Phase 2: Sequential _do_update (PK index modification, must be serial).
+        RETURN_IF_ERROR(state.prepare_for_parallel(params));
+
+        // Per-segment containers to avoid concurrent writes to shared containers.
+        std::vector<std::map<int, FileInfo>> per_seg_replace(local_segments);
+        std::vector<std::vector<FileMetaPB>> per_seg_orphans(local_segments);
+
+        std::mutex status_mutex;
+        Status shared_status;
+        auto token = ExecEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
+
+        for (uint32_t i = 0; i < local_segments; i++) {
+            auto func = [&, i]() {
+                auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
+                                             false /*no need lock*/);
+                if (st.ok()) {
+                    st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
+                }
+                // Release heavy state (write_columns), keep upserts for Phase 2.
+                state.release_segment_partial_state(i);
+
+                std::lock_guard<std::mutex> l(status_mutex);
+                shared_status.update(st);
+            };
+            auto submit_st = token->submit_func(func);
+            if (!submit_st.ok()) {
+                std::lock_guard<std::mutex> l(status_mutex);
+                shared_status.update(submit_st);
+            }
+        }
+        token->wait();
+        RETURN_IF_ERROR(shared_status);
+
+        // Merge per-segment results and update rssid_fileinfo_container.
+        for (uint32_t i = 0; i < local_segments; i++) {
+            replace_segments.merge(per_seg_replace[i]);
+            orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[i].begin()),
+                                std::make_move_iterator(per_seg_orphans[i].end()));
+            rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), i,
+                                                       replace_segments);
+        }
         _update_state_cache.update_object_size(state_entry, state.memory_usage());
-        // 2.1 For partial update, rewrite the segment file to generate replace segments and orphan files.
-        RETURN_IF_ERROR(state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
-        rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
-                                                   replace_segments);
-        VLOG(2) << strings::Substitute(
-                "[publish_pk_tablet][segment_loop] tablet:$0 txn:$1 assigned:$2 local_id:$3 global_id:$4 "
-                "segments_local:$5",
-                tablet->id(), txn_id, assigned_global_segments, local_id, global_segment_id, local_segments);
-        // Determine merge strategy based on whether a condition column is specified.
-        // Condition column enables value-based conflict resolution (e.g., keep row with max timestamp).
-        int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
-        const bool has_condition_update = (condition_column >= 0);
-        // 2.2 Update primary index and collect delete information caused by key replacement.
-        TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-        DCHECK(state.upserts(local_id) != nullptr);
-        if (!has_condition_update) {
-            // Standard primary key update: last-write-wins semantics
+
+        // Phase 2: Sequential PK index update (same as normal upsert, unchanged).
+        for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
+            uint32_t global_segment_id = rowset_segment_ids[local_id];
+            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+            DCHECK(state.upserts(local_id) != nullptr);
             RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
                                        op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-        } else if (op_write.ssts_size() > 0) {
-            // PARALLEL CONDITION MERGE PATH (new optimization):
-            // When SST files exist, condition values were pre-written to SSTs during ingestion,
-            // allowing parallel comparison without blocking on segment iteration.
-            // WHY SSTs enable parallelism: Each chunk's condition values are already materialized
-            // in SST files, so we can parallelize chunk-level condition comparisons.
-            // PERFORMANCE: 3-5x faster for large datasets vs serial path.
-            RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id, condition_column,
-                                                               state.upserts(local_id), index, &new_deletes));
-            auto itr = new_deletes.find(rowset_id + global_segment_id);
-            if (itr != new_deletes.end() && itr->second.size() > 0) {
-                // Condition comparison resulted in deleting some newly ingested rows (old value won).
-                // Build deletion vector to mark these rows as deleted in the SST file.
-                dv_generated_during_merge_update = std::make_shared<DelVector>();
-                dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
-                builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+            if (state.auto_increment_deletes(local_id) != nullptr) {
+                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
+                                            del_rebuild_rssid));
             }
-        } else {
-            // SERIAL CONDITION MERGE PATH (original):
-            // No SST files means condition values only exist in segment data, requiring serial
-            // iteration through standalone PK column to read condition values on-demand.
-            // Used when load spilling is disabled or not applicable.
-            RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                      state.upserts(local_id)->standalone_pk_column(), index,
-                                                      &new_deletes));
-        }
-        // 2.3 Apply deletes generated by auto-increment conflict handling (if any).
-        if (state.auto_increment_deletes(local_id) != nullptr) {
-            RETURN_IF_ERROR(
-                    index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes, del_rebuild_rssid));
-        }
-        // Refresh memory accounting after index/state changes.
-        _index_cache.update_object_size(index_entry, index.memory_usage());
-        state.release_segment(local_id);
-        _update_state_cache.update_object_size(state_entry, state.memory_usage());
-        if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
-            // Ingest SST file into the cloud-native primary key index.
-            // IMPORTANT: Must pass the deletion vector generated during condition merge to ensure
-            // the index correctly marks rows deleted by condition comparison.
-            // WHY: Condition merge may determine that old values should win, requiring new rows
-            // to be marked deleted. The delvec must be applied atomically with SST ingestion
-            // to maintain index consistency.
-            DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
-            delvec_page_pb.set_version(metadata->version());
-            RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
-                                             rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
-                                             dv_generated_during_merge_update));
-        }
-        if (async_compact_cb) {
-            TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-            bool succ = true;
-            ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
-            if (succ) {
-                LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
-                                         tablet->id(), txn_id,
-                                         index.current_fileset_index() - current_fileset_start_idx,
-                                         async_compact_cb->trace()->MetricsAsJSON());
-                async_compact_cb = nullptr;
+            _index_cache.update_object_size(index_entry, index.memory_usage());
+            state.release_segment(local_id);
+            _update_state_cache.update_object_size(state_entry, state.memory_usage());
+            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+                DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
+                delvec_page_pb.set_version(metadata->version());
+                RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
+                                                 rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
+                                                 nullptr));
             }
         }
-        if (async_compact_cb == nullptr && !has_condition_update &&
-            index.current_fileset_index() - current_fileset_start_idx >=
-                    config::pk_index_early_sst_compaction_threshold) {
-            // Do early sst compaction when too many sst files ingested.
-            TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
-            ASSIGN_OR_RETURN(async_compact_cb,
-                             index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
-                                                     metadata, current_fileset_start_idx + 1 /* new fileset*/));
+    } else {
+        // ==================== Serial path (original) ====================
+        // 2. Process segments sequentially to minimize peak memory usage.
+        for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
+            std::shared_ptr<DelVector> dv_generated_during_merge_update;
+            uint32_t global_segment_id = rowset_segment_ids[local_id];
+            RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
+                                               false /*no need lock*/));
+            _update_state_cache.update_object_size(state_entry, state.memory_usage());
+            RETURN_IF_ERROR(state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
+            rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
+                                                       replace_segments);
+            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+            DCHECK(state.upserts(local_id) != nullptr);
+            if (!has_condition_update) {
+                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
+                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
+            } else if (op_write.ssts_size() > 0) {
+                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
+                                                                   condition_column, state.upserts(local_id), index,
+                                                                   &new_deletes));
+                auto itr = new_deletes.find(rowset_id + global_segment_id);
+                if (itr != new_deletes.end() && itr->second.size() > 0) {
+                    dv_generated_during_merge_update = std::make_shared<DelVector>();
+                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
+                                                           itr->second.size());
+                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+                }
+            } else {
+                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
+                                                          state.upserts(local_id)->standalone_pk_column(), index,
+                                                          &new_deletes));
+            }
+            if (state.auto_increment_deletes(local_id) != nullptr) {
+                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
+                                            del_rebuild_rssid));
+            }
+            _index_cache.update_object_size(index_entry, index.memory_usage());
+            state.release_segment(local_id);
+            _update_state_cache.update_object_size(state_entry, state.memory_usage());
+            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+                DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
+                delvec_page_pb.set_version(metadata->version());
+                RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
+                                                 rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
+                                                 dv_generated_during_merge_update));
+            }
+            if (async_compact_cb) {
+                TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
+                bool succ = true;
+                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
+                if (succ) {
+                    LOG(INFO) << fmt::format(
+                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
+                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
+                            async_compact_cb->trace()->MetricsAsJSON());
+                    async_compact_cb = nullptr;
+                }
+            }
+            if (async_compact_cb == nullptr && !has_condition_update &&
+                index.current_fileset_index() - current_fileset_start_idx >=
+                        config::pk_index_early_sst_compaction_threshold) {
+                TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
+                ASSIGN_OR_RETURN(async_compact_cb,
+                                 index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
+                                                         metadata, current_fileset_start_idx + 1 /* new fileset*/));
+            }
         }
     }
     if (async_compact_cb) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -313,11 +313,11 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // Check if parallel row-mode partial update is applicable.
     int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
     const bool has_condition_update = (condition_column >= 0);
-    const bool is_row_mode_partial_update = op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 &&
-                                            op_write.rowset().num_rows() > 0;
-    const bool use_parallel_partial_update =
-            config::enable_pk_index_parallel_execution && is_row_mode_partial_update && !has_condition_update &&
-            local_segments > 1 && ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
+    const bool is_row_mode_partial_update =
+            op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 && op_write.rowset().num_rows() > 0;
+    const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution && is_row_mode_partial_update &&
+                                             !has_condition_update && local_segments > 1 &&
+                                             ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
 
     if (use_parallel_partial_update) {
         // ==================== Parallel row-mode partial update ====================
@@ -336,8 +336,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
 
         for (uint32_t i = 0; i < local_segments; i++) {
             auto func = [&, i]() {
-                auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
-                                             false /*no need lock*/);
+                auto st =
+                        state.load_segment(i, params, base_version, true /*resolve conflict*/, false /*no need lock*/);
                 if (st.ok()) {
                     st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
                 }
@@ -412,8 +412,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 auto itr = new_deletes.find(rowset_id + global_segment_id);
                 if (itr != new_deletes.end() && itr->second.size() > 0) {
                     dv_generated_during_merge_update = std::make_shared<DelVector>();
-                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
-                                                           itr->second.size());
+                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
                     builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
                 }
             } else {
@@ -440,10 +439,10 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 bool succ = true;
                 ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
                 if (succ) {
-                    LOG(INFO) << fmt::format(
-                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
-                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
-                            async_compact_cb->trace()->MetricsAsJSON());
+                    LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
+                                             tablet->id(), txn_id,
+                                             index.current_fileset_index() - current_fileset_start_idx,
+                                             async_compact_cb->trace()->MetricsAsJSON());
                     async_compact_cb = nullptr;
                 }
             }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -319,122 +319,135 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                              is_row_mode_partial_update && local_segments > 1 &&
                                              use_cloud_native_pk_index(*metadata);
 
-    // 2. Load and rewrite segments: parallel when applicable, otherwise serial.
+    // 2. Process segments in batches. In parallel mode, each batch runs Phase 1 (parallel
+    // load+rewrite) then Phase 2 (sequential _do_update), releasing upserts per batch to
+    // prevent memory accumulation. In serial mode, batch_size=1 degenerates to original logic.
     if (use_parallel_partial_update) {
-        // Parallel Phase 1: load_segment + rewrite_segment across segments concurrently.
         RETURN_IF_ERROR(state.prepare_for_parallel(params));
+    }
+    const uint32_t batch_size =
+            use_parallel_partial_update
+                    ? ExecEnv::GetInstance()->lake_partial_update_thread_pool()->max_threads()
+                    : 1;
 
-        std::vector<std::map<int, FileInfo>> per_seg_replace(local_segments);
-        std::vector<std::vector<FileMetaPB>> per_seg_orphans(local_segments);
+    for (uint32_t batch_start = 0; batch_start < local_segments; batch_start += batch_size) {
+        uint32_t batch_end = std::min(batch_start + batch_size, local_segments);
 
-        std::mutex status_mutex;
-        Status shared_status;
-        auto token = ExecEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
-                ThreadPool::ExecutionMode::CONCURRENT);
+        // Phase 1: parallel load + rewrite for this batch.
+        if (use_parallel_partial_update && batch_end - batch_start > 1) {
+            std::vector<std::map<int, FileInfo>> per_seg_replace(local_segments);
+            std::vector<std::vector<FileMetaPB>> per_seg_orphans(local_segments);
 
-        for (uint32_t i = 0; i < local_segments; i++) {
-            auto func = [&, i]() {
-                auto st =
-                        state.load_segment(i, params, base_version, true /*resolve conflict*/, false /*no need lock*/);
-                if (st.ok()) {
-                    st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
+            std::mutex status_mutex;
+            Status shared_status;
+            auto token = ExecEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
+                    ThreadPool::ExecutionMode::CONCURRENT);
+
+            for (uint32_t i = batch_start; i < batch_end; i++) {
+                auto func = [&, i]() {
+                    auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
+                                                 false /*no need lock*/);
+                    if (st.ok()) {
+                        st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
+                    }
+                    state.release_segment_partial_state(i);
+
+                    std::lock_guard<std::mutex> l(status_mutex);
+                    shared_status.update(st);
+                };
+                auto submit_st = token->submit_func(func);
+                if (!submit_st.ok()) {
+                    std::lock_guard<std::mutex> l(status_mutex);
+                    shared_status.update(submit_st);
                 }
-                state.release_segment_partial_state(i);
-
-                std::lock_guard<std::mutex> l(status_mutex);
-                shared_status.update(st);
-            };
-            auto submit_st = token->submit_func(func);
-            if (!submit_st.ok()) {
-                std::lock_guard<std::mutex> l(status_mutex);
-                shared_status.update(submit_st);
             }
-        }
-        token->wait();
-        RETURN_IF_ERROR(shared_status);
+            token->wait();
+            RETURN_IF_ERROR(shared_status);
 
-        for (uint32_t i = 0; i < local_segments; i++) {
-            replace_segments.merge(per_seg_replace[i]);
-            orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[i].begin()),
-                                std::make_move_iterator(per_seg_orphans[i].end()));
-            rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), i,
-                                                       replace_segments);
-        }
-        _update_state_cache.update_object_size(state_entry, state.memory_usage());
-    }
-
-    // 3. Sequential per-segment: PK index update, condition merge, SST ingestion.
-    // Shared by both parallel and serial paths. In the parallel path load+rewrite is already done;
-    // in the serial path it happens inline at the beginning of each iteration.
-    for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
-        std::shared_ptr<DelVector> dv_generated_during_merge_update;
-        uint32_t global_segment_id = rowset_segment_ids[local_id];
-
-        if (!use_parallel_partial_update) {
-            // Serial: load + rewrite inline.
-            RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
-                                               false /*no need lock*/));
+            for (uint32_t i = batch_start; i < batch_end; i++) {
+                replace_segments.merge(per_seg_replace[i]);
+                orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[i].begin()),
+                                    std::make_move_iterator(per_seg_orphans[i].end()));
+                rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), i,
+                                                           replace_segments);
+            }
             _update_state_cache.update_object_size(state_entry, state.memory_usage());
-            RETURN_IF_ERROR(state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
-            rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
-                                                       replace_segments);
         }
 
-        // PK index update + condition merge.
-        TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-        DCHECK(state.upserts(local_id) != nullptr);
-        if (!has_condition_update) {
-            RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                       op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-        } else if (op_write.ssts_size() > 0) {
-            RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id, condition_column,
-                                                               state.upserts(local_id), index, &new_deletes));
-            auto itr = new_deletes.find(rowset_id + global_segment_id);
-            if (itr != new_deletes.end() && itr->second.size() > 0) {
-                dv_generated_during_merge_update = std::make_shared<DelVector>();
-                dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
-                builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+        // Phase 2: sequential _do_update for this batch (shared by parallel and serial paths).
+        for (uint32_t local_id = batch_start; local_id < batch_end; ++local_id) {
+            std::shared_ptr<DelVector> dv_generated_during_merge_update;
+            uint32_t global_segment_id = rowset_segment_ids[local_id];
+
+            if (!use_parallel_partial_update || batch_end - batch_start <= 1) {
+                // Serial path: load + rewrite inline.
+                RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
+                                                   false /*no need lock*/));
+                _update_state_cache.update_object_size(state_entry, state.memory_usage());
+                RETURN_IF_ERROR(
+                        state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
+                rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
+                                                           replace_segments);
             }
-        } else {
-            RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                      state.upserts(local_id)->standalone_pk_column(), index,
-                                                      &new_deletes));
-        }
-        if (state.auto_increment_deletes(local_id) != nullptr) {
-            RETURN_IF_ERROR(
-                    index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes, del_rebuild_rssid));
-        }
-        _index_cache.update_object_size(index_entry, index.memory_usage());
-        state.release_segment(local_id);
-        _update_state_cache.update_object_size(state_entry, state.memory_usage());
-        if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
-            DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
-            delvec_page_pb.set_version(metadata->version());
-            RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
-                                             rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
-                                             dv_generated_during_merge_update));
-        }
-        if (async_compact_cb) {
-            TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-            bool succ = true;
-            ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
-            if (succ) {
-                LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
-                                         tablet->id(), txn_id,
-                                         index.current_fileset_index() - current_fileset_start_idx,
-                                         async_compact_cb->trace()->MetricsAsJSON());
-                async_compact_cb = nullptr;
+
+            // PK index update + condition merge.
+            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+            DCHECK(state.upserts(local_id) != nullptr);
+            if (!has_condition_update) {
+                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
+                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
+            } else if (op_write.ssts_size() > 0) {
+                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
+                                                                   condition_column, state.upserts(local_id), index,
+                                                                   &new_deletes));
+                auto itr = new_deletes.find(rowset_id + global_segment_id);
+                if (itr != new_deletes.end() && itr->second.size() > 0) {
+                    dv_generated_during_merge_update = std::make_shared<DelVector>();
+                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
+                                                           itr->second.size());
+                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+                }
+            } else {
+                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
+                                                          state.upserts(local_id)->standalone_pk_column(), index,
+                                                          &new_deletes));
             }
-        }
-        if (async_compact_cb == nullptr && !has_condition_update &&
-            index.current_fileset_index() - current_fileset_start_idx >=
-                    config::pk_index_early_sst_compaction_threshold) {
-            TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
-            ASSIGN_OR_RETURN(async_compact_cb,
-                             index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
-                                                     metadata, current_fileset_start_idx + 1 /* new fileset*/));
-        }
-    }
+            if (state.auto_increment_deletes(local_id) != nullptr) {
+                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
+                                            del_rebuild_rssid));
+            }
+            _index_cache.update_object_size(index_entry, index.memory_usage());
+            state.release_segment(local_id);
+            _update_state_cache.update_object_size(state_entry, state.memory_usage());
+            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+                DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
+                delvec_page_pb.set_version(metadata->version());
+                RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
+                                                 rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
+                                                 dv_generated_during_merge_update));
+            }
+            if (async_compact_cb) {
+                TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
+                bool succ = true;
+                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
+                if (succ) {
+                    LOG(INFO) << fmt::format(
+                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
+                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
+                            async_compact_cb->trace()->MetricsAsJSON());
+                    async_compact_cb = nullptr;
+                }
+            }
+            if (async_compact_cb == nullptr && !has_condition_update &&
+                index.current_fileset_index() - current_fileset_start_idx >=
+                        config::pk_index_early_sst_compaction_threshold) {
+                TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
+                ASSIGN_OR_RETURN(async_compact_cb,
+                                 index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
+                                                         metadata, current_fileset_start_idx + 1 /* new fileset*/));
+            }
+        } // end Phase 2 per-segment loop
+    } // end batch loop
     if (async_compact_cb) {
         TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
         RETURN_IF_ERROR(async_compact_cb->wait_for());

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -279,6 +279,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             .container = rssid_fileinfo_container,
     };
     state.init(params);
+    RETURN_IF_ERROR(state.prepare(params));
     // Init delvec state.
     // Map from rssid (rowset id + segment offset) to the list of deleted rowids collected during this publish.
     PrimaryIndex::DeletesMap new_deletes;
@@ -321,9 +322,6 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // 2. Process segments in batches. In parallel mode, each batch runs Phase 1 (parallel
     // load+rewrite) then Phase 2 (sequential _do_update), releasing upserts per batch to
     // prevent memory accumulation. In serial mode, batch_size=1 degenerates to original logic.
-    if (use_parallel_partial_update) {
-        RETURN_IF_ERROR(state.prepare_for_parallel(params));
-    }
     const uint32_t batch_size =
             use_parallel_partial_update ? ExecEnv::GetInstance()->lake_partial_update_thread_pool()->max_threads() : 1;
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -319,13 +319,11 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                              is_row_mode_partial_update && local_segments > 1 &&
                                              use_cloud_native_pk_index(*metadata);
 
+    // 2. Load and rewrite segments: parallel when applicable, otherwise serial.
     if (use_parallel_partial_update) {
-        // ==================== Parallel row-mode partial update ====================
-        // Phase 1: Parallel load + rewrite segments (I/O heavy).
-        // Phase 2: Sequential _do_update (PK index modification, must be serial).
+        // Parallel Phase 1: load_segment + rewrite_segment across segments concurrently.
         RETURN_IF_ERROR(state.prepare_for_parallel(params));
 
-        // Per-segment containers to avoid concurrent writes to shared containers.
         std::vector<std::map<int, FileInfo>> per_seg_replace(local_segments);
         std::vector<std::vector<FileMetaPB>> per_seg_orphans(local_segments);
 
@@ -341,7 +339,6 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 if (st.ok()) {
                     st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
                 }
-                // Release heavy state (write_columns), keep upserts for Phase 2.
                 state.release_segment_partial_state(i);
 
                 std::lock_guard<std::mutex> l(status_mutex);
@@ -356,7 +353,6 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         token->wait();
         RETURN_IF_ERROR(shared_status);
 
-        // Merge per-segment results and update rssid_fileinfo_container.
         for (uint32_t i = 0; i < local_segments; i++) {
             replace_segments.merge(per_seg_replace[i]);
             orphan_files.insert(orphan_files.end(), std::make_move_iterator(per_seg_orphans[i].begin()),
@@ -365,133 +361,78 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                                        replace_segments);
         }
         _update_state_cache.update_object_size(state_entry, state.memory_usage());
+    }
 
-        // Phase 2: Sequential PK index update (same logic as serial path).
-        for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
-            std::shared_ptr<DelVector> dv_generated_during_merge_update;
-            uint32_t global_segment_id = rowset_segment_ids[local_id];
-            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-            DCHECK(state.upserts(local_id) != nullptr);
-            if (!has_condition_update) {
-                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-            } else if (op_write.ssts_size() > 0) {
-                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
-                                                                   condition_column, state.upserts(local_id), index,
-                                                                   &new_deletes));
-                auto itr = new_deletes.find(rowset_id + global_segment_id);
-                if (itr != new_deletes.end() && itr->second.size() > 0) {
-                    dv_generated_during_merge_update = std::make_shared<DelVector>();
-                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
-                                                           itr->second.size());
-                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
-                }
-            } else {
-                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                          state.upserts(local_id)->standalone_pk_column(), index,
-                                                          &new_deletes));
-            }
-            if (state.auto_increment_deletes(local_id) != nullptr) {
-                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
-                                            del_rebuild_rssid));
-            }
-            _index_cache.update_object_size(index_entry, index.memory_usage());
-            state.release_segment(local_id);
-            _update_state_cache.update_object_size(state_entry, state.memory_usage());
-            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
-                DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
-                delvec_page_pb.set_version(metadata->version());
-                RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
-                                                 rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
-                                                 dv_generated_during_merge_update));
-            }
-            if (async_compact_cb) {
-                TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-                bool succ = true;
-                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
-                if (succ) {
-                    LOG(INFO) << fmt::format(
-                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
-                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
-                            async_compact_cb->trace()->MetricsAsJSON());
-                    async_compact_cb = nullptr;
-                }
-            }
-            if (async_compact_cb == nullptr && !has_condition_update &&
-                index.current_fileset_index() - current_fileset_start_idx >=
-                        config::pk_index_early_sst_compaction_threshold) {
-                TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
-                ASSIGN_OR_RETURN(async_compact_cb,
-                                 index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
-                                                         metadata, current_fileset_start_idx + 1 /* new fileset*/));
-            }
-        }
-    } else {
-        // ==================== Serial path (original) ====================
-        // 2. Process segments sequentially to minimize peak memory usage.
-        for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
-            std::shared_ptr<DelVector> dv_generated_during_merge_update;
-            uint32_t global_segment_id = rowset_segment_ids[local_id];
+    // 3. Sequential per-segment: PK index update, condition merge, SST ingestion.
+    // Shared by both parallel and serial paths. In the parallel path load+rewrite is already done;
+    // in the serial path it happens inline at the beginning of each iteration.
+    for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
+        std::shared_ptr<DelVector> dv_generated_during_merge_update;
+        uint32_t global_segment_id = rowset_segment_ids[local_id];
+
+        if (!use_parallel_partial_update) {
+            // Serial: load + rewrite inline.
             RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
                                                false /*no need lock*/));
             _update_state_cache.update_object_size(state_entry, state.memory_usage());
             RETURN_IF_ERROR(state.rewrite_segment(local_id, txn_id, params, &replace_segments, &orphan_files));
             rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
                                                        replace_segments);
-            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-            DCHECK(state.upserts(local_id) != nullptr);
-            if (!has_condition_update) {
-                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-            } else if (op_write.ssts_size() > 0) {
-                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
-                                                                   condition_column, state.upserts(local_id), index,
-                                                                   &new_deletes));
-                auto itr = new_deletes.find(rowset_id + global_segment_id);
-                if (itr != new_deletes.end() && itr->second.size() > 0) {
-                    dv_generated_during_merge_update = std::make_shared<DelVector>();
-                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
-                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
-                }
-            } else {
-                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                          state.upserts(local_id)->standalone_pk_column(), index,
-                                                          &new_deletes));
+        }
+
+        // PK index update + condition merge.
+        TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+        DCHECK(state.upserts(local_id) != nullptr);
+        if (!has_condition_update) {
+            RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
+                                       op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
+        } else if (op_write.ssts_size() > 0) {
+            RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id, condition_column,
+                                                               state.upserts(local_id), index, &new_deletes));
+            auto itr = new_deletes.find(rowset_id + global_segment_id);
+            if (itr != new_deletes.end() && itr->second.size() > 0) {
+                dv_generated_during_merge_update = std::make_shared<DelVector>();
+                dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
+                builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
             }
-            if (state.auto_increment_deletes(local_id) != nullptr) {
-                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
-                                            del_rebuild_rssid));
+        } else {
+            RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
+                                                      state.upserts(local_id)->standalone_pk_column(), index,
+                                                      &new_deletes));
+        }
+        if (state.auto_increment_deletes(local_id) != nullptr) {
+            RETURN_IF_ERROR(
+                    index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes, del_rebuild_rssid));
+        }
+        _index_cache.update_object_size(index_entry, index.memory_usage());
+        state.release_segment(local_id);
+        _update_state_cache.update_object_size(state_entry, state.memory_usage());
+        if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+            DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
+            delvec_page_pb.set_version(metadata->version());
+            RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
+                                             rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
+                                             dv_generated_during_merge_update));
+        }
+        if (async_compact_cb) {
+            TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
+            bool succ = true;
+            ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
+            if (succ) {
+                LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
+                                         tablet->id(), txn_id,
+                                         index.current_fileset_index() - current_fileset_start_idx,
+                                         async_compact_cb->trace()->MetricsAsJSON());
+                async_compact_cb = nullptr;
             }
-            _index_cache.update_object_size(index_entry, index.memory_usage());
-            state.release_segment(local_id);
-            _update_state_cache.update_object_size(state_entry, state.memory_usage());
-            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
-                DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
-                delvec_page_pb.set_version(metadata->version());
-                RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
-                                                 rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
-                                                 dv_generated_during_merge_update));
-            }
-            if (async_compact_cb) {
-                TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-                bool succ = true;
-                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
-                if (succ) {
-                    LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
-                                             tablet->id(), txn_id,
-                                             index.current_fileset_index() - current_fileset_start_idx,
-                                             async_compact_cb->trace()->MetricsAsJSON());
-                    async_compact_cb = nullptr;
-                }
-            }
-            if (async_compact_cb == nullptr && !has_condition_update &&
-                index.current_fileset_index() - current_fileset_start_idx >=
-                        config::pk_index_early_sst_compaction_threshold) {
-                TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
-                ASSIGN_OR_RETURN(async_compact_cb,
-                                 index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
-                                                         metadata, current_fileset_start_idx + 1 /* new fileset*/));
-            }
+        }
+        if (async_compact_cb == nullptr && !has_condition_update &&
+            index.current_fileset_index() - current_fileset_start_idx >=
+                    config::pk_index_early_sst_compaction_threshold) {
+            TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
+            ASSIGN_OR_RETURN(async_compact_cb,
+                             index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
+                                                     metadata, current_fileset_start_idx + 1 /* new fileset*/));
         }
     }
     if (async_compact_cb) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -344,10 +344,12 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 auto func = [&, i]() {
                     auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
                                                  false /*no need lock*/);
+                    _update_state_cache.update_object_size(state_entry, state.memory_usage());
                     if (st.ok()) {
                         st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[i], &per_seg_orphans[i]);
                     }
                     state.release_segment_partial_state(i);
+                    _update_state_cache.update_object_size(state_entry, state.memory_usage());
 
                     std::lock_guard<std::mutex> l(status_mutex);
                     shared_status.update(st);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -315,10 +315,9 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool has_condition_update = (condition_column >= 0);
     const bool is_row_mode_partial_update =
             op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 && op_write.rowset().num_rows() > 0;
-    const bool use_parallel_partial_update =
-            config::enable_pk_index_parallel_execution && is_row_mode_partial_update && !has_condition_update &&
-            local_segments > 1 && use_cloud_native_pk_index(*metadata) &&
-            ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
+    const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution &&
+                                             is_row_mode_partial_update && local_segments > 1 &&
+                                             use_cloud_native_pk_index(*metadata);
 
     if (use_parallel_partial_update) {
         // ==================== Parallel row-mode partial update ====================
@@ -367,13 +366,31 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         }
         _update_state_cache.update_object_size(state_entry, state.memory_usage());
 
-        // Phase 2: Sequential PK index update (same as normal upsert, unchanged).
+        // Phase 2: Sequential PK index update (same logic as serial path).
         for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
+            std::shared_ptr<DelVector> dv_generated_during_merge_update;
             uint32_t global_segment_id = rowset_segment_ids[local_id];
             TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
             DCHECK(state.upserts(local_id) != nullptr);
-            RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                       op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
+            if (!has_condition_update) {
+                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
+                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
+            } else if (op_write.ssts_size() > 0) {
+                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
+                                                                   condition_column, state.upserts(local_id), index,
+                                                                   &new_deletes));
+                auto itr = new_deletes.find(rowset_id + global_segment_id);
+                if (itr != new_deletes.end() && itr->second.size() > 0) {
+                    dv_generated_during_merge_update = std::make_shared<DelVector>();
+                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
+                                                           itr->second.size());
+                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+                }
+            } else {
+                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
+                                                          state.upserts(local_id)->standalone_pk_column(), index,
+                                                          &new_deletes));
+            }
             if (state.auto_increment_deletes(local_id) != nullptr) {
                 RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
                                             del_rebuild_rssid));
@@ -386,7 +403,27 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                 delvec_page_pb.set_version(metadata->version());
                 RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),
                                                  rowset_id + global_segment_id, metadata->version(), delvec_page_pb,
-                                                 nullptr));
+                                                 dv_generated_during_merge_update));
+            }
+            if (async_compact_cb) {
+                TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
+                bool succ = true;
+                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
+                if (succ) {
+                    LOG(INFO) << fmt::format(
+                            "early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}", tablet->id(),
+                            txn_id, index.current_fileset_index() - current_fileset_start_idx,
+                            async_compact_cb->trace()->MetricsAsJSON());
+                    async_compact_cb = nullptr;
+                }
+            }
+            if (async_compact_cb == nullptr && !has_condition_update &&
+                index.current_fileset_index() - current_fileset_start_idx >=
+                        config::pk_index_early_sst_compaction_threshold) {
+                TRACE_COUNTER_INCREMENT("early_sst_compact_times", 1);
+                ASSIGN_OR_RETURN(async_compact_cb,
+                                 index.early_sst_compact(ExecEnv::GetInstance()->parallel_compact_mgr(), _tablet_mgr,
+                                                         metadata, current_fileset_start_idx + 1 /* new fileset*/));
             }
         }
     } else {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -315,9 +315,10 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool has_condition_update = (condition_column >= 0);
     const bool is_row_mode_partial_update =
             op_write.has_txn_meta() && op_write.rewrite_segments_size() > 0 && op_write.rowset().num_rows() > 0;
-    const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution && is_row_mode_partial_update &&
-                                             !has_condition_update && local_segments > 1 &&
-                                             ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
+    const bool use_parallel_partial_update =
+            config::enable_pk_index_parallel_execution && is_row_mode_partial_update && !has_condition_update &&
+            local_segments > 1 && use_cloud_native_pk_index(*metadata) &&
+            ExecEnv::GetInstance()->lake_partial_update_thread_pool() != nullptr;
 
     if (use_parallel_partial_update) {
         // ==================== Parallel row-mode partial update ====================

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -330,6 +330,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
 
         // Phase 1: parallel load + rewrite for this batch.
         if (use_parallel_partial_update && batch_end - batch_start > 1) {
+            TRACE_COUNTER_SCOPE_LATENCY_US("parallel_load_rewrite_seg_latency_us");
             uint32_t batch_count = batch_end - batch_start;
             std::vector<std::map<int, FileInfo>> per_seg_replace(batch_count);
             std::vector<std::vector<FileMetaPB>> per_seg_orphans(batch_count);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -4013,9 +4013,8 @@ TEST_P(LakePartialUpdateTest, test_parallel_row_mode_partial_update_multi_segmen
 
     // Step 3: Verify correctness - c1 should be updated (c0 * 7),
     // c2 should remain unchanged (c0 * 4).
-    ASSERT_EQ(kChunkSize * kNumSourceWrites, check(version, [](int c0, int c1, int c2) {
-                  return (c0 * 7 == c1) && (c0 * 4 == c2);
-              }));
+    ASSERT_EQ(kChunkSize * kNumSourceWrites,
+              check(version, [](int c0, int c1, int c2) { return (c0 * 7 == c1) && (c0 * 4 == c2); }));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -3937,4 +3937,85 @@ TEST_P(LakePartialUpdateTest, test_parallel_column_mode_partial_update_multi_seg
     EXPECT_GT(md->dcg_meta().dcgs_size(), 0);
 }
 
+// Test parallel row-mode partial update publish with multiple segments.
+// This exercises the parallel Phase 1 (load_segment + rewrite_segment in parallel)
+// and sequential Phase 2 (_do_update) path.
+TEST_P(LakePartialUpdateTest, test_parallel_row_mode_partial_update_multi_segments) {
+    if (GetParam().partial_update_mode != PartialUpdateMode::ROW_MODE) {
+        GTEST_SKIP() << "Only ROW_MODE uses parallel row-mode partial update";
+    }
+
+    const int kNumSourceWrites = 3;
+
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // Step 1: Create initial full data with multiple key ranges.
+    for (int i = 0; i < kNumSourceWrites; i++) {
+        auto chunk_full = generate_data(kChunkSize, i, false, 3);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * kNumSourceWrites,
+              check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+
+    // Step 2: Perform row-mode partial update with multiple segments per txn.
+    // Using write_buffer_size=1 forces each write() call to flush as a separate segment,
+    // creating multiple update segments that exercise parallel load + rewrite.
+    const int64_t old_write_buffer_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    DeferOp restore_cfg([&]() { config::write_buffer_size = old_write_buffer_size; });
+
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::ROW_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        // Write partial updates for different key ranges, creating multiple update segments.
+        for (int j = 0; j < kNumSourceWrites; j++) {
+            auto chunk_partial = generate_data(kChunkSize, j, true, 7);
+            ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+        }
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish triggers parallel row-mode partial update:
+        // - Phase 1: parallel load_segment + rewrite_segment
+        // - Phase 2: sequential _do_update
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Step 3: Verify correctness - c1 should be updated (c0 * 7),
+    // c2 should remain unchanged (c0 * 4).
+    ASSERT_EQ(kChunkSize * kNumSourceWrites, check(version, [](int c0, int c1, int c2) {
+                  return (c0 * 7 == c1) && (c0 * 4 == c2);
+              }));
+}
+
 } // namespace starrocks::lake

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -915,7 +915,7 @@ This topic introduces the following types of FE configurations:
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for lake partial update segment-level parallelism in a shared-data cluster. This thread pool is used by both row-mode and column-mode partial updates to parallelize I/O-heavy segment operations (load_segment + rewrite_segment for row-mode, DCG generation for column-mode). `0` means automatically set to the number of CPU cores. Runtime on/off is controlled by `enable_pk_index_parallel_execution`.
+- Description: The maximum number of threads in the thread pool for lake partial update segment-level parallelism in a shared-data cluster. This thread pool is used by both row-mode and column-mode partial updates to parallelize I/O-heavy segment operations (load_segment + rewrite_segment for row-mode, DCG generation for column-mode). `0` means automatically set to half of the number of CPU cores. Runtime on/off is controlled by `enable_pk_index_parallel_execution`.
 - Introduced in: v4.1
 
 ### lake_partial_update_thread_pool_queue_size

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -909,6 +909,24 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of threads in the thread pool for Primary Key index parallel execution in a shared-data cluster. `0` means automatically set to half of the number of CPU cores.
 - Introduced in: -
 
+### lake_partial_update_thread_pool_max_threads
+
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of threads in the thread pool for lake partial update segment-level parallelism in a shared-data cluster. This thread pool is used by both row-mode and column-mode partial updates to parallelize I/O-heavy segment operations (load_segment + rewrite_segment for row-mode, DCG generation for column-mode). `0` means automatically set to the number of CPU cores. Runtime on/off is controlled by `enable_pk_index_parallel_execution`.
+- Introduced in: -
+
+### lake_partial_update_thread_pool_queue_size
+
+- Default: 2048
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The task queue size for the lake partial update thread pool.
+- Introduced in: -
+
 ### pk_index_size_tiered_level_multiplier
 
 - Default: 10

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -916,7 +916,7 @@ This topic introduces the following types of FE configurations:
 - Unit: -
 - Is mutable: Yes
 - Description: The maximum number of threads in the thread pool for lake partial update segment-level parallelism in a shared-data cluster. This thread pool is used by both row-mode and column-mode partial updates to parallelize I/O-heavy segment operations (load_segment + rewrite_segment for row-mode, DCG generation for column-mode). `0` means automatically set to the number of CPU cores. Runtime on/off is controlled by `enable_pk_index_parallel_execution`.
-- Introduced in: -
+- Introduced in: v4.1
 
 ### lake_partial_update_thread_pool_queue_size
 
@@ -925,7 +925,7 @@ This topic introduces the following types of FE configurations:
 - Unit: -
 - Is mutable: Yes
 - Description: The task queue size for the lake partial update thread pool.
-- Introduced in: -
+- Introduced in: v4.1
 
 ### pk_index_size_tiered_level_multiplier
 

--- a/docs/ja/administration/management/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/BE_parameters/stats_storage.md
@@ -780,7 +780,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - タイプ: Int
 - 単位: -
 - 変更可能: はい
-- 説明: 共有データモードでの部分更新セグメントレベル並列実行用のスレッドプールの最大スレッド数。このスレッドプールは行モード（並列 load_segment + rewrite_segment）と列モード（並列 DCG 生成）の両方の部分更新で使用されます。0 は CPU コア数に自動設定されることを意味します。実行時のオン/オフは `enable_pk_index_parallel_execution` で制御されます。
+- 説明: 共有データモードでの部分更新セグメントレベル並列実行用のスレッドプールの最大スレッド数。このスレッドプールは行モード（並列 load_segment + rewrite_segment）と列モード（並列 DCG 生成）の両方の部分更新で使用されます。0 は CPU コア数の半分に自動設定されることを意味します。実行時のオン/オフは `enable_pk_index_parallel_execution` で制御されます。
 - 導入バージョン: v4.1
 
 ### lake_partial_update_thread_pool_queue_size

--- a/docs/ja/administration/management/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/BE_parameters/stats_storage.md
@@ -781,7 +781,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: -
 - 変更可能: はい
 - 説明: 共有データモードでの部分更新セグメントレベル並列実行用のスレッドプールの最大スレッド数。このスレッドプールは行モード（並列 load_segment + rewrite_segment）と列モード（並列 DCG 生成）の両方の部分更新で使用されます。0 は CPU コア数に自動設定されることを意味します。実行時のオン/オフは `enable_pk_index_parallel_execution` で制御されます。
-- 導入バージョン: -
+- 導入バージョン: v4.1
 
 ### lake_partial_update_thread_pool_queue_size
 
@@ -790,7 +790,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: -
 - 変更可能: はい
 - 説明: 部分更新スレッドプールのタスクキューサイズ。
-- 導入バージョン: -
+- 導入バージョン: v4.1
 
 ### pk_index_size_tiered_level_multiplier
 

--- a/docs/ja/administration/management/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/BE_parameters/stats_storage.md
@@ -774,6 +774,24 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データモードでのプライマリキーインデックス並列実行用のスレッドプールの最大スレッド数。0 は CPU コア数の半分に自動設定されることを意味します。
 - 導入バージョン: -
 
+### lake_partial_update_thread_pool_max_threads
+
+- デフォルト: 0
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 共有データモードでの部分更新セグメントレベル並列実行用のスレッドプールの最大スレッド数。このスレッドプールは行モード（並列 load_segment + rewrite_segment）と列モード（並列 DCG 生成）の両方の部分更新で使用されます。0 は CPU コア数に自動設定されることを意味します。実行時のオン/オフは `enable_pk_index_parallel_execution` で制御されます。
+- 導入バージョン: -
+
+### lake_partial_update_thread_pool_queue_size
+
+- デフォルト: 2048
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 部分更新スレッドプールのタスクキューサイズ。
+- 導入バージョン: -
+
 ### pk_index_size_tiered_level_multiplier
 
 - デフォルト: 10

--- a/docs/zh/administration/management/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/BE_parameters/stats_storage.md
@@ -905,7 +905,7 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离集群中，部分列更新 segment 级并行执行的线程池最大线程数。该线程池同时用于行模式（并行 load_segment + rewrite_segment）和列模式（并行 DCG 生成）的部分列更新。0 表示自动设置为 CPU 核数。运行时开关由 `enable_pk_index_parallel_execution` 控制。
+- 描述：存算分离集群中，部分列更新 segment 级并行执行的线程池最大线程数。该线程池同时用于行模式（并行 load_segment + rewrite_segment）和列模式（并行 DCG 生成）的部分列更新。0 表示自动设置为 CPU 核数的一半。运行时开关由 `enable_pk_index_parallel_execution` 控制。
 - 引入版本：v4.1
 
 ### lake_partial_update_thread_pool_queue_size

--- a/docs/zh/administration/management/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/BE_parameters/stats_storage.md
@@ -906,7 +906,7 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 单位：-
 - 是否动态：是
 - 描述：存算分离集群中，部分列更新 segment 级并行执行的线程池最大线程数。该线程池同时用于行模式（并行 load_segment + rewrite_segment）和列模式（并行 DCG 生成）的部分列更新。0 表示自动设置为 CPU 核数。运行时开关由 `enable_pk_index_parallel_execution` 控制。
-- 引入版本：-
+- 引入版本：v4.1
 
 ### lake_partial_update_thread_pool_queue_size
 
@@ -915,7 +915,7 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 单位：-
 - 是否动态：是
 - 描述：部分列更新线程池的任务队列大小。
-- 引入版本：-
+- 引入版本：v4.1
 
 ### pk_index_size_tiered_level_multiplier
 

--- a/docs/zh/administration/management/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/BE_parameters/stats_storage.md
@@ -899,6 +899,24 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 描述：存算分离集群中，主键索引并行执行的线程池最大线程数。0 表示自动设置为 CPU 核数的一半。
 - 引入版本：-
 
+### lake_partial_update_thread_pool_max_threads
+
+- 默认值：0
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离集群中，部分列更新 segment 级并行执行的线程池最大线程数。该线程池同时用于行模式（并行 load_segment + rewrite_segment）和列模式（并行 DCG 生成）的部分列更新。0 表示自动设置为 CPU 核数。运行时开关由 `enable_pk_index_parallel_execution` 控制。
+- 引入版本：-
+
+### lake_partial_update_thread_pool_queue_size
+
+- 默认值：2048
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：部分列更新线程池的任务队列大小。
+- 引入版本：-
+
 ### pk_index_size_tiered_level_multiplier
 
 - 默认值：10


### PR DESCRIPTION
## Why I'm doing:

For shared-data (lake) primary key tables, the row-mode partial update publish processes segments sequentially within a tablet: `load_segment → rewrite_segment → _do_update → release_segment`. The `load_segment` (PK index lookup + reading unmodified columns) and `rewrite_segment` (merging and writing complete segment files) are I/O-heavy operations. For large tablets (e.g., 50GB with many segments), this serial execution becomes a bottleneck.

## What I'm doing:

Parallelize the I/O-heavy `load_segment + rewrite_segment` phase across segments using a dedicated thread pool, while keeping the PK index update phase (`_do_update`) sequential.

**Architecture:**
```
Phase 1 (parallel, per segment):
    load_segment + rewrite_segment  (I/O heavy, parallelized)

Phase 2 (sequential, unchanged):
    _do_update + SST ingestion      (PK index modification, must be serial)
```

**Key changes:**
- Add dedicated `lake_partial_update_thread_pool` (max_threads controls concurrency and memory)
- Add `RowsetUpdateState::prepare_for_parallel()` to pre-initialize shared state before parallel execution
- Add `RowsetUpdateState::release_segment_partial_state()` to release write_columns while keeping upserts for Phase 2
- Make `RowsetUpdateState::_memory_usage` atomic for concurrent updates
- Condition merge (`merge_condition`) falls back to serial path in this version

**Correctness guarantee:** Within a single transaction, all segments read unmodified columns from the base_version snapshot. The unmodified column values are identical regardless of segment processing order, so parallelization is semantically equivalent to serial execution.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4