### PR TITLE
[Doc] allow [] in docs when not used for URL

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -28,5 +28,6 @@
   "MD048": false,
   "MD050": false,
   "MD051": false,
+  "MD053": false,
   "MD060": false
 }


### PR DESCRIPTION
## Why I'm doing:

We often want to have choices in the docs, and these are normally specified as `[ this | that ]`. Unfortunately, the linter barfs on this thinking that we want a link and forgot to add a URL.

The lychee link checker will catch broken links, so we can turn off MD053 in the markdownlint linter.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4