### PR TITLE
[BugFix] fix arrow flight empty set column name is 'r' (backport #71534)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -28,11 +28,14 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidConfException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -194,19 +197,19 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
                 String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
 
-                // To prevent the client from mistakenly interpreting an empty Schema as an update statement (instead of a query statement),
-                // we need to ensure that the Schema returned by createPreparedStatement includes the query metadata.
-                // This means we need to correctly set the DatasetSchema and ParameterSchema in ActionCreatePreparedStatementResult.
-                // We generate a minimal Schema. This minimal Schema can include an integer column to ensure the Schema is not empty.
-                try (VectorSchemaRoot schemaRoot = ArrowUtil.createSingleSchemaRoot("r", "0")) {
-                    Schema schema = schemaRoot.getSchema();
-                    FlightSql.ActionCreatePreparedStatementResult result =
-                            FlightSql.ActionCreatePreparedStatementResult.newBuilder()
-                                    .setPreparedStatementHandle(ByteString.copyFromUtf8(preparedStmtId))
-                                    .setDatasetSchema(ByteString.copyFrom(serializeMetadata(schema)))
-                                    .setParameterSchema(ByteString.copyFrom(serializeMetadata(schema))).build();
-                    listener.onNext(new Result(Any.pack(result).toByteArray()));
-                }
+                // Try to plan the query to get the real schema for the prepared statement.
+                // This is important because clients (JDBC, ADBC) use the schema returned here
+                // to determine column names and types. Without this, a placeholder schema with
+                // a single column named "r" would be returned, which is incorrect.
+                Schema schema = buildSchemaFromQuery(ctx, request.getQuery());
+
+                FlightSql.ActionCreatePreparedStatementResult result =
+                        FlightSql.ActionCreatePreparedStatementResult.newBuilder()
+                                .setPreparedStatementHandle(ByteString.copyFromUtf8(preparedStmtId))
+                                .setDatasetSchema(ByteString.copyFrom(serializeMetadata(schema)))
+                                .setParameterSchema(ByteString.copyFrom(serializeMetadata(new Schema(Collections.emptyList()))))
+                                .build();
+                listener.onNext(new Result(Any.pack(result).toByteArray()));
                 listener.onCompleted();
             } catch (Exception e) {
                 listener.onError(
@@ -898,6 +901,52 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         final Ticket ticket = new Ticket(Any.pack(request).toByteArray());
         final List<FlightEndpoint> endpoints = Collections.singletonList(new FlightEndpoint(ticket, endpoint));
         return new FlightInfo(schema, descriptor, endpoints, -1, -1);
+    }
+
+    /**
+     * Analyze the query to obtain the real output schema (column names and types).
+     * Only performs semantic analysis (not full planning) to avoid side effects that
+     * could interfere with the subsequent query execution in getFlightInfoPreparedStatement.
+     * For non-query statements or if analysis fails, a placeholder schema is returned.
+     */
+    private Schema buildSchemaFromQuery(ArrowFlightSqlConnectContext ctx, String query) {
+        try {
+            try (var scope = ctx.bindScope()) {
+                List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(query, ctx.getSessionVariable());
+                if (stmts.isEmpty()) {
+                    return buildPlaceholderSchema();
+                }
+                StatementBase stmt = stmts.get(0);
+                if (!(stmt instanceof QueryStatement)) {
+                    return buildPlaceholderSchema();
+                }
+                stmt.setOrigStmt(new OriginStatement(query));
+
+                Analyzer.analyze(stmt, ctx);
+
+                QueryStatement queryStmt = (QueryStatement) stmt;
+                List<String> colNames = queryStmt.getQueryRelation().getColumnOutputNames();
+                List<Expr> outputExprs = queryStmt.getQueryRelation().getOutputExpression();
+
+                List<Field> arrowFields = Lists.newArrayList();
+                for (int i = 0; i < colNames.size(); i++) {
+                    Expr expr = outputExprs.get(i);
+                    Field arrowField = ArrowUtils.convertToArrowType(
+                            expr.getOriginType(), colNames.get(i), expr.isNullable());
+                    arrowFields.add(arrowField);
+                }
+                return new Schema(arrowFields);
+            }
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to analyze query for schema in createPreparedStatement, " +
+                    "falling back to placeholder schema. query={}", query, e);
+            return buildPlaceholderSchema();
+        }
+    }
+
+    private static Schema buildPlaceholderSchema() {
+        return new Schema(Lists.newArrayList(
+                ArrowUtils.convertToArrowType(com.starrocks.type.IntegerType.INT, "result", true)));
     }
 
     public static Schema buildSchema(ExecPlan execPlan) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -946,7 +946,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     private static Schema buildPlaceholderSchema() {
         return new Schema(Lists.newArrayList(
-                ArrowUtils.convertToArrowType(com.starrocks.type.IntegerType.INT, "result", true)));
+                ArrowUtils.convertToArrowType(com.starrocks.catalog.Type.INT, "result", true)));
     }
 
     public static Schema buildSchema(ExecPlan execPlan) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -15,14 +15,15 @@
 package com.starrocks.service.arrow.flight.sql;
 
 import com.google.common.cache.Cache;
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.plugin.AuditEvent;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
@@ -56,24 +57,30 @@ import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
 import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Method;
+import java.nio.channels.Channels;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -93,6 +100,7 @@ public class ArrowFlightSqlServiceImplTest {
     private ArrowFlightSqlSessionManager sessionManager;
     private ArrowFlightSqlConnectContext mockContext;
     private FlightProducer.CallContext mockCallContext;
+    private SessionVariable mockSessionVariable;
     @Mocked
     AuditEncryptionChecker mockChecker;
 
@@ -116,6 +124,34 @@ public class ArrowFlightSqlServiceImplTest {
         }
     }
 
+    private static class CapturingResultListener implements FlightProducer.StreamListener<Result> {
+        private final CountDownLatch finished = new CountDownLatch(1);
+        private volatile Result result;
+        private volatile Throwable error;
+        private volatile boolean completed;
+
+        @Override
+        public void onNext(Result val) {
+            this.result = val;
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            this.error = t;
+            finished.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+            finished.countDown();
+        }
+
+        public boolean await() throws InterruptedException {
+            return finished.await(5, TimeUnit.SECONDS);
+        }
+    }
+
     @BeforeEach
     public void setUp() throws IllegalAccessException, NoSuchFieldException, InterruptedException {
         sessionManager = mock(ArrowFlightSqlSessionManager.class);
@@ -129,7 +165,7 @@ public class ArrowFlightSqlServiceImplTest {
         when(mockContext.getExecutionId()).thenReturn(new com.starrocks.thrift.TUniqueId(1, 1));
         when(mockContext.getArrowFlightSqlToken()).thenReturn("token123");
 
-        SessionVariable mockSessionVariable = mock(SessionVariable.class);
+        mockSessionVariable = mock(SessionVariable.class);
         when(mockContext.getSessionVariable()).thenReturn(mockSessionVariable);
         when(mockContext.acquireRunningToken(anyLong())).thenReturn(true);
         when(mockSessionVariable.getQueryTimeoutS()).thenReturn(10);
@@ -519,42 +555,75 @@ public class ArrowFlightSqlServiceImplTest {
     }
 
     @Test
-    public void testCreatePreparedStatement() throws Exception {
-        // mock request
+    public void testCreatePreparedStatementUsesAnalyzedSchema() throws Exception {
+        String query = "SELECT 1 AS c1, 'x' AS c2";
         FlightSql.ActionCreatePreparedStatementRequest request = mock(FlightSql.ActionCreatePreparedStatementRequest.class);
-        when(request.getQuery()).thenReturn("SELECT 1");
+        when(request.getQuery()).thenReturn(query);
+        ArrowFlightSqlConnectContext realContext = new ArrowFlightSqlConnectContext("token123");
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
 
-        // mock context
-        FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
-        when(callContext.peerIdentity()).thenReturn("token123");
+        CapturingResultListener listener = new CapturingResultListener();
+        service.createPreparedStatement(request, mockCallContext, listener);
 
-        // mock sessionManager
-        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(mockContext);
+        FlightSql.ActionCreatePreparedStatementResult preparedStatementResult = awaitPreparedStatementResult(listener);
 
-        // mock listener
-        FlightProducer.StreamListener<Result> listener = mock(FlightProducer.StreamListener.class);
+        String preparedStatementHandle = preparedStatementResult.getPreparedStatementHandle().toStringUtf8();
+        assertNotNull(preparedStatementHandle);
+        assertEquals(query, realContext.getPreparedStatement(preparedStatementHandle));
 
-        // mock ArrowUtil.createSingleSchemaRoot
-        try (
-                MockedStatic<ArrowUtil> mockArrowUtil = mockStatic(ArrowUtil.class);
-                MockedStatic<ArrowFlightSqlServiceImpl> mockStatic =
-                        mockStatic(ArrowFlightSqlServiceImpl.class, CALLS_REAL_METHODS)
-        ) {
-            // mock createSingleSchemaRoot
-            VectorSchemaRoot mockRoot = mock(VectorSchemaRoot.class);
-            Schema mockSchema = mock(Schema.class);
-            when(mockRoot.getSchema()).thenReturn(mockSchema);
-            mockArrowUtil.when(() -> ArrowUtil.createSingleSchemaRoot(anyString(), anyString())).thenReturn(mockRoot);
+        Schema datasetSchema = deserializeSchema(preparedStatementResult.getDatasetSchema());
+        assertEquals(2, datasetSchema.getFields().size());
+        assertEquals("c1", datasetSchema.getFields().get(0).getName());
+        assertTrue(datasetSchema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Int);
+        assertEquals("c2", datasetSchema.getFields().get(1).getName());
+        assertTrue(datasetSchema.getFields().get(1).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Utf8);
 
-            // mock serializeMetadata
-            mockStatic.when(() -> ArrowFlightSqlServiceImpl.serializeMetadata(mockSchema))
-                    .thenReturn(ByteBuffer.wrap("mock".getBytes(StandardCharsets.UTF_8)));
+        Schema parameterSchema = deserializeSchema(preparedStatementResult.getParameterSchema());
+        assertTrue(parameterSchema.getFields().isEmpty());
+    }
 
-            // call method
-            service.createPreparedStatement(request, callContext, listener);
+    @Test
+    public void testCreatePreparedStatementFallsBackToPlaceholderSchemaForNonQueryStatement() throws Exception {
+        String query = "SHOW DATABASES";
+        FlightSql.ActionCreatePreparedStatementRequest request = mock(FlightSql.ActionCreatePreparedStatementRequest.class);
+        when(request.getQuery()).thenReturn(query);
+        ArrowFlightSqlConnectContext realContext = new ArrowFlightSqlConnectContext("token123");
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
 
-            // wait executor
-            Thread.sleep(500);
+        CapturingResultListener listener = new CapturingResultListener();
+        service.createPreparedStatement(request, mockCallContext, listener);
+
+        FlightSql.ActionCreatePreparedStatementResult preparedStatementResult = awaitPreparedStatementResult(listener);
+
+        String preparedStatementHandle = preparedStatementResult.getPreparedStatementHandle().toStringUtf8();
+        assertNotNull(preparedStatementHandle);
+        assertEquals(query, realContext.getPreparedStatement(preparedStatementHandle));
+
+        Schema datasetSchema = deserializeSchema(preparedStatementResult.getDatasetSchema());
+        assertEquals(1, datasetSchema.getFields().size());
+        assertEquals("result", datasetSchema.getFields().get(0).getName());
+        assertTrue(datasetSchema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Int);
+        assertTrue(datasetSchema.getFields().get(0).isNullable());
+
+        Schema parameterSchema = deserializeSchema(preparedStatementResult.getParameterSchema());
+        assertTrue(parameterSchema.getFields().isEmpty());
+    }
+
+    @Test
+    public void testBuildSchemaFromQueryRestoresPreviousConnectContext() throws Exception {
+        ConnectContext previous = new ConnectContext();
+        previous.setThreadLocalInfo();
+        ArrowFlightSqlConnectContext arrowContext = new ArrowFlightSqlConnectContext("token123");
+        Method method = ArrowFlightSqlServiceImpl.class
+                .getDeclaredMethod("buildSchemaFromQuery", ArrowFlightSqlConnectContext.class, String.class);
+        method.setAccessible(true);
+
+        try {
+            Schema schema = (Schema) method.invoke(service, arrowContext, "SELECT 1 AS c1");
+            assertNotNull(schema);
+            assertSame(previous, ConnectContext.get());
+        } finally {
+            ConnectContext.remove();
         }
     }
 
@@ -609,6 +678,20 @@ public class ArrowFlightSqlServiceImplTest {
         Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(target, value);
+    }
+
+    private FlightSql.ActionCreatePreparedStatementResult awaitPreparedStatementResult(CapturingResultListener listener)
+            throws Exception {
+        assertTrue(listener.await(), "Timed out waiting for createPreparedStatement result");
+        assertNull(listener.error, "Unexpected createPreparedStatement error: " + listener.error);
+        assertTrue(listener.completed);
+        assertNotNull(listener.result);
+        return Any.parseFrom(listener.result.getBody()).unpack(FlightSql.ActionCreatePreparedStatementResult.class);
+    }
+
+    private Schema deserializeSchema(ByteString schemaBytes) throws IOException {
+        return MessageSerializer.deserializeSchema(
+                new ReadChannel(Channels.newChannel(new ByteArrayInputStream(schemaBytes.toByteArray()))));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
For query return empty set, like `select * from table.t1 limit 0`, this will return column name `'r' , 'r'`.

The column name is set as 'r' to be a placeholder. But if no data arrived, the jdbc driver will not replace it with correct names.
## What I'm doing:
Fixes https://github.com/StarRocks/starrocks/pull/71534

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

## Backport notes:
- This manual backport resolves the `branch-3.5` cherry-pick conflict by adapting the imported `Expr` and `OriginStatement` types to the older branch-3.5 package layout.
- Local validation was limited because `./run-fe-ut.sh --test com.starrocks.service.arrow.flight.sql.ArrowFlightSqlServiceImplTest` could not run in this environment: `mvn` is not installed.
