### PR TITLE
[Perf] Prefetch SST blocks in MultiGet to reduce PK publish P99

### DIFF
--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -5,6 +5,7 @@
 #include "storage/sstable/table.h"
 
 #include <butil/time.h> // NOLINT
+#include <limits>
 
 #include "base/coding.h"
 #include "base/container/lru_cache.h"
@@ -273,6 +274,48 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     Status s;
     Iterator* iiter = rep_->index_block->NewIterator(rep_->options.comparator);
     std::unique_ptr<Iterator> current_block_itr_ptr;
+
+    // Prefetch pass: scan index to identify all needed blocks and warm the data cache.
+    // This converts sequential blocking reads into parallel prefetches, reducing P99 latency
+    // when multiple SST blocks must be fetched from the data cache (local disk or remote).
+    {
+        Cache* block_cache = rep_->options.block_cache;
+        RandomAccessFile* prefetch_file = (options.file != nullptr) ? options.file : rep_->file;
+        Iterator* prefetch_iiter = rep_->index_block->NewIterator(rep_->options.comparator);
+        int64_t prefetch_cnt = 0;
+        uint64_t prev_offset = std::numeric_limits<uint64_t>::max();
+        for (auto it = begin; it != end; ++it) {
+            auto& k = keys[*it];
+            prefetch_iiter->Seek(k);
+            if (!prefetch_iiter->Valid()) continue;
+            Slice handle_value = prefetch_iiter->value();
+            BlockHandle handle;
+            if (!handle.DecodeFrom(&handle_value).ok()) continue;
+            if (handle.offset() == prev_offset) continue; // same block as previous key
+            prev_offset = handle.offset();
+            // Check bloom filter
+            FilterBlockReader* filter = rep_->filter;
+            if (filter != nullptr && !filter->KeyMayMatch(handle.offset(), k)) continue;
+            // Check in-memory block cache
+            if (block_cache != nullptr) {
+                char cache_key_buffer[16];
+                encode_fixed64_le(reinterpret_cast<uint8_t*>(cache_key_buffer), rep_->cache_id);
+                encode_fixed64_le(reinterpret_cast<uint8_t*>(cache_key_buffer + 8), handle.offset());
+                CacheKey key(cache_key_buffer, sizeof(cache_key_buffer));
+                auto ch = block_cache->lookup(key);
+                if (ch != nullptr) {
+                    block_cache->release(ch);
+                    continue; // already in memory cache
+                }
+            }
+            // Not in cache — issue prefetch to warm the data cache layer
+            (void)prefetch_file->touch_cache(handle.offset(),
+                                             static_cast<size_t>(handle.size()) + kBlockTrailerSize);
+            prefetch_cnt++;
+        }
+        delete prefetch_iiter;
+        TRACE_COUNTER_INCREMENT("prefetch_block_cnt", prefetch_cnt);
+    }
 
     // return true if find k
     auto search_in_block = [](const Slice& k, std::string* value, Iterator* current_block_itr) -> StatusOr<bool> {

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -5,6 +5,7 @@
 #include "storage/sstable/table.h"
 
 #include <butil/time.h> // NOLINT
+
 #include <limits>
 
 #include "base/coding.h"
@@ -309,8 +310,7 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
                 }
             }
             // Not in cache — issue prefetch to warm the data cache layer
-            (void)prefetch_file->touch_cache(handle.offset(),
-                                             static_cast<size_t>(handle.size()) + kBlockTrailerSize);
+            (void)prefetch_file->touch_cache(handle.offset(), static_cast<size_t>(handle.size()) + kBlockTrailerSize);
             prefetch_cnt++;
         }
         delete prefetch_iiter;


### PR DESCRIPTION
## Why

In the 1000-table concurrent ingestion benchmark (950×1GB + 50×10GB tables, 1K rows/sec each),
upsert P99 latency is **7,320ms** (target ≤ 3,000ms). The bottleneck is in `Table::MultiGet()`
during PK index publish — SST blocks are read **sequentially**, and each data cache miss blocks
for 100-750ms. With 11-27 cache misses per MultiGet call, latencies compound to seconds.

### Benchmark Evidence

| Tablet | Total (ms) | multi_get (ms) | block_read_io (ms) | max_single_block (ms) | cache_misses |
|--------|-----------|---------------|-------------------|--------------------|-------------|
| 12648  | 1,173     | 1,159         | 1,155             | 748                | 11          |
| 15078  | 333       | 317           | 314               | 205                | 27          |
| 15033  | 206       | 183           | 177               | 168                | 14          |

Key: `sst_prefetch_hit_count = 0` in all traces — no prefetch is happening.

## What

Add a **prefetch pass** before the main `MultiGet()` loop:

1. Scan the index to identify all distinct blocks that will be needed
2. Check bloom filter and in-memory block cache for each
3. For uncached blocks, call `touch_cache(offset, size)` to warm the data cache layer

The existing `touch_cache()` API on `RandomAccessFile` (Starlet FS) warms data from
remote/disk into the cache. By issuing all prefetches upfront, we convert sequential
blocking I/O into parallel cache warming.

### Expected Impact

- **P99 reduction: 5-10×** for cache-miss-heavy publishes
- A publish with 11 cache misses: `sum(11×200ms) = 2.2s` → `max(11×200ms) ≈ 200ms`
- Minimal overhead: prefetch pass adds one index scan + cache lookups (microseconds)

## How Tested

To be validated by the next benchmark iteration (commit-before-verify pattern).
Benchmark: `950_1gb_50_10gb` template, 1 FE + 3 CN shared-data cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)