### PR TITLE
[BugFix] Incorrect Session Variable Usage in Paimon Split Calculation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -244,6 +244,10 @@ public class PaimonScanNode extends ScanNode {
 
     public void splitRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile) {
         long splitSize = ConnectContext.get().getSessionVariable().getConnectorMaxSplitSize();
+        // Guard against invalid values: 0 or negative
+        if (splitSize <= 0) {
+            splitSize = SessionVariable.DEFAULT_SESSION_VARIABLE.getConnectorMaxSplitSize();
+        }
         long totalSize = rawFile.length();
         long offset = rawFile.offset();
         boolean needSplit = totalSize > splitSize;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -243,8 +243,7 @@ public class PaimonScanNode extends ScanNode {
     }
 
     public void splitRawFileScanRangeLocations(RawFile rawFile, @Nullable DeletionFile deletionFile) {
-        SessionVariable sv = SessionVariable.DEFAULT_SESSION_VARIABLE;
-        long splitSize = sv.getConnectorMaxSplitSize();
+        long splitSize = ConnectContext.get().getSessionVariable().getConnectorMaxSplitSize();
         long totalSize = rawFile.length();
         long offset = rawFile.offset();
         boolean needSplit = totalSize > splitSize;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.THdfsFileFormat;
 import com.starrocks.thrift.TScanRangeLocations;
@@ -123,6 +124,9 @@ public class PaimonScanNodeTest {
 
     @Test
     public void testSplitRawFileScanRange(@Mocked PaimonTable table, @Mocked RawFile rawFile) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+
         BinaryRow row1 = new BinaryRow(2);
         BinaryRowWriter writer = new BinaryRowWriter(row1, 10);
         writer.writeInt(0, 2000);
@@ -156,6 +160,9 @@ public class PaimonScanNodeTest {
 
     @Test
     public void testAddSplitScanRangeLocations(@Mocked PaimonTable table, @Mocked RawFile rawFile) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+
         BinaryRow row1 = new BinaryRow(2);
         BinaryRowWriter writer = new BinaryRowWriter(row1, 10);
         writer.writeInt(0, 2000);
@@ -178,5 +185,30 @@ public class PaimonScanNodeTest {
         Assertions.assertEquals(1, scanNode.getScanRangeLocations(10).size());
         TScanRangeLocations tScanRangeLocations = scanNode.getScanRangeLocations(10).get(0);
         Assertions.assertEquals(THdfsFileFormat.UNKNOWN, tScanRangeLocations.getScan_range().getHdfs_scan_range().getFile_format());
+    }
+
+    @Test
+    public void testSplitRawFileScanRangeLocationsWithSessionVariable(@Mocked PaimonTable table, @Mocked RawFile rawFile) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        ctx.getSessionVariable().setConnectorMaxSplitSize(50L);
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        new Expectations() {
+            {
+                rawFile.format();
+                result = "orc";
+                rawFile.offset();
+                result = 100L;
+                rawFile.length();
+                result = 120L;
+                rawFile.path();
+                result = "hdfs://dummy";
+            }
+        };
+        desc.setTable(table);
+        PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+        scanNode.splitRawFileScanRangeLocations(rawFile, null);
+        Assertions.assertEquals(2, scanNode.getScanRangeLocations(10).size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In PaimonScanNode.splitRawFileScanRangeLocations(), the code forces SessionVariable sv = SessionVariable.DEFAULT_SESSION_VARIABLE; to get ConnectorMaxSplitSize. It ignores the user's connection-specific SessionVariable context. If a user tries to tune connector_max_split_size to optimize scan parallelism, it takes no effect.

## What I'm doing:
Change to SessionVariable sv = ConnectContext.get().getSessionVariable();

Fixes #

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
