### PR TITLE
[Doc] Correct valid values of BE sys_log_level (WARN -> WARNING)

### DIFF
--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -100,7 +100,7 @@ This topic introduces the following types of FE configurations:
 - Type: String
 - Unit: -
 - Is mutable: Yes (from v3.3.0, v3.2.7, and v3.1.12)
-- Description: The severity levels into which system log entries are classified. Valid values: INFO, WARN, ERROR, and FATAL. This item was changed to a dynamic configuration from v3.3.0, v3.2.7, and v3.1.12 onwards.
+- Description: The severity levels into which system log entries are classified. Valid values: INFO, WARNING, ERROR, and FATAL. This item was changed to a dynamic configuration from v3.3.0, v3.2.7, and v3.1.12 onwards.
 - Introduced in: -
 
 ### sys_log_roll_mode

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -73,7 +73,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - タイプ: String
 - 単位: -
 - 変更可能: はい (v3.3.0、v3.2.7、v3.1.12 から)
-- 説明: システムログエントリが分類される重大度レベル。 有効な値: INFO、WARN、ERROR、FATAL。この項目は v3.3.0、v3.2.7、v3.1.12 以降、動的設定に変更されました。
+- 説明: システムログエントリが分類される重大度レベル。 有効な値: INFO、WARNING、ERROR、FATAL。この項目は v3.3.0、v3.2.7、v3.1.12 以降、動的設定に変更されました。
 - 導入バージョン: -
 
 ### sys_log_roll_mode


### PR DESCRIPTION
## Why I'm doing:

The BE configuration documentation for `sys_log_level` lists the valid values as `INFO, WARN, ERROR, and FATAL`. This does not match the actual BE parser behavior: `be/src/runtime/logconfig.cpp` (the `init_glog()` function around lines 360-371) uses glog and only accepts `INFO`, `WARNING`, `ERROR`, `FATAL`. Passing `WARN` causes `init_glog` to print `sys_log_level needs to be INFO, WARNING, ERROR, FATAL` to stderr and return `false`. The caller in `be/src/service/daemon.cpp` (`Daemon::init`, around line 443) does not check this return value, so BE continues startup in a degraded logging state (default `INFO` min level, skipped log rotation and signal handler setup) rather than honoring the intended level.

Operators following the public documentation can hit this discrepancy when trying to lower BE log verbosity.

The Chinese version of the documentation is already correct (it lists `INFO、WARNING、ERROR、FATAL`). Only the English and Japanese pages were out of sync with the code and with the Chinese documentation.

## What I'm doing:

Updating the English and Japanese BE configuration docs to list `WARNING` (instead of `WARN`) as a valid value for `sys_log_level`, matching the actual BE parser behavior and the Chinese documentation.

Two files touched, one line each:

- `docs/en/administration/management/BE_parameters/log_server_meta.md`
- `docs/ja/administration/management/BE_parameters/log_server_meta.md`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4