### PR TITLE
[BugFix] Avoid repeated metadata loading in get_tablet_stats for PK tablets

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1166,9 +1166,9 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                         if (is_pk_tablet) {
                             if (accurate_mode) {
                                 // Accurate mode (default): fetch delete vectors from object storage.
-                                // NOTE!! Each segment incurs a remote metadata read - expensive for large tablets.
+                                // Reuses the already-loaded tablet metadata to avoid repeated loads per segment.
                                 num_deletes = static_cast<int64_t>(
-                                        _tablet_mgr->update_mgr()->get_rowset_num_deletes(tablet_id, version, rowset));
+                                        _tablet_mgr->update_mgr()->get_rowset_num_deletes(**tablet_metadata, rowset));
                             } else {
                                 // Approximate mode: prefer the pre-stored num_dels field in rowset
                                 // metadata. This avoids additional I/O while still providing a reasonable estimate.
@@ -1179,7 +1179,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                                     // Fallback for old metadata without num_dels.
                                     num_deletes =
                                             static_cast<int64_t>(_tablet_mgr->update_mgr()->get_rowset_num_deletes(
-                                                    tablet_id, version, rowset));
+                                                    **tablet_metadata, rowset));
                                 }
                             }
                         }

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -184,8 +184,6 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         return rowset_indexes;
     }
     std::vector<RowsetCandidate> rowset_vec;
-    const auto tablet_id = tablet_metadata->id();
-    const auto tablet_version = tablet_metadata->version();
     const int64_t compaction_data_size_threshold =
             static_cast<int64_t>((double)_get_data_size(tablet_metadata) * config::update_compaction_ratio_threshold);
     // 1. generate rowset candidate vector
@@ -197,7 +195,7 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         if (rowset_pb.has_num_dels()) {
             stat.num_dels = rowset_pb.num_dels();
         } else {
-            stat.num_dels = mgr->get_rowset_num_deletes(tablet_id, tablet_version, rowset_pb);
+            stat.num_dels = mgr->get_rowset_num_deletes(*tablet_metadata, rowset_pb);
         }
         rowset_vec.emplace_back(&rowset_pb, stat, i);
     }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1533,6 +1533,27 @@ size_t UpdateManager::get_rowset_num_deletes(int64_t tablet_id, int64_t version,
     return num_dels;
 }
 
+size_t UpdateManager::get_rowset_num_deletes(const TabletMetadata& metadata,
+                                             const RowsetMetadataPB& rowset_meta) {
+    size_t num_dels = 0;
+    LakeIOOptions lake_io_opts;
+    lake_io_opts.fill_data_cache = false;
+    for (int i = 0; i < rowset_meta.segments_size(); i++) {
+        DelVector delvec;
+        uint32_t segment_id = get_rssid(rowset_meta, i);
+        auto st = lake::get_del_vec(_tablet_mgr, metadata, segment_id,
+                                    false /*fill_cache*/, lake_io_opts, &delvec);
+        if (!st.ok()) {
+            LOG(WARNING) << "get_rowset_num_deletes: error get del vector"
+                         << " tablet_id=" << metadata.id() << " metadata_version=" << metadata.version()
+                         << " segment_id=" << segment_id << " status=" << st;
+            continue;
+        }
+        num_dels += delvec.cardinality();
+    }
+    return num_dels;
+}
+
 bool UpdateManager::_use_light_publish_primary_compaction(TabletManager* mgr,
                                                           const TxnLogPB_OpCompaction& op_compaction, int64_t tablet_id,
                                                           int64_t txn_id) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1533,16 +1533,14 @@ size_t UpdateManager::get_rowset_num_deletes(int64_t tablet_id, int64_t version,
     return num_dels;
 }
 
-size_t UpdateManager::get_rowset_num_deletes(const TabletMetadata& metadata,
-                                             const RowsetMetadataPB& rowset_meta) {
+size_t UpdateManager::get_rowset_num_deletes(const TabletMetadata& metadata, const RowsetMetadataPB& rowset_meta) {
     size_t num_dels = 0;
     LakeIOOptions lake_io_opts;
     lake_io_opts.fill_data_cache = false;
     for (int i = 0; i < rowset_meta.segments_size(); i++) {
         DelVector delvec;
         uint32_t segment_id = get_rssid(rowset_meta, i);
-        auto st = lake::get_del_vec(_tablet_mgr, metadata, segment_id,
-                                    false /*fill_cache*/, lake_io_opts, &delvec);
+        auto st = lake::get_del_vec(_tablet_mgr, metadata, segment_id, false /*fill_cache*/, lake_io_opts, &delvec);
         if (!st.ok()) {
             LOG(WARNING) << "get_rowset_num_deletes: error get del vector"
                          << " tablet_id=" << metadata.id() << " metadata_version=" << metadata.version()

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -132,6 +132,10 @@ public:
     // get del nums from rowset, for compaction policy
     size_t get_rowset_num_deletes(int64_t tablet_id, int64_t version, const RowsetMetadataPB& rowset_meta);
 
+    // Get del nums from rowset using already-loaded tablet metadata,
+    // avoiding repeated metadata loads for each segment.
+    size_t get_rowset_num_deletes(const TabletMetadata& metadata, const RowsetMetadataPB& rowset_meta);
+
     Status publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
                                       const TabletMetadata& metadata, const Tablet& tablet, IndexEntry* index_entry,
                                       MetaFileBuilder* builder, int64_t base_version);


### PR DESCRIPTION
## Why I'm doing:

`get_tablet_stats` collects statistics for PK tablets by calling `get_rowset_num_deletes(tablet_id, version, rowset)` for each rowset. The old implementation internally calls `get_del_vec_in_meta()` for every segment, which reloads the entire `TabletMetadata` (including a deep protobuf copy) each time, with `fill_cache=false` preventing cache hits.

For a large PK tablet with M segments across all rowsets, this causes M redundant metadata loads + deep copies, blocking the 3-thread pool used by `get_tablet_stats` and leading to timeouts — after which all statistics are reported as 0.

## What I'm doing:

Add a new overload `get_rowset_num_deletes(const TabletMetadata&, const RowsetMetadataPB&)` that accepts the already-loaded tablet metadata and uses `lake::get_del_vec(TabletManager*, const TabletMetadata&, segment_id, ...)` to look up delvec pages directly from the in-memory metadata, instead of reloading the entire metadata per segment.

Updated all three call sites:
- `lake_service.cpp`: accurate mode and approximate mode fallback now pass the already-loaded `**tablet_metadata`
- `primary_key_compaction_policy.cpp`: passes the already-loaded `*tablet_metadata`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
