### PR TITLE
[Tool] add ai-sr-skills.yml with docker exec and debug output

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -1,0 +1,43 @@
+name: AI SR SKILLS
+
+on:
+  pull_request_target:
+    branches:
+      - branch-ci-test-qa
+    types:
+      - opened
+      - reopened
+
+concurrency:
+  group: AI-SR-SKILLS-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewer:
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    if: >
+      github.event.action == 'opened' &&
+      !startsWith(github.head_ref, 'mergify/')
+    steps:
+      - name: Assign PR Reviewer
+        run: |
+          echo "=== DEBUG ==="
+          echo "PR: ${{ github.event.number }}"
+          echo "ACTION: ${{ github.event.action }}"
+          echo "BASE_REF: ${{ github.base_ref }}"
+          echo "HEAD_REF: ${{ github.head_ref }}"
+          echo "CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN}"
+          echo "GITHUB_TOKEN length: ${#GITHUB_TOKEN}"
+          echo "=== RUN ==="
+          docker exec -i -u claudeuser \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
+            claude-cli claude --dangerously-skip-permissions \
+            -p "/starrocks-assign-pr-reviewer https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" || true


### PR DESCRIPTION
## Why I'm doing:

Re-add ai-sr-skills.yml to main so pull_request_target can trigger it. The previous version used a wrong path. This version uses docker exec to call claude-cli directly.

## What I'm doing:

- Restrict `branches` to `branch-ci-test-qa` only during testing phase
- Use `docker exec claude-cli` directly (NAS path not mounted in runner containers)
- Add debug output to verify token injection and env context

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4