### PR TITLE
[Enhancement] Add snapshot-aware partition API for Iceberg pinned mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -225,6 +225,12 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
+    public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        return normal.getPartitions(table, partitionNames, requestContext);
+    }
+
+    @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TvrVersionRange version) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -207,6 +207,15 @@ public interface ConnectorMetadata {
     }
 
     /**
+     * Get partition info at a specific snapshot identified by the request context.
+     * Default implementation ignores the context and falls back to the live-snapshot variant.
+     */
+    default List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                              ConnectorMetadatRequestContext requestContext) {
+        return getPartitions(table, partitionNames);
+    }
+
+    /**
      * Get statistics for the table.
      *
      * @param session           optimizer context

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.partitiontraits.BenchmarkPartitionTraits;
 import com.starrocks.connector.partitiontraits.CachedPartitionTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
@@ -131,10 +132,35 @@ public abstract class ConnectorPartitionTraits {
         return buildWithCache(ctx, null, table);
     }
 
+    /**
+     * Build traits with a pinned version range. Subclasses that support snapshot-aware partition
+     * operations (currently Iceberg) will use the pinned snapshot instead of the live one.
+     * Other connectors store the range but ignore it in their partition methods.
+     */
+    public static ConnectorPartitionTraits build(Table table, TvrVersionRange pinnedVersionRange) {
+        ConnectorPartitionTraits traits = build(table);
+        if (pinnedVersionRange != null) {
+            traits.setPinnedVersionRange(pinnedVersionRange);
+        }
+        return traits;
+    }
+
     private static ConnectorPartitionTraits buildWithoutCache(Table table) {
         ConnectorPartitionTraits res = build(table.getType());
         res.table = table;
         return res;
+    }
+
+    // When set, subclasses that support snapshot-aware partition operations (e.g. Iceberg)
+    // use this version range instead of the live snapshot. Other connectors ignore it.
+    protected TvrVersionRange pinnedVersionRange;
+
+    public void setPinnedVersionRange(TvrVersionRange range) {
+        this.pinnedVersionRange = range;
+    }
+
+    public TvrVersionRange getPinnedVersionRange() {
+        return pinnedVersionRange;
     }
 
     public Table getTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/MVPartitionCellBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MVPartitionCellBuilder.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.iceberg.IcebergPartitionKeyResolver;
 import com.starrocks.mv.pct.BaseToMVPartitionMapping;
 import com.starrocks.sql.ast.expression.Expr;
@@ -150,26 +151,43 @@ public class MVPartitionCellBuilder {
      * Get range partition cells for any table type (OLAP or external).
      * For OLAP tables, reads directly from OlapTable's range partition map.
      * For external tables, resolves partition names via the resolver pipeline.
+     * @param pinnedVersionRange if non-null, partition enumeration uses this snapshot (Iceberg);
+     *                           if null, uses the live snapshot (current behavior).
      */
     public static BaseToMVPartitionMapping getPartitionKeyRange(Table table, Column partitionColumn,
-                                                       Expr partitionExpr) throws AnalysisException {
+                                                                Expr partitionExpr,
+                                                                TvrVersionRange pinnedVersionRange)
+            throws AnalysisException {
         if (table.isNativeTableOrMaterializedView()) {
             return BaseToMVPartitionMapping.of(getOlapRangePartitionMap((OlapTable) table));
         }
-        return buildRangeCells(table, partitionColumn, getPartitionNames(table), partitionExpr);
+        return buildRangeCells(table, partitionColumn, getPartitionNames(table, pinnedVersionRange), partitionExpr);
+    }
+
+    public static BaseToMVPartitionMapping getPartitionKeyRange(Table table, Column partitionColumn,
+                                                                Expr partitionExpr) throws AnalysisException {
+        return getPartitionKeyRange(table, partitionColumn, partitionExpr, null);
     }
 
     /**
      * Get list partition cells for any table type (OLAP or external).
      * For OLAP tables, reads directly from OlapTable's partition cells.
      * For external tables, resolves partition names via the resolver pipeline.
+     * @param pinnedVersionRange if non-null, partition enumeration uses this snapshot (Iceberg);
+     *                           if null, uses the live snapshot (current behavior).
      */
-    public static BaseToMVPartitionMapping getPartitionCells(Table table, List<Column> partitionColumns)
+    public static BaseToMVPartitionMapping getPartitionCells(Table table, List<Column> partitionColumns,
+                                                             TvrVersionRange pinnedVersionRange)
             throws AnalysisException {
         if (table.isNativeTableOrMaterializedView()) {
             return BaseToMVPartitionMapping.of(((OlapTable) table).getPartitionCells(Optional.of(partitionColumns)));
         }
-        return buildListCells(table, partitionColumns, getPartitionNames(table));
+        return buildListCells(table, partitionColumns, getPartitionNames(table, pinnedVersionRange));
+    }
+
+    public static BaseToMVPartitionMapping getPartitionCells(Table table, List<Column> partitionColumns)
+            throws AnalysisException {
+        return getPartitionCells(table, partitionColumns, null);
     }
 
     private static PCellSortedSet getOlapRangePartitionMap(OlapTable olapTable) {
@@ -179,8 +197,12 @@ public class MVPartitionCellBuilder {
         return olapTable.getRangePartitionMap();
     }
 
-    private static List<String> getPartitionNames(Table table) {
-        return ConnectorPartitionTraits.build(table).getPartitionNames();
+    /**
+     * Get partition names, optionally at a pinned snapshot.
+     * @param pinnedVersionRange if non-null, uses this snapshot for Iceberg; if null, uses live snapshot.
+     */
+    public static List<String> getPartitionNames(Table table, TvrVersionRange pinnedVersionRange) {
+        return ConnectorPartitionTraits.build(table, pinnedVersionRange).getPartitionNames();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -545,6 +545,9 @@ public interface IcebergCatalog extends MemoryTrackable {
         }
     }
 
+    /**
+     * Get partition info by names using the current (live) snapshot.
+     */
     default List<Partition> getPartitionsByNames(IcebergTable icebergTable,
                                                  ExecutorService executorService,
                                                  List<String> partitionNames) {
@@ -553,7 +556,18 @@ public interface IcebergCatalog extends MemoryTrackable {
         if (nativeTable.currentSnapshot() != null) {
             snapshotId = nativeTable.currentSnapshot().snapshotId();
         }
+        return getPartitionsByNames(icebergTable, snapshotId, executorService, partitionNames);
+    }
 
+    /**
+     * Get partition info by names at a specific snapshot.
+     * @param snapshotId the Iceberg snapshot ID to read partitions from, or -1 for current snapshot
+     */
+    default List<Partition> getPartitionsByNames(IcebergTable icebergTable,
+                                                 long snapshotId,
+                                                 ExecutorService executorService,
+                                                 List<String> partitionNames) {
+        Table nativeTable = icebergTable.getNativeTable();
         // Call public method so subclasses can override and optimize this method.
         Map<String, Partition> partitionMap = getPartitions(icebergTable, snapshotId, executorService);
         if (nativeTable.spec().isUnpartitioned()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -882,6 +882,15 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        long snapshotId = requestContext.getSnapshotId();
+        List<Partition> ans =
+                icebergCatalog.getPartitionsByNames((IcebergTable) table, snapshotId, null, partitionNames);
+        return new ArrayList<>(ans);
+    }
+
+    @Override
     public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
         IcebergTable icebergTable;
         icebergTable = (IcebergTable) item.getTable();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ThrowingSupplier;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
@@ -102,6 +103,12 @@ public class CachedPartitionTraits extends DefaultTraits {
         });
         stats.incr(cacheKey);
         return Optional.ofNullable(result).map(x -> (T) x).orElse(defaultSupplier.get());
+    }
+
+    @Override
+    public void setPinnedVersionRange(TvrVersionRange range) {
+        super.setPinnedVersionRange(range);
+        delegate.setPinnedVersionRange(range);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -58,6 +58,12 @@ public class IcebergPartitionTraits extends DefaultTraits {
     @Override
     public List<PartitionInfo> getPartitions(List<String> partitionNames) {
         IcebergTable icebergTable = (IcebergTable) table;
+        if (pinnedVersionRange != null) {
+            ConnectorMetadatRequestContext ctx = new ConnectorMetadatRequestContext();
+            ctx.setTableVersionRange(pinnedVersionRange);
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                    getPartitions(icebergTable.getCatalogName(), table, partitionNames, ctx);
+        }
         return GlobalStateMgr.getCurrentState().getMetadataMgr().
                 getPartitions(icebergTable.getCatalogName(), table, partitionNames);
     }
@@ -75,11 +81,15 @@ public class IcebergPartitionTraits extends DefaultTraits {
         }
 
         IcebergTable icebergTable = (IcebergTable) table;
-        Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
-                .map(Snapshot::snapshotId);
         ConnectorMetadatRequestContext requestContext = new ConnectorMetadatRequestContext();
         requestContext.setQueryMVRewrite(isQueryMVRewrite());
-        requestContext.setTableVersionRange(TvrTableSnapshot.of(snapshotId));
+        if (pinnedVersionRange != null) {
+            requestContext.setTableVersionRange(pinnedVersionRange);
+        } else {
+            Optional<Long> snapshotId = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot())
+                    .map(Snapshot::snapshotId);
+            requestContext.setTableVersionRange(TvrTableSnapshot.of(snapshotId));
+        }
         return GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                 table.getCatalogName(), getCatalogDBName(), getTableName(), requestContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -50,6 +50,7 @@ import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTableVersion;
@@ -849,6 +850,23 @@ public class MetadataMgr {
         if (connectorMetadata.isPresent()) {
             try {
                 return connectorMetadata.get().getPartitions(table, partitionNames);
+            } catch (Exception e) {
+                LOG.error("Failed to get partitions on catalog [{}], table [{}]", catalogName, table, e);
+                throw e;
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Get partition info at a specific snapshot identified by the request context.
+     */
+    public List<PartitionInfo> getPartitions(String catalogName, Table table, List<String> partitionNames,
+                                             ConnectorMetadatRequestContext requestContext) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        if (connectorMetadata.isPresent()) {
+            try {
+                return connectorMetadata.get().getPartitions(table, partitionNames, requestContext);
             } catch (Exception e) {
                 LOG.error("Failed to get partitions on catalog [{}], table [{}]", catalogName, table, e);
                 throw e;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.connector.paimon.Partition;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
 import com.starrocks.connector.partitiontraits.DeltaLakePartitionTraits;
@@ -349,5 +350,80 @@ public class ConnectorPartitionTraitsTest {
 
         Set<String> updated = traits.getUpdatedPartitionNames(List.of(baseTableInfo), context);
         Assertions.assertEquals(Set.of(), updated);
+    }
+
+    @Test
+    public void testPinnedVersionRangeDefaultNull() {
+        // Base class default: pinnedVersionRange is null
+        ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(Table.TableType.ICEBERG);
+        Assertions.assertNull(traits.getPinnedVersionRange());
+    }
+
+    @Test
+    public void testPinnedVersionRangeSetOnIcebergTraits(@Mocked org.apache.iceberg.Table nativeTable) {
+        IcebergTable icebergTable = new IcebergTable(0, "name", "iceberg_catalog", "resource_name", "icebergDb",
+                "icebergTable", "",
+                Lists.newArrayList(), nativeTable, Maps.newHashMap());
+        TvrTableSnapshot pinnedSnapshot = TvrTableSnapshot.of(42L);
+
+        // build(table, pinnedRange) should propagate to the traits
+        ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(icebergTable, pinnedSnapshot);
+        Assertions.assertNotNull(traits.getPinnedVersionRange());
+        Assertions.assertEquals(42L, traits.getPinnedVersionRange().to().getVersion());
+    }
+
+    @Test
+    public void testPinnedVersionRangeNullFallsBackToLive(@Mocked org.apache.iceberg.Table nativeTable) {
+        IcebergTable icebergTable = new IcebergTable(0, "name", "iceberg_catalog", "resource_name", "icebergDb",
+                "icebergTable", "",
+                Lists.newArrayList(), nativeTable, Maps.newHashMap());
+
+        // build(table, null) should leave pinnedVersionRange as null
+        ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(icebergTable, null);
+        Assertions.assertNull(traits.getPinnedVersionRange());
+    }
+
+    @Test
+    public void testPinnedVersionRangeIgnoredForNonIceberg() {
+        HiveTable hiveTable = new HiveTable(0, "name", Lists.newArrayList(), "resource_name", "hive_catalog",
+                "hiveDb", "hiveTable", "location", "", 0,
+                Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap(), Maps.newHashMap(), null,
+                HiveTable.HiveTableType.MANAGED_TABLE);
+        TvrTableSnapshot pinnedSnapshot = TvrTableSnapshot.of(42L);
+
+        // For non-Iceberg, setPinnedVersionRange is called but getPartitionNames won't use it
+        ConnectorPartitionTraits traits = ConnectorPartitionTraits.build(hiveTable, pinnedSnapshot);
+        // The range is stored on the base class, but Hive's getPartitionNames ignores it
+        Assertions.assertNotNull(traits.getPinnedVersionRange());
+        Assertions.assertTrue(traits instanceof HivePartitionTraits);
+    }
+
+    @Test
+    public void testCachedPartitionTraitsPropagatesPinnedVersionRange(@Mocked org.apache.iceberg.Table nativeTable) {
+        IcebergTable icebergTable = new IcebergTable(0, "name", "iceberg_catalog", "resource_name", "icebergDb",
+                "icebergTable", "",
+                Lists.newArrayList(), nativeTable, Maps.newHashMap());
+
+        // Create inner traits and wrap in CachedPartitionTraits
+        ConnectorPartitionTraits innerTraits = ConnectorPartitionTraits.build(icebergTable);
+        Assertions.assertTrue(innerTraits instanceof IcebergPartitionTraits);
+
+        com.github.benmanes.caffeine.cache.Cache<Object, Object> cache =
+                com.github.benmanes.caffeine.cache.Caffeine.newBuilder().build();
+        com.starrocks.sql.optimizer.QueryMaterializationContext.QueryCacheStats stats =
+                Mockito.mock(com.starrocks.sql.optimizer.QueryMaterializationContext.QueryCacheStats.class);
+        com.starrocks.connector.partitiontraits.CachedPartitionTraits cached =
+                new com.starrocks.connector.partitiontraits.CachedPartitionTraits(
+                        cache, innerTraits, stats, null);
+
+        // Set pinned range on the wrapper
+        TvrTableSnapshot pinnedSnapshot = TvrTableSnapshot.of(99L);
+        cached.setPinnedVersionRange(pinnedSnapshot);
+
+        // Both wrapper and delegate should have the pinned range
+        Assertions.assertNotNull(cached.getPinnedVersionRange());
+        Assertions.assertEquals(99L, cached.getPinnedVersionRange().to().getVersion());
+        Assertions.assertNotNull(innerTraits.getPinnedVersionRange());
+        Assertions.assertEquals(99L, innerTraits.getPinnedVersionRange().to().getVersion());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add snapshot-aware overloads throughout the partition metadata stack so callers can retrieve partition names and partition details at a specific Iceberg snapshot instead of always using currentSnapshot().

Changes:
- IcebergCatalog: getPartitionsByNames(table, snapshotId, executor, names)
- ConnectorMetadata/CatalogConnectorMetadata: getPartitions with ConnectorMetadatRequestContext (default falls back to live variant)
- IcebergMetadata: getPartitions delegates to snapshot-aware catalog method
- MetadataMgr: getPartitions(catalog, table, names, requestContext)
- IcebergPartitionTraits: pinnedVersionRange field; getPartitionNames() and getPartitions() respect it when set
- ConnectorPartitionTraits: build(Table, TvrVersionRange) factory overload
- MVPartitionCellBuilder: getPartitionNames/getPartitionKeyRange/ getPartitionCells overloads that accept TvrVersionRange

All existing call sites are unchanged. New overloads are additive — no behavior change until PR 3 (pinned PCT mode) starts calling them.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
