### PR TITLE
[Doc] Add starlet_cache_dir BE configuration

### DIFF
--- a/docs/en/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/BE_parameters/shared_lake_other.md
@@ -112,6 +112,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of cached client instances retained for each remote host by BE-wide client caches. This single setting is used when creating BackendServiceClientCache, FrontendServiceClientCache, and BrokerServiceClientCache during ExecEnv initialization, so it limits the number of client stubs/connections kept per host across those caches. Raising this value reduces reconnects and stub creation overhead at the cost of increased memory and file-descriptor usage; lowering it saves resources but may increase connection churn. The value is read at startup and cannot be changed at runtime. Currently one shared setting controls all client cache types; separate per-cache configuration may be introduced later.
 - Introduced in: v3.2.0
 
+### starlet_cache_dir
+
+- Default: "" (empty)
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The local data cache directory for cloud native tables. If left empty, the system uses `<storage_root_path>/starlet_cache` for each path in `storage_root_path`, joined with `:`.
+- Introduced in: v3.0
+
 ### starlet_filesystem_instance_cache_capacity
 
 - Default: 10000

--- a/docs/ja/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/BE_parameters/shared_lake_other.md
@@ -103,6 +103,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BE/CN プロセスが終了する際に待機するループ回数。各ループは固定間隔の 10 秒です。ループ待機を無効にするには `0` に設定できます。v3.4 以降、この項目は変更可能になり、デフォルト値は `0` から `2` に変更されました。
 - 導入バージョン: v2.5
 
+### starlet_cache_dir
+
+- デフォルト: ""（空）
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: 共有データテーブルのローカルデータキャッシュディレクトリ。空のままにすると、`storage_root_path` 内の各パスに対して `starlet_cache` サブディレクトリが使用され、複数のパスは `:` で結合されます。
+- 導入バージョン: v3.0
+
 ### starlet_filesystem_instance_cache_capacity
 
 - デフォルト: 10000

--- a/docs/zh/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/BE_parameters/shared_lake_other.md
@@ -109,6 +109,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 范围内的客户端缓存为每个远程主机保留的最大缓存 client 实例数。提高此值可以减少重连和 stub 创建开销，但会增加内存和文件描述符使用；降低它则节省资源但可能增加连接 churn。该值在启动时读取，运行时无法更改。目前一个共享设置控制所有客户端缓存类型；将来可能会引入每种缓存的独立配置。
 - 引入版本：v3.2.0
 
+### starlet_cache_dir
+
+- 默认值：""（空）
+- 类型：String
+- 单位：-
+- 是否动态：否
+- 描述：存算分离表的本地数据缓存目录。若设置为空，系统将使用 `storage_root_path` 中每个路径下的 `starlet_cache` 子目录，多个路径以 `:` 分隔。
+- 引入版本：v3.0
+
 ### starlet_filesystem_instance_cache_capacity
 
 - 默认值：10000


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Document the `starlet_cache_dir` config in EN/ZH/JA BE parameter reference.
When empty, the cache path defaults to `<storage_root_path>/starlet_cache`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4