### PR TITLE
[Refactor] Remove legacy raw_data() side-effect workarounds

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -85,13 +85,6 @@ public:
                       "precision and scale param");
         auto ptr = RunTimeColumnType<Type>::create();
         ptr->append_datum(Datum(value));
-        // @FIXME: BinaryColumn get_data() will call build_slice() to modify the column's memory data,
-        // but the operator is thread-unsafe, it's will cause crash in multi-thread(OLAP_SCANNER) when
-        // OLAP_SCANNER call expression.
-        // Call the raw_data() when create ConstColumn is a short-term solution
-        if constexpr (!lt_is_object_family<Type>) {
-            ptr->raw_data();
-        }
         return ConstColumn::create(std::move(ptr), chunk_size);
     }
 

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -158,10 +158,6 @@ Status ColumnModePartialUpdateHandler::_load_upserts(const RowsetUpdateStatePara
     header_ptr->offsets.push_back(header_ptr->upserts->size());
     header_ptr->end_idx = *end_idx;
     DCHECK(header_ptr->offsets.size() == header_ptr->end_idx - header_ptr->start_idx + 1);
-    // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
-    // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
-    // So we try build slice in advance in here to make sure the correctness of memory statistics
-    header_ptr->upserts->raw_data();
     const auto upserts_memory_usage = header_ptr->upserts->memory_usage();
     _tracker->consume(upserts_memory_usage);
     _memory_usage += upserts_memory_usage;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -878,7 +878,6 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
     const auto* begin = reinterpret_cast<const uint8_t*>(read_buffer.data());
     const auto* end = begin + read_buffer.size();
     RETURN_IF_ERROR(Serd::deserialize(begin, end, col.get()));
-    col->raw_data();
     _memory_usage += col->memory_usage();
     _deletes[del_id] = std::move(col);
     TRACE("end read $0-th deletes files", del_id);

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -100,7 +100,6 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
         itr->close();
     }
     dest = std::move(col);
-    TRY_CATCH_BAD_ALLOC(dest->raw_data());
     _memory_usage += dest->memory_usage();
     _update_manager->compaction_state_mem_tracker()->consume(dest->memory_usage());
     return Status::OK();

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -962,15 +962,13 @@ Status StringColumnWriter::check_string_lengths(const Column& column) {
     } else {
         bin_col = down_cast<const BinaryColumn*>(&column);
     }
+    const auto& datas = bin_col->immutable_data();
     for (size_t i = 0; i < row_count; i++) {
         // skip string length check if it is null
-        if (null != nullptr && null[i] == starrocks::DATUM_NULL) {
+        if (null != nullptr && null[i] == DATUM_NULL) {
             continue;
         }
-        // here we shouldn't use raw_data() api of column to get a vector of slices in advance,
-        // because raw_data() will call _build_slices() api, which will create a vector of slices,
-        // if there are many StringColumnWriter, each of them will have a vector of slices, which will consume many memory.
-        Slice slice = bin_col->get_slice(i);
+        Slice slice = datas[i];
         if (slice.get_size() > limit) {
             return Status::InvalidArgument(fmt::format("string length({}) > limit({}), string: {}", slice.get_size(),
                                                        limit, slice.to_string()));

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -962,13 +962,12 @@ Status StringColumnWriter::check_string_lengths(const Column& column) {
     } else {
         bin_col = down_cast<const BinaryColumn*>(&column);
     }
-    const auto& datas = bin_col->immutable_data();
     for (size_t i = 0; i < row_count; i++) {
         // skip string length check if it is null
         if (null != nullptr && null[i] == DATUM_NULL) {
             continue;
         }
-        Slice slice = datas[i];
+        Slice slice = bin_col->get_slice(i);
         if (slice.get_size() > limit) {
             return Status::InvalidArgument(fmt::format("string length({}) > limit({}), string: {}", slice.get_size(),
                                                        limit, slice.to_string()));

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -159,10 +159,6 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, MemTracker* update
     TRY_CATCH_BAD_ALLOC(header_ptr->offsets.push_back(header_ptr->upserts->size()));
     header_ptr->end_idx = *end_idx;
     DCHECK(header_ptr->offsets.size() == header_ptr->end_idx - header_ptr->start_idx + 1);
-    // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
-    // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
-    // So we try build slice in advance in here to make sure the correctness of memory statistics
-    TRY_CATCH_BAD_ALLOC(header_ptr->upserts->raw_data());
     _memory_usage += header_ptr->upserts->memory_usage();
 
     return Status::OK();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -91,7 +91,6 @@ Status RowsetUpdateState::_load_deletes(Rowset* rowset, uint32_t idx, Column* pk
     auto col = pk_column->clone();
     const auto* end = read_buffer.data() + read_buffer.size();
     RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), end, col.get()));
-    TRY_CATCH_BAD_ALLOC(col->raw_data());
     _memory_usage += col != nullptr ? col->memory_usage() : 0;
     _deletes[idx] = std::move(col);
     return Status::OK();
@@ -151,10 +150,6 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
         itr->close();
     }
     dest = std::move(col);
-    // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
-    // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
-    // So we try build slice in advance in here to make sure the correctness of memory statistics
-    TRY_CATCH_BAD_ALLOC(dest->raw_data());
     _memory_usage += dest != nullptr ? dest->memory_usage() : 0;
 
     return Status::OK();

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -125,7 +125,6 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
         RETURN_ERROR_IF_FALSE(col->size() == num_rows, "read segment: iter rows != num rows");
     }
     dest = std::move(col);
-    TRY_CATCH_BAD_ALLOC(dest->raw_data());
     _memory_usage += dest->memory_usage();
     tracker->consume(dest->memory_usage());
 


### PR DESCRIPTION
## Why I'm doing:

This is the 19th step for https://github.com/StarRocks/starrocks/issues/69589

## What I'm doing:

All callers of BinaryColumn::raw_data have been removed, so it is now safe to remove the legacy raw_data() side-effect workarounds.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
