### PR TITLE
[Tool] skip clang-format auto-fix when merge conflict markers exist

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -59,6 +59,11 @@ jobs:
           BASE_REPO: ${{ github.repository }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
+          if git grep -l '^<<<<<<<' -- be/src be/test 2>/dev/null | grep -q .; then
+            echo "Merge conflict markers found; skipping clang-format."
+            exit 0
+          fi
+
           fetched_files=(
             "build-support/format_changed_files.py"
             "build-support/run_clang_format.py"


### PR DESCRIPTION
## Why I'm doing:

Backport PRs created by mergify with conflicts have `<<<<<<<` markers in BE source files. The clang-format auto-fix job was running on these files anyway, producing a noisy style-fix commit on top of an unresolvable PR.

## What I'm doing:

Add a conflict marker check at the start of the **Auto-fix formatting** step. If any file under `be/src` or `be/test` contains a `^<<<<<<<` marker, the step exits early and skips formatting entirely.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4