### PR TITLE
[BugFix] Fix SIGFPE in lake compaction when rowset num_rows is zero

### DIFF
--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -131,7 +131,9 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         chunk->reset();
         rssid_rowids.clear();
 
-        _context->progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
+        if (total_num_rows > 0) {
+            _context->progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
+        }
         _context->stats->collect(reader.stats());
     }
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -269,8 +269,11 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
             source_masks->clear();
         }
 
-        _context->progress.update((100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) /
-                                  column_group_size);
+        if (_total_num_rows > 0 && column_group_size > 0) {
+            _context->progress.update(
+                    (100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) /
+                    column_group_size);
+        }
         CompactionTaskStats temp_stats;
         temp_stats.collect(reader.stats());
         CompactionTaskStats diff_stats = temp_stats - prev_stats;

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -257,6 +257,64 @@ TEST_P(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     ASSERT_EQ(0, read(version));
 }
 
+// Regression test for SIGFPE in compaction when rowset metadata reports
+// num_rows=0 but the underlying physical segments still contain readable
+// rows. This simulates the state after an online tablet split where sub-tablet
+// metadata inherits zeroed stats while the shared physical segments remain
+// populated. Before the fix, the divide-by-zero in progress.update triggered
+// a crash; after the fix, the guards skip the progress update and compaction
+// completes normally.
+TEST_P(LakeDuplicateKeyCompactionTest, test_zero_num_rows_no_crash) {
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 3, read(version));
+
+    // Simulate post-split metadata inconsistency: zero the per-rowset stats
+    // while leaving the physical segments intact.
+    {
+        ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto mutated = std::make_shared<TabletMetadata>(*tablet_metadata);
+        for (auto& rowset : *mutated->mutable_rowsets()) {
+            rowset.set_num_rows(0);
+            rowset.set_data_size(0);
+        }
+        mutated->set_version(version + 1);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*mutated));
+        version++;
+    }
+
+    auto txn_id = next_id();
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+    check_task(task);
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
+}
+
 class LakeDuplicateKeyOverlapSegmentsCompactionTest : public LakeCompactionTest {
 public:
     LakeDuplicateKeyOverlapSegmentsCompactionTest() : LakeCompactionTest(kTestDirectory) {


### PR DESCRIPTION
  ## Why I'm doing:

  In shared-data mode, after an online range-distribution tablet split, a sub-tablet can inherit rowsets whose metadata `num_rows` was rewritten to `0`, while the shared physical segments still contain rows that fall inside the sub-tablet's range. When compaction subsequently runs on such a sub-tablet, both compaction paths use `total_num_rows` as a divisor when computing progress:

  - `horizontal_compaction_task.cpp:134`: `100 * reader.stats().raw_rows_read / total_num_rows`
  - `vertical_compaction_task.cpp:272-273`: `(100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) / column_group_size`

  When the denominator is `0`, this triggers a BE SIGFPE (integer divide-by-zero) and crashes the process.

  ## What I'm doing:

  A minimal, backport-safe hotfix that guards the two progress-update divisions. When the denominator is zero, we skip the incremental update and preserve the previous progress value. The final unconditional `_context->progress.update(100)` at `execute()` exit still guarantees the terminal state, so observers relying on `progress.value() == 100` at completion remain unaffected.

  The root-cause fix — eliminating the splitter-vs-reader overlap disagreement that produces the inconsistent metadata — will be addressed in a separate follow-up PR against `main` only. This PR ships L1 first as a narrow hotfix to unblock affected users on release branches.

  Changes:
  - `be/src/storage/lake/horizontal_compaction_task.cpp`: guard the divide with `if (total_num_rows > 0)`.
  - `be/src/storage/lake/vertical_compaction_task.cpp`: guard the divide with `if (_total_num_rows > 0 && column_group_size > 0)`.
  - `be/test/storage/lake/compaction_task_test.cpp`: add `test_zero_num_rows_no_crash` (parameterized across HORIZONTAL / VERTICAL × size-tiered on/off — 4 variants) that reproduces the exact post-split scenario: write data, zero out per-rowset `num_rows` / `data_size` in metadata, then run compaction. Before the fix this crashes; after the fix it completes and reaches `progress.value() == 100`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
