### PR TITLE
[BugFix] Make star_mgr_meta_sync_interval_sec runtime mutable

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -527,7 +527,7 @@ This topic introduces the following types of FE configurations:
 - Default: 600
 - Type: Long
 - Unit: Seconds
-- Is mutable: No
+- Is mutable: Yes
 - Description: The interval at which FE runs the periodical metadata synchronization with StarMgr in a shared-data cluster.
 - Introduced in: -
 

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -527,7 +527,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - デフォルト：600
 - タイプ：Long
 - 単位：Seconds
-- 変更可能：No
+- 変更可能：Yes
 - 説明：FE が共有データクラスターで StarMgr と定期的なメタデータ同期を実行する間隔。
 - 導入時期：-
 

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -527,7 +527,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 600
 - 类型: Long
 - 单位: 秒
-- 是否可变: No
+- 是否可变: Yes
 - 描述: FE 在共享数据集群中与 StarMgr 进行周期性元数据同步的间隔。
 - 引入版本: -
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3072,7 +3072,8 @@ public class Config extends ConfigBase {
     /**
      * fe sync with star mgr meta interval in seconds
      */
-    @ConfField
+    @ConfField(mutable = true, comment = "The interval in seconds at which StarMgrMetaSyncer runs periodical" +
+            " metadata synchronization between FE and StarMgr in a shared-data cluster.")
     public static long star_mgr_meta_sync_interval_sec = 600L;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -608,6 +608,10 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
+        long newInterval = Config.star_mgr_meta_sync_interval_sec * 1000L;
+        if (newInterval > 0 && getInterval() != newInterval) {
+            setInterval(newInterval);
+        }
         long start = System.currentTimeMillis();
         acquireBackgroundComputeResource();
         deleteUnusedShardAndShardGroup();


### PR DESCRIPTION
Allow star_mgr_meta_sync_interval_sec to be changed at runtime via ADMIN SET FRONTEND CONFIG. StarMgrMetaSyncer re-reads the config value at the start of each cycle so the new interval takes effect on the next run without requiring an FE restart.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4