### PR TITLE
[BugFix] Paimon primary key columns incorrectly marked as non-nullable when querying external catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -600,7 +600,7 @@ public class ColumnTypeConverter {
             String fieldName = field.name();
             org.apache.paimon.types.DataType type = field.type();
             Type fieldType = ColumnTypeConverter.fromPaimonType(type);
-            Column column = new Column(fieldName, fieldType, type.isNullable(), field.description());
+            Column column = new Column(fieldName, fieldType, true, field.description());
             columns.add(column);
         }
         return columns;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -600,6 +600,7 @@ public class ColumnTypeConverter {
             String fieldName = field.name();
             org.apache.paimon.types.DataType type = field.type();
             Type fieldType = ColumnTypeConverter.fromPaimonType(type);
+            // Force all Paimon columns to be nullable (true) regardless of their DataType's nullable property.
             Column column = new Column(fieldName, fieldType, true, field.description());
             columns.add(column);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -473,4 +473,22 @@ public class ColumnTypeConverterTest {
         StructType outerStruct = new StructType(Lists.newArrayList(a, b));
         Assertions.assertEquals(typeStr, toHiveType(outerStruct));
     }
+
+    @Test
+    public void testFromPaimonSchemas() {
+        org.apache.paimon.types.DataField field1 = new org.apache.paimon.types.DataField(
+                0, "pk", new org.apache.paimon.types.IntType(false));
+        org.apache.paimon.types.DataField field2 = new org.apache.paimon.types.DataField(
+                1, "v1", new org.apache.paimon.types.VarCharType(true, 10));
+
+        List<Column> columns = ColumnTypeConverter.fromPaimonSchemas(ImmutableList.of(field1, field2));
+
+        Assertions.assertEquals(2, columns.size());
+
+        Assertions.assertEquals("pk", columns.get(0).getName());
+        Assertions.assertTrue(columns.get(0).isAllowNull(), "Paimon PK should be nullable");
+
+        Assertions.assertEquals("v1", columns.get(1).getName());
+        Assertions.assertTrue(columns.get(1).isAllowNull());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -245,7 +245,7 @@ public class PaimonMetadataTest {
         assertEquals("db1", paimonTable.getCatalogDBName());
         assertEquals("tbl1", paimonTable.getCatalogTableName());
         assertEquals("CREATE TABLE `tbl1` (\n" +
-                        "  `col2` int(11) NOT NULL,\n" +
+                        "  `col2` int(11) DEFAULT NULL,\n" +
                         "  `col3` double DEFAULT NULL\n" +
                         ")\n" +
                         "PRIMARY KEY (`col2`)\n" +
@@ -254,7 +254,7 @@ public class PaimonMetadataTest {
         assertEquals(Lists.newArrayList("col1"), paimonTable.getPartitionColumnNames());
         assertEquals("hdfs://127.0.0.1:10000/paimon", paimonTable.getTableLocation());
         assertEquals(IntegerType.INT, paimonTable.getBaseSchema().get(0).getType());
-        org.junit.jupiter.api.Assertions.assertFalse(paimonTable.getBaseSchema().get(0).isAllowNull());
+        org.junit.jupiter.api.Assertions.assertTrue(paimonTable.getBaseSchema().get(0).isAllowNull());
         assertEquals(FloatType.DOUBLE, paimonTable.getBaseSchema().get(1).getType());
         org.junit.jupiter.api.Assertions.assertTrue(paimonTable.getBaseSchema().get(1).isAllowNull());
         assertEquals("paimon_catalog", paimonTable.getCatalogName());


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:
In Paimon, primary key columns are NOT nullable by default at the DataType level. When you create a table with a primary key, Paimon marks those columns as non-nullable in their DataType definition, even if you don't explicitly set NOT NULL.
starRocks relies on type.isNullable() to set the Column's nullable flag, but for Paimon primary keys, this always returns false. the fix removes the type.isNullable(), and sets the parameter to true.

Fixes #71657
<img width="1103" height="931" alt="image" src="https://github.com/user-attachments/assets/79a9d858-0fae-446d-91e5-dcec36b7b1d4" />

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
